### PR TITLE
feat(messages): is_visible_to_human flag for human/agent message visibility

### DIFF
--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -143,6 +143,7 @@ class PuffoAgent:
                 space_id=channel_meta.get("space_id", ""),
                 space_name=channel_meta.get("space_name", ""),
                 sender_display_name=msg.get("sender_display_name", ""),
+                is_visible_to_human=msg.get("is_visible_to_human", True),
             )
         # Route logging uses the LAST sender in the batch as the
         # display "trigger" for log lines — purely cosmetic, the
@@ -334,6 +335,7 @@ class PuffoAgent:
         space_id: str = "",
         space_name: str = "",
         sender_display_name: str = "",
+        is_visible_to_human: bool = True,
     ):
         content = self._format_user_block(
             channel_name=channel_name,
@@ -351,6 +353,7 @@ class PuffoAgent:
             space_id=space_id,
             space_name=space_name,
             sender_display_name=sender_display_name,
+            is_visible_to_human=is_visible_to_human,
         )
         self.log.append({"role": "user", "content": content})
         self._truncate_log()
@@ -373,6 +376,7 @@ class PuffoAgent:
         space_id: str = "",
         space_name: str = "",
         sender_display_name: str = "",
+        is_visible_to_human: bool = True,
     ) -> str:
         # Structured markdown block keeps context metadata distinct
         # from message content, preventing the LLM from echoing
@@ -407,6 +411,9 @@ class PuffoAgent:
         lines.append(f"- sender: {display}")
         lines.append(f"- sender_slug: {sender}")
         lines.append(f"- sender_type: {'bot' if sender_is_bot else 'human'}")
+        lines.append(
+            f"- is_visible_to_human: {'true' if is_visible_to_human else 'false'}"
+        )
         if mentions:
             lines.append("- mentions:")
             for m in mentions:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -411,7 +411,7 @@ class PuffoCoreMessageClient:
         self.store = message_store
         self._key_cache = DeviceKeyCache(http_client)
         self._ws: Optional[PuffoCoreWsClient] = None
-        # Most recent DM sender. ``post_message(channel_id="")`` means
+        # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
         # "reply to whoever just DMed me". Single-slot is fine since
         # the worker handles one envelope at a time; concurrent DM
         # handlers would need a per-turn lookup keyed by envelope_id.
@@ -600,7 +600,7 @@ class PuffoCoreMessageClient:
             else:
                 raw_text = str(payload.content) if payload.content else ""
 
-            # Stash the sender so `post_message("")` can route replies.
+            # Stash the sender so `send_fallback_message("")` can route replies.
             # Always overwrite — first-write would pin replies to a
             # stale peer when a different person DMs us.
             if is_dm:
@@ -1945,7 +1945,7 @@ class PuffoCoreMessageClient:
         self, recipient_slug: str, text: str, root_id: str,
     ) -> dict | None:
         """Send a DM to a specific slug (rather than to
-        ``_last_dm_sender`` like ``post_message`` does). Returns the
+        ``_last_dm_sender`` like ``send_fallback_message`` does). Returns the
         encrypted envelope on success (caller can read its
         envelope_id), or ``None`` when the recipient has no
         resolvable devices.
@@ -2025,7 +2025,7 @@ class PuffoCoreMessageClient:
                 break
         return devices
 
-    async def post_message(
+    async def send_fallback_message(
         self, channel_id: str, text: str, root_id: str = "",
     ) -> None:
         """Post a reply. Empty ``channel_id`` ⇒ DM back to
@@ -2069,7 +2069,7 @@ class PuffoCoreMessageClient:
             recipient = self._last_dm_sender
             if not recipient:
                 logger.warning(
-                    "post_message called with empty channel_id but no DM "
+                    "send_fallback_message called with empty channel_id but no DM "
                     "context — dropping reply",
                 )
                 return
@@ -2087,7 +2087,7 @@ class PuffoCoreMessageClient:
             return
 
         logger.info(
-            "post_message: kind=%s target=%s devices=%d",
+            "send_fallback_message: kind=%s target=%s devices=%d",
             envelope_kind, recipient_slug or channel_id, len(devices),
         )
 
@@ -2113,12 +2113,12 @@ class PuffoCoreMessageClient:
         try:
             resp = await self.http.post("/messages", envelope)
             logger.info(
-                "post_message sent: envelope_id=%s queued=%s",
+                "send_fallback_message sent: envelope_id=%s queued=%s",
                 envelope.get("envelope_id"),
                 (resp or {}).get("devices_queued"),
             )
         except Exception:
-            logger.exception("post_message: POST /messages failed")
+            logger.exception("send_fallback_message: POST /messages failed")
             raise
 
         # No mirror-write here anymore. The WS echo path now persists

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -717,6 +717,7 @@ class PuffoCoreMessageClient:
                 "mentions": mentions,
                 "envelope_id": payload.envelope_id,
                 "sent_at": payload.sent_at,
+                "is_visible_to_human": payload.is_visible_to_human,
             }
             channel_meta = {
                 "channel_id": channel_id,
@@ -1965,6 +1966,8 @@ class PuffoCoreMessageClient:
             envelope_kind="dm",
             sender_slug=self.slug,
             sender_subkey_id=sess.subkey_id,
+            # Operator-facing notices (invite approvals) — always visible.
+            is_visible_to_human=True,
             recipient_slug=recipient_slug,
             thread_root_id=root_id if root_id else None,
             content_type="text/plain",
@@ -2092,6 +2095,10 @@ class PuffoCoreMessageClient:
             envelope_kind=envelope_kind,
             sender_slug=self.slug,
             sender_subkey_id=sess.subkey_id,
+            # Fallback path (agent skipped send_message + [SILENT]) —
+            # folded by default; the primer steers agents to
+            # send_message, where they set visibility consciously.
+            is_visible_to_human=False,
             space_id=send_space_id,
             channel_id=send_channel_id,
             recipient_slug=recipient_slug,

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -38,6 +38,7 @@ Every user message is wrapped in a metadata block:
 - timestamp: <ISO-8601>
 - sender: <slug>                 # e.g. alice-1234, agent-5678
 - sender_type: human | bot
+- is_visible_to_human: true | false  # false = folded out of the human's view; agent-to-agent only
 - mentions:                      # present when the message @-mentions
   - puffotest-19b1 (you)
   - alice-1234 (human)
@@ -91,14 +92,27 @@ Common examples:
 There are exactly two ways to deliver a reply, and you must pick
 one explicitly on every turn:
 
-1. **`mcp__puffo__send_message(channel, text, root_id="")` — the
-   default.** Use this for *every* user-visible reply, including
-   the obvious "answer the message I just received" case. Pass
-   the metadata's `channel_id` as `channel` and (if you want to
-   stay in the same thread) `thread_root_id` as `root_id`. You
-   may call it more than once per turn — for example to reply in
-   the originating channel AND notify another channel in the
-   same turn — and every send is treated as intentional.
+1. **`mcp__puffo__send_message(channel, text, is_visible_to_human, root_id="")`
+   — the default.** Use this for *every* user-visible reply,
+   including the obvious "answer the message I just received"
+   case. Pass the metadata's `channel_id` as `channel` and (if
+   you want to stay in the same thread) `thread_root_id` as
+   `root_id`. You may call it more than once per turn — for
+   example to reply in the originating channel AND notify another
+   channel in the same turn — and every send is treated as
+   intentional.
+
+   `is_visible_to_human` is **required** — there is no default,
+   you decide on every call. Pass `true` for anything a human
+   should read: replies to people, status updates, anything an
+   operator would want in their feed. Pass `false` only for
+   agent-to-agent chatter a human watching the channel would find
+   pure noise — coordination handshakes between bots, payloads
+   addressed to another agent. When in doubt, pass `true`: a
+   visible message a human skims past is cheaper than a useful
+   one folded out of sight. Human clients collapse runs of
+   `false` messages behind a placeholder; they are still
+   delivered, searchable, and visible to other agents.
 
 2. **`[SILENT]` in your `assistant.text`** — when no reply is
    needed (the conversation is between other people, the
@@ -114,8 +128,11 @@ your `assistant.text` frames into a markdown bullet list and
 posting that as the reply. Treat the fallback as a safety net,
 not a target: it costs the operator a `[fallback] ...skipped
 both send_message and [SILENT] markers` warning in their daemon
-log, and the bullet-list rendering rarely matches what you'd
-have written if you'd composed the reply directly.
+log, the bullet-list rendering rarely matches what you'd have
+written if you'd composed the reply directly, and the fallback
+posts with `is_visible_to_human=false` — so the human may never
+see it. Always prefer an explicit `send_message` call where you
+set visibility consciously.
 
 **Self-mention marker.** If a message @-mentions you, the shell
 rewrites your handle in the `message:` field as `@you(<your-slug>)`
@@ -174,10 +191,10 @@ entry is an absolute path under your workspace
 already decrypted and saved the file for you. Use your `Read` /
 `Bash` tools on those paths directly.
 
-To send files, use `mcp__puffo__upload_file` with a list of
-workspace-relative paths. All files in one call ride together in a
-single message envelope (recipients see one bubble with N
-attachments, not N separate messages).
+To send files, use `mcp__puffo__send_message_with_attachments` with
+a list of workspace-relative paths. All files in one call ride
+together in a single message envelope (recipients see one bubble
+with N attachments, not N separate messages).
 
 ## Markdown
 
@@ -197,13 +214,16 @@ for reading context and managing yourself. See `.claude/skills/`
 for one doc per tool.
 
 **Write / post tools:**
-- `mcp__puffo__send_message(channel, text, root_id="")` — your
-  reply mechanism. Channel may be a `ch_<uuid>` for a channel
-  post or `@<slug>` for a DM.
-- `mcp__puffo__upload_file(paths, channel, caption="", root_id="")` —
-  upload one or more files from your workspace. ``paths`` is a list;
-  all files ride together in a single envelope. ``root_id`` lets you
-  attach inside an existing thread.
+- `mcp__puffo__send_message(channel, text, is_visible_to_human, root_id="")`
+  — your reply mechanism. Channel may be a `ch_<uuid>` for a
+  channel post or `@<slug>` for a DM. `is_visible_to_human` is
+  required — see "How to reply" above.
+- `mcp__puffo__send_message_with_attachments(paths, channel, is_visible_to_human, caption="", root_id="")`
+  — send one or more files from your workspace. ``paths`` is a
+  list; all files ride together in a single envelope.
+  `is_visible_to_human` is required, same meaning as on
+  `send_message`. ``root_id`` lets you attach inside an existing
+  thread.
 
 **Read / discovery tools:**
 - `mcp__puffo__list_channels()` — channels in your configured space,
@@ -349,6 +369,13 @@ Post a message to a Puffo.ai channel or DM a user.
     `list_channels` to look up an id.
 - `text` (required) — message body. Markdown is preserved on the
   wire; the client will render it when the formatting upgrade ships.
+- `is_visible_to_human` (required) — bool, no default. `true` for
+  anything a human should read — the right choice for replies,
+  status updates, and operator pings. `false` only for
+  agent-to-agent chatter a human watching the channel would find
+  pure noise. Human clients fold runs of `false` messages behind
+  a placeholder; they are still delivered, searchable, and
+  visible to other agents. When in doubt, `true`.
 - `root_id` (optional) — envelope_id (`env_<uuid>`) of the post you
   are replying to; opens a thread.
 
@@ -372,26 +399,27 @@ Post a message to a Puffo.ai channel or DM a user.
 ```
 send_message(channel="ch_b3c4d5e6-...",
              text="Got it; running the migration now.",
+             is_visible_to_human=True,
              root_id="env_abcdef-...")
 ```
 
 **Example — proactive notifications:**
 
 ```
-send_message(channel="@alice-1234", text="Heads up — your build finished.")
-send_message(channel="ch_b3c4d5e6-...", text="Daily: shipped X, in progress Y.")
+send_message(channel="@alice-1234", text="Heads up — your build finished.", is_visible_to_human=True)
+send_message(channel="ch_b3c4d5e6-...", text="Daily: shipped X, in progress Y.", is_visible_to_human=True)
 ```
 """
 
 
-DEFAULT_SKILL_UPLOAD_FILE = """\
-# Skill: upload_file
+DEFAULT_SKILL_SEND_MESSAGE_WITH_ATTACHMENTS = """\
+# Skill: send_message_with_attachments
 
-Upload one or more files from your workspace to a Puffo.ai channel
+Send one or more files from your workspace to a Puffo.ai channel
 or DM. Recipients see them as one bubble with N attachments (not N
 separate messages).
 
-**Tool:** `mcp__puffo__upload_file(paths, channel, caption="", root_id="")`
+**Tool:** `mcp__puffo__send_message_with_attachments(paths, channel, is_visible_to_human, caption="", root_id="")`
 
 **Arguments:**
 - `paths`: list of workspace-relative file paths. Pass a one-element
@@ -399,6 +427,9 @@ separate messages).
   rejected; the cap is 10 files per call and 8 MiB per file.
 - `channel`: same syntax as `send_message` — `@<slug>` for a DM,
   `ch_<uuid>` for a channel.
+- `is_visible_to_human`: required bool, no default — same meaning
+  as on `send_message`. `true` for files a human should see,
+  `false` for agent-to-agent payloads. When in doubt, `true`.
 - `caption`: optional text posted alongside the files. Empty by
   default; recipients see just the attachments.
 - `root_id`: optional — reply with the attachments inside an
@@ -430,8 +461,8 @@ turn starts and saves it under your workspace at
   with your `Read` tool, same as any other workspace file.
 - For images, the saved path is a real file your tools can pass
   along (e.g. to a vision model, or to embed in a reply via
-  `mcp__puffo__upload_file`). Don't try to interpret the bytes
-  inline.
+  `mcp__puffo__send_message_with_attachments`). Don't try to
+  interpret the bytes inline.
 - The inbox dir is per-envelope so you won't collide across turns.
   Files persist across runs; clean them up if storage matters.
 
@@ -440,7 +471,8 @@ turn starts and saves it under your workspace at
   on disk by the time you see the path.
 - Worry about a "not yet implemented" stub — the API is live.
 
-To send files back, use `mcp__puffo__upload_file` (see its skill).
+To send files back, use `mcp__puffo__send_message_with_attachments`
+(see its skill).
 """
 
 
@@ -552,8 +584,9 @@ your workspace.
 **Status:** the puffo-core blob *query* endpoint is still a
 server-side stub. Calling this tool today returns
 `"(fetch_channel_files: blob query API not yet implemented)"`.
-Note that `mcp__puffo__upload_file` IS implemented — only the
-back-fill / search-by-channel flow is pending.
+Note that `mcp__puffo__send_message_with_attachments` IS
+implemented — only the back-fill / search-by-channel flow is
+pending.
 
 **Today's workaround:** the daemon already saves any incoming
 attachment to ``<workspace>/.puffo/inbox/<envelope_id>/`` as the
@@ -666,7 +699,7 @@ reach for `refresh` after `install_skill` / `install_mcp_server`.
 
 DEFAULT_SKILLS: dict[str, str] = {
     "send-message.md": DEFAULT_SKILL_SEND_MESSAGE,
-    "upload-file.md": DEFAULT_SKILL_UPLOAD_FILE,
+    "send-message-with-attachments.md": DEFAULT_SKILL_SEND_MESSAGE_WITH_ATTACHMENTS,
     "attachments.md": DEFAULT_SKILL_ATTACHMENTS,
     "permissions.md": DEFAULT_SKILL_PERMISSIONS,
     "channel-history.md": DEFAULT_SKILL_CHANNEL_HISTORY,

--- a/src/puffo_agent/crypto/message.py
+++ b/src/puffo_agent/crypto/message.py
@@ -34,6 +34,7 @@ class EncryptInput:
     envelope_kind: str  # "channel" or "dm"
     sender_slug: str
     sender_subkey_id: str
+    is_visible_to_human: bool
     space_id: Optional[str] = None
     channel_id: Optional[str] = None
     recipient_slug: Optional[str] = None
@@ -65,6 +66,7 @@ class MessagePayload:
     message_nonce: str
     content_type: str
     content: Any
+    is_visible_to_human: bool
     space_id: Optional[str] = None
     channel_id: Optional[str] = None
     recipient_slug: Optional[str] = None
@@ -94,6 +96,7 @@ class MessagePayload:
             "reply_to_id": self.reply_to_id,
             "content_type": self.content_type,
             "content": self.content,
+            "is_visible_to_human": self.is_visible_to_human,
         }
 
 
@@ -135,6 +138,7 @@ def encrypt_message(
         reply_to_id=inp.reply_to_id,
         content_type=inp.content_type,
         content=inp.content,
+        is_visible_to_human=inp.is_visible_to_human,
     )
 
     payload_dict = payload.to_payload_dict()
@@ -269,4 +273,5 @@ def decrypt_message(
         reply_to_id=payload_dict.get("reply_to_id"),
         content_type=payload_dict["content_type"],
         content=payload_dict["content"],
+        is_visible_to_human=payload_dict.get("is_visible_to_human", True),
     )

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -23,7 +23,7 @@ MCP_SERVER_NAME = "puffo"
 
 PUFFO_CORE_TOOL_NAMES = (
     "send_message",
-    "upload_file",
+    "send_message_with_attachments",
     "list_channels",
     "list_channel_members",
     "get_channel_history",

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -46,8 +46,9 @@ class PuffoCoreToolsConfig:
     http_client: PuffoCoreHttpClient
     data_client: DataClient
     space_id: Optional[str] = None
-    # Workspace root used by ``upload_file`` to safety-resolve LLM-
-    # supplied relative paths (no ``..`` escape, no absolutes).
+    # Workspace root used by ``send_message_with_attachments`` to
+    # safety-resolve LLM-supplied relative paths (no ``..`` escape,
+    # no absolutes).
     workspace: Optional[str] = None
 
 
@@ -113,13 +114,23 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
-    async def send_message(channel: str, text: str, root_id: str = "") -> str:
+    async def send_message(
+        channel: str,
+        text: str,
+        is_visible_to_human: bool,
+        root_id: str = "",
+    ) -> str:
         """Post a message to a Puffo.ai channel or DM a user.
 
         channel: '@<slug>' for a DM (e.g. '@alice-1234'), or a raw
             channel id (e.g. 'ch_<uuid>'). Use ``list_channels`` to
             discover ids — '#name' shortcuts are not supported.
         text: message body. Markdown preserved verbatim.
+        is_visible_to_human: REQUIRED — decide whether a human should
+            see this message inline. ``true`` for anything a person
+            needs to read; ``false`` for agent-to-agent coordination
+            chatter, which human clients fold away. There is no
+            default — judge every message.
         root_id: optional — reply inside a thread; pass the
             envelope_id of the message you're replying to.
         """
@@ -190,6 +201,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             envelope_kind=envelope_kind,
             sender_slug=cfg.slug,
             sender_subkey_id=sess.subkey_id,
+            is_visible_to_human=is_visible_to_human,
             space_id=send_space_id,
             channel_id=channel_id,
             recipient_slug=recipient_slug,
@@ -512,21 +524,27 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         )
 
     @mcp.tool()
-    async def upload_file(
+    async def send_message_with_attachments(
         paths: list[str],
         channel: str,
+        is_visible_to_human: bool,
         caption: str = "",
         root_id: str = "",
     ) -> str:
-        """Upload one or more workspace files to a channel or DM.
+        """Send a message carrying one or more workspace files to a
+        channel or DM.
 
         All files ride in a single envelope — recipients see one
-        bubble with N attachments.
+        message bubble with N attachments.
 
         paths: workspace-relative file paths. ``..`` and absolute
             paths are rejected.
         channel: same syntax as ``send_message`` (``@<slug>`` or a
             raw channel id).
+        is_visible_to_human: REQUIRED — same semantics as
+            ``send_message``: ``true`` when a person should see this,
+            ``false`` for agent-to-agent chatter that human clients
+            fold away. No default — judge every send.
         caption: optional text alongside the files.
         root_id: optional thread reply, same semantics as
             ``send_message``'s ``root_id``.
@@ -536,13 +554,18 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
 
         if not cfg.workspace:
             raise RuntimeError(
-                "upload_file: agent has no configured workspace dir"
+                "send_message_with_attachments: agent has no configured "
+                "workspace dir"
             )
         if not paths or not isinstance(paths, list):
-            raise RuntimeError("upload_file: paths is required (non-empty list)")
+            raise RuntimeError(
+                "send_message_with_attachments: paths is required "
+                "(non-empty list)"
+            )
         if len(paths) > 10:
             raise RuntimeError(
-                f"upload_file: too many files ({len(paths)} > 10 cap)"
+                f"send_message_with_attachments: too many files "
+                f"({len(paths)} > 10 cap)"
             )
         workspace_dir = Path(cfg.workspace).resolve()
 
@@ -552,21 +575,27 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         for raw in paths:
             rel = (raw or "").strip()
             if not rel:
-                raise RuntimeError("upload_file: paths contains empty entry")
+                raise RuntimeError(
+                    "send_message_with_attachments: paths contains empty entry"
+                )
             rel_path = Path(rel)
             if rel_path.is_absolute():
                 raise RuntimeError(
-                    f"upload_file: absolute paths not allowed ({rel!r})"
+                    f"send_message_with_attachments: absolute paths not "
+                    f"allowed ({rel!r})"
                 )
             try:
                 target = (workspace_dir / rel_path).resolve()
                 target.relative_to(workspace_dir)
             except (OSError, ValueError):
                 raise RuntimeError(
-                    f"upload_file: {rel!r} escapes the workspace"
+                    f"send_message_with_attachments: {rel!r} escapes the "
+                    f"workspace"
                 )
             if not target.is_file():
-                raise RuntimeError(f"upload_file: {rel!r} is not a file")
+                raise RuntimeError(
+                    f"send_message_with_attachments: {rel!r} is not a file"
+                )
             targets.append(target)
 
         # Encrypt + upload each file. ``blob_id`` is patched in
@@ -577,7 +606,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             plaintext = target.read_bytes()
             if len(plaintext) > 8 * 1024 * 1024:
                 raise RuntimeError(
-                    f"upload_file: {target.name!r} is {len(plaintext)} bytes "
+                    f"send_message_with_attachments: {target.name!r} is {len(plaintext)} bytes "
                     "(server caps at 8 MiB)"
                 )
             mime_type, _ = mimetypes.guess_type(target.name)
@@ -594,7 +623,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             blob_id = upload.get("blob_id") if isinstance(upload, dict) else None
             if not blob_id:
                 raise RuntimeError(
-                    f"upload_file: server returned no blob_id for "
+                    f"send_message_with_attachments: server returned no blob_id for "
                     f"{target.name!r} ({upload!r})"
                 )
             meta.blob_id = blob_id
@@ -627,7 +656,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             )
             if not send_space_id:
                 raise RuntimeError(
-                    f"upload_file: channel {channel_id} not seen before "
+                    f"send_message_with_attachments: channel {channel_id} not seen before "
                     "and the agent has no configured space_id"
                 )
             members_resp = await cfg.http_client.get(
@@ -640,12 +669,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             ]
             if not recipient_slugs:
                 raise RuntimeError(
-                    f"upload_file: channel {channel_id} has no resolvable members"
+                    f"send_message_with_attachments: channel {channel_id} has no resolvable members"
                 )
 
         devices = await _fetch_device_keys(cfg.http_client, recipient_slugs)
         if not devices:
-            raise RuntimeError("upload_file: no recipient devices found")
+            raise RuntimeError("send_message_with_attachments: no recipient devices found")
 
         sess = cfg.keystore.load_session(cfg.slug)
         signing_key = Ed25519KeyPair.from_secret_bytes(
@@ -659,6 +688,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             envelope_kind=envelope_kind,
             sender_slug=cfg.slug,
             sender_subkey_id=sess.subkey_id,
+            is_visible_to_human=is_visible_to_human,
             space_id=send_space_id,
             channel_id=channel_id,
             recipient_slug=recipient_slug,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -668,7 +668,7 @@ class Worker:
                 # Fallback reply when the agent skipped both
                 # send_message and [SILENT]. Post to root so the
                 # reply lands in the thread the agent was reading.
-                await client.post_message(channel_id, reply, root_id=root_id)
+                await client.send_fallback_message(channel_id, reply, root_id=root_id)
 
         async def on_api_error_retry(
             root_id: str,
@@ -696,7 +696,7 @@ class Worker:
             self.runtime.msg_count += 1
             self.runtime.last_event_at = int(time.time())
             if reply:
-                await client.post_message(channel_id, reply, root_id=root_id)
+                await client.send_fallback_message(channel_id, reply, root_id=root_id)
 
         async def heartbeat():
             interval = max(1.0, self.daemon_cfg.runtime_heartbeat_seconds)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -22,11 +22,14 @@ def _make_recipient() -> tuple[RecipientDevice, KemKeyPair]:
     ), kp
 
 
-def _channel_input(recipients: list[RecipientDevice]) -> EncryptInput:
+def _channel_input(
+    recipients: list[RecipientDevice], is_visible_to_human: bool = True
+) -> EncryptInput:
     return EncryptInput(
         envelope_kind="channel",
         sender_slug="alice-0001",
         sender_subkey_id="sk_alice",
+        is_visible_to_human=is_visible_to_human,
         space_id="sp_1",
         channel_id="ch_1",
         content_type="text/plain",
@@ -35,11 +38,14 @@ def _channel_input(recipients: list[RecipientDevice]) -> EncryptInput:
     )
 
 
-def _dm_input(recipients: list[RecipientDevice]) -> EncryptInput:
+def _dm_input(
+    recipients: list[RecipientDevice], is_visible_to_human: bool = True
+) -> EncryptInput:
     return EncryptInput(
         envelope_kind="dm",
         sender_slug="alice-0001",
         sender_subkey_id="sk_alice",
+        is_visible_to_human=is_visible_to_human,
         recipient_slug="bob-0001",
         content_type="text/plain",
         content="Secret message",
@@ -279,3 +285,89 @@ class TestDecryptMessage:
 
         assert payload.thread_root_id is None
         assert payload.reply_to_id is None
+
+    def test_is_visible_to_human_true_roundtrip(self):
+        signing_key = Ed25519KeyPair.generate()
+        dev, kp = _make_recipient()
+        env = encrypt_message(
+            _channel_input([dev], is_visible_to_human=True), signing_key
+        )
+
+        payload = decrypt_message(env, dev.device_id, kp, signing_key.public_key_bytes())
+
+        assert payload.is_visible_to_human is True
+
+    def test_is_visible_to_human_false_roundtrip(self):
+        signing_key = Ed25519KeyPair.generate()
+        dev, kp = _make_recipient()
+        env = encrypt_message(
+            _channel_input([dev], is_visible_to_human=False), signing_key
+        )
+
+        payload = decrypt_message(env, dev.device_id, kp, signing_key.public_key_bytes())
+
+        assert payload.is_visible_to_human is False
+
+    def test_is_visible_to_human_defaults_true_when_absent(self):
+        # Old senders predate the field; decrypt must default it to
+        # True rather than KeyError.
+        signing_key = Ed25519KeyPair.generate()
+        dev, kp = _make_recipient()
+        inp = _channel_input([dev], is_visible_to_human=False)
+        env = encrypt_message(inp, signing_key)
+
+        # Re-seal a payload with the field stripped, re-signed so the
+        # signature check still passes.
+        from puffo_agent.crypto.canonical import canonicalize_for_signing
+        from puffo_agent.crypto.primitives import (
+            aead_decrypt,
+            aead_encrypt,
+            generate_aead_nonce,
+            hpke_open,
+        )
+        from puffo_agent.crypto.primitives import MESSAGE_HPKE_INFO
+        from puffo_agent.crypto.v2_aad import compute_outer_aad, compute_wrap_aad
+
+        entry = env["recipients"][0]
+        envelope_id = env["envelope_id"]
+        wrap_aad = compute_wrap_aad(envelope_id, dev.device_id)
+        content_key = hpke_open(
+            kp,
+            base64url_decode(entry["hpke_enc"]),
+            MESSAGE_HPKE_INFO,
+            wrap_aad,
+            base64url_decode(entry["wrapped_content_key"]),
+        )
+        outer_aad = compute_outer_aad(
+            envelope_id=envelope_id,
+            envelope_kind=env["envelope_kind"],
+            sender_slug=env["sender_slug"],
+            sent_at_ms=env["sent_at"],
+            space_id=env.get("space_id"),
+            channel_id=env.get("channel_id"),
+            recipient_slug=env.get("recipient_slug"),
+        )
+        plaintext = aead_decrypt(
+            content_key,
+            base64url_decode(env["content_nonce"]),
+            base64url_decode(env["content_ciphertext"]),
+            outer_aad,
+        )
+        signed = json.loads(plaintext)
+        signed["payload"].pop("is_visible_to_human")
+        canonical = canonicalize_for_signing(signed["payload"])
+        signed["signature"] = base64url_encode(signing_key.sign(canonical))
+
+        new_nonce = generate_aead_nonce()
+        new_ct = aead_encrypt(
+            content_key,
+            new_nonce,
+            json.dumps(signed, separators=(",", ":")).encode(),
+            outer_aad,
+        )
+        env["content_nonce"] = base64url_encode(new_nonce)
+        env["content_ciphertext"] = base64url_encode(new_ct)
+
+        payload = decrypt_message(env, dev.device_id, kp, signing_key.public_key_bytes())
+
+        assert payload.is_visible_to_human is True

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -155,7 +155,11 @@ async def test_send_message_channel():
         "has_more": False,
     }
     mcp = _build_tools(cfg)
-    result = await _call(mcp, "send_message", {"channel": "ch_abc", "text": "hello world"})
+    result = await _call(
+        mcp,
+        "send_message",
+        {"channel": "ch_abc", "text": "hello world", "is_visible_to_human": True},
+    )
     assert "posted" in result
     assert "ch_abc" in result
 
@@ -210,7 +214,11 @@ async def test_send_message_dm():
         "has_more": False,
     }
     mcp = _build_tools(cfg)
-    result = await _call(mcp, "send_message", {"channel": "@alice-0001", "text": "hey"})
+    result = await _call(
+        mcp,
+        "send_message",
+        {"channel": "@alice-0001", "text": "hey", "is_visible_to_human": True},
+    )
     assert "posted" in result
 
     post_calls = [(p, b) for m, p, b in http.calls if m == "POST"]
@@ -232,7 +240,11 @@ async def test_send_message_rejects_named_channel():
     cfg, _, _ = _setup()
     mcp = _build_tools(cfg)
     with pytest.raises(Exception) as excinfo:
-        await _call(mcp, "send_message", {"channel": "#general", "text": "hi"})
+        await _call(
+            mcp,
+            "send_message",
+            {"channel": "#general", "text": "hi", "is_visible_to_human": True},
+        )
     assert "isn't supported" in str(excinfo.value) or "not supported" in str(excinfo.value)
 
 
@@ -494,16 +506,18 @@ async def test_get_post_not_found():
 
 
 @pytest.mark.asyncio
-async def test_upload_file_requires_workspace():
-    """Without ``cfg.workspace``, upload_file refuses rather than
-    silently dropping into a "no agent dir" hole. Real upload path
-    is exercised end-to-end against a live daemon."""
+async def test_send_message_with_attachments_requires_workspace():
+    """Without ``cfg.workspace``, send_message_with_attachments refuses
+    rather than silently dropping into a "no agent dir" hole. Real
+    upload path is exercised end-to-end against a live daemon."""
     cfg, _, _ = _setup()
     # Fixture leaves cfg.workspace as None.
     mcp = _build_tools(cfg)
     with pytest.raises(Exception) as exc_info:
         await _call(
-            mcp, "upload_file", {"paths": ["test.txt"], "channel": "ch_1"},
+            mcp,
+            "send_message_with_attachments",
+            {"paths": ["test.txt"], "channel": "ch_1", "is_visible_to_human": True},
         )
     assert "workspace" in str(exc_info.value).lower()
 
@@ -524,6 +538,6 @@ async def test_all_9_tools_registered():
     expected = {
         "whoami", "send_message", "get_channel_history",
         "list_channels", "list_channel_members", "get_user_info",
-        "get_post", "upload_file", "fetch_channel_files",
+        "get_post", "send_message_with_attachments", "fetch_channel_files",
     }
     assert expected.issubset(tool_names)

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -274,8 +274,8 @@ async def test_message_store_wal_mode():
 
 
 @pytest.mark.asyncio
-async def test_puffo_core_client_post_message_encrypts():
-    """Smoke test: post_message resolves channel members and their
+async def test_puffo_core_client_send_fallback_message_encrypts():
+    """Smoke test: send_fallback_message resolves channel members and their
     device certs, encrypts the reply, and posts the bare envelope.
 
     Mocked endpoints reflect the real puffo-core wire shape:
@@ -340,7 +340,7 @@ async def test_puffo_core_client_post_message_encrypts():
         http_client=http,
         message_store=ms,
     )
-    await client.post_message("ch_abc", "hello world", root_id="")
+    await client.send_fallback_message("ch_abc", "hello world", root_id="")
 
     # Channel resolution: members endpoint -> /certs/sync.
     assert any(


### PR DESCRIPTION
## Summary
- Adds `is_visible_to_human` to the encrypted `MessagePayload` (Python crypto path) so agents can mark a message as human-facing or as agent-to-agent chatter that human clients fold away. `decrypt_message` defaults it to `true` for pre-field senders.
- `send_message` MCP tool now takes a **required** `is_visible_to_human` param — no default, the agent judges every message. `upload_file` is renamed `send_message_with_attachments` with the same required param.
- Internal sends are explicit: operator-facing DMs (`_send_dm`) stay `true`; the `[SILENT]`-skip fallback (`post_message`) posts `false` (folded), with the primer steering agents toward `send_message` where they set visibility consciously.
- Incoming messages surface `is_visible_to_human` in the agent's metadata block.
- Primer (`shared_content.py`) updated: documents the new required param on both write tools, renames all `upload_file` references, and reinforces using `send_message` over the fallback.

Part of the cross-repo `is_visible_to_human` feature. Pairs with core-v2 PR #19 (merged) and puffo-server PR #57.

## Test plan
- [x] `tests/test_message.py` — `is_visible_to_human` true/false encrypt-decrypt round-trips + absent-field defaults-to-true
- [x] `tests/test_puffo_core_tools.py` — `send_message` calls pass the required param; `upload_file` → `send_message_with_attachments` rename
- [x] Full suite: 535 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)