### PR TITLE
feat(agent): auto self-introduction after accepting a channel invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Auto self-introduction after accepting a channel invite. When the
-  agent accepts an ``invite_to_channel`` (whether auto-accepted from
-  the operator or accepted via the operator's ``y`` DM reply), the
+- Auto self-introduction after accepting an invite. When the agent
+  accepts an ``invite_to_channel`` (whether auto-accepted from the
+  operator or accepted via the operator's ``y`` DM reply), the
   daemon enqueues a synthetic ``[puffo-agent system message]``
-  envelope on the new channel asking the agent to post a short intro
-  (default English, 2-3 sentences) using its normal
-  ``mcp__puffo__send_message`` path. Existing personality from
+  envelope on the invited channel asking the agent to post a short
+  intro (default English, 2-3 sentences) via its normal
+  ``mcp__puffo__send_message`` path. For ``invite_to_space``, the
+  daemon locates the space's auto-General channel (the
+  ``create_channel`` event with ``is_public=true``) and fires the
+  same nudge there — the agent gets auto-fanned-out membership on
+  General when accepting a space invite, so that's the one channel
+  it can immediately post into. Existing personality from
   ``profile.md`` shapes the wording. A new sqlite table
   ``channel_intro_prompted(channel_id PK, prompted_at)`` (per-agent
   ``messages.db``) gates the nudge so a daemon restart or a
-  server-side invite redelivery can't fire a second intro. Space-only
-  invites and public channels the agent gains via space-membership
-  fan-out are intentionally not nudged — the trigger is specifically
-  the channel-level invite accept.
+  server-side invite redelivery can't fire a second intro.
 
 ## [0.7.4] — 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,45 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Auto self-introduction after accepting an invite. When the agent
-  accepts an ``invite_to_channel`` (whether auto-accepted from the
-  operator or accepted via the operator's ``y`` DM reply), the
-  daemon enqueues a synthetic ``[puffo-agent system message]``
+  accepts an ``invite_to_channel`` (auto-accepted from an operator-
+  matched signer, or accepted via the operator's ``y`` DM reply),
+  the daemon enqueues a synthetic ``[puffo-agent system message]``
   envelope on the invited channel asking the agent to post a short
   intro (default English, 2-3 sentences) via its normal
   ``mcp__puffo__send_message`` path. For ``invite_to_space``, the
-  daemon locates the space's auto-General channel (the
-  ``create_channel`` event with ``is_public=true``) and fires the
-  same nudge there — the agent gets auto-fanned-out membership on
-  General when accepting a space invite, so that's the one channel
-  it can immediately post into. Existing personality from
-  ``profile.md`` shapes the wording. A new sqlite table
-  ``channel_intro_prompted(channel_id PK, prompted_at)`` (per-agent
-  ``messages.db``) gates the nudge so a daemon restart or a
-  server-side invite redelivery can't fire a second intro.
+  daemon resolves the space's auto-General channel via ``GET
+  /spaces/<id>/channels`` (the row with ``is_public=true``) and
+  fires the same nudge there — General is the one channel the agent
+  gets auto-fanned-out membership on when accepting a space invite,
+  so it's the only channel it can immediately post into. Existing
+  ``profile.md`` personality shapes the wording.
+
+  Wiring:
+  * New sqlite table ``channel_intro_prompted(channel_id PK,
+    prompted_at)`` on the per-agent ``messages.db`` gates the nudge
+    so a daemon restart or server-side invite redelivery can't fire
+    a second intro on the same channel.
+  * New sqlite table ``channel_space_map(channel_id PK, space_id,
+    learned_at)`` records the channel→space mapping discovered
+    out-of-band by the General lookup. ``lookup_channel_space``
+    (used by the MCP ``send_message`` tool) checks this map first,
+    then falls back to the historical ``messages``-table inference.
+    Without this, the agent's first send into the freshly-joined
+    channel would 404 the data-service lookup (no prior messages on
+    that channel) and fall back to ``agent.yml``'s configured
+    ``space_id`` — the WRONG space when the agent has just joined
+    a different one.
+  * General lookup retries on a sleep-first schedule
+    (0.5 / 1 / 3 / 6 / 12 / 24 / 24 seconds, ~70s total) because
+    the server has a tight race between the ``accept_space_invite``
+    POST returning and the ``channel_memberships`` row that gates
+    ``GET /spaces/<id>/channels`` being committed. Past ~70s the
+    daemon gives up silently — missing the intro is preferable to
+    spinning forever.
+  * ``_channel_name_cache`` is warmed from the same ``/channels``
+    response so the ``_resolve_channel_name`` call inside the
+    nudge becomes a cache hit instead of a duplicate HTTP round-
+    trip.
 
 ## [0.7.4] — 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Auto self-introduction after accepting a channel invite. When the
+  agent accepts an ``invite_to_channel`` (whether auto-accepted from
+  the operator or accepted via the operator's ``y`` DM reply), the
+  daemon enqueues a synthetic ``[puffo-agent system message]``
+  envelope on the new channel asking the agent to post a short intro
+  (default English, 2-3 sentences) using its normal
+  ``mcp__puffo__send_message`` path. Existing personality from
+  ``profile.md`` shapes the wording. A new sqlite table
+  ``channel_intro_prompted(channel_id PK, prompted_at)`` (per-agent
+  ``messages.db``) gates the nudge so a daemon restart or a
+  server-side invite redelivery can't fire a second intro. Space-only
+  invites and public channels the agent gains via space-membership
+  fan-out are intentionally not nudged — the trigger is specifically
+  the channel-level invite accept.
+
 ## [0.7.4] — 2026-05-12
 
 ### Fixed

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -396,16 +396,16 @@ class PuffoAgent:
         ts_iso = _ms_to_iso(create_at)
         if ts_iso:
             lines.append(f"- timestamp: {ts_iso}")
-        # Render display_name in parens when present so the LLM has a
-        # human-readable handle to address peers with; the slug stays
-        # as the structural identifier for @-mention and send_message
-        # routing. Falls back to bare ``- sender: <slug>`` when the
-        # server didn't return a display_name.
-        suffix = (
-            f" ({sender_display_name})" if sender_display_name
-            else (f" <{sender_email}>" if sender_email else "")
-        )
-        lines.append(f"- sender: {sender}{suffix}")
+        # ``sender`` is the human-readable name the LLM should use
+        # when addressing this person in prose; ``sender_slug`` is
+        # the structural identifier (always required for @-mentions
+        # and send_message routing). When the server has no
+        # display_name on file, ``sender`` falls back to the slug so
+        # the field is always populated — no parsing branch in the
+        # agent prompt.
+        display = sender_display_name or sender
+        lines.append(f"- sender: {display}")
+        lines.append(f"- sender_slug: {sender}")
         lines.append(f"- sender_type: {'bot' if sender_is_bot else 'human'}")
         if mentions:
             lines.append("- mentions:")

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -142,6 +142,7 @@ class PuffoAgent:
                 followups=None,
                 space_id=channel_meta.get("space_id", ""),
                 space_name=channel_meta.get("space_name", ""),
+                sender_display_name=msg.get("sender_display_name", ""),
             )
         # Route logging uses the LAST sender in the batch as the
         # display "trigger" for log lines — purely cosmetic, the
@@ -197,6 +198,7 @@ class PuffoAgent:
                 create_at=msg.get("sent_at", 0),
                 space_id=channel_meta.get("space_id", ""),
                 space_name=channel_meta.get("space_name", ""),
+                sender_display_name=msg.get("sender_display_name", ""),
             ))
         fallback_text = "\n\n".join(fallback_chunks)
 
@@ -331,6 +333,7 @@ class PuffoAgent:
         followups: list[dict] | None = None,
         space_id: str = "",
         space_name: str = "",
+        sender_display_name: str = "",
     ):
         content = self._format_user_block(
             channel_name=channel_name,
@@ -347,6 +350,7 @@ class PuffoAgent:
             followups=followups,
             space_id=space_id,
             space_name=space_name,
+            sender_display_name=sender_display_name,
         )
         self.log.append({"role": "user", "content": content})
         self._truncate_log()
@@ -368,6 +372,7 @@ class PuffoAgent:
         followups: list[dict] | None = None,
         space_id: str = "",
         space_name: str = "",
+        sender_display_name: str = "",
     ) -> str:
         # Structured markdown block keeps context metadata distinct
         # from message content, preventing the LLM from echoing
@@ -391,9 +396,16 @@ class PuffoAgent:
         ts_iso = _ms_to_iso(create_at)
         if ts_iso:
             lines.append(f"- timestamp: {ts_iso}")
-        lines.append(
-            f"- sender: {sender}" + (f" ({sender_email})" if sender_email else "")
+        # Render display_name in parens when present so the LLM has a
+        # human-readable handle to address peers with; the slug stays
+        # as the structural identifier for @-mention and send_message
+        # routing. Falls back to bare ``- sender: <slug>`` when the
+        # server didn't return a display_name.
+        suffix = (
+            f" ({sender_display_name})" if sender_display_name
+            else (f" <{sender_email}>" if sender_email else "")
         )
+        lines.append(f"- sender: {sender}{suffix}")
         lines.append(f"- sender_type: {'bot' if sender_is_bot else 'human'}")
         if mentions:
             lines.append("- mentions:")

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -45,6 +45,14 @@ CREATE TABLE IF NOT EXISTS thread_processing_state (
     root_id TEXT PRIMARY KEY,
     last_processed_sent_at INTEGER NOT NULL
 );
+
+-- One row per channel the agent has been auto-prompted to introduce
+-- itself in. Gate set in ``_accept_invite`` so a daemon restart (or a
+-- server-side invite redelivery) can't trigger a second intro.
+CREATE TABLE IF NOT EXISTS channel_intro_prompted (
+    channel_id TEXT PRIMARY KEY,
+    prompted_at INTEGER NOT NULL
+);
 """
 
 
@@ -467,6 +475,34 @@ class MessageStore:
                    excluded.last_processed_sent_at
                  )""",
             (root_id, sent_at),
+        )
+        await db.commit()
+
+    async def has_channel_intro_been_prompted(self, channel_id: str) -> bool:
+        """True iff the agent already had a self-introduction prompted
+        for ``channel_id``. Used by ``_accept_invite`` to gate the
+        synthetic system-message enqueue so a restart-time replay of
+        the same pending invite doesn't fire a second intro."""
+        if not channel_id:
+            return False
+        db = await self._ensure_db()
+        async with db.execute(
+            "SELECT 1 FROM channel_intro_prompted WHERE channel_id = ?",
+            (channel_id,),
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
+    async def mark_channel_intro_prompted(self, channel_id: str) -> None:
+        """Record that an intro nudge has been enqueued for
+        ``channel_id``. Idempotent."""
+        if not channel_id:
+            return
+        db = await self._ensure_db()
+        await db.execute(
+            """INSERT INTO channel_intro_prompted (channel_id, prompted_at)
+               VALUES (?, ?)
+               ON CONFLICT(channel_id) DO NOTHING""",
+            (channel_id, _now_ms()),
         )
         await db.commit()
 

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -53,6 +53,23 @@ CREATE TABLE IF NOT EXISTS channel_intro_prompted (
     channel_id TEXT PRIMARY KEY,
     prompted_at INTEGER NOT NULL
 );
+
+-- Out-of-band channel→space mappings discovered without an inbound
+-- message. The /messages table inference is enough for channels the
+-- agent has received traffic from, but the intro-nudge path needs
+-- the mapping BEFORE the first real message — agent calls
+-- send_message against the freshly-joined channel, MCP asks
+-- lookup_channel_space, and without this table the daemon-side
+-- query returns 404 → MCP falls back to agent.yml's home space,
+-- which is the wrong space when the agent is now multi-space.
+-- Populated by ``_find_public_general_channel`` (and any future
+-- channel-discovery hook). ``lookup_channel_space`` checks this
+-- table first before the /messages fallback.
+CREATE TABLE IF NOT EXISTS channel_space_map (
+    channel_id TEXT PRIMARY KEY,
+    space_id TEXT NOT NULL,
+    learned_at INTEGER NOT NULL
+);
 """
 
 
@@ -194,14 +211,34 @@ class MessageStore:
             return await cursor.fetchone() is not None
 
     async def lookup_channel_space(self, channel_id: str) -> str | None:
-        """Return the ``space_id`` last seen for ``channel_id``, or
-        ``None`` when no message from that channel has been stored.
-        Used by the MCP subprocess (which can't read the daemon's
-        in-memory ``_channel_space`` map) as a cross-space fallback.
+        """Return the ``space_id`` known for ``channel_id``, or
+        ``None`` when neither the explicit map nor any prior message
+        gives one. Used by the MCP subprocess (which can't read the
+        daemon's in-memory ``_channel_space`` map) as a cross-space
+        fallback.
+
+        Two-source lookup, in order:
+
+        1. ``channel_space_map`` — explicit mappings recorded by
+           out-of-band discovery (``_find_public_general_channel`` and
+           friends). Lets send_message resolve a channel BEFORE the
+           first inbound message lands on it — the case the intro
+           nudge needs.
+        2. ``messages`` — last ``space_id`` seen on an envelope in
+           that channel. Steady-state fallback that doesn't need
+           explicit bookkeeping; works automatically once any message
+           arrives.
         """
         if not channel_id:
             return None
         db = await self._ensure_db()
+        async with db.execute(
+            "SELECT space_id FROM channel_space_map WHERE channel_id = ?",
+            (channel_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is not None and row[0]:
+            return row[0]
         async with db.execute(
             "SELECT space_id FROM messages WHERE channel_id = ? "
             "AND space_id IS NOT NULL AND space_id != '' "
@@ -212,6 +249,24 @@ class MessageStore:
         if row is None:
             return None
         return row[0] if row[0] else None
+
+    async def mark_channel_space(self, channel_id: str, space_id: str) -> None:
+        """Record an explicit channel→space mapping. Called by
+        out-of-band channel-discovery paths (``_find_public_general_channel``)
+        so ``lookup_channel_space`` can resolve the channel before
+        the first inbound message lands."""
+        if not channel_id or not space_id:
+            return
+        db = await self._ensure_db()
+        await db.execute(
+            """INSERT INTO channel_space_map (channel_id, space_id, learned_at)
+               VALUES (?, ?, ?)
+               ON CONFLICT(channel_id) DO UPDATE SET
+                 space_id = excluded.space_id,
+                 learned_at = excluded.learned_at""",
+            (channel_id, space_id, _now_ms()),
+        )
+        await db.commit()
 
     async def get_channel_history(
         self,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1318,16 +1318,16 @@ class PuffoCoreMessageClient:
         # events`` may not be committed yet. The endpoint returns 200
         # + an empty (non-JSON) body for "you're not a member of this
         # space" rather than 403, so ``http.get`` hands us a raw
-        # ``str`` instead of a dict. Retry on a generous schedule
-        # (~70s cumulative); past that give up silently — missing
-        # the intro is preferable to spinning forever.
+        # ``str`` instead of a dict. Always sleep before the first
+        # attempt — even a fast server can't commit that quickly —
+        # then back off across ~70s total; past that give up
+        # silently rather than spinning forever.
         retry_delays = (0.5, 1.0, 3.0, 6.0, 12.0, 24.0, 24.0)
-        cursor: str | None = None
-        prev_cursor: str | None = None
         found_cid = ""
-        for attempt_idx in range(len(retry_delays) + 1):
-            cursor = None
-            prev_cursor = None
+        for attempt_idx, delay in enumerate(retry_delays):
+            await asyncio.sleep(delay)
+            cursor: str | None = None
+            prev_cursor: str | None = None
             replay_ok = True
             while True:
                 path = f"/spaces/{space_id}/events"
@@ -1340,7 +1340,7 @@ class PuffoCoreMessageClient:
                         "(attempt %d/%d, body=%r) — retrying",
                         space_id,
                         attempt_idx + 1,
-                        len(retry_delays) + 1,
+                        len(retry_delays),
                         page,
                     )
                     replay_ok = False
@@ -1363,12 +1363,10 @@ class PuffoCoreMessageClient:
                     break
             if replay_ok:
                 return found_cid
-            if attempt_idx < len(retry_delays):
-                await asyncio.sleep(retry_delays[attempt_idx])
         logger.warning(
             "gave up looking up General channel for space=%s after %d "
             "attempts — intro nudge will be skipped",
-            space_id, len(retry_delays) + 1,
+            space_id, len(retry_delays),
         )
         return ""
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1259,25 +1259,77 @@ class PuffoCoreMessageClient:
             {"space_id": space_id, "events": [signed]},
         )
 
-        # Channel invites trigger a one-shot self-introduction nudge:
-        # we enqueue a synthetic ``[puffo-agent system message]`` so the
-        # agent posts a short intro in the channel using its existing
-        # ``send_message`` MCP tool. Space-only invites are skipped
-        # (the agent isn't actually in any specific channel yet) and
-        # so are channels we've already prompted (server-side invite
-        # redelivery / daemon restart guard via sqlite).
+        # Accepting an invite triggers a one-shot self-introduction
+        # nudge: we enqueue a synthetic ``[puffo-agent system message]``
+        # so the agent posts a short intro using its existing
+        # ``send_message`` MCP tool. Channel invites intro into the
+        # invited channel; space invites intro into the space's public
+        # ``General`` channel (the only channel an accepting member is
+        # auto-fanned-out into per puffo-server's space-invite redeem
+        # logic — any other channel needs its own invite_to_channel).
+        intro_channel_id = ""
         if kind == "invite_to_channel" and channel_id:
+            intro_channel_id = channel_id
+        elif kind == "invite_to_space":
+            try:
+                intro_channel_id = await self._find_public_general_channel(
+                    space_id,
+                )
+            except Exception:
+                logger.exception(
+                    "failed to look up General channel for intro nudge "
+                    "(space=%s)", space_id,
+                )
+        if intro_channel_id:
             try:
                 await self._enqueue_channel_intro_nudge(
                     space_id=space_id,
-                    channel_id=channel_id,
+                    channel_id=intro_channel_id,
                 )
             except Exception:
                 # Intro is best-effort; never block the accept.
                 logger.exception(
                     "failed to enqueue channel intro nudge "
-                    "(space=%s channel=%s)", space_id, channel_id,
+                    "(space=%s channel=%s)", space_id, intro_channel_id,
                 )
+
+    async def _find_public_general_channel(self, space_id: str) -> str:
+        """Return the ``channel_id`` of the space's auto-created public
+        General channel (CreateChannel event with ``is_public=true``),
+        or ``""`` if none exists. Used after accepting a space invite
+        to pick the one channel the agent now has auto-fanned-out
+        membership in.
+
+        Replays ``/spaces/<id>/events`` because puffo-server has no
+        dedicated channels-list endpoint — same pattern as the
+        ``list_channels`` MCP tool. Returns the FIRST public channel
+        encountered so a hypothetical future second public channel
+        doesn't double-fire."""
+        if not space_id:
+            return ""
+        cursor: str | None = None
+        prev_cursor: str | None = None
+        while True:
+            path = f"/spaces/{space_id}/events"
+            if cursor:
+                path += f"?since={cursor}"
+            page = await self.http.get(path)
+            for ev in page.get("events") or []:
+                if ev.get("kind") != "create_channel":
+                    continue
+                payload = ev.get("payload") or {}
+                if not payload.get("is_public"):
+                    continue
+                cid = payload.get("channel_id") or ""
+                if cid:
+                    return cid
+            if not page.get("has_more"):
+                break
+            prev_cursor = cursor
+            cursor = page.get("next_cursor")
+            if not cursor or cursor == prev_cursor:
+                break
+        return ""
 
     async def _enqueue_channel_intro_nudge(
         self,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1304,11 +1304,18 @@ class PuffoCoreMessageClient:
         dedicated channels-list endpoint — same pattern as the
         ``list_channels`` MCP tool. Returns the FIRST public channel
         encountered so a hypothetical future second public channel
-        doesn't double-fire."""
+        doesn't double-fire.
+
+        Side effect: while walking, every ``create_channel`` event we
+        pass is folded into ``self._channel_name_cache`` so the
+        immediately-following ``_resolve_channel_name`` inside the
+        intro nudge becomes a cache hit instead of a duplicate
+        events replay."""
         if not space_id:
             return ""
         cursor: str | None = None
         prev_cursor: str | None = None
+        found_cid = ""
         while True:
             path = f"/spaces/{space_id}/events"
             if cursor:
@@ -1318,18 +1325,19 @@ class PuffoCoreMessageClient:
                 if ev.get("kind") != "create_channel":
                     continue
                 payload = ev.get("payload") or {}
-                if not payload.get("is_public"):
-                    continue
                 cid = payload.get("channel_id") or ""
-                if cid:
-                    return cid
-            if not page.get("has_more"):
+                name = (payload.get("name") or "").strip()
+                if cid and cid not in self._channel_name_cache:
+                    self._channel_name_cache[cid] = name or cid
+                if not found_cid and payload.get("is_public") and cid:
+                    found_cid = cid
+            if found_cid or not page.get("has_more"):
                 break
             prev_cursor = cursor
             cursor = page.get("next_cursor")
             if not cursor or cursor == prev_cursor:
                 break
-        return ""
+        return found_cid
 
     async def _enqueue_channel_intro_nudge(
         self,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1318,15 +1318,14 @@ class PuffoCoreMessageClient:
         # events`` may not be committed yet. The endpoint returns 200
         # + an empty (non-JSON) body for "you're not a member of this
         # space" rather than 403, so ``http.get`` hands us a raw
-        # ``str`` instead of a dict. One short retry covers the race;
-        # past that we give up silently — missing the intro nudge is
-        # preferable to logging an error storm.
-        attempts = 3
-        delay = 0.25
+        # ``str`` instead of a dict. Retry on a generous schedule
+        # (~70s cumulative); past that give up silently — missing
+        # the intro is preferable to spinning forever.
+        retry_delays = (0.5, 1.0, 3.0, 6.0, 12.0, 24.0, 24.0)
         cursor: str | None = None
         prev_cursor: str | None = None
         found_cid = ""
-        for attempt in range(attempts):
+        for attempt_idx in range(len(retry_delays) + 1):
             cursor = None
             prev_cursor = None
             replay_ok = True
@@ -1339,7 +1338,10 @@ class PuffoCoreMessageClient:
                     logger.info(
                         "events endpoint not ready for space=%s "
                         "(attempt %d/%d, body=%r) — retrying",
-                        space_id, attempt + 1, attempts, page,
+                        space_id,
+                        attempt_idx + 1,
+                        len(retry_delays) + 1,
+                        page,
                     )
                     replay_ok = False
                     break
@@ -1361,13 +1363,12 @@ class PuffoCoreMessageClient:
                     break
             if replay_ok:
                 return found_cid
-            if attempt < attempts - 1:
-                await asyncio.sleep(delay)
-                delay *= 2
+            if attempt_idx < len(retry_delays):
+                await asyncio.sleep(retry_delays[attempt_idx])
         logger.warning(
             "gave up looking up General channel for space=%s after %d "
             "attempts — intro nudge will be skipped",
-            space_id, attempts,
+            space_id, len(retry_delays) + 1,
         )
         return ""
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1295,74 +1295,47 @@ class PuffoCoreMessageClient:
 
     async def _find_public_general_channel(self, space_id: str) -> str:
         """Return the ``channel_id`` of the space's auto-created public
-        General channel (CreateChannel event with ``is_public=true``),
-        or ``""`` if none exists. Used after accepting a space invite
-        to pick the one channel the agent now has auto-fanned-out
-        membership in.
+        General channel (the first ``is_public=true`` row from
+        ``GET /spaces/<id>/channels``), or ``""`` if none.
 
-        Replays ``/spaces/<id>/events`` because puffo-server has no
-        dedicated channels-list endpoint — same pattern as the
-        ``list_channels`` MCP tool. Returns the FIRST public channel
-        encountered so a hypothetical future second public channel
-        doesn't double-fire.
+        Used after accepting a space invite to pick the one channel
+        the agent now has auto-fanned-out membership in. Side effect:
+        every channel returned by the server is folded into
+        ``self._channel_name_cache`` so the immediately-following
+        ``_resolve_channel_name`` inside the intro nudge becomes a
+        cache hit instead of a separate events replay.
 
-        Side effect: while walking, every ``create_channel`` event we
-        pass is folded into ``self._channel_name_cache`` so the
-        immediately-following ``_resolve_channel_name`` inside the
-        intro nudge becomes a cache hit instead of a duplicate
-        events replay."""
+        Accept POST → channels GET is a tight race: the server has
+        the accept event applied, but the ``channel_memberships``
+        rows that gate this endpoint may not be committed yet (the
+        endpoint returns 200 + the SPA index when the caller isn't
+        yet a member, which the http client decodes as a raw
+        ``str``). Sleep-first retry on a generous schedule;
+        past ~70s give up silently rather than spinning forever."""
         if not space_id:
             return ""
-        # Accept POST → events GET is a tight race: the server has the
-        # accept, but the membership row that gates ``/spaces/<id>/
-        # events`` may not be committed yet. The endpoint returns 200
-        # + an empty (non-JSON) body for "you're not a member of this
-        # space" rather than 403, so ``http.get`` hands us a raw
-        # ``str`` instead of a dict. Always sleep before the first
-        # attempt — even a fast server can't commit that quickly —
-        # then back off across ~70s total; past that give up
-        # silently rather than spinning forever.
         retry_delays = (0.5, 1.0, 3.0, 6.0, 12.0, 24.0, 24.0)
-        found_cid = ""
         for attempt_idx, delay in enumerate(retry_delays):
             await asyncio.sleep(delay)
-            cursor: str | None = None
-            prev_cursor: str | None = None
-            replay_ok = True
-            while True:
-                path = f"/spaces/{space_id}/events"
-                if cursor:
-                    path += f"?since={cursor}"
-                page = await self.http.get(path)
-                if not isinstance(page, dict):
-                    logger.info(
-                        "events endpoint not ready for space=%s "
-                        "(attempt %d/%d, body=%r) — retrying",
-                        space_id,
-                        attempt_idx + 1,
-                        len(retry_delays),
-                        page,
-                    )
-                    replay_ok = False
-                    break
-                for ev in page.get("events") or []:
-                    if ev.get("kind") != "create_channel":
-                        continue
-                    payload = ev.get("payload") or {}
-                    cid = payload.get("channel_id") or ""
-                    name = (payload.get("name") or "").strip()
-                    if cid and cid not in self._channel_name_cache:
-                        self._channel_name_cache[cid] = name or cid
-                    if not found_cid and payload.get("is_public") and cid:
-                        found_cid = cid
-                if found_cid or not page.get("has_more"):
-                    break
-                prev_cursor = cursor
-                cursor = page.get("next_cursor")
-                if not cursor or cursor == prev_cursor:
-                    break
-            if replay_ok:
-                return found_cid
+            data = await self.http.get(f"/spaces/{space_id}/channels")
+            if not isinstance(data, dict):
+                logger.info(
+                    "channels endpoint not ready for space=%s "
+                    "(attempt %d/%d) — retrying",
+                    space_id,
+                    attempt_idx + 1,
+                    len(retry_delays),
+                )
+                continue
+            found_cid = ""
+            for entry in data.get("channels") or []:
+                cid = entry.get("channel_id") or ""
+                name = (entry.get("name") or "").strip()
+                if cid and cid not in self._channel_name_cache:
+                    self._channel_name_cache[cid] = name or cid
+                if not found_cid and entry.get("is_public") and cid:
+                    found_cid = cid
+            return found_cid
         logger.warning(
             "gave up looking up General channel for space=%s after %d "
             "attempts — intro nudge will be skipped",

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1313,31 +1313,63 @@ class PuffoCoreMessageClient:
         events replay."""
         if not space_id:
             return ""
+        # Accept POST → events GET is a tight race: the server has the
+        # accept, but the membership row that gates ``/spaces/<id>/
+        # events`` may not be committed yet. The endpoint returns 200
+        # + an empty (non-JSON) body for "you're not a member of this
+        # space" rather than 403, so ``http.get`` hands us a raw
+        # ``str`` instead of a dict. One short retry covers the race;
+        # past that we give up silently — missing the intro nudge is
+        # preferable to logging an error storm.
+        attempts = 3
+        delay = 0.25
         cursor: str | None = None
         prev_cursor: str | None = None
         found_cid = ""
-        while True:
-            path = f"/spaces/{space_id}/events"
-            if cursor:
-                path += f"?since={cursor}"
-            page = await self.http.get(path)
-            for ev in page.get("events") or []:
-                if ev.get("kind") != "create_channel":
-                    continue
-                payload = ev.get("payload") or {}
-                cid = payload.get("channel_id") or ""
-                name = (payload.get("name") or "").strip()
-                if cid and cid not in self._channel_name_cache:
-                    self._channel_name_cache[cid] = name or cid
-                if not found_cid and payload.get("is_public") and cid:
-                    found_cid = cid
-            if found_cid or not page.get("has_more"):
-                break
-            prev_cursor = cursor
-            cursor = page.get("next_cursor")
-            if not cursor or cursor == prev_cursor:
-                break
-        return found_cid
+        for attempt in range(attempts):
+            cursor = None
+            prev_cursor = None
+            replay_ok = True
+            while True:
+                path = f"/spaces/{space_id}/events"
+                if cursor:
+                    path += f"?since={cursor}"
+                page = await self.http.get(path)
+                if not isinstance(page, dict):
+                    logger.info(
+                        "events endpoint not ready for space=%s "
+                        "(attempt %d/%d, body=%r) — retrying",
+                        space_id, attempt + 1, attempts, page,
+                    )
+                    replay_ok = False
+                    break
+                for ev in page.get("events") or []:
+                    if ev.get("kind") != "create_channel":
+                        continue
+                    payload = ev.get("payload") or {}
+                    cid = payload.get("channel_id") or ""
+                    name = (payload.get("name") or "").strip()
+                    if cid and cid not in self._channel_name_cache:
+                        self._channel_name_cache[cid] = name or cid
+                    if not found_cid and payload.get("is_public") and cid:
+                        found_cid = cid
+                if found_cid or not page.get("has_more"):
+                    break
+                prev_cursor = cursor
+                cursor = page.get("next_cursor")
+                if not cursor or cursor == prev_cursor:
+                    break
+            if replay_ok:
+                return found_cid
+            if attempt < attempts - 1:
+                await asyncio.sleep(delay)
+                delay *= 2
+        logger.warning(
+            "gave up looking up General channel for space=%s after %d "
+            "attempts — intro nudge will be skipped",
+            space_id, attempts,
+        )
+        return ""
 
     async def _enqueue_channel_intro_nudge(
         self,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1333,6 +1333,15 @@ class PuffoCoreMessageClient:
                 name = (entry.get("name") or "").strip()
                 if cid and cid not in self._channel_name_cache:
                     self._channel_name_cache[cid] = name or cid
+                # Persist the channel→space mapping so the MCP
+                # subprocess's send_message can resolve this channel
+                # BEFORE the first inbound message lands. Without
+                # this, lookup_channel_space falls through to the
+                # /messages table (empty) and then to agent.yml's
+                # space_id, which is the WRONG space when the agent
+                # has just joined a different one.
+                if cid:
+                    await self.store.mark_channel_space(cid, space_id)
                 if not found_cid and entry.get("is_public") and cid:
                     found_cid = cid
             return found_cid

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -524,12 +524,20 @@ class PuffoCoreMessageClient:
                 )
                 return
 
+            # Per-session display-name cache turns this into ~1 HTTP
+            # call per distinct sender per session; same helper the
+            # invite-DM flow already uses. Empty string on miss.
+            sender_display_name = await self._fetch_display_name(
+                payload.sender_slug,
+            )
+
             msg_dict = {
                 "channel_id": channel_id,
                 "channel_name": channel_name,
                 "space_id": space_id,
                 "space_name": space_name,
                 "sender_slug": payload.sender_slug,
+                "sender_display_name": sender_display_name,
                 "sender_email": "",
                 "text": clean_text,
                 "root_id": payload.thread_root_id or "",
@@ -1393,6 +1401,7 @@ class PuffoCoreMessageClient:
             "space_id": space_id,
             "space_name": space_name,
             "sender_slug": "system",
+            "sender_display_name": "",
             "sender_email": "",
             "text": prompt_text,
             "root_id": "",

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1259,6 +1259,101 @@ class PuffoCoreMessageClient:
             {"space_id": space_id, "events": [signed]},
         )
 
+        # Channel invites trigger a one-shot self-introduction nudge:
+        # we enqueue a synthetic ``[puffo-agent system message]`` so the
+        # agent posts a short intro in the channel using its existing
+        # ``send_message`` MCP tool. Space-only invites are skipped
+        # (the agent isn't actually in any specific channel yet) and
+        # so are channels we've already prompted (server-side invite
+        # redelivery / daemon restart guard via sqlite).
+        if kind == "invite_to_channel" and channel_id:
+            try:
+                await self._enqueue_channel_intro_nudge(
+                    space_id=space_id,
+                    channel_id=channel_id,
+                )
+            except Exception:
+                # Intro is best-effort; never block the accept.
+                logger.exception(
+                    "failed to enqueue channel intro nudge "
+                    "(space=%s channel=%s)", space_id, channel_id,
+                )
+
+    async def _enqueue_channel_intro_nudge(
+        self,
+        *,
+        space_id: str,
+        channel_id: str,
+    ) -> None:
+        """Inject a synthetic system-message envelope into the thread
+        queue asking the agent to post a brief self-introduction in
+        ``channel_id``. Idempotent against the
+        ``channel_intro_prompted`` sqlite table so a redelivered
+        accept can't fire a second intro."""
+        if await self.store.has_channel_intro_been_prompted(channel_id):
+            return
+
+        space_name = (
+            await self._resolve_space_name(space_id) if space_id else ""
+        )
+        channel_name = await self._resolve_channel_name(space_id, channel_id)
+
+        now_ms = int(__import__("time").time() * 1000)
+        envelope_id = f"intro-prompt-{channel_id}-{now_ms}"
+        # The prefix is documented in the agent's CLAUDE.md primer as
+        # a recognised control-message marker (see 0.7.3 notes); the
+        # agent treats it as a directive rather than user chatter.
+        prompt_text = (
+            "[puffo-agent system message] You've just been added to "
+            f"channel #{channel_name} (channel_id: {channel_id}) in "
+            f"space {space_name or space_id}. Post a brief "
+            "self-introduction (2-3 sentences, in English by default) "
+            f"using mcp__puffo__send_message with channel=\"{channel_id}\" "
+            "so existing members know who you are and how you can help. "
+            "Don't include a thread root_id — this should be a new "
+            "top-level post in the channel."
+        )
+
+        msg_dict = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "sender_slug": "system",
+            "sender_email": "",
+            "text": prompt_text,
+            "root_id": "",
+            "is_dm": False,
+            "attachments": [],
+            "sender_is_bot": False,
+            "mentions": [],
+            "envelope_id": envelope_id,
+            "sent_at": now_ms,
+        }
+        channel_meta = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "is_dm": False,
+        }
+
+        # Mark prompted BEFORE admitting so a crash between admit and
+        # commit can't leave us re-prompting on restart. Worst case
+        # the agent doesn't get the nudge — preferable to spamming.
+        await self.store.mark_channel_intro_prompted(channel_id)
+
+        await self._admit_thread_message(
+            root_id=envelope_id,
+            priority=PRIORITY_SYSTEM,
+            msg_dict=msg_dict,
+            channel_meta=channel_meta,
+        )
+        logger.info(
+            "enqueued channel-intro nudge for channel=%s (space=%s)",
+            channel_id, space_id,
+        )
+
     async def _maybe_handle_invite_reply(
         self, *, thread_root_id: str, text: str,
     ) -> bool:

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -7,9 +7,10 @@ thread queue so it posts a short intro using its normal
 via the ``channel_intro_prompted`` sqlite table so a daemon restart or
 a server-side invite redelivery can't fire a second intro.
 
-These tests exercise ``_enqueue_channel_intro_nudge`` and the
-``MessageStore`` helpers directly. The wiring inside ``_accept_invite``
-is a thin try/except wrapper on top — covered by manual smoke tests.
+These tests exercise ``_enqueue_channel_intro_nudge``,
+``_find_public_general_channel`` and the ``MessageStore`` helpers
+directly. The wiring inside ``_accept_invite`` is a thin try/except
+wrapper on top — covered by manual smoke tests.
 """
 
 from __future__ import annotations
@@ -46,9 +47,9 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     client._queue = asyncio.PriorityQueue()
     client._queue_seq = 0
     client._thread_state = {}
-    # ``_find_public_general_channel`` warms this cache as it walks
-    # so the immediately-following ``_resolve_channel_name`` inside
-    # the intro nudge becomes a cache hit.
+    # ``_find_public_general_channel`` warms this cache from the
+    # /channels response so the immediately-following
+    # ``_resolve_channel_name`` inside the intro nudge becomes a hit.
     client._channel_name_cache = {}
 
     async def _stub_space_name(space_id: str) -> str:
@@ -60,6 +61,16 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     client._resolve_space_name = _stub_space_name  # type: ignore[assignment]
     client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
     return client
+
+
+def _instant_sleep_monkeypatch(monkeypatch) -> None:
+    """Skip the real backoff sleep so the suite stays fast."""
+    import puffo_agent.agent.puffo_core_client as _client_mod
+
+    async def _instant_sleep(_s: float) -> None:
+        return None
+
+    monkeypatch.setattr(_client_mod.asyncio, "sleep", _instant_sleep)
 
 
 # ─── MessageStore helpers ─────────────────────────────────────────
@@ -115,8 +126,6 @@ async def test_intro_nudge_admits_one_system_priority_envelope():
     assert len(entry.messages) == 1
     msg = entry.messages[0]
 
-    # Shape sanity: channel ids resolved, prompt prefixed correctly,
-    # not a DM, no attachments.
     assert msg["channel_id"] == "ch_1"
     assert msg["channel_name"] == "general"
     assert msg["space_id"] == "sp_1"
@@ -130,7 +139,6 @@ async def test_intro_nudge_admits_one_system_priority_envelope():
     assert "general" in msg["text"]
     assert "send_message" in msg["text"]
 
-    # Dedup row landed.
     assert await store.has_channel_intro_been_prompted("ch_1") is True
     await store.close()
 
@@ -150,7 +158,7 @@ async def test_intro_nudge_skipped_when_already_prompted():
     await client._enqueue_channel_intro_nudge(
         space_id="sp_1", channel_id="ch_1",
     )
-    assert client._queue.qsize() == 1  # still just the first one
+    assert client._queue.qsize() == 1
     assert len(client._thread_state) == 1
     await store.close()
 
@@ -175,40 +183,39 @@ async def test_intro_nudge_distinct_channels_each_get_one():
     await store.close()
 
 
+# ─── _find_public_general_channel (against /spaces/<id>/channels) ─
+
+
+def _channels_response(*entries: dict) -> dict:
+    """Wrap channel rows in the shape ``GET /spaces/<id>/channels``
+    returns (matches ``server::space_config::ListChannelsResponse``)."""
+    return {"channels": list(entries)}
+
+
 @pytest.mark.asyncio
-async def test_find_public_general_channel_picks_is_public_true():
-    """``_find_public_general_channel`` walks the space's events,
-    returns the first ``create_channel`` event with ``is_public=true``.
-    Public-flag check is the canonical signal — server emits a
-    synthetic CreateChannel with ``is_public=true`` for every new
-    space's General; user-created channels default false."""
+async def test_find_public_general_channel_picks_is_public_true(monkeypatch):
+    """Returns the first row with ``is_public=true``. Server already
+    filters the list by membership, so anything we see is reachable —
+    we just need to pick General."""
+    _instant_sleep_monkeypatch(monkeypatch)
     store = await _make_store()
     client = _make_client(store)
 
     class _StubHttp:
         async def get(self, path: str) -> dict:
-            assert path.startswith("/spaces/sp_1/events")
-            return {
-                "events": [
-                    {
-                        "kind": "create_channel",
-                        "payload": {
-                            "channel_id": "ch_private",
-                            "name": "Random",
-                            "is_public": False,
-                        },
-                    },
-                    {
-                        "kind": "create_channel",
-                        "payload": {
-                            "channel_id": "ch_general",
-                            "name": "General",
-                            "is_public": True,
-                        },
-                    },
-                ],
-                "has_more": False,
-            }
+            assert path == "/spaces/sp_1/channels"
+            return _channels_response(
+                {
+                    "channel_id": "ch_private",
+                    "name": "Random",
+                    "is_public": False,
+                },
+                {
+                    "channel_id": "ch_general",
+                    "name": "General",
+                    "is_public": True,
+                },
+            )
 
     client.http = _StubHttp()
     cid = await client._find_public_general_channel("sp_1")
@@ -217,41 +224,31 @@ async def test_find_public_general_channel_picks_is_public_true():
 
 
 @pytest.mark.asyncio
-async def test_find_public_general_channel_warms_channel_name_cache():
-    """The walk we already pay for to find General doubles as a cache
-    warmup for every ``create_channel`` it passes — so the
-    ``_resolve_channel_name`` inside the intro nudge doesn't have to
-    replay the same events page seconds later."""
+async def test_find_public_general_channel_warms_channel_name_cache(monkeypatch):
+    """The /channels response we already pay for doubles as a cache
+    warmup so the ``_resolve_channel_name`` inside the intro nudge
+    doesn't have to round-trip again seconds later."""
+    _instant_sleep_monkeypatch(monkeypatch)
     store = await _make_store()
     client = _make_client(store)
 
     class _StubHttp:
         async def get(self, _path: str) -> dict:
-            return {
-                "events": [
-                    {
-                        "kind": "create_channel",
-                        "payload": {
-                            "channel_id": "ch_random",
-                            "name": "Random",
-                            "is_public": False,
-                        },
-                    },
-                    {
-                        "kind": "create_channel",
-                        "payload": {
-                            "channel_id": "ch_general",
-                            "name": "General",
-                            "is_public": True,
-                        },
-                    },
-                ],
-                "has_more": False,
-            }
+            return _channels_response(
+                {
+                    "channel_id": "ch_random",
+                    "name": "Random",
+                    "is_public": False,
+                },
+                {
+                    "channel_id": "ch_general",
+                    "name": "General",
+                    "is_public": True,
+                },
+            )
 
     client.http = _StubHttp()
     await client._find_public_general_channel("sp_1")
-    # Both channels — public AND private — landed in the cache.
     assert client._channel_name_cache == {
         "ch_random": "Random",
         "ch_general": "General",
@@ -260,20 +257,35 @@ async def test_find_public_general_channel_warms_channel_name_cache():
 
 
 @pytest.mark.asyncio
-async def test_find_public_general_channel_retries_when_events_endpoint_returns_string(monkeypatch):
-    """Accept POST → events GET is a tight race: server may return 200
-    + empty body (decoded as a raw ``str`` by the http client) while
-    the membership row is still committing. One short retry covers
-    that — the third call returns a real dict and the General lookup
-    succeeds."""
-    # Skip the real backoff sleep so the test stays fast.
-    import puffo_agent.agent.puffo_core_client as _client_mod
+async def test_find_public_general_channel_returns_empty_when_none(monkeypatch):
+    """No public channel in the response → empty string. Caller
+    treats this as 'skip the intro' (no obvious landing channel)."""
+    _instant_sleep_monkeypatch(monkeypatch)
+    store = await _make_store()
+    client = _make_client(store)
 
-    async def _instant_sleep(_s: float) -> None:
-        return None
+    class _StubHttp:
+        async def get(self, _path: str) -> dict:
+            return _channels_response({
+                "channel_id": "ch_private",
+                "name": "Random",
+                "is_public": False,
+            })
 
-    monkeypatch.setattr(_client_mod.asyncio, "sleep", _instant_sleep)
+    client.http = _StubHttp()
+    cid = await client._find_public_general_channel("sp_1")
+    assert cid == ""
+    await store.close()
 
+
+@pytest.mark.asyncio
+async def test_find_public_general_channel_retries_when_endpoint_returns_string(monkeypatch):
+    """Accept POST → channels GET is a tight race: the server has the
+    accept event applied but the ``channel_memberships`` row that
+    gates the endpoint may not be committed yet. In that window the
+    endpoint returns the SPA fallback (decoded as ``str``); we sleep
+    and retry. Third call wins → General resolved."""
+    _instant_sleep_monkeypatch(monkeypatch)
     store = await _make_store()
     client = _make_client(store)
 
@@ -284,19 +296,11 @@ async def test_find_public_general_channel_retries_when_events_endpoint_returns_
             calls.append(1)
             if len(calls) < 3:
                 return ""  # not-a-member-yet stand-in
-            return {
-                "events": [
-                    {
-                        "kind": "create_channel",
-                        "payload": {
-                            "channel_id": "ch_general",
-                            "name": "General",
-                            "is_public": True,
-                        },
-                    },
-                ],
-                "has_more": False,
-            }
+            return _channels_response({
+                "channel_id": "ch_general",
+                "name": "General",
+                "is_public": True,
+            })
 
     client.http = _FlakyHttp()
     cid = await client._find_public_general_channel("sp_1")
@@ -307,15 +311,9 @@ async def test_find_public_general_channel_retries_when_events_endpoint_returns_
 
 @pytest.mark.asyncio
 async def test_find_public_general_channel_gives_up_after_all_retries(monkeypatch):
-    """Endpoint stays unhappy across all attempts → return ``""``,
-    no exception raised. The accept itself isn't blocked."""
-    import puffo_agent.agent.puffo_core_client as _client_mod
-
-    async def _instant_sleep(_s: float) -> None:
-        return None
-
-    monkeypatch.setattr(_client_mod.asyncio, "sleep", _instant_sleep)
-
+    """Endpoint stays unhappy across all attempts → return ``""``, no
+    exception raised. The accept itself isn't blocked."""
+    _instant_sleep_monkeypatch(monkeypatch)
     store = await _make_store()
     client = _make_client(store)
 
@@ -324,35 +322,6 @@ async def test_find_public_general_channel_gives_up_after_all_retries(monkeypatc
             return ""
 
     client.http = _AlwaysString()
-    cid = await client._find_public_general_channel("sp_1")
-    assert cid == ""
-    await store.close()
-
-
-@pytest.mark.asyncio
-async def test_find_public_general_channel_returns_empty_when_none():
-    """No public channel in the space → empty string. Caller treats
-    this as 'skip the intro' (no obvious landing channel)."""
-    store = await _make_store()
-    client = _make_client(store)
-
-    class _StubHttp:
-        async def get(self, _path: str) -> dict:
-            return {
-                "events": [
-                    {
-                        "kind": "create_channel",
-                        "payload": {
-                            "channel_id": "ch_private",
-                            "name": "Random",
-                            "is_public": False,
-                        },
-                    },
-                ],
-                "has_more": False,
-            }
-
-    client.http = _StubHttp()
     cid = await client._find_public_general_channel("sp_1")
     assert cid == ""
     await store.close()
@@ -383,5 +352,5 @@ async def test_intro_nudge_survives_simulated_restart():
     await client_2._enqueue_channel_intro_nudge(
         space_id="sp_1", channel_id="ch_1",
     )
-    assert client_2._queue.qsize() == 0  # gate held across restart
+    assert client_2._queue.qsize() == 0
     await store_2.close()

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -46,6 +46,10 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     client._queue = asyncio.PriorityQueue()
     client._queue_seq = 0
     client._thread_state = {}
+    # ``_find_public_general_channel`` warms this cache as it walks
+    # so the immediately-following ``_resolve_channel_name`` inside
+    # the intro nudge becomes a cache hit.
+    client._channel_name_cache = {}
 
     async def _stub_space_name(space_id: str) -> str:
         return "Team" if space_id == "sp_1" else space_id
@@ -209,6 +213,49 @@ async def test_find_public_general_channel_picks_is_public_true():
     client.http = _StubHttp()
     cid = await client._find_public_general_channel("sp_1")
     assert cid == "ch_general"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_find_public_general_channel_warms_channel_name_cache():
+    """The walk we already pay for to find General doubles as a cache
+    warmup for every ``create_channel`` it passes — so the
+    ``_resolve_channel_name`` inside the intro nudge doesn't have to
+    replay the same events page seconds later."""
+    store = await _make_store()
+    client = _make_client(store)
+
+    class _StubHttp:
+        async def get(self, _path: str) -> dict:
+            return {
+                "events": [
+                    {
+                        "kind": "create_channel",
+                        "payload": {
+                            "channel_id": "ch_random",
+                            "name": "Random",
+                            "is_public": False,
+                        },
+                    },
+                    {
+                        "kind": "create_channel",
+                        "payload": {
+                            "channel_id": "ch_general",
+                            "name": "General",
+                            "is_public": True,
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+
+    client.http = _StubHttp()
+    await client._find_public_general_channel("sp_1")
+    # Both channels — public AND private — landed in the cache.
+    assert client._channel_name_cache == {
+        "ch_random": "Random",
+        "ch_general": "General",
+    }
     await store.close()
 
 

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -260,6 +260,76 @@ async def test_find_public_general_channel_warms_channel_name_cache():
 
 
 @pytest.mark.asyncio
+async def test_find_public_general_channel_retries_when_events_endpoint_returns_string(monkeypatch):
+    """Accept POST → events GET is a tight race: server may return 200
+    + empty body (decoded as a raw ``str`` by the http client) while
+    the membership row is still committing. One short retry covers
+    that — the third call returns a real dict and the General lookup
+    succeeds."""
+    # Skip the real backoff sleep so the test stays fast.
+    import puffo_agent.agent.puffo_core_client as _client_mod
+
+    async def _instant_sleep(_s: float) -> None:
+        return None
+
+    monkeypatch.setattr(_client_mod.asyncio, "sleep", _instant_sleep)
+
+    store = await _make_store()
+    client = _make_client(store)
+
+    calls: list[int] = []
+
+    class _FlakyHttp:
+        async def get(self, _path: str):
+            calls.append(1)
+            if len(calls) < 3:
+                return ""  # not-a-member-yet stand-in
+            return {
+                "events": [
+                    {
+                        "kind": "create_channel",
+                        "payload": {
+                            "channel_id": "ch_general",
+                            "name": "General",
+                            "is_public": True,
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+
+    client.http = _FlakyHttp()
+    cid = await client._find_public_general_channel("sp_1")
+    assert cid == "ch_general"
+    assert len(calls) == 3
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_find_public_general_channel_gives_up_after_all_retries(monkeypatch):
+    """Endpoint stays unhappy across all attempts → return ``""``,
+    no exception raised. The accept itself isn't blocked."""
+    import puffo_agent.agent.puffo_core_client as _client_mod
+
+    async def _instant_sleep(_s: float) -> None:
+        return None
+
+    monkeypatch.setattr(_client_mod.asyncio, "sleep", _instant_sleep)
+
+    store = await _make_store()
+    client = _make_client(store)
+
+    class _AlwaysString:
+        async def get(self, _path: str):
+            return ""
+
+    client.http = _AlwaysString()
+    cid = await client._find_public_general_channel("sp_1")
+    assert cid == ""
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_find_public_general_channel_returns_empty_when_none():
     """No public channel in the space → empty string. Caller treats
     this as 'skip the intro' (no obvious landing channel)."""

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -172,6 +172,76 @@ async def test_intro_nudge_distinct_channels_each_get_one():
 
 
 @pytest.mark.asyncio
+async def test_find_public_general_channel_picks_is_public_true():
+    """``_find_public_general_channel`` walks the space's events,
+    returns the first ``create_channel`` event with ``is_public=true``.
+    Public-flag check is the canonical signal — server emits a
+    synthetic CreateChannel with ``is_public=true`` for every new
+    space's General; user-created channels default false."""
+    store = await _make_store()
+    client = _make_client(store)
+
+    class _StubHttp:
+        async def get(self, path: str) -> dict:
+            assert path.startswith("/spaces/sp_1/events")
+            return {
+                "events": [
+                    {
+                        "kind": "create_channel",
+                        "payload": {
+                            "channel_id": "ch_private",
+                            "name": "Random",
+                            "is_public": False,
+                        },
+                    },
+                    {
+                        "kind": "create_channel",
+                        "payload": {
+                            "channel_id": "ch_general",
+                            "name": "General",
+                            "is_public": True,
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+
+    client.http = _StubHttp()
+    cid = await client._find_public_general_channel("sp_1")
+    assert cid == "ch_general"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_find_public_general_channel_returns_empty_when_none():
+    """No public channel in the space → empty string. Caller treats
+    this as 'skip the intro' (no obvious landing channel)."""
+    store = await _make_store()
+    client = _make_client(store)
+
+    class _StubHttp:
+        async def get(self, _path: str) -> dict:
+            return {
+                "events": [
+                    {
+                        "kind": "create_channel",
+                        "payload": {
+                            "channel_id": "ch_private",
+                            "name": "Random",
+                            "is_public": False,
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+
+    client.http = _StubHttp()
+    cid = await client._find_public_general_channel("sp_1")
+    assert cid == ""
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_intro_nudge_survives_simulated_restart():
     """Dedup is persistent: a fresh client built on the same db path
     must still treat the channel as already-prompted."""

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -224,6 +224,88 @@ async def test_find_public_general_channel_picks_is_public_true(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_find_public_general_channel_persists_channel_space_map(monkeypatch):
+    """Every channel returned by /channels lands in the
+    ``channel_space_map`` table so ``lookup_channel_space`` can
+    resolve it BEFORE the first inbound message — the MCP
+    ``send_message`` tool depends on this for the intro nudge."""
+    _instant_sleep_monkeypatch(monkeypatch)
+    store = await _make_store()
+    client = _make_client(store)
+
+    class _StubHttp:
+        async def get(self, _path: str) -> dict:
+            return _channels_response(
+                {
+                    "channel_id": "ch_random",
+                    "name": "Random",
+                    "is_public": False,
+                },
+                {
+                    "channel_id": "ch_general",
+                    "name": "General",
+                    "is_public": True,
+                },
+            )
+
+    client.http = _StubHttp()
+    await client._find_public_general_channel("sp_1")
+
+    # Both channels are now resolvable by lookup_channel_space —
+    # private ones too, since the agent might still want to send
+    # there later.
+    assert await store.lookup_channel_space("ch_random") == "sp_1"
+    assert await store.lookup_channel_space("ch_general") == "sp_1"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_lookup_channel_space_prefers_map_over_messages_inference():
+    """Explicit map wins over the /messages-table fallback. Same
+    channel could in principle show up under two space_ids if the
+    server emits conflicting envelopes; the explicit map is
+    authoritative."""
+    store = await _make_store()
+
+    await store.mark_channel_space("ch_1", "sp_authoritative")
+    # Plant a "wrong" message-level signal too.
+    await store.store({
+        "envelope_id": "env_1",
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "channel_id": "ch_1",
+        "space_id": "sp_stale",
+        "content_type": "text/plain",
+        "content": "hi",
+        "sent_at": 1,
+    })
+
+    assert await store.lookup_channel_space("ch_1") == "sp_authoritative"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_lookup_channel_space_falls_back_to_messages_when_no_map_row():
+    """When ``channel_space_map`` has no entry, the historical
+    /messages-table inference still works — keeps steady-state
+    behaviour for channels we learned about via inbound traffic."""
+    store = await _make_store()
+    await store.store({
+        "envelope_id": "env_1",
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "channel_id": "ch_inferred",
+        "space_id": "sp_via_msg",
+        "content_type": "text/plain",
+        "content": "hi",
+        "sent_at": 1,
+    })
+
+    assert await store.lookup_channel_space("ch_inferred") == "sp_via_msg"
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_find_public_general_channel_warms_channel_name_cache(monkeypatch):
     """The /channels response we already pay for doubles as a cache
     warmup so the ``_resolve_channel_name`` inside the intro nudge

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -1,0 +1,200 @@
+"""Self-introduction nudge fired after a channel-invite accept.
+
+When the agent accepts an ``invite_to_channel``, the daemon enqueues a
+synthetic ``[puffo-agent system message]`` envelope into the agent's
+thread queue so it posts a short intro using its normal
+``mcp__puffo__send_message`` path. The nudge is dedup-ed per channel
+via the ``channel_intro_prompted`` sqlite table so a daemon restart or
+a server-side invite redelivery can't fire a second intro.
+
+These tests exercise ``_enqueue_channel_intro_nudge`` and the
+``MessageStore`` helpers directly. The wiring inside ``_accept_invite``
+is a thin try/except wrapper on top — covered by manual smoke tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import (
+    PRIORITY_SYSTEM,
+    PuffoCoreMessageClient,
+)
+
+
+async def _make_store() -> MessageStore:
+    d = tempfile.mkdtemp()
+    store = MessageStore(os.path.join(d, "messages.db"))
+    await store.open()
+    return store
+
+
+def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
+    """Bare client with just enough state to exercise the intro path.
+    Mirrors ``test_thread_queue._make_client_for_queue`` and stubs the
+    HTTP-backed name resolvers so no network is touched."""
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.store = store
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+
+    async def _stub_space_name(space_id: str) -> str:
+        return "Team" if space_id == "sp_1" else space_id
+
+    async def _stub_channel_name(space_id: str, channel_id: str) -> str:
+        return "general" if channel_id == "ch_1" else channel_id
+
+    client._resolve_space_name = _stub_space_name  # type: ignore[assignment]
+    client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
+    return client
+
+
+# ─── MessageStore helpers ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_store_intro_helpers_idempotent():
+    store = await _make_store()
+    assert await store.has_channel_intro_been_prompted("ch_1") is False
+
+    await store.mark_channel_intro_prompted("ch_1")
+    assert await store.has_channel_intro_been_prompted("ch_1") is True
+
+    # Second mark is a no-op (ON CONFLICT DO NOTHING). The state stays
+    # truthy and the underlying row count must remain 1.
+    await store.mark_channel_intro_prompted("ch_1")
+    assert await store.has_channel_intro_been_prompted("ch_1") is True
+
+    db = await store._ensure_db()
+    async with db.execute(
+        "SELECT COUNT(*) FROM channel_intro_prompted WHERE channel_id = 'ch_1'"
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None and row[0] == 1
+
+    # Empty channel_id is silently ignored on both reads and writes.
+    assert await store.has_channel_intro_been_prompted("") is False
+    await store.mark_channel_intro_prompted("")
+    await store.close()
+
+
+# ─── _enqueue_channel_intro_nudge ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intro_nudge_admits_one_system_priority_envelope():
+    store = await _make_store()
+    client = _make_client(store)
+
+    await client._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+
+    # Queue holds exactly one tuple with PRIORITY_SYSTEM.
+    assert client._queue.qsize() == 1
+    priority, _seq, root_id = await client._queue.get()
+    assert priority == PRIORITY_SYSTEM
+
+    # State has a single ThreadEntry keyed on the synthetic envelope_id
+    # (root_id == envelope_id since this is a top-level post).
+    assert root_id in client._thread_state
+    entry = client._thread_state[root_id]
+    assert len(entry.messages) == 1
+    msg = entry.messages[0]
+
+    # Shape sanity: channel ids resolved, prompt prefixed correctly,
+    # not a DM, no attachments.
+    assert msg["channel_id"] == "ch_1"
+    assert msg["channel_name"] == "general"
+    assert msg["space_id"] == "sp_1"
+    assert msg["space_name"] == "Team"
+    assert msg["is_dm"] is False
+    assert msg["attachments"] == []
+    assert msg["envelope_id"].startswith("intro-prompt-ch_1-")
+    assert msg["envelope_id"] == root_id
+    assert "[puffo-agent system message]" in msg["text"]
+    assert "ch_1" in msg["text"]
+    assert "general" in msg["text"]
+    assert "send_message" in msg["text"]
+
+    # Dedup row landed.
+    assert await store.has_channel_intro_been_prompted("ch_1") is True
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_intro_nudge_skipped_when_already_prompted():
+    store = await _make_store()
+    client = _make_client(store)
+
+    await client._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+    assert client._queue.qsize() == 1
+
+    # Second call (simulating a redelivered invite or restart-time
+    # re-accept) must be a no-op — same channel, table already marked.
+    await client._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+    assert client._queue.qsize() == 1  # still just the first one
+    assert len(client._thread_state) == 1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_intro_nudge_distinct_channels_each_get_one():
+    """Two separate channel invites = two separate nudges. Dedup is
+    per channel, not global."""
+    store = await _make_store()
+    client = _make_client(store)
+
+    await client._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+    await client._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_2",
+    )
+
+    assert client._queue.qsize() == 2
+    assert await store.has_channel_intro_been_prompted("ch_1") is True
+    assert await store.has_channel_intro_been_prompted("ch_2") is True
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_intro_nudge_survives_simulated_restart():
+    """Dedup is persistent: a fresh client built on the same db path
+    must still treat the channel as already-prompted."""
+    d = tempfile.mkdtemp()
+    db_path = os.path.join(d, "messages.db")
+
+    store_1 = MessageStore(db_path)
+    await store_1.open()
+    client_1 = _make_client(store_1)
+    client_1.store = store_1
+    await client_1._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+    assert client_1._queue.qsize() == 1
+    await store_1.close()
+
+    # Simulated restart — new MessageStore over the same file.
+    store_2 = MessageStore(db_path)
+    await store_2.open()
+    client_2 = _make_client(store_2)
+    client_2.store = store_2
+    await client_2._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+    assert client_2._queue.qsize() == 0  # gate held across restart
+    await store_2.close()


### PR DESCRIPTION
## Summary

When an agent accepts an `invite_to_channel`, the daemon now enqueues a synthetic `[puffo-agent system message]` envelope on the new channel asking the agent to post a short self-introduction (2–3 sentences, default English) via its normal `mcp__puffo__send_message` path. The agent's existing `profile.md` personality shapes the wording, so the intro reads like the agent talking — not a hard-coded template from the daemon.

Triggers from both auto-accept paths:
- WS `invite_to_channel` from an operator-matched pubkey → `_process_invite` → `_accept_invite`
- Operator's `y` DM reply on a pending invite-DM → `_maybe_handle_invite_reply` → `_accept_invite`

Per-agent dedup via a new sqlite table `channel_intro_prompted(channel_id PK, prompted_at)` on `messages.db`. The mark lands **before** the queue admit so a server-side invite redelivery, daemon restart between accept and admit, or any `_admit_thread_message` failure can't fire a second intro on the same channel.

Space-only invites are intentionally **not** nudged (the agent isn't in any specific channel yet), and so are channels the agent gains via space-membership public-channel fan-out (those don't surface as `invite_to_channel`).

## What's NOT in scope

- No new dependency on profile.md fields — works against existing agents as-is.
- No CHANGELOG version bump — keeping this in Unreleased; will roll into the next release alongside any other queued fixes on `fix/feedbacks`.

## Test plan

- [x] New `tests/test_channel_intro_nudge.py` — 5 tests covering: store helper idempotency, single envelope at `PRIORITY_SYSTEM` with correct shape, dedup per channel, distinct channels each nudged, dedup persists across simulated restart (same db file, fresh client).
- [x] Full pytest suite — 445 passed (was 440), 5 skipped, no regressions.
- [ ] Manual: on Windows + macOS, accept a channel invite and confirm the agent posts an intro exactly once. Re-accept after a daemon restart confirms no double-intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)