### PR TITLE
chore(release): 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.8.3] — 2026-05-15
 
 ### Fixed
 
@@ -737,7 +737,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.3
 [0.8.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.2
 [0.8.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.1
 [0.8.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.2"
+version = "0.8.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Cut version 0.8.3: send_message channel→space discovery + fail-loud, plus http_client safety net for non-JSON 2xx (PR #18, already merged).
- Bumps `pyproject.toml` 0.8.2 → 0.8.3 and rolls `CHANGELOG.md` `[Unreleased]` into `[0.8.3] — 2026-05-15`.

## Test plan
- [x] `pip install -e .` shows `puffo-agent 0.8.3`
- [ ] Tag `v0.8.3` after merge triggers PyPI publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)