### PR TITLE
fix(agent): use ?since= for /spaces/{id}/events cursor pagination

### DIFF
--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -792,12 +792,21 @@ class PuffoCoreMessageClient:
         if channel_id in self._channel_name_cache:
             return self._channel_name_cache[channel_id]
         cursor: str | None = None
+        prev_cursor: str | None = None
         name = channel_id
         try:
             while True:
+                # Server's query parameter is ``since`` (see
+                # ``SpaceEventsParams`` in puffo-server
+                # membership.rs). Earlier copies of this client used
+                # ``cursor=``, which axum's Query extractor silently
+                # ignored — every paginated request came back with
+                # the first page, ``has_more: true``, and the same
+                # cursor, looping forever (the web client had the
+                # same bug; see commit 5b031cc in puffo-core-han-group).
                 path = f"/spaces/{space_id}/events"
                 if cursor:
-                    path += f"?cursor={cursor}"
+                    path += f"?since={cursor}"
                 page = await self.http.get(path)
                 for ev in page.get("events") or []:
                     if ev.get("kind") != "create_channel":
@@ -808,8 +817,14 @@ class PuffoCoreMessageClient:
                         break
                 if name != channel_id or not page.get("has_more"):
                     break
+                prev_cursor = cursor
                 cursor = page.get("next_cursor")
                 if not cursor:
+                    break
+                # Defensive: a server-side regression that ignores
+                # ``since`` would echo the same cursor back and wedge
+                # this loop. Bail rather than spin.
+                if cursor == prev_cursor:
                     break
         except Exception:
             pass

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -796,14 +796,7 @@ class PuffoCoreMessageClient:
         name = channel_id
         try:
             while True:
-                # Server's query parameter is ``since`` (see
-                # ``SpaceEventsParams`` in puffo-server
-                # membership.rs). Earlier copies of this client used
-                # ``cursor=``, which axum's Query extractor silently
-                # ignored — every paginated request came back with
-                # the first page, ``has_more: true``, and the same
-                # cursor, looping forever (the web client had the
-                # same bug; see commit 5b031cc in puffo-core-han-group).
+                # Server expects ``?since=``, not ``?cursor=``.
                 path = f"/spaces/{space_id}/events"
                 if cursor:
                     path += f"?since={cursor}"
@@ -819,12 +812,7 @@ class PuffoCoreMessageClient:
                     break
                 prev_cursor = cursor
                 cursor = page.get("next_cursor")
-                if not cursor:
-                    break
-                # Defensive: a server-side regression that ignores
-                # ``since`` would echo the same cursor back and wedge
-                # this loop. Bail rather than spin.
-                if cursor == prev_cursor:
+                if not cursor or cursor == prev_cursor:
                     break
         except Exception:
             pass

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -267,12 +267,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 break
             prev_cursor = cursor
             cursor = data.get("next_cursor")
-            if cursor is None:
-                break
-            # Defensive: cursor must strictly advance whenever
-            # ``has_more`` is set. A repeated value means the server
-            # isn't making progress; bail instead of spinning.
-            if cursor == prev_cursor:
+            if cursor is None or cursor == prev_cursor:
                 break
         if not channels:
             return "(no channels in this space)"

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -245,6 +245,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         # cursor is ``<issued_at>:<signer_slug>:<event_id>``. Colons
         # are legal in query strings but encode anyway for safety.
         cursor: Optional[str] = None
+        prev_cursor: Optional[str] = None
         channels: list[tuple[str, str]] = []
         while True:
             if cursor is not None:
@@ -264,8 +265,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                         channels.append((cid, name))
             if not data.get("has_more"):
                 break
+            prev_cursor = cursor
             cursor = data.get("next_cursor")
             if cursor is None:
+                break
+            # Defensive: cursor must strictly advance whenever
+            # ``has_more`` is set. A repeated value means the server
+            # isn't making progress; bail instead of spinning.
+            if cursor == prev_cursor:
                 break
         if not channels:
             return "(no channels in this space)"

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -297,6 +297,75 @@ async def test_list_channels():
 
 
 @pytest.mark.asyncio
+async def test_list_channels_paginates_via_since():
+    """``list_channels`` walks ``/spaces/<sp>/events`` page-by-page
+    using ``?since=<next_cursor>``. Guards against a regression of
+    the ``?cursor=`` bug — the server's axum extractor silently
+    ignored the wrong-named key, so paginated calls re-fetched the
+    first page forever and the tool never returned."""
+    cfg, http, _ = _setup()
+    # Page 1: one channel + cursor pointing at page 2.
+    http.responses["/spaces/sp_test/events"] = {
+        "events": [
+            {"kind": "create_channel", "payload": {"channel_id": "ch_1", "name": "General"}},
+        ],
+        "has_more": True,
+        "next_cursor": "cursor_page2",
+    }
+    # Page 2: second channel + end of stream. Registered against the
+    # exact ``?since=`` URL so a regression to ``?cursor=`` would miss
+    # this entry and fall back to page 1 (loop forever).
+    http.responses["/spaces/sp_test/events?since=cursor_page2"] = {
+        "events": [
+            {"kind": "create_channel", "payload": {"channel_id": "ch_2", "name": "Random"}},
+        ],
+        "has_more": False,
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels")
+
+    assert "General" in result
+    assert "ch_1" in result
+    assert "Random" in result
+    assert "ch_2" in result
+
+    events_calls = [c for c in http.calls if c[1].startswith("/spaces/sp_test/events")]
+    # Exactly two requests: page 1 (no query) + page 2 (?since=).
+    assert len(events_calls) == 2, events_calls
+    assert events_calls[0][1] == "/spaces/sp_test/events"
+    assert "?since=cursor_page2" in events_calls[1][1]
+
+
+@pytest.mark.asyncio
+async def test_list_channels_bails_on_stuck_cursor():
+    """If the server ever regresses and returns the same cursor it
+    was just sent, the tool must stop instead of spinning. Mirrors
+    the strict-advance guard in ``fetchChannelsFromEvents``
+    (web) and ``_resolve_channel_name`` (this package)."""
+    cfg, http, _ = _setup()
+    # Both the initial and the ``?since=stuck`` request hand back
+    # the same ``next_cursor`` — a real regression would loop, the
+    # guarded loop bails after the second fetch.
+    page = {
+        "events": [
+            {"kind": "create_channel", "payload": {"channel_id": "ch_1", "name": "General"}},
+        ],
+        "has_more": True,
+        "next_cursor": "stuck",
+    }
+    http.responses["/spaces/sp_test/events"] = page
+    http.responses["/spaces/sp_test/events?since=stuck"] = page
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels")
+
+    assert "General" in result
+    events_calls = [c for c in http.calls if c[1].startswith("/spaces/sp_test/events")]
+    # Two calls: initial, then one with ``?since=stuck`` whose
+    # ``next_cursor`` is also ``stuck`` — the guard breaks the loop.
+    assert len(events_calls) == 2, events_calls
+
+
+@pytest.mark.asyncio
 async def test_list_channel_members():
     """Channel members come from
     ``/spaces/<sp>/channels/<ch>/members`` keyed by space_id."""


### PR DESCRIPTION
## Summary

Parallel fix to [puffo-core-han-group#67](https://github.com/puffo-ai/puffo-core-han-group/pull/67). Same bug, same call site, same fix — applied here so the published `puffo-agent` wheel doesn't ship the infinite-loop pagination.

The server's `SpaceEventsParams` expects `since` but `PuffoCoreMessageClient._resolve_channel_name` was sending `cursor=`. axum's `Query` extractor silently ignored the unknown key, so every paginated request returned the first page again with `has_more: true` and the same `next_cursor` — the loop ran forever.

**Production impact already observed**: an agent receiving a message for a channel whose `create_channel` event lived past page 1 of `/spaces/<sp>/events` spun in the loop while its WS receive queue grew unbounded behind it. The daemon pinned its memory, then the host OOM'd and took down every Python process on the machine (including a separate Mattermost-only `puffoagent` daemon that wasn't even vulnerable). Restart with the fixed code is required.

## What this changes

1. Rename `cursor` → `since` in `PuffoCoreMessageClient._resolve_channel_name`.
2. Add a defensive strict-advance guard to both `_resolve_channel_name` and the MCP `list_channels` tool (already used the right param name but lacked the guard). If `next_cursor == cursor`, bail. Same guard the web fix added (`5b031cc` in puffo-core-han-group).

## Test plan

- [x] `pytest tests/test_puffo_core_tools.py` — 16/16 pass, includes two new cases:
  - `test_list_channels_paginates_via_since` walks two pages and asserts every channel is collected.
  - `test_list_channels_bails_on_stuck_cursor` registers a server that echoes the same `next_cursor` it was sent; the strict-advance guard breaks the loop after the second fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)