### PR TITLE
is_visible_to_human root-level coercion + agent reset-primer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.1] — 2026-05-14
+
+### Added
+
+- **`puffo-agent agent reset-primer <id> ...`** — re-seed the shared
+  platform primer to the installed version. The shared primer
+  (`~/.puffo-agent/docker/shared/CLAUDE.md` + `skills/`) is
+  seed-once: `ensure_shared_primer` never overwrites it, so a
+  `puffo-agent` upgrade never reached existing installs — primer
+  updates only landed on brand-new machines. The new command
+  force-rewrites the managed shared files to this install's version
+  (unchanged files skipped, edited ones backed up to `<file>.bak`
+  first), then rebuilds each listed agent's managed `CLAUDE.md` /
+  `GEMINI.md` from the fresh primer. The re-seed is global — the
+  agent id list only scopes which agents get rebuilt. Running
+  workers keep their loaded prompt; the rebuild takes effect on the
+  worker's next restart.
+
+### Fixed
+
+- **`is_visible_to_human=false` on a root-level message is no longer
+  a silent no-op.** Root-level (non-threaded) messages can't fold in
+  the human UI — only threaded replies do — so an agent passing
+  `false` on a root-level `send_message` /
+  `send_message_with_attachments` was producing a message that
+  rendered visible anyway but was inconsistently excluded from
+  unread counts. The tools now coerce the flag back to visible (the
+  message still goes out — a warning, not an error) and splice a
+  note into the tool response so the agent learns at the point of
+  the mistake rather than depending on a possibly-stale primer. The
+  primer and tool docstrings now state that `false` only takes
+  effect on threaded replies.
+
 ## [0.8.0] — 2026-05-14
 
 ### Added
@@ -629,7 +662,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.1
 [0.8.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.0
 [0.7.5]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.5
 [0.7.4]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.0"
+version = "0.8.1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -9,6 +9,7 @@ combines primer + profile + memory snapshot into the per-agent prompt.
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
 
@@ -722,23 +723,72 @@ DEFAULT_SKILLS: dict[str, str] = {
 }
 
 
+def _managed_primer_files(shared_dir: Path) -> Iterator[tuple[Path, str]]:
+    """The shared-primer files the daemon owns, paired with the
+    content baked into this install. Single source of truth for both
+    ``ensure_shared_primer`` (seed-if-missing) and
+    ``reseed_shared_primer`` (force back to this version).
+    """
+    yield shared_dir / "CLAUDE.md", DEFAULT_SHARED_CLAUDE_MD
+    yield shared_dir / "README.md", DEFAULT_SHARED_README
+    for name, body in DEFAULT_SKILLS.items():
+        yield shared_dir / "skills" / name, body
+
+
 def ensure_shared_primer(shared_dir: Path) -> None:
     """Create ``shared_dir`` and seed defaults. Idempotent — never
-    overwrites existing files so operator edits survive.
+    overwrites existing files so operator edits survive. Use
+    ``reseed_shared_primer`` to force the files back to this install's
+    version (e.g. after a ``puffo-agent`` upgrade).
     """
     shared_dir.mkdir(parents=True, exist_ok=True)
-    primer = shared_dir / "CLAUDE.md"
-    if not primer.exists():
-        primer.write_text(DEFAULT_SHARED_CLAUDE_MD, encoding="utf-8")
-    readme = shared_dir / "README.md"
-    if not readme.exists():
-        readme.write_text(DEFAULT_SHARED_README, encoding="utf-8")
-    skills_dir = shared_dir / "skills"
-    skills_dir.mkdir(exist_ok=True)
-    for name, body in DEFAULT_SKILLS.items():
-        path = skills_dir / name
+    (shared_dir / "skills").mkdir(exist_ok=True)
+    for path, body in _managed_primer_files(shared_dir):
         if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(body, encoding="utf-8")
+
+
+def reseed_shared_primer(shared_dir: Path) -> list[tuple[str, str]]:
+    """Force the managed shared-primer files (CLAUDE.md, README.md,
+    skills/*) back to the versions baked into this install. Unlike
+    ``ensure_shared_primer`` this DOES overwrite — but only files
+    whose content differs, and it saves a ``.bak`` of anything it
+    replaces so operator edits are recoverable.
+
+    Returns ``[(relative_path, action)]`` sorted by path, where action
+    is ``"created"``, ``"updated (backed up)"``, or ``"unchanged"``.
+    """
+    shared_dir.mkdir(parents=True, exist_ok=True)
+    (shared_dir / "skills").mkdir(exist_ok=True)
+    results: list[tuple[str, str]] = []
+    for path, body in _managed_primer_files(shared_dir):
+        rel = path.relative_to(shared_dir).as_posix()
+        if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+            results.append((rel, "created"))
+            continue
+        try:
+            current = path.read_text(encoding="utf-8")
+        except OSError:
+            current = None
+        if current == body:
+            results.append((rel, "unchanged"))
+            continue
+        # Content differs (operator edit, or a stale pre-upgrade
+        # version) — keep a recoverable copy, then overwrite.
+        if current is not None:
+            try:
+                path.with_suffix(path.suffix + ".bak").write_text(
+                    current, encoding="utf-8",
+                )
+            except OSError:
+                pass
+        path.write_text(body, encoding="utf-8")
+        results.append((rel, "updated (backed up)"))
+    results.sort()
+    return results
 
 
 def sync_shared_skills(shared_dir: Path, workspace_dir: Path) -> None:
@@ -837,6 +887,42 @@ def write_gemini_md(gemini_dir: Path, content: str) -> Path:
     path = gemini_dir / "GEMINI.md"
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def rebuild_agent_claude_md(
+    *,
+    shared_dir: Path,
+    profile_path: Path,
+    memory_dir: Path,
+    workspace_dir: Path,
+    claude_user_dir: Path,
+    gemini_user_dir: Path,
+) -> str:
+    """Assemble + write one agent's managed CLAUDE.md / GEMINI.md.
+
+    Seeds the shared primer if missing, mirrors shared skills into the
+    workspace, reads the agent's ``profile.md`` + memory snapshot, then
+    writes the combined prompt to the agent's USER-level ``.claude/`` /
+    ``.gemini/`` dirs. Returns the assembled CLAUDE.md string.
+
+    Shared by the worker's startup path and the ``agent reset-primer``
+    CLI command so the assembly sequence lives in exactly one place.
+    """
+    ensure_shared_primer(shared_dir)
+    sync_shared_skills(shared_dir, workspace_dir)
+    primer = read_shared_primer(shared_dir)
+    try:
+        profile_text = profile_path.read_text(encoding="utf-8")
+    except OSError:
+        profile_text = ""
+    claude_md = assemble_claude_md(
+        shared_primer=primer,
+        profile=profile_text,
+        memory_snapshot=read_memory_snapshot(memory_dir),
+    )
+    write_claude_md(claude_user_dir, claude_md)
+    write_gemini_md(gemini_user_dir, claude_md)
+    return claude_md
 
 
 # First line of the default shared primer. Used to identify

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -114,6 +114,12 @@ one explicitly on every turn:
    `false` messages behind a placeholder; they are still
    delivered, searchable, and visible to other agents.
 
+   `false` only folds **threaded replies** (calls with `root_id`
+   set). A root-level message can't fold, so `false` on one is
+   ignored — the tool coerces it to visible and tells you so in
+   the response. If you want agent-to-agent chatter folded away,
+   keep it in a thread.
+
 2. **`[SILENT]` in your `assistant.text`** — when no reply is
    needed (the conversation is between other people, the
    `mentions:` list doesn't include you, you're in a possible
@@ -375,7 +381,10 @@ Post a message to a Puffo.ai channel or DM a user.
   agent-to-agent chatter a human watching the channel would find
   pure noise. Human clients fold runs of `false` messages behind
   a placeholder; they are still delivered, searchable, and
-  visible to other agents. When in doubt, `true`.
+  visible to other agents. When in doubt, `true`. **`false` only
+  takes effect on threaded replies** (with `root_id`) — on a
+  root-level message it's ignored, coerced to visible, and the
+  tool response says so.
 - `root_id` (optional) — envelope_id (`env_<uuid>`) of the post you
   are replying to; opens a thread.
 
@@ -430,6 +439,8 @@ separate messages).
 - `is_visible_to_human`: required bool, no default — same meaning
   as on `send_message`. `true` for files a human should see,
   `false` for agent-to-agent payloads. When in doubt, `true`.
+  `false` only folds threaded replies (with `root_id`); on a
+  root-level send it's ignored and coerced to visible.
 - `caption`: optional text posted alongside the files. Empty by
   default; recipients see just the attachments.
 - `root_id`: optional — reply with the attachments inside an

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -94,6 +94,28 @@ async def _fetch_device_keys(
     return devices
 
 
+def _coerce_root_visibility(
+    is_visible_to_human: bool, root_id: str,
+) -> tuple[bool, str]:
+    """Root-level (non-threaded) messages can't fold in the human UI —
+    only threaded replies do. When an agent marks a root-level message
+    ``is_visible_to_human=false`` we coerce it back to visible (so the
+    message still goes out) and return a note to splice into the tool
+    response. The agent learns from the tool result on the spot,
+    rather than depending on the primer being current.
+
+    Returns ``(effective_visibility, note)`` — ``note`` is empty
+    unless a coercion happened.
+    """
+    if is_visible_to_human is False and not root_id.strip():
+        return True, (
+            "\nnote: is_visible_to_human=false ignored — root-level "
+            "messages can't fold; sent as visible. Use false only on "
+            "threaded replies (pass root_id)."
+        )
+    return is_visible_to_human, ""
+
+
 def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
 
     @mcp.tool()
@@ -130,7 +152,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             see this message inline. ``true`` for anything a person
             needs to read; ``false`` for agent-to-agent coordination
             chatter, which human clients fold away. There is no
-            default — judge every message.
+            default — judge every message. NOTE: ``false`` only takes
+            effect on threaded replies (when ``root_id`` is set) —
+            root-level messages can't fold, so ``false`` on one is
+            ignored and the message is sent visible.
         root_id: optional — reply inside a thread; pass the
             envelope_id of the message you're replying to.
         """
@@ -197,11 +222,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             decode_secret(sess.subkey_secret_key)
         )
 
+        effective_visible, fold_note = _coerce_root_visibility(
+            is_visible_to_human, root_id,
+        )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
             sender_slug=cfg.slug,
             sender_subkey_id=sess.subkey_id,
-            is_visible_to_human=is_visible_to_human,
+            is_visible_to_human=effective_visible,
             space_id=send_space_id,
             channel_id=channel_id,
             recipient_slug=recipient_slug,
@@ -213,7 +241,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         envelope = encrypt_message(inp, signing_key)
         # Server expects the envelope at the top level, not wrapped.
         await cfg.http_client.post("/messages", envelope)
-        return f"posted {envelope.get('envelope_id', '?')} to {channel}"
+        return (
+            f"posted {envelope.get('envelope_id', '?')} to {channel}"
+            f"{fold_note}"
+        )
 
     @mcp.tool()
     async def get_channel_history(
@@ -544,7 +575,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         is_visible_to_human: REQUIRED — same semantics as
             ``send_message``: ``true`` when a person should see this,
             ``false`` for agent-to-agent chatter that human clients
-            fold away. No default — judge every send.
+            fold away. No default — judge every send. NOTE: ``false``
+            only takes effect on threaded replies (when ``root_id`` is
+            set); on a root-level message it's ignored and the
+            message is sent visible.
         caption: optional text alongside the files.
         root_id: optional thread reply, same semantics as
             ``send_message``'s ``root_id``.
@@ -684,11 +718,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             "text": caption,
             "attachments": [m.to_dict() for m in attachment_metas],
         }
+        effective_visible, fold_note = _coerce_root_visibility(
+            is_visible_to_human, root_id,
+        )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
             sender_slug=cfg.slug,
             sender_subkey_id=sess.subkey_id,
-            is_visible_to_human=is_visible_to_human,
+            is_visible_to_human=effective_visible,
             space_id=send_space_id,
             channel_id=channel_id,
             recipient_slug=recipient_slug,
@@ -705,6 +742,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             f"uploaded {len(targets)} file(s) [{names}] ({total_bytes} bytes "
             f"total) to {channel}{thread_note} "
             f"(envelope_id {envelope.get('envelope_id', '?')})"
+            f"{fold_note}"
         )
 
     @mcp.tool()

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -28,6 +28,7 @@ from .state import (
     RuntimeConfig,
     RuntimeState,
     TriggerRules,
+    agent_claude_user_dir,
     agent_dir,
     agent_home_dir,
     agent_yml_path,
@@ -38,6 +39,7 @@ from .state import (
     daemon_yml_path,
     daemon_pid_path,
     discover_agents,
+    docker_shared_dir,
     home_dir,
     is_daemon_alive,
     is_valid_agent_id,
@@ -1125,6 +1127,65 @@ def cmd_agent_export(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
+    """Re-seed the shared platform primer to this install's version,
+    then rebuild the listed agents' managed CLAUDE.md from it.
+
+    The shared primer is a single file shared by every agent, so the
+    re-seed is global — the agent id list only scopes which agents'
+    CLAUDE.md gets rebuilt. Running workers keep their already-loaded
+    prompt; the rebuilt file takes effect on their next restart.
+    """
+    from ..agent.shared_content import (
+        rebuild_agent_claude_md,
+        reseed_shared_primer,
+    )
+
+    shared_dir = docker_shared_dir()
+    actions = reseed_shared_primer(shared_dir)
+    print(f"shared primer ({shared_dir}):")
+    for rel, action in actions:
+        print(f"  {rel}: {action}")
+
+    rc = 0
+    rebuilt: list[str] = []
+    for agent_id in args.ids:
+        if not agent_yml_path(agent_id).exists():
+            print(f"error: agent {agent_id!r} not found", file=sys.stderr)
+            rc = 2
+            continue
+        try:
+            cfg = AgentConfig.load(agent_id)
+        except Exception as exc:
+            print(f"error: agent {agent_id!r}: {exc}", file=sys.stderr)
+            rc = 2
+            continue
+        rebuild_agent_claude_md(
+            shared_dir=shared_dir,
+            profile_path=cfg.resolve_profile_path(),
+            memory_dir=cfg.resolve_memory_dir(),
+            workspace_dir=cfg.resolve_workspace_dir(),
+            claude_user_dir=agent_claude_user_dir(agent_id),
+            gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
+        )
+        rebuilt.append(agent_id)
+        print(f"rebuilt CLAUDE.md for {agent_id!r}")
+
+    if rebuilt:
+        if is_daemon_alive():
+            print(
+                "note: a running worker keeps its already-loaded prompt — "
+                "the rebuilt CLAUDE.md takes effect when the agent's worker "
+                "next restarts (or it calls reload_system_prompt)."
+            )
+        else:
+            print(
+                "note: agents will pick up the rebuilt CLAUDE.md on the "
+                "next `puffo-agent start`."
+            )
+    return rc
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1409,6 +1470,21 @@ def build_parser() -> argparse.ArgumentParser:
     export.add_argument("id")
     export.add_argument("dest", help="Destination .zip file")
     export.set_defaults(func=cmd_agent_export)
+
+    reset_primer = agent_sub.add_parser(
+        "reset-primer",
+        help=(
+            "Re-seed the shared platform primer to this install's version "
+            "and rebuild the listed agents' CLAUDE.md from it"
+        ),
+    )
+    reset_primer.add_argument(
+        "ids",
+        nargs="+",
+        metavar="agent_id",
+        help="agent id(s) whose CLAUDE.md to rebuild",
+    )
+    reset_primer.set_defaults(func=cmd_agent_reset_primer)
 
     # Bridge / local HTTP API admin.
     pairing = sub.add_parser(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -20,15 +20,8 @@ from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
 from ..agent.status_reporter import StatusReporter
 from ..agent.shared_content import (
-
-    assemble_claude_md,
-    ensure_shared_primer,
     looks_like_managed_claude_md,
-    read_memory_snapshot,
-    read_shared_primer,
-    sync_shared_skills,
-    write_claude_md,
-    write_gemini_md,
+    rebuild_agent_claude_md,
 )
 from .state import (
     AgentConfig,
@@ -434,24 +427,13 @@ class Worker:
             # chat-local / sdk-local don't auto-discover, so the same
             # string is passed as PuffoAgent's system_prompt.
             shared_path = docker_shared_dir()
-            ensure_shared_primer(shared_path)
-            sync_shared_skills(shared_path, Path(workspace_path))
-            primer = read_shared_primer(shared_path)
-            try:
-                profile_text = Path(profile_path).read_text(encoding="utf-8")
-            except OSError:
-                profile_text = ""
-            claude_md = assemble_claude_md(
-                shared_primer=primer,
-                profile=profile_text,
-                memory_snapshot=read_memory_snapshot(Path(memory_path)),
-            )
-            write_claude_md(agent_claude_user_dir(agent_id), claude_md)
-
-            # Mirror the same content to user-level GEMINI.md so a
-            # harness swap doesn't need another sync cycle.
-            write_gemini_md(
-                agent_home_dir(agent_id) / ".gemini", claude_md,
+            claude_md = rebuild_agent_claude_md(
+                shared_dir=shared_path,
+                profile_path=Path(profile_path),
+                memory_dir=Path(memory_path),
+                workspace_dir=Path(workspace_path),
+                claude_user_dir=agent_claude_user_dir(agent_id),
+                gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
             )
 
             # One-time migration: remove an older project-level
@@ -825,19 +807,14 @@ async def _reload_from_disk(
     any cached subprocess. Failures are logged but don't drop the
     turn — a stale prompt beats a dropped message."""
     try:
-        ensure_shared_primer(shared_path)
-        sync_shared_skills(shared_path, Path(workspace_path))
-        primer = read_shared_primer(shared_path)
-        try:
-            profile_text = Path(profile_path).read_text(encoding="utf-8")
-        except OSError:
-            profile_text = ""
-        new_md = assemble_claude_md(
-            shared_primer=primer,
-            profile=profile_text,
-            memory_snapshot=read_memory_snapshot(Path(memory_path)),
+        new_md = rebuild_agent_claude_md(
+            shared_dir=shared_path,
+            profile_path=Path(profile_path),
+            memory_dir=Path(memory_path),
+            workspace_dir=Path(workspace_path),
+            claude_user_dir=agent_claude_user_dir(agent_id),
+            gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
         )
-        write_claude_md(agent_claude_user_dir(agent_id), new_md)
         puffo.system_prompt = new_md
         await adapter.reload(new_md)
         logger.info("agent %s: reloaded system prompt from disk", agent_id)

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -14,6 +14,7 @@ from puffo_agent.crypto.keystore import KeyStore, Session, StoredIdentity, encod
 from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
 from puffo_agent.mcp.puffo_core_tools import (
     PuffoCoreToolsConfig,
+    _coerce_root_visibility,
     register_core_tools,
 )
 
@@ -186,6 +187,94 @@ async def test_send_message_channel():
     assert r["device_id"] == "dev_recipient_1"
     assert "hpke_enc" in r
     assert "wrapped_content_key" in r
+
+
+def test_coerce_root_visibility():
+    # Root-level false → coerced to visible + a note for the agent.
+    visible, note = _coerce_root_visibility(False, "")
+    assert visible is True
+    assert "ignored" in note and "root-level" in note
+    # Threaded false (root_id set) → left alone, no note.
+    visible, note = _coerce_root_visibility(False, "msg_root")
+    assert visible is False
+    assert note == ""
+    # true is never touched, root-level or threaded.
+    assert _coerce_root_visibility(True, "") == (True, "")
+    assert _coerce_root_visibility(True, "msg_root") == (True, "")
+    # Whitespace-only root_id counts as root-level.
+    visible, note = _coerce_root_visibility(False, "   ")
+    assert visible is True and note != ""
+
+
+@pytest.mark.asyncio
+async def test_send_message_root_level_false_coerced():
+    """A root-level send with is_visible_to_human=false still posts —
+    the flag is coerced to visible and the tool response carries a
+    note so the agent learns on the spot."""
+    cfg, http, _ = _setup()
+    recipient_kem = KemKeyPair.generate()
+    http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
+        "members": [{"slug": "alice-0001", "role": "owner"}],
+    }
+    http.responses["/certs/sync?slugs=alice-0001"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_recipient_1",
+                "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp,
+        "send_message",
+        {"channel": "ch_abc", "text": "agent chatter", "is_visible_to_human": False},
+    )
+    # Message still went out (warning, not error).
+    assert "posted" in result
+    assert len([1 for m, _, _ in http.calls if m == "POST"]) == 1
+    # ...and the agent is told the flag was ignored.
+    assert "is_visible_to_human=false ignored" in result
+
+
+@pytest.mark.asyncio
+async def test_send_message_threaded_false_not_coerced():
+    """A threaded reply (root_id set) keeps is_visible_to_human=false
+    — no coercion, no note."""
+    cfg, http, _ = _setup()
+    recipient_kem = KemKeyPair.generate()
+    http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
+        "members": [{"slug": "alice-0001", "role": "owner"}],
+    }
+    http.responses["/certs/sync?slugs=alice-0001"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_recipient_1",
+                "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp,
+        "send_message",
+        {
+            "channel": "ch_abc",
+            "text": "agent-to-agent reply",
+            "is_visible_to_human": False,
+            "root_id": "msg_root_abc",
+        },
+    )
+    assert "posted" in result
+    assert "ignored" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -1,0 +1,134 @@
+import tempfile
+from pathlib import Path
+
+from puffo_agent.agent.shared_content import (
+    DEFAULT_SHARED_CLAUDE_MD,
+    rebuild_agent_claude_md,
+    reseed_shared_primer,
+)
+from puffo_agent.portal.cli import build_parser
+
+
+def _tmp() -> Path:
+    return Path(tempfile.mkdtemp())
+
+
+# ── reseed_shared_primer ────────────────────────────────────────────
+
+
+def test_reseed_creates_on_fresh_dir():
+    shared = _tmp() / "shared"
+    actions = reseed_shared_primer(shared)
+    assert actions, "expected managed files to be reported"
+    assert all(action == "created" for _, action in actions)
+    # CLAUDE.md landed with this install's content.
+    assert (
+        (shared / "CLAUDE.md").read_text(encoding="utf-8")
+        == DEFAULT_SHARED_CLAUDE_MD
+    )
+    # skill files are reported with a posix-style relative path.
+    assert any(rel.startswith("skills/") for rel, _ in actions)
+
+
+def test_reseed_is_noop_when_already_current():
+    shared = _tmp() / "shared"
+    reseed_shared_primer(shared)
+    actions = reseed_shared_primer(shared)
+    assert all(action == "unchanged" for _, action in actions)
+
+
+def test_reseed_overwrites_edited_file_and_backs_it_up():
+    shared = _tmp() / "shared"
+    reseed_shared_primer(shared)
+    primer = shared / "CLAUDE.md"
+    primer.write_text("operator's local edit", encoding="utf-8")
+
+    by_rel = dict(reseed_shared_primer(shared))
+    assert by_rel["CLAUDE.md"] == "updated (backed up)"
+    # Untouched files aren't churned.
+    assert by_rel["README.md"] == "unchanged"
+    # The edit is recoverable, and the file is back to the install version.
+    assert (
+        (shared / "CLAUDE.md.bak").read_text(encoding="utf-8")
+        == "operator's local edit"
+    )
+    assert primer.read_text(encoding="utf-8") == DEFAULT_SHARED_CLAUDE_MD
+
+
+# ── rebuild_agent_claude_md ─────────────────────────────────────────
+
+
+def test_rebuild_agent_claude_md_assembles_primer_profile_memory():
+    root = _tmp()
+    shared = root / "shared"
+    profile = root / "profile.md"
+    profile.write_text("# Soul\nI am a test agent.", encoding="utf-8")
+    memory = root / "memory"
+    memory.mkdir()
+    (memory / "notes.md").write_text("a remembered fact", encoding="utf-8")
+    workspace = root / "workspace"
+    workspace.mkdir()
+    claude_user = root / ".claude"
+    gemini_user = root / ".gemini"
+
+    out = rebuild_agent_claude_md(
+        shared_dir=shared,
+        profile_path=profile,
+        memory_dir=memory,
+        workspace_dir=workspace,
+        claude_user_dir=claude_user,
+        gemini_user_dir=gemini_user,
+    )
+    # Shared primer is seeded on demand, then primer + profile + memory
+    # all land in the assembled prompt.
+    assert "Puffo.ai platform primer" in out
+    assert "I am a test agent." in out
+    assert "a remembered fact" in out
+    # Written to both user-level dirs.
+    assert (claude_user / "CLAUDE.md").read_text(encoding="utf-8") == out
+    assert (gemini_user / "GEMINI.md").read_text(encoding="utf-8") == out
+
+
+# ── agent reset-primer CLI ──────────────────────────────────────────
+
+
+def _seed_agent(home: Path, agent_id: str) -> Path:
+    adir = home / "agents" / agent_id
+    (adir / "memory").mkdir(parents=True)
+    (adir / "profile.md").write_text(
+        "# Soul\nI test things.", encoding="utf-8",
+    )
+    (adir / "agent.yml").write_text(
+        f"id: {agent_id}\nstate: running\nruntime:\n  kind: chat-local\n",
+        encoding="utf-8",
+    )
+    return adir
+
+
+def test_cli_reset_primer_rebuilds_listed_agent(monkeypatch):
+    home = _tmp()
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(home))
+    adir = _seed_agent(home, "tester-0001")
+
+    args = build_parser().parse_args(
+        ["agent", "reset-primer", "tester-0001"],
+    )
+    assert args.func(args) == 0
+
+    claude_md = (adir / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "Puffo.ai platform primer" in claude_md
+    assert "I test things." in claude_md
+    # The shared primer was seeded as a side effect.
+    assert (home / "docker" / "shared" / "CLAUDE.md").exists()
+
+
+def test_cli_reset_primer_unknown_agent_returns_error(monkeypatch):
+    home = _tmp()
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(home))
+
+    args = build_parser().parse_args(
+        ["agent", "reset-primer", "does-not-exist"],
+    )
+    # Shared primer still re-seeds; the unknown agent yields a non-zero rc.
+    assert args.func(args) == 2
+    assert (home / "docker" / "shared" / "CLAUDE.md").exists()


### PR DESCRIPTION
Two related changes to how agents learn / pick up `is_visible_to_human` and primer guidance.

## 1. Coerce `is_visible_to_human=false` on root-level sends
Root-level (non-threaded) messages can't fold in the human UI — only threaded replies do. An agent passing `false` on a root-level send had no signal the flag did nothing.

- `send_message` / `send_message_with_attachments`: detect `false` + no `root_id`, **coerce to visible** (message still goes out — a warning, not an error), and splice a note into the tool response so the agent learns on the spot.
- Primer + tool docstrings: `false` only takes effect on threaded replies.

## 2. `agent reset-primer` — re-seed the shared primer after upgrade
The shared platform primer (`~/.puffo-agent/docker/shared/CLAUDE.md` + `skills/`) is **seed-once** — `ensure_shared_primer` never overwrites, so a `puffo-agent` upgrade never reaches existing installs. Primer edits (like #1's docstring guidance, or the `is_visible_to_human` docs) only land on brand-new machines.

New `puffo-agent agent reset-primer <id> [<id> ...]`:
- `reseed_shared_primer()` force-rewrites the managed shared files to this install's version — unchanged files skipped, edited ones backed up to `<file>.bak` first.
- Rebuilds each listed agent's managed `CLAUDE.md` / `GEMINI.md` from the fresh primer.
- The re-seed is **global** (one shared file); the id list only scopes which agents get rebuilt.
- No `--restart-agent`: running workers keep their loaded prompt; the rebuild takes effect on the worker's next restart.
- Factors the worker's CLAUDE.md assembly into a shared `rebuild_agent_claude_md` helper (worker startup, reload-from-disk, and the CLI command now share one path).

## Test plan
- [x] `_coerce_root_visibility` unit test (true/false × root/threaded + whitespace)
- [x] `send_message` root-level `false` → posts + note; threaded `false` → posts, no note
- [x] `reseed_shared_primer` — created / unchanged / updated+`.bak` backup
- [x] `rebuild_agent_claude_md` — assembles primer + profile + memory, writes both user-level files
- [x] `agent reset-primer` CLI — rebuilds the listed agent's CLAUDE.md; unknown id → rc 2
- [x] Full suite: 544 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)