### PR TITLE
feat(agent): thread-batched queue + kick-retry + MCP history restructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   claude-code API simultaneously and trips its rate limit; the
   random sleep desynchronises them. Each agent picks its own delay
   independently — no host-wide coordination needed.
+- Status telemetry follows the thread-batch lifecycle. The first
+  message in a batch still gets a single `/processing/start`
+  (yellow dot lands there), but the per-message `/end` fan-out is
+  replaced by a single `/messages/processing/end:batch` call that
+  flips every message in the batch to green at once. Requires the
+  puffo-server endpoint added in puffo-server#46 (deployed
+  2026-05-11).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.7.3] — 2026-05-11
 
+### Added
+
+- New MCP tool `mcp__puffo__get_thread_history(root_id, limit,
+  since, before, after)` — root post + every reply in one thread,
+  oldest-first. Companion to the restructured
+  `get_channel_history`; agents drill into a thread only when
+  `get_channel_history` shows a non-zero reply count worth reading.
+- `[puffo-agent system message]` prefix on control messages the
+  runtime injects into the agent's claude-code transcript (today
+  used for the rate-limit retry kick; the prefix is documented in
+  CLAUDE.md so the agent recognises future control messages
+  without another prompt update).
+
 ### Changed
 
 - Message processing is now thread-batched instead of per-message.
@@ -34,6 +47,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   flips every message in the batch to green at once. Requires the
   puffo-server endpoint added in puffo-server#46 (deployed
   2026-05-11).
+- `mcp__puffo__get_channel_history` now returns **root posts only**
+  with a per-thread `(N replies)` annotation instead of inlining
+  every reply. One busy thread no longer eats the whole channel's
+  view. Same call also accepts `since=<envelope_id>` / `before=<ms>`
+  / `after=<ms>` filters for incremental polling.
+- Both `get_channel_history` and `get_thread_history` distinguish
+  "unknown channel/thread" (HTTP 404 → "(no such channel: …)" /
+  "(no such thread: …)") from "known but window-empty after
+  filters" (HTTP 200 + `[]` → "(no … in the requested window)").
+  Agents can tell a typoed id from a quiet polling window.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   last_processed_sent_at)` table records the last `sent_at` drained
   per thread. On startup the runtime skips anything at or below that
   cursor so a crash mid-batch doesn't replay the whole thread.
+- Pre-dispatch jitter (0.0–1.5s) before each batch is sent to the
+  agent. When multiple agents on the same host get activated by one
+  broadcast message, unblocked dispatch sends them all into the
+  claude-code API simultaneously and trips its rate limit; the
+  random sleep desynchronises them. Each agent picks its own delay
+  independently — no host-wide coordination needed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Thread-batched dispatch could feed the agent the same envelope
+  multiple times in one batch when the server's pending-message
+  redelivery overlapped with live WS delivery (most easily reproduced
+  after a daemon restart). `MessageStore.store` already used
+  `INSERT OR IGNORE`, but the in-memory `_ThreadEntry.messages`
+  batch had no envelope-level dedup. Now `_admit_thread_message`
+  drops the append when the incoming `envelope_id` is already in the
+  pending batch.
 - cli-local adapter silently dropped MCP servers passed via
   `--mcp-config`. claude-code gates MCP registration on the per-
   project trust dialog stored in `~/.claude.json`, and the dialog has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   batch had no envelope-level dedup. Now `_admit_thread_message`
   drops the append when the incoming `envelope_id` is already in the
   pending batch.
+- A duplicate WS delivery that landed during a successful dispatch
+  was being added to a fresh batch and re-fed to the agent on the
+  next turn — observed as the same `envelope_id` appearing twice
+  across consecutive claude-code turns (with a system-reminder
+  injected between them). The handle_envelope cursor check couldn't
+  catch it because `mark_thread_processed` runs *after* the dispatch
+  finishes, and the in-batch dedup couldn't catch it because the
+  consumer empties `entry.messages` to claim the batch. Adds a per-
+  thread `dispatching_ids` set populated at claim time and consulted
+  at the top of `_admit_thread_message`; cleared after the cursor
+  advances on successful dispatch.
 - `AgentAPIError` retry path was clobbering mid-dispatch arrivals.
   When the dispatch failed AND a new message had landed on the same
   thread during the failed dispatch (admitted through the reopen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,15 +69,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   session, so the same user message got appended to the transcript
   once per retry. A receiver who saw `×4` was hitting the rate
   limit four times before succeeding, with each attempt being a
-  legitimate retry of one real wire delivery. Adds
-  `Adapter.invalidate_session()` (implemented in cli-local /
-  cli-docker via a new `ClaudeSession.invalidate`) and calls it in
-  `_run_turn_and_route` right before re-raising `AgentAPIError`.
-  Each retry now starts a fresh claude-code session with no
-  `--resume`, so the agent's transcript shows the input exactly
-  once. Tracks `_appended_envelope_ids` on the `PuffoAgent` so the
-  retry's `handle_message_batch` doesn't re-`_append_user` the
-  same envelope into `self.log` either.
+  legitimate retry of one real wire delivery. New behaviour:
+  preserve `--resume`, send a kick-only "session errored on rate
+  limiting, please resume processing" instead of re-appending the
+  batch. The cli adapter falls back to the full payload only when
+  `_ResumeFailed` was caught and a fresh claude-code session was
+  spawned (so the transcript has no original input to resume from).
+  Plumbed via a new `Adapter.run_retry_turn(kick_text,
+  fallback_user_message, ctx)` and a parallel
+  `_consume_queue(on_api_error_retry=...)` callback. Capped at 3
+  retries per batch; on exhaustion the cursor stays put so the
+  failed envelopes remain readable via `get_channel_history` on
+  the agent's next normal turn.
 - cli-docker now auto-recreates a reused container when its
   `/opt/puffoagent-pkg` bind mount no longer resolves to the host
   path that contains `puffo_agent` (typical cause: the operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.3] — 2026-05-11
+
+### Changed
+
+- Message processing is now thread-batched instead of per-message.
+  Each root message id (`envelope_id` of the thread root) is a single
+  slot in the priority queue; new messages on the same thread coalesce
+  into the existing slot, a higher-priority arrival bumps the slot but
+  preserves the batch cursor, and the consumer drains the full batch
+  in one `on_message_batch` dispatch. The agent reads the whole thread
+  and decides on its own who to reply to — no trigger-message concept.
+- Cross-restart dedup: a new `thread_processing_state(root_id PK,
+  last_processed_sent_at)` table records the last `sent_at` drained
+  per thread. On startup the runtime skips anything at or below that
+  cursor so a crash mid-batch doesn't replay the whole thread.
+
+### Fixed
+
+- cli-local adapter silently dropped MCP servers passed via
+  `--mcp-config`. claude-code gates MCP registration on the per-
+  project trust dialog stored in `~/.claude.json`, and the dialog has
+  no TUI surface under `--input-format stream-json`, so it never
+  resolved. Switched the `bypassPermissions` permission-mode to emit
+  `--dangerously-skip-permissions` (which also bypasses the trust
+  dialog) instead of `--permission-mode bypassPermissions` (which
+  only bypasses per-tool prompts). cli-docker already used the right
+  flag; this aligns cli-local.
+
 ## [0.7.2] — 2026-05-10
 
 First public PyPI release.
@@ -26,5 +54,6 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.3
 [0.7.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `on_message_batch`, logging a warning if anything is dropped. The
   agent must never see the same envelope twice in one turn, even if
   some upstream race we haven't characterised slips through.
+- cli-docker now auto-recreates a reused container when its
+  `/opt/puffoagent-pkg` bind mount no longer resolves to the host
+  path that contains `puffo_agent` (typical cause: the operator
+  reinstalled puffo-agent from a different path, e.g. moved off
+  `puffo-core-han-group/agent` to the standalone repo). Without
+  this, `python3 -m puffo_agent.mcp.puffo_core_server` inside the
+  container would fail with `ModuleNotFoundError`, claude-code's
+  MCP subprocess wouldn't initialise, and every puffo MCP tool
+  surfaced as "No such tool available". Detected by `docker exec
+  test -f /opt/puffoagent-pkg/puffo_agent/__init__.py`.
 - `AgentAPIError` retry path was clobbering mid-dispatch arrivals.
   When the dispatch failed AND a new message had landed on the same
   thread during the failed dispatch (admitted through the reopen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,23 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `on_message_batch`, logging a warning if anything is dropped. The
   agent must never see the same envelope twice in one turn, even if
   some upstream race we haven't characterised slips through.
+- `AgentAPIError` retry was duplicating the user input in the
+  agent's claude-code transcript on every retry. When claude-code
+  returns `API Error: Server is temporarily limiting requests`, the
+  consumer re-enqueues the batch and `handle_message_batch` runs
+  again — and the cli adapter `--resume`s the same claude-code
+  session, so the same user message got appended to the transcript
+  once per retry. A receiver who saw `×4` was hitting the rate
+  limit four times before succeeding, with each attempt being a
+  legitimate retry of one real wire delivery. Adds
+  `Adapter.invalidate_session()` (implemented in cli-local /
+  cli-docker via a new `ClaudeSession.invalidate`) and calls it in
+  `_run_turn_and_route` right before re-raising `AgentAPIError`.
+  Each retry now starts a fresh claude-code session with no
+  `--resume`, so the agent's transcript shows the input exactly
+  once. Tracks `_appended_envelope_ids` on the `PuffoAgent` so the
+  retry's `handle_message_batch` doesn't re-`_append_user` the
+  same envelope into `self.log` either.
 - cli-docker now auto-recreates a reused container when its
   `/opt/puffoagent-pkg` bind mount no longer resolves to the host
   path that contains `puffo_agent` (typical cause: the operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   batch had no envelope-level dedup. Now `_admit_thread_message`
   drops the append when the incoming `envelope_id` is already in the
   pending batch.
+- `AgentAPIError` retry path was clobbering mid-dispatch arrivals.
+  When the dispatch failed AND a new message had landed on the same
+  thread during the failed dispatch (admitted through the reopen
+  branch of `_admit_thread_message`), the handler set
+  `entry.messages = batch` and silently dropped the new message.
+  The retry now dedupe-prepends the failed batch to whatever is
+  already in `entry.messages` so the next attempt carries both.
 - cli-local adapter silently dropped MCP servers passed via
   `--mcp-config`. claude-code gates MCP registration on the per-
   project trust dialog stored in `~/.claude.json`, and the dialog has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   thread `dispatching_ids` set populated at claim time and consulted
   at the top of `_admit_thread_message`; cleared after the cursor
   advances on successful dispatch.
+- Belt-and-suspenders: the consumer now dedupes `batch` by
+  `envelope_id` one final time immediately before invoking
+  `on_message_batch`, logging a warning if anything is dropped. The
+  agent must never see the same envelope twice in one turn, even if
+  some upstream race we haven't characterised slips through.
 - `AgentAPIError` retry path was clobbering mid-dispatch arrivals.
   When the dispatch failed AND a new message had landed on the same
   thread during the failed dispatch (admitted through the reopen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.7.2"
+version = "0.7.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -94,27 +94,30 @@ class Adapter(ABC):
         """
         return None
 
-    async def invalidate_session(self) -> None:
-        """Discard the underlying runtime's resumable session so the
-        next turn starts from scratch.
+    async def run_retry_turn(
+        self,
+        kick_text: str,
+        fallback_user_message: str,
+        ctx: TurnContext,
+    ) -> TurnResult:
+        """Retry the most recent turn after an ``AgentAPIError``.
 
-        Called by ``core.py`` right before re-raising
-        ``AgentAPIError`` (e.g. claude-code's
-        ``API Error: Server is temporarily limiting requests``). The
-        AgentAPIError retry path in the consumer re-dispatches the
-        same batch, and the cli adapters by default ``--resume`` the
-        same claude-code session — so the agent's transcript would
-        show ``user: msg_X / assistant: "API Error" / user: msg_X /
-        ...`` accumulating one duplicate per retry. Clearing the
-        session means each retry starts a fresh claude-code session
-        with just the current input. The cost is losing prior
-        conversation history; the agent's memory + MCP
-        ``get_channel_history`` can rebuild context if needed.
-
-        Default no-op for adapters that don't maintain a resumable
-        session (SDK / chat-only).
+        Default: stateless adapters (SDK, chat-only) have no
+        resumable session, so the kick is meaningless on its own;
+        send the full ``fallback_user_message`` as a normal turn.
+        cli adapters override this to send the cheap kick on
+        ``--resume`` success and fall back to the full payload only
+        when ``--resume`` failed.
         """
-        return None
+        ctx_fallback = TurnContext(
+            system_prompt=ctx.system_prompt,
+            messages=[{"role": "user", "content": fallback_user_message}],
+            workspace_dir=ctx.workspace_dir,
+            claude_dir=ctx.claude_dir,
+            memory_dir=ctx.memory_dir,
+            on_progress=ctx.on_progress,
+        )
+        return await self.run_turn(ctx_fallback)
 
     async def refresh_ping(self) -> None:
         """Force an OAuth round-trip so Anthropic's rotating refresh

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -94,6 +94,28 @@ class Adapter(ABC):
         """
         return None
 
+    async def invalidate_session(self) -> None:
+        """Discard the underlying runtime's resumable session so the
+        next turn starts from scratch.
+
+        Called by ``core.py`` right before re-raising
+        ``AgentAPIError`` (e.g. claude-code's
+        ``API Error: Server is temporarily limiting requests``). The
+        AgentAPIError retry path in the consumer re-dispatches the
+        same batch, and the cli adapters by default ``--resume`` the
+        same claude-code session — so the agent's transcript would
+        show ``user: msg_X / assistant: "API Error" / user: msg_X /
+        ...`` accumulating one duplicate per retry. Clearing the
+        session means each retry starts a fresh claude-code session
+        with just the current input. The cost is losing prior
+        conversation history; the agent's memory + MCP
+        ``get_channel_history`` can rebuild context if needed.
+
+        Default no-op for adapters that don't maintain a resumable
+        session (SDK / chat-only).
+        """
+        return None
+
     async def refresh_ping(self) -> None:
         """Force an OAuth round-trip so Anthropic's rotating refresh
         token gets exchanged before the access token dies. Guarded by

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -263,6 +263,19 @@ class ClaudeSession:
         async with self._lock:
             await self._kill_proc()
 
+    async def invalidate(self) -> None:
+        """Clear the resumable session id and kill the running
+        subprocess so the next ``run_turn`` spawns a fresh claude-
+        code with no ``--resume`` and an empty transcript. Used by
+        the adapter when the previous turn failed with
+        ``API Error`` — the AgentAPIError retry path would otherwise
+        ``--resume`` the same session and the duplicate user input
+        would surface in the agent's transcript on every retry.
+        """
+        async with self._lock:
+            self._clear_session_id()
+            await self._kill_proc()
+
     # ── Session id persistence ────────────────────────────────────────────────
 
     def _load_session_id(self) -> str:

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -182,6 +182,14 @@ class ClaudeSession:
         self._session_id: str = self._load_session_id()
         self._lock = asyncio.Lock()
         self._stderr_drain_task: asyncio.Task | None = None
+        # True iff the most recent ``_spawn`` used ``--resume``. False
+        # after a fresh spawn (no session id) or when ``_ResumeFailed``
+        # forced a fresh fallback. ``run_retry_turn`` reads this to
+        # decide whether the cheap "session errored, please resume"
+        # kick is enough, or whether the caller's full-payload
+        # fallback needs to be sent because claude-code has no
+        # transcript to resume.
+        self._last_spawn_resumed: bool = False
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -245,6 +253,46 @@ class ClaudeSession:
                 )
             return TurnResult(reply="", metadata=md)
 
+    async def run_retry_turn(
+        self,
+        kick_text: str,
+        fallback_user_message: str,
+        system_prompt: str,
+    ) -> TurnResult:
+        """Retry the most recently failed turn.
+
+        If claude-code's session was resumed successfully (the
+        previous user input is still in its transcript), send just
+        ``kick_text`` — a small control message like "session
+        errored on rate limiting, please resume processing". The
+        agent reads the transcript and retries its previous response
+        without seeing a duplicate of the original input.
+
+        If ``--resume`` failed (the session id is no longer valid),
+        ``_ensure_running`` has already cleared the session id and
+        spawned a fresh claude-code with no transcript. The kick
+        would be meaningless on its own, so we send
+        ``fallback_user_message`` instead — the full original payload
+        that the caller would have sent for a normal turn.
+
+        Auth-error retry inside ``run_turn`` would normally re-send
+        the user message on each attempt; for the API-error path the
+        consumer drives retries from outside (with its own backoff),
+        so this method is a single-shot.
+        """
+        async with self._lock:
+            await self._ensure_running(system_prompt)
+            if self._last_spawn_resumed:
+                user_message = kick_text
+            else:
+                logger.warning(
+                    "agent %s: --resume not in effect for retry; "
+                    "falling back to the original payload",
+                    self.agent_id,
+                )
+                user_message = fallback_user_message
+            return await self._one_turn(user_message)
+
     async def warm(self, system_prompt: str) -> None:
         """Spawn the claude subprocess without running a turn so the
         first real message doesn't pay process + init latency.
@@ -261,19 +309,6 @@ class ClaudeSession:
 
     async def aclose(self) -> None:
         async with self._lock:
-            await self._kill_proc()
-
-    async def invalidate(self) -> None:
-        """Clear the resumable session id and kill the running
-        subprocess so the next ``run_turn`` spawns a fresh claude-
-        code with no ``--resume`` and an empty transcript. Used by
-        the adapter when the previous turn failed with
-        ``API Error`` — the AgentAPIError retry path would otherwise
-        ``--resume`` the same session and the duplicate user input
-        would surface in the agent's transcript on every retry.
-        """
-        async with self._lock:
-            self._clear_session_id()
             await self._kill_proc()
 
     # ── Session id persistence ────────────────────────────────────────────────
@@ -314,8 +349,15 @@ class ClaudeSession:
             )
             self._proc = None
 
+        had_session_id = bool(self._session_id)
         try:
             await self._spawn(system_prompt)
+            # _spawn either uses --resume (when _session_id was set
+            # going in) or starts a fresh session and learns the new
+            # session id on system/init. ``_last_spawn_resumed``
+            # captures the former path so ``run_retry_turn`` can
+            # decide whether the kick alone is sufficient.
+            self._last_spawn_resumed = had_session_id
             return
         except _ResumeFailed as exc:
             logger.warning(
@@ -324,6 +366,7 @@ class ClaudeSession:
             )
             self._clear_session_id()
             await self._spawn(system_prompt)
+            self._last_spawn_resumed = False
 
     async def _spawn(self, system_prompt: str) -> None:
         # --verbose is required with --output-format stream-json +

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -209,6 +209,31 @@ class DockerCLIAdapter(Adapter):
         session = self._ensure_session()
         return await session.run_turn(user_message, ctx.system_prompt)
 
+    async def run_retry_turn(
+        self,
+        kick_text: str,
+        fallback_user_message: str,
+        ctx: TurnContext,
+    ) -> TurnResult:
+        # claude-code only — hermes / gemini-cli always run one-shot
+        # without --resume, so a retry is just a normal turn against
+        # the fallback payload.
+        if self.harness.name() != "claude-code":
+            ctx_fallback = TurnContext(
+                system_prompt=ctx.system_prompt,
+                messages=[{"role": "user", "content": fallback_user_message}],
+                workspace_dir=ctx.workspace_dir,
+                claude_dir=ctx.claude_dir,
+                memory_dir=ctx.memory_dir,
+                on_progress=ctx.on_progress,
+            )
+            return await self.run_turn(ctx_fallback)
+        await self._ensure_started()
+        session = self._ensure_session()
+        return await session.run_retry_turn(
+            kick_text, fallback_user_message, ctx.system_prompt,
+        )
+
     async def _run_turn_hermes(self, user_message: str, system_prompt: str) -> TurnResult:
         """One-shot hermes turn via ``hermes chat --provider anthropic
         --quiet [--continue] -q <prompt>``.
@@ -598,10 +623,6 @@ class DockerCLIAdapter(Adapter):
         if self._session is not None:
             await self._session.aclose()
             self._session = None
-
-    async def invalidate_session(self) -> None:
-        if self._session is not None:
-            await self._session.invalidate()
 
     def _credentials_expires_in_seconds(self) -> int | None:
         # Every cli-docker agent's container reads the host's

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -761,6 +761,32 @@ class DockerCLIAdapter(Adapter):
         )
         return []
 
+    async def _puffo_pkg_mount_is_current(self) -> bool:
+        """``True`` iff the existing container's
+        ``/opt/puffoagent-pkg`` bind mount still resolves to a
+        directory containing the ``puffo_agent`` package.
+
+        Implemented as a ``docker exec test -f`` rather than
+        comparing ``docker inspect``'s Mount.Source against
+        ``_puffo_agent_pkg_dir()`` because Docker Desktop on Windows
+        rewrites the source path (``/run/desktop/mnt/host/c/...``)
+        and a literal string compare wouldn't survive that. The
+        in-container probe is authoritative: if claude-code's MCP
+        subprocess can ``import puffo_agent`` from the bind mount,
+        ``__init__.py`` must be visible — and if it isn't, the
+        subprocess will crash and every puffo MCP tool will surface
+        as "No such tool available".
+        """
+        rc, _, _ = await _run_cmd(
+            [
+                "docker", "exec", self.container_name,
+                "test", "-f",
+                "/opt/puffoagent-pkg/puffo_agent/__init__.py",
+            ],
+            check=False,
+        )
+        return rc == 0
+
     async def _container_state(self) -> str:
         """Docker-reported container State.Status (``running``,
         ``exited``, ``paused``, ``created``, ``dead``), or ``""``
@@ -878,6 +904,7 @@ class DockerCLIAdapter(Adapter):
             # next turn instead of paying container boot + image
             # pull every restart.
             state = await self._container_state()
+            existed = state != ""
             if state == "running":
                 logger.info(
                     "agent %s: reusing running container %r",
@@ -897,6 +924,37 @@ class DockerCLIAdapter(Adapter):
                 await _run_cmd(["docker", "unpause", self.container_name])
             else:
                 # state == "" — no container with this name.
+                await self._ensure_image()
+                await self._start_container()
+
+            # Validate the puffo_agent bind mount on REUSED
+            # containers. The /opt/puffoagent-pkg bind mount source
+            # is baked in at ``docker run`` time and immutable until
+            # the container is recreated. If the operator pip-
+            # reinstalled puffo-agent from a different host path
+            # (e.g. uninstalled the editable install from
+            # puffo-core-han-group/agent and re-installed from
+            # puffo-ai/puffo-agent), the container is still bound to
+            # the old — now non-existent — path. ``python3 -m
+            # puffo_agent.mcp.puffo_core_server`` inside the
+            # container then fails with ModuleNotFoundError, and
+            # claude-code reports every puffo MCP tool as
+            # "No such tool available". Detect that case here and
+            # recreate.
+            if existed and not await self._puffo_pkg_mount_is_current():
+                logger.warning(
+                    "agent %s: container %r has a stale "
+                    "/opt/puffoagent-pkg bind mount (the host path it "
+                    "was created with no longer contains puffo_agent). "
+                    "Recreating so claude-code's MCP subprocess can "
+                    "import the package again — typical cause is a "
+                    "pip reinstall from a different path.",
+                    self.agent_id, self.container_name,
+                )
+                await _run_cmd(
+                    ["docker", "rm", "-f", self.container_name],
+                    check=False,
+                )
                 await self._ensure_image()
                 await self._start_container()
             self._started = True

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -599,6 +599,10 @@ class DockerCLIAdapter(Adapter):
             await self._session.aclose()
             self._session = None
 
+    async def invalidate_session(self) -> None:
+        if self._session is not None:
+            await self._session.invalidate()
+
     def _credentials_expires_in_seconds(self) -> int | None:
         # Every cli-docker agent's container reads the host's
         # credentials file via bind-mount, so the host copy is the

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -175,6 +175,10 @@ class LocalCLIAdapter(Adapter):
             await self._session.aclose()
             self._session = None
 
+    async def invalidate_session(self) -> None:
+        if self._session is not None:
+            await self._session.invalidate()
+
     def _credentials_expires_in_seconds(self) -> int | None:
         # All cli-local agents share the HOST's .credentials.json
         # (symlink where permitted, periodic copy elsewhere). Parse

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -152,6 +152,18 @@ class LocalCLIAdapter(Adapter):
         session = self._ensure_session()
         return await session.run_turn(user_message, ctx.system_prompt)
 
+    async def run_retry_turn(
+        self,
+        kick_text: str,
+        fallback_user_message: str,
+        ctx: TurnContext,
+    ) -> TurnResult:
+        self._verify()
+        session = self._ensure_session()
+        return await session.run_retry_turn(
+            kick_text, fallback_user_message, ctx.system_prompt,
+        )
+
     async def warm(self, system_prompt: str) -> None:
         """Spawn the claude subprocess eagerly when this agent has a
         persisted session; fresh agents wait for their first message
@@ -174,10 +186,6 @@ class LocalCLIAdapter(Adapter):
         if self._session is not None:
             await self._session.aclose()
             self._session = None
-
-    async def invalidate_session(self) -> None:
-        if self._session is not None:
-            await self._session.invalidate()
 
     def _credentials_expires_in_seconds(self) -> int | None:
         # All cli-local agents share the HOST's .credentials.json

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -399,11 +399,28 @@ class LocalCLIAdapter(Adapter):
         # host by ClaudeSession._spawn; the kwarg here is just for
         # symmetry with the docker adapter.
         del env_overrides
-        # ``--permission-mode`` (not ``--dangerously-skip-permissions``)
-        # lets the user control which tool categories auto-approve;
-        # the rest flow through the MCP permission-prompt callback,
-        # which fails closed on timeout.
-        cmd = ["claude", "--permission-mode", self.permission_mode]
+        cmd = ["claude"]
+        # ``--dangerously-skip-permissions`` bypasses BOTH the per-tool
+        # approval prompt AND the per-project trust dialog. Claude
+        # code's stream-json mode has no UI surface to accept the
+        # trust dialog, so anything short of this flag leaves the
+        # cwd un-trusted, which silently drops MCP servers supplied
+        # via ``--mcp-config`` — exactly the "agent can't see the
+        # puffo MCP" symptom on cli-local. ``--permission-mode
+        # bypassPermissions`` (the previous flag here) only handles
+        # the per-tool prompt path, not the trust dialog, so the MCP
+        # was getting dropped before its tools could even register.
+        # When the bypass mode is anything other than
+        # ``bypassPermissions`` (e.g. the future ``default`` /
+        # ``acceptEdits`` modes that route through the PreToolUse
+        # hook), fall back to ``--permission-mode <mode>`` so the
+        # hook controls each tool category — those modes implicitly
+        # require an operator-supervised setup where the trust
+        # dialog has already been accepted in a real claude session.
+        if self.permission_mode == "bypassPermissions":
+            cmd.append("--dangerously-skip-permissions")
+        else:
+            cmd.extend(["--permission-mode", self.permission_mode])
         if self.model:
             cmd.extend(["--model", self.model])
         cmd.extend(extra_args)

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -96,7 +96,73 @@ class PuffoAgent:
             space_id=space_id,
             space_name=space_name,
         )
+        return await self._run_turn_and_route(
+            channel_name=channel_name,
+            sender=sender,
+            on_progress=on_progress,
+        )
 
+    async def handle_message_batch(
+        self,
+        root_id: str,
+        batch: list[dict],
+        channel_meta: dict,
+        on_progress=None,
+    ) -> str | None:
+        """One adapter turn over a whole thread batch.
+
+        Each entry in ``batch`` is the same decoded-message dict the
+        listen handler used to enqueue (envelope_id, sender_slug,
+        text, attachments, mentions, sent_at, sender_is_bot,
+        is_dm…). The thread/channel context is constant across the
+        batch and rides on ``channel_meta`` (channel_id,
+        channel_name, space_id, space_name).
+
+        The agent sees every message in order as separate ``user``
+        turns in the shell log so the LLM can reason about who said
+        what and decide on its own how many replies to issue. The
+        ``followups`` field on the old single-message path is gone —
+        every message is a real user turn now.
+        """
+        if not batch:
+            return None
+        for msg in batch:
+            self._append_user(
+                channel_meta.get("channel_name", ""),
+                msg.get("sender_slug", ""),
+                msg.get("sender_email", ""),
+                msg.get("text", ""),
+                channel_id=channel_meta.get("channel_id", ""),
+                root_id=root_id,
+                attachments=msg.get("attachments") or [],
+                sender_is_bot=msg.get("sender_is_bot", False),
+                mentions=msg.get("mentions") or [],
+                post_id=msg.get("envelope_id", ""),
+                create_at=msg.get("sent_at", 0),
+                followups=None,
+                space_id=channel_meta.get("space_id", ""),
+                space_name=channel_meta.get("space_name", ""),
+            )
+        # Route logging uses the LAST sender in the batch as the
+        # display "trigger" for log lines — purely cosmetic, the
+        # agent itself decides who to reply to.
+        last_msg = batch[-1]
+        return await self._run_turn_and_route(
+            channel_name=channel_meta.get("channel_name", ""),
+            sender=last_msg.get("sender_slug", ""),
+            on_progress=on_progress,
+        )
+
+    async def _run_turn_and_route(
+        self,
+        channel_name: str,
+        sender: str,
+        on_progress=None,
+    ) -> str | None:
+        """Shared tail for ``handle_message`` and ``handle_message_batch``.
+        Runs one adapter turn against the current ``self.log`` and
+        routes the reply per the rules below.
+        """
         ctx = TurnContext(
             system_prompt=self.system_prompt,
             messages=list(self.log),

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -62,6 +62,19 @@ class PuffoAgent:
         # Conversation log shared across all channels.
         self.log: list[dict] = []
 
+        # Envelopes already appended to ``self.log`` (and hence the
+        # adapter's claude-code session). On AgentAPIError the consumer
+        # re-enqueues the failed batch and ``handle_message_batch``
+        # runs again — without this set, the same envelope would be
+        # ``_append_user``ed a second time, doubling its appearance in
+        # the agent's transcript. The agent then sees what looks like
+        # a dup wire delivery (it isn't — it's a retry of a single
+        # delivery whose previous turn failed with rate-limiting). Set
+        # lives for the lifetime of this PuffoAgent (one per worker
+        # lifecycle) so cross-restart redeliveries that hit the
+        # cursor check upstream don't even reach here.
+        self._appended_envelope_ids: set[str] = set()
+
     # ── Message handling ──────────────────────────────────────────────────────
 
     async def handle_message(
@@ -126,7 +139,23 @@ class PuffoAgent:
         """
         if not batch:
             return None
+        appended_this_call = 0
         for msg in batch:
+            env_id = msg.get("envelope_id", "")
+            # Skip envelopes already in the session log. This is the
+            # AgentAPIError retry path: the previous attempt at this
+            # batch failed (rate-limited or otherwise), the consumer
+            # re-enqueued, and we're here again. The envelope is
+            # already in claude-code's transcript — appending it a
+            # second time would surface as a "duplicate user input"
+            # in the agent's own conversation view.
+            if env_id and env_id in self._appended_envelope_ids:
+                self.logger.info(
+                    "handle_message_batch: skipping re-append of "
+                    "already-seen envelope=%s (likely AgentAPIError retry)",
+                    env_id,
+                )
+                continue
             self._append_user(
                 channel_meta.get("channel_name", ""),
                 msg.get("sender_slug", ""),
@@ -137,12 +166,15 @@ class PuffoAgent:
                 attachments=msg.get("attachments") or [],
                 sender_is_bot=msg.get("sender_is_bot", False),
                 mentions=msg.get("mentions") or [],
-                post_id=msg.get("envelope_id", ""),
+                post_id=env_id,
                 create_at=msg.get("sent_at", 0),
                 followups=None,
                 space_id=channel_meta.get("space_id", ""),
                 space_name=channel_meta.get("space_name", ""),
             )
+            if env_id:
+                self._appended_envelope_ids.add(env_id)
+            appended_this_call += 1
         # Route logging uses the LAST sender in the batch as the
         # display "trigger" for log lines — purely cosmetic, the
         # agent itself decides who to reply to.
@@ -210,6 +242,24 @@ class PuffoAgent:
                 f"[api-error] [{channel_name}] @{sender}: adapter output "
                 "contained 'API Error'; suppressing post + flagging for retry"
             )
+            # Forget the adapter's resumable claude-code session
+            # before the retry. Without this, the consumer's
+            # AgentAPIError handler re-dispatches the batch, the
+            # cli adapter ``--resume``s the same session, and
+            # claude-code appends the same user input again — the
+            # agent then sees the message twice (or N times for N
+            # retries) inside its own conversation transcript even
+            # though the wire only delivered once. Forgetting the
+            # session means the retry starts fresh: lost prior
+            # conversation history is the tradeoff for not faking
+            # a duplicate delivery to the LLM.
+            try:
+                await self.adapter.invalidate_session()
+            except Exception:
+                self.logger.exception(
+                    "adapter.invalidate_session() failed; retry may "
+                    "still duplicate the user input in the transcript"
+                )
             raise AgentAPIError(
                 "agent adapter output contained 'API Error'"
             )

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -62,19 +62,6 @@ class PuffoAgent:
         # Conversation log shared across all channels.
         self.log: list[dict] = []
 
-        # Envelopes already appended to ``self.log`` (and hence the
-        # adapter's claude-code session). On AgentAPIError the consumer
-        # re-enqueues the failed batch and ``handle_message_batch``
-        # runs again — without this set, the same envelope would be
-        # ``_append_user``ed a second time, doubling its appearance in
-        # the agent's transcript. The agent then sees what looks like
-        # a dup wire delivery (it isn't — it's a retry of a single
-        # delivery whose previous turn failed with rate-limiting). Set
-        # lives for the lifetime of this PuffoAgent (one per worker
-        # lifecycle) so cross-restart redeliveries that hit the
-        # cursor check upstream don't even reach here.
-        self._appended_envelope_ids: set[str] = set()
-
     # ── Message handling ──────────────────────────────────────────────────────
 
     async def handle_message(
@@ -139,23 +126,7 @@ class PuffoAgent:
         """
         if not batch:
             return None
-        appended_this_call = 0
         for msg in batch:
-            env_id = msg.get("envelope_id", "")
-            # Skip envelopes already in the session log. This is the
-            # AgentAPIError retry path: the previous attempt at this
-            # batch failed (rate-limited or otherwise), the consumer
-            # re-enqueued, and we're here again. The envelope is
-            # already in claude-code's transcript — appending it a
-            # second time would surface as a "duplicate user input"
-            # in the agent's own conversation view.
-            if env_id and env_id in self._appended_envelope_ids:
-                self.logger.info(
-                    "handle_message_batch: skipping re-append of "
-                    "already-seen envelope=%s (likely AgentAPIError retry)",
-                    env_id,
-                )
-                continue
             self._append_user(
                 channel_meta.get("channel_name", ""),
                 msg.get("sender_slug", ""),
@@ -166,15 +137,12 @@ class PuffoAgent:
                 attachments=msg.get("attachments") or [],
                 sender_is_bot=msg.get("sender_is_bot", False),
                 mentions=msg.get("mentions") or [],
-                post_id=env_id,
+                post_id=msg.get("envelope_id", ""),
                 create_at=msg.get("sent_at", 0),
                 followups=None,
                 space_id=channel_meta.get("space_id", ""),
                 space_name=channel_meta.get("space_name", ""),
             )
-            if env_id:
-                self._appended_envelope_ids.add(env_id)
-            appended_this_call += 1
         # Route logging uses the LAST sender in the batch as the
         # display "trigger" for log lines — purely cosmetic, the
         # agent itself decides who to reply to.
@@ -184,6 +152,93 @@ class PuffoAgent:
             sender=last_msg.get("sender_slug", ""),
             on_progress=on_progress,
         )
+
+    async def handle_api_error_retry(
+        self,
+        root_id: str,
+        channel_meta: dict,
+        fallback_batch: list[dict],
+        on_progress=None,
+    ) -> str | None:
+        """Retry the most recently failed turn.
+
+        Doesn't touch ``self.log`` — the original user input is
+        already in there from the first attempt. The adapter sends
+        a small kick ("session errored on rate limiting, please
+        resume processing") when ``--resume`` is still live, or
+        falls back to the original ``fallback_batch`` payload when
+        the resumable session has been lost.
+
+        Reply routing is the same as ``_run_turn_and_route`` (the
+        ``AgentAPIError`` raise still happens here on consecutive
+        failures, so the consumer keeps incrementing its retry
+        counter).
+        """
+        kick_text = (
+            "[system] session errored on rate limiting, "
+            "please resume processing."
+        )
+        # Fallback is the same payload ``_append_user`` would have
+        # produced. For multi-message batches we only have the
+        # adapter API for a single user_message, so concatenate.
+        fallback_chunks: list[str] = []
+        for msg in fallback_batch:
+            fallback_chunks.append(self._format_user_block(
+                channel_name=channel_meta.get("channel_name", ""),
+                sender=msg.get("sender_slug", ""),
+                sender_email=msg.get("sender_email", ""),
+                text=msg.get("text", ""),
+                channel_id=channel_meta.get("channel_id", ""),
+                root_id=root_id,
+                attachments=msg.get("attachments") or [],
+                sender_is_bot=msg.get("sender_is_bot", False),
+                mentions=msg.get("mentions") or [],
+                post_id=msg.get("envelope_id", ""),
+                create_at=msg.get("sent_at", 0),
+                space_id=channel_meta.get("space_id", ""),
+                space_name=channel_meta.get("space_name", ""),
+            ))
+        fallback_text = "\n\n".join(fallback_chunks)
+
+        ctx = TurnContext(
+            system_prompt=self.system_prompt,
+            messages=list(self.log),
+            workspace_dir=self.workspace_dir,
+            claude_dir=self.claude_dir,
+            memory_dir=self.memory_dir,
+            on_progress=on_progress,
+        )
+        result = await self.adapter.run_retry_turn(
+            kick_text, fallback_text, ctx,
+        )
+
+        # Route reply the same way as a normal turn so the consumer
+        # picks up AgentAPIError again on consecutive rate-limit
+        # failures.
+        send_message_called = bool(result.metadata.get("send_message_targets"))
+        text_parts: list[str] = result.metadata.get("assistant_text_parts") or []
+        if send_message_called:
+            if result.reply:
+                self._append_assistant(
+                    channel_meta.get("channel_name", ""), result.reply,
+                )
+            return None
+        joined = "\n".join(text_parts) if text_parts else (result.reply or "")
+        if "[SILENT]" in joined:
+            return None
+        if "API Error" in joined:
+            self.logger.warning(
+                "[api-error-retry] adapter still rate-limited; "
+                "raising for consumer-side backoff"
+            )
+            raise AgentAPIError(
+                "agent adapter output contained 'API Error' on retry"
+            )
+        if not text_parts and not result.reply:
+            return None
+        fallback = _format_assistant_fallback(text_parts, result.reply)
+        self._append_assistant(channel_meta.get("channel_name", ""), fallback)
+        return fallback
 
     async def _run_turn_and_route(
         self,
@@ -240,26 +295,8 @@ class PuffoAgent:
         if "API Error" in joined:
             self.logger.warning(
                 f"[api-error] [{channel_name}] @{sender}: adapter output "
-                "contained 'API Error'; suppressing post + flagging for retry"
+                "contained 'API Error'; suppressing post, abandoning batch"
             )
-            # Forget the adapter's resumable claude-code session
-            # before the retry. Without this, the consumer's
-            # AgentAPIError handler re-dispatches the batch, the
-            # cli adapter ``--resume``s the same session, and
-            # claude-code appends the same user input again — the
-            # agent then sees the message twice (or N times for N
-            # retries) inside its own conversation transcript even
-            # though the wire only delivered once. Forgetting the
-            # session means the retry starts fresh: lost prior
-            # conversation history is the tradeoff for not faking
-            # a duplicate delivery to the LLM.
-            try:
-                await self.adapter.invalidate_session()
-            except Exception:
-                self.logger.exception(
-                    "adapter.invalidate_session() failed; retry may "
-                    "still duplicate the user input in the transcript"
-                )
             raise AgentAPIError(
                 "agent adapter output contained 'API Error'"
             )
@@ -295,6 +332,43 @@ class PuffoAgent:
         space_id: str = "",
         space_name: str = "",
     ):
+        content = self._format_user_block(
+            channel_name=channel_name,
+            sender=sender,
+            sender_email=sender_email,
+            text=text,
+            attachments=attachments,
+            channel_id=channel_id,
+            root_id=root_id,
+            sender_is_bot=sender_is_bot,
+            mentions=mentions,
+            post_id=post_id,
+            create_at=create_at,
+            followups=followups,
+            space_id=space_id,
+            space_name=space_name,
+        )
+        self.log.append({"role": "user", "content": content})
+        self._truncate_log()
+
+    def _format_user_block(
+        self,
+        *,
+        channel_name: str,
+        sender: str,
+        sender_email: str,
+        text: str,
+        attachments: list[str] | None,
+        channel_id: str = "",
+        root_id: str = "",
+        sender_is_bot: bool = False,
+        mentions: list[dict] | None = None,
+        post_id: str = "",
+        create_at: int = 0,
+        followups: list[dict] | None = None,
+        space_id: str = "",
+        space_name: str = "",
+    ) -> str:
         # Structured markdown block keeps context metadata distinct
         # from message content, preventing the LLM from echoing
         # "[#channel] @user:" style prefixes back into replies. Format
@@ -351,8 +425,7 @@ class PuffoAgent:
                 lines.append(
                     f"  - [{ts} post:{fid}] @{fsender}: {ftext}"
                 )
-        self.log.append({"role": "user", "content": "\n".join(lines)})
-        self._truncate_log()
+        return "\n".join(lines)
 
     def _append_assistant(self, channel_name: str, reply: str):
         self.log.append({"role": "assistant", "content": reply})

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -175,8 +175,8 @@ class PuffoAgent:
         counter).
         """
         kick_text = (
-            "[system] session errored on rate limiting, "
-            "please resume processing."
+            "[puffo-agent system message] session errored on rate "
+            "limiting, please resume processing."
         )
         # Fallback is the same payload ``_append_user`` would have
         # produced. For multi-message batches we only have the

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -68,6 +68,18 @@ class StoredMessage:
     reply_to_id: Optional[str] = None
 
 
+@dataclass
+class ChannelRoot:
+    """One root post in a channel plus how many replies it accrued.
+    Used by ``get_channel_roots`` to surface thread heads without
+    blasting every reply into the agent's context window — the agent
+    sees N=reply_count and calls ``get_thread_messages`` only on
+    threads it actually wants to read into.
+    """
+    message: StoredMessage
+    reply_count: int
+
+
 class MessageStore:
     def __init__(self, db_path: str | Path):
         self.db_path = Path(db_path)
@@ -257,6 +269,134 @@ class MessageStore:
         ) as cursor:
             rows = await cursor.fetchall()
         return [self._row_to_msg(r) for r in rows]
+
+    async def _resolve_since_sent_at(self, since_envelope_id: str | None) -> int | None:
+        """Look up the ``sent_at`` of a reference envelope. Used by
+        ``get_channel_roots`` / ``get_thread_messages`` to translate
+        a ``since=<envelope_id>`` filter into an exclusive sent_at
+        lower bound. Returns ``None`` when the envelope isn't in the
+        store (caller treats that as "no since filter")."""
+        if not since_envelope_id:
+            return None
+        db = await self._ensure_db()
+        async with db.execute(
+            "SELECT sent_at FROM messages WHERE envelope_id = ?",
+            (since_envelope_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return int(row[0]) if row else None
+
+    async def get_channel_roots(
+        self,
+        channel_id: str,
+        limit: int = 20,
+        since_envelope_id: str | None = None,
+        before_ts: int | None = None,
+        after_ts: int | None = None,
+    ) -> list[ChannelRoot]:
+        """Recent root posts in ``channel_id`` (``thread_root_id``
+        IS NULL) with the count of replies that point at each.
+
+        Replies in any thread are excluded from the result — the
+        agent gets one bullet per conversation head and can drill
+        into the threads it actually cares about via
+        ``get_thread_messages``. Filtering options:
+
+        - ``since_envelope_id`` — return roots whose ``sent_at`` is
+          strictly greater than that envelope's. Convenient when
+          the agent already knows the latest root it processed.
+        - ``after_ts`` (ms-epoch) — exclusive lower bound on
+          ``sent_at``. Combined with ``since`` we take the larger.
+        - ``before_ts`` (ms-epoch) — exclusive upper bound on
+          ``sent_at``.
+
+        Returned newest-first up to ``limit``.
+        """
+        db = await self._ensure_db()
+        lower_bounds: list[int] = []
+        since_resolved = await self._resolve_since_sent_at(since_envelope_id)
+        if since_resolved is not None:
+            lower_bounds.append(since_resolved)
+        if after_ts is not None:
+            lower_bounds.append(int(after_ts))
+        effective_after = max(lower_bounds) if lower_bounds else None
+
+        # ``reply_count`` is a correlated subquery on the same
+        # ``messages`` table; the WAL writer is the only producer, so
+        # the count is point-in-time consistent.
+        clauses = ["m.channel_id = ?", "m.thread_root_id IS NULL"]
+        params: list = [channel_id]
+        if effective_after is not None:
+            clauses.append("m.sent_at > ?")
+            params.append(effective_after)
+        if before_ts is not None:
+            clauses.append("m.sent_at < ?")
+            params.append(int(before_ts))
+        where = " AND ".join(clauses)
+        sql = (
+            "SELECT m.*, "
+            "(SELECT COUNT(*) FROM messages r "
+            " WHERE r.thread_root_id = m.envelope_id) AS reply_count "
+            f"FROM messages m WHERE {where} "
+            "ORDER BY m.sent_at DESC, m.envelope_id DESC LIMIT ?"
+        )
+        params.append(max(1, min(int(limit), 200)))
+
+        async with db.execute(sql, tuple(params)) as cursor:
+            rows = await cursor.fetchall()
+        # Reverse so callers see oldest-first inside the window.
+        return [
+            ChannelRoot(
+                message=self._row_to_msg(r),
+                reply_count=int(r["reply_count"]),
+            )
+            for r in reversed(rows)
+        ]
+
+    async def get_thread_messages(
+        self,
+        root_id: str,
+        limit: int = 50,
+        since_envelope_id: str | None = None,
+        before_ts: int | None = None,
+        after_ts: int | None = None,
+    ) -> list[StoredMessage]:
+        """Messages belonging to a thread (the root itself plus
+        every reply pointing at it), filtered the same way as
+        ``get_channel_roots``. Newest-first selection, then
+        reversed to oldest-first in the returned list — matches
+        ``get_channel_history``'s shape so the MCP tool can format
+        either the same way.
+        """
+        if not root_id:
+            return []
+        db = await self._ensure_db()
+        lower_bounds: list[int] = []
+        since_resolved = await self._resolve_since_sent_at(since_envelope_id)
+        if since_resolved is not None:
+            lower_bounds.append(since_resolved)
+        if after_ts is not None:
+            lower_bounds.append(int(after_ts))
+        effective_after = max(lower_bounds) if lower_bounds else None
+
+        clauses = ["(envelope_id = ? OR thread_root_id = ?)"]
+        params: list = [root_id, root_id]
+        if effective_after is not None:
+            clauses.append("sent_at > ?")
+            params.append(effective_after)
+        if before_ts is not None:
+            clauses.append("sent_at < ?")
+            params.append(int(before_ts))
+        where = " AND ".join(clauses)
+        sql = (
+            f"SELECT * FROM messages WHERE {where} "
+            "ORDER BY sent_at DESC, envelope_id DESC LIMIT ?"
+        )
+        params.append(max(1, min(int(limit), 200)))
+
+        async with db.execute(sql, tuple(params)) as cursor:
+            rows = await cursor.fetchall()
+        return [self._row_to_msg(r) for r in reversed(rows)]
 
     async def get_last_processed_sent_at(self, root_id: str) -> int:
         """``sent_at`` of the last message in the most recently

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -31,6 +31,20 @@ CREATE INDEX IF NOT EXISTS idx_messages_dm
     ON messages (sender_slug, sent_at) WHERE envelope_kind = 'dm';
 CREATE INDEX IF NOT EXISTS idx_messages_received
     ON messages (received_at);
+CREATE INDEX IF NOT EXISTS idx_messages_thread_root
+    ON messages (thread_root_id, sent_at) WHERE thread_root_id IS NOT NULL;
+
+-- Per-thread cursor used by the thread-batched priority queue. After
+-- ``on_message_batch`` finishes successfully, the consumer advances
+-- this to the ``sent_at`` of the last message in the dispatched
+-- batch. The listen handler then drops any inbound message whose
+-- ``sent_at`` is <= the stored cursor, so server-side pending-message
+-- redeliveries after a daemon restart don't re-trigger the agent on
+-- already-processed threads.
+CREATE TABLE IF NOT EXISTS thread_processing_state (
+    root_id TEXT PRIMARY KEY,
+    last_processed_sent_at INTEGER NOT NULL
+);
 """
 
 
@@ -220,6 +234,68 @@ class MessageStore:
         if row is None:
             return None
         return self._row_to_msg(row)
+
+    async def get_thread_batch(
+        self,
+        root_id: str,
+        since_sent_at: int,
+    ) -> list[StoredMessage]:
+        """Root message + every reply in its thread with
+        ``sent_at > since_sent_at``, ordered ascending. The root row
+        itself has ``thread_root_id IS NULL`` and matches via the
+        ``envelope_id = root_id`` arm of the OR.
+        """
+        if not root_id:
+            return []
+        db = await self._ensure_db()
+        async with db.execute(
+            """SELECT * FROM messages
+               WHERE (envelope_id = ? OR thread_root_id = ?)
+                 AND sent_at > ?
+               ORDER BY sent_at ASC, envelope_id ASC""",
+            (root_id, root_id, since_sent_at),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [self._row_to_msg(r) for r in rows]
+
+    async def get_last_processed_sent_at(self, root_id: str) -> int:
+        """``sent_at`` of the last message in the most recently
+        dispatched batch for this thread, or ``0`` if the agent has
+        never processed it. Used at enqueue time to drop redelivered
+        messages whose work has already been done.
+        """
+        if not root_id:
+            return 0
+        db = await self._ensure_db()
+        async with db.execute(
+            "SELECT last_processed_sent_at FROM thread_processing_state "
+            "WHERE root_id = ?",
+            (root_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    async def mark_thread_processed(
+        self, root_id: str, sent_at: int,
+    ) -> None:
+        """Upsert the per-thread cursor. ``MAX(existing, new)`` so
+        out-of-order writes (extremely unlikely but cheap to guard)
+        never regress the cursor.
+        """
+        if not root_id:
+            return
+        db = await self._ensure_db()
+        await db.execute(
+            """INSERT INTO thread_processing_state (root_id, last_processed_sent_at)
+               VALUES (?, ?)
+               ON CONFLICT(root_id) DO UPDATE SET
+                 last_processed_sent_at = MAX(
+                   thread_processing_state.last_processed_sent_at,
+                   excluded.last_processed_sent_at
+                 )""",
+            (root_id, sent_at),
+        )
+        await db.commit()
 
     async def cleanup(self, retention_days: int = 90) -> int:
         db = await self._ensure_db()

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -52,6 +52,14 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
+class DataNotFound(Exception):
+    """Raised by reads that need to distinguish "this channel /
+    thread has never been seen" from "seen, but the requested
+    window is empty after filters". The MCP tool layer surfaces a
+    different user-facing message for each.
+    """
+
+
 @dataclass
 class StoredMessage:
     envelope_id: str
@@ -153,6 +161,22 @@ class MessageStore:
             ),
         )
         await db.commit()
+
+    async def channel_exists(self, channel_id: str) -> bool:
+        """True iff the store has ever recorded a message in
+        ``channel_id``. Used by the data service to return 404 when
+        the caller asks for history on a channel the agent has never
+        seen — distinguishes "unknown channel" from "known channel,
+        empty window after filters" (200 + empty list).
+        """
+        if not channel_id:
+            return False
+        db = await self._ensure_db()
+        async with db.execute(
+            "SELECT 1 FROM messages WHERE channel_id = ? LIMIT 1",
+            (channel_id,),
+        ) as cursor:
+            return await cursor.fetchone() is not None
 
     async def has_message(self, envelope_id: str) -> bool:
         db = await self._ensure_db()
@@ -310,8 +334,13 @@ class MessageStore:
         - ``before_ts`` (ms-epoch) — exclusive upper bound on
           ``sent_at``.
 
-        Returned newest-first up to ``limit``.
+        Returned newest-first up to ``limit``. Raises
+        ``DataNotFound`` if the channel has never had any message
+        stored — so the MCP layer can distinguish "unknown channel"
+        from "known but empty window".
         """
+        if not await self.channel_exists(channel_id):
+            raise DataNotFound(f"channel not found: {channel_id}")
         db = await self._ensure_db()
         lower_bounds: list[int] = []
         since_resolved = await self._resolve_since_sent_at(since_envelope_id)
@@ -366,10 +395,14 @@ class MessageStore:
         ``get_channel_roots``. Newest-first selection, then
         reversed to oldest-first in the returned list — matches
         ``get_channel_history``'s shape so the MCP tool can format
-        either the same way.
+        either the same way. Raises ``DataNotFound`` when no
+        message with that envelope_id has been stored — same
+        rationale as ``get_channel_roots``.
         """
         if not root_id:
-            return []
+            raise DataNotFound("thread root not found: (empty)")
+        if not await self.has_message(root_id):
+            raise DataNotFound(f"thread root not found: {root_id}")
         db = await self._ensure_db()
         lower_bounds: list[int] = []
         since_resolved = await self._resolve_since_sent_at(since_envelope_id)

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -615,6 +615,19 @@ class PuffoCoreMessageClient:
             await self._queue.put((priority, entry.current_seq, root_id))
             return
 
+        # Dedup by envelope_id within the live batch. The same wire
+        # envelope can land here twice when the server's pending-
+        # message redelivery overlaps with live WS delivery (e.g.
+        # after a daemon restart or brief WS reconnect). sqlite-side
+        # INSERT OR IGNORE in MessageStore.store already covers the
+        # durable table, but the in-memory batch is independent and
+        # would otherwise feed the agent the same post N times.
+        incoming_id = msg_dict.get("envelope_id", "")
+        if incoming_id and any(
+            m.get("envelope_id") == incoming_id for m in entry.messages
+        ):
+            return
+
         entry.messages.append(msg_dict)
         if priority < entry.current_priority:
             self._queue_seq += 1

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -320,12 +320,21 @@ class PuffoCoreMessageClient:
     async def listen(
         self,
         on_message: Callable[..., Coroutine[Any, Any, Any]],
+        on_api_error_retry: Callable[..., Coroutine[Any, Any, Any]] | None = None,
     ) -> None:
         """``on_message`` is the thread-batch callback. Despite the
         legacy parameter name kept for caller compatibility, it's
         invoked as ``on_message(root_id, batch, channel_meta)`` —
         the consumer collapses every arrival on the same thread
         into a single dispatch (see ``_consume_queue``).
+
+        ``on_api_error_retry`` is the kick-retry callback invoked
+        after the consumer catches an ``AgentAPIError``. Same
+        signature, but the implementation is expected to nudge
+        claude-code via ``--resume`` rather than re-sending the
+        ``batch`` payload (so the agent's transcript doesn't pick up
+        a duplicate of the original user input on every retry). When
+        omitted, the consumer abandons the batch on first failure.
         """
         identity = self.keystore.load_identity(self.slug)
         kem_kp = KemKeyPair.from_secret_bytes(
@@ -557,7 +566,9 @@ class PuffoCoreMessageClient:
         # Reset on every (re)connect — the auto-accept path is
         # idempotent against server-side state.
         self._processed_invite_ids = set()
-        consumer_task = asyncio.ensure_future(self._consume_queue(on_message))
+        consumer_task = asyncio.ensure_future(
+            self._consume_queue(on_message, on_api_error_retry),
+        )
         invite_poll_task = asyncio.ensure_future(self._invite_poll_loop())
 
         self._ws = PuffoCoreWsClient(
@@ -672,9 +683,114 @@ class PuffoCoreMessageClient:
             entry.current_seq = self._queue_seq
             await self._queue.put((priority, entry.current_seq, root_id))
 
+    # Upper bound on consecutive AgentAPIError retries for a single
+    # batch before we give up. claude-code's rate limit usually lifts
+    # well inside 3 × (15-45s) of backoff; staying any longer is
+    # bad for everything else queued behind this thread.
+    MAX_API_ERROR_RETRIES = 3
+
+    async def _do_api_error_retries(
+        self,
+        *,
+        root_id: str,
+        entry: "_ThreadEntry",
+        batch: list[dict],
+        channel_meta: dict,
+        on_api_error_retry: Optional[Callable[..., Coroutine[Any, Any, Any]]],
+        last_envelope: str,
+    ) -> None:
+        """Loop the API-Error kick-retry path until the agent
+        succeeds, the retry cap is hit, or a non-retry exception
+        bubbles up. The original ``batch`` doesn't go back into
+        ``entry.messages`` — the kick path tells claude-code (via
+        --resume) to re-attempt its previous turn; if --resume is
+        gone, the adapter falls back to the payload internally.
+
+        Mid-dispatch arrivals: any new messages that landed on the
+        same thread during the failed dispatch were admitted via
+        ``_admit_thread_message``'s reopen branch and are now in
+        ``entry.messages`` with a fresh queue tuple. We don't touch
+        them; the consumer picks them up after this retry loop
+        exits.
+
+        Cursor is NOT advanced on the failed batch — if a later
+        message succeeds on this thread it'll mark a higher
+        ``sent_at`` past the failed one, effectively leaving the
+        failed envelope readable via ``get_channel_history`` for the
+        agent if it wants to backfill.
+        """
+        # Reset the in-flight set for this slot. The failed batch is
+        # no longer "currently dispatching"; future duplicates of
+        # those envelopes need to be caught by the cursor (advanced
+        # by the kick's successful dispatch) or by in-batch dedup.
+        entry.dispatching_ids = set()
+
+        if on_api_error_retry is None:
+            logger.warning(
+                "agent reply contained 'API Error' for thread %s "
+                "(last envelope %s); no retry callback wired, "
+                "abandoning batch",
+                root_id, last_envelope,
+            )
+            return
+
+        for attempt in range(1, self.MAX_API_ERROR_RETRIES + 1):
+            delay = random.uniform(15.0, 45.0)
+            logger.warning(
+                "agent reply contained 'API Error' for thread %s "
+                "(last envelope %s); kick-retry %d/%d in %.1fs",
+                root_id, last_envelope, attempt,
+                self.MAX_API_ERROR_RETRIES, delay,
+            )
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                raise
+            try:
+                await on_api_error_retry(root_id, batch, channel_meta)
+                # Success path: no exception. The agent processed
+                # the retry. Advance cursor past the failed batch
+                # so we don't re-trigger on redelivery.
+                if batch:
+                    tail_sent_at = batch[-1].get("sent_at", 0)
+                    try:
+                        await self.store.mark_thread_processed(
+                            root_id, tail_sent_at,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "mark_thread_processed(%s, %d) failed "
+                            "after kick-retry; agent may re-process "
+                            "after restart",
+                            root_id, tail_sent_at,
+                        )
+                logger.info(
+                    "agent thread %s recovered after kick-retry %d/%d",
+                    root_id, attempt, self.MAX_API_ERROR_RETRIES,
+                )
+                return
+            except AgentAPIError:
+                # Still rate-limited; loop with another backoff.
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "kick-retry %d/%d for thread %s raised; abandoning",
+                    attempt, self.MAX_API_ERROR_RETRIES, root_id,
+                )
+                return
+        logger.warning(
+            "agent thread %s exhausted %d kick-retries (last envelope %s); "
+            "abandoning the batch — agent will see these messages via "
+            "get_channel_history on the next dispatch",
+            root_id, self.MAX_API_ERROR_RETRIES, last_envelope,
+        )
+
     async def _consume_queue(
         self,
         on_message_batch: Callable[..., Coroutine[Any, Any, Any]],
+        on_api_error_retry: Callable[..., Coroutine[Any, Any, Any]] | None = None,
     ) -> None:
         """Drain the priority queue serially. One turn at a time so
         the underlying session keeps a coherent conversation history;
@@ -760,49 +876,30 @@ class PuffoCoreMessageClient:
             try:
                 await on_message_batch(root_id, batch, channel_meta)
             except AgentAPIError:
-                # Adapter surfaced "API Error". Reopen the slot
-                # with the SAME batch (cursor untouched) and push a
-                # fresh queue tuple with the original priority so
-                # the next pop tries again. Back off 15-45s
-                # randomised to avoid a thundering herd across a
-                # fleet hit by the same outage.
+                # Adapter surfaced "API Error" — most commonly
+                # claude-code's transient rate-limit error. The
+                # original user input is already in claude-code's
+                # ``--resume``-backed transcript from the failed
+                # dispatch; the retry just needs to nudge the agent
+                # to try again, NOT re-send the payload (which would
+                # accumulate visible duplicates in the agent's
+                # transcript on every retry).
                 #
-                # Mid-dispatch arrivals: a new message on this thread
-                # that landed while the failed dispatch was awaiting
-                # would have hit the reopen branch of
-                # ``_admit_thread_message`` (in_queue was False) and
-                # set ``entry.messages = [new]``. We must preserve
-                # those — dedupe-prepend ``batch`` instead of
-                # overwriting, so the retry includes both the failed
-                # messages AND any in-flight arrivals.
-                self._queue_seq += 1
-                existing_ids = {
-                    m.get("envelope_id")
-                    for m in entry.messages
-                    if m.get("envelope_id")
-                }
-                carry = [
-                    m for m in batch
-                    if m.get("envelope_id") not in existing_ids
-                ]
-                entry.messages = carry + entry.messages
-                entry.in_queue = True
-                entry.current_seq = self._queue_seq
-                await self._queue.put(
-                    (entry.current_priority, entry.current_seq, root_id),
-                )
-                delay = random.uniform(15.0, 45.0)
+                # The retry path uses a small kick message ("session
+                # errored on rate limiting, please resume processing")
+                # via ``on_api_error_retry``; if ``--resume`` is no
+                # longer valid the adapter falls back to the original
+                # payload on its own so the agent has something to
+                # work from.
                 last_envelope = batch[-1].get("envelope_id", "") if batch else ""
-                logger.warning(
-                    "agent reply contained 'API Error' for thread %s "
-                    "(last envelope %s); re-queued and pausing %.1fs "
-                    "before next message",
-                    root_id, last_envelope, delay,
+                await self._do_api_error_retries(
+                    root_id=root_id,
+                    entry=entry,
+                    batch=batch,
+                    channel_meta=channel_meta,
+                    on_api_error_retry=on_api_error_retry,
+                    last_envelope=last_envelope,
                 )
-                try:
-                    await asyncio.sleep(delay)
-                except asyncio.CancelledError:
-                    raise
                 continue
             except asyncio.CancelledError:
                 raise

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Optional
 
 from ..crypto.encoding import base64url_decode
@@ -34,6 +35,41 @@ PRIORITY_MENTIONED_BOT = 2
 PRIORITY_HUMAN = 3
 PRIORITY_BOT = 4
 PRIORITY_SYSTEM = 5
+
+
+@dataclass
+class _ThreadEntry:
+    """Per-thread queue state.
+
+    The PriorityQueue itself stores ``(priority, seq, root_id)``
+    tuples so the heap can order by priority and break ties on
+    monotonic seq (dicts aren't orderable). The real per-thread
+    state lives here, keyed by ``root_id``:
+
+    - ``messages`` holds every decoded message dict for this
+      thread that has been enqueued but not yet dispatched. The
+      consumer drains the whole list in a single ``on_message_batch``
+      call, so messages that arrived between the first enqueue and
+      the eventual pop all reach the agent as one turn.
+    - ``current_priority`` / ``current_seq`` are the priority and
+      seq currently active in the queue. When a new arrival on the
+      same root bumps priority, we DON'T remove the stale heap
+      entry (``asyncio.PriorityQueue`` doesn't support that); we
+      push a fresh tuple and let the consumer drop the old one when
+      it pops and notices ``seq`` no longer matches the entry's
+      ``current_seq``.
+    - ``in_queue`` flips False between successful dispatch and the
+      next arrival on this root, so a later message reopens the
+      entry cleanly instead of stacking into a stale batch.
+    - ``channel_meta`` is captured on the first enqueue and reused
+      on dispatch; the thread/channel/space context is invariant
+      for a given root.
+    """
+    current_priority: int
+    current_seq: int
+    messages: list[dict] = field(default_factory=list)
+    in_queue: bool = True
+    channel_meta: dict = field(default_factory=dict)
 
 
 async def _fetch_blob_with_retry(
@@ -273,6 +309,12 @@ class PuffoCoreMessageClient:
         self,
         on_message: Callable[..., Coroutine[Any, Any, Any]],
     ) -> None:
+        """``on_message`` is the thread-batch callback. Despite the
+        legacy parameter name kept for caller compatibility, it's
+        invoked as ``on_message(root_id, batch, channel_meta)`` —
+        the consumer collapses every arrival on the same thread
+        into a single dispatch (see ``_consume_queue``).
+        """
         identity = self.keystore.load_identity(self.slug)
         kem_kp = KemKeyPair.from_secret_bytes(
             decode_secret(identity.kem_secret_key)
@@ -433,14 +475,29 @@ class PuffoCoreMessageClient:
             else:
                 channel_name = channel_id
 
-            # Monotonic ``seq`` tiebreaker keeps PriorityQueue from
-            # comparing the args dict on ties (dicts aren't orderable
-            # so a same-priority pair would TypeError).
             direct = is_dm or is_mention
             sender_is_bot = False  # puffo-core has no is_bot flag yet
             priority = _compute_priority(direct, sender_is_bot)
-            self._queue_seq += 1
-            await self._queue.put((priority, self._queue_seq, {
+
+            # Thread-batched queue: every message coalesces under
+            # its ``root_id`` (the envelope's ``thread_root_id``, or
+            # the message itself when it's a top-level post). The
+            # PriorityQueue holds one slot per root; new arrivals on
+            # the same thread either join the existing batch
+            # (priority same or lower) or bump the slot to the new
+            # higher priority. The agent processes one whole thread
+            # at a time in ``on_message_batch``.
+            root_id = payload.thread_root_id or payload.envelope_id
+
+            # Cross-restart dedup: after a daemon restart the server
+            # redelivers anything in /messages/pending. If we already
+            # dispatched a batch that covers ``payload.sent_at``,
+            # skip — the agent has seen this.
+            last_processed = await self.store.get_last_processed_sent_at(root_id)
+            if payload.sent_at <= last_processed:
+                return
+
+            msg_dict = {
                 "channel_id": channel_id,
                 "channel_name": channel_name,
                 "space_id": space_id,
@@ -455,13 +512,30 @@ class PuffoCoreMessageClient:
                 "mentions": mentions,
                 "envelope_id": payload.envelope_id,
                 "sent_at": payload.sent_at,
-            }))
+            }
+            channel_meta = {
+                "channel_id": channel_id,
+                "channel_name": channel_name,
+                "space_id": space_id,
+                "space_name": space_name,
+                "is_dm": is_dm,
+            }
+
+            await self._admit_thread_message(
+                root_id=root_id,
+                priority=priority,
+                msg_dict=msg_dict,
+                channel_meta=channel_meta,
+            )
 
         # Per-listen() queue. A reconnect drops any envelopes not yet
         # drained; the server redelivers via /messages/pending on the
-        # next subscribe.
+        # next subscribe, and the sqlite ``thread_processing_state``
+        # cursor keeps the agent from re-running on threads it already
+        # handled before the restart.
         self._queue = asyncio.PriorityQueue()
         self._queue_seq = 0
+        self._thread_state: dict[str, _ThreadEntry] = {}
         # Reset on every (re)connect — the auto-accept path is
         # idempotent against server-side state.
         self._processed_invite_ids = set()
@@ -488,55 +562,160 @@ class PuffoCoreMessageClient:
                 except (asyncio.CancelledError, Exception):
                     pass
 
+    async def _admit_thread_message(
+        self,
+        *,
+        root_id: str,
+        priority: int,
+        msg_dict: dict,
+        channel_meta: dict,
+    ) -> None:
+        """Add (or coalesce) a message into the thread-batched queue.
+
+        Cases (all keyed on ``root_id``):
+
+        - **New root** (no entry yet): build a fresh ``_ThreadEntry``
+          with this message as the only element and push a heap tuple.
+        - **Reopen** (entry exists but ``in_queue`` is False — a
+          previous batch was already dispatched): reset the entry with
+          this message as the new cursor and push a fresh heap tuple.
+        - **In-queue, same-or-lower priority** (priority numeric value
+          unchanged or larger): append to the existing batch. The
+          cursor (``messages[0]``) stays pinned; the heap tuple
+          doesn't move.
+        - **In-queue, higher priority** (smaller numeric value): append
+          to the batch AND push a new heap tuple with the upgraded
+          priority and a fresh seq. The old tuple is left in the heap
+          and gets skipped on pop via the ``current_seq`` mismatch
+          check in ``_consume_queue``.
+
+        Caller must have already filtered out messages whose
+        ``sent_at`` is at or below
+        ``store.get_last_processed_sent_at(root_id)``; this method
+        doesn't re-check the durable cursor.
+        """
+        entry = self._thread_state.get(root_id)
+        if entry is None or not entry.in_queue:
+            self._queue_seq += 1
+            if entry is None:
+                entry = _ThreadEntry(
+                    current_priority=priority,
+                    current_seq=self._queue_seq,
+                    messages=[msg_dict],
+                    in_queue=True,
+                    channel_meta=channel_meta,
+                )
+                self._thread_state[root_id] = entry
+            else:
+                entry.current_priority = priority
+                entry.current_seq = self._queue_seq
+                entry.messages = [msg_dict]
+                entry.in_queue = True
+                entry.channel_meta = channel_meta
+            await self._queue.put((priority, entry.current_seq, root_id))
+            return
+
+        entry.messages.append(msg_dict)
+        if priority < entry.current_priority:
+            self._queue_seq += 1
+            entry.current_priority = priority
+            entry.current_seq = self._queue_seq
+            await self._queue.put((priority, entry.current_seq, root_id))
+
     async def _consume_queue(
         self,
-        on_message: Callable[..., Coroutine[Any, Any, Any]],
+        on_message_batch: Callable[..., Coroutine[Any, Any, Any]],
     ) -> None:
         """Drain the priority queue serially. One turn at a time so
         the underlying session keeps a coherent conversation history;
         concurrent turns would interleave context.
+
+        Each pop yields a ``root_id``. We look up the per-thread
+        entry, drop the message batch out (claim it), and dispatch
+        the whole list as one agent invocation. While the agent is
+        running, new arrivals on the same thread create a fresh
+        entry that will be picked up on the next pop — the agent
+        won't re-see messages it already processed.
         """
         while True:
             try:
-                item = await self._queue.get()
+                _priority, popped_seq, root_id = await self._queue.get()
             except asyncio.CancelledError:
                 return
-            _priority, _seq, args = item
+
+            entry = self._thread_state.get(root_id)
+            if entry is None or not entry.in_queue or entry.current_seq != popped_seq:
+                # Stale heap entry: a higher-priority arrival
+                # already pushed a fresh tuple for this root, or
+                # the slot has been closed since we popped. Drop
+                # and continue.
+                continue
+
+            # Claim the batch atomically — mark the slot closed
+            # before dispatch so concurrent arrivals open a fresh
+            # entry instead of stacking into a batch the agent is
+            # already chewing through.
+            batch = entry.messages
+            channel_meta = entry.channel_meta
+            entry.messages = []
+            entry.in_queue = False
+
             try:
-                await on_message(
-                    args["channel_id"], args["channel_name"],
-                    args["sender_slug"], args["sender_email"],
-                    args["text"], args["root_id"], args["is_dm"],
-                    args["attachments"], args["sender_is_bot"],
-                    args["mentions"],
-                    args["envelope_id"], args["sent_at"], [],
-                    space_id=args.get("space_id", ""),
-                    space_name=args.get("space_name", ""),
-                )
+                await on_message_batch(root_id, batch, channel_meta)
             except AgentAPIError:
-                # Adapter surfaced "API Error". Re-enqueue the same
-                # tuple so the message keeps its priority band slot
-                # (later arrivals have strictly larger ``seq``), then
-                # back off 15-45s randomised to avoid a thundering
-                # herd across a fleet hit by the same outage.
-                await self._queue.put(item)
+                # Adapter surfaced "API Error". Reopen the slot
+                # with the SAME batch (cursor untouched) and push a
+                # fresh queue tuple with the original priority so
+                # the next pop tries again. Back off 15-45s
+                # randomised to avoid a thundering herd across a
+                # fleet hit by the same outage.
+                self._queue_seq += 1
+                entry.messages = batch
+                entry.in_queue = True
+                entry.current_seq = self._queue_seq
+                await self._queue.put(
+                    (entry.current_priority, entry.current_seq, root_id),
+                )
                 delay = random.uniform(15.0, 45.0)
+                last_envelope = batch[-1].get("envelope_id", "") if batch else ""
                 logger.warning(
-                    "agent reply contained 'API Error' for envelope %s; "
-                    "re-queued and pausing %.1fs before next message",
-                    args.get("envelope_id"), delay,
+                    "agent reply contained 'API Error' for thread %s "
+                    "(last envelope %s); re-queued and pausing %.1fs "
+                    "before next message",
+                    root_id, last_envelope, delay,
                 )
                 try:
                     await asyncio.sleep(delay)
                 except asyncio.CancelledError:
                     raise
+                continue
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.exception(
-                    "on_message handler failed for envelope %s",
-                    args.get("envelope_id"),
+                    "on_message_batch handler failed for thread %s (%d messages)",
+                    root_id, len(batch),
                 )
+                # Treat poison-message style failures as terminal for
+                # the batch — don't loop forever. The sqlite cursor
+                # stays untouched so a restart can retry, but we mark
+                # the slot done in-memory so live arrivals keep
+                # flowing for other threads.
+                continue
+
+            # Success: persist the cursor so a restart-then-redeliver
+            # doesn't re-trigger this thread. ``batch[-1].sent_at`` is
+            # the high-water mark we just covered.
+            if batch:
+                tail_sent_at = batch[-1].get("sent_at", 0)
+                try:
+                    await self.store.mark_thread_processed(root_id, tail_sent_at)
+                except Exception:
+                    logger.exception(
+                        "mark_thread_processed(%s, %d) failed; agent "
+                        "may re-process this thread after a restart",
+                        root_id, tail_sent_at,
+                    )
 
     async def _invite_poll_loop(self) -> None:
         """Poll ``/invites`` to catch invites the WS can't reach (the

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -64,12 +64,24 @@ class _ThreadEntry:
     - ``channel_meta`` is captured on the first enqueue and reused
       on dispatch; the thread/channel/space context is invariant
       for a given root.
+    - ``dispatching_ids`` is the set of envelope_ids currently being
+      sent to the agent (the batch the consumer just claimed but
+      hasn't finished). A duplicate WS delivery that lands during
+      that window can't be caught by the handle_envelope cursor
+      (cursor advances only after dispatch succeeds) or by the
+      in-memory dedup (the consumer just emptied ``messages`` to
+      claim the batch), so the reopen branch of
+      ``_admit_thread_message`` would otherwise put the duplicate
+      into a fresh batch — causing the agent to see the same post
+      across two turns. This set is checked at admit time and
+      cleared on successful cursor advance.
     """
     current_priority: int
     current_seq: int
     messages: list[dict] = field(default_factory=list)
     in_queue: bool = True
     channel_meta: dict = field(default_factory=dict)
+    dispatching_ids: set[str] = field(default_factory=set)
 
 
 async def _fetch_blob_with_retry(
@@ -595,6 +607,17 @@ class PuffoCoreMessageClient:
         doesn't re-check the durable cursor.
         """
         entry = self._thread_state.get(root_id)
+        incoming_id = msg_dict.get("envelope_id", "")
+
+        # Cross-batch dedup: skip a duplicate of an envelope the
+        # consumer just claimed and is sending to the agent right
+        # now. Without this, the reopen branch below would create a
+        # fresh ``entry.messages = [dup]`` slot and the duplicate
+        # gets dispatched as the next batch — agent sees the same
+        # envelope across two turns. See ``_ThreadEntry`` docstring.
+        if entry is not None and incoming_id and incoming_id in entry.dispatching_ids:
+            return
+
         if entry is None or not entry.in_queue:
             self._queue_seq += 1
             if entry is None:
@@ -622,7 +645,6 @@ class PuffoCoreMessageClient:
         # INSERT OR IGNORE in MessageStore.store already covers the
         # durable table, but the in-memory batch is independent and
         # would otherwise feed the agent the same post N times.
-        incoming_id = msg_dict.get("envelope_id", "")
         if incoming_id and any(
             m.get("envelope_id") == incoming_id for m in entry.messages
         ):
@@ -667,11 +689,18 @@ class PuffoCoreMessageClient:
             # Claim the batch atomically — mark the slot closed
             # before dispatch so concurrent arrivals open a fresh
             # entry instead of stacking into a batch the agent is
-            # already chewing through.
+            # already chewing through. Record the batch's
+            # envelope_ids in ``dispatching_ids`` so that a duplicate
+            # arriving mid-dispatch can be rejected at admit time
+            # (the durable cursor hasn't advanced yet, so it can't
+            # catch it).
             batch = entry.messages
             channel_meta = entry.channel_meta
             entry.messages = []
             entry.in_queue = False
+            entry.dispatching_ids = {
+                m.get("envelope_id") for m in batch if m.get("envelope_id")
+            }
 
             # Pre-dispatch jitter. When several agents on the same
             # host get activated by the same message (e.g. a channel
@@ -760,6 +789,11 @@ class PuffoCoreMessageClient:
                         "may re-process this thread after a restart",
                         root_id, tail_sent_at,
                     )
+            # Cursor now covers the dispatched batch — duplicates of
+            # any of its envelopes will be caught by the handle_envelope
+            # cursor check from this point on, so the in-memory
+            # dispatching_ids set has done its job and can be released.
+            entry.dispatching_ids = set()
 
     async def _invite_poll_loop(self) -> None:
         """Poll ``/invites`` to catch invites the WS can't reach (the

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -695,8 +695,26 @@ class PuffoCoreMessageClient:
                 # the next pop tries again. Back off 15-45s
                 # randomised to avoid a thundering herd across a
                 # fleet hit by the same outage.
+                #
+                # Mid-dispatch arrivals: a new message on this thread
+                # that landed while the failed dispatch was awaiting
+                # would have hit the reopen branch of
+                # ``_admit_thread_message`` (in_queue was False) and
+                # set ``entry.messages = [new]``. We must preserve
+                # those — dedupe-prepend ``batch`` instead of
+                # overwriting, so the retry includes both the failed
+                # messages AND any in-flight arrivals.
                 self._queue_seq += 1
-                entry.messages = batch
+                existing_ids = {
+                    m.get("envelope_id")
+                    for m in entry.messages
+                    if m.get("envelope_id")
+                }
+                carry = [
+                    m for m in batch
+                    if m.get("envelope_id") not in existing_ids
+                ]
+                entry.messages = carry + entry.messages
                 entry.in_queue = True
                 entry.current_seq = self._queue_seq
                 await self._queue.put(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -673,6 +673,19 @@ class PuffoCoreMessageClient:
             entry.messages = []
             entry.in_queue = False
 
+            # Pre-dispatch jitter. When several agents on the same
+            # host get activated by the same message (e.g. a channel
+            # broadcast), unblocked dispatch sends them all into the
+            # claude-code API at once and trips its rate limit. A
+            # 0.0–1.5s random sleep here desynchronises them; each
+            # agent picks independently. Messages that arrive during
+            # the sleep land in the next batch because in_queue is
+            # already False.
+            try:
+                await asyncio.sleep(random.uniform(0.0, 1.5))
+            except asyncio.CancelledError:
+                raise
+
             try:
                 await on_message_batch(root_id, batch, channel_meta)
             except AgentAPIError:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -702,6 +702,33 @@ class PuffoCoreMessageClient:
                 m.get("envelope_id") for m in batch if m.get("envelope_id")
             }
 
+            # Safety net: paranoid in-batch dedup right before
+            # dispatch. ``_admit_thread_message``'s in-queue dedup
+            # plus ``dispatching_ids`` should already guarantee
+            # ``batch`` is duplicate-free, but if some upstream race
+            # we haven't characterised slips a duplicate envelope_id
+            # past both, we must NOT hand the same envelope to the
+            # agent twice in one turn. The warning log lets us spot
+            # the offending path if it ever fires.
+            seen_ids: set[str] = set()
+            deduped: list[dict] = []
+            dropped: list[str] = []
+            for m in batch:
+                mid = m.get("envelope_id", "")
+                if mid and mid in seen_ids:
+                    dropped.append(mid)
+                    continue
+                if mid:
+                    seen_ids.add(mid)
+                deduped.append(m)
+            if dropped:
+                logger.warning(
+                    "consumer dropped %d in-batch duplicate envelope_id(s) "
+                    "for thread %s before dispatch: %s",
+                    len(dropped), root_id, dropped,
+                )
+                batch = deduped
+
             # Pre-dispatch jitter. When several agents on the same
             # host get activated by the same message (e.g. a channel
             # broadcast), unblocked dispatch sends them all into the

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -507,6 +507,12 @@ class PuffoCoreMessageClient:
             # skip — the agent has seen this.
             last_processed = await self.store.get_last_processed_sent_at(root_id)
             if payload.sent_at <= last_processed:
+                logger.info(
+                    "handle_envelope: cursor-rejected duplicate envelope=%s "
+                    "(sent_at=%d <= last_processed=%d, root=%s)",
+                    payload.envelope_id, payload.sent_at,
+                    last_processed, root_id,
+                )
                 return
 
             msg_dict = {
@@ -616,6 +622,10 @@ class PuffoCoreMessageClient:
         # gets dispatched as the next batch — agent sees the same
         # envelope across two turns. See ``_ThreadEntry`` docstring.
         if entry is not None and incoming_id and incoming_id in entry.dispatching_ids:
+            logger.info(
+                "_admit_thread_message: dispatching_ids-rejected duplicate "
+                "envelope=%s root=%s", incoming_id, root_id,
+            )
             return
 
         if entry is None or not entry.in_queue:
@@ -648,6 +658,11 @@ class PuffoCoreMessageClient:
         if incoming_id and any(
             m.get("envelope_id") == incoming_id for m in entry.messages
         ):
+            logger.info(
+                "_admit_thread_message: in-batch-rejected duplicate "
+                "envelope=%s root=%s (pending batch=%d)",
+                incoming_id, root_id, len(entry.messages),
+            )
             return
 
         entry.messages.append(msg_dict)

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -51,6 +51,31 @@ Reply only to the `message:` field's content. Never echo the metadata
 block, field labels (`message:`), or bracketed prefixes in your
 response. Address users with `@<slug>` inline when needed.
 
+## `[puffo-agent system message]` lines
+
+Occasionally a user-role turn arrives whose body starts with the
+literal prefix:
+
+```
+[puffo-agent system message] <text>
+```
+
+These are **not** messages from a real Puffo.ai user — they're the
+runtime talking to you. They never carry a `post_id` /
+`thread_root_id` / `sender` block (or, if those fields are present,
+ignore them — they're just a side-effect of the same envelope
+shape). Treat each `[puffo-agent system message]` as an
+informational/control note from your operator's daemon and act on
+its instruction. Do not reply *to* the system message itself with
+`send_message`; respond to whatever real user content the
+instruction points at.
+
+Common examples:
+- `[puffo-agent system message] session errored on rate limiting,
+  please resume processing.` — the previous turn was interrupted by
+  a provider rate limit. Your previous user input is still in this
+  transcript; re-attempt your response now.
+
 ## How to reply (read this carefully)
 
 There are exactly two ways to deliver a reply, and you must pick

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -199,8 +199,17 @@ for one doc per tool.
 - `mcp__puffo__list_channels()` — channels in your configured space,
   derived from the space's event stream.
 - `mcp__puffo__list_channel_members(channel)` — slugs + roles.
-- `mcp__puffo__get_channel_history(channel, limit=20)` — recent
-  posts from the daemon's local message store.
+- `mcp__puffo__get_channel_history(channel, limit=20, since="", before=0, after=0)`
+  — recent **root posts** in the channel, with the reply count
+  per thread. Replies are NOT inlined; if a thread looks
+  interesting, follow up with `get_thread_history`. Optional
+  filters: ``since=<envelope_id>`` (results after that message),
+  ``after=<ms-epoch>`` / ``before=<ms-epoch>`` (timestamp bounds).
+- `mcp__puffo__get_thread_history(root_id, limit=50, since="", before=0, after=0)`
+  — root post + every reply in a thread, oldest-first. Same
+  ``since`` / ``after`` / ``before`` filter shape as
+  ``get_channel_history``. Use after ``get_channel_history`` shows
+  a thread with a non-zero reply count you want to read into.
 - `mcp__puffo__get_post(post_ref)` — one envelope by id, from the
   local message store.
 - `mcp__puffo__get_user_info(username)` — slug, display name, bio,

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -93,6 +93,47 @@ class StatusReporter:
         except Exception as exc:  # noqa: BLE001
             logger.warning("end_turn message=%s errored (%s)", message_id, exc)
 
+    async def end_turn_batch(self, runs: list[dict]) -> None:
+        """Mark every message in a thread batch as processed in one
+        round trip.
+
+        ``runs`` is the list of ``{run_id, message_id, succeeded,
+        error_text?}`` dicts the server's ``/messages/processing/
+        end:batch`` endpoint accepts. The first message in the batch
+        has a ``run_id`` from a prior ``begin_turn`` call (so it gets
+        a yellow dot); the rest are UPSERTed by the server with
+        ``started_at = ended_at = now`` and skip straight to green.
+        """
+        if not runs:
+            return
+        payload_runs: list[dict[str, Any]] = []
+        for r in runs:
+            entry: dict[str, Any] = {
+                "run_id": r["run_id"],
+                "message_id": r["message_id"],
+                "succeeded": bool(r["succeeded"]),
+            }
+            err = r.get("error_text")
+            if err is not None:
+                entry["error_text"] = err[:1024]
+            payload_runs.append(entry)
+        try:
+            await self._http.post(
+                "/messages/processing/end:batch", {"runs": payload_runs},
+            )
+            # Server flips agent_status atomically — mirror locally.
+            any_failed = any(not r["succeeded"] for r in runs)
+            self._current_status = "error" if any_failed else "idle"
+            self._current_message_id = None
+        except HttpError as exc:
+            logger.warning(
+                "end_turn_batch (%d runs) failed (%s)", len(runs), exc,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "end_turn_batch (%d runs) errored (%s)", len(runs), exc,
+            )
+
     async def report_error(self, error_text: str) -> None:
         """Catch-all for unrecoverable failures; cleared by the
         next successful heartbeat.

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -26,6 +26,7 @@ PUFFO_CORE_TOOL_NAMES = (
     "list_channels",
     "list_channel_members",
     "get_channel_history",
+    "get_thread_history",
     "fetch_channel_files",
     "get_post",
     "get_user_info",

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -34,6 +34,13 @@ class StoredMessageDict:
     reply_to_id: Optional[str]
 
 
+# Re-exported from ``message_store`` so both the network-backed
+# DataClient and the in-process MessageStore (used as a duck-type
+# drop-in in tests) raise the same type — the MCP tool layer can
+# ``except DataNotFound`` regardless of which one it has.
+from ..agent.message_store import DataNotFound  # noqa: E402  (intentional placement)
+
+
 @dataclass
 class ChannelRootDict:
     """Per-thread head + reply count returned by
@@ -170,7 +177,7 @@ class DataClient:
                 f"{self.base_url}{path}", params=params,
             ) as resp:
                 if resp.status == 404:
-                    return []
+                    raise DataNotFound(f"channel not found: {channel_id}")
                 if resp.status >= 400:
                     body = await resp.text()
                     logger.warning(
@@ -218,7 +225,7 @@ class DataClient:
                 f"{self.base_url}{path}", params=params,
             ) as resp:
                 if resp.status == 404:
-                    return []
+                    raise DataNotFound(f"thread root not found: {root_id}")
                 if resp.status >= 400:
                     body = await resp.text()
                     logger.warning(

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -34,6 +34,17 @@ class StoredMessageDict:
     reply_to_id: Optional[str]
 
 
+@dataclass
+class ChannelRootDict:
+    """Per-thread head + reply count returned by
+    ``get_channel_roots``. ``message`` is the root post itself
+    (``thread_root_id`` is None); ``reply_count`` is how many
+    replies currently point at its ``envelope_id``.
+    """
+    message: "StoredMessageDict"
+    reply_count: int
+
+
 def _msg_from_dict(d: dict[str, Any]) -> StoredMessageDict:
     return StoredMessageDict(
         envelope_id=d.get("envelope_id", ""),
@@ -124,6 +135,102 @@ class DataClient:
                 return [_msg_from_dict(m) for m in msgs]
         except aiohttp.ClientError as exc:
             logger.warning("data-service: get_channel_history transport: %s", exc)
+            return []
+
+    async def get_channel_roots(
+        self,
+        channel_id: str,
+        limit: int = 20,
+        since_envelope_id: str | None = None,
+        before_ts: int | None = None,
+        after_ts: int | None = None,
+    ) -> list[ChannelRootDict]:
+        """Root posts in ``channel_id`` with reply counts. Filters:
+        ``since_envelope_id`` (results have ``sent_at >`` that
+        envelope's ``sent_at``), ``before_ts`` / ``after_ts``
+        (ms-epoch bounds).
+        """
+        path = (
+            f"/v1/data/{urllib.parse.quote(self.agent_id, safe='')}"
+            f"/channels/roots"
+        )
+        params: dict[str, str] = {
+            "channel": channel_id,
+            "limit": str(limit),
+        }
+        if since_envelope_id:
+            params["since"] = since_envelope_id
+        if before_ts is not None:
+            params["before"] = str(before_ts)
+        if after_ts is not None:
+            params["after"] = str(after_ts)
+        session = await self._get_session()
+        try:
+            async with session.get(
+                f"{self.base_url}{path}", params=params,
+            ) as resp:
+                if resp.status == 404:
+                    return []
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.warning(
+                        "data-service: get_channel_roots %s -> %d %s",
+                        path, resp.status, body,
+                    )
+                    return []
+                data = await resp.json()
+                roots = data.get("roots") or []
+                return [
+                    ChannelRootDict(
+                        message=_msg_from_dict(r.get("message") or {}),
+                        reply_count=int(r.get("reply_count") or 0),
+                    )
+                    for r in roots
+                ]
+        except aiohttp.ClientError as exc:
+            logger.warning("data-service: get_channel_roots transport: %s", exc)
+            return []
+
+    async def get_thread_messages(
+        self,
+        root_id: str,
+        limit: int = 50,
+        since_envelope_id: str | None = None,
+        before_ts: int | None = None,
+        after_ts: int | None = None,
+    ) -> list[StoredMessageDict]:
+        """Root + every reply in the thread anchored at ``root_id``.
+        Same filters as ``get_channel_roots``."""
+        path = (
+            f"/v1/data/{urllib.parse.quote(self.agent_id, safe='')}"
+            f"/threads/{urllib.parse.quote(root_id, safe='')}"
+        )
+        params: dict[str, str] = {"limit": str(limit)}
+        if since_envelope_id:
+            params["since"] = since_envelope_id
+        if before_ts is not None:
+            params["before"] = str(before_ts)
+        if after_ts is not None:
+            params["after"] = str(after_ts)
+        session = await self._get_session()
+        try:
+            async with session.get(
+                f"{self.base_url}{path}", params=params,
+            ) as resp:
+                if resp.status == 404:
+                    return []
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.warning(
+                        "data-service: get_thread_messages %s -> %d %s",
+                        path, resp.status, body,
+                    )
+                    return []
+                data = await resp.json()
+                msgs = data.get("messages") or []
+                return [_msg_from_dict(m) for m in msgs]
+        except aiohttp.ClientError as exc:
+            logger.warning("data-service: get_thread_messages transport: %s", exc)
             return []
 
     async def get_message_by_envelope(

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -204,13 +204,32 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return f"posted {envelope.get('envelope_id', '?')} to {channel}"
 
     @mcp.tool()
-    async def get_channel_history(channel: str, limit: int = 20) -> str:
-        """Fetch the last N messages in a channel from local storage.
+    async def get_channel_history(
+        channel: str,
+        limit: int = 20,
+        since: str = "",
+        before: int = 0,
+        after: int = 0,
+    ) -> str:
+        """List recent **root posts** in a channel from local storage,
+        with the reply count for each thread.
 
-        Each line shows timestamp, sender, and text. Read from the
-        local store — no server round-trip. Pass a raw channel id
-        (``ch_<uuid>``).
-        """
+        Replies are NOT inlined — call ``get_thread_history`` if you
+        want to drill into a specific thread. This keeps a single
+        ``get_channel_history`` call from dragging hundreds of replies
+        into your context just because one thread is active.
+
+        Filters (optional, can be combined):
+        - ``since`` — an envelope_id (``msg_<uuid>``). Results have
+          ``sent_at >`` that envelope's ``sent_at``. Use this when
+          you remember the latest root you already saw.
+        - ``after`` — ms-epoch timestamp; exclusive lower bound.
+        - ``before`` — ms-epoch timestamp; exclusive upper bound.
+
+        Output lines: ``<ts>  @<sender>: <text>  (N replies)`` where
+        ``N`` is the current reply count (omitted for 0). Oldest-
+        first inside the returned window. Channel id is a raw
+        ``ch_<uuid>`` (no ``#name`` shortcut)."""
         limit = max(1, min(int(limit), 200))
         channel_ref = channel.strip()
         if channel_ref.startswith("#"):
@@ -220,16 +239,72 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             )
         channel_id = channel_ref
 
-        msgs = await cfg.data_client.get_channel_history(channel_id, limit)
+        roots = await cfg.data_client.get_channel_roots(
+            channel_id,
+            limit=limit,
+            since_envelope_id=since or None,
+            before_ts=int(before) if before else None,
+            after_ts=int(after) if after else None,
+        )
+        if not roots:
+            return "(no root posts in the requested window)"
+        lines = []
+        for entry in roots:
+            m = entry.message
+            ts = _ts_to_iso(m.sent_at)
+            text = str(m.content).replace("\n", " ") if m.content else ""
+            suffix = (
+                f"  ({entry.reply_count} repl{'y' if entry.reply_count == 1 else 'ies'})"
+                if entry.reply_count > 0 else ""
+            )
+            lines.append(
+                f"{ts}  post:{m.envelope_id}  @{m.sender_slug}: {text}{suffix}"
+            )
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def get_thread_history(
+        root_id: str,
+        limit: int = 50,
+        since: str = "",
+        before: int = 0,
+        after: int = 0,
+    ) -> str:
+        """List messages in one thread (the root post + every reply
+        that points at it) from local storage.
+
+        Used after ``get_channel_history`` shows a thread you want
+        to read into. Same filter semantics as
+        ``get_channel_history``: ``since`` is an envelope_id whose
+        ``sent_at`` becomes the exclusive lower bound; ``after`` /
+        ``before`` are ms-epoch bounds. All filters optional.
+
+        ``root_id`` is the thread root envelope_id (``msg_<uuid>``).
+        For a top-level post that has no replies, this returns just
+        that post.
+
+        Output lines: ``<ts>  post:<envelope_id>  @<sender>: <text>``,
+        oldest-first."""
+        if not root_id.strip():
+            raise RuntimeError("root_id required")
+        limit = max(1, min(int(limit), 200))
+        msgs = await cfg.data_client.get_thread_messages(
+            root_id.strip(),
+            limit=limit,
+            since_envelope_id=since or None,
+            before_ts=int(before) if before else None,
+            after_ts=int(after) if after else None,
+        )
         if not msgs:
-            return "(no messages in local history)"
-        rows = []
+            return "(no messages in this thread)"
+        lines = []
         for m in msgs:
             ts = _ts_to_iso(m.sent_at)
             text = str(m.content).replace("\n", " ") if m.content else ""
-            thread = f" [thread:{m.thread_root_id[:10]}...]" if m.thread_root_id else ""
-            rows.append(f"{ts}  @{m.sender_slug}: {text}{thread}")
-        return "\n".join(rows)
+            lines.append(
+                f"{ts}  post:{m.envelope_id}  @{m.sender_slug}: {text}"
+            )
+        return "\n".join(lines)
 
     @mcp.tool()
     async def list_channels() -> str:

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -27,7 +27,7 @@ from ..crypto.http_client import PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import EncryptInput, RecipientDevice, encrypt_message
 from ..crypto.primitives import Ed25519KeyPair
-from .data_client import DataClient
+from .data_client import DataClient, DataNotFound
 
 logger = logging.getLogger(__name__)
 
@@ -239,13 +239,16 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             )
         channel_id = channel_ref
 
-        roots = await cfg.data_client.get_channel_roots(
-            channel_id,
-            limit=limit,
-            since_envelope_id=since or None,
-            before_ts=int(before) if before else None,
-            after_ts=int(after) if after else None,
-        )
+        try:
+            roots = await cfg.data_client.get_channel_roots(
+                channel_id,
+                limit=limit,
+                since_envelope_id=since or None,
+                before_ts=int(before) if before else None,
+                after_ts=int(after) if after else None,
+            )
+        except DataNotFound:
+            return f"(no such channel: {channel_id})"
         if not roots:
             return "(no root posts in the requested window)"
         lines = []
@@ -288,15 +291,18 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         if not root_id.strip():
             raise RuntimeError("root_id required")
         limit = max(1, min(int(limit), 200))
-        msgs = await cfg.data_client.get_thread_messages(
-            root_id.strip(),
-            limit=limit,
-            since_envelope_id=since or None,
-            before_ts=int(before) if before else None,
-            after_ts=int(after) if after else None,
-        )
+        try:
+            msgs = await cfg.data_client.get_thread_messages(
+                root_id.strip(),
+                limit=limit,
+                since_envelope_id=since or None,
+                before_ts=int(before) if before else None,
+                after_ts=int(after) if after else None,
+            )
+        except DataNotFound:
+            return f"(no such thread: {root_id.strip()})"
         if not msgs:
-            return "(no messages in this thread)"
+            return "(no messages in this thread for the requested window)"
         lines = []
         for m in msgs:
             ts = _ts_to_iso(m.sent_at)

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -169,6 +169,14 @@ async def list_channel_roots(request: web.Request) -> web.Response:
     if store is None:
         return web.json_response({"error": "agent db not found"}, status=404)
     try:
+        # Distinguish "channel never seen" (true 404) from "channel
+        # seen but window after filters is empty" (200 + []). The
+        # latter is a routine case for ``since=<last_id>`` polling
+        # and must NOT look the same to the MCP tool.
+        if not await store.channel_exists(channel_id):
+            return web.json_response(
+                {"error": "channel not found"}, status=404,
+            )
         roots = await store.get_channel_roots(
             channel_id,
             limit=limit,
@@ -213,6 +221,14 @@ async def list_thread_messages(request: web.Request) -> web.Response:
     if store is None:
         return web.json_response({"error": "agent db not found"}, status=404)
     try:
+        # Mirrors ``list_channel_roots``: 404 when the agent has
+        # never recorded anything for ``root_id`` (the root message
+        # itself isn't in the store), 200 + [] when the root is
+        # known but the requested window is empty.
+        if not await store.has_message(root_id):
+            return web.json_response(
+                {"error": "thread root not found"}, status=404,
+            )
         msgs = await store.get_thread_messages(
             root_id,
             limit=limit,

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -130,6 +130,109 @@ async def list_recent_messages(request: web.Request) -> web.Response:
     })
 
 
+def _parse_int_param(value: str | None, name: str) -> tuple[int | None, web.Response | None]:
+    """Return (parsed, error_response). ``None, None`` if missing."""
+    if value is None or value == "":
+        return None, None
+    try:
+        return int(value), None
+    except ValueError:
+        return None, web.json_response(
+            {"error": f"{name} must be an integer"}, status=400,
+        )
+
+
+async def list_channel_roots(request: web.Request) -> web.Response:
+    """Root posts in a channel with reply counts. Replaces the
+    flat ``messages/recent`` view for agents that want to see what
+    conversations exist without dragging every reply into context.
+    Query params: ``channel`` (required), ``limit``, ``since`` (an
+    envelope_id), ``before`` (ms-epoch), ``after`` (ms-epoch)."""
+    agent_id = request.match_info["agent_id"]
+    channel_id = request.query.get("channel", "")
+    if not channel_id:
+        return web.json_response(
+            {"error": "channel query param required"}, status=400,
+        )
+    limit, err = _parse_int_param(request.query.get("limit", "20"), "limit")
+    if err is not None:
+        return err
+    before_ts, err = _parse_int_param(request.query.get("before"), "before")
+    if err is not None:
+        return err
+    after_ts, err = _parse_int_param(request.query.get("after"), "after")
+    if err is not None:
+        return err
+    since = request.query.get("since") or None
+    limit = max(1, min(limit or 20, 200))
+    store = await _store_for(request.app, agent_id)
+    if store is None:
+        return web.json_response({"error": "agent db not found"}, status=404)
+    try:
+        roots = await store.get_channel_roots(
+            channel_id,
+            limit=limit,
+            since_envelope_id=since,
+            before_ts=before_ts,
+            after_ts=after_ts,
+        )
+    except Exception as exc:
+        logger.exception(
+            "data-service: get_channel_roots failed (agent=%s ch=%s)",
+            agent_id, channel_id,
+        )
+        return web.json_response(
+            {"error": f"roots fetch failed: {exc}"}, status=500,
+        )
+    return web.json_response({
+        "roots": [
+            {"message": _msg_to_dict(r.message), "reply_count": r.reply_count}
+            for r in roots
+        ],
+    })
+
+
+async def list_thread_messages(request: web.Request) -> web.Response:
+    """Messages in a thread (the root + every reply), filtered by
+    optional ``since`` (envelope_id), ``before`` / ``after`` (ms-
+    epoch). Returned oldest-first up to ``limit``."""
+    agent_id = request.match_info["agent_id"]
+    root_id = request.match_info["root_id"]
+    limit, err = _parse_int_param(request.query.get("limit", "50"), "limit")
+    if err is not None:
+        return err
+    before_ts, err = _parse_int_param(request.query.get("before"), "before")
+    if err is not None:
+        return err
+    after_ts, err = _parse_int_param(request.query.get("after"), "after")
+    if err is not None:
+        return err
+    since = request.query.get("since") or None
+    limit = max(1, min(limit or 50, 200))
+    store = await _store_for(request.app, agent_id)
+    if store is None:
+        return web.json_response({"error": "agent db not found"}, status=404)
+    try:
+        msgs = await store.get_thread_messages(
+            root_id,
+            limit=limit,
+            since_envelope_id=since,
+            before_ts=before_ts,
+            after_ts=after_ts,
+        )
+    except Exception as exc:
+        logger.exception(
+            "data-service: get_thread_messages failed (agent=%s root=%s)",
+            agent_id, root_id,
+        )
+        return web.json_response(
+            {"error": f"thread fetch failed: {exc}"}, status=500,
+        )
+    return web.json_response({
+        "messages": [_msg_to_dict(m) for m in msgs],
+    })
+
+
 async def get_message_by_envelope(request: web.Request) -> web.Response:
     """GET a single message by envelope_id. 404 if not stored."""
     agent_id = request.match_info["agent_id"]
@@ -182,6 +285,14 @@ def build_app(cfg: DataServiceConfig) -> web.Application:
     app.router.add_get(
         "/v1/data/{agent_id}/messages/recent",
         list_recent_messages,
+    )
+    app.router.add_get(
+        "/v1/data/{agent_id}/channels/roots",
+        list_channel_roots,
+    )
+    app.router.add_get(
+        "/v1/data/{agent_id}/threads/{root_id}",
+        list_thread_messages,
     )
     app.router.add_get(
         "/v1/data/{agent_id}/messages/{envelope_id}",

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import sys
 import time
+import uuid
 from pathlib import Path
 
 from ..agent.adapters import Adapter
@@ -517,7 +518,13 @@ class Worker:
             """
             if not batch:
                 return
-            triggering_post_id = batch[-1].get("envelope_id", "")
+            # Status telemetry is now per-thread-batch. The first
+            # message in arrival order gets the /processing/start
+            # call (yellow dot lands there) — that's what the human
+            # who triggered the agent will see go yellow first. The
+            # rest of the batch flips straight from white to green
+            # via /processing/end:batch at the end of the turn.
+            first_post_id = batch[0].get("envelope_id", "")
             channel_id = channel_meta.get("channel_id", "")
 
             # Honour reload before the turn so the first batch after
@@ -551,7 +558,7 @@ class Worker:
                     json.dumps({
                         "channel_id": channel_id,
                         "root_id": root_id,
-                        "triggering_post_id": triggering_post_id,
+                        "triggering_post_id": first_post_id,
                     }),
                     encoding="utf-8",
                 )
@@ -564,8 +571,8 @@ class Worker:
             # Reporter swallows network errors so a flaky status push
             # never blocks the actual reply.
             run_id = (
-                await reporter.begin_turn(triggering_post_id)
-                if triggering_post_id
+                await reporter.begin_turn(first_post_id)
+                if first_post_id
                 else None
             )
             turn_succeeded = True
@@ -594,13 +601,28 @@ class Worker:
                 turn_succeeded = False
                 turn_error = f"{type(exc).__name__}: {exc}"
             finally:
-                if run_id is not None and triggering_post_id:
-                    await reporter.end_turn(
-                        triggering_post_id,
-                        run_id,
-                        succeeded=turn_succeeded,
-                        error_text=turn_error,
-                    )
+                if run_id is not None and first_post_id:
+                    # Build the batch payload: first row reuses the
+                    # /start run_id (server UPDATEs its row); the
+                    # rest get fresh run_ids and are UPSERTed by the
+                    # server with started_at = ended_at = now.
+                    runs: list[dict] = [{
+                        "run_id": run_id,
+                        "message_id": first_post_id,
+                        "succeeded": turn_succeeded,
+                        "error_text": turn_error,
+                    }]
+                    for msg in batch[1:]:
+                        mid = msg.get("envelope_id", "")
+                        if not mid:
+                            continue
+                        runs.append({
+                            "run_id": f"run_{uuid.uuid4().hex}",
+                            "message_id": mid,
+                            "succeeded": turn_succeeded,
+                            "error_text": turn_error,
+                        })
+                    await reporter.end_turn_batch(runs)
                 # Clear turn context so post-turn background work
                 # doesn't inherit a stale channel/root. Hook
                 # fails-open when the file is absent.
@@ -674,6 +696,8 @@ class Worker:
                 async def begin_turn(self, _mid):
                     return None
                 async def end_turn(self, *_a, **_kw):
+                    return None
+                async def end_turn_batch(self, *_a, **_kw):
                     return None
                 async def report_error(self, _t):
                     return None

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -650,6 +650,34 @@ class Worker:
                 # reply lands in the thread the agent was reading.
                 await client.post_message(channel_id, reply, root_id=root_id)
 
+        async def on_api_error_retry(
+            root_id: str,
+            batch: list[dict],
+            channel_meta: dict,
+        ):
+            """Kick-retry path after an ``AgentAPIError``. Calls the
+            agent's retry method, which sends a small "session
+            errored on rate limiting, please resume processing"
+            kick to claude-code over ``--resume`` instead of
+            re-appending the original batch. If ``--resume`` is no
+            longer valid, the adapter falls back to the full
+            ``batch`` payload on its own.
+
+            Raises ``AgentAPIError`` again if the kick also surfaces
+            the rate limit, so the consumer's outer retry loop can
+            apply another backoff or give up after the cap.
+            """
+            channel_id = channel_meta.get("channel_id", "")
+            reply = await puffo.handle_api_error_retry(
+                root_id=root_id,
+                channel_meta=channel_meta,
+                fallback_batch=batch,
+            )
+            self.runtime.msg_count += 1
+            self.runtime.last_event_at = int(time.time())
+            if reply:
+                await client.post_message(channel_id, reply, root_id=root_id)
+
         async def heartbeat():
             interval = max(1.0, self.daemon_cfg.runtime_heartbeat_seconds)
             while not self._stop.is_set():
@@ -723,7 +751,10 @@ class Worker:
         try:
             while not self._stop.is_set():
                 try:
-                    await client.listen(on_message=on_message_batch)
+                    await client.listen(
+                        on_message=on_message_batch,
+                        on_api_error_retry=on_api_error_retry,
+                    )
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -497,16 +497,31 @@ class Worker:
         # channel + root to reply to.
         current_turn_path = Path(workspace_path) / ".puffo-agent" / "current_turn.json"
 
-        async def on_message(
-            channel_id, channel_name, sender, sender_email, text,
-            root_id, direct, attachments, sender_is_bot, mentions,
-            post_id, create_at, followups,
-            *, space_id="", space_name="",
+        async def on_message_batch(
+            root_id: str,
+            batch: list[dict],
+            channel_meta: dict,
         ):
-            # Honour reload before the turn so the first message after
+            """One agent turn per thread batch. The puffo-core client
+            collapses every arrival on the same ``root_id`` into a
+            single list and hands it here in arrival order. The agent
+            sees every message in one turn and decides whom (and how
+            many times) to reply on its own.
+
+            Server-side processing-run telemetry is keyed on the
+            triggering post id; we use the LAST envelope in the batch
+            as that anchor since it's the most recent thing the agent
+            is reasoning about. The reply, if any, posts back to
+            ``root_id`` as a thread reply (or to the channel root for
+            a top-level batch).
+            """
+            if not batch:
+                return
+            triggering_post_id = batch[-1].get("envelope_id", "")
+            channel_id = channel_meta.get("channel_id", "")
+
+            # Honour reload before the turn so the first batch after
             # a flag-drop picks up fresh CLAUDE.md / profile / memory.
-            # Flag-drops happen mid-turn; the next turn is the earliest
-            # safe point to reload.
             if reload_flag_path.exists():
                 await _reload_from_disk(
                     agent_id=agent_id,
@@ -536,7 +551,7 @@ class Worker:
                     json.dumps({
                         "channel_id": channel_id,
                         "root_id": root_id,
-                        "triggering_post_id": post_id,
+                        "triggering_post_id": triggering_post_id,
                     }),
                     encoding="utf-8",
                 )
@@ -548,40 +563,40 @@ class Worker:
             # Server-side processing-run + status transitions.
             # Reporter swallows network errors so a flaky status push
             # never blocks the actual reply.
-            run_id = await reporter.begin_turn(post_id) if post_id else None
+            run_id = (
+                await reporter.begin_turn(triggering_post_id)
+                if triggering_post_id
+                else None
+            )
             turn_succeeded = True
             turn_error: str | None = None
             try:
-                reply = await puffo.handle_message(
-                    channel_id, channel_name, sender, sender_email, text, direct,
-                    attachments=attachments,
-                    sender_is_bot=sender_is_bot,
-                    mentions=mentions,
-                    post_id=post_id,
+                reply = await puffo.handle_message_batch(
                     root_id=root_id,
-                    create_at=create_at,
-                    followups=followups,
-                    space_id=space_id,
-                    space_name=space_name,
+                    batch=batch,
+                    channel_meta=channel_meta,
                 )
             except AgentAPIError as exc:
                 # Adapter surfaced an "API Error" string. Mark turn
                 # errored and re-raise; the consumer loop re-enqueues
-                # the message and backs off.
+                # the batch with cursor preserved and backs off.
                 logger.warning("agent %s: api-error retry: %s", agent_id, exc)
                 reply = None
                 turn_succeeded = False
                 turn_error = "API Error"
                 raise
             except Exception as exc:
-                logger.error("agent %s: handle_message error: %s", agent_id, exc, exc_info=True)
+                logger.error(
+                    "agent %s: handle_message_batch error: %s",
+                    agent_id, exc, exc_info=True,
+                )
                 reply = None
                 turn_succeeded = False
                 turn_error = f"{type(exc).__name__}: {exc}"
             finally:
-                if run_id is not None and post_id:
+                if run_id is not None and triggering_post_id:
                     await reporter.end_turn(
-                        post_id,
+                        triggering_post_id,
                         run_id,
                         succeeded=turn_succeeded,
                         error_text=turn_error,
@@ -593,9 +608,14 @@ class Worker:
                     current_turn_path.unlink()
                 except OSError:
                     pass
+            # One batch = one "message" for the runtime counter; the
+            # display still reads as "N messages processed."
             self.runtime.msg_count += 1
             self.runtime.last_event_at = int(time.time())
             if reply:
+                # Fallback reply when the agent skipped both
+                # send_message and [SILENT]. Post to root so the
+                # reply lands in the thread the agent was reading.
                 await client.post_message(channel_id, reply, root_id=root_id)
 
         async def heartbeat():
@@ -669,7 +689,7 @@ class Worker:
         try:
             while not self._stop.is_set():
                 try:
-                    await client.listen(on_message=on_message)
+                    await client.listen(on_message=on_message_batch)
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -518,6 +518,16 @@ class Worker:
             """
             if not batch:
                 return
+            # Diagnostic: log every dispatched batch so we can trace
+            # cross-batch duplicates (same envelope_id surfacing in
+            # consecutive turns). If the SAME envelope_id appears
+            # across two log lines for one agent within a few
+            # seconds, the cursor or dispatching_ids check missed it.
+            batch_ids = [m.get("envelope_id", "") for m in batch]
+            logger.info(
+                "agent %s: on_message_batch root=%s size=%d envelopes=%s",
+                agent_id, root_id, len(batch), batch_ids,
+            )
             # Status telemetry is now per-thread-batch. The first
             # message in arrival order gets the /processing/start
             # call (yellow dot lands there) — that's what the human

--- a/tests/test_cli_local_mcp_trust.py
+++ b/tests/test_cli_local_mcp_trust.py
@@ -1,0 +1,85 @@
+"""cli-local must bypass claude-code's per-project trust dialog so
+MCP servers supplied via ``--mcp-config`` actually register.
+
+Background: claude-code stores per-project trust state in
+``~/.claude.json`` under ``projects[<cwd>].hasTrustDialogAccepted``.
+A project that hasn't accepted the trust dialog gets its MCP
+servers silently dropped — claude shows a TUI dialog interactively,
+but ``--input-format stream-json`` has no surface for accepting,
+so the dialog never resolves.
+
+``--dangerously-skip-permissions`` bypasses BOTH the per-tool
+approval prompt AND the trust dialog. ``--permission-mode
+bypassPermissions`` only bypasses the per-tool prompt, leaving the
+trust dialog blocking MCP registration. This file pins the cli-
+local adapter to ``--dangerously-skip-permissions`` for the
+``bypassPermissions`` mode so it matches cli-docker (which already
+uses the right flag).
+
+Unlike ``test_permission_mode.py`` (module-skipped pending the
+permission-DM flow), this file is *always* exercised — the bypass
+case is the one path cli-local actually serves today.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+
+
+def _make_adapter(permission_mode: str = "bypassPermissions") -> LocalCLIAdapter:
+    return LocalCLIAdapter(
+        agent_id="a",
+        model="claude-opus-4-7",
+        workspace_dir="/tmp/ws",
+        claude_dir="/tmp/ws/.claude",
+        session_file="/tmp/a/cli_session.json",
+        mcp_config_file="/tmp/a/mcp-config.json",
+        agent_home_dir="/tmp/a",
+        permission_mode=permission_mode,
+    )
+
+
+def test_bypass_mode_uses_dangerously_skip_permissions():
+    adapter = _make_adapter("bypassPermissions")
+    cmd = adapter._build_command(extra_args=[])
+    assert "--dangerously-skip-permissions" in cmd
+    assert "--permission-mode" not in cmd
+
+
+def test_dangerously_skip_appears_before_extra_args():
+    # Order matters: claude-code parses left to right and
+    # --dangerously-skip-permissions has to be set before --mcp-config
+    # is interpreted so the trust check is bypassed when the MCP
+    # servers are loaded.
+    adapter = _make_adapter("bypassPermissions")
+    cmd = adapter._build_command(extra_args=["--mcp-config", "/some/path.json"])
+    idx_skip = cmd.index("--dangerously-skip-permissions")
+    idx_mcp = cmd.index("--mcp-config")
+    assert idx_skip < idx_mcp
+
+
+def test_model_flag_still_emitted():
+    adapter = _make_adapter("bypassPermissions")
+    cmd = adapter._build_command(extra_args=[])
+    assert "--model" in cmd
+    assert "claude-opus-4-7" in cmd
+
+
+def test_command_shape_matches_cli_docker_for_bypass():
+    # cli-docker emits ``claude --dangerously-skip-permissions --model
+    # <model> ...``. cli-local in bypassPermissions mode should
+    # produce the same shape on the claude argv (the docker prefix
+    # is irrelevant here).
+    adapter = _make_adapter("bypassPermissions")
+    cmd = adapter._build_command(extra_args=["--verbose"])
+    assert cmd[0] == "claude"
+    assert cmd[1] == "--dangerously-skip-permissions"
+    # --model + value sit right after the bypass flag.
+    assert cmd[2] == "--model"
+    assert cmd[3] == "claude-opus-4-7"
+    assert "--verbose" in cmd[4:]

--- a/tests/test_message_store.py
+++ b/tests/test_message_store.py
@@ -7,7 +7,11 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from puffo_agent.agent.message_store import MessageStore, StoredMessage
+from puffo_agent.agent.message_store import (
+    ChannelRoot,
+    MessageStore,
+    StoredMessage,
+)
 
 
 def _now_ms() -> int:
@@ -251,3 +255,111 @@ async def test_for_agent_factory():
     store = MessageStore.for_agent("test-agent-123")
     assert "test-agent-123" in str(store.db_path)
     assert str(store.db_path).endswith("messages.db")
+
+
+# ── get_channel_roots ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_channel_roots_excludes_replies_and_counts_them():
+    """Only thread_root_id IS NULL rows are returned; the
+    ``reply_count`` field is the running count of replies."""
+    store = _temp_store()
+    await store.open()
+    # Two roots in the same channel.
+    await store.store(_channel_payload("root_a", sent_at=100))
+    await store.store(_channel_payload("root_b", sent_at=200))
+    # Three replies on root_a, one on root_b.
+    for i, rt in enumerate(["root_a", "root_a", "root_a"], start=1):
+        await store.store(_channel_payload(
+            f"reply_a_{i}", sent_at=100 + i, thread_root_id=rt,
+        ))
+    await store.store(_channel_payload(
+        "reply_b_1", sent_at=210, thread_root_id="root_b",
+    ))
+
+    roots = await store.get_channel_roots("ch_1")
+    assert [r.message.envelope_id for r in roots] == ["root_a", "root_b"]
+    counts = {r.message.envelope_id: r.reply_count for r in roots}
+    assert counts == {"root_a": 3, "root_b": 1}
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_roots_since_envelope_id_filters_by_sent_at():
+    """``since=<envelope_id>`` resolves to that envelope's sent_at
+    and applies an exclusive lower bound."""
+    store = _temp_store()
+    await store.open()
+    await store.store(_channel_payload("root_old", sent_at=100))
+    await store.store(_channel_payload("root_mid", sent_at=200))
+    await store.store(_channel_payload("root_new", sent_at=300))
+
+    roots = await store.get_channel_roots(
+        "ch_1", since_envelope_id="root_old",
+    )
+    # Strictly after root_old's sent_at, so root_mid + root_new.
+    assert [r.message.envelope_id for r in roots] == ["root_mid", "root_new"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_roots_before_and_after_ts():
+    """``before`` / ``after`` are exclusive ms-epoch bounds."""
+    store = _temp_store()
+    await store.open()
+    for env_id, ts in [
+        ("r_1", 100), ("r_2", 200), ("r_3", 300), ("r_4", 400),
+    ]:
+        await store.store(_channel_payload(env_id, sent_at=ts))
+
+    roots = await store.get_channel_roots(
+        "ch_1", after_ts=100, before_ts=400,
+    )
+    assert [r.message.envelope_id for r in roots] == ["r_2", "r_3"]
+    await store.close()
+
+
+# ── get_thread_messages ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_thread_messages_includes_root_and_replies():
+    store = _temp_store()
+    await store.open()
+    await store.store(_channel_payload("root_x", sent_at=100))
+    await store.store(_channel_payload(
+        "reply_1", sent_at=110, thread_root_id="root_x",
+    ))
+    await store.store(_channel_payload(
+        "reply_2", sent_at=120, thread_root_id="root_x",
+    ))
+    # An unrelated root + reply mustn't leak in.
+    await store.store(_channel_payload("root_other", sent_at=130))
+    await store.store(_channel_payload(
+        "other_reply", sent_at=140, thread_root_id="root_other",
+    ))
+
+    msgs = await store.get_thread_messages("root_x")
+    assert [m.envelope_id for m in msgs] == ["root_x", "reply_1", "reply_2"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_thread_messages_since_filter():
+    store = _temp_store()
+    await store.open()
+    await store.store(_channel_payload("root_x", sent_at=100))
+    await store.store(_channel_payload(
+        "reply_1", sent_at=110, thread_root_id="root_x",
+    ))
+    await store.store(_channel_payload(
+        "reply_2", sent_at=120, thread_root_id="root_x",
+    ))
+
+    msgs = await store.get_thread_messages(
+        "root_x", since_envelope_id="reply_1",
+    )
+    # Strictly after reply_1's sent_at → only reply_2.
+    assert [m.envelope_id for m in msgs] == ["reply_2"]
+    await store.close()

--- a/tests/test_permission_mode.py
+++ b/tests/test_permission_mode.py
@@ -110,20 +110,28 @@ class TestBuildCommand:
         cmd = adapter._build_command(extra_args=[])
         assert "--model" not in cmd
 
-    def test_bypass_permissions_passes_through(self):
+    def test_bypass_permissions_uses_dangerously_skip_permissions(self):
+        # bypassPermissions is the only path today; it MUST emit
+        # --dangerously-skip-permissions (and not --permission-mode)
+        # so claude-code in stream-json mode bypasses the per-project
+        # trust dialog. Otherwise MCP servers supplied via
+        # --mcp-config get silently dropped on the first run.
         adapter = _make_adapter(permission_mode="bypassPermissions")
         cmd = adapter._build_command(extra_args=[])
-        i = cmd.index("--permission-mode")
-        assert cmd[i + 1] == "bypassPermissions"
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--permission-mode" not in cmd
 
-    def test_never_passes_dangerously_skip_permissions(self):
-        # Regression guard: this flag is deprecated in favour of
-        # --permission-mode. If it returns, permission decisions
-        # silent-bypass and the MCP proxy never fires.
+    def test_non_bypass_modes_pass_dangerously_skip_permissions_off(self):
+        # The other modes route per-tool decisions through the
+        # PreToolUse hook; they MUST NOT use --dangerously-skip-
+        # permissions or the hook never fires.
         for mode in VALID_PERMISSION_MODES:
+            if mode == "bypassPermissions":
+                continue
             adapter = _make_adapter(permission_mode=mode)
             cmd = adapter._build_command(extra_args=["--foo", "bar"])
             assert "--dangerously-skip-permissions" not in cmd
+            assert "--permission-mode" in cmd
 
     def test_unknown_mode_sanitised_at_construction(self, caplog):
         with caplog.at_level(logging.WARNING):

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -265,12 +265,71 @@ async def test_get_channel_history_from_local():
 
 
 @pytest.mark.asyncio
-async def test_get_channel_history_empty():
+async def test_get_channel_history_unknown_channel():
+    """Channel never seen → 'no such channel: …'. Distinct from
+    the empty-window message so the agent doesn't conflate a
+    bad channel id with a quiet one."""
     cfg, _, ms = _setup()
     await ms.open()
     mcp = _build_tools(cfg)
     result = await _call(mcp, "get_channel_history", {"channel": "ch_nonexistent"})
+    assert "no such channel" in result
+    assert "ch_nonexistent" in result
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_get_channel_history_empty_window():
+    """Channel exists but the ``since`` filter pushes past every
+    root → 'no root posts in the requested window'."""
+    cfg, _, ms = _setup()
+    await ms.open()
+    base = _now_ms()
+    await ms.store({
+        "envelope_id": "env_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_seen",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "Hello", "sent_at": base,
+    })
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp, "get_channel_history",
+        {"channel": "ch_seen", "since": "env_root"},
+    )
     assert "no root posts" in result
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_get_thread_history_unknown_root():
+    cfg, _, ms = _setup()
+    await ms.open()
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "get_thread_history", {"root_id": "msg_nonexistent"})
+    assert "no such thread" in result
+    assert "msg_nonexistent" in result
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_get_thread_history_empty_window():
+    cfg, _, ms = _setup()
+    await ms.open()
+    base = _now_ms()
+    await ms.store({
+        "envelope_id": "env_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_t",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "Root", "sent_at": base,
+    })
+    mcp = _build_tools(cfg)
+    # ``since=env_root`` filters out the root itself; thread has no
+    # replies → empty window.
+    result = await _call(
+        mcp, "get_thread_history",
+        {"root_id": "env_root", "since": "env_root"},
+    )
+    assert "no messages in this thread" in result
     await ms.close()
 
 

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -270,7 +270,7 @@ async def test_get_channel_history_empty():
     await ms.open()
     mcp = _build_tools(cfg)
     result = await _call(mcp, "get_channel_history", {"channel": "ch_nonexistent"})
-    assert "no messages" in result
+    assert "no root posts" in result
     await ms.close()
 
 

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -220,3 +220,75 @@ async def test_heartbeat_interval_clamped_to_minimum():
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=0.5)
     assert rep._interval == 10.0
+
+
+# ─── end_turn_batch ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_end_turn_batch_posts_all_runs_in_one_call():
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    rep._current_status = "busy"
+    rep._current_message_id = "msg_a"
+
+    await rep.end_turn_batch([
+        {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
+        {"run_id": "run_b", "message_id": "msg_b", "succeeded": True},
+        {"run_id": "run_c", "message_id": "msg_c", "succeeded": True},
+    ])
+
+    assert len(http.calls) == 1
+    path, body = http.calls[0]
+    assert path == "/messages/processing/end:batch"
+    assert body == {"runs": [
+        {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
+        {"run_id": "run_b", "message_id": "msg_b", "succeeded": True},
+        {"run_id": "run_c", "message_id": "msg_c", "succeeded": True},
+    ]}
+    assert rep._current_status == "idle"
+    assert rep._current_message_id is None
+
+
+@pytest.mark.asyncio
+async def test_end_turn_batch_failure_flips_status_to_error():
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    await rep.end_turn_batch([
+        {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
+        {"run_id": "run_b", "message_id": "msg_b", "succeeded": False,
+         "error_text": "claude rate limit"},
+    ])
+
+    _path, body = http.calls[0]
+    # error_text only emitted on the failing run, capped at 1024 chars.
+    assert body["runs"][0] == {
+        "run_id": "run_a", "message_id": "msg_a", "succeeded": True,
+    }
+    assert body["runs"][1] == {
+        "run_id": "run_b", "message_id": "msg_b", "succeeded": False,
+        "error_text": "claude rate limit",
+    }
+    assert rep._current_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_end_turn_batch_empty_is_no_op():
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    await rep.end_turn_batch([])
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_end_turn_batch_swallows_http_error():
+    http = FakeHttp()
+    http.side_effect = HttpError(500, "boom")
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    # No raise — telemetry must not break the agent loop.
+    await rep.end_turn_batch([
+        {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
+    ])
+    assert len(http.calls) == 1

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -603,6 +603,67 @@ async def test_arrival_during_dispatch_lands_in_next_batch():
 
 
 @pytest.mark.asyncio
+async def test_consumer_dedupes_batch_before_dispatch_as_safety_net():
+    """Even if some upstream path somehow leaves duplicate
+    envelope_ids in ``entry.messages``, the agent must never see the
+    same envelope twice in one ``on_message_batch`` dispatch (the
+    user's strict requirement #1). The consumer's pre-dispatch
+    safety-net dedup guarantees that. To verify, we bypass admit and
+    inject the duplicate directly into the in-memory state.
+    """
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    # Build entry state by hand — same shape admit would produce,
+    # but with an extra duplicate of env_x sneaked into messages.
+    entry = _ThreadEntry(
+        current_priority=PRIORITY_HUMAN,
+        current_seq=1,
+        messages=[
+            _msg("env_x", sent_at=100),
+            _msg("env_x", sent_at=100),  # duplicate
+            _msg("env_y", sent_at=200),
+        ],
+        in_queue=True,
+        channel_meta=_channel_meta(),
+    )
+    client._thread_state["env_root"] = entry
+    client._queue_seq = 1
+    await client._queue.put((PRIORITY_HUMAN, 1, "env_root"))
+
+    batches: list[list[str]] = []
+
+    async def callback(root_id, batch, channel_meta):
+        batches.append([m["envelope_id"] for m in batch])
+        raise asyncio.CancelledError()
+
+    import puffo_agent.agent.puffo_core_client as mod
+    original_uniform = mod.random.uniform
+
+    def fake_uniform(a, b):
+        return 0.0 if (a, b) == (0.0, 1.5) else original_uniform(a, b)
+
+    mod.random.uniform = fake_uniform  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(client._consume_queue(callback))
+        try:
+            await asyncio.wait_for(task, timeout=2.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        mod.random.uniform = original_uniform  # type: ignore[assignment]
+
+    # The batch dispatched to the agent must have each envelope_id
+    # exactly once, in arrival order.
+    assert batches == [["env_x", "env_y"]], batches
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_duplicate_envelope_during_dispatch_is_skipped():
     """A duplicate of an envelope that the consumer just claimed for
     dispatch must not produce a second batch. The bug: the consumer

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -538,6 +538,147 @@ async def test_consume_jitters_before_dispatch():
 
 
 @pytest.mark.asyncio
+async def test_arrival_during_dispatch_lands_in_next_batch():
+    """While the consumer is awaiting ``on_message_batch`` for batch
+    A, a new message arrives on the same thread. The new message
+    must end up in a second dispatch (batch B), not silently dropped.
+    Reproduces the bug where mid-dispatch arrivals get lost.
+    """
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1", sent_at=100),
+        channel_meta=_channel_meta(),
+    )
+
+    batches: list[list[str]] = []
+    in_first_dispatch = asyncio.Event()
+    resume_first = asyncio.Event()
+    second_done = asyncio.Event()
+
+    async def callback(root_id, batch, channel_meta):
+        batches.append([m["envelope_id"] for m in batch])
+        if len(batches) == 1:
+            in_first_dispatch.set()
+            await resume_first.wait()
+        elif len(batches) == 2:
+            second_done.set()
+
+    # Neutralise the 0-1.5s pre-dispatch jitter without touching
+    # asyncio.sleep itself (the consumer still needs real yields).
+    import puffo_agent.agent.puffo_core_client as mod
+    original_uniform = mod.random.uniform
+
+    def fake_uniform(a, b):
+        return 0.0 if (a, b) == (0.0, 1.5) else original_uniform(a, b)
+
+    mod.random.uniform = fake_uniform  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(client._consume_queue(callback))
+        try:
+            await asyncio.wait_for(in_first_dispatch.wait(), timeout=2.0)
+            # Admit msg2 mid-dispatch.
+            await client._admit_thread_message(
+                root_id="env_root",
+                priority=PRIORITY_HUMAN,
+                msg_dict=_msg("env_2", sent_at=200),
+                channel_meta=_channel_meta(),
+            )
+            resume_first.set()
+            await asyncio.wait_for(second_done.wait(), timeout=2.0)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        mod.random.uniform = original_uniform  # type: ignore[assignment]
+
+    assert batches == [["env_1"], ["env_2"]], batches
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_api_error_preserves_mid_dispatch_arrivals():
+    """When the agent dispatch raises AgentAPIError AND a new message
+    arrived on the same thread during that failed dispatch, the new
+    message must NOT be lost. The retry batch should include both the
+    original (failed) messages AND the mid-dispatch arrival.
+    """
+    from puffo_agent.agent.core import AgentAPIError
+
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1", sent_at=100),
+        channel_meta=_channel_meta(),
+    )
+
+    batches: list[list[str]] = []
+    in_first_dispatch = asyncio.Event()
+    resume_first = asyncio.Event()
+    second_done = asyncio.Event()
+
+    async def callback(root_id, batch, channel_meta):
+        batches.append([m["envelope_id"] for m in batch])
+        if len(batches) == 1:
+            in_first_dispatch.set()
+            await resume_first.wait()
+            raise AgentAPIError("provider 429")
+        elif len(batches) == 2:
+            second_done.set()
+
+    # Neutralise jitter (0-1.5s) and the API-error backoff (15-45s)
+    # so the test doesn't burn real wall-clock time.
+    import puffo_agent.agent.puffo_core_client as mod
+    original_uniform = mod.random.uniform
+
+    def fake_uniform(a, b):
+        if (a, b) == (0.0, 1.5):
+            return 0.0
+        if (a, b) == (15.0, 45.0):
+            return 0.0
+        return original_uniform(a, b)
+
+    mod.random.uniform = fake_uniform  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(client._consume_queue(callback))
+        try:
+            await asyncio.wait_for(in_first_dispatch.wait(), timeout=2.0)
+            # Mid-dispatch arrival: must survive the failed dispatch.
+            await client._admit_thread_message(
+                root_id="env_root",
+                priority=PRIORITY_HUMAN,
+                msg_dict=_msg("env_2", sent_at=200),
+                channel_meta=_channel_meta(),
+            )
+            resume_first.set()
+            await asyncio.wait_for(second_done.wait(), timeout=2.0)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        mod.random.uniform = original_uniform  # type: ignore[assignment]
+
+    # The retry should include both env_1 (the failed batch) and
+    # env_2 (the mid-dispatch arrival). Without the fix, env_2 was
+    # clobbered by ``entry.messages = batch`` and dropped silently.
+    assert batches[0] == ["env_1"]
+    assert batches[1] == ["env_1", "env_2"]
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_api_error_requeues_same_batch_preserves_cursor():
     """``AgentAPIError`` re-enqueues the same batch without advancing
     the durable cursor. The next pop must see the same messages."""

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -603,6 +603,83 @@ async def test_arrival_during_dispatch_lands_in_next_batch():
 
 
 @pytest.mark.asyncio
+async def test_duplicate_envelope_during_dispatch_is_skipped():
+    """A duplicate of an envelope that the consumer just claimed for
+    dispatch must not produce a second batch. The bug: the consumer
+    sets ``entry.messages = []`` and ``in_queue = False`` before
+    dispatching; a duplicate WS delivery during that window slips
+    past the handle_envelope cursor check (cursor hasn't advanced
+    yet) and hits ``_admit_thread_message``'s reopen branch, which
+    creates a fresh batch the consumer dispatches next — so the
+    agent sees the same envelope across two turns.
+    """
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_x", sent_at=100),
+        channel_meta=_channel_meta(),
+    )
+
+    batches: list[list[str]] = []
+    in_first_dispatch = asyncio.Event()
+    resume_first = asyncio.Event()
+    second_done = asyncio.Event()
+
+    async def callback(root_id, batch, channel_meta):
+        batches.append([m["envelope_id"] for m in batch])
+        if len(batches) == 1:
+            in_first_dispatch.set()
+            await resume_first.wait()
+        else:
+            second_done.set()
+
+    import puffo_agent.agent.puffo_core_client as mod
+    original_uniform = mod.random.uniform
+
+    def fake_uniform(a, b):
+        return 0.0 if (a, b) == (0.0, 1.5) else original_uniform(a, b)
+
+    mod.random.uniform = fake_uniform  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(client._consume_queue(callback))
+        try:
+            await asyncio.wait_for(in_first_dispatch.wait(), timeout=2.0)
+            # Duplicate of env_x arrives mid-dispatch (same envelope_id,
+            # same sent_at — exactly what server pending-message
+            # redelivery + live WS can produce).
+            await client._admit_thread_message(
+                root_id="env_root",
+                priority=PRIORITY_HUMAN,
+                msg_dict=_msg("env_x", sent_at=100),
+                channel_meta=_channel_meta(),
+            )
+            resume_first.set()
+            # If a duplicate-driven second dispatch is going to fire,
+            # it'll fire within a few hundred ms. Generous budget so
+            # sqlite IO doesn't race the assertion.
+            try:
+                await asyncio.wait_for(second_done.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        mod.random.uniform = original_uniform  # type: ignore[assignment]
+
+    # Exactly one dispatch — the duplicate must be skipped at admit
+    # time. Without the dispatching_ids fix this would be 2.
+    assert batches == [["env_x"]], batches
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_api_error_preserves_mid_dispatch_arrivals():
     """When the agent dispatch raises AgentAPIError AND a new message
     arrived on the same thread during that failed dispatch, the new

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -1,0 +1,530 @@
+"""Thread-batched priority queue for the puffo-core message client.
+
+The queue keys on ``root_id`` (the thread root envelope id, or the
+message itself when it's a top-level post). Every arrival on the
+same thread coalesces into a single ``_ThreadEntry``; the consumer
+pops a root, drains the whole batch, and invokes
+``on_message_batch`` once per pop. Priority bumps push a fresh
+heap tuple with a new seq so stale lower-priority tuples can be
+recognised and dropped on pop.
+
+These tests drive the queue + state machine directly via
+``_admit_thread_message`` and the per-class ``_thread_state``
+without spinning up the full WS / decryption stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import (
+    PRIORITY_BOT,
+    PRIORITY_HUMAN,
+    PRIORITY_MENTIONED_BOT,
+    PRIORITY_MENTIONED_HUMAN,
+    PuffoCoreMessageClient,
+    _ThreadEntry,
+    _compute_priority,
+)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def _make_store() -> MessageStore:
+    d = tempfile.mkdtemp()
+    store = MessageStore(os.path.join(d, "messages.db"))
+    await store.open()
+    return store
+
+
+def _make_client_for_queue(store: MessageStore) -> PuffoCoreMessageClient:
+    """Build a bare PuffoCoreMessageClient with just enough state to
+    exercise the queue machinery. Bypasses the constructor because
+    the real one requires a keystore + http client + WS bookkeeping
+    we don't need here.
+    """
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.store = store
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    return client
+
+
+def _msg(envelope_id: str, sender: str = "alice-0001", sent_at: int | None = None) -> dict:
+    return {
+        "channel_id": "ch_1",
+        "channel_name": "general",
+        "space_id": "sp_1",
+        "space_name": "Team",
+        "sender_slug": sender,
+        "sender_email": "",
+        "text": f"hello from {envelope_id}",
+        "root_id": "",
+        "is_dm": False,
+        "attachments": [],
+        "sender_is_bot": False,
+        "mentions": [],
+        "envelope_id": envelope_id,
+        "sent_at": sent_at if sent_at is not None else _now_ms(),
+    }
+
+
+def _channel_meta() -> dict:
+    return {
+        "channel_id": "ch_1",
+        "channel_name": "general",
+        "space_id": "sp_1",
+        "space_name": "Team",
+        "is_dm": False,
+    }
+
+
+# ─── _compute_priority sanity ─────────────────────────────────────
+
+
+def test_compute_priority_bands():
+    assert _compute_priority(direct=True, sender_is_bot=False) == PRIORITY_MENTIONED_HUMAN
+    assert _compute_priority(direct=True, sender_is_bot=True) == PRIORITY_MENTIONED_BOT
+    assert _compute_priority(direct=False, sender_is_bot=False) == PRIORITY_HUMAN
+    assert _compute_priority(direct=False, sender_is_bot=True) == PRIORITY_BOT
+
+
+# ─── MessageStore: thread-batch helpers ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_thread_batch_includes_root_and_replies():
+    store = await _make_store()
+    base = _now_ms()
+    await store.store({
+        "envelope_id": "env_root",
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "kickoff",
+        "sent_at": base + 1,
+        "thread_root_id": None,
+    })
+    await store.store({
+        "envelope_id": "env_reply_a",
+        "envelope_kind": "channel",
+        "sender_slug": "bob-0002",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "reply A",
+        "sent_at": base + 2,
+        "thread_root_id": "env_root",
+    })
+    await store.store({
+        "envelope_id": "env_reply_b",
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "reply B",
+        "sent_at": base + 3,
+        "thread_root_id": "env_root",
+    })
+
+    batch = await store.get_thread_batch("env_root", since_sent_at=0)
+    assert [m.envelope_id for m in batch] == ["env_root", "env_reply_a", "env_reply_b"]
+    assert batch[0].thread_root_id is None
+    assert batch[1].thread_root_id == "env_root"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_get_thread_batch_filters_by_since_sent_at():
+    store = await _make_store()
+    await store.store({
+        "envelope_id": "env_root",
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "kickoff",
+        "sent_at": 100,
+        "thread_root_id": None,
+    })
+    await store.store({
+        "envelope_id": "env_reply",
+        "envelope_kind": "channel",
+        "sender_slug": "bob-0002",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "reply",
+        "sent_at": 200,
+        "thread_root_id": "env_root",
+    })
+
+    batch = await store.get_thread_batch("env_root", since_sent_at=100)
+    # Strict ``>``: root at sent_at=100 is excluded; reply at 200 included.
+    assert [m.envelope_id for m in batch] == ["env_reply"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_mark_and_get_last_processed_sent_at():
+    store = await _make_store()
+    assert await store.get_last_processed_sent_at("env_root") == 0
+
+    await store.mark_thread_processed("env_root", 1000)
+    assert await store.get_last_processed_sent_at("env_root") == 1000
+
+    # MAX semantics: a regress doesn't lower the cursor.
+    await store.mark_thread_processed("env_root", 500)
+    assert await store.get_last_processed_sent_at("env_root") == 1000
+
+    # Advance updates.
+    await store.mark_thread_processed("env_root", 2000)
+    assert await store.get_last_processed_sent_at("env_root") == 2000
+    await store.close()
+
+
+# ─── _admit_thread_message ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admit_first_message_creates_entry_and_pushes_tuple():
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    msg = _msg("env_1")
+    await client._admit_thread_message(
+        root_id="env_1",
+        priority=PRIORITY_HUMAN,
+        msg_dict=msg,
+        channel_meta=_channel_meta(),
+    )
+
+    assert "env_1" in client._thread_state
+    entry = client._thread_state["env_1"]
+    assert entry.in_queue is True
+    assert entry.current_priority == PRIORITY_HUMAN
+    assert entry.messages == [msg]
+    # One heap tuple.
+    assert client._queue.qsize() == 1
+    priority, seq, root_id = await client._queue.get()
+    assert priority == PRIORITY_HUMAN
+    assert seq == entry.current_seq
+    assert root_id == "env_1"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_admit_second_same_priority_coalesces_no_new_heap_tuple():
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1"),
+        channel_meta=_channel_meta(),
+    )
+    qsize_before = client._queue.qsize()
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_2"),
+        channel_meta=_channel_meta(),
+    )
+
+    entry = client._thread_state["env_root"]
+    assert len(entry.messages) == 2
+    assert [m["envelope_id"] for m in entry.messages] == ["env_1", "env_2"]
+    # No new heap tuple — same-priority arrivals don't move the slot.
+    assert client._queue.qsize() == qsize_before
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_admit_lower_priority_arrival_does_not_replace_slot():
+    """Higher priority = lower numeric value. A LATER arrival with a
+    LOWER priority (larger numeric) joins the batch but doesn't push
+    a new heap tuple."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_MENTIONED_HUMAN,  # priority=1
+        msg_dict=_msg("env_1"),
+        channel_meta=_channel_meta(),
+    )
+    qsize_before = client._queue.qsize()
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,  # priority=3 — lower priority
+        msg_dict=_msg("env_2"),
+        channel_meta=_channel_meta(),
+    )
+
+    entry = client._thread_state["env_root"]
+    # Slot priority stays at the higher value (numeric 1).
+    assert entry.current_priority == PRIORITY_MENTIONED_HUMAN
+    assert [m["envelope_id"] for m in entry.messages] == ["env_1", "env_2"]
+    assert client._queue.qsize() == qsize_before
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_admit_higher_priority_arrival_pushes_new_tuple_keeps_cursor():
+    """Spec point 1c: when a higher-priority arrival lands on a root
+    already in the queue, push a NEW heap tuple with the upgraded
+    priority + a fresh seq. Cursor (``messages[0]``) stays at the
+    earliest unprocessed message."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_first"),
+        channel_meta=_channel_meta(),
+    )
+    first_seq = client._thread_state["env_root"].current_seq
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_MENTIONED_HUMAN,  # higher priority
+        msg_dict=_msg("env_second"),
+        channel_meta=_channel_meta(),
+    )
+
+    entry = client._thread_state["env_root"]
+    assert entry.current_priority == PRIORITY_MENTIONED_HUMAN
+    assert entry.current_seq > first_seq
+    # Cursor preserved: earliest message is still env_first.
+    assert entry.messages[0]["envelope_id"] == "env_first"
+    assert entry.messages[1]["envelope_id"] == "env_second"
+    # Two heap tuples now (the old one stays — will be detected as
+    # stale on pop via the seq mismatch).
+    assert client._queue.qsize() == 2
+    await store.close()
+
+
+# ─── _consume_queue ──────────────────────────────────────────────
+
+
+async def _run_consumer_one_batch(client: PuffoCoreMessageClient) -> tuple[str, list[dict], dict]:
+    """Drive ``_consume_queue`` until it dispatches exactly one
+    batch, then cancel the task. Returns the (root_id, batch,
+    channel_meta) tuple the callback saw.
+    """
+    received: list[tuple[str, list[dict], dict]] = []
+    done = asyncio.Event()
+
+    async def callback(root_id, batch, channel_meta):
+        received.append((root_id, batch, channel_meta))
+        done.set()
+
+    task = asyncio.create_task(client._consume_queue(callback))
+    try:
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    assert len(received) == 1
+    return received[0]
+
+
+@pytest.mark.asyncio
+async def test_consume_yields_whole_batch():
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+    for i in range(3):
+        await client._admit_thread_message(
+            root_id="env_root",
+            priority=PRIORITY_HUMAN,
+            msg_dict=_msg(f"env_{i}", sent_at=100 + i),
+            channel_meta=_channel_meta(),
+        )
+
+    root_id, batch, channel_meta = await _run_consumer_one_batch(client)
+    assert root_id == "env_root"
+    assert [m["envelope_id"] for m in batch] == ["env_0", "env_1", "env_2"]
+    assert channel_meta["channel_id"] == "ch_1"
+    # In-queue flag flipped off; slot reopens on next arrival.
+    assert client._thread_state["env_root"].in_queue is False
+    # Cursor persisted.
+    assert await store.get_last_processed_sent_at("env_root") == 102
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_consume_skips_stale_seq():
+    """When a re-prioritisation pushes a new tuple, the old one stays
+    in the heap. ``_consume_queue`` must skip it on pop without
+    invoking the callback, then process the fresh tuple."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_a", sent_at=10),
+        channel_meta=_channel_meta(),
+    )
+    # Bump priority — second tuple in the queue.
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_MENTIONED_HUMAN,
+        msg_dict=_msg("env_b", sent_at=20),
+        channel_meta=_channel_meta(),
+    )
+    assert client._queue.qsize() == 2
+
+    root_id, batch, _meta = await _run_consumer_one_batch(client)
+    assert root_id == "env_root"
+    # The batch is the full coalesced list — cursor preserved.
+    assert [m["envelope_id"] for m in batch] == ["env_a", "env_b"]
+    # The stale tuple still in the heap should be dropped before
+    # any further batches dispatch.
+    assert client._queue.qsize() <= 1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_arrival_after_processing_does_not_replay():
+    """After a successful dispatch, subsequent arrivals on the same
+    thread enqueue ONLY the new messages — the agent doesn't see
+    already-processed entries."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1", sent_at=100),
+        channel_meta=_channel_meta(),
+    )
+    root_id, first_batch, _ = await _run_consumer_one_batch(client)
+    assert [m["envelope_id"] for m in first_batch] == ["env_1"]
+    assert await store.get_last_processed_sent_at("env_root") == 100
+
+    # New message arrives in the same thread post-dispatch.
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_2", sent_at=200),
+        channel_meta=_channel_meta(),
+    )
+    root_id_2, second_batch, _ = await _run_consumer_one_batch(client)
+    assert root_id_2 == "env_root"
+    assert [m["envelope_id"] for m in second_batch] == ["env_2"]
+    assert await store.get_last_processed_sent_at("env_root") == 200
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_api_error_requeues_same_batch_preserves_cursor():
+    """``AgentAPIError`` re-enqueues the same batch without advancing
+    the durable cursor. The next pop must see the same messages."""
+    from puffo_agent.agent.core import AgentAPIError
+
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1", sent_at=100),
+        channel_meta=_channel_meta(),
+    )
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_2", sent_at=200),
+        channel_meta=_channel_meta(),
+    )
+
+    call_count = 0
+    seen_batches: list[list[dict]] = []
+
+    async def callback(root_id, batch, channel_meta):
+        nonlocal call_count
+        seen_batches.append(list(batch))
+        call_count += 1
+        if call_count == 1:
+            raise AgentAPIError("provider 429")
+        # second call: success, stop consumer
+        raise asyncio.CancelledError()
+
+    # Patch the sleep so we don't wait 15-45s in tests.
+    import puffo_agent.agent.puffo_core_client as mod
+    original_sleep = mod.asyncio.sleep
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        return None
+
+    mod.asyncio.sleep = fake_sleep  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(client._consume_queue(callback))
+        try:
+            await asyncio.wait_for(task, timeout=2.0)
+        except asyncio.CancelledError:
+            pass
+        except asyncio.TimeoutError:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        mod.asyncio.sleep = original_sleep  # type: ignore[assignment]
+
+    assert call_count == 2
+    # Both invocations saw the same batch (cursor preserved).
+    assert [m["envelope_id"] for m in seen_batches[0]] == ["env_1", "env_2"]
+    assert [m["envelope_id"] for m in seen_batches[1]] == ["env_1", "env_2"]
+    # We slept for the back-off between the two attempts.
+    assert any(s > 0 for s in sleeps)
+    # Cursor was NOT advanced for the failing turn but IS advanced
+    # for the successful one (the second call was cancelled before
+    # mark_thread_processed ran, so cursor stays at 0). Acceptable —
+    # the second attempt's failure-mode (CancelledError) is an
+    # artificial stop signal in this test, not a real success path.
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_pre_existing_cursor_blocks_redelivered_messages():
+    """If the sqlite cursor says a thread is processed past
+    ``sent_at``, the listen-handler-equivalent skip check (the same
+    one ``handle_envelope`` runs before ``_admit_thread_message``)
+    must reject the redelivered message. We exercise the cursor lookup
+    directly since the skip lives in the closure."""
+    store = await _make_store()
+    await store.mark_thread_processed("env_root", 500)
+
+    # Anything with sent_at <= 500 should be skipped by the listen
+    # handler. We verify the cursor query returns the right value;
+    # the integration of "compare and skip" is tested by inspection
+    # of the listen() body.
+    assert await store.get_last_processed_sent_at("env_root") == 500
+    # A fresh root has no entry → returns 0 → admits everything.
+    assert await store.get_last_processed_sent_at("env_fresh") == 0
+    await store.close()

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -485,6 +485,59 @@ async def test_arrival_after_processing_does_not_replay():
 
 
 @pytest.mark.asyncio
+async def test_consume_jitters_before_dispatch():
+    """Pre-dispatch sleep of 0.0–1.5s desynchronises agents on the
+    same host that get activated by one broadcast message. Verifies
+    ``asyncio.sleep`` is awaited with a value in that range BEFORE
+    the on_message_batch callback fires."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1", sent_at=100),
+        channel_meta=_channel_meta(),
+    )
+
+    import puffo_agent.agent.puffo_core_client as mod
+    original_sleep = mod.asyncio.sleep
+    sleeps_before_callback: list[float] = []
+    done = asyncio.Event()
+
+    async def fake_sleep(seconds):
+        if not done.is_set():
+            sleeps_before_callback.append(seconds)
+        return None
+
+    async def callback(root_id, batch, channel_meta):
+        done.set()
+
+    mod.asyncio.sleep = fake_sleep  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(client._consume_queue(callback))
+        try:
+            # Wait on the Event directly so we don't issue any sleep
+            # calls that would pollute the recording.
+            await asyncio.wait_for(done.wait(), timeout=2.0)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        mod.asyncio.sleep = original_sleep  # type: ignore[assignment]
+
+    assert done.is_set(), "callback never fired"
+    # Exactly one pre-dispatch sleep, and it sits in the jitter band.
+    assert len(sleeps_before_callback) == 1
+    delay = sleeps_before_callback[0]
+    assert 0.0 <= delay <= 1.5
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_api_error_requeues_same_batch_preserves_cursor():
     """``AgentAPIError`` re-enqueues the same batch without advancing
     the durable cursor. The next pop must see the same messages."""

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -741,11 +741,16 @@ async def test_duplicate_envelope_during_dispatch_is_skipped():
 
 
 @pytest.mark.asyncio
-async def test_api_error_preserves_mid_dispatch_arrivals():
-    """When the agent dispatch raises AgentAPIError AND a new message
-    arrived on the same thread during that failed dispatch, the new
-    message must NOT be lost. The retry batch should include both the
-    original (failed) messages AND the mid-dispatch arrival.
+async def test_api_error_calls_kick_retry_not_re_enqueue():
+    """``AgentAPIError`` from the main dispatch should trigger the
+    ``on_api_error_retry`` callback (the kick path) instead of
+    re-dispatching the original batch. The original user input is
+    already in claude-code's ``--resume`` transcript; re-sending
+    would duplicate it.
+
+    The kick callback receives the same ``(root_id, batch,
+    channel_meta)`` as a fallback in case ``--resume`` itself fails;
+    on success the cursor advances past the failed batch.
     """
     from puffo_agent.agent.core import AgentAPIError
 
@@ -759,46 +764,33 @@ async def test_api_error_preserves_mid_dispatch_arrivals():
         channel_meta=_channel_meta(),
     )
 
-    batches: list[list[str]] = []
-    in_first_dispatch = asyncio.Event()
-    resume_first = asyncio.Event()
-    second_done = asyncio.Event()
+    dispatched: list[list[str]] = []
+    retry_batches: list[list[str]] = []
+    retry_done = asyncio.Event()
 
-    async def callback(root_id, batch, channel_meta):
-        batches.append([m["envelope_id"] for m in batch])
-        if len(batches) == 1:
-            in_first_dispatch.set()
-            await resume_first.wait()
-            raise AgentAPIError("provider 429")
-        elif len(batches) == 2:
-            second_done.set()
+    async def on_message_batch(root_id, batch, channel_meta):
+        dispatched.append([m["envelope_id"] for m in batch])
+        raise AgentAPIError("provider 429")
 
-    # Neutralise jitter (0-1.5s) and the API-error backoff (15-45s)
-    # so the test doesn't burn real wall-clock time.
+    async def on_retry(root_id, batch, channel_meta):
+        retry_batches.append([m["envelope_id"] for m in batch])
+        retry_done.set()
+        # First kick succeeds (no AgentAPIError).
+
+    # Patch jitter + API-error backoff to zero so the test runs fast.
     import puffo_agent.agent.puffo_core_client as mod
     original_uniform = mod.random.uniform
 
     def fake_uniform(a, b):
-        if (a, b) == (0.0, 1.5):
-            return 0.0
-        if (a, b) == (15.0, 45.0):
-            return 0.0
-        return original_uniform(a, b)
+        return 0.0 if (a, b) in ((0.0, 1.5), (15.0, 45.0)) else original_uniform(a, b)
 
     mod.random.uniform = fake_uniform  # type: ignore[assignment]
     try:
-        task = asyncio.create_task(client._consume_queue(callback))
+        task = asyncio.create_task(
+            client._consume_queue(on_message_batch, on_retry),
+        )
         try:
-            await asyncio.wait_for(in_first_dispatch.wait(), timeout=2.0)
-            # Mid-dispatch arrival: must survive the failed dispatch.
-            await client._admit_thread_message(
-                root_id="env_root",
-                priority=PRIORITY_HUMAN,
-                msg_dict=_msg("env_2", sent_at=200),
-                channel_meta=_channel_meta(),
-            )
-            resume_first.set()
-            await asyncio.wait_for(second_done.wait(), timeout=2.0)
+            await asyncio.wait_for(retry_done.wait(), timeout=2.0)
         finally:
             task.cancel()
             try:
@@ -808,19 +800,26 @@ async def test_api_error_preserves_mid_dispatch_arrivals():
     finally:
         mod.random.uniform = original_uniform  # type: ignore[assignment]
 
-    # The retry should include both env_1 (the failed batch) and
-    # env_2 (the mid-dispatch arrival). Without the fix, env_2 was
-    # clobbered by ``entry.messages = batch`` and dropped silently.
-    assert batches[0] == ["env_1"]
-    assert batches[1] == ["env_1", "env_2"]
+    # One main dispatch + one kick retry. The kick gets the
+    # original batch as fallback (so the adapter has something to
+    # send if --resume failed), but the consumer never re-enqueued
+    # the batch through the main on_message_batch path.
+    assert dispatched == [["env_1"]]
+    assert retry_batches == [["env_1"]]
+    # Cursor advanced after successful kick so a redelivered env_1
+    # via /messages/pending after a restart won't re-trigger.
+    assert await store.get_last_processed_sent_at("env_root") == 100
     await store.close()
 
 
 @pytest.mark.asyncio
-async def test_api_error_requeues_same_batch_preserves_cursor():
-    """``AgentAPIError`` re-enqueues the same batch without advancing
-    the durable cursor. The next pop must see the same messages."""
+async def test_api_error_kick_retries_capped():
+    """If the kick itself keeps raising AgentAPIError, the consumer
+    gives up after ``MAX_API_ERROR_RETRIES`` attempts. The failed
+    batch is abandoned (cursor stays at 0) so the agent can pick
+    those envelopes up via tools the next time it runs."""
     from puffo_agent.agent.core import AgentAPIError
+    from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
 
     store = await _make_store()
     client = _make_client_for_queue(store)
@@ -831,61 +830,50 @@ async def test_api_error_requeues_same_batch_preserves_cursor():
         msg_dict=_msg("env_1", sent_at=100),
         channel_meta=_channel_meta(),
     )
-    await client._admit_thread_message(
-        root_id="env_root",
-        priority=PRIORITY_HUMAN,
-        msg_dict=_msg("env_2", sent_at=200),
-        channel_meta=_channel_meta(),
-    )
 
-    call_count = 0
-    seen_batches: list[list[dict]] = []
+    main_calls = 0
+    retry_calls = 0
 
-    async def callback(root_id, batch, channel_meta):
-        nonlocal call_count
-        seen_batches.append(list(batch))
-        call_count += 1
-        if call_count == 1:
-            raise AgentAPIError("provider 429")
-        # second call: success, stop consumer
-        raise asyncio.CancelledError()
+    async def on_message_batch(root_id, batch, channel_meta):
+        nonlocal main_calls
+        main_calls += 1
+        raise AgentAPIError("provider 429")
 
-    # Patch the sleep so we don't wait 15-45s in tests.
+    async def on_retry(root_id, batch, channel_meta):
+        nonlocal retry_calls
+        retry_calls += 1
+        raise AgentAPIError("still rate limited")
+
     import puffo_agent.agent.puffo_core_client as mod
-    original_sleep = mod.asyncio.sleep
-    sleeps: list[float] = []
+    original_uniform = mod.random.uniform
 
-    async def fake_sleep(seconds):
-        sleeps.append(seconds)
-        return None
+    def fake_uniform(a, b):
+        return 0.0 if (a, b) in ((0.0, 1.5), (15.0, 45.0)) else original_uniform(a, b)
 
-    mod.asyncio.sleep = fake_sleep  # type: ignore[assignment]
+    mod.random.uniform = fake_uniform  # type: ignore[assignment]
     try:
-        task = asyncio.create_task(client._consume_queue(callback))
+        task = asyncio.create_task(
+            client._consume_queue(on_message_batch, on_retry),
+        )
         try:
-            await asyncio.wait_for(task, timeout=2.0)
-        except asyncio.CancelledError:
-            pass
-        except asyncio.TimeoutError:
+            # Loop should exit after the main dispatch + cap retries,
+            # then block on queue.get for the next thread. Cancel
+            # after a short window.
+            await asyncio.sleep(0.2)
+        finally:
             task.cancel()
             try:
                 await task
             except (asyncio.CancelledError, Exception):
                 pass
     finally:
-        mod.asyncio.sleep = original_sleep  # type: ignore[assignment]
+        mod.random.uniform = original_uniform  # type: ignore[assignment]
 
-    assert call_count == 2
-    # Both invocations saw the same batch (cursor preserved).
-    assert [m["envelope_id"] for m in seen_batches[0]] == ["env_1", "env_2"]
-    assert [m["envelope_id"] for m in seen_batches[1]] == ["env_1", "env_2"]
-    # We slept for the back-off between the two attempts.
-    assert any(s > 0 for s in sleeps)
-    # Cursor was NOT advanced for the failing turn but IS advanced
-    # for the successful one (the second call was cancelled before
-    # mark_thread_processed ran, so cursor stays at 0). Acceptable —
-    # the second attempt's failure-mode (CancelledError) is an
-    # artificial stop signal in this test, not a real success path.
+    assert main_calls == 1
+    assert retry_calls == PuffoCoreMessageClient.MAX_API_ERROR_RETRIES
+    # Cursor NOT advanced — the failed batch wasn't successfully
+    # processed by the agent.
+    assert await store.get_last_processed_sent_at("env_root") == 0
     await store.close()
 
 

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -257,6 +257,53 @@ async def test_admit_second_same_priority_coalesces_no_new_heap_tuple():
 
 
 @pytest.mark.asyncio
+async def test_admit_dedups_same_envelope_id_within_batch():
+    """Server-side pending-message redelivery (or a WS reconnect) can
+    push the same wire envelope at us twice while the previous batch
+    is still in-flight. The in-memory batch must NOT stack duplicates
+    — the agent should see each envelope_id at most once per dispatch.
+    """
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_1"),
+        channel_meta=_channel_meta(),
+    )
+    # Second arrival is a true new envelope on the same thread.
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_2"),
+        channel_meta=_channel_meta(),
+    )
+    qsize_before = client._queue.qsize()
+    # Now the wire redelivers env_2 twice more — same envelope_id,
+    # same content. These must be dropped.
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_2"),
+        channel_meta=_channel_meta(),
+    )
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=_msg("env_2"),
+        channel_meta=_channel_meta(),
+    )
+
+    entry = client._thread_state["env_root"]
+    assert [m["envelope_id"] for m in entry.messages] == ["env_1", "env_2"]
+    # No spurious heap tuples either — dedup short-circuits before
+    # the priority-bump branch.
+    assert client._queue.qsize() == qsize_before
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_admit_lower_priority_arrival_does_not_replace_slot():
     """Higher priority = lower numeric value. A LATER arrival with a
     LOWER priority (larger numeric) joins the batch but doesn't push


### PR DESCRIPTION
Rolls up everything on `feat/thread-batched-queue` (17 commits). Originally just the thread-batched queue refactor; grew to cover several rate-limit and dedup bugs the team hit while testing, plus an MCP read-path restructure agents asked for. All 438 tests pass.

## Headline changes

### Thread-batched message processing
The `asyncio.PriorityQueue` is now keyed on `root_id` (the thread root envelope id, or the message itself for top-level posts). Arrivals on the same thread coalesce into one `_ThreadEntry`; the consumer pops a root and drains the whole batch in a single `on_message_batch` dispatch. The agent decides on its own who to reply to — no trigger-message concept.

Persistence: a new `thread_processing_state(root_id PK, last_processed_sent_at)` sqlite table records the high-water mark per thread. On every arrival the listen handler drops messages whose `sent_at` is ≤ the stored cursor, so server-side pending-message redelivery after a daemon restart can't replay a thread the agent already handled.

### Pre-dispatch jitter (0.0–1.5s)
When multiple agents on one host get activated by a single broadcast message they used to fire into the claude-code API simultaneously and trip its rate limit. Each agent now picks an independent random delay before dispatch — no host-wide coordination needed.

### Status telemetry: `/processing/end:batch`
First message in a batch still gets a single `/processing/start` (yellow dot on the trigger), but the per-message `/end` fan-out is replaced by one `/messages/processing/end:batch` call that flips every message in the batch to green at once. Requires the server endpoint added in [puffo-server#46](https://github.com/puffo-ai/puffo-server/pull/46), deployed 2026-05-11.

### `AgentAPIError` kick-retry (preserves `--resume`)
Rate-limit retries used to re-enqueue the same batch, which re-appended the original user input to claude-code's `--resume`'d transcript on every attempt — agents saw `msg_X ×4` for 4 retry attempts. New behaviour: keep `--resume`, send a small kick `"[puffo-agent system message] session errored on rate limiting, please resume processing."` instead of re-sending the payload. The cli adapter falls back to the full payload only when `_ResumeFailed` was caught and a fresh session got spawned. Capped at 3 retries per batch; on exhaustion the cursor stays put so the agent can pick the failed envelopes up via `get_channel_history` on its next normal turn.

### MCP read-path restructure
- `mcp__puffo__get_channel_history` now returns **root posts only** with a `(N replies)` annotation per thread instead of inlining every reply. One busy thread no longer drowns out the rest of the channel.
- New `mcp__puffo__get_thread_history(root_id, …)` tool for thread drill-down.
- Both accept `since=<envelope_id>` / `before=<ms>` / `after=<ms>` filters for incremental polling.
- Both distinguish unknown channel/thread (404 → `"(no such channel: …)"` / `"(no such thread: …)"`) from window-empty-after-filters (200 + `[]` → `"(no … in the requested window)"`).

### Dedup hardening (8 layers of belt-and-suspenders)
While testing the thread-batched queue the team kept reporting "msg_X ×N" patterns. Each had a different root cause; all are now closed:

1. **Same-batch dedup** — `_admit_thread_message` drops appends whose `envelope_id` is already in the pending `entry.messages` (fixes WS redelivery during catchup window).
2. **Cross-batch dedup via `dispatching_ids`** — once the consumer claims a batch, the envelope_ids it's currently sending to the agent are in `entry.dispatching_ids`; duplicates arriving mid-dispatch fail the admit at the top before reopen branch can put them into a "next batch".
3. **Consumer-side safety net** — final dedup pass on `batch` immediately before `on_message_batch` invokes the agent, with a warning log if anything is dropped. Hard guarantee that the agent never sees the same envelope twice in one turn.
4. **AgentAPIError mid-flight preservation** — the retry handler used to clobber mid-flight admits via `entry.messages = batch`. Now dedupe-prepends `batch` so the retry includes both the failed messages AND any new arrivals.
5. **Kick-retry** — replaces re-enqueue of the payload (see above). Stops the "same envelope ×N retries" pattern claude-code's `--resume` transcript showed.

### cli-docker stale-mount auto-recovery
After a `pip uninstall` + `pip install -e <new-path>` the bind mount source for `/opt/puffoagent-pkg` baked in at `docker run` time becomes stale. `python3 -m puffo_agent.mcp.puffo_core_server` then fails with `ModuleNotFoundError` and every puffo MCP tool surfaces as `"No such tool available"`. The reused-container branch now probes `docker exec test -f /opt/puffoagent-pkg/puffo_agent/__init__.py`; mismatch → `docker rm -f` and recreate so the current host path is bound in.

### cli-local trust-dialog bypass
claude-code's per-project trust dialog can't be accepted under `--input-format stream-json` (no TUI surface). Switched the `bypassPermissions` permission-mode to emit `--dangerously-skip-permissions` instead of `--permission-mode bypassPermissions`, matching what cli-docker already did. Without this every cli-local agent silently dropped its `--mcp-config` MCP servers.

## API surface added

- `Worker.on_message_batch(root_id, batch, channel_meta)` replaces the old per-message dispatch.
- `PuffoCoreMessageClient.listen(on_message, on_api_error_retry=…)` second callback for the kick-retry path.
- `Adapter.run_retry_turn(kick_text, fallback_user_message, ctx)` — cli adapters delegate to a new `ClaudeSession.run_retry_turn`; SDK / chat-only fall back to running `run_turn` against the payload.
- `PuffoAgent.handle_api_error_retry(root_id, channel_meta, fallback_batch)`.
- `MessageStore.get_channel_roots` / `get_thread_messages` / `channel_exists` plus a `ChannelRoot` dataclass.
- `DataClient.get_channel_roots` / `get_thread_messages` with `DataNotFound` re-exported from `MessageStore`.
- Data-service routes: `GET /v1/data/{agent_id}/channels/roots`, `GET /v1/data/{agent_id}/threads/{root_id}`.

## Test plan

- [x] `pytest tests/` — 438 passed, 5 skipped (host-dependent symlink + permission-proxy tests).
- [x] New tests cover: every admit path + the safety net dedup; AgentAPIError kick-retry success + retry cap; cli-local `--dangerously-skip-permissions` ordering; status reporter `end_turn_batch`; `get_channel_roots` reply counts + `since` resolution + `before`/`after` bounds; `get_thread_messages` similar; MCP-tool unknown channel/thread vs empty-window messages.
- [x] Manual end-to-end on 6 live agents (abb, agtab, agt-1243, agt-2773, agt-3810, d2d2): batched ingestion, jittered dispatch, kick-retry path on real rate-limit hits, MCP `get_channel_history` returning root-only output. Two `reload.flag` waves rolled out the new CLAUDE.md sections (system-message prefix + new tool docs).
- [ ] Final manual smoke after merge: `pip install --user -e .` from main, `puffo-agent stop && puffo-agent start`, send a message to one agent in a thread and one in a fresh channel.

## Server submodule

The status-batch wiring needs puffo-server's `POST /messages/processing/end:batch` endpoint. That's merged + deployed (puffo-server#46) and the submodule pointer is bumped in puffo-core-han-group#74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)