### PR TITLE
fix(mcp): pin PYTHONUSERBASE so cli-local MCP can import mcp under per-agent HOME (v0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.4] — 2026-05-12
+
+### Fixed
+
+- cli-local: MCP server was crashing on agent startup with
+  `ModuleNotFoundError: No module named 'mcp'` on macOS / Linux
+  installs where `mcp` lives in real-user user-site (e.g. installed
+  via `pip install --user` or as a transitive dep of `pip install
+  -e .`). The adapter rewrites `HOME` (and `USERPROFILE`) on the
+  claude subprocess so each agent has its own `~/.claude`; the MCP
+  subprocess claude spawns inherited that HOME, and Python computed
+  user-site relative to it (`<per-agent-home>/Library/Python/...`),
+  landing on an empty per-agent directory. Result: every
+  `mcp__puffo__*` tool went missing and the agent fell back to
+  plain-text replies. Now `puffo_core_mcp_env` injects
+  `PYTHONUSERBASE` pointing at the daemon's real user base
+  (captured via `site.getuserbase()` at module load time, before
+  any HOME mutation), which the spawned MCP subprocess uses to
+  resolve user-site independent of HOME — `.pth` files processed,
+  editable installs honoured. cli-docker is excluded (container
+  has its own Python tree with deps baked in, so a host path would
+  be meaningless inside it); Windows is unaffected in practice
+  because Windows user-site reads `APPDATA`, not `HOME`, but the
+  `PYTHONUSERBASE` injection is harmless there.
+
 ## [0.7.3] — 2026-05-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.7.3"
+version = "0.7.4"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -13,6 +13,7 @@ that form.
 from __future__ import annotations
 
 import json
+import site
 import sys
 from pathlib import Path
 
@@ -86,6 +87,43 @@ def default_python_executable() -> str:
     return sys.executable or "python3"
 
 
+# cli-local adapter overrides ``HOME`` (and ``USERPROFILE``) on the
+# claude subprocess so each agent has its own ``~/.claude``. The
+# MCP server claude spawns inherits that HOME, which makes Python's
+# user-site path resolve to ``<per-agent-home>/Library/Python/...``
+# (macOS) / ``<per-agent-home>/AppData/...`` (Windows) — a directory
+# that doesn't exist on disk. Result: ``import mcp`` (installed in
+# the real user's user-site) raises ModuleNotFoundError, the MCP
+# server exits, and the agent loses every ``mcp__puffo__*`` tool.
+#
+# ``PYTHONUSERBASE`` overrides where Python computes user-site from,
+# independent of HOME. By snapshotting ``site.getuserbase()`` while
+# we're in the daemon process (real HOME) and forwarding it via the
+# MCP env, the spawned subprocess locates the same user-site the
+# daemon does — ``.pth`` files included, so editable installs of
+# ``puffo_agent`` keep working too.
+_REAL_USER_BASE = site.getuserbase()
+
+
+def _python_user_base_env(runtime_kind: str) -> dict[str, str]:
+    """Env additions that pin ``PYTHONUSERBASE`` so subprocesses with
+    a per-agent HOME still resolve user-site to the daemon's real
+    base. Returns an empty dict if ``site.getuserbase()`` produced
+    nothing usable (defensive — shouldn't happen on supported
+    platforms, but failing silent beats taking the MCP down).
+
+    ``cli-docker`` is excluded: the MCP runs inside a container with
+    its own Python install and baked-in deps, so the host's user-base
+    path is meaningless there (a non-existent dir Python would just
+    skip). Forwarding a host-relative path into the container env is
+    semantically wrong even if harmless, so we keep the env clean."""
+    if runtime_kind == "cli-docker":
+        return {}
+    if not _REAL_USER_BASE:
+        return {}
+    return {"PYTHONUSERBASE": _REAL_USER_BASE}
+
+
 # ── puffo-core config builders ────────────────────────────────────
 
 
@@ -117,6 +155,12 @@ def puffo_core_mcp_env(
         "PUFFO_CORE_KEYSTORE_DIR": keystore_dir,
         "PUFFO_WORKSPACE": workspace,
         "PUFFO_DATA_SERVICE_URL": data_service_url,
+        # See ``_python_user_base_env`` — pins user-site to the
+        # daemon's real base so the per-agent HOME override the
+        # cli-local adapter applies doesn't hide ``mcp`` from the
+        # spawned MCP subprocess. Skipped for cli-docker where the
+        # container has its own Python tree.
+        **_python_user_base_env(runtime_kind),
     }
     if agent_id:
         env["PUFFO_AGENT_ID"] = agent_id

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -144,6 +144,39 @@ def test_puffo_core_mcp_env_optional_fields():
     assert "PUFFO_AGENT_ID" not in env
 
 
+def test_puffo_core_mcp_env_pins_python_user_base():
+    """cli-local rewrites HOME on the claude subprocess, which
+    would move Python's user-site to an empty per-agent path and
+    hide ``mcp`` from the MCP subprocess. ``PYTHONUSERBASE`` pins
+    user-site to the daemon's real base regardless of HOME."""
+    import site
+    env = puffo_core_mcp_env(
+        slug="bot-0001",
+        device_id="dev_1",
+        server_url="http://localhost:3000",
+        keystore_dir="/tmp/keys",
+        workspace="/workspace",
+        runtime_kind="cli-local",
+    )
+    assert env["PYTHONUSERBASE"] == site.getuserbase()
+
+
+def test_puffo_core_mcp_env_skips_python_user_base_for_docker():
+    """The container has its own Python install with baked-in deps,
+    so the host's user-base path is meaningless inside it. We
+    deliberately don't forward ``PYTHONUSERBASE`` into the docker
+    env block to keep the contract semantically clean."""
+    env = puffo_core_mcp_env(
+        slug="bot-0001",
+        device_id="dev_1",
+        server_url="http://localhost:3000",
+        keystore_dir="/tmp/keys",
+        workspace="/workspace",
+        runtime_kind="cli-docker",
+    )
+    assert "PYTHONUSERBASE" not in env
+
+
 def test_puffo_core_stdio_sdk_config():
     cfg = puffo_core_stdio_sdk_config(
         python="/usr/bin/python3",


### PR DESCRIPTION
## Summary

- Fixes `ModuleNotFoundError: No module named 'mcp'` in the cli-local MCP server on macOS / Linux. Root cause: the adapter rewrites `HOME` (and `USERPROFILE`) on the claude subprocess so each agent has its own `~/.claude`; the MCP subprocess claude spawns inherits that HOME and Python recomputes user-site relative to it, landing on an empty `<per-agent-home>/Library/Python/.../site-packages` instead of the real user-site where `mcp` lives.
- Diagnosed externally on a macOS install (`puffo_agent` was editable-installed → loaded via absolute-path `.pth` so it survived; `mcp` was in real user-site so it broke).
- Fix: snapshot `site.getuserbase()` at module load (daemon-side, real HOME) and inject it as `PYTHONUSERBASE` in the MCP env block. Python honours `PYTHONUSERBASE` over HOME-derived paths, so the spawned subprocess resolves user-site to the daemon's real base — `.pth` files processed, editable installs honoured.
- `cli-docker` deliberately excluded (container has its own Python tree, host paths are meaningless inside).
- Windows unaffected in practice (Windows user-site reads `APPDATA`, not `HOME` — the adapter doesn't touch `APPDATA`), but injection is harmless there too.
- Bump to 0.7.4.

## Test plan

- [x] `pytest tests/` on Windows: 439 passed, 5 skipped (unchanged).
- [x] New test `test_puffo_core_mcp_env_pins_python_user_base` (cli-local injects).
- [x] New test `test_puffo_core_mcp_env_skips_python_user_base_for_docker` (cli-docker skips).
- [ ] Manual: macOS, create a fresh agent → daemon restart → confirm MCP log no longer shows `ModuleNotFoundError: No module named 'mcp'` and `mcp__puffo__send_message` is available in the agent's tool list.
- [ ] Manual: Windows, cli-local + cli-docker both still spawn correctly with v0.7.4 installed (no regression on the platform that wasn't broken).
- [ ] Manual: macOS cli-docker still works — container env should NOT contain `PYTHONUSERBASE` (the host's user-base path would be nonexistent inside the container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)