### PR TITLE
feat(cli): puffo-agent agent autoaccept — per-space owner-invite toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- ``puffo-agent agent autoaccept <id> --space <space_id> --owner on|off``
+  — toggles the agent's per-space ``auto_accept_owner_invite``
+  flag via signed PATCH to puffo-server's new
+  ``/spaces/{id}/members/me/settings`` endpoint. When ON, the
+  agent silently joins any channel its space owner invites it to;
+  when OFF, the invite goes through the normal DM-operator
+  confirmation path. Member-invite flag is deliberately not
+  exposed — the server returns 403 for agents on that field. CLI
+  uses the agent's own keystore (same auth model as the
+  ``profile`` subcommand: operator controls the local keystore,
+  so a CLI invocation IS an operator decision).
+
 ## [0.7.7] — 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   ``profile`` subcommand: operator controls the local keystore,
   so a CLI invocation IS an operator decision).
 
+### Changed
+
+- **Self-introduction nudge now fires on server-side auto-accept
+  too.** Previously the synthetic ``AcceptChannelInvite`` event the
+  server emits when it short-circuits an InviteToChannel
+  (``auto_accept_owner_invite=TRUE`` + inviter is the space owner)
+  was silently ignored by the daemon's WS handler, so the agent
+  never posted its 2-3-sentence intro in the auto-joined channel.
+  The handler now recognises the synthetic variant via the
+  ``payload.original_invite`` marker and routes through the same
+  ``_enqueue_channel_intro_nudge`` path that the operator-signed
+  accept already uses. Idempotent: redelivered events hit the
+  existing per-channel dedup gate. 5 new unit tests pin the
+  branch + negative cases (other-slug fan-out, operator-signed
+  echo, malformed payload).
+
 ## [0.7.7] — 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.8] — 2026-05-13
+
 ### Added
 
 - ``puffo-agent agent autoaccept <id> --space <space_id> --owner on|off``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.7.7"
+version = "0.7.8"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -985,14 +985,49 @@ class PuffoCoreMessageClient:
         prevents the next periodic poll from double-acting.
         """
         kind = event.get("kind")
-        if kind not in ("invite_to_space", "invite_to_channel"):
+        payload = event.get("payload") or {}
+
+        if kind in ("invite_to_space", "invite_to_channel"):
+            if payload.get("invitee_slug") != self.slug:
+                return  # Server fans the event to space members too.
+            await self._poll_pending_invites()
             return
 
-        payload = event.get("payload") or {}
-        if payload.get("invitee_slug") != self.slug:
-            return  # Server fans the event to space members too.
-
-        await self._poll_pending_invites()
+        # Server-side auto-accept synthetic event. When the server
+        # short-circuits an InviteToChannel because this agent's
+        # ``auto_accept_owner_invite`` flag is on AND the inviter is
+        # the space owner, it emits an ``accept_channel_invite``
+        # signed-as-the-invitee with the original signed invite
+        # nested under ``payload.original_invite``. There's no
+        # pending_invites row to poll and ``_accept_invite`` never
+        # runs, so the self-intro nudge that path normally fires
+        # would otherwise be silently dropped on auto-accept.
+        # Mirror just the nudge here.
+        if kind == "accept_channel_invite":
+            if event.get("signer_slug") != self.slug:
+                return  # Someone else's accept — not our business.
+            # Distinguish the server-emitted synthetic from a
+            # real signed accept that's bouncing back over WS.
+            # ``original_invite`` is the canonical marker — the
+            # operator-signed path never embeds the source invite.
+            if not isinstance(payload.get("original_invite"), dict):
+                return
+            space_id = payload.get("space_id") or ""
+            channel_id = payload.get("channel_id") or ""
+            if not space_id or not channel_id:
+                return
+            try:
+                await self._enqueue_channel_intro_nudge(
+                    space_id=space_id,
+                    channel_id=channel_id,
+                )
+            except Exception:
+                logger.exception(
+                    "failed to enqueue intro nudge for server-auto-"
+                    "accepted channel (space=%s channel=%s)",
+                    space_id, channel_id,
+                )
+            return
 
     async def _poll_pending_invites(self) -> None:
         """Pull pending invites the agent hasn't acted on. Space

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -764,6 +764,61 @@ def cmd_agent_rename(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_agent_autoaccept(args: argparse.Namespace) -> int:
+    """Flip the agent's per-space ``auto_accept_owner_invite`` flag
+    via the server's PATCH endpoint. Signed by the agent's own subkey
+    (mirrors the ``profile`` CLI's auth model — the operator
+    controls the local keystore, so a CLI invocation IS an operator
+    decision).
+
+    The member-invite flag is intentionally not exposed: the server
+    rejects PATCH-with-member-flag from agent identities (403), so
+    surfacing it as a CLI flag would just produce a confusing
+    server error. If/when the policy changes, add ``--member``
+    here in lockstep with relaxing the server-side gate.
+    """
+    import asyncio
+
+    agent_id = args.id
+    if not agent_yml_path(agent_id).exists():
+        print(f"error: agent {agent_id!r} not found", file=sys.stderr)
+        return 2
+    cfg = AgentConfig.load(agent_id)
+    space_id = args.space
+    owner_on = args.owner == "on"
+
+    async def patch_settings() -> dict:
+        from ..crypto.http_client import PuffoCoreHttpClient
+        from ..crypto.keystore import KeyStore
+
+        pc = cfg.puffo_core
+        ks = KeyStore.for_agent(cfg.id)
+        http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
+        try:
+            return await http.patch(
+                f"/spaces/{space_id}/members/me/settings",
+                {"auto_accept_owner_invite": owner_on},
+            )
+        finally:
+            await http.close()
+
+    try:
+        resp = asyncio.run(patch_settings())
+    except Exception as exc:
+        print(f"error: server PATCH failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"agent {agent_id!r} in space {space_id}: "
+        f"auto_accept_owner_invite = {resp.get('auto_accept_owner_invite')!r}"
+    )
+    print(
+        f"  auto_accept_member_invite (unchanged, locked for agents): "
+        f"{resp.get('auto_accept_member_invite')!r}"
+    )
+    return 0
+
+
 def cmd_agent_profile(args: argparse.Namespace) -> int:
     """Show or update the identity-profile fields (display_name, role,
     role_short) and best-effort sync them to puffo-server signed by
@@ -1309,6 +1364,27 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     profile.set_defaults(func=cmd_agent_profile)
+
+    autoaccept = agent_sub.add_parser(
+        "autoaccept",
+        help=(
+            "Toggle this agent's auto-accept-channel-invite preference "
+            "in a given space. With --owner on, the agent silently "
+            "joins any channel its space-owner invites it to; with off, "
+            "the agent goes through the normal DM-operator confirmation "
+            "path. The member-invite flag is locked off for agents in "
+            "this build (server returns 403)."
+        ),
+    )
+    autoaccept.add_argument("id")
+    autoaccept.add_argument("--space", required=True, help="space_id (sp_<uuid>) to scope the toggle to")
+    autoaccept.add_argument(
+        "--owner",
+        choices=["on", "off"],
+        required=True,
+        help="Auto-accept channel invites from the space owner",
+    )
+    autoaccept.set_defaults(func=cmd_agent_autoaccept)
 
     archive = agent_sub.add_parser("archive", help="Stop and archive an agent to ~/.puffo-agent/archived/")
     archive.add_argument("id")

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -478,3 +478,167 @@ async def test_intro_nudge_survives_simulated_restart():
     )
     assert client_2._queue.qsize() == 0
     await store_2.close()
+
+
+# ─── _handle_event: server-side auto-accept synthetic event ───────
+#
+# When the server short-circuits an InviteToChannel (because the
+# agent's ``auto_accept_owner_invite`` flag is on AND the inviter
+# is the space owner), it emits a synthetic AcceptChannelInvite
+# event signed-as-the-invitee with the original signed invite
+# nested under ``payload.original_invite``. The agent's
+# ``_accept_invite`` path — which normally fires the self-intro
+# nudge — never runs in this case, so ``_handle_event`` has to
+# trigger the nudge directly off the WS push. These tests pin
+# that branch.
+
+
+def _synthetic_accept_event(
+    *, agent_slug: str, space_id: str, channel_id: str,
+    invite_event_id: str = "ev_invite_1",
+    inviter_slug: str = "alice-0001",
+) -> dict:
+    """Wire-shape mirror of the synthetic event the server emits
+    from ``build_auto_accept_synthetic_event`` (puffo-server
+    ``spaces.rs``). The agent only reads a handful of fields here
+    (``kind``, ``signer_slug``, ``payload.space_id`` /
+    ``channel_id`` / ``original_invite``); the rest of the payload
+    is included so the fixture stays a faithful copy of the wire."""
+    return {
+        "type": "signed_event",
+        "version": 1,
+        "event_id": "ev_auto_accept_1",
+        "kind": "accept_channel_invite",
+        "signer_slug": agent_slug,
+        "signer_device_id": "",
+        "signer_subkey_id": "",
+        "signature": "server-auto:default-general-channel",
+        "payload": {
+            "space_id": space_id,
+            "channel_id": channel_id,
+            "invitation_event_id": invite_event_id,
+            "accepted_at": 1_700_000_000_000,
+            "nonce": "test-nonce",
+            "channel_name": "secret-room",
+            # Real inviter signature would live here on the wire;
+            # the agent treats the presence of this object as the
+            # "this is a server auto-accept" marker.
+            "original_invite": {
+                "type": "signed_event",
+                "version": 1,
+                "event_id": invite_event_id,
+                "kind": "invite_to_channel",
+                "signer_slug": inviter_slug,
+                "signer_device_id": "dev_alice",
+                "signer_subkey_id": "sk_alice",
+                "signature": "real-signature-bytes-b64",
+                "payload": {
+                    "space_id": space_id,
+                    "channel_id": channel_id,
+                    "invitee_slug": agent_slug,
+                    "issued_at": 1_700_000_000_000,
+                    "nonce": "invite-nonce",
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_event_fires_intro_on_synthetic_auto_accept():
+    """The happy path: server-emitted accept_channel_invite event
+    addressed to this agent → intro nudge lands on the queue."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="sp_1", channel_id="ch_1",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert client._queue.qsize() == 1
+    assert await store.has_channel_intro_been_prompted("ch_1") is True
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ignores_accept_for_other_slug():
+    """A space owner accepting a different invitee's invite gets
+    fanned out to us too; we must not react."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="someone-else", space_id="sp_1", channel_id="ch_1",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert client._queue.qsize() == 0
+    assert await store.has_channel_intro_been_prompted("ch_1") is False
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ignores_operator_signed_accept():
+    """A real signed accept the agent itself (or its operator) posted
+    bounces back over WS. Without ``original_invite`` it must NOT
+    fire a nudge — ``_accept_invite`` already did, and double-firing
+    would be visible as two intros in the channel."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="sp_1", channel_id="ch_1",
+    )
+    # Strip the marker the synthetic event carries.
+    del event["payload"]["original_invite"]
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert client._queue.qsize() == 0
+    assert await store.has_channel_intro_been_prompted("ch_1") is False
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_synthetic_accept_is_idempotent():
+    """Server WS catch-up after a reconnect can redeliver the same
+    synthetic accept event. The per-channel dedup gate must hold —
+    only one intro lands in the queue across redeliveries."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="sp_1", channel_id="ch_1",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert client._queue.qsize() == 1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_synthetic_accept_missing_ids_is_safe():
+    """A malformed payload (missing space_id or channel_id) must
+    not crash the WS handler — it should just no-op."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="", channel_id="ch_1",
+    )
+    await client._handle_event(scope="", event=event)
+    assert client._queue.qsize() == 0
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="sp_1", channel_id="",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+    assert client._queue.qsize() == 0
+
+    await store.close()


### PR DESCRIPTION
## Summary

New CLI subcommand for the agent operator to toggle whether an agent silently auto-joins channels its space owner invites it to, on a per-space basis. Pairs with [puffo-server#52](https://github.com/puffo-ai/puffo-server/pull/52) (server-side InviteToChannel auto-accept materialization).

## Usage

```bash
puffo-agent agent autoaccept <agent-id> --space <space_id> --owner on
puffo-agent agent autoaccept <agent-id> --space <space_id> --owner off
```

Wraps a signed PATCH to ``/spaces/{space_id}/members/me/settings``. Auth path mirrors the existing ``puffo-agent agent profile`` CLI: signed by the agent's own subkey from the local keystore. The operator controls the local keystore, so a CLI invocation is effectively an operator decision.

## Why no ``--member`` flag

Agent identities can't toggle ``auto_accept_member_invite`` in this build — the server returns 403 (Han 2026-05-13 Q4b "目前不可修改"). Surfacing it as a CLI flag would just produce confusing server errors. When the policy relaxes, add ``--member`` here in lockstep with relaxing the server-side gate.

## Test plan

- [x] ``pytest`` — 496 passed / 7 skipped (no regression).
- [x] CLI parses cleanly (``puffo-agent agent autoaccept --help``).
- [ ] **Manual after server PR #52 + agent 0.7.8 build**: spin up local server → register an agent → join a space → ``puffo-agent agent autoaccept <id> --space <id> --owner off`` → invite from the owner → confirm pending flow kicked in. Flip back on → re-invite → confirm membership materialized directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)