### PR TITLE
chore(release): 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.5] — 2026-05-12
+
 ### Added
 
 - Auto self-introduction after accepting an invite. When the agent
@@ -48,6 +50,31 @@ this project adheres to [Semantic Versioning](https://semver.org/).
     response so the ``_resolve_channel_name`` call inside the
     nudge becomes a cache hit instead of a duplicate HTTP round-
     trip.
+
+- Every message fed to the agent now carries the sender's
+  ``display_name`` alongside the slug, rendered as two distinct
+  fields in the user block:
+
+  ```
+  - sender: Alice Wong
+  - sender_slug: alice-0001
+  - sender_type: human
+  ```
+
+  ``sender`` is the human-readable handle the LLM uses to address
+  peers in prose; ``sender_slug`` stays the structural identifier
+  for @-mentions and ``send_message`` routing. When the server has
+  no display_name on file, ``sender`` echoes the slug so the field
+  is always populated. Resolution piggy-backs on the existing
+  per-session display-name cache (one ``/identities/profiles?slugs=``
+  call per distinct sender per session; subsequent messages from
+  the same sender are free).
+
+### Changed
+
+- ``- sender: <slug> <email>`` rendering removed from the user
+  block; ``sender_email`` was hardcoded to ``""`` everywhere it
+  was populated and just cluttered the prompt.
 
 ## [0.7.4] — 2026-05-12
 
@@ -219,6 +246,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.7.3...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.7.5...HEAD
+[0.7.5]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.5
+[0.7.4]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.4
 [0.7.3]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.3
 [0.7.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.7.4"
+version = "0.7.5"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Version bump + CHANGELOG for v0.7.5. All code already landed via #6 (intro-nudge feature + sender display_name plumbing).

## Highlights

- **Auto self-introduction after invite accept** — channel invite → intro in the channel; space invite → intro in General. New sqlite tables `channel_intro_prompted` (dedup) and `channel_space_map` (channel→space resolution before first inbound message).
- **Sender display_name in every message** — `- sender: Alice Wong` + `- sender_slug: alice-0001` rendered as two distinct lines. Display name comes from the existing per-session profile cache; one HTTP call per distinct sender per session.

Full details in CHANGELOG.md.

## Release plan after merge

1. Tag `v0.7.5` on main
2. Create GitHub Release (triggers `publish-pypi.yml` workflow)
3. Approve the `pypi` environment gate
4. shields.io badges auto-update once PyPI metadata refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)