### PR TITLE
fix(FB-76): send_message channel→space resolution + http_client safety net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`send_message` no longer silently sends to the wrong space when a
+  channel id isn't in the local cache.** The previous resolver fell
+  back to `cfg.space_id` (the agent's home space) whenever
+  `lookup_channel_space` had no record of the channel — but the
+  channel may actually live in a *different* accessible space, in
+  which case the next call (`/spaces/<home>/channels/<ch>/members`)
+  targeted the wrong space. The relay's response in that case wasn't
+  the documented 403/400; it was a 2xx with a non-JSON body, which
+  the caller then `.get()`-ed and crashed three layers up with the
+  opaque `'str' object has no attribute 'get'` (FB-76 root cause).
+
+  Two-stage resolver now:
+  1. local cache (`data_client.lookup_channel_space` — unchanged);
+  2. on miss, walk `GET /spaces` + `GET /spaces/<sp>/channels` to
+     find a definitive match across the agent's accessible spaces.
+
+  When both miss, raise a clear unresolved-channel error rather than
+  guessing. The previous `or cfg.space_id` fallback is removed
+  entirely. 2 new tests in `test_puffo_core_tools.py` (discovery
+  succeeds in another space; full miss → clear error). The
+  `PuffoCoreHttpClient` fail-loud fix below remains as the
+  safety-net for any other caller that hits the same non-JSON-2xx
+  shape from the relay.
+
 - **`PuffoCoreHttpClient` no longer hands callers a raw string body
   as if it were a parsed JSON response.** When a 2xx response carried
   a non-empty, non-JSON body — a proxy / CDN error page, a gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`PuffoCoreHttpClient` no longer hands callers a raw string body
+  as if it were a parsed JSON response.** When a 2xx response carried
+  a non-empty, non-JSON body — a proxy / CDN error page, a gateway
+  interstitial, a plain-text error — `_do_request`'s `json.loads`
+  fallback returned the raw string, and every caller of
+  `get()` / `post()` (`mcp__puffo__send_message` channel resolution,
+  `list_channels`, …) then did `.get()` on it and crashed three
+  layers up with the opaque `'str' object has no attribute 'get'`.
+  Reported via FB-76: `send_message` to a channel id and
+  `list_channels` failing identically — the shared `http_client`
+  layer, not an endpoint-specific bug. `_request` now raises
+  `HttpError` with the actual body when a 2xx response isn't JSON, so
+  the failure is diagnosable at the source. Empty 2xx bodies (204 No
+  Content etc.) are unaffected. 2 new tests in `test_http_client.py`.
+
 ## [0.8.2] — 2026-05-14
 
 ### Fixed

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -97,6 +97,20 @@ class PuffoCoreHttpClient:
             status, data = await self._do_request(method, path, body)
         if status >= 400:
             raise HttpError(status, json.dumps(data) if isinstance(data, dict) else str(data))
+        # Fail loud on a 2xx whose body wasn't JSON. ``_do_request``
+        # falls back to the raw string when ``json.loads`` fails;
+        # every caller of get()/post()/etc. expects a dict/list, so a
+        # *non-empty* non-JSON 2xx body — an HTML error page, a
+        # proxy/CDN interstitial, a plain-text gateway error — is a
+        # broken response. Surfacing it here turns the otherwise
+        # cryptic downstream ``'str' object has no attribute 'get'``
+        # into a diagnosable HttpError carrying the actual body.
+        # Empty bodies (204 No Content etc.) stay untouched.
+        if isinstance(data, str) and data.strip():
+            raise HttpError(
+                status,
+                f"non-JSON body on {status} response: {data[:500]}",
+            )
         return status, data
 
     async def _do_request(

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -32,6 +32,67 @@ from .data_client import DataClient, DataNotFound
 logger = logging.getLogger(__name__)
 
 
+async def _discover_channel_space(http_client: Any, channel_id: str) -> Optional[str]:
+    """Walk the agent's accessible spaces to find which one contains
+    ``channel_id``. Used as the second-stage resolver when the local
+    cache (``data_client.lookup_channel_space``) has no record of the
+    channel — typically because the agent was just added to it and
+    hasn't received an inbound message there yet.
+
+    Bounded by ``GET /spaces`` — only spaces the agent has access to
+    are scanned, so a hit also proves access. Returns ``None`` when
+    no accessible space contains the channel, or when ``/spaces`` is
+    unreachable; the caller (``send_message``) fails loud at that
+    point rather than guessing.
+
+    Replaces an earlier silent fallback to ``cfg.space_id`` (the
+    agent's home space) that produced wrong-space members requests
+    when an unseen channel actually lived in a *different* accessible
+    space — the FB-76 root cause.
+    """
+    try:
+        spaces_resp = await http_client.get("/spaces")
+    except Exception as exc:
+        logger.warning(
+            "discover_channel_space %s: GET /spaces failed: %s",
+            channel_id, exc,
+        )
+        return None
+    spaces = (
+        spaces_resp.get("spaces", [])
+        if isinstance(spaces_resp, dict)
+        else []
+    )
+    for space in spaces:
+        if not isinstance(space, dict):
+            continue
+        sp_id = space.get("space_id") or space.get("id")
+        if not sp_id:
+            continue
+        try:
+            channels_resp = await http_client.get(
+                f"/spaces/{urllib.parse.quote(sp_id, safe='')}/channels"
+            )
+        except Exception as exc:
+            logger.warning(
+                "discover_channel_space %s: GET /spaces/%s/channels failed: %s",
+                channel_id, sp_id, exc,
+            )
+            continue
+        channels = (
+            channels_resp.get("channels", [])
+            if isinstance(channels_resp, dict)
+            else []
+        )
+        for ch in channels:
+            if not isinstance(ch, dict):
+                continue
+            cid = ch.get("channel_id") or ch.get("id")
+            if cid == channel_id:
+                return sp_id
+    return None
+
+
 def _ts_to_iso(ms: int) -> str:
     if not ms:
         return ""
@@ -183,21 +244,38 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             channel_id = channel_ref
             envelope_kind = "channel"
             recipient_slug = None
-            # Look up the space this channel lives in. Inbound
-            # envelopes are tagged with ``space_id`` in the local
-            # message store, so any prior message on this channel
-            # gives us the mapping. Falls back to the agent's home
-            # space when we've never seen the channel — server
-            # returns 403/400 for channels we have no rights on.
-            send_space_id: str | None = (
-                await cfg.data_client.lookup_channel_space(channel_id)
-                or cfg.space_id
+            # Resolve which space this channel lives in. Two-stage:
+            # (1) local cache — inbound envelopes tag ``space_id`` in
+            # the message store, so any prior message in this channel
+            # gives the mapping for free. (2) On miss (channel never
+            # seen — typical right after the agent gets added) walk
+            # ``GET /spaces`` + ``GET /spaces/<sp>/channels`` for a
+            # definitive match across the agent's accessible spaces.
+            #
+            # Previously the cache miss fell back to ``cfg.space_id``
+            # (the agent's home space). When the channel actually
+            # lived in a *different* accessible space, the next call
+            # (``/spaces/<home>/channels/<ch>/members``) targeted the
+            # wrong space. The response in that case wasn't the
+            # expected 403/400 — it was a 2xx with a non-JSON body
+            # (proxy / gateway interstitial), which surfaced three
+            # layers up as ``'str' object has no attribute 'get'``.
+            # FB-76's root cause. We now fail loud when both stages
+            # miss rather than guessing.
+            send_space_id: Optional[str] = await cfg.data_client.lookup_channel_space(
+                channel_id,
             )
             if not send_space_id:
+                send_space_id = await _discover_channel_space(
+                    cfg.http_client, channel_id,
+                )
+            if not send_space_id:
                 raise RuntimeError(
-                    f"channel {channel_id} not seen before and the agent "
-                    "has no configured `puffo_core.space_id` — can't "
-                    "resolve which space to send into."
+                    f"can't resolve which space channel {channel_id} belongs "
+                    f"to: the agent has no local record of it, and it doesn't "
+                    f"appear in any space the agent currently has access to. "
+                    f"The agent may need to be invited to that space first, "
+                    f"or the channel id may be wrong."
                 )
             members_resp = await cfg.http_client.get(
                 f"/spaces/{send_space_id}/channels/{channel_id}/members"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -150,6 +150,8 @@ class TestHttpClientErrors(AioHTTPTestCase):
         app = web.Application()
         app.router.add_route("GET", "/not-found", self._handle_404)
         app.router.add_route("GET", "/server-error", self._handle_500)
+        app.router.add_route("GET", "/html-ok", self._handle_html_ok)
+        app.router.add_route("GET", "/empty-ok", self._handle_empty_ok)
         return app
 
     async def _handle_404(self, request):
@@ -157,6 +159,20 @@ class TestHttpClientErrors(AioHTTPTestCase):
 
     async def _handle_500(self, request):
         return web.json_response({"error": "internal"}, status=500)
+
+    async def _handle_html_ok(self, request):
+        # A 2xx with a non-JSON body — the shape a proxy / CDN error
+        # page or gateway interstitial takes when it slips past the
+        # status check.
+        return web.Response(
+            text="<!doctype html><html><body>gateway error</body></html>",
+            status=200,
+            content_type="text/html",
+        )
+
+    async def _handle_empty_ok(self, request):
+        # A legitimately empty 2xx (204 No Content) — must NOT raise.
+        return web.Response(status=204)
 
     @unittest_run_loop
     async def test_404_raises_http_error(self):
@@ -179,6 +195,34 @@ class TestHttpClientErrors(AioHTTPTestCase):
             assert False, "should have raised"
         except HttpError as e:
             assert e.status == 500
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_non_json_2xx_raises_http_error(self):
+        # A 2xx whose body isn't JSON must fail loud here — not three
+        # layers up as `'str' object has no attribute 'get'`.
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001")
+        try:
+            await client.get("/html-ok")
+            assert False, "should have raised"
+        except HttpError as e:
+            assert e.status == 200
+            assert "non-JSON body" in e.body
+            assert "gateway error" in e.body
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_empty_2xx_does_not_raise(self):
+        # An empty 2xx body (204 No Content etc.) is legitimate —
+        # callers that ignore the result must keep working.
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001")
+        try:
+            result = await client.get("/empty-ok")
+            assert not result, f"expected falsy empty result, got {result!r}"
         finally:
             await client.close()
 

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -136,10 +136,14 @@ async def test_whoami():
 
 @pytest.mark.asyncio
 async def test_send_message_channel():
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
     # Channel reply: members from /spaces/<sp>/channels/<ch>/members,
     # device certs from /certs/sync.
+    # Pre-cache the channel→space mapping the way an inbound message
+    # would: send_message now resolves space via the local cache, then
+    # via /spaces walking, and refuses to fall back to cfg.space_id.
+    await ms.mark_channel_space("ch_abc", "sp_test")
     http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
         "members": [{"slug": "alice-0001", "role": "owner"}],
     }
@@ -211,8 +215,12 @@ async def test_send_message_root_level_false_coerced():
     """A root-level send with is_visible_to_human=false still posts —
     the flag is coerced to visible and the tool response carries a
     note so the agent learns on the spot."""
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
+    # Pre-cache the channel→space mapping the way an inbound message
+    # would: send_message now resolves space via the local cache, then
+    # via /spaces walking, and refuses to fall back to cfg.space_id.
+    await ms.mark_channel_space("ch_abc", "sp_test")
     http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
         "members": [{"slug": "alice-0001", "role": "owner"}],
     }
@@ -245,8 +253,12 @@ async def test_send_message_root_level_false_coerced():
 async def test_send_message_threaded_false_not_coerced():
     """A threaded reply (root_id set) keeps is_visible_to_human=false
     — no coercion, no note."""
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
+    # Pre-cache the channel→space mapping the way an inbound message
+    # would: send_message now resolves space via the local cache, then
+    # via /spaces walking, and refuses to fall back to cfg.space_id.
+    await ms.mark_channel_space("ch_abc", "sp_test")
     http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
         "members": [{"slug": "alice-0001", "role": "owner"}],
     }
@@ -278,8 +290,104 @@ async def test_send_message_threaded_false_not_coerced():
 
 
 @pytest.mark.asyncio
-async def test_send_message_dm():
+async def test_send_message_discovers_channel_in_other_space():
+    """When the channel id isn't in the local cache (no inbound seen
+    yet), send_message walks ``/spaces`` + ``/spaces/<sp>/channels``
+    for a definitive match — and aims the members call at the
+    *discovered* space, not at ``cfg.space_id``. Fixes FB-76: the
+    previous silent fallback to ``cfg.space_id`` produced wrong-space
+    members requests that surfaced as ``'str' object has no attribute
+    'get'`` three layers up."""
     cfg, http, _ = _setup()
+    recipient_kem = KemKeyPair.generate()
+    # cfg.space_id is "sp_test"; the channel actually lives in a
+    # DIFFERENT space the agent has access to.
+    http.responses["/spaces"] = {
+        "spaces": [
+            {"space_id": "sp_test", "name": "Home"},
+            {"space_id": "sp_other", "name": "Other Team"},
+        ],
+    }
+    http.responses["/spaces/sp_test/channels"] = {
+        "channels": [{"channel_id": "ch_home", "name": "general"}],
+    }
+    http.responses["/spaces/sp_other/channels"] = {
+        "channels": [{"channel_id": "ch_elsewhere", "name": "general"}],
+    }
+    http.responses["/spaces/sp_other/channels/ch_elsewhere/members"] = {
+        "members": [{"slug": "alice-0001", "role": "member"}],
+    }
+    http.responses["/certs/sync?slugs=alice-0001"] = {
+        "entries": [{
+            "seq": 1, "kind": "device_cert", "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_recipient_1",
+                "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp, "send_message",
+        {
+            "channel": "ch_elsewhere",
+            "text": "hello other space",
+            "is_visible_to_human": True,
+        },
+    )
+    assert "posted" in result, f"expected success, got: {result}"
+    # Critical: the members call must target sp_other (correct), NOT
+    # sp_test (the previous wrong-space fallback) — that's the
+    # regression we're guarding against.
+    members_paths = [
+        path for method, path, _ in http.calls
+        if method == "GET" and "ch_elsewhere/members" in path
+    ]
+    assert any("/spaces/sp_other/" in p for p in members_paths), (
+        f"members call must target sp_other, got: {members_paths}"
+    )
+    assert not any("/spaces/sp_test/" in p for p in members_paths), (
+        f"must NOT hit sp_test (wrong-space fallback regression): {members_paths}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_fails_loud_when_channel_not_in_any_space():
+    """When neither the local cache nor any accessible space contains
+    the channel, send_message raises a clear unresolved-channel error
+    instead of silently sending to the wrong space — FB-76 fix."""
+    cfg, http, _ = _setup()
+    http.responses["/spaces"] = {
+        "spaces": [{"space_id": "sp_test", "name": "Home"}],
+    }
+    http.responses["/spaces/sp_test/channels"] = {
+        "channels": [{"channel_id": "ch_known", "name": "general"}],
+    }
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(
+            mcp, "send_message",
+            {
+                "channel": "ch_nowhere",
+                "text": "should not send",
+                "is_visible_to_human": True,
+            },
+        )
+    assert "can't resolve which space" in str(excinfo.value), (
+        f"expected an unresolved-channel error, got: {excinfo.value}"
+    )
+    # And critically: no wrong-space members call was issued.
+    assert not any(
+        "ch_nowhere/members" in path
+        for method, path, _ in http.calls
+        if method == "GET"
+    ), "must not issue a members call when space resolution fails"
+
+
+@pytest.mark.asyncio
+async def test_send_message_dm():
+    cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
     sender_kem = KemKeyPair.generate()
     # DM fans to recipient + sender's own devices via /certs/sync.
@@ -438,7 +546,7 @@ async def test_get_thread_history_empty_window():
 async def test_list_channels():
     """Channels come from ``/spaces/<sp>/events`` replay — there's no
     standalone channels endpoint on puffo-server."""
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     http.responses["/spaces/sp_test/events"] = {
         "events": [
             {"kind": "create_space", "payload": {"space_id": "sp_test", "name": "Test"}},
@@ -463,7 +571,7 @@ async def test_list_channels_paginates_via_since():
     the ``?cursor=`` bug — the server's axum extractor silently
     ignored the wrong-named key, so paginated calls re-fetched the
     first page forever and the tool never returned."""
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     # Page 1: one channel + cursor pointing at page 2.
     http.responses["/spaces/sp_test/events"] = {
         "events": [
@@ -502,7 +610,7 @@ async def test_list_channels_bails_on_stuck_cursor():
     was just sent, the tool must stop instead of spinning. Mirrors
     the strict-advance guard in ``fetchChannelsFromEvents``
     (web) and ``_resolve_channel_name`` (this package)."""
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     # Both the initial and the ``?since=stuck`` request hand back
     # the same ``next_cursor`` — a real regression would loop, the
     # guarded loop bails after the second fetch.
@@ -529,7 +637,11 @@ async def test_list_channels_bails_on_stuck_cursor():
 async def test_list_channel_members():
     """Channel members come from
     ``/spaces/<sp>/channels/<ch>/members`` keyed by space_id."""
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
+    # Pre-cache the channel→space mapping the way an inbound message
+    # would: send_message now resolves space via the local cache, then
+    # via /spaces walking, and refuses to fall back to cfg.space_id.
+    await ms.mark_channel_space("ch_abc", "sp_test")
     http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
         "members": [
             {"slug": "alice-0001", "role": "owner"},
@@ -549,7 +661,7 @@ async def test_list_channel_members():
 async def test_get_user_info():
     """Profile lookups go through ``/identities/profiles?slugs=<slug>``.
     """
-    cfg, http, _ = _setup()
+    cfg, http, ms = _setup()
     http.responses["/identities/profiles?slugs=alice-0001"] = {
         "profiles": [{
             "slug": "alice-0001",


### PR DESCRIPTION
## Root cause (FB-76)

`send_message`'s space resolver was:
```python
send_space_id = await lookup_channel_space(channel_id) or cfg.space_id
```
When the local cache had no record of the channel, it silently fell back to the agent's **home space**. If the channel actually lived in a *different* accessible space, the next call (`/spaces/<home>/channels/<ch>/members`) hit the wrong space. The relay's response in that case wasn't the documented 403/400 — it was a 2xx with a non-JSON body, which the caller then `.get()`-ed and crashed three layers up as the opaque `'str' object has no attribute 'get'`.

The original FB-76 repro fits exactly: one channel of a broadcast fails consistently (the one not in the agent's local message store), other channels in the same broadcast succeed.

## Fix — two layers

### 1. Root cause: `send_message` resolves correctly or fails loud

`puffo_core_tools.py` `send_message` now:
1. **Local cache** (`data_client.lookup_channel_space`) — unchanged.
2. **On miss**, walk `GET /spaces` + `GET /spaces/<sp>/channels` to find a definitive match across the agent's accessible spaces (new `_discover_channel_space` helper).
3. **Both miss** → raise a clear unresolved-channel error.

The `or cfg.space_id` fallback is **removed entirely**. No more silent wrong-space requests.

2 new tests in `test_puffo_core_tools.py`: discovery succeeds in another space; full miss → clear error. 3 existing channel-send tests updated to pre-cache via `mark_channel_space` (they were relying on the now-removed silent fallback).

### 2. Safety net: `http_client` fail-loud on non-JSON 2xx

`PuffoCoreHttpClient._do_request` used to fall back to `data = text` (raw string) when `json.loads` failed. On a `>= 400` that fed `HttpError`; but on a **2xx** it was returned as-is, so any caller doing `.get()` on it would crash three layers up with the opaque `'str' object has no attribute 'get'`.

`_request` now raises `HttpError` with the actual body when a 2xx is non-empty and non-JSON, so the failure is diagnosable at the source. Empty 2xx bodies (204 etc.) are unaffected.

This is the safety net — any other caller that hits a similar non-JSON-2xx shape now surfaces a real diagnosable error instead of crashing three layers up. 2 new tests in `test_http_client.py`.

## Test plan

- [x] `pytest tests/test_puffo_core_tools.py tests/test_http_client.py` — pass
- [x] Full suite: **552 passed, 7 skipped** (no regressions; +2 send_message tests + 2 http_client tests + 3 existing tests updated for the new contract)
- The original FB-76 repro (broadcast to a channel the agent hasn't seen yet) now sends to the **right** space; if no accessible space contains the channel, fails with a clear actionable error rather than the opaque AttributeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)