### PR TITLE
ci: PyPI / TestPyPI publish workflows via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,61 @@
+# Production PyPI publish. Fires when a GitHub Release is published.
+# Tag the release `vX.Y.Z` to match the version in pyproject.toml;
+# the build picks up the version from pyproject, not the tag, so the
+# tag is just a label for humans. Uses Trusted Publishing — no
+# secrets stored, OIDC exchange only.
+#
+# One-time setup on pypi.org:
+#
+#   1. Sign in at pypi.org.
+#   2. Account settings → Publishing → "Add a new pending publisher".
+#   3. PyPI project name: puffo-agent
+#      Owner:               puffo-ai
+#      Repository name:     puffo-agent
+#      Workflow filename:   publish-pypi.yml
+#      Environment name:    pypi
+#   4. Save. After the first successful run the publisher converts
+#      from "pending" to a real one.
+#
+# Strongly recommended: in repo Settings → Environments → pypi, add a
+# "Required reviewers" rule so the upload step waits on a manual
+# approval before publishing. Once a version is on PyPI it can never
+# be re-uploaded — the approval gate is the last cheap chance to
+# catch a bad build.
+
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/puffo-agent
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Smoke-install the wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --upgrade pip
+          /tmp/smoke/bin/pip install dist/*.whl
+          /tmp/smoke/bin/puffo-agent --help > /dev/null
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,58 @@
+# Manual TestPyPI publish. Trigger from the GitHub Actions UI
+# ("Run workflow") on any branch to dry-run a release before the real
+# PyPI one. Uses Trusted Publishing — no token stored, OIDC exchange
+# only. One-time setup on test.pypi.org:
+#
+#   1. Sign in at test.pypi.org.
+#   2. Settings → Publishing → "Add a new pending publisher".
+#   3. PyPI project name: puffo-agent
+#      Owner:               puffo-ai
+#      Repository name:     puffo-agent
+#      Workflow filename:   publish-testpypi.yml
+#      Environment name:    testpypi
+#   4. Save. After the first successful run the publisher converts
+#      from "pending" to a real one.
+#
+# Verify after a run with:
+#   pip install -i https://test.pypi.org/simple/ \
+#     --extra-index-url https://pypi.org/simple/ puffo-agent
+# (the extra index lets test-pypi resolve real deps from real PyPI).
+
+name: Publish to TestPyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/puffo-agent
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Smoke-install the wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --upgrade pip
+          /tmp/smoke/bin/pip install dist/*.whl
+          /tmp/smoke/bin/puffo-agent --help > /dev/null
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

Two GitHub Actions workflows under `.github/workflows/`:

- **`publish-testpypi.yml`** — manual `workflow_dispatch`. Use this to dry-run a publish to test.pypi.org before the real PyPI one. Gated behind a `testpypi` GitHub Environment.
- **`publish-pypi.yml`** — fires when a GitHub Release is published. Gated behind a `pypi` GitHub Environment (recommend adding a required-reviewers rule on that env once setup is done — PyPI uploads can never be re-uploaded for a given version).

Both use **OIDC Trusted Publishing** — no PyPI API tokens stored as repo secrets. Each workflow runs `python -m build`, smoke-installs the wheel into a throwaway venv and calls `puffo-agent --help` to catch broken entry points before the upload step.

## One-time setup (you do these once, before the first release)

**On test.pypi.org:**
1. Sign in.
2. *Account settings → Publishing → "Add a new pending publisher"*.
3. Fill in:
   - PyPI project name: `puffo-agent`
   - Owner: `puffo-ai`
   - Repository name: `puffo-agent`
   - Workflow filename: `publish-testpypi.yml`
   - Environment name: `testpypi`
4. Save.

**On pypi.org:** identical, but with workflow filename `publish-pypi.yml` and environment name `pypi`.

**On the repo (after merge):**
1. *Settings → Environments → New environment → `testpypi`*. No protection needed.
2. *Settings → Environments → New environment → `pypi`*. **Recommended: add a required-reviewers rule** so each upload waits on your manual approval.

## Release flow after setup

1. Bump `version` in `pyproject.toml` (e.g. `0.7.2` → `0.7.3`), commit, push.
2. (Optional) *Actions → Publish to TestPyPI → Run workflow* on the new commit. Verify with `pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ puffo-agent` from a clean venv.
3. Create a GitHub Release tagged `v0.7.3` pointing at the same commit. The release-published trigger fires `publish-pypi.yml`; if the `pypi` env has a reviewer rule, the upload waits for your approval, then publishes.

## Test plan

- [x] Workflows syntactically valid (committed; GitHub will validate on push).
- [ ] After merge: configure both pending publishers + both environments.
- [ ] Trigger `publish-testpypi.yml` manually; confirm 0.7.2 lands on test.pypi.org.
- [ ] Install from TestPyPI into a clean venv, run `puffo-agent --help`, `puffo-agent agent list`.
- [ ] Create release `v0.7.2` to fire `publish-pypi.yml`; approve in the `pypi` environment; confirm 0.7.2 on pypi.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)