### PR TITLE
fix(portal): soul section can open with its own heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.2] — 2026-05-14
+
+### Fixed
+
+- **A `# Soul` section whose body opens with its own heading is no
+  longer read as empty — or duplicated on update.** Soul templates
+  (and the operator-authored souls) open `# Soul` with a
+  `# <agent-name>` title line. Both the `_profile_summary` reader and
+  the `_update_profile_summary` writer detected the section's end as
+  "the next heading of the same-or-higher level" — and the body's own
+  opening H1 *is* such a heading:
+  - **Read** closed the section instantly and returned `""`, so the
+    web client's agent card showed "Soul not configured" even though
+    `profile.md` carried a full soul.
+  - **Write** skipped "the old body until the next heading", hit that
+    same opening H1, skipped nothing, and inserted the new summary
+    *above* the old body — an append/duplicate instead of a replace.
+    Repeated UI soul edits stacked multiple souls into one file.
+
+  Both paths now share one `_soul_section_span` helper: a
+  same-or-higher heading only closes the section once real prose (a
+  non-blank, non-heading line) has been collected. An *opening*
+  heading is part of the soul; a *trailing* `# Notes` section after
+  real soul prose still closes it and stays out. Follow-up to the
+  0.7.6 multi-line `_profile_summary` change that introduced the
+  walk-to-next-heading logic.
+
+  4 new tests in `test_profile_summary.py` (read with an opening
+  heading, write replaces an opening-heading body without
+  duplication, trailing section preserved on update, append-when-
+  absent). Full suite: 548 passed, 7 skipped.
+
 ## [0.8.1] — 2026-05-14
 
 ### Added
@@ -662,7 +694,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.2
 [0.8.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.1
 [0.8.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.0
 [0.7.5]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.7.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.1"
+version = "0.8.2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -278,69 +278,100 @@ async def list_agents(request: web.Request) -> web.Response:
     return web.json_response({"agents": items})
 
 
+_DESCRIPTION_HEADINGS = {"soul", "description", "about", "summary"}
+
+
+def _atx_heading(raw: str) -> tuple[int, str]:
+    """``(level, lowercased text)`` for an ATX markdown heading, or
+    ``(0, "")`` for any non-heading line. ``#hashtag`` (no space after
+    the ``#``) isn't a heading in CommonMark and reads as level 0."""
+    stripped = raw.lstrip()
+    if not stripped.startswith("#"):
+        return 0, ""
+    i = 0
+    while i < len(stripped) and stripped[i] == "#":
+        i += 1
+    if i < len(stripped) and stripped[i] in " \t":
+        return i, stripped[i:].strip().lower()
+    return 0, ""
+
+
+def _soul_section_span(lines: list[str]) -> tuple[int, int, int] | None:
+    """Locate the description / ``# Soul`` section in a profile.md.
+
+    Returns ``(heading_idx, body_start, body_end)``:
+      - ``heading_idx`` — index of the ``# Soul`` (or ``description`` /
+        ``about`` / ``summary``) heading line,
+      - ``body_start`` — first line after that heading,
+      - ``body_end`` — exclusive index where the section ends: the
+        next heading of the same-or-higher level that appears *after*
+        the soul body has real (non-blank, non-heading) content, or
+        EOF.
+
+    ``None`` when there is no description-like heading.
+
+    The "after real content" gate is the fix for the opening-heading
+    footgun: a soul body legitimately opens with its own heading
+    (``# Soul`` immediately followed by ``# <agent-name>``), and that
+    heading must not be mistaken for the *end* of the section. A
+    same-or-higher heading only closes the section once actual prose
+    has been collected — matching the operator's intent: a trailing
+    ``# Notes`` section is theirs, an opening ``# Name`` line is the
+    soul's. Single source of truth for both the read path
+    (``_profile_summary``) and the write path
+    (``_update_profile_summary``)."""
+    heading_idx = -1
+    section_level = 0
+    for idx, raw in enumerate(lines):
+        level, text = _atx_heading(raw)
+        if level and text in _DESCRIPTION_HEADINGS:
+            heading_idx = idx
+            section_level = level
+            break
+    if heading_idx == -1:
+        return None
+
+    body_start = heading_idx + 1
+    body_end = len(lines)
+    has_text = False
+    for idx in range(body_start, len(lines)):
+        raw = lines[idx]
+        level, _ = _atx_heading(raw)
+        if level:
+            if level <= section_level and has_text:
+                body_end = idx
+                break
+            # Deeper heading, or a heading before any prose — part of
+            # the soul body either way.
+            continue
+        if raw.strip():
+            has_text = True
+    return heading_idx, body_start, body_end
+
+
 def _profile_summary(cfg: AgentConfig) -> str:
     """Return the full body of the agent's ``# Soul`` section from
     profile.md (or any description-like heading: ``description`` /
-    ``about`` / ``summary``). Picks up everything between the
-    matching heading and the next heading **of the same or higher
-    level** (or EOF). Sub-headings inside the section (``## Tone``,
-    ``## What you don't do`` etc.) stay part of the body so the
-    operator's structured markdown round-trips faithfully.
+    ``about`` / ``summary``) — see ``_soul_section_span`` for exactly
+    where the section starts and ends. Sub-headings inside the
+    section (``## Tone`` etc.), and an opening heading the soul body
+    leads with, stay part of the body so the operator's structured
+    markdown round-trips faithfully.
 
     Surrounding blank lines are trimmed; internal blank lines are
-    preserved.
-
-    Empty string when no such section exists or the profile is
-    unreadable.
-
-    The asymmetric "read first line, write full body" the helper had
-    before broke the new agent-card Soul-expand UI; the H2-stops-
-    collection bug then truncated multi-section souls (the operator's
-    helper template uses ``## How you act`` / ``## Tone`` / etc.)
-    even after the multi-line fix landed."""
+    preserved. Empty string when no such section exists or the
+    profile is unreadable."""
     try:
         text = cfg.resolve_profile_path().read_text(encoding="utf-8")
     except Exception:
         return ""
 
-    description_heading = {"soul", "description", "about", "summary"}
-    body_lines: list[str] = []
-    in_description = False
-    section_level = 0  # ``#`` → 1, ``##`` → 2, etc.
-
-    for raw in text.splitlines():
-        stripped = raw.lstrip()
-        # Recognise a heading: one or more leading ``#`` followed by
-        # whitespace then text. ``#hashtag`` (no space) isn't a
-        # heading in CommonMark; ignore it.
-        is_heading = False
-        level = 0
-        heading_text = ""
-        if stripped.startswith("#"):
-            # Count consecutive '#'s.
-            i = 0
-            while i < len(stripped) and stripped[i] == "#":
-                i += 1
-            if i < len(stripped) and stripped[i] in " \t":
-                level = i
-                heading_text = stripped[i:].strip().lower()
-                is_heading = True
-
-        if is_heading:
-            if in_description:
-                if level <= section_level:
-                    # Same-or-higher-level heading closes the section.
-                    break
-                # Deeper heading — part of the soul body.
-                body_lines.append(raw)
-                continue
-            if heading_text in description_heading:
-                in_description = True
-                section_level = level
-            continue
-
-        if in_description:
-            body_lines.append(raw)
+    lines = text.splitlines()
+    span = _soul_section_span(lines)
+    if span is None:
+        return ""
+    _, body_start, body_end = span
+    body_lines = lines[body_start:body_end]
 
     # Trim leading + trailing blank lines so the returned body
     # doesn't carry the layout whitespace operators leave around
@@ -664,40 +695,31 @@ def _derive_role_short(role: str) -> str:
 
 def _update_profile_summary(cfg: AgentConfig, new_summary: str) -> None:
     """Rewrite the description section of profile.md with
-    ``new_summary``. Replaces the body of the first matching heading
-    (soul / description / about / summary); appends a new ``# Soul``
-    section when no such heading exists.
+    ``new_summary``. Replaces the whole body of the ``# Soul`` (or
+    description / about / summary) section — its bounds come from
+    ``_soul_section_span``, the same logic the read path uses, so an
+    update round-trips faithfully and never appends a duplicate.
+    Appends a fresh ``# Soul`` section when no such heading exists.
     """
     try:
         path = cfg.resolve_profile_path()
         text = path.read_text(encoding="utf-8")
         lines = text.splitlines(keepends=True)
 
-        description_heading = {"soul", "description", "about", "summary"}
-        new_lines: list[str] = []
-        i = 0
-        found = False
-
-        while i < len(lines):
-            raw = lines[i]
-            stripped = raw.strip()
-            if stripped.startswith("#"):
-                heading = stripped.lstrip("#").strip().lower()
-                if heading in description_heading:
-                    new_lines.append(raw)  # keep the heading line
-                    i += 1
-                    # Skip existing body lines until the next heading or EOF
-                    while i < len(lines) and not lines[i].strip().startswith("#"):
-                        i += 1
-                    # Insert updated summary (single line)
-                    new_lines.append(new_summary + "\n")
-                    found = True
-                    continue
-            new_lines.append(raw)
-            i += 1
-
-        if not found:
-            # No matching heading — append a new Soul section
+        # Span is computed on newline-stripped copies so the indices
+        # line up 1:1 with ``lines`` (splitlines(keepends=True) yields
+        # the same element count, just with the line endings kept).
+        span = _soul_section_span([raw.rstrip("\r\n") for raw in lines])
+        if span is not None:
+            _, body_start, body_end = span
+            new_lines = (
+                lines[:body_start]
+                + ["\n", new_summary + "\n"]
+                + lines[body_end:]
+            )
+        else:
+            # No matching heading — append a fresh Soul section.
+            new_lines = list(lines)
             if new_lines and not new_lines[-1].endswith("\n"):
                 new_lines.append("\n")
             new_lines.extend(["\n# Soul\n", new_summary + "\n"])

--- a/tests/test_profile_summary.py
+++ b/tests/test_profile_summary.py
@@ -16,7 +16,10 @@ import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from puffo_agent.portal.api.handlers import _profile_summary
+from puffo_agent.portal.api.handlers import (
+    _profile_summary,
+    _update_profile_summary,
+)
 from puffo_agent.portal.state import AgentConfig
 
 
@@ -175,3 +178,83 @@ def test_trims_blank_lines_around_body(monkeypatch):
         )
         out = _profile_summary(cfg)
         assert out == "Line 1.\nLine 2."
+
+
+def test_soul_body_may_open_with_its_own_heading(monkeypatch):
+    """A soul body that leads with its own H1 — ``# Soul`` immediately
+    followed by ``# <agent-name>`` — is captured in full. The opening
+    heading is part of the soul, not the end of the section.
+
+    Regression: before the span fix this returned an empty string
+    because the second H1 was read as a sibling heading closing
+    ``# Soul`` instantly. The original templates (and the operator's
+    ~/Downloads/markdowns souls) all open this way."""
+    with tempfile.TemporaryDirectory() as home:
+        monkeypatch.setenv("PUFFO_AGENT_HOME", home)
+        body = (
+            "# Identity\nd2d2\n\n"
+            "# Soul\n"
+            "# d2d2-butler\n\n"
+            "> Language rule: match the human.\n\n"
+            "## Identity\n\n"
+            "You are the household butler.\n"
+        )
+        cfg = _agent_with_profile(home, body)
+        out = _profile_summary(cfg)
+        assert "# d2d2-butler" in out
+        assert "> Language rule: match the human." in out
+        assert "## Identity" in out
+        assert "You are the household butler." in out
+
+
+def test_update_replaces_body_that_opens_with_a_heading(monkeypatch):
+    """Updating the soul of a profile whose body opens with its own
+    H1 REPLACES the whole body — it must not insert the new text
+    above the old (the append-duplicate bug). A post-update read
+    sees only the new content; the Identity section is untouched."""
+    with tempfile.TemporaryDirectory() as home:
+        monkeypatch.setenv("PUFFO_AGENT_HOME", home)
+        body = (
+            "# Identity\nd2d2\n\n"
+            "# Soul\n"
+            "# old-title\n\n"
+            "Old soul body.\n"
+        )
+        cfg = _agent_with_profile(home, body)
+        _update_profile_summary(cfg, "# new-title\n\nBrand new soul body.")
+        out = _profile_summary(cfg)
+        assert "# new-title" in out
+        assert "Brand new soul body." in out
+        assert "old-title" not in out
+        assert "Old soul body." not in out
+        text = cfg.resolve_profile_path().read_text(encoding="utf-8")
+        assert text.startswith("# Identity\nd2d2\n")
+
+
+def test_update_preserves_trailing_section(monkeypatch):
+    """A ``# Notes`` section after ``# Soul`` survives an update —
+    only the soul body between the headings is replaced."""
+    with tempfile.TemporaryDirectory() as home:
+        monkeypatch.setenv("PUFFO_AGENT_HOME", home)
+        body = (
+            "# Soul\n\nOld soul.\n\n"
+            "# Notes\n\nOperator's private notes.\n"
+        )
+        cfg = _agent_with_profile(home, body)
+        _update_profile_summary(cfg, "New soul.")
+        text = cfg.resolve_profile_path().read_text(encoding="utf-8")
+        assert "New soul." in text
+        assert "Old soul." not in text
+        assert "# Notes" in text
+        assert "Operator's private notes." in text
+
+
+def test_update_appends_soul_when_absent(monkeypatch):
+    """A profile with no description-like heading gets a fresh
+    ``# Soul`` section appended."""
+    with tempfile.TemporaryDirectory() as home:
+        monkeypatch.setenv("PUFFO_AGENT_HOME", home)
+        cfg = _agent_with_profile(home, "# Identity\nd2d2\n")
+        _update_profile_summary(cfg, "Freshly added soul.")
+        out = _profile_summary(cfg)
+        assert out == "Freshly added soul."


### PR DESCRIPTION
## The bug

A `profile.md` whose soul body leads with its own H1 — `# Soul`
immediately followed by `# <agent-name>`, which **every soul template
does** — broke both the read and write paths of the bridge's
profile-summary handling:

- **Read (`_profile_summary`)** — collected the `# Soul` section "until
  the next same-or-higher-level heading." The body's *own opening H1*
  is exactly such a heading, so the section closed instantly →
  returned `""` → the agent card shows "Soul not configured".
- **Write (`_update_profile_summary`)** — skipped the old body "until
  the next heading", hit that same opening H1 immediately → skipped
  *nothing* → inserted the new summary **above** the old body. An
  append/duplicate instead of a replace. (Repeated UI edits stacked
  multiple souls in one file.)

Both bugs have the same root cause: the section-end detection can't
tell "an H1 that opens the soul body" from "an H1 that starts a new
top-level section."

## The fix

Both paths now share one `_soul_section_span(lines)` helper that
returns `(heading_idx, body_start, body_end)`. The key rule: a
same-or-higher-level heading only **closes** the soul section once
real prose (a non-blank, non-heading line) has already been collected.
So:

- an *opening* `# <agent-name>` heading is part of the soul body —
  the operator's intent;
- a *trailing* `# Notes` section after real soul prose still closes
  the section and stays out — preserved behaviour, still tested.

`_profile_summary` extracts `lines[body_start:body_end]`;
`_update_profile_summary` replaces exactly that range — a faithful,
duplicate-free round-trip.

## Test plan

- [x] `pytest tests/test_profile_summary.py tests/test_bridge_handlers.py` — pass
- [x] full suite: `548 passed, 7 skipped` (skips pre-existing: symlink / permission-mode)
- Added: `test_soul_body_may_open_with_its_own_heading` (read), `test_update_replaces_body_that_opens_with_a_heading` (write, no-duplicate), `test_update_preserves_trailing_section`, `test_update_appends_soul_when_absent`. Existing `test_stops_on_same_level_heading_after_soul` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)