### PR TITLE
fix: oversized inbound image no longer dead-locks the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
     Pillow can't open are left untouched.
   - **Recovery** — if a poison reaches the API anyway (or is already
     stuck in an existing transcript), the ``claude`` session adapter
-    now recognises the rejection, clears the persisted session id,
-    and kills the subprocess so the next turn spawns a FRESH session
-    instead of ``--resume``-ing onto the same poisoned transcript.
-    The dropped turn stays in ``messages.db`` for the agent to page
-    back in on its next turn.
+    recognises the rejection, clears the persisted session id, kills
+    the subprocess, and **re-runs the same turn on a fresh session**
+    (no ``--resume`` onto the poisoned transcript). The poison was
+    content from an earlier turn the fresh session no longer has, so
+    the re-sent message goes through — the triggering message is
+    NOT dropped. Retried once; if the message itself still poisons
+    the fresh session it's surfaced rather than looped.
 
   Existing stuck agents recover automatically on their next inbound
   message — no operator action needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **An oversized inbound image can no longer dead-lock an agent.**
+  Anthropic's API rejects any conversation containing an image whose
+  longest edge tops 2000px ("exceeds the dimension limit for
+  many-image requests — start a new session with fewer images").
+  Once claude-code Read such an attachment into its session
+  transcript, EVERY later turn failed wholesale and the agent was
+  permanently stuck — the image analogue of the long-message
+  problem fixed in 0.7.9.
+
+  Two-part fix:
+  - **Prevention** — inbound image attachments are dimension-checked
+    and downscaled in place at save time (longest edge pinned to
+    1568px, Anthropic's recommended max, well under the hard cap),
+    so claude-code only ever loads in-bounds images. Adds a Pillow
+    dependency; non-images, already-small images, and anything
+    Pillow can't open are left untouched.
+  - **Recovery** — if a poison reaches the API anyway (or is already
+    stuck in an existing transcript), the ``claude`` session adapter
+    now recognises the rejection, clears the persisted session id,
+    and kills the subprocess so the next turn spawns a FRESH session
+    instead of ``--resume``-ing onto the same poisoned transcript.
+    The dropped turn stays in ``messages.db`` for the agent to page
+    back in on its next turn.
+
+  Existing stuck agents recover automatically on their next inbound
+  message — no operator action needed.
+
 ## [0.7.9] — 2026-05-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
     "anthropic>=0.25",
     "cryptography>=43.0",
     "mcp>=1.0",
+    # Pillow: dimension-check + downscale inbound image attachments so
+    # an oversized image can't poison the agent's claude session.
+    "pillow>=10.0",
     "pyhpke>=0.6",
     "openai>=1.30",
     "psutil>=5.9",

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -217,6 +217,34 @@ class ClaudeSession:
 
     # ── Public API ────────────────────────────────────────────────────────────
 
+    async def _one_turn_with_poison_recovery(
+        self, user_message: str, system_prompt: str,
+    ) -> TurnResult:
+        """``_one_turn`` plus a single fresh-session retry when the
+        turn comes back poisoned.
+
+        ``_one_turn`` already cleared the session id + killed the
+        subprocess on detection, so ``_ensure_running`` here spawns a
+        FRESH session with no transcript — the poison was content from
+        an EARLIER turn that the fresh session simply doesn't have.
+        The current message's own image attachments are downscaled at
+        save time, so re-sending it on the clean transcript succeeds;
+        without this retry the triggering message would be silently
+        dropped (it never gets another turn if it's the only inbound
+        message). Retried at most once: if the message itself somehow
+        still poisons the fresh session, return the (empty) poisoned
+        result rather than loop."""
+        result = await self._one_turn(user_message)
+        if not result.metadata.get("poisoned_session"):
+            return result
+        logger.warning(
+            "agent %s: re-running the turn on a fresh session after "
+            "poisoned-transcript recovery so the message isn't dropped",
+            self.agent_id,
+        )
+        await self._ensure_running(system_prompt)
+        return await self._one_turn(user_message)
+
     async def run_turn(self, user_message: str, system_prompt: str) -> TurnResult:
         async with self._lock:
             await self._ensure_running(system_prompt)
@@ -238,7 +266,9 @@ class ClaudeSession:
                     # during the wait. Respawn re-reads the shared
                     # credentials file.
                     await self._ensure_running(system_prompt)
-                result = await self._one_turn(user_message)
+                result = await self._one_turn_with_poison_recovery(
+                    user_message, system_prompt,
+                )
                 if not _looks_like_auth_error(result.reply):
                     return result
                 last_result = result
@@ -315,7 +345,9 @@ class ClaudeSession:
                     self.agent_id,
                 )
                 user_message = fallback_user_message
-            return await self._one_turn(user_message)
+            return await self._one_turn_with_poison_recovery(
+                user_message, system_prompt,
+            )
 
     async def warm(self, system_prompt: str) -> None:
         """Spawn the claude subprocess without running a turn so the

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -67,11 +67,35 @@ _AUTH_ERROR_MARKERS = (
 AUTH_RETRY_BACKOFFS_SECONDS = (3, 6, 12, 24)
 
 
+# Case-insensitive substrings that mark a claude reply as a POISONED
+# SESSION: the conversation transcript accumulated content the API
+# now rejects wholesale (most commonly an image whose longest edge
+# tops 2000px). ``--resume`` reloads the same poisoned transcript, so
+# every later turn fails identically and the agent dead-locks. The
+# only fix is what the API itself advises — start a fresh session.
+# Kept STRONG-ONLY: these are verbatim API error strings, vanishingly
+# unlikely in normal chatter. The inbound-image downscale
+# (puffo_core_client._downscale_oversized_image) is the prevention
+# half; this is the recovery half for anything that slips through or
+# is already stuck in an existing transcript.
+_POISONED_SESSION_MARKERS = (
+    "exceeds the dimension limit for many-image requests",
+    "start a new session with fewer images",
+)
+
+
 def _looks_like_auth_error(text: str) -> bool:
     if not text:
         return False
     low = text.lower()
     return any(marker in low for marker in _AUTH_ERROR_MARKERS)
+
+
+def _looks_like_poisoned_session(text: str) -> bool:
+    if not text:
+        return False
+    low = text.lower()
+    return any(marker in low for marker in _POISONED_SESSION_MARKERS)
 
 
 class AuditLog:
@@ -499,6 +523,28 @@ class ClaudeSession:
             )
         await self._kill_proc()
 
+    async def _handle_poisoned_session(self, reply: str) -> None:
+        """Recovery for a poisoned session transcript (see
+        ``_POISONED_SESSION_MARKERS``). ``--resume`` would reload the
+        same rejected content, so clear the session id AND kill the
+        subprocess: the next turn spawns a FRESH session with no
+        transcript. The dropped turn is re-readable from messages.db,
+        so the agent can rebuild context on its next turn."""
+        logger.error(
+            "agent %s: claude session poisoned (API rejects the whole "
+            "conversation) — clearing session id, respawning fresh. "
+            "reply: %s",
+            self.agent_id, reply[:300],
+        )
+        if self.audit is not None:
+            self.audit.write(
+                "session.poisoned",
+                reply=reply,
+                action="cleared_session_id_and_respawned_fresh",
+            )
+        self._clear_session_id()
+        await self._kill_proc()
+
     async def _kill_proc(self) -> None:
         if self._proc is None:
             return
@@ -651,6 +697,18 @@ class ClaudeSession:
                 break
 
         reply = "".join(reply_parts).strip()
+
+        # Poisoned-session recovery. If the API rejected the whole
+        # conversation (oversized image in the transcript, etc),
+        # ``--resume`` would just reload the same poison — clear the
+        # session id + kill the subprocess so the next turn starts
+        # fresh. Empty reply (mirrors the stream-error contract) so
+        # the shell suppresses the post; the metadata flag lets the
+        # worker surface the reset.
+        if _looks_like_poisoned_session(reply):
+            await self._handle_poisoned_session(reply)
+            return TurnResult(reply="", metadata={"poisoned_session": True})
+
         if not reply:
             logger.warning(
                 "agent %s: claude turn produced no text reply. events seen: %s",

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -277,6 +277,51 @@ def _maybe_redact_long_text(
     return placeholder
 
 
+# Anthropic's API rejects any conversation containing an image whose
+# longest edge tops 2000px. Claude-code Read-ing such an attachment
+# poisons the session transcript — every later turn then fails
+# wholesale (see ClaudeSession._looks_like_poisoned_session). We
+# can't stop claude-code Read-ing a file, but we CAN keep the file
+# on disk in bounds. 1568px is Anthropic's recommended max — well
+# under the 2000px hard cap.
+_MAX_IMAGE_EDGE_PX = 1568
+
+
+def _downscale_oversized_image(path) -> None:
+    """Resize ``path`` in place if it's an image whose longest edge
+    tops ``_MAX_IMAGE_EDGE_PX``. No-op for non-images, small images,
+    or anything Pillow can't open (claude-code's loader can't open
+    it either, so it can't reach the API as an oversized image).
+    Best-effort — never raises."""
+    try:
+        from PIL import Image
+    except ImportError:
+        logger.warning(
+            "Pillow missing — inbound images aren't dimension-checked; "
+            "an oversized image can dead-lock the claude session "
+            "(pip install pillow)",
+        )
+        return
+    try:
+        with Image.open(path) as img:
+            img.load()
+            w, h = img.size
+            longest = max(w, h)
+            if longest <= _MAX_IMAGE_EDGE_PX:
+                return
+            scale = _MAX_IMAGE_EDGE_PX / longest
+            new_size = (max(1, round(w * scale)), max(1, round(h * scale)))
+            fmt = img.format or "PNG"
+            img.resize(new_size, Image.LANCZOS).save(path, format=fmt)
+        logger.info(
+            "downscaled inbound image %s: %dx%d -> %dx%d "
+            "(claude image dimension cap)",
+            getattr(path, "name", path), w, h, new_size[0], new_size[1],
+        )
+    except Exception as exc:
+        logger.warning("could not dimension-check image %s: %s", path, exc)
+
+
 class DeviceKeyCache:
     """Caches sender signing public keys.
 
@@ -1888,6 +1933,10 @@ class PuffoCoreMessageClient:
                     "attachment save failed (%s): %s", target, exc,
                 )
                 continue
+            # Shrink oversized images before the agent can Read them
+            # into — and poison — its claude session. Off-loop: Pillow
+            # decode/resize is blocking.
+            await asyncio.to_thread(_downscale_oversized_image, target)
             paths.append(str(target))
         return paths
 

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -18,6 +18,7 @@ from puffo_agent.agent.adapters.cli_session import (
     STREAM_READER_LIMIT_BYTES,
     AuditLog,
     ClaudeSession,
+    _looks_like_poisoned_session,
 )
 
 
@@ -306,3 +307,111 @@ def test_refresh_oneshot_sets_auth_healthy_on_success(tmp_path):
         asyncio.run(adapter._run_refresh_oneshot())
 
     assert adapter.auth_healthy is True
+
+
+# ── Test 4: poisoned-session recovery ────────────────────────────────────────
+
+
+def test_looks_like_poisoned_session_matches_image_dimension_error():
+    """Verbatim API error strings match; ordinary chat does not."""
+    assert _looks_like_poisoned_session(
+        "API Error: An image in the conversation exceeds the dimension "
+        "limit for many-image requests (2000px). Start a new session "
+        "with fewer images."
+    )
+    # Case-insensitive.
+    assert _looks_like_poisoned_session("START A NEW SESSION WITH FEWER IMAGES")
+    # No false positive on normal replies.
+    assert not _looks_like_poisoned_session("Sure, here's the image you asked about.")
+    assert not _looks_like_poisoned_session("")
+
+
+def test_one_turn_recovers_from_poisoned_session(tmp_path, caplog):
+    """A reply carrying the oversized-image API error must: return an
+    empty reply (so the channel sees nothing), flag
+    ``poisoned_session`` in metadata, CLEAR the persisted session id
+    (so the next spawn is fresh, not ``--resume`` onto the same
+    poisoned transcript), kill the subprocess, and audit the reset.
+    """
+    poison = (
+        "API Error: An image in the conversation exceeds the dimension "
+        "limit for many-image requests (2000px). Start a new session "
+        "with fewer images."
+    )
+    assistant = {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": poison}]},
+    }
+    result = {
+        "type": "result",
+        "subtype": "success",
+        "session_id": "sess-poisoned",
+        "usage": {"input_tokens": 5, "output_tokens": 5},
+    }
+    lines = [
+        (json.dumps(assistant) + "\n").encode("utf-8"),
+        (json.dumps(result) + "\n").encode("utf-8"),
+    ]
+    session = _make_session(tmp_path)
+    # Pretend a prior turn persisted a session id — that's what makes
+    # the next spawn try --resume onto the poisoned transcript.
+    session._save_session_id("sess-poisoned")
+    assert session.session_file.exists()
+
+    async def drive():
+        session._proc = _FakeProc(stdout_lines=lines)
+        return await session._one_turn("look at this picture")
+
+    with caplog.at_level(logging.ERROR):
+        out = asyncio.run(drive())
+
+    # Empty reply — the raw API error must not post as a bot message.
+    assert out.reply == ""
+    assert out.metadata.get("poisoned_session") is True
+    # Session id cleared on disk AND in memory — next spawn is fresh.
+    assert not session.session_file.exists()
+    assert session._session_id == ""
+    # Subprocess killed so the next turn respawns.
+    assert session._proc is None
+
+    events = _read_audit_events(tmp_path / "audit.log")
+    poisoned = [e for e in events if e.get("event") == "session.poisoned"]
+    assert len(poisoned) == 1
+    assert poisoned[0]["action"] == "cleared_session_id_and_respawned_fresh"
+
+    assert any(
+        "poisoned" in r.message and r.levelno == logging.ERROR
+        for r in caplog.records
+    ), "expected an ERROR log naming the poisoned session"
+
+
+def test_one_turn_normal_reply_keeps_session(tmp_path):
+    """A clean reply leaves the persisted session id intact — the
+    recovery path must not fire on ordinary turns."""
+    assistant = {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": "all good, here you go"}]},
+    }
+    result = {
+        "type": "result",
+        "subtype": "success",
+        "session_id": "sess-healthy",
+        "usage": {"input_tokens": 5, "output_tokens": 5},
+    }
+    lines = [
+        (json.dumps(assistant) + "\n").encode("utf-8"),
+        (json.dumps(result) + "\n").encode("utf-8"),
+    ]
+    session = _make_session(tmp_path)
+    session._save_session_id("sess-healthy")
+
+    async def drive():
+        session._proc = _FakeProc(stdout_lines=lines)
+        return await session._one_turn("hello")
+
+    out = asyncio.run(drive())
+
+    assert out.reply == "all good, here you go"
+    assert out.metadata.get("poisoned_session") is None
+    assert session.session_file.exists()
+    assert session._session_id == "sess-healthy"

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -385,6 +385,80 @@ def test_one_turn_recovers_from_poisoned_session(tmp_path, caplog):
     ), "expected an ERROR log naming the poisoned session"
 
 
+def test_poison_recovery_reruns_the_turn_on_a_fresh_session(tmp_path):
+    """The triggering message must NOT be dropped. After ``_one_turn``
+    detects the poison + clears the session, ``_one_turn_with_poison_
+    recovery`` re-ensures running (a fresh spawn) and re-sends the
+    SAME message — which succeeds on the clean transcript. Without
+    this rerun the message is lost forever when it's the only inbound
+    one (no later turn ever pages it back in)."""
+    poison_lines = [
+        (
+            json.dumps({
+                "type": "assistant",
+                "message": {"content": [{
+                    "type": "text",
+                    "text": (
+                        "An image in the conversation exceeds the "
+                        "dimension limit for many-image requests (2000px)."
+                    ),
+                }]},
+            }) + "\n"
+        ).encode("utf-8"),
+        (
+            json.dumps({
+                "type": "result", "subtype": "success",
+                "session_id": "sess-poison",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }) + "\n"
+        ).encode("utf-8"),
+    ]
+    clean_lines = [
+        (
+            json.dumps({
+                "type": "assistant",
+                "message": {"content": [
+                    {"type": "text", "text": "processed your message fine"}
+                ]},
+            }) + "\n"
+        ).encode("utf-8"),
+        (
+            json.dumps({
+                "type": "result", "subtype": "success",
+                "session_id": "sess-fresh",
+                "usage": {"input_tokens": 2, "output_tokens": 3},
+            }) + "\n"
+        ).encode("utf-8"),
+    ]
+    session = _make_session(tmp_path)
+    session._save_session_id("sess-poison")
+
+    async def drive():
+        # Turn 1: the poisoned proc.
+        session._proc = _FakeProc(stdout_lines=poison_lines)
+        # _ensure_running is what would respawn — patch it to inject
+        # the fresh (clean) proc, modelling a no-session-id spawn.
+        clean_proc = _FakeProc(stdout_lines=clean_lines)
+
+        async def fake_ensure(_system_prompt):
+            session._proc = clean_proc
+
+        with patch.object(session, "_ensure_running", side_effect=fake_ensure):
+            return await session._one_turn_with_poison_recovery(
+                "look at this picture", "sysprompt",
+            )
+
+    out = asyncio.run(drive())
+
+    # The rerun succeeded — the message produced a real reply, not an
+    # empty drop.
+    assert out.reply == "processed your message fine"
+    assert out.metadata.get("poisoned_session") is None
+    assert out.input_tokens == 2
+    # Poisoned id cleared by turn 1; the fresh turn learned a new one.
+    assert session._session_id == "sess-fresh"
+
+
 def test_one_turn_normal_reply_keeps_session(tmp_path):
     """A clean reply leaves the persisted session id intact — the
     recovery path must not fire on ordinary turns."""

--- a/tests/test_image_dimension_guard.py
+++ b/tests/test_image_dimension_guard.py
@@ -1,0 +1,94 @@
+"""Tests for ``_downscale_oversized_image`` — the prevention half of
+the oversized-image session-poison fix. An inbound image whose longest
+edge tops Anthropic's 2000px many-image cap, once Read into the claude
+session, makes every later turn fail wholesale. We downscale the file
+on disk at save time so claude-code only ever loads in-bounds images.
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from puffo_agent.agent.puffo_core_client import (
+    _MAX_IMAGE_EDGE_PX,
+    _downscale_oversized_image,
+)
+
+
+def test_oversized_landscape_image_is_downscaled(tmp_path):
+    """A wide image over the cap is resized in place, longest edge
+    pinned to the cap, aspect ratio preserved."""
+    path = tmp_path / "wide.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+
+    _downscale_oversized_image(path)
+
+    with Image.open(path) as img:
+        w, h = img.size
+    assert max(w, h) <= _MAX_IMAGE_EDGE_PX
+    # 4000:1000 == 4:1 — within rounding.
+    assert abs(w / h - 4.0) < 0.05
+    assert w == _MAX_IMAGE_EDGE_PX
+
+
+def test_oversized_portrait_image_is_downscaled(tmp_path):
+    """Tall image: the HEIGHT is the longest edge and gets pinned."""
+    path = tmp_path / "tall.png"
+    Image.new("RGB", (800, 3200), color="blue").save(path)
+
+    _downscale_oversized_image(path)
+
+    with Image.open(path) as img:
+        w, h = img.size
+    assert max(w, h) <= _MAX_IMAGE_EDGE_PX
+    assert h == _MAX_IMAGE_EDGE_PX
+
+
+def test_image_at_the_cap_is_untouched(tmp_path):
+    """An image already within bounds is left byte-for-byte alone —
+    no needless re-encode."""
+    path = tmp_path / "ok.png"
+    Image.new("RGB", (_MAX_IMAGE_EDGE_PX, 900), color="green").save(path)
+    before = path.read_bytes()
+
+    _downscale_oversized_image(path)
+
+    assert path.read_bytes() == before
+
+
+def test_small_jpeg_preserves_format(tmp_path):
+    """Format is preserved on resize — a JPEG stays a JPEG. (Use an
+    oversized JPEG so the resize+save path actually runs.)"""
+    path = tmp_path / "photo.jpg"
+    Image.new("RGB", (5000, 2500), color="white").save(path, format="JPEG")
+
+    _downscale_oversized_image(path)
+
+    with Image.open(path) as img:
+        assert img.format == "JPEG"
+        assert max(img.size) <= _MAX_IMAGE_EDGE_PX
+
+
+def test_non_image_file_is_left_alone(tmp_path):
+    """A non-image attachment (text, pdf, …) is a no-op, no raise."""
+    path = tmp_path / "notes.txt"
+    path.write_text("just some text, definitely not a PNG", encoding="utf-8")
+    before = path.read_bytes()
+
+    _downscale_oversized_image(path)  # must not raise
+
+    assert path.read_bytes() == before
+
+
+def test_corrupt_image_is_left_alone(tmp_path):
+    """A file with an image extension but garbage bytes: Pillow can't
+    open it (claude-code's loader can't either, so it can't reach the
+    API as an oversized image). Best-effort — no raise, file untouched.
+    """
+    path = tmp_path / "broken.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)  # header, junk body
+    before = path.read_bytes()
+
+    _downscale_oversized_image(path)  # must not raise
+
+    assert path.read_bytes() == before


### PR DESCRIPTION
## The bug

An agent got permanently stuck. Root cause: an inbound message carried an image whose dimensions exceed Anthropic's 2000px many-image cap. The API rejects the **whole conversation**:

> An image in the conversation exceeds the dimension limit for many-image requests (2000px). Start a new session with fewer images.

Once claude-code Read that attachment into its session transcript, every later turn failed identically on `--resume`. Dead-lock. This is the image analogue of the long-message problem fixed in 0.7.9.

puffo-agent passes attachments to claude-code as **file paths**, not image content blocks — claude-code itself Reads the file. We can't stop it Read-ing an attachment, but we can keep the file in-bounds, and recover the session if a poison gets through anyway.

## Two-part fix

### Prevention — downscale oversized images at save time
`_downscale_oversized_image` (puffo_core_client.py), called from `_save_inbound_attachments` right after the file is written:
- Resizes in place if the longest edge tops **1568px** (Anthropic's recommended max, well under the 2000px hard cap), aspect ratio + format preserved.
- Off-loop via `asyncio.to_thread` (Pillow decode/resize is blocking).
- No-op for non-images, already-small images, and anything Pillow can't open (claude-code's loader can't open it either → can't reach the API as an oversized image).
- Best-effort, never raises. Adds a **Pillow** dependency.

### Recovery — fresh session on a poisoned transcript
`_looks_like_poisoned_session` + `_handle_poisoned_session` (cli_session.py):
- Recognises the verbatim API rejection in a reply.
- Clears the persisted session id + kills the subprocess → the next turn spawns a **fresh** session instead of `--resume`-ing onto the same poisoned transcript.
- Mirrors the existing stream-error contract: empty reply (channel sees nothing) + metadata flag. The dropped turn stays in `messages.db` for the agent to page back in.
- Markers are STRONG-ONLY (verbatim API error strings), same false-positive discipline as the auth-error markers.

**Existing stuck agents recover automatically on their next inbound message** — no operator action needed (unlike 0.7.9's long-message fix, which needed a manual session-file clear).

## Test plan

- [x] `test_image_dimension_guard.py` — oversized landscape/portrait downscaled, aspect + format preserved; image at the cap left byte-identical; non-image + corrupt files untouched, no raise.
- [x] `test_cli_session_recovery.py` — marker matches the verbatim error, case-insensitive, no false positive on normal replies; `_one_turn` on a poisoned reply → empty + `poisoned_session` metadata, session id cleared on disk + in memory, proc killed, `session.poisoned` audited; clean reply leaves the session id intact.
- [x] Full suite: 531 passed, 7 skipped (pre-existing env skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)