### PR TITLE
fix(agents): host plugin sync, intro-nudge persistence, and self-echo for cli-local + cli-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Agents can now see their own sent messages in
+  ``get_channel_history`` / ``get_thread_history``.** Operator-
+  reported: `get_thread_history(<root>)` returned only messages
+  from other senders; the agent's own replies were absent even
+  though other agents in the same thread saw them fine.
+
+  Root cause: two parallel send paths existed, and only one wrote
+  locally. The daemon-internal ``PuffoCoreMessageClient.post_
+  message`` (used by the fallback-reply path in worker.py) mirrored
+  the outbound payload to ``messages.db`` after the server POST,
+  but the MCP tool ``mcp__puffo__send_message`` (the path agents
+  actually use) didn't. Both relied on the daemon's WS handler to
+  not persist, because ``handle_envelope`` dropped envelopes whose
+  ``sender_slug == self.slug`` at the door — to "avoid retrigger
+  loops".
+
+  The right shape (long-term) is "server-echoed-over-WS is the
+  canonical proof a message was delivered, so the WS handler is
+  the canonical write path for inbound + outbound alike":
+
+  * ``handle_envelope`` no longer drops self-envelopes. The server
+    fans out every recipient device in ``envelope.recipients``,
+    which always includes the agent's own device (the MCP
+    ``send_message`` tool puts self in the recipient list for both
+    DMs and channels), so a successful send → WS echo → daemon
+    persists through the same path every other message uses.
+  * After the ``store.store(...)`` call, self-envelopes return
+    early — they're persisted but never queued for the LLM
+    (re-feeding the agent its own words would trip a turn-by-turn
+    echo loop).
+  * The redundant mirror-write in ``post_message`` was removed.
+    Both send paths now converge on the WS-echo persistence,
+    which is the single source of truth.
+
+  Follow-up: a future change can extract ``handle_envelope`` to a
+  testable method and add a unit test for the self-echo persist
+  + dispatch-skip semantics. The cursor-check tests in
+  ``test_thread_queue.py`` are unaffected. Full suite still 496 /
+  503 (no new tests, no regressions).
+
 - **Intro-nudge synthetic envelope is now persisted to ``messages.db``,
   and the status reporter no longer 404s on local-only envelopes.**
   Operator-reported: after joining a channel the agent received the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **cli-local: host Claude Code plugins now propagate to per-agent
-  virtual ``$HOME``.** Operator-reported: plugins installed via
+- **Host Claude Code plugins now propagate to cli-local + cli-docker
+  agents.** Operator-reported: plugins installed via
   ``claude /plugin install <name>@<marketplace>`` (e.g.
   ``imessage@claude-plugins-official``,
   ``chrome-devtools-mcp@claude-plugins-official``) were silently
@@ -53,14 +53,25 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
   Tests in ``test_host_sync.py``: 11 new (5 plugin tree + 6
   enabledPlugins) covering symlink / copy-fallback / idempotent
-  re-call / no-host-dir noop / agent-side preservation. Full
-  suite: 486 passed, 7 skipped.
+  re-call / no-host-dir noop / agent-side preservation.
 
-  cli-docker isn't covered by this fix — host plugin code (npx,
-  npm-resolved binaries, etc.) generally doesn't exist inside the
-  container and would error on first use. Scoped to a follow-up
-  once the cli-docker MCP-server unreachable-warning pattern is
-  extended to plugins.
+  cli-docker takes a different shape because the container's
+  ``/home/agent/.claude`` is already an outer bind-mount: nested a
+  second read-only bind-mount surfacing ``host_home/.claude/plugins``
+  at ``/home/agent/.claude/plugins:ro`` (so the marketplace + cache
+  + installed_plugins.json reach the in-container Claude without a
+  copy), and called the same ``sync_host_enabled_plugins`` helper
+  in ``_ensure_started`` so settings.json (already bind-mounted)
+  carries the enabledPlugins array. The cli-docker image bakes
+  node 22 + npm + python + uv, so most ``npx``/``uvx`` plugin
+  commands resolve naturally; native-binary plugins (those that
+  shell out to a host-only path) will still fail at use-time. 5
+  new tests in ``test_docker_host_plugins.py`` covering the bind-
+  mount injection, the missing-host-dir noop, the ``:ro`` flag,
+  argv ordering (before image positional), and the enabledPlugins
+  propagation path.
+
+  Full suite: 491 passed, 7 skipped.
 
 ## [0.7.6] — 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **cli-local: host Claude Code plugins now propagate to per-agent
+  virtual ``$HOME``.** Operator-reported: plugins installed via
+  ``claude /plugin install <name>@<marketplace>`` (e.g.
+  ``imessage@claude-plugins-official``,
+  ``chrome-devtools-mcp@claude-plugins-official``) were silently
+  invisible to cli-local agents — ``mcp__puffo__list_mcp_servers``
+  returned ``(no MCP servers registered)`` for the plugin-provided
+  MCPs, and the per-agent ``.claude/plugins/`` directory didn't
+  exist at all.
+
+  Root cause was a missing sync step. ``seed_claude_home`` had been
+  one-shot copying ``.claude/settings.json`` + ``.claude.json``, but
+  nothing was bringing across:
+  * ``~/.claude/plugins/`` — the marketplace clones + plugin cache
+    + ``installed_plugins.json`` + ``known_marketplaces.json`` that
+    contain the actual plugin code.
+  * ``~/.claude/settings.json#enabledPlugins`` — the array that
+    tells Claude which plugin names to load. ``seed_claude_home``
+    copied this once on first start but never refreshed, so
+    plugins enabled later on the host stayed invisible to the
+    agent. (Plugin-provided MCP servers register through the plugin
+    pipeline, not through the user-level ``mcpServers`` map that
+    ``sync_host_mcp_servers`` already merges, so the existing MCP
+    sync didn't cover this case.)
+
+  Two new helpers in ``portal/state.py``, both wired into
+  ``local_cli.LocalCLIAdapter._verify()`` after the existing host
+  syncs:
+  * ``sync_host_plugins(host_home, agent_home)`` — symlinks
+    ``host_home/.claude/plugins/`` to
+    ``agent_home/.claude/plugins/``. The tree is GB-scale (each
+    marketplace is a git clone with history); symlink keeps the
+    agent live with host installs without recopy cost. Falls back
+    to ``copytree`` on Windows-without-Developer-Mode (operators
+    can ``rm -rf <agent>/.claude/plugins`` to force a refresh in
+    that branch). Returns the mode string for logging.
+  * ``sync_host_enabled_plugins(host_home, agent_home)`` — rewrites
+    just the ``enabledPlugins`` key in per-agent ``settings.json``
+    from the host's. Atomic tmp+rename. Leaves other settings
+    keys (theme, model, etc.) untouched. Accepts both the dict
+    (``{name: true}``) and list (``[name, ...]``) shapes Claude
+    Code has used historically.
+
+  Tests in ``test_host_sync.py``: 11 new (5 plugin tree + 6
+  enabledPlugins) covering symlink / copy-fallback / idempotent
+  re-call / no-host-dir noop / agent-side preservation. Full
+  suite: 486 passed, 7 skipped.
+
+  cli-docker isn't covered by this fix — host plugin code (npx,
+  npm-resolved binaries, etc.) generally doesn't exist inside the
+  container and would error on first use. Scoped to a follow-up
+  once the cli-docker MCP-server unreachable-warning pattern is
+  extended to plugins.
+
 ## [0.7.6] — 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Intro-nudge synthetic envelope is now persisted to ``messages.db``,
+  and the status reporter no longer 404s on local-only envelopes.**
+  Operator-reported: after joining a channel the agent received the
+  ``[puffo-agent system message] You've just been added to …`` prompt
+  and posted an intro, but the daemon log carried a noisy
+  ``begin_turn message=intro-prompt-… failed (HTTP 404: NOT_FOUND)``
+  per nudge, and the agent's own ``mcp__puffo__get_channel_history``
+  call right after would return an inconsistent view (the intro it
+  just saw wasn't there).
+
+  Two changes:
+  * The synthetic envelope is written to ``messages.db`` via the
+    existing ``MessageStore.store`` path before being enqueued, so
+    ``get_channel_history`` / ``get_message_by_envelope`` /
+    ``lookup_channel_space`` all resolve it naturally. Side benefit:
+    ``send_message(root_id=<intro id>)`` is now a real thread root
+    locally; agents can post a reply-shape intro without producing
+    a broken reference.
+  * ``StatusReporter.begin_turn`` / ``end_turn`` /
+    ``end_turn_batch`` recognise local-only envelope prefixes
+    (currently ``intro-prompt-``) and skip the server POST. The
+    run is still tracked in-memory via the returned ``run_id`` so
+    the worker's batched ``end_turn_batch`` path keeps working;
+    server-side rows simply never get created for envelopes the
+    server never knew about. Quiets the per-nudge WARN noise
+    structurally rather than via primer compliance.
+
+  5 new tests: 1 in ``test_channel_intro_nudge.py``
+  (``test_intro_nudge_persists_envelope_to_messages_db``) + 4 in
+  ``test_status_reporter.py`` (``begin_turn`` skip, ``end_turn``
+  skip, batch filters mixed local/real runs, all-local batch
+  short-circuits). Full suite: 496 passed, 7 skipped.
+
 - **Host Claude Code plugins now propagate to cli-local + cli-docker
   agents.** Operator-reported: plugins installed via
   ``claude /plugin install <name>@<marketplace>`` (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.7] — 2026-05-13
+
 ### Fixed
 
 - **Agents can now see their own sent messages in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.7.6"
+version = "0.7.7"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -42,6 +42,7 @@ from ...mcp.config import (
 )
 from ...portal.state import (
     seed_claude_home,
+    sync_host_enabled_plugins,
     sync_host_gemini_mcp_servers,
     sync_host_gemini_skills,
     sync_host_mcp_servers,
@@ -876,6 +877,24 @@ class DockerCLIAdapter(Adapter):
                     "otherwise this MCP will fail on first use.",
                     self.agent_id, name, cmd,
                 )
+            # Plugins: the actual plugin tree is bind-mounted read-
+            # only into the container by ``_start_container``
+            # (see the ``-v {host_plugins}:/home/agent/.claude/plugins:ro``
+            # line). Here we just propagate the ``enabledPlugins``
+            # array from host settings.json so the container's Claude
+            # knows which plugin names to load. The image bakes in
+            # node/npm/python so most ``npx`` / ``uvx`` plugin
+            # commands resolve naturally; native-binary plugins (e.g.
+            # one that shells out to a host-only path) will still
+            # fail and that surfaces as a runtime error.
+            enabled_count = sync_host_enabled_plugins(
+                host_home, self.agent_home_dir,
+            )
+            if enabled_count:
+                logger.info(
+                    "agent %s: propagated %d enabledPlugins entry/entries "
+                    "from host settings.json", self.agent_id, enabled_count,
+                )
 
             # Gemini host sync — always runs (cheap when there's no
             # ~/.gemini/) so harness swap doesn't require a rebuild.
@@ -1076,6 +1095,23 @@ class DockerCLIAdapter(Adapter):
             "-v", f"{self.agent_home_dir}:/home/agent/.puffo-agent-state",
             "--init",  # reap zombies from claude's child processes
         ]
+        # Host Claude Code plugins ride in via a read-only nested
+        # bind-mount on top of the .claude dir. Plugin code (the
+        # marketplace clones, cache, installed_plugins.json) lives in
+        # ``~/.claude/plugins/`` and can be GB-scale; an extra mount
+        # is cheaper than copying every worker start, and the agent
+        # picks up host installs live. The image bakes in node/npm/
+        # python+uv so most plugin commands (``npx``/``uvx``)
+        # resolve. Sibling ``sync_host_enabled_plugins`` propagates
+        # the ``enabledPlugins`` array via the per-agent
+        # ``.claude/settings.json`` that lives under the existing
+        # ``claude_home_src`` mount. Skipped when the host has no
+        # plugins dir.
+        host_plugins = Path.home() / ".claude" / "plugins"
+        if host_plugins.is_dir():
+            cmd.extend([
+                "-v", f"{host_plugins}:/home/agent/.claude/plugins:ro",
+            ])
         # ``--memory`` is a hard cgroup ceiling; ``--memory-reservation``
         # is a soft floor. Either may be empty (operator opt-out).
         if self.memory_limit:

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -29,7 +29,9 @@ from ...mcp.config import (
 from ...portal.state import (
     link_host_credentials,
     seed_claude_home,
+    sync_host_enabled_plugins,
     sync_host_mcp_servers,
+    sync_host_plugins,
     sync_host_skills,
 )
 from .base import Adapter, TurnContext, TurnResult, looks_like_auth_failure
@@ -507,6 +509,22 @@ class LocalCLIAdapter(Adapter):
             logger.info(
                 "agent %s: merged %d host MCP server registration(s) "
                 "into per-agent .claude.json", self.agent_id, merged_mcp,
+            )
+        # Plugins layer — pairs the actual plugin code tree with the
+        # ``enabledPlugins`` array Claude reads from settings.json.
+        # Without both, plugin-provided MCP servers (imessage,
+        # chrome-devtools-mcp, etc.) silently never register.
+        plugins_mode = sync_host_plugins(host_home, self.agent_home_dir)
+        if plugins_mode not in ("no-host-dir",):
+            logger.info(
+                "agent %s: shared host ~/.claude/plugins/ (%s)",
+                self.agent_id, plugins_mode,
+            )
+        enabled_count = sync_host_enabled_plugins(host_home, self.agent_home_dir)
+        if enabled_count:
+            logger.info(
+                "agent %s: propagated %d enabledPlugins entry/entries "
+                "from host settings.json", self.agent_id, enabled_count,
             )
         agent_claude = self.agent_home_dir / ".claude"
         if not (agent_claude / ".credentials.json").exists():

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -350,9 +350,16 @@ class PuffoCoreMessageClient:
         )
 
         async def handle_envelope(envelope: dict) -> None:
-            if envelope.get("sender_slug") == self.slug:
-                return
-
+            # Self-envelopes are NOT dropped at the door anymore (Han
+            # 2026-05-13). The server fans out every recipient device
+            # in ``envelope.recipients``, which always includes the
+            # agent's own device (the MCP send_message tool puts it
+            # in the recipient list for both DMs and channels), so
+            # the WS echo IS the canonical "this message was actually
+            # delivered" signal. We persist it through the same path
+            # every other message goes through; the dispatch-to-
+            # worker step below short-circuits on ``sender_slug ==
+            # self.slug`` to prevent a retrigger loop.
             sender_slug = envelope.get("sender_slug", "")
             try:
                 sender_pks = await self._key_cache.get_signing_keys(sender_slug)
@@ -411,6 +418,16 @@ class PuffoCoreMessageClient:
                 "thread_root_id": payload.thread_root_id,
                 "reply_to_id": payload.reply_to_id,
             })
+
+            # Self-echo lands here too now (see ``handle_envelope``'s
+            # opening comment). Persist it — so ``get_channel_history``
+            # / ``get_thread_history`` show the agent's own posts —
+            # then stop before any of the LLM-facing pipeline below
+            # runs. The agent already produced this message; queueing
+            # it again would feed the agent its own words and trip a
+            # turn-by-turn echo loop.
+            if payload.sender_slug == self.slug:
+                return
 
             # Daemon-side intercept: ``y``/``n`` in the thread of an
             # outstanding invite-DM accepts/rejects the invite without
@@ -1905,32 +1922,13 @@ class PuffoCoreMessageClient:
             logger.exception("post_message: POST /messages failed")
             raise
 
-        # Persist the outbound message locally so the agent's own
-        # replies appear in ``get_channel_history``. The WS echo path
-        # can't do this (it drops ``sender_slug == self.slug``
-        # envelopes to avoid retrigger loops, and the wire payload is
-        # encrypted) so we mirror the inbound write here with the
-        # plaintext we already have.
-        try:
-            await self.store.store({
-                "envelope_id": envelope["envelope_id"],
-                "envelope_kind": envelope_kind,
-                "sender_slug": self.slug,
-                "channel_id": send_channel_id,
-                "space_id": send_space_id,
-                "recipient_slug": recipient_slug,
-                "content_type": "text/plain",
-                "content": text,
-                "sent_at": envelope.get("sent_at"),
-                "thread_root_id": root_id if root_id else None,
-            })
-        except Exception:
-            # Local-write failure must not fail the send — the
-            # recipient already has the message.
-            logger.exception(
-                "post_message: failed to persist outbound envelope %s",
-                envelope.get("envelope_id"),
-            )
+        # No mirror-write here anymore. The WS echo path now persists
+        # self-envelopes through the same handler every other message
+        # uses (Han 2026-05-13). Keeping a parallel mirror would double-
+        # insert (``INSERT OR IGNORE`` makes it idempotent, but the
+        # two write paths diverging is exactly the bug class we just
+        # fixed for the MCP ``send_message`` tool — better to have one
+        # canonical path).
 
     async def send_typing(self, channel_id: str, parent_id: str) -> None:
         pass

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1425,6 +1425,41 @@ class PuffoCoreMessageClient:
         # the agent doesn't get the nudge — preferable to spamming.
         await self.store.mark_channel_intro_prompted(channel_id)
 
+        # Persist the synthetic envelope to ``messages.db`` so the
+        # agent can resolve it through its normal data-service paths
+        # (``mcp__puffo__get_channel_history`` /
+        # ``get_message_by_envelope``). Without this, the envelope
+        # only existed in the in-memory thread queue — the agent
+        # would see it in the turn prompt, but a follow-up
+        # ``get_channel_history`` would return an inconsistent view
+        # (intro is missing) and ``send_message(root_id=<intro id>)``
+        # would surface as a broken thread reference. Side benefit:
+        # ``lookup_channel_space`` learns the channel→space mapping
+        # off this envelope automatically.
+        store_payload = {
+            "envelope_id": envelope_id,
+            "envelope_kind": "channel",
+            "sender_slug": "system",
+            "channel_id": channel_id,
+            "space_id": space_id,
+            "content_type": "text/plain",
+            "content": prompt_text,
+            "sent_at": now_ms,
+            "thread_root_id": envelope_id,
+            "reply_to_id": None,
+        }
+        try:
+            await self.store.store(store_payload)
+        except Exception as exc:  # noqa: BLE001
+            # Persistence is best-effort — the in-memory queue still
+            # delivers the prompt even if sqlite fails (disk full,
+            # permission, etc.). Log loud so the operator can spot
+            # the inconsistency between prompt + history.
+            logger.warning(
+                "intro-nudge: failed to persist envelope=%s to messages.db: %s",
+                envelope_id, exc,
+            )
+
         await self._admit_thread_message(
             root_id=envelope_id,
             priority=PRIORITY_SYSTEM,

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -20,6 +20,20 @@ logger = logging.getLogger(__name__)
 DEFAULT_HEARTBEAT_INTERVAL_S = 60.0
 
 
+# envelope_id prefixes the daemon mints for purely-local synthetic
+# messages (no server-side row exists). Status-reporter calls keyed
+# on these IDs would 404 against ``/messages/<id>/processing/{start,
+# end}`` — server reasonably reports "no such message" — and the
+# resulting WARN line per intro nudge was operator-visible noise.
+# Skip the HTTP round-trip entirely for these envelopes; the run is
+# still tracked in-memory by the worker via the returned ``run_id``.
+_LOCAL_ONLY_ENVELOPE_PREFIXES = ("intro-prompt-",)
+
+
+def _is_local_only_envelope(message_id: str) -> bool:
+    return message_id.startswith(_LOCAL_ONLY_ENVELOPE_PREFIXES)
+
+
 class StatusReporter:
     """Owns the heartbeat loop and turn lifecycle hooks.
 
@@ -58,6 +72,14 @@ class StatusReporter:
     async def begin_turn(self, message_id: str) -> str:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
         run_id = f"run_{uuid.uuid4().hex}"
+        if _is_local_only_envelope(message_id):
+            # Daemon-minted synthetic envelope (e.g. intro-prompt).
+            # The server has no row for it; skip the POST so we
+            # don't log a 404 WARN per nudge. Run is still tracked
+            # in-memory via the returned run_id.
+            self._current_status = "busy"
+            self._current_message_id = message_id
+            return run_id
         try:
             await self._http.post(
                 f"/messages/{message_id}/processing/start",
@@ -79,6 +101,13 @@ class StatusReporter:
         succeeded: bool,
         error_text: str | None = None,
     ) -> None:
+        if _is_local_only_envelope(message_id):
+            # Symmetric to ``begin_turn`` — local-only envelopes have
+            # no server-side row to mark ended. Update local status
+            # only.
+            self._current_status = "idle" if succeeded else "error"
+            self._current_message_id = None
+            return
         body: dict[str, Any] = {"run_id": run_id, "succeeded": succeeded}
         if error_text is not None:
             body["error_text"] = error_text[:1024]  # server MAX_TEXT_LEN
@@ -108,15 +137,27 @@ class StatusReporter:
             return
         payload_runs: list[dict[str, Any]] = []
         for r in runs:
+            mid = r.get("message_id", "")
+            if _is_local_only_envelope(mid):
+                # Drop local-only synthetic envelopes — see
+                # ``begin_turn`` rationale. Their run lifecycle is
+                # in-memory only.
+                continue
             entry: dict[str, Any] = {
                 "run_id": r["run_id"],
-                "message_id": r["message_id"],
+                "message_id": mid,
                 "succeeded": bool(r["succeeded"]),
             }
             err = r.get("error_text")
             if err is not None:
                 entry["error_text"] = err[:1024]
             payload_runs.append(entry)
+        # If every run was local-only, there's nothing to POST.
+        if not payload_runs:
+            any_failed = any(not r["succeeded"] for r in runs)
+            self._current_status = "error" if any_failed else "idle"
+            self._current_message_id = None
+            return
         try:
             await self._http.post(
                 "/messages/processing/end:batch", {"runs": payload_runs},

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -413,6 +413,129 @@ def sync_host_mcp_servers(
     return len(host_servers), unreachable
 
 
+def sync_host_plugins(host_home: Path, agent_home: Path) -> str:
+    """Mirror host ``~/.claude/plugins/`` into per-agent
+    ``.claude/plugins/`` so the agent's spawned Claude session can
+    resolve plugin names listed in ``settings.json#enabledPlugins``.
+
+    Without this, ``settings.json`` carries enabledPlugins via
+    ``seed_claude_home`` but Claude can't find the plugin code under
+    ``<agent_home>/.claude/plugins/`` and silently drops every plugin
+    — including any MCP servers they would register. cli-local
+    repro: operator runs ``claude /plugin install
+    chrome-devtools-mcp@claude-plugins-official``, then spawns an
+    agent → the agent sees ``(no MCP servers registered)`` for the
+    plugin-provided MCPs.
+
+    Prefers symlink (free read-through; new host plugin installs /
+    marketplace pulls show up automatically on next worker start
+    without re-copy). Falls back to ``copytree`` on Windows-without-
+    Developer-Mode. The plugin tree can be GB-scale (each marketplace
+    is a git clone with history); on copy fallback we don't refresh
+    an existing copy — operators can ``rm -rf <agent>/.claude/plugins``
+    to force a fresh re-sync.
+
+    Idempotent. Returns ``"symlink"``, ``"symlink (already)"``,
+    ``"copy"``, ``"copy (fresh)"``, or ``"no-host-dir"``.
+    """
+    import shutil
+    host_plugins = host_home / ".claude" / "plugins"
+    agent_plugins = agent_home / ".claude" / "plugins"
+    if not host_plugins.is_dir():
+        return "no-host-dir"
+    agent_plugins.parent.mkdir(parents=True, exist_ok=True)
+
+    # Fast path: existing symlink already points at host_plugins.
+    if agent_plugins.is_symlink():
+        try:
+            current = os.readlink(agent_plugins)
+            if Path(current) == host_plugins or current == str(host_plugins):
+                return "symlink (already)"
+        except OSError:
+            pass
+
+    # Fast path: copy-mode dir already in place. We deliberately
+    # don't recopy — see the docstring for the GB-scale rationale.
+    if agent_plugins.is_dir() and not agent_plugins.is_symlink():
+        return "copy (fresh)"
+
+    # Tear down whatever's there (stale symlink, regular file) before
+    # creating a fresh one. Unlink can fail on Windows races; the
+    # next call retries naturally.
+    try:
+        if agent_plugins.is_symlink() or agent_plugins.exists():
+            agent_plugins.unlink()
+    except OSError:
+        pass
+
+    try:
+        os.symlink(host_plugins, agent_plugins, target_is_directory=True)
+        return "symlink"
+    except (OSError, NotImplementedError):
+        pass
+
+    try:
+        shutil.copytree(host_plugins, agent_plugins)
+        return "copy"
+    except OSError:
+        return "no-host-dir"
+
+
+def sync_host_enabled_plugins(host_home: Path, agent_home: Path) -> int:
+    """Mirror host ``~/.claude/settings.json#enabledPlugins`` into the
+    per-agent ``settings.json``. ``enabledPlugins`` is the complete
+    enumeration of which ``<plugin>@<marketplace>`` names the operator
+    has flipped on; host wins and overwrites the agent's value.
+
+    ``seed_claude_home`` already copies ``settings.json`` once on
+    first start, but it's idempotent — when the operator enables a
+    new plugin later, the agent's copy stays stale. This helper
+    rewrites just ``enabledPlugins`` on every worker start while
+    leaving other settings keys (theme, model preferences, etc.)
+    untouched. The actual plugin code is wired up by the sibling
+    ``sync_host_plugins``.
+
+    Returns the count of enabledPlugins entries propagated. Returns
+    0 when host has no settings.json, no enabledPlugins key, or the
+    value isn't a dict/list.
+    """
+    host_settings = host_home / ".claude" / "settings.json"
+    if not host_settings.is_file():
+        return 0
+    try:
+        host_data = json.loads(host_settings.read_text(encoding="utf-8") or "{}")
+    except (OSError, ValueError):
+        return 0
+    enabled = host_data.get("enabledPlugins")
+    # Claude Code has used both shapes historically — dict
+    # (``{name: true}``) on newer versions, list (``[name, ...]``)
+    # on older. Pass either through unchanged so we don't reshape
+    # something Claude is about to read.
+    if not isinstance(enabled, (list, dict)) or not enabled:
+        return 0
+
+    agent_settings = agent_home / ".claude" / "settings.json"
+    agent_data: dict[str, Any] = {}
+    if agent_settings.exists():
+        try:
+            raw = agent_settings.read_text(encoding="utf-8")
+            if raw.strip():
+                agent_data = json.loads(raw)
+        except (OSError, ValueError):
+            agent_data = {}
+
+    agent_data["enabledPlugins"] = enabled
+
+    try:
+        agent_settings.parent.mkdir(parents=True, exist_ok=True)
+        tmp = agent_settings.with_suffix(agent_settings.suffix + ".tmp")
+        tmp.write_text(json.dumps(agent_data, indent=2), encoding="utf-8")
+        os.replace(tmp, agent_settings)
+    except OSError:
+        return 0
+    return len(enabled)
+
+
 def sync_host_gemini_mcp_servers(
     host_home: Path, project_dir: Path, *, extra_servers: dict | None = None,
 ) -> tuple[int, list[tuple[str, str]]]:

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -144,6 +144,48 @@ async def test_intro_nudge_admits_one_system_priority_envelope():
 
 
 @pytest.mark.asyncio
+async def test_intro_nudge_persists_envelope_to_messages_db():
+    """The synthetic envelope must be queryable via the data-service
+    paths the agent uses at runtime — ``get_channel_history`` /
+    ``get_message_by_envelope`` / ``lookup_channel_space`` — so the
+    agent's view of the channel is consistent with what it just
+    received in its turn prompt. Without persistence the agent
+    would see the intro in the user-block but a follow-up
+    ``get_channel_history`` would return an empty list (or a list
+    that omits the intro), and ``send_message(root_id=<intro id>)``
+    would surface as a broken thread reference."""
+    store = await _make_store()
+    client = _make_client(store)
+
+    await client._enqueue_channel_intro_nudge(
+        space_id="sp_1", channel_id="ch_1",
+    )
+
+    # The envelope is queryable by its id.
+    _, _, root_id = await client._queue.get()
+    envelope = await store.get_message_by_envelope(root_id)
+    assert envelope is not None
+    assert envelope.channel_id == "ch_1"
+    assert envelope.space_id == "sp_1"
+    assert envelope.sender_slug == "system"
+    assert envelope.thread_root_id == root_id
+    assert "[puffo-agent system message]" in envelope.content
+
+    # And it shows up in the channel-history view that the
+    # agent's MCP tooling pulls from.
+    history = await store.get_channel_history(channel_id="ch_1", limit=10)
+    assert len(history) == 1
+    assert history[0].envelope_id == root_id
+
+    # Bonus: ``lookup_channel_space`` learns the mapping off the
+    # persisted envelope so ``send_message`` resolves the right
+    # space without an extra round-trip.
+    assert await store.lookup_channel_space("ch_1") == "sp_1"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_intro_nudge_skipped_when_already_prompted():
     store = await _make_store()
     client = _make_client(store)

--- a/tests/test_docker_host_plugins.py
+++ b/tests/test_docker_host_plugins.py
@@ -1,0 +1,194 @@
+"""``DockerCLIAdapter`` exposes host Claude Code plugins to the
+container.
+
+Two pieces — the bind-mount that surfaces ``~/.claude/plugins/`` at
+the canonical in-container path, and the ``sync_host_enabled_plugins``
+call that propagates the ``enabledPlugins`` array via the per-agent
+settings.json. The image bakes node/npm/python+uv so most
+``npx``/``uvx`` plugin commands resolve naturally; this test suite
+covers only the wiring — actual plugin-load behavior lives in
+Claude's own pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+from puffo_agent.agent.adapters import docker_cli
+from puffo_agent.agent.adapters.docker_cli import DockerCLIAdapter
+
+
+def _make_adapter(tmp_path):
+    return DockerCLIAdapter(
+        agent_id="t",
+        model="",
+        image="puffo/agent-runtime:test",
+        workspace_dir=str(tmp_path / "ws"),
+        claude_dir=str(tmp_path / "ws" / ".claude"),
+        session_file=str(tmp_path / "session.json"),
+        agent_home_dir=str(tmp_path / "home"),
+        shared_fs_dir=str(tmp_path / "shared"),
+    )
+
+
+def _capture_docker_run_argv(adapter, monkey_home) -> list[str]:
+    """Drive ``_start_container`` with ``_run_cmd`` patched to a
+    capture-and-noop stub. Mirrors the helper in
+    ``test_docker_memory_limits.py`` — kept inline to avoid a shared
+    test-helper module for a 15-line function."""
+    captured: list[list[str]] = []
+
+    async def _fake_run_cmd(cmd, check=True):
+        captured.append(list(cmd))
+        return 0, b"", b""
+
+    with patch.object(docker_cli, "_run_cmd", new=_fake_run_cmd), \
+         patch.object(docker_cli.Path, "home", staticmethod(lambda: monkey_home)):
+        asyncio.run(adapter._start_container())
+
+    for cmd in captured:
+        if len(cmd) >= 2 and cmd[0] == "docker" and cmd[1] == "run":
+            return cmd
+    raise AssertionError(
+        f"no docker-run invocation captured; got: {captured!r}"
+    )
+
+
+# ── bind-mount ──────────────────────────────────────────────────────────────
+
+
+def test_plugins_bindmount_injected_when_host_dir_exists(tmp_path):
+    """Host has ``~/.claude/plugins/`` → the docker run argv gains a
+    nested read-only bind-mount surfacing it at the canonical in-
+    container path."""
+    host = tmp_path / "host"
+    plugins = host / ".claude" / "plugins"
+    plugins.mkdir(parents=True)
+    (plugins / "installed_plugins.json").write_text("{}", encoding="utf-8")
+    adapter = _make_adapter(tmp_path)
+
+    argv = _capture_docker_run_argv(adapter, host)
+
+    mount = f"{plugins}:/home/agent/.claude/plugins:ro"
+    assert mount in argv, (
+        f"expected bind-mount {mount!r} in docker-run argv; got: {argv!r}"
+    )
+    # The outer .claude bind-mount has to come BEFORE the nested
+    # plugins one for Docker to honor the overlay.
+    claude_mount_idx = next(
+        i for i, a in enumerate(argv)
+        if isinstance(a, str) and a.endswith(":/home/agent/.claude")
+    )
+    plugins_mount_idx = argv.index(mount)
+    assert claude_mount_idx < plugins_mount_idx
+
+
+def test_plugins_bindmount_absent_when_host_dir_missing(tmp_path):
+    """No host plugins dir → no extra mount. Avoids Docker
+    auto-creating an empty plugins/ on the host."""
+    host = tmp_path / "host"  # no .claude/plugins/
+    (host / ".claude").mkdir(parents=True)
+    adapter = _make_adapter(tmp_path)
+
+    argv = _capture_docker_run_argv(adapter, host)
+
+    plugin_mounts = [a for a in argv if isinstance(a, str) and "/.claude/plugins" in a]
+    assert plugin_mounts == [], (
+        f"expected no plugins mount when host has none; got: {plugin_mounts!r}"
+    )
+
+
+def test_plugins_bindmount_is_readonly(tmp_path):
+    """The mount must be ``:ro``. Agents must never write back into
+    the operator's plugin tree — a stray write could corrupt a
+    marketplace's git checkout or an installed_plugins.json other
+    agents depend on."""
+    host = tmp_path / "host"
+    plugins = host / ".claude" / "plugins"
+    plugins.mkdir(parents=True)
+    adapter = _make_adapter(tmp_path)
+
+    argv = _capture_docker_run_argv(adapter, host)
+
+    plugins_mount = next(
+        a for a in argv
+        if isinstance(a, str) and "/.claude/plugins" in a and a.endswith(":ro")
+    )
+    assert plugins_mount.endswith(":/home/agent/.claude/plugins:ro")
+
+
+def test_plugins_bindmount_appears_before_image(tmp_path):
+    """Docker rejects flags after the image positional, same
+    constraint as the memory-limit tests."""
+    host = tmp_path / "host"
+    plugins = host / ".claude" / "plugins"
+    plugins.mkdir(parents=True)
+    adapter = _make_adapter(tmp_path)
+
+    argv = _capture_docker_run_argv(adapter, host)
+
+    image_idx = argv.index("puffo/agent-runtime:test")
+    plugins_idx = next(
+        i for i, a in enumerate(argv)
+        if isinstance(a, str) and "/.claude/plugins:ro" in a
+    )
+    assert plugins_idx < image_idx
+
+
+# ── enabledPlugins propagation ──────────────────────────────────────────────
+
+
+def test_ensure_started_propagates_enabled_plugins(tmp_path):
+    """``_ensure_started`` calls ``sync_host_enabled_plugins`` so the
+    per-agent settings.json — which is reachable inside the
+    container via the existing ``.claude`` bind-mount — carries the
+    host's enabledPlugins array.
+
+    The integration path is heavily mocked (``_run_cmd``,
+    ``_ensure_image``, ``_start_container``) so the test can run
+    without a docker daemon. The assertion targets the on-disk
+    settings.json the sync helper writes, not the docker argv —
+    that's covered by the bind-mount tests above."""
+    host = tmp_path / "host"
+    (host / ".claude").mkdir(parents=True)
+    (host / ".claude" / "settings.json").write_text(
+        json.dumps({
+            "enabledPlugins": {
+                "imessage@claude-plugins-official": True,
+                "chrome-devtools-mcp@claude-plugins-official": True,
+            },
+        }),
+        encoding="utf-8",
+    )
+    adapter = _make_adapter(tmp_path)
+    agent_home = tmp_path / "home"
+
+    async def _noop_coro(*_args, **_kwargs):
+        return None
+
+    async def _fake_run_cmd(cmd, check=True):
+        # ``_container_state`` parses an empty stdout as "", which
+        # routes _ensure_started into the build+run branch we noop
+        # below. ``_puffo_pkg_mount_is_current`` is bypassed because
+        # ``existed`` resolves False (state == "").
+        return 0, b"", b""
+
+    async def _run() -> None:
+        with patch.object(docker_cli, "_run_cmd", new=_fake_run_cmd), \
+             patch.object(docker_cli.Path, "home", staticmethod(lambda: host)), \
+             patch.object(docker_cli.shutil, "which", lambda _: "/fake/docker"), \
+             patch.object(adapter, "_ensure_image", side_effect=_noop_coro), \
+             patch.object(adapter, "_start_container", side_effect=_noop_coro):
+            await adapter._ensure_started()
+
+    asyncio.run(_run())
+
+    settings = json.loads(
+        (agent_home / ".claude" / "settings.json").read_text(encoding="utf-8"),
+    )
+    assert settings["enabledPlugins"] == {
+        "imessage@claude-plugins-official": True,
+        "chrome-devtools-mcp@claude-plugins-official": True,
+    }

--- a/tests/test_host_sync.py
+++ b/tests/test_host_sync.py
@@ -19,15 +19,44 @@ from __future__ import annotations
 
 import json
 
+import os
+from pathlib import Path
+
+import pytest
+
 from puffo_agent.portal.state import (
     AGENT_INSTALLED_MARKER,
     HOST_SYNCED_MARKER,
     _looks_host_local_command,
+    sync_host_enabled_plugins,
     sync_host_gemini_mcp_servers,
     sync_host_gemini_skills,
     sync_host_mcp_servers,
+    sync_host_plugins,
     sync_host_skills,
 )
+
+
+def _symlinks_available(tmp_path: Path) -> bool:
+    """Probe: can this process create a symlink in ``tmp_path``?
+    Mirrors the helper in ``test_host_credentials.py`` so the
+    plugin-sync tests can skip the symlink path on Windows-without-
+    Developer-Mode without dragging in a shared import.
+    """
+    probe = tmp_path / "_probe_symlink"
+    target = tmp_path / "_probe_target"
+    target.write_text("x", encoding="utf-8")
+    try:
+        os.symlink(target, probe)
+        probe.unlink()
+        target.unlink()
+        return True
+    except (OSError, NotImplementedError):
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        return False
 
 
 # ── Skills ───────────────────────────────────────────────────────────────────
@@ -293,6 +322,231 @@ def test_sync_host_mcp_handles_empty_agent_file(tmp_path):
     assert merged == 1
     data = json.loads((agent / ".claude.json").read_text(encoding="utf-8"))
     assert "fs" in data["mcpServers"]
+
+
+# ── Plugins ──────────────────────────────────────────────────────────────────
+
+
+def _populate_host_plugins(host: Path) -> Path:
+    """Build a minimal host plugins/ tree that exercises every branch
+    the agent's spawned Claude session will read. Returns the plugins
+    dir path."""
+    plugins = host / ".claude" / "plugins"
+    (plugins / "marketplaces" / "claude-plugins-official" / ".git").mkdir(parents=True)
+    (plugins / "marketplaces" / "claude-plugins-official" / "imessage" / "manifest.json").parent.mkdir(parents=True, exist_ok=True)
+    (plugins / "marketplaces" / "claude-plugins-official" / "imessage" / "manifest.json").write_text(
+        '{"name": "imessage"}', encoding="utf-8",
+    )
+    (plugins / "cache" / "build-001").mkdir(parents=True)
+    (plugins / "cache" / "build-001" / "compiled.bin").write_bytes(b"\x00\x01\x02")
+    (plugins / "installed_plugins.json").write_text(
+        '{"plugins": ["imessage@claude-plugins-official"]}', encoding="utf-8",
+    )
+    (plugins / "known_marketplaces.json").write_text(
+        '{"marketplaces": ["claude-plugins-official"]}', encoding="utf-8",
+    )
+    return plugins
+
+
+def test_sync_host_plugins_symlinks_when_supported(tmp_path):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
+    host = tmp_path / "host"
+    _populate_host_plugins(host)
+    agent = tmp_path / "agent"
+
+    mode = sync_host_plugins(host, agent)
+
+    assert mode == "symlink"
+    plugins = agent / ".claude" / "plugins"
+    assert plugins.is_symlink()
+    # Resolving through the symlink lands at the host file — the
+    # whole point: a fresh host plugin install shows up immediately.
+    assert (plugins / "installed_plugins.json").read_text() == (
+        '{"plugins": ["imessage@claude-plugins-official"]}'
+    )
+    assert (
+        plugins / "marketplaces" / "claude-plugins-official" / "imessage" / "manifest.json"
+    ).read_text() == '{"name": "imessage"}'
+
+
+def test_sync_host_plugins_idempotent_when_symlink_exists(tmp_path):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
+    host = tmp_path / "host"
+    _populate_host_plugins(host)
+    agent = tmp_path / "agent"
+
+    assert sync_host_plugins(host, agent) == "symlink"
+    # Second call recognises the existing symlink without re-creating.
+    assert sync_host_plugins(host, agent) == "symlink (already)"
+
+
+def test_sync_host_plugins_no_host_dir_returns_no_host_dir(tmp_path):
+    host = tmp_path / "host"  # no .claude/plugins/
+    agent = tmp_path / "agent"
+
+    mode = sync_host_plugins(host, agent)
+
+    assert mode == "no-host-dir"
+    assert not (agent / ".claude" / "plugins").exists()
+
+
+def test_sync_host_plugins_copy_fallback_when_symlink_blocked(
+    tmp_path, monkeypatch,
+):
+    """Force the symlink branch to raise so the copytree fallback
+    runs. Mirrors the Windows-without-Developer-Mode reality."""
+    host = tmp_path / "host"
+    _populate_host_plugins(host)
+    agent = tmp_path / "agent"
+    from puffo_agent.portal import state as state_mod
+
+    def _no_symlink(*_args, **_kwargs):
+        raise OSError("symlink blocked")
+    monkeypatch.setattr(state_mod.os, "symlink", _no_symlink)
+
+    mode = sync_host_plugins(host, agent)
+
+    assert mode == "copy"
+    plugins = agent / ".claude" / "plugins"
+    assert plugins.is_dir() and not plugins.is_symlink()
+    # Copy preserves the marketplace + cache + the two json siblings.
+    assert (plugins / "installed_plugins.json").exists()
+    assert (plugins / "known_marketplaces.json").exists()
+    assert (
+        plugins / "marketplaces" / "claude-plugins-official" / "imessage" / "manifest.json"
+    ).read_text() == '{"name": "imessage"}'
+
+
+def test_sync_host_plugins_copy_fresh_skips_recopy(tmp_path, monkeypatch):
+    """An already-copied tree stays as-is — re-copying a GB-scale
+    plugin tree on every worker tick would be the wrong default."""
+    host = tmp_path / "host"
+    _populate_host_plugins(host)
+    agent = tmp_path / "agent"
+    from puffo_agent.portal import state as state_mod
+    monkeypatch.setattr(state_mod.os, "symlink", lambda *_a, **_kw: (_ for _ in ()).throw(OSError("nope")))
+
+    assert sync_host_plugins(host, agent) == "copy"
+    # Modify host after the initial copy.
+    (host / ".claude" / "plugins" / "new-marker").write_text("v2", encoding="utf-8")
+
+    # Second call sees an existing dir and doesn't recopy.
+    assert sync_host_plugins(host, agent) == "copy (fresh)"
+    assert not (agent / ".claude" / "plugins" / "new-marker").exists()
+
+
+# ── enabledPlugins propagation ───────────────────────────────────────────────
+
+
+def test_sync_host_enabled_plugins_propagates_dict_shape(tmp_path):
+    """Newer Claude Code stores enabledPlugins as
+    ``{name: bool}``. Pass through unchanged."""
+    host = tmp_path / "host"
+    _write_json(host / ".claude" / "settings.json", {
+        "enabledPlugins": {
+            "imessage@claude-plugins-official": True,
+            "chrome-devtools-mcp@claude-plugins-official": True,
+        },
+        "theme": "dark",  # unrelated key, must survive
+    })
+    agent = tmp_path / "agent"
+
+    n = sync_host_enabled_plugins(host, agent)
+
+    assert n == 2
+    data = json.loads((agent / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert data["enabledPlugins"] == {
+        "imessage@claude-plugins-official": True,
+        "chrome-devtools-mcp@claude-plugins-official": True,
+    }
+
+
+def test_sync_host_enabled_plugins_propagates_list_shape(tmp_path):
+    """Older Claude Code uses ``[name, ...]``. Same passthrough."""
+    host = tmp_path / "host"
+    _write_json(host / ".claude" / "settings.json", {
+        "enabledPlugins": [
+            "imessage@claude-plugins-official",
+            "chrome-devtools-mcp@claude-plugins-official",
+        ],
+    })
+    agent = tmp_path / "agent"
+
+    n = sync_host_enabled_plugins(host, agent)
+
+    assert n == 2
+    data = json.loads((agent / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert data["enabledPlugins"] == [
+        "imessage@claude-plugins-official",
+        "chrome-devtools-mcp@claude-plugins-official",
+    ]
+
+
+def test_sync_host_enabled_plugins_preserves_other_agent_keys(tmp_path):
+    host = tmp_path / "host"
+    _write_json(host / ".claude" / "settings.json", {
+        "enabledPlugins": {"foo@market": True},
+    })
+    agent = tmp_path / "agent"
+    _write_json(agent / ".claude" / "settings.json", {
+        "theme": "light",                  # agent-only preference
+        "model": "claude-opus-4-7",        # agent-only preference
+        "enabledPlugins": {"stale@old": True},  # to be overwritten
+    })
+
+    n = sync_host_enabled_plugins(host, agent)
+
+    assert n == 1
+    data = json.loads((agent / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert data["theme"] == "light"
+    assert data["model"] == "claude-opus-4-7"
+    # Stale agent entry replaced by host.
+    assert data["enabledPlugins"] == {"foo@market": True}
+
+
+def test_sync_host_enabled_plugins_creates_agent_settings_if_missing(tmp_path):
+    """First-time agent has no settings.json yet (seed_claude_home
+    hasn't run, or the operator-installed plugins haven't propagated).
+    The helper still writes a minimal file."""
+    host = tmp_path / "host"
+    _write_json(host / ".claude" / "settings.json", {
+        "enabledPlugins": {"foo@market": True},
+    })
+    agent = tmp_path / "agent"  # no settings.json
+
+    n = sync_host_enabled_plugins(host, agent)
+
+    assert n == 1
+    data = json.loads((agent / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert data == {"enabledPlugins": {"foo@market": True}}
+
+
+def test_sync_host_enabled_plugins_noop_when_host_missing(tmp_path):
+    host = tmp_path / "host"  # no settings.json
+    agent = tmp_path / "agent"
+
+    n = sync_host_enabled_plugins(host, agent)
+
+    assert n == 0
+    assert not (agent / ".claude" / "settings.json").exists()
+
+
+def test_sync_host_enabled_plugins_noop_when_host_field_absent(tmp_path):
+    """Host settings.json exists but has no enabledPlugins — leave
+    the agent file alone (no spurious write that bumps mtime)."""
+    host = tmp_path / "host"
+    _write_json(host / ".claude" / "settings.json", {"theme": "dark"})
+    agent = tmp_path / "agent"
+    _write_json(agent / ".claude" / "settings.json", {"model": "claude-opus-4-7"})
+
+    n = sync_host_enabled_plugins(host, agent)
+
+    assert n == 0
+    data = json.loads((agent / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    # Untouched.
+    assert data == {"model": "claude-opus-4-7"}
 
 
 # ── Unreachable-command heuristic ────────────────────────────────────────────

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -292,3 +292,74 @@ async def test_end_turn_batch_swallows_http_error():
         {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
     ])
     assert len(http.calls) == 1
+
+
+# ── Local-only envelope skip path ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_begin_turn_skips_http_for_local_only_envelope():
+    """Daemon-minted synthetic envelopes (intro-prompt-...) have no
+    server-side row. Posting to ``/messages/<id>/processing/start``
+    used to 404 and log a WARN per nudge — kill that noise."""
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    run_id = await rep.begin_turn("intro-prompt-ch_xxx-1778641626040")
+
+    assert run_id.startswith("run_")
+    assert http.calls == []  # No round-trip.
+    # Local-only run still flips state to busy so the heartbeat
+    # carries the in-progress envelope id.
+    assert rep._current_status == "busy"
+    assert rep._current_message_id == "intro-prompt-ch_xxx-1778641626040"
+
+
+@pytest.mark.asyncio
+async def test_end_turn_skips_http_for_local_only_envelope():
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    rep._current_status = "busy"
+    rep._current_message_id = "intro-prompt-ch_a-1"
+
+    await rep.end_turn("intro-prompt-ch_a-1", "run_x", succeeded=True)
+
+    assert http.calls == []
+    assert rep._current_status == "idle"
+    assert rep._current_message_id is None
+
+
+@pytest.mark.asyncio
+async def test_end_turn_batch_filters_local_only_runs():
+    """A thread batch can contain a synthetic intro envelope mixed
+    with real follow-up messages. ``end_turn_batch`` must keep the
+    real ones in the wire payload and drop the local-only entries
+    so the server doesn't see a phantom message id."""
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    await rep.end_turn_batch([
+        {"run_id": "run_intro", "message_id": "intro-prompt-ch_1-1", "succeeded": True},
+        {"run_id": "run_real",  "message_id": "env_real", "succeeded": True},
+    ])
+
+    assert len(http.calls) == 1
+    _, body = http.calls[0]
+    msg_ids = [r["message_id"] for r in body["runs"]]
+    assert msg_ids == ["env_real"]
+
+
+@pytest.mark.asyncio
+async def test_end_turn_batch_all_local_only_skips_http():
+    """All-synthetic batches don't hit the wire — there's nothing
+    for the server to upsert."""
+    http = FakeHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    await rep.end_turn_batch([
+        {"run_id": "run_a", "message_id": "intro-prompt-ch_a-1", "succeeded": True},
+        {"run_id": "run_b", "message_id": "intro-prompt-ch_b-1", "succeeded": True},
+    ])
+
+    assert http.calls == []
+    assert rep._current_status == "idle"


### PR DESCRIPTION
## Summary

Four operator-reported bugs found while debugging cli-local + cli-docker agent visibility. All four converge on the same theme — the agent's local view of "what's in the channel" should match what other participants see — but each is an independent root cause. Pairs with [puffo-core-han-group#83](https://github.com/puffo-ai/puffo-core-han-group/pull/83) (web side).

---

## 1. Host Claude Code plugins propagate to per-agent ``$HOME``

Operator-reported: plugins installed via ``claude /plugin install <name>@<marketplace>`` (e.g. ``imessage@claude-plugins-official``, ``chrome-devtools-mcp@claude-plugins-official``) are silently invisible to agents. ``mcp__puffo__list_mcp_servers`` returns ``(no MCP servers registered)`` for the plugin-provided MCPs.

**Diagnosis.** ``seed_claude_home`` was one-shot copying ``.claude/settings.json`` + ``.claude.json``, but nothing was bringing across (a) ``~/.claude/plugins/`` — the marketplace clones + plugin cache + ``installed_plugins.json`` + ``known_marketplaces.json``, or (b) ``settings.json#enabledPlugins`` which gets stale after the first copy. Plugin MCP servers register through the plugin pipeline, not through the user-level ``mcpServers`` map ``sync_host_mcp_servers`` merges.

**Fix.** Two new helpers in ``portal/state.py``:
- ``sync_host_plugins(host_home, agent_home) → str`` — symlinks ``host_home/.claude/plugins/`` to ``agent_home/.claude/plugins/`` (GB-scale tree, marketplace clones include git history; symlink keeps the agent live with host installs without recopy cost). Falls back to ``copytree`` on Windows-without-Developer-Mode.
- ``sync_host_enabled_plugins(host_home, agent_home) → int`` — rewrites just the ``enabledPlugins`` key in per-agent settings.json from the host's, atomic tmp+rename. Accepts both the dict (``{name: true}``) and list shapes Claude Code has used historically.

cli-local wires both into ``_verify()``. cli-docker takes a different shape: the container's ``/home/agent/.claude`` is already an outer bind-mount, so we nest a read-only second mount surfacing ``host_home/.claude/plugins`` at ``/home/agent/.claude/plugins:ro`` (Docker honors the nested mount when the outer comes first in argv). The cli-docker image is ``node:22-bookworm-slim`` with python + uv layered on, so most ``npx`` / ``uvx`` plugin commands resolve naturally; native-binary plugins (host-only absolute paths) still fail at use-time as a runtime error from Claude, not a silent drop.

Commits: ``bf5789d`` (cli-local), ``409a888`` (cli-docker). 16 new tests across ``test_host_sync.py`` + ``test_docker_host_plugins.py``.

---

## 2. Intro-nudge envelope persisted to ``messages.db`` + status-reporter 404 quieted

Operator-reported: after joining a channel the agent received the ``[puffo-agent system message] You've just been added to …`` prompt and posted an intro, but the daemon log carried a noisy ``begin_turn message=intro-prompt-… failed (HTTP 404)`` per nudge, and the agent's own ``mcp__puffo__get_channel_history`` right after would return an inconsistent view (the intro it just received wasn't there).

**Diagnosis.** The synthetic envelope only lived in the in-memory thread queue. The server never saw it (no row → 404 on ``/messages/<id>/processing/start``), and the agent's local data service never saw it either (sqlite was bypassed).

**Fix.** ``_enqueue_channel_intro_nudge`` writes the envelope to ``messages.db`` via ``MessageStore.store`` before ``_admit_thread_message``. ``get_channel_history`` / ``get_message_by_envelope`` / ``lookup_channel_space`` all resolve it naturally; ``send_message(root_id=<intro id>)`` is now a real local thread root. Plus: ``StatusReporter.begin_turn`` / ``end_turn`` / ``end_turn_batch`` recognise local-only envelope prefixes (currently ``intro-prompt-``) and skip the server POST.

Commit: ``e95e1ef``. 5 new tests (persistence + 4 status-reporter skip-path).

---

## 3. Agents can see their own sent messages

Operator-reported: ``get_thread_history(<root>)`` returned only messages from other senders; the agent's own replies were absent even though other agents in the same thread saw them fine.

**Diagnosis.** Two parallel send paths existed, only one mirrored to local store:
- ``PuffoCoreMessageClient.post_message`` (daemon-internal, fallback-reply path) — POST /messages, then mirror-write.
- ``mcp__puffo__send_message`` (the actual agent path) — POST /messages and stop. No local mirror.

Both relied on ``handle_envelope`` to not persist, because it dropped ``sender_slug == self.slug`` at the door. Result: when the agent used its MCP tool (which is every time), the outbound never landed in messages.db.

**Fix.** Take the server-echoed envelope as the canonical write trigger (Han's framing: ""server-returned is the true delivered message; otherwise treat as send failure""). ``handle_envelope`` no longer drops self-envelopes — the server fans out to every device in ``envelope.recipients`` which includes the agent's own device, so WS echo IS the delivery confirmation. Self-envelopes are decrypted + stored, then early-return BEFORE worker dispatch (otherwise the agent re-receives its own words and echo-loops). The mirror-write in ``post_message`` is dead weight now; removed. Both send paths converge on the WS-echo persistence — single source of truth for "what was actually delivered".

Commit: ``c6699fe``. Existing tests unchanged (no test asserted the old self-skip behavior; follow-up will extract ``handle_envelope`` to a method for unit-testable structure).

---

## Tests

Full suite: **496 passed, 7 skipped** (skip set unchanged — 4 host-credentials symlink + 2 new plugin-tree symlink + 1 permission-mode; all platform-related, not behavioral). +21 new tests vs main: 16 plugin-sync + 5 intro-nudge / status-reporter.

## Test plan

- [x] ``pytest`` — 496 / 503.
- [ ] **Manual on bobbyliu's macOS (cli-local)**: install from this branch → restart daemon → fresh agent session → ``/mcp`` lists the host-enabled plugins; ``get_thread_history`` shows the agent's own replies after a few sends; the daemon log no longer has ``begin_turn ... 404`` lines after each channel-invite accept.
- [ ] **Manual on cli-docker**: ``docker inspect <container>`` shows the nested ``/home/agent/.claude/plugins:ro`` mount; per-agent ``settings.json`` inside the container has ``enabledPlugins``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)