### PR TITLE
fix(prompt-budget): redact long inbound messages, page back via MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.9] — 2026-05-13
+
+### Added
+
+- **Inbound long-message redaction + ``get_post_segment`` MCP
+  tool.** Operators occasionally paste large code blocks into a DM
+  or channel; combined with the agent's system prompt + history
+  the result can blow past the provider's context window. Before
+  this release that surfaced as an "API Error: Prompt is too
+  long" string from claude-code, which the rate-limit retry loop
+  bounced through ``--resume`` three times and then abandoned —
+  but with the cursor stuck at the failed batch, any new message
+  in the same thread re-triggered the same failure. From the
+  operator's perspective the agent was wedged and ``restart``
+  didn't help (the claude-code session still held the oversize
+  transcript); ``pause`` was the only way out.
+
+  Fix: in ``puffo_core_client.handle_envelope``, any message
+  whose text exceeds ``DaemonConfig.max_inline_message_chars``
+  (default 4000) gets replaced — *for the LLM view only* — with a
+  ``[puffo-agent system message]`` placeholder citing the
+  envelope_id, total length, segment count, sender, and a short
+  preview. The full envelope is still persisted to
+  ``messages.db`` unmodified. The new
+  ``mcp__puffo__get_post_segment(envelope_id, segment,
+  segment_size)`` tool pages the body back ``segment_chars``
+  bytes at a time (default 2000) so the agent can fetch only
+  what it needs.
+
+  Logged when triggered:
+  ```
+  agent <id>: inlined message <env_id> truncated
+  (47832 → 4000 chars, 24 segments) for prompt budget
+  ```
+
+  New tunables in ``daemon.yml``:
+  ```yaml
+  max_inline_message_chars: 4000   # redact above this
+  segment_chars: 2000              # page size for get_post_segment
+  ```
+
+  Existing oversize content already in a claude-code session
+  isn't unstuck by this release — clear the agent's
+  ``.claude-session.json`` (under ``~/.puffo-agent/agents/<id>/``)
+  once to force a fresh transcript on next start.
+
 ## [0.7.8] — 2026-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.7.9] — 2026-05-13
 
+### Fixed
+
+- **``mcp__puffo__list_mcp_servers`` now enumerates plugin-routed
+  MCP servers too.** Operator + agent feedback: plugins installed
+  via ``claude /plugin install`` (e.g. ``imessage``,
+  ``chrome-devtools-mcp``) register their MCP servers under
+  ``~/.claude/plugins/cache/<plugin>/<version>/.mcp.json`` — a
+  third scope distinct from system (``~/.claude.json``) and agent
+  (``<workspace>/.mcp.json``). The listing tool only walked the
+  first two, so plugin-provided servers were invisible to the
+  agent even though it could call them.
+
+  Fix walks the plugin cache too and tags each entry ``plugin``
+  with a ``(from <plugin>/<version>)`` source label so the
+  operator can map server-back-to-plugin at a glance. Defensive
+  on the file system: missing cache dir, missing per-version
+  ``.mcp.json``, malformed JSON in one plugin's file, and
+  multiple cached versions all handled without taking the whole
+  listing down.
+
+  5 new tests in ``test_agent_install.py``; the 2 pre-existing
+  list tests updated to the new 3-tuple shape
+  ``(scope, name, source)``.
+
 ### Added
 
 - **Inbound long-message redaction + ``get_post_segment`` MCP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.7.8"
+version = "0.7.9"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -198,6 +198,85 @@ def _compute_priority(direct: bool, sender_is_bot: bool) -> int:
     return PRIORITY_BOT
 
 
+# Hard cap on the preview length embedded in the redaction
+# placeholder. Big enough to convey the message's flavour to the
+# agent (so it knows whether to bother fetching segments) but
+# small enough that pasting a 100kB log doesn't itself blow the
+# prompt budget through the preview alone.
+_LONG_MESSAGE_PREVIEW_CHARS = 240
+
+
+def _maybe_redact_long_text(
+    text: str,
+    *,
+    envelope_id: str,
+    sender_slug: str,
+    sender_display_name: str,
+    max_inline_chars: int,
+    segment_chars: int,
+    agent_slug: str,
+) -> str:
+    """Substitute oversize message bodies with a placeholder that
+    points the agent at ``get_post_segment``. Anything ≤
+    ``max_inline_chars`` is returned untouched.
+
+    The placeholder lives in the *prompt-facing* view of the message
+    only — the original ``text`` is still persisted into
+    ``messages.db`` via ``store.store()`` upstream of this call, so
+    the segment tool can paginate the full body back to the agent
+    on demand.
+
+    A daemon log is emitted whenever redaction fires so an operator
+    debugging "my agent didn't see my paste" can grep for the
+    envelope_id without tailing turn output.
+    """
+    if not text:
+        return text
+    total = len(text)
+    if total <= max_inline_chars:
+        return text
+
+    # Segment count is ceil(total / segment_chars), at least 1.
+    seg_count = (total + segment_chars - 1) // segment_chars
+
+    # Preview: the first ~240 chars of the (already-mention-rewritten)
+    # text, with line breaks normalised to spaces so the placeholder
+    # stays one tidy block. Truncated with an ellipsis so the agent
+    # doesn't mistake the cut for the end of the message.
+    raw_preview = text[:_LONG_MESSAGE_PREVIEW_CHARS].replace("\n", " ").strip()
+    if total > _LONG_MESSAGE_PREVIEW_CHARS:
+        raw_preview = raw_preview + "…"
+
+    sender_label = (
+        f"@{sender_display_name} ({sender_slug})"
+        if sender_display_name
+        else f"@{sender_slug}"
+    )
+    placeholder = (
+        "[puffo-agent system message] inbound message was too long "
+        "to embed inline and has been redacted from this prompt for "
+        "context-budget reasons.\n"
+        f"  envelope_id: {envelope_id}\n"
+        f"  total_chars: {total}\n"
+        f"  segments: {seg_count} (0-indexed, up to {segment_chars} chars each)\n"
+        f"  sender: {sender_label}\n"
+        f"  preview: {raw_preview}\n"
+        "Retrieve the full body one chunk at a time with "
+        "mcp__puffo__get_post_segment("
+        f"envelope_id=\"{envelope_id}\", segment=N) where N runs "
+        f"0..{seg_count - 1}. Fetch only the segments you actually "
+        "need — the placeholder above already tells you what kind "
+        "of content it is."
+    )
+
+    logger.info(
+        "agent %s: inlined message %s truncated (%d → %d chars, %d segments) "
+        "for prompt budget",
+        agent_slug, envelope_id, total, max_inline_chars, seg_count,
+    )
+    return placeholder
+
+
 class DeviceKeyCache:
     """Caches sender signing public keys.
 
@@ -261,6 +340,8 @@ class PuffoCoreMessageClient:
         message_store: MessageStore,
         operator_slug: str = "",
         workspace: str = "",
+        max_inline_chars: int = 4000,
+        segment_chars: int = 2000,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -271,6 +352,15 @@ class PuffoCoreMessageClient:
         # Absolute path to the agent's workspace. Inbound attachments
         # are decrypted into ``<workspace>/.puffo/inbox/<envelope_id>/``.
         self.workspace = workspace
+        # Long-message redaction thresholds. When an inbound message's
+        # ``text`` field exceeds ``max_inline_chars`` the LLM sees a
+        # placeholder pointing at ``get_post_segment`` instead of the
+        # raw body. ``segment_chars`` is the page size that tool
+        # returns. Both come from ``DaemonConfig`` so the operator can
+        # tune per host; we keep generous defaults that survive a
+        # 200k-context model with a verbose system prompt.
+        self._max_inline_chars = max(1, int(max_inline_chars))
+        self._segment_chars = max(1, int(segment_chars))
         self.keystore = keystore
         self.http = http_client
         self.store = message_store
@@ -548,6 +638,24 @@ class PuffoCoreMessageClient:
                 payload.sender_slug,
             )
 
+            # Long-message redaction. Operators paste big chunks of
+            # code or transcripts that, combined with the agent's
+            # system prompt + thread history, can blow past the LLM
+            # context window — historically observable as the agent
+            # getting stuck in a "Prompt is too long" retry loop the
+            # restart path didn't recover from. The full envelope
+            # stays in messages.db; only the in-prompt view collapses
+            # to a placeholder pointing at ``get_post_segment``.
+            llm_text = _maybe_redact_long_text(
+                clean_text,
+                envelope_id=payload.envelope_id,
+                sender_slug=payload.sender_slug,
+                sender_display_name=sender_display_name,
+                max_inline_chars=self._max_inline_chars,
+                segment_chars=self._segment_chars,
+                agent_slug=self.slug,
+            )
+
             msg_dict = {
                 "channel_id": channel_id,
                 "channel_name": channel_name,
@@ -556,7 +664,7 @@ class PuffoCoreMessageClient:
                 "sender_slug": payload.sender_slug,
                 "sender_display_name": sender_display_name,
                 "sender_email": "",
-                "text": clean_text,
+                "text": llm_text,
                 "root_id": payload.thread_root_id or "",
                 "is_dm": is_dm,
                 "attachments": attachment_paths,

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -75,6 +75,16 @@ Common examples:
   please resume processing.` — the previous turn was interrupted by
   a provider rate limit. Your previous user input is still in this
   transcript; re-attempt your response now.
+- `[puffo-agent system message] inbound message was too long to
+  embed inline and has been redacted from this prompt ...` — the
+  user pasted a body larger than the daemon's prompt-budget cap.
+  The full text is still on disk in the agent's message store;
+  page it back one chunk at a time with
+  `mcp__puffo__get_post_segment(envelope_id=..., segment=N,
+  segment_size=...)` using the values the placeholder cites.
+  Fetch only the segments you actually need — the `preview:` line
+  in the placeholder is usually enough to decide. If you've seen
+  enough from the preview to reply, do so without paging.
 
 ## How to reply (read this carefully)
 

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -30,6 +30,7 @@ PUFFO_CORE_TOOL_NAMES = (
     "get_thread_history",
     "fetch_channel_files",
     "get_post",
+    "get_post_segment",
     "get_user_info",
     "whoami",
     "reload_system_prompt",

--- a/src/puffo_agent/mcp/host_tools.py
+++ b/src/puffo_agent/mcp/host_tools.py
@@ -77,6 +77,71 @@ def _system_claude_json_path(home: Path) -> Path:
     return home / ".claude.json"
 
 
+def _plugin_cache_root(home: Path) -> Path:
+    """Where Claude Code's plugin loader keeps the *active* snapshot
+    of installed plugins. Each entry is
+    ``<plugin_name>/<version>/.mcp.json`` (plus other plugin files);
+    only the ``.mcp.json`` matters for MCP enumeration.
+
+    A separate ``plugins/marketplaces/<marketplace>/...`` tree holds
+    plugin source / catalog data — that one is informational, NOT
+    what claude-code actually loads at runtime. We list cache only:
+    the goal of ``list_mcp_servers`` is to tell the agent what it
+    can call right now, not what's available on the host.
+    """
+    return home / ".claude" / "plugins" / "cache"
+
+
+def _plugin_mcp_entries(home: Path) -> list[tuple[str, str]]:
+    """Walk ``~/.claude/plugins/cache/<plugin>/<version>/.mcp.json``
+    and return ``[(plugin_label, mcp_server_name), ...]`` where
+    ``plugin_label`` is ``<plugin>/<version>``.
+
+    Per the agent feedback that prompted this code: chrome-devtools-
+    mcp and imessage are installed via ``claude /plugin install``,
+    land in the cache tree above, and register their MCP servers
+    through claude-code's plugin pipeline — bypassing the user-
+    scope ``~/.claude.json#mcpServers`` map that the system-scope
+    branch above reads. Without walking the plugin tree those
+    server names never show up in ``list_mcp_servers`` output even
+    though the agent can call them.
+
+    Tolerates a missing cache dir (return []), missing per-version
+    ``.mcp.json`` (skip), malformed JSON in a single plugin file
+    (skip that plugin, keep listing the rest). A bad plugin must
+    NOT take the whole listing down.
+    """
+    root = _plugin_cache_root(home)
+    if not root.is_dir():
+        return []
+    out: list[tuple[str, str]] = []
+    # Sort for stable output: <plugin>, then <version>. Listing
+    # order matters because the formatter prints in-order; the
+    # agent reads top-down looking for what it needs.
+    for plugin_dir in sorted(root.iterdir()):
+        if not plugin_dir.is_dir():
+            continue
+        for version_dir in sorted(plugin_dir.iterdir()):
+            if not version_dir.is_dir():
+                continue
+            mcp_path = version_dir / ".mcp.json"
+            if not mcp_path.is_file():
+                continue
+            try:
+                data = _read_json_or_empty(mcp_path)
+            except RuntimeError:
+                # Bad JSON in this plugin — log nothing (host_tools
+                # is stdlib-only by contract), just skip.
+                continue
+            servers = data.get("mcpServers")
+            if not isinstance(servers, dict):
+                continue
+            label = f"{plugin_dir.name}/{version_dir.name}"
+            for name in sorted(servers.keys()):
+                out.append((label, name))
+    return out
+
+
 def _read_json_or_empty(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
@@ -219,20 +284,45 @@ def _uninstall_mcp_server(workspace: Path, name: str) -> Path:
     return path
 
 
-def _list_mcp_servers(workspace: Path, home: Path) -> list[tuple[str, str]]:
-    out: list[tuple[str, str]] = []
+def _list_mcp_servers(
+    workspace: Path, home: Path,
+) -> list[tuple[str, str, str]]:
+    """Return ``[(scope, name, source), ...]`` for every MCP server
+    the agent's runtime can reach.
+
+    Three scopes:
+      * ``"system"`` — user-installed via ``claude mcp add``, lives
+        in ``<home>/.claude.json#mcpServers``. ``source`` is ``""``.
+      * ``"agent"``  — project-scope, installed by the agent via
+        ``install_mcp_server``, lives in
+        ``<workspace>/.mcp.json#mcpServers``. ``source`` is ``""``.
+      * ``"plugin"`` — provided by a ``claude /plugin install``-ed
+        plugin under ``<home>/.claude/plugins/cache/<plugin>/
+        <version>/.mcp.json``. ``source`` is the
+        ``"<plugin>/<version>"`` label so the operator can tell
+        which plugin owns it.
+
+    Pre-existing 0.7.8 callers expected a 2-tuple — every callsite
+    in this repo was updated in lockstep when this scope was
+    added; downstream code that destructures should switch to
+    3-tuple. Malformed configs in any scope are tolerated (skip
+    that file, keep listing the rest).
+    """
+    out: list[tuple[str, str, str]] = []
     try:
         sys_data = _read_json_or_empty(_system_claude_json_path(home))
     except RuntimeError:
         sys_data = {}
     for n in sorted((sys_data.get("mcpServers") or {}).keys()):
-        out.append(("system", n))
+        out.append(("system", n, ""))
     try:
         agent_data = _read_json_or_empty(_workspace_mcp_path(workspace))
     except RuntimeError:
         agent_data = {}
     for n in sorted((agent_data.get("mcpServers") or {}).keys()):
-        out.append(("agent", n))
+        out.append(("agent", n, ""))
+    for source, name in _plugin_mcp_entries(home):
+        out.append(("plugin", name, source))
     return out
 
 

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -142,14 +142,31 @@ def _register_local_tools(
 
     @mcp.tool()
     async def list_mcp_servers() -> str:
-        """List every MCP server available to you, tagged by scope."""
+        """List every MCP server available to you, tagged by scope.
+
+        Scopes:
+          * ``system`` — installed via ``claude mcp add`` on the host.
+          * ``agent``  — project-scope, installed by this agent via
+            ``install_mcp_server``.
+          * ``plugin`` — provided by a ``claude /plugin install``-ed
+            plugin; trailing ``(from <plugin>/<version>)`` cites the
+            owning plugin so the operator can tell which plugin
+            registered the server (and ``claude /plugin uninstall``
+            the right one if needed).
+        """
         entries = _list_mcp_servers(Path(workspace), Path.home())
         if not entries:
             return "(no MCP servers registered)"
-        return "\n".join(
-            f"[{scope}]{' ' if scope == 'agent' else ''} {n}"
-            for scope, n in entries
-        )
+        lines: list[str] = []
+        for scope, name, source in entries:
+            # Pad scope tag so columns line up across rows — every
+            # scope fits in 6 chars, ``[plugin]`` is the widest.
+            tag = f"[{scope:<6}]"
+            if source:
+                lines.append(f"{tag} {name}  (from {source})")
+            else:
+                lines.append(f"{tag} {name}")
+        return "\n".join(lines)
 
 
 def build_server(

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -440,6 +440,78 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
+    async def get_post_segment(
+        envelope_id: str,
+        segment: int,
+        segment_size: int = 2000,
+    ) -> str:
+        """Page a long message body back in chunks.
+
+        When the daemon redacts an oversize inbound message it
+        replaces the in-prompt body with a ``[puffo-agent system
+        message]`` placeholder citing this tool's name plus the
+        envelope_id and total segment count. Call this tool with
+        ``segment=N`` (zero-indexed) and the same ``segment_size``
+        the placeholder reported to retrieve chunk ``N`` of the
+        full body. Only fetch the segments you actually need —
+        the placeholder preview usually tells you whether the
+        content is worth paging through.
+
+        Returns: ``segment <i>/<total> (chars <start>..<end> of <total>):
+        \n<chunk body>``. Out-of-range segment numbers return
+        ``segment out of range`` so the agent knows it overshot.
+
+        Special cases:
+          * unknown envelope_id → "message <id> not found in local storage"
+          * empty content       → "message <id> has no text body"
+
+        ``segment_size`` defaults to 2000 to match the daemon's
+        default redaction page size; pass the value the placeholder
+        cited if the operator has overridden it on their host.
+        """
+        envelope_id = (envelope_id or "").strip()
+        if not envelope_id:
+            raise RuntimeError("envelope_id is required")
+        if segment < 0:
+            raise RuntimeError("segment must be >= 0")
+        if segment_size <= 0:
+            raise RuntimeError("segment_size must be > 0")
+
+        msg = await cfg.data_client.get_message_by_envelope(envelope_id)
+        if msg is None:
+            return f"message {envelope_id} not found in local storage"
+
+        # ``content`` carries either a bare string (plain message)
+        # or the ``puffo/message+attachments/v1`` dict shape; pull
+        # the text out of the latter so segmenting works on the
+        # human-readable portion in both cases.
+        content = msg.content
+        if isinstance(content, dict):
+            text = str(content.get("text") or "")
+        else:
+            text = str(content) if content else ""
+
+        if not text:
+            return f"message {envelope_id} has no text body"
+
+        total = len(text)
+        # ceil(total / segment_size); at least 1 when total > 0.
+        seg_count = (total + segment_size - 1) // segment_size
+        if segment >= seg_count:
+            return (
+                f"segment {segment} out of range (envelope_id={envelope_id} "
+                f"has {seg_count} segment(s) at segment_size={segment_size}, "
+                "indexed 0..{0})".format(seg_count - 1)
+            )
+        start = segment * segment_size
+        end = min(start + segment_size, total)
+        chunk = text[start:end]
+        return (
+            f"segment {segment}/{seg_count - 1} "
+            f"(chars {start}..{end - 1} of {total}):\n{chunk}"
+        )
+
+    @mcp.tool()
     async def upload_file(
         paths: list[str],
         channel: str,

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -708,6 +708,19 @@ class DaemonConfig:
     # per-agent overrides live on ``runtime``.
     docker_memory_limit: str = "1.5g"
     docker_memory_reservation: str = "500m"
+    # Inbound message redaction. When an envelope's text exceeds
+    # ``max_inline_message_chars`` the daemon replaces the body the
+    # LLM sees with a system-message placeholder (carrying
+    # envelope_id, total length, segment count, and a preview), and
+    # the agent fetches the full content one chunk at a time via
+    # the ``get_post_segment`` MCP tool. The original envelope is
+    # stored unmodified in ``messages.db`` — only the prompt-budget
+    # view is redacted. Tuned for Claude's 200k window minus a
+    # generous system-prompt + history headroom; defaults pinned at
+    # 4000/2000 so a single 8-segment paste fits comfortably even
+    # with a verbose primer.
+    max_inline_message_chars: int = 4000
+    segment_chars: int = 2000
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(
         default_factory=lambda: DataServiceConfig(),
@@ -729,6 +742,8 @@ class DaemonConfig:
             runtime_heartbeat_seconds=float(raw.get("runtime_heartbeat_seconds", 5.0)),
             docker_memory_limit=raw.get("docker_memory_limit", "1.5g"),
             docker_memory_reservation=raw.get("docker_memory_reservation", "500m"),
+            max_inline_message_chars=int(raw.get("max_inline_message_chars", 4000)),
+            segment_chars=int(raw.get("segment_chars", 2000)),
         )
         for name in ("anthropic", "openai", "google"):
             p = raw.get(name) or {}
@@ -764,6 +779,8 @@ class DaemonConfig:
             "runtime_heartbeat_seconds": self.runtime_heartbeat_seconds,
             "docker_memory_limit": self.docker_memory_limit,
             "docker_memory_reservation": self.docker_memory_reservation,
+            "max_inline_message_chars": self.max_inline_message_chars,
+            "segment_chars": self.segment_chars,
             "anthropic": asdict(self.anthropic),
             "openai": asdict(self.openai),
             "google": asdict(self.google),

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -283,8 +283,17 @@ def _ensure_agent_identity_imported(agent_id: str, slug: str) -> None:
         )
 
 
-def _build_puffo_core_client(agent_cfg: AgentConfig, agent_id: str):
-    """Construct a PuffoCoreMessageClient from the agent's config."""
+def _build_puffo_core_client(
+    agent_cfg: AgentConfig,
+    agent_id: str,
+    daemon_cfg: "DaemonConfig | None" = None,
+):
+    """Construct a PuffoCoreMessageClient from the agent's config.
+    ``daemon_cfg`` carries the host-wide tunables (currently the
+    long-message redaction thresholds); accepts ``None`` so legacy
+    test seeds that didn't have a daemon config keep working with
+    the dataclass defaults.
+    """
     from ..agent.message_store import MessageStore
     from ..agent.puffo_core_client import PuffoCoreMessageClient
     from ..crypto.http_client import PuffoCoreHttpClient
@@ -297,6 +306,13 @@ def _build_puffo_core_client(agent_cfg: AgentConfig, agent_id: str):
     http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
     ms = MessageStore(str(agent_dir(agent_id) / "messages.db"))
 
+    max_inline = (
+        daemon_cfg.max_inline_message_chars if daemon_cfg is not None else 4000
+    )
+    segment_chars = (
+        daemon_cfg.segment_chars if daemon_cfg is not None else 2000
+    )
+
     return PuffoCoreMessageClient(
         slug=pc.slug,
         device_id=pc.device_id,
@@ -306,6 +322,8 @@ def _build_puffo_core_client(agent_cfg: AgentConfig, agent_id: str):
         http_client=http,
         message_store=ms,
         workspace=str(agent_cfg.resolve_workspace_dir()),
+        max_inline_chars=max_inline,
+        segment_chars=segment_chars,
     )
 
 
@@ -468,7 +486,9 @@ class Worker:
                     "is incomplete. Required fields: server_url, slug, "
                     "device_id, space_id."
                 )
-            client = _build_puffo_core_client(self.agent_cfg, agent_id)
+            client = _build_puffo_core_client(
+                self.agent_cfg, agent_id, daemon_cfg=self.daemon_cfg,
+            )
             self._client = client
         except Exception as e:
             logger.error("agent %s: failed to initialise: %s", agent_id, e, exc_info=True)

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -269,7 +269,13 @@ def test_list_mcp_servers_tags_scope(tmp_path):
 
     entries = _list_mcp_servers(workspace, home)
 
-    assert entries == [("system", "sys-mcp"), ("agent", "agent-mcp")]
+    # 3-tuple shape: (scope, name, source). System + agent entries
+    # leave ``source`` blank; only plugin entries fill it in (see
+    # the plugin-scope tests below).
+    assert entries == [
+        ("system", "sys-mcp", ""),
+        ("agent", "agent-mcp", ""),
+    ]
 
 
 def test_list_mcp_servers_empty_when_nothing_registered(tmp_path):
@@ -287,7 +293,148 @@ def test_list_mcp_servers_tolerates_malformed_system_config(tmp_path):
 
     entries = _list_mcp_servers(workspace, home)
 
-    assert entries == [("agent", "agent-mcp")]
+    assert entries == [("agent", "agent-mcp", "")]
+
+
+# ── plugin-scope listing ────────────────────────────────────────
+
+
+def _seed_plugin_mcp(home, plugin: str, version: str, servers: dict) -> None:
+    """Drop a ``<home>/.claude/plugins/cache/<plugin>/<version>/.mcp.json``
+    matching the shape claude-code's plugin loader writes."""
+    plugin_dir = home / ".claude" / "plugins" / "cache" / plugin / version
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": servers}),
+        encoding="utf-8",
+    )
+
+
+def test_list_mcp_servers_includes_plugin_scope(tmp_path):
+    """Plugin-routed MCP servers live under
+    ``~/.claude/plugins/cache/<plugin>/<version>/.mcp.json`` — a
+    distinct scope from the system + agent paths. They must show
+    up tagged ``plugin`` so the agent can call them and the
+    operator can tell which plugin owns each entry. The agent-
+    reported case that motivated this: imessage + chrome-devtools-
+    mcp returning empty from ``list_mcp_servers`` despite being
+    installed via ``claude /plugin install``."""
+    workspace = tmp_path / "ws"
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    _seed_plugin_mcp(home, "imessage", "0.1.0", {
+        "imessage": {"command": "bun", "args": ["run"]},
+    })
+    _seed_plugin_mcp(home, "chrome-devtools-mcp", "0.22.0", {
+        "chrome-devtools": {"command": "npx", "args": ["chrome-devtools-mcp@latest"]},
+    })
+
+    entries = _list_mcp_servers(workspace, home)
+
+    # Sorted alphabetically by plugin name, then by server name
+    # within a plugin. ``source`` carries the ``<plugin>/<version>``
+    # label so the operator can match server back to plugin.
+    assert entries == [
+        ("plugin", "chrome-devtools", "chrome-devtools-mcp/0.22.0"),
+        ("plugin", "imessage", "imessage/0.1.0"),
+    ]
+
+
+def test_list_mcp_servers_combines_all_three_scopes(tmp_path):
+    """System / agent / plugin entries coexist; the listing emits
+    them in scope order (system, agent, plugin) so the agent can
+    eyeball "did my install land?" from the bottom up."""
+    workspace = tmp_path / "ws"
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / ".claude.json").write_text(
+        json.dumps({"mcpServers": {"sys-mcp": {"command": "npx"}}}),
+        encoding="utf-8",
+    )
+    _install_mcp_server(workspace, "agent-mcp", "uvx")
+    _seed_plugin_mcp(home, "imessage", "0.1.0", {
+        "imessage": {"command": "bun"},
+    })
+
+    entries = _list_mcp_servers(workspace, home)
+
+    assert entries == [
+        ("system", "sys-mcp", ""),
+        ("agent", "agent-mcp", ""),
+        ("plugin", "imessage", "imessage/0.1.0"),
+    ]
+
+
+def test_list_mcp_servers_skips_malformed_plugin_mcp_json(tmp_path):
+    """One plugin with garbled JSON must not nuke the whole listing
+    — the agent should still see every other plugin's servers.
+    Defensive because plugin authors aren't operating under our
+    quality bar and a half-written download / git pull could land
+    a partial file."""
+    workspace = tmp_path / "ws"
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    bad = home / ".claude" / "plugins" / "cache" / "bad-plugin" / "9.9.9"
+    bad.mkdir(parents=True)
+    (bad / ".mcp.json").write_text("{not json", encoding="utf-8")
+    _seed_plugin_mcp(home, "good-plugin", "0.1.0", {
+        "good-srv": {"command": "npx"},
+    })
+
+    entries = _list_mcp_servers(workspace, home)
+
+    assert entries == [
+        ("plugin", "good-srv", "good-plugin/0.1.0"),
+    ]
+
+
+def test_list_mcp_servers_skips_plugin_dirs_without_mcp_json(tmp_path):
+    """A plugin can be installed without registering any MCP server
+    (skills-only / hooks-only plugins are a real category). The
+    plugin tree exists but has no ``.mcp.json`` — listing must
+    treat the directory as empty for MCP purposes rather than
+    crashing on the missing file."""
+    workspace = tmp_path / "ws"
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    skills_only = home / ".claude" / "plugins" / "cache" / "skills-pkg" / "0.1.0"
+    skills_only.mkdir(parents=True)
+    # No .mcp.json in this dir — only SKILL.md, hooks, etc. would
+    # normally live here.
+    (skills_only / "README.md").write_text("docs", encoding="utf-8")
+    _seed_plugin_mcp(home, "real-mcp", "0.1.0", {
+        "srv": {"command": "npx"},
+    })
+
+    entries = _list_mcp_servers(workspace, home)
+
+    assert entries == [
+        ("plugin", "srv", "real-mcp/0.1.0"),
+    ]
+
+
+def test_list_mcp_servers_handles_multiple_versions(tmp_path):
+    """A plugin can have several versions cached side-by-side after
+    an upgrade dance; each version that ships a ``.mcp.json`` gets
+    its own row so the agent + operator can see exactly which
+    version's MCP server is actually live (or, in a half-upgraded
+    state, that both are)."""
+    workspace = tmp_path / "ws"
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    _seed_plugin_mcp(home, "imessage", "0.1.0", {
+        "imessage": {"command": "bun"},
+    })
+    _seed_plugin_mcp(home, "imessage", "0.2.0", {
+        "imessage": {"command": "bun"},
+    })
+
+    entries = _list_mcp_servers(workspace, home)
+
+    assert entries == [
+        ("plugin", "imessage", "imessage/0.1.0"),
+        ("plugin", "imessage", "imessage/0.2.0"),
+    ]
 
 
 # ── refresh.flag ─────────────────────────────────────────────────────────────

--- a/tests/test_long_message_redaction.py
+++ b/tests/test_long_message_redaction.py
@@ -1,0 +1,353 @@
+"""Long-message redaction at turn-context build time + the
+``get_post_segment`` MCP tool that pages the full body back in
+chunks.
+
+Background: an operator pasted a long code block into a DM; the
+agent's adapter hit Anthropic's ``Prompt is too long`` and the
+existing rate-limit retry loop bounced the same payload through
+claude-code's ``--resume`` repeatedly without progress. Restart
+didn't help because the failed batch's cursor stays put (by
+design — we never silently drop a user message). The fix is at
+the source: redact oversize bodies before they ever reach the
+LLM, store the original verbatim in messages.db, and give the
+agent a paging tool to fetch it back when it needs to.
+
+These tests pin:
+  * the redact helper's threshold + placeholder shape
+  * the MCP tool's slice math, error paths, and dict-content
+    extraction (attachments-content envelopes still segment)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.puffo_core_client import _maybe_redact_long_text
+
+
+# ─── _maybe_redact_long_text ──────────────────────────────────────
+
+
+def test_redact_passthrough_when_under_threshold():
+    """Messages at or below the threshold must come through
+    unchanged — the placeholder is only for messages we'd otherwise
+    blow the context budget on."""
+    short = "Hello, how's it going?"
+    out = _maybe_redact_long_text(
+        short,
+        envelope_id="env_short",
+        sender_slug="alice",
+        sender_display_name="",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    assert out == short
+
+
+def test_redact_passthrough_at_exact_threshold():
+    """``len(text) == max_inline_chars`` is still allowed (the
+    cutoff is strict ``>``). Boundary pins ensure tuning the
+    threshold doesn't accidentally swap < for ≤ / vice versa."""
+    payload = "x" * 4000
+    out = _maybe_redact_long_text(
+        payload,
+        envelope_id="env_boundary",
+        sender_slug="alice",
+        sender_display_name="",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    assert out == payload
+
+
+def test_redact_emits_placeholder_with_envelope_id_and_segments():
+    """The placeholder must carry every datum the agent needs to
+    decide whether — and how — to page the body back:
+      * the marker prefix the primer recognises
+      * envelope_id (so the tool call resolves)
+      * total_chars + segment count + per-segment size
+      * sender (so the agent has provenance without a fetch)
+      * a preview (so the agent can skip fetching trivial content)
+      * the tool-call recipe."""
+    payload = "A" * 5000
+    out = _maybe_redact_long_text(
+        payload,
+        envelope_id="env_long",
+        sender_slug="alice",
+        sender_display_name="Alice",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    assert "[puffo-agent system message]" in out
+    assert "envelope_id: env_long" in out
+    assert "total_chars: 5000" in out
+    # ceil(5000/2000) == 3, indexed 0..2.
+    assert "segments: 3 (0-indexed, up to 2000 chars each)" in out
+    assert "sender: @Alice (alice)" in out
+    assert "mcp__puffo__get_post_segment" in out
+    assert "segment=N) where N runs 0..2" in out
+    # The placeholder itself shouldn't be longer than the
+    # original by an order of magnitude (sanity — a buggy preview
+    # that includes the whole payload would defeat the redaction).
+    assert len(out) < 1500
+
+
+def test_redact_preview_truncated_with_ellipsis():
+    """The preview must be short enough not to itself blow the
+    context budget — and it must mark the cut so the agent knows
+    it's looking at a head, not the full body."""
+    payload = "abcdefghij" * 1000  # 10k chars
+    out = _maybe_redact_long_text(
+        payload,
+        envelope_id="env_preview",
+        sender_slug="alice",
+        sender_display_name="",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    # Preview is the first 240 chars of the payload + ellipsis.
+    expected_preview_head = "abcdefghij" * 24
+    assert expected_preview_head in out
+    assert "…" in out
+
+
+def test_redact_normalises_newlines_in_preview():
+    """Preview is single-line so the placeholder stays a tidy
+    block in the agent's prompt; original newlines reach the
+    agent via the segment tool when it actually pages the body."""
+    payload = "line1\nline2\nline3\n" + ("x" * 5000)
+    out = _maybe_redact_long_text(
+        payload,
+        envelope_id="env_lines",
+        sender_slug="alice",
+        sender_display_name="",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    # The preview shouldn't break the placeholder block by
+    # injecting raw newlines.
+    preview_line = [
+        line for line in out.split("\n") if line.startswith("  preview: ")
+    ]
+    assert len(preview_line) == 1
+    assert "line1 line2 line3" in preview_line[0]
+
+
+def test_redact_empty_text_returns_empty():
+    """No body, no placeholder — caller handles the "no text"
+    case (e.g. attachments-only envelopes) separately."""
+    out = _maybe_redact_long_text(
+        "",
+        envelope_id="env_empty",
+        sender_slug="alice",
+        sender_display_name="",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    assert out == ""
+
+
+def test_redact_sender_label_falls_back_to_slug():
+    """When the profile cache hasn't hydrated a display_name we
+    show the bare slug — better than ``@ (alice)`` with an empty
+    name in parens."""
+    payload = "z" * 5000
+    out = _maybe_redact_long_text(
+        payload,
+        envelope_id="env_nameless",
+        sender_slug="alice",
+        sender_display_name="",
+        max_inline_chars=4000,
+        segment_chars=2000,
+        agent_slug="d2d2",
+    )
+    assert "sender: @alice" in out
+    assert "@ (alice)" not in out
+
+
+# ─── get_post_segment MCP tool ────────────────────────────────────
+#
+# The tool body lives inside ``register_core_tools``'s closure, so
+# we exercise it by stubbing a minimal ``data_client`` + ``cfg``,
+# capturing the tool via a fake ``mcp.tool()`` decorator, and
+# calling it directly.
+
+
+class _StubDataClient:
+    def __init__(self, message=None):
+        self._message = message
+
+    async def get_message_by_envelope(self, envelope_id: str):
+        return self._message
+
+
+class _StubMessage:
+    """Mirrors enough of ``StoredMessageDict`` for the tool's
+    assertions about ``content`` shape."""
+    def __init__(self, envelope_id="env_x", sender_slug="alice",
+                 envelope_kind="dm", channel_id=None,
+                 thread_root_id=None, sent_at=1_700_000_000_000,
+                 content=""):
+        self.envelope_id = envelope_id
+        self.sender_slug = sender_slug
+        self.envelope_kind = envelope_kind
+        self.channel_id = channel_id
+        self.thread_root_id = thread_root_id
+        self.sent_at = sent_at
+        self.content = content
+
+
+def _collect_tool(name: str, data_client):
+    """Build the ``get_post_segment`` closure by running
+    ``register_core_tools`` against a fake FastMCP that captures
+    every ``@mcp.tool()`` decoration into a dict."""
+    from puffo_agent.mcp.puffo_core_tools import (
+        PuffoCoreToolsConfig, register_core_tools,
+    )
+
+    captured: dict[str, callable] = {}
+
+    class _FakeMcp:
+        def tool(self, *args, **kwargs):
+            def decorator(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return decorator
+
+    cfg = PuffoCoreToolsConfig(
+        slug="d2d2",
+        device_id="dev_x",
+        keystore=types.SimpleNamespace(),  # unused by this tool
+        http_client=types.SimpleNamespace(),  # unused by this tool
+        data_client=data_client,
+        space_id=None,
+        workspace=None,
+    )
+    register_core_tools(_FakeMcp(), cfg)
+    return captured[name]
+
+
+@pytest.mark.asyncio
+async def test_segment_returns_chunk_with_range_metadata():
+    """Happy path: segment 1 of a 5000-char body at size 2000.
+
+    Indices: 2000..3999 (inclusive), 2000 chars long. The
+    response header gives the agent enough context (segment x/y,
+    char range, total) to chain fetches sensibly."""
+    payload = "".join(str(i % 10) for i in range(5000))  # 5000 chars
+    tool = _collect_tool("get_post_segment", _StubDataClient(
+        _StubMessage(envelope_id="env_5k", content=payload),
+    ))
+    out = await tool(envelope_id="env_5k", segment=1, segment_size=2000)
+    assert out.startswith("segment 1/2 (chars 2000..3999 of 5000):\n")
+    assert payload[2000:4000] in out
+
+
+@pytest.mark.asyncio
+async def test_segment_last_chunk_is_short():
+    """The final segment of a body whose length isn't a multiple
+    of segment_size carries the leftover characters only — the
+    tool must NOT pad or overrun the string slice."""
+    payload = "x" * 4500  # 4500 chars; with size 2000 → 3 segments
+    tool = _collect_tool("get_post_segment", _StubDataClient(
+        _StubMessage(envelope_id="env_4500", content=payload),
+    ))
+    out = await tool(envelope_id="env_4500", segment=2, segment_size=2000)
+    # Segment 2 covers chars 4000..4499 (500 chars).
+    assert "segment 2/2 (chars 4000..4499 of 4500):\n" in out
+    # Body part of the output is exactly the leftover slice.
+    body = out.split("\n", 1)[1]
+    assert body == payload[4000:]
+    assert len(body) == 500
+
+
+@pytest.mark.asyncio
+async def test_segment_out_of_range_returns_explanation():
+    """An overshooting segment index returns a human-readable
+    error string the agent can correct from, NOT a raw exception
+    or a silent empty body."""
+    payload = "y" * 1500
+    tool = _collect_tool("get_post_segment", _StubDataClient(
+        _StubMessage(envelope_id="env_1500", content=payload),
+    ))
+    out = await tool(envelope_id="env_1500", segment=99, segment_size=2000)
+    assert "out of range" in out
+    assert "env_1500" in out
+
+
+@pytest.mark.asyncio
+async def test_segment_unknown_envelope_id_returns_not_found():
+    """The tool resolves through the data-service; a 404 from the
+    daemon comes back as a string the agent can parse instead of
+    an exception."""
+    tool = _collect_tool("get_post_segment", _StubDataClient(None))
+    out = await tool(envelope_id="env_gone", segment=0, segment_size=2000)
+    assert "not found in local storage" in out
+    assert "env_gone" in out
+
+
+@pytest.mark.asyncio
+async def test_segment_attachments_content_dict_segments_text():
+    """``puffo/message+attachments/v1`` carries content as a dict
+    with a ``text`` field and an ``attachments`` list. The
+    segmenting tool reads the text portion only — attachments are
+    already separately materialised on disk via the inbox path."""
+    payload = "z" * 3000
+    tool = _collect_tool("get_post_segment", _StubDataClient(
+        _StubMessage(envelope_id="env_attach", content={
+            "text": payload,
+            "attachments": [{"name": "screenshot.png"}],
+        }),
+    ))
+    out = await tool(envelope_id="env_attach", segment=0, segment_size=2000)
+    assert "segment 0/1 (chars 0..1999 of 3000):\n" in out
+    assert payload[:2000] in out
+
+
+@pytest.mark.asyncio
+async def test_segment_empty_body_message_returns_marker():
+    """An envelope whose text body is empty (attachments-only or
+    a future control message) returns an explicit marker instead
+    of a misleading "segment 0 (chars 0..-1 of 0)" header."""
+    tool = _collect_tool("get_post_segment", _StubDataClient(
+        _StubMessage(envelope_id="env_blank", content=""),
+    ))
+    out = await tool(envelope_id="env_blank", segment=0, segment_size=2000)
+    assert "no text body" in out
+
+
+@pytest.mark.asyncio
+async def test_segment_rejects_missing_envelope_id():
+    """Empty envelope_id is a programmer error, not a not-found —
+    surface it as a ``RuntimeError`` so the agent's adapter can
+    log + skip rather than burn a fetch on a clearly-bad call."""
+    tool = _collect_tool("get_post_segment", _StubDataClient(None))
+    with pytest.raises(RuntimeError, match="envelope_id"):
+        await tool(envelope_id="", segment=0, segment_size=2000)
+
+
+@pytest.mark.asyncio
+async def test_segment_rejects_negative_segment():
+    tool = _collect_tool("get_post_segment", _StubDataClient(None))
+    with pytest.raises(RuntimeError, match="segment must be >= 0"):
+        await tool(envelope_id="env_x", segment=-1, segment_size=2000)
+
+
+@pytest.mark.asyncio
+async def test_segment_rejects_non_positive_segment_size():
+    tool = _collect_tool("get_post_segment", _StubDataClient(None))
+    with pytest.raises(RuntimeError, match="segment_size must be > 0"):
+        await tool(envelope_id="env_x", segment=0, segment_size=0)


### PR DESCRIPTION
## Summary

- Inbound message bodies above ``DaemonConfig.max_inline_message_chars`` (default 4000) are redacted *from the LLM view only* — replaced with a ``[puffo-agent system message]`` placeholder citing envelope_id, total length, segment count, sender, and a 240-char preview. Full text still stored in ``messages.db``.
- New ``mcp__puffo__get_post_segment(envelope_id, segment, segment_size)`` tool pages the original body back ``segment_chars`` (default 2000) bytes at a time, with range metadata in the response header.
- Two new ``daemon.yml`` tunables: ``max_inline_message_chars`` + ``segment_chars``.
- Daemon log entry on every redact so operators can grep "did the agent see my paste?" by envelope_id.
- Primer (``shared_content.py``) extended with the long-message placeholder example.

Fixes the "Prompt is too long" wedge an operator hit pasting a long code block into a DM: claude-code's API error went through three rate-limit retries against the same payload, then the cursor-stays-put policy (we never silently drop user messages) meant any subsequent message in the thread re-triggered the same failure. Restart didn't unstick the agent because the failed transcript persists in claude-code's session file. Now the prompt budget is enforced at receive time, no retries needed.

## Test plan

- [x] ``pytest tests/`` — 517 passed / 7 skipped (Windows symlink limitations, pre-existing).
- [x] Direct invocation of ``_maybe_redact_long_text`` against passthrough + oversize inputs.
- [x] 16 new tests in ``test_long_message_redaction.py``:
  - Redact passthrough at + below threshold + boundary
  - Placeholder shape: envelope_id, total_chars, segments, sender, preview, tool-call recipe
  - Preview length + ellipsis + newline normalisation
  - Empty-text passthrough, missing display_name fallback
  - Segment slice math (mid, last short, off-the-end)
  - Attachments-content dict extraction
  - Unknown envelope_id → 404 string (not raise)
  - Bad-argument validation (empty envelope_id, negative segment, zero segment_size)
- [ ] **Manual smoke against production** (operator): bounce ``d2d2``, paste a long code block, verify the agent posts a normal reply instead of wedging. Confirm ``get_post_segment`` works when the agent decides to fetch.

## Migration note

Operators with an already-wedged agent should delete that agent's ``~/.puffo-agent/agents/<id>/.claude-session.json`` once before bouncing it on 0.7.9 — the existing claude-code session still holds the oversize transcript and would replay the same too-long context on the next turn. Documented in the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)