### PR TITLE
feat(macos): transparent Keychain credential management (0.9.0a1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,134 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.0a3] — 2026-05-19
+
+_Pre-release published to TestPyPI only — not for general install._
+
+### Changed
+
+- **macOS Keychain integration on top of the daemon-owned
+  `CredentialRefresher`.** Claude Code 2.x stores its OAuth token in
+  the system Keychain (`"Claude Code-credentials"`), and per-agent
+  `$HOME` overrides don't isolate Keychain access (the ACL is keyed
+  on UID + signing identity, not HOME). Without daemon-level
+  intermediation, the host's `claude` binary running under a
+  puffo-agent worker re-prompts the ACL every spawn and the per-agent
+  `.credentials.json` files diverge from the operator's main CLI
+  view. GitHub issue anthropics/claude-code#37512 compounds the
+  problem: setting `CLAUDE_CODE_OAUTH_TOKEN` triggers a
+  `security delete-generic-password "Claude Code-credentials"`
+  cleanup on exit that kicks the user's main CLI / VS Code extension
+  off Keychain entirely.
+
+  This release extends the 0.8.8 `CredentialRefresher` with a
+  pluggable backend abstraction so the macOS Keychain path and the
+  Linux/Windows host-file path share the same daemon-owned lock,
+  agent fan-out, and 401-wake invariants while differing only on
+  storage:
+
+  - `CredentialBackend` Protocol (`portal/credential_refresh.py`) —
+    four methods: `expires_in_seconds`, `refresh` (async, returns
+    `RefreshOutcome.{REFRESHED, UNCHANGED, FAILED}`), `sync_to_agent`,
+    and `bootstrap`.
+  - `FileBackend` — preserves bit-identical 0.8.8 behavior on
+    Linux/Windows. Host `~/.claude/.credentials.json` is canonical;
+    refresh spawns `claude --print` with `HOME=host_home`; sync is a
+    symlink (or copy fallback) via `link_host_credentials`. External
+    rotation propagates atomically through the symlink — no
+    external-poll needed.
+  - `KeychainBackend` — macOS path. Keychain is canonical; the
+    daemon maintains a cache at
+    `~/.puffo-agent/run/claude-credentials.json` (atomic-write JSON
+    blob, chmod 600); refresh runs a sandboxed `claude --print`
+    under a tempdir `HOME` seeded from the cache so claude rotates
+    the token against Anthropic and writes the new blob back to the
+    sandbox file (which we then copy to the cache); writeback to
+    Keychain is best-effort so the operator's main CLI sees the new
+    token; `sync_to_agent` is a per-agent file copy (Keychain ACL
+    forces this — symlinking the cache wouldn't help because the
+    per-agent `claude` process still goes through Keychain anyway).
+  - `CredentialRefresher` itself stays platform-agnostic: owns the
+    `asyncio.Lock` (single-writer across all refreshes), the agent
+    home registry, the `_refresh_request` event for 401-wake, the
+    2-minute file-expiry poll, and the post-tick fan-out that calls
+    `backend.sync_to_agent(agent_home)` for every registered agent.
+    Daemon `daemon.py` picks the backend at startup based on
+    `is_macos()`.
+  - **External-rotation poll** (macOS-only): `KeychainBackend`
+    exposes `poll_external_rotation()` and the refresher runs it as
+    a sibling task on `KEYCHAIN_POLL_INTERVAL_SECONDS = 5 * 60`. The
+    poll re-reads Keychain (silent after the first "Always Allow"
+    grant), diffs against the last propagated blob, and on detected
+    change updates the cache + triggers fan-out via the same
+    `_sync_views` path. This catches rotations done by the
+    operator's main `claude` CLI or by an agent's own claude
+    subprocess self-refreshing on a 401 — neither of which the
+    daemon initiates, so neither would be visible to siblings
+    without this poll.
+  - **PATH shim** (issue #37512 workaround): every daemon start
+    writes a bash shim to
+    `~/.puffo-agent/run/keychain-shim/security` that intercepts
+    `security delete-generic-password "Claude Code-credentials"`
+    and silently no-ops it, passing every other `security`
+    invocation through to `/usr/bin/security`. The shim dir is
+    prepended to `$PATH` for every per-agent `claude` spawn and for
+    the daemon's own refresh oneshot.
+  - **`local_cli` adapter macOS env-injection**: on macOS, each
+    agent's `claude` subprocess gets `CLAUDE_CONFIG_DIR=<agent_home>/.claude`
+    and `PATH=<shim_dir>:<original PATH>`. **Deliberately does NOT
+    set `CLAUDE_CODE_OAUTH_TOKEN`** — that env var triggers the
+    same bug #37512 cleanup path and would defeat the shim's
+    protection. The per-agent `.credentials.json` is materialised by
+    `KeychainBackend.sync_to_agent` whenever the refresher's tick
+    fans out, so claude reads from there normally. Linux/Windows
+    spawn env is unchanged.
+  - Diagnostic CLI: `puffo-agent test ...` subcommand tree with 5
+    probes (`keychain-read`, `keychain-write`, `refresh-flush`,
+    `keychain-survives-token-env`, `full-probe`) plus a
+    side-effectful `refresh-flush-forced` (gated on `--yes`). Writes
+    a redacted-markdown probe report to
+    `~/.puffo-agent/probe-report.md`. Tokens are shown only as
+    `len=NNN sha256_prefix=XXXXXXXX`. Each probe SKIPs cleanly on
+    non-Darwin so the same CLI works as a sanity-check tool on
+    Linux/Windows.
+
+  The PUF-221 public API (`CredentialRefresher.register_agent` /
+  `unregister_agent` / `notify_refresh_needed` / `run_loop` /
+  `expires_in_seconds`) is unchanged — the refactor is invisible to
+  the daemon's reconcile loop and to `Worker`'s `notify_refresh_needed`
+  callback. The 0.8.8 `host_home=...` constructor signature still
+  works (it implicitly constructs a `FileBackend`) so the existing
+  `tests/test_credential_refresher.py` pins the public-API contract
+  without modification.
+
+### Tests
+
+- `tests/test_macos_credential_manager.py` (~30 tests) — pure-function
+  tests for `CredentialCache`, `install_path_shim`, the keychain
+  read/write primitives (subprocess.run mocked), `refresh_via_oneshot`
+  + `_run_claude_oneshot` (asyncio.create_subprocess_exec mocked),
+  `bootstrap_from_keychain`, plus end-to-end tests for
+  `KeychainBackend` plugged into `CredentialRefresher`
+  (`expires_in_seconds` cache-vs-Keychain path, `refresh` returning
+  `REFRESHED`/`UNCHANGED`/`FAILED`, `sync_to_agent` writing per-agent
+  files, `poll_external_rotation` detecting changes / swallowing
+  read failures, the refresher's fan-out invoking `sync_to_agent`
+  on every registered agent, FD-leak regression for the timeout
+  drain path).
+- `tests/test_macos_diagnostic.py` (~19 tests) — report rendering,
+  token redaction (raw tokens never appear in stdout / saved
+  report), off-macOS SKIPPED path on every probe, on-macOS happy
+  path with mocked subprocess, forced-expiry helpers, and the
+  `refresh-flush-forced` `--yes` gate.
+- `tests/test_credential_refresher.py` (the 12 0.8.8 pinned tests)
+  pass unchanged against the refactored class — the backend
+  abstraction is invisible to the public API.
+
+Full suite: **726 passed / 7 skipped / 0 failed** on Windows
+(macOS-specific assertions still execute because they monkeypatch
+`is_macos` to True; symlink-unavailable skips on Windows are normal).
+
 ## [0.8.8] — 2026-05-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.0b1] — 2026-05-19
+
+_Pre-release published to TestPyPI only — not for general install._
+
+Beta-promote of `0.9.0a3` with the post-review polish folded in.
+Code is unchanged from the architectural pass; this is the first
+version intended for macOS-colleague verification.
+
+### Polished (from PR #20 review)
+
+- **`portal/credential_refresh.py`**: dropped the unconditional
+  top-level import of `KEYCHAIN_POLL_INTERVAL_SECONDS` from the
+  macos package. Now lazy-imported inside `_external_rotation_loop`,
+  matching every other macos touchpoint in the file. The
+  platform-agnostic module no longer pulls the macos package into
+  its import graph on Linux/Windows.
+
+- **`portal/credential_refresh.py`**: restored the `cwd=host_home`
+  justification comment in `FileBackend.refresh` that was
+  accidentally dropped in the 0.9.0a3 backend-abstraction port.
+  The choice is non-obvious — `claude --print` writes project-
+  transcript files into cwd, so pointing it at the daemon's launch
+  directory would leak them. Mirror of the rationale that landed in
+  PUF-221 PR #32 round 4.
+
+- **`agent/adapters/local_cli.py`**: adapter spawn no longer
+  re-installs the PATH shim on every worker spawn. `KeychainBackend.
+  bootstrap()` already runs `install_path_shim` once at daemon
+  start; the adapter now just computes `shim_dir(home_dir())` for
+  the env var. Removes per-spawn `write_text` + `chmod` overhead and
+  closes a concurrent-spawn write-write race the bootstrap path
+  doesn't have.
+
+- **`portal/diagnostic.py`**: noted in code that the `#37512` repro
+  probe (the only place we deliberately set `CLAUDE_CODE_OAUTH_TOKEN
+  =<real token>`) makes the token briefly visible to `ps auxe` for
+  the duration of the claude subprocess. Intentional — the probe's
+  whole purpose is to reproduce that issue — but worth surfacing for
+  anyone running on a shared host.
+
+- **`portal/diagnostic.py` + `macos/keychain.py`**: paired
+  ``keep in sync`` warnings on `_run_sandboxed_claude_oneshot`
+  (sync, diagnostic-side) and `refresh_via_oneshot` (async,
+  production-side). They share env shape + claude args; the
+  diagnostic loses its load-bearing value the moment they drift.
+
+- **`portal/diagnostic.py`** module docstring: stale
+  `puffo_agent.macos.credential_manager` → `puffo_agent.macos.keychain`
+  (one-word swap, the post-rebase module path).
+
+Tests unchanged: **726 passed / 7 skipped / 0 failed** locally on
+Windows.
+
 ## [0.9.0a3] — 2026-05-19
 
 _Pre-release published to TestPyPI only — not for general install._

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.8"
+version = "0.9.0a3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.9.0a3"
+version = "0.9.0b1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -23,7 +23,6 @@ import time
 from pathlib import Path
 
 from ...macos.keychain import (
-    install_path_shim,
     is_macos,
     shim_dir,
 )
@@ -252,7 +251,13 @@ class LocalCLIAdapter(Adapter):
         """
         if not is_macos():
             return {}
-        shim_path = install_path_shim(home_dir())
+        # Just compute the shim path — ``KeychainBackend.bootstrap()``
+        # installed the actual script once at daemon start
+        # (credential_refresh.py → keychain.install_path_shim).
+        # Re-installing on every adapter spawn would be wasted I/O
+        # and would race on the same file path when two workers spawn
+        # concurrently.
+        shim_path = shim_dir(home_dir())
         existing_path = os.environ.get("PATH", "")
         return {
             "CLAUDE_CONFIG_DIR": str(Path(self.agent_home_dir) / ".claude"),

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -22,11 +22,17 @@ import shutil
 import time
 from pathlib import Path
 
+from ...macos.keychain import (
+    install_path_shim,
+    is_macos,
+    shim_dir,
+)
 from ...mcp.config import (
     default_python_executable,
     write_cli_mcp_config,
 )
 from ...portal.state import (
+    home_dir,
     link_host_credentials,
     seed_claude_home,
     sync_host_enabled_plugins,
@@ -207,6 +213,7 @@ class LocalCLIAdapter(Adapter):
             "HOME": str(self.agent_home_dir),
             "USERPROFILE": str(self.agent_home_dir),
             **self._permission_hook_env(),
+            **self._macos_credential_env(),
         }
         self._session = ClaudeSession(
             agent_id=self.agent_id,
@@ -221,6 +228,36 @@ class LocalCLIAdapter(Adapter):
             extra_args=extra,
         )
         return self._session
+
+    def _macos_credential_env(self) -> dict[str, str]:
+        """macOS-only env hardening:
+
+        - ``CLAUDE_CONFIG_DIR`` points at the per-agent .claude so the
+          agent's claude reads from ``<agent_home>/.claude/.credentials.json``
+          (which the daemon's ``KeychainBackend.sync_to_agent`` keeps
+          fresh) rather than racing the operator's main CLI for the
+          Keychain entry.
+        - ``PATH`` is prepended with the security-shim dir so the
+          buggy ``security delete-generic-password`` call from Claude
+          Code issue #37512 is intercepted before it can flush the
+          operator's main CLI auth.
+
+        Deliberately does NOT set ``CLAUDE_CODE_OAUTH_TOKEN`` — that
+        env var triggers the same fallback-combiner cleanup path that
+        deletes the Keychain entry. We let claude read its token
+        from the per-agent ``.credentials.json`` like normal.
+
+        Returns ``{}`` on non-macOS so the Linux/Windows spawn env is
+        unchanged.
+        """
+        if not is_macos():
+            return {}
+        shim_path = install_path_shim(home_dir())
+        existing_path = os.environ.get("PATH", "")
+        return {
+            "CLAUDE_CONFIG_DIR": str(Path(self.agent_home_dir) / ".claude"),
+            "PATH": f"{shim_path}{os.pathsep}{existing_path}",
+        }
 
     def _permission_hook_env(self) -> dict[str, str]:
         """Env vars the PreToolUse hook script reads. Claude inherits

--- a/src/puffo_agent/macos/__init__.py
+++ b/src/puffo_agent/macos/__init__.py
@@ -1,0 +1,40 @@
+"""macOS-specific helpers for puffo-agent.
+
+The async ``CredentialRefresher`` lifecycle is platform-agnostic and
+lives in ``puffo_agent.portal.credential_refresh``; this package owns
+the macOS storage primitives (Keychain read/write, PATH shim,
+credential cache, refresh oneshot) it delegates to via
+``KeychainBackend``.
+"""
+
+from .keychain import (
+    CACHE_FILENAME,
+    KEYCHAIN_POLL_INTERVAL_SECONDS,
+    KEYCHAIN_SERVICE,
+    SHIM_FILENAME,
+    CredentialCache,
+    KeychainReadResult,
+    bootstrap_from_keychain,
+    install_path_shim,
+    is_macos,
+    read_keychain_blob,
+    refresh_via_oneshot,
+    shim_dir,
+    writeback_to_keychain,
+)
+
+__all__ = [
+    "CACHE_FILENAME",
+    "KEYCHAIN_POLL_INTERVAL_SECONDS",
+    "KEYCHAIN_SERVICE",
+    "SHIM_FILENAME",
+    "CredentialCache",
+    "KeychainReadResult",
+    "bootstrap_from_keychain",
+    "install_path_shim",
+    "is_macos",
+    "read_keychain_blob",
+    "refresh_via_oneshot",
+    "shim_dir",
+    "writeback_to_keychain",
+]

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -333,6 +333,11 @@ async def refresh_via_oneshot(
     ``.credentials.json`` with a fresh token; copy it back to the cache.
 
     Returns (ok, reason_when_not_ok).
+
+    ⚠️ **Keep in sync with** ``portal.diagnostic._run_sandboxed_claude_oneshot``:
+    that probe is a sync mirror of this function so the diagnostic
+    can run without an asyncio event loop. Any env / arg change here
+    must be mirrored there or the probe stops validating prod.
     """
     if not is_macos():
         return (False, "not_macos")

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -1,0 +1,385 @@
+"""macOS Keychain primitives for Claude Code OAuth credentials.
+
+Claude Code 2.x stores its OAuth token in the system Keychain
+(``"Claude Code-credentials"``). Per-agent ``$HOME`` overrides don't
+isolate Keychain access (Keychain ACL is keyed by user UID + signing
+identity, not by HOME), so the host's claude binary running under a
+puffo-agent worker can trigger an ACL re-prompt every spawn.
+
+Also: GitHub issue anthropics/claude-code#37512 documents that setting
+``CLAUDE_CODE_OAUTH_TOKEN`` causes the CLI to silently
+``security delete-generic-password "Claude Code-credentials"`` on exit
+via its fallback-combiner cleanup path — which kicks the user's main
+CLI / VS Code extension off. Anthropic did not fix it; the issue auto-
+closed in April 2026.
+
+This module provides the storage primitives only:
+
+  - **Keychain read / write** via the ``security`` CLI.
+  - **PATH shim** that intercepts the buggy delete-generic-password
+    call from issue #37512.
+  - **CredentialCache** — atomic-write JSON blob to
+    ``~/.puffo-agent/run/claude-credentials.json``, daemon-owned.
+  - **Bootstrap** — populate the cache from Keychain on first call.
+  - **Refresh oneshot** — run a sandboxed ``claude --print`` so claude
+    rotates the token and writes the new blob back to the cache.
+
+The async ``CredentialRefresher`` lifecycle (poll loop, agent fan-out,
+401-wake) lives in ``portal/credential_refresh.py`` and delegates here
+via the ``KeychainBackend`` adapter — this module stays
+synchronous-primitive-only so it's straightforward to unit-test off
+macOS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# The macOS Keychain "service" name Claude Code uses. Hard-coded by
+# Claude Code itself; verified via reverse-engineered cli.js in issue
+# #37512 and reproducible with ``security dump-keychain | grep``.
+KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+# File names — picked deliberately short + obvious.
+CACHE_FILENAME = "claude-credentials.json"
+SHIM_FILENAME = "security"
+
+# Refresh every 6h. Claude Code OAuth access tokens TTL is 8h, so the
+# 2h margin means a slow / failed refresh has a retry before tokens
+# actually expire.
+REFRESH_INTERVAL_SECONDS = 6 * 3600
+
+# How long we wait for a single ``security`` invocation.
+SECURITY_TIMEOUT_SECONDS = 60
+
+# Refresh oneshot timeout.
+REFRESH_ONESHOT_TIMEOUT_SECONDS = 90
+
+# How often the Keychain-poll loop wakes to detect tokens rotated by
+# OTHER processes (operator's main CLI, an agent's own claude
+# subprocess self-refreshing on 401).
+KEYCHAIN_POLL_INTERVAL_SECONDS = 5 * 60
+
+
+def is_macos() -> bool:
+    return platform.system() == "Darwin"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Keychain read / write primitives
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class KeychainReadResult:
+    ok: bool
+    blob: Optional[str]
+    error: Optional[str]
+    stderr: Optional[str]
+
+
+def read_keychain_blob(timeout: float = SECURITY_TIMEOUT_SECONDS) -> KeychainReadResult:
+    """Read the ``"Claude Code-credentials"`` entry from the user's
+    login Keychain. Returns the raw stdout (a JSON-shaped string written
+    by Claude Code) or an error reason.
+    """
+    if not is_macos():
+        return KeychainReadResult(False, None, "not_macos", None)
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except FileNotFoundError:
+        return KeychainReadResult(False, None, "security_binary_missing", None)
+    except subprocess.TimeoutExpired:
+        return KeychainReadResult(
+            False, None, "timeout (ACL prompt may be open)", None,
+        )
+    if result.returncode != 0:
+        return KeychainReadResult(
+            False, None, f"exit_code={result.returncode}", result.stderr or None,
+        )
+    blob = result.stdout.strip()
+    if not blob:
+        return KeychainReadResult(False, None, "empty_stdout", None)
+    try:
+        json.loads(blob)
+    except json.JSONDecodeError as exc:
+        return KeychainReadResult(False, None, f"invalid_json: {exc}", None)
+    return KeychainReadResult(True, blob, None, None)
+
+
+def writeback_to_keychain(
+    blob: str, timeout: float = SECURITY_TIMEOUT_SECONDS,
+) -> tuple[bool, Optional[str]]:
+    """Upsert the JSON blob into the Keychain entry. Best-effort."""
+    if not is_macos():
+        return (False, "not_macos")
+    try:
+        result = subprocess.run(
+            [
+                "security", "add-generic-password",
+                "-U",
+                "-s", KEYCHAIN_SERVICE,
+                "-a", os.environ.get("USER", "claude"),
+                "-w", blob,
+            ],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return (False, f"security_failed: {exc}")
+    if result.returncode != 0:
+        return (False, f"exit_code={result.returncode}; stderr={result.stderr.strip()!r}")
+    return (True, None)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PATH shim
+# ─────────────────────────────────────────────────────────────────────────────
+
+_SHIM_BODY = r"""#!/bin/bash
+# Auto-generated by puffo-agent. Intercepts
+# `security delete-generic-password "Claude Code-credentials"` and
+# silently no-ops it (Claude Code issue #37512), passing every other
+# `security` invocation through to the real binary.
+#
+# DO NOT EDIT — overwritten on daemon start.
+REAL=/usr/bin/security
+
+is_delete=0
+for arg in "$@"; do
+  if [ "$arg" = "delete-generic-password" ]; then
+    is_delete=1
+    break
+  fi
+done
+
+if [ "$is_delete" = "1" ]; then
+  for arg in "$@"; do
+    if [ "$arg" = "Claude Code-credentials" ]; then
+      exit 0
+    fi
+  done
+fi
+
+exec "$REAL" "$@"
+"""
+
+
+def shim_dir(home: Path) -> Path:
+    """Where the PATH shim binary lives. Inside daemon run dir so it
+    auto-cleans on uninstall."""
+    return home / "run" / "keychain-shim"
+
+
+def install_path_shim(home: Path) -> Path:
+    """Write the security-shim script and chmod it executable. Returns
+    the directory to prepend to ``PATH``. Idempotent."""
+    d = shim_dir(home)
+    d.mkdir(parents=True, exist_ok=True)
+    binary = d / SHIM_FILENAME
+    binary.write_text(_SHIM_BODY, encoding="utf-8")
+    binary.chmod(
+        stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+        | stat.S_IRGRP | stat.S_IXGRP
+        | stat.S_IROTH | stat.S_IXOTH,
+    )
+    return d
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Credential cache
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class CredentialCache:
+    """The on-disk cache of the OAuth blob, daemon-owned. Lives at
+    ``~/.puffo-agent/run/claude-credentials.json``."""
+    path: Path
+
+    @classmethod
+    def at(cls, home: Path) -> "CredentialCache":
+        return cls(home / "run" / CACHE_FILENAME)
+
+    def exists(self) -> bool:
+        return self.path.exists()
+
+    def write(self, blob: str) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.parent / f".{self.path.name}.tmp.{os.getpid()}"
+        tmp.write_text(blob, encoding="utf-8")
+        tmp.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        os.replace(tmp, self.path)
+
+    def read(self) -> Optional[str]:
+        try:
+            return self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+    def access_token(self) -> Optional[str]:
+        raw = self.read()
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return ((data.get("claudeAiOauth") or {}).get("accessToken")) or None
+
+    def expires_at_seconds(self) -> Optional[float]:
+        """Unix-seconds expiry for the cached token, or None if the
+        blob is missing/malformed. ``expiresAt`` is stored in
+        milliseconds."""
+        raw = self.read()
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+            ms = int((data.get("claudeAiOauth") or {}).get("expiresAt"))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        return ms / 1000.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bootstrap + Refresh
+# ─────────────────────────────────────────────────────────────────────────────
+
+def bootstrap_from_keychain(cache: CredentialCache) -> tuple[bool, Optional[str]]:
+    """Materialise the cache from the Keychain if the cache is missing
+    or empty. Returns (ok, reason_when_not_ok)."""
+    if cache.exists() and cache.access_token():
+        return (True, "cache_already_warm")
+    read = read_keychain_blob()
+    if not read.ok:
+        return (False, read.error)
+    cache.write(read.blob)
+    return (True, "bootstrapped")
+
+
+async def _run_claude_oneshot(
+    env: dict[str, str],
+    cwd: str,
+    *,
+    timeout: float = REFRESH_ONESHOT_TIMEOUT_SECONDS,
+) -> tuple[Optional[int], str]:
+    """Spawn ``claude --print --max-turns 1 "ok"`` and wait. Returns
+    ``(returncode, error_reason)`` — ``returncode`` is None on
+    failure paths. Always cleans up the subprocess + pipe FDs even on
+    early-return paths (timeout / spawn error)."""
+    if shutil.which("claude") is None:
+        return (None, "claude_binary_missing")
+    proc: asyncio.subprocess.Process | None = None
+    try:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "claude", "--dangerously-skip-permissions",
+                "--print", "--max-turns", "1",
+                "--output-format", "stream-json", "--verbose",
+                "ok",
+                env=env, cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return (None, "claude_binary_missing")
+
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await proc.communicate()
+            except Exception:
+                pass
+            return (None, "refresh_oneshot_timeout")
+        return (proc.returncode, "")
+    finally:
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except (ProcessLookupError, OSError):
+                pass
+
+
+async def refresh_via_oneshot(
+    cache: CredentialCache,
+    shim_dir_path: Path,
+    *,
+    timeout: float = REFRESH_ONESHOT_TIMEOUT_SECONDS,
+) -> tuple[bool, Optional[str]]:
+    """macOS path: run a one-turn ``claude --print`` in a sandbox $HOME
+    seeded from the cache. On exit, Claude has rewritten
+    ``.credentials.json`` with a fresh token; copy it back to the cache.
+
+    Returns (ok, reason_when_not_ok).
+    """
+    if not is_macos():
+        return (False, "not_macos")
+    blob = cache.read()
+    if not blob:
+        return (False, "cache_empty")
+    try:
+        old_token = ((json.loads(blob).get("claudeAiOauth") or {}).get("accessToken")) or ""
+    except json.JSONDecodeError:
+        old_token = ""
+
+    with tempfile.TemporaryDirectory(prefix="puffo-agent-refresh-") as sandbox:
+        sandbox_path = Path(sandbox)
+        sandbox_claude_dir = sandbox_path / ".claude"
+        sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
+        sandbox_creds = sandbox_claude_dir / ".credentials.json"
+        sandbox_creds.write_text(blob, encoding="utf-8")
+
+        env = {
+            **os.environ,
+            "HOME": str(sandbox_path),
+            "USERPROFILE": str(sandbox_path),
+            "CLAUDE_CONFIG_DIR": str(sandbox_claude_dir),
+            "PATH": f"{shim_dir_path}{os.pathsep}{os.environ.get('PATH', '')}",
+        }
+        # Deliberately NO ``CLAUDE_CODE_OAUTH_TOKEN``: we want claude's
+        # native refresh path to engage (read .credentials.json → if
+        # expired refresh against Anthropic → write back). The env-var
+        # mode would bypass storage entirely.
+        rc, err = await _run_claude_oneshot(env, str(sandbox_path), timeout=timeout)
+        if rc is None:
+            return (False, err)
+        if rc != 0:
+            return (False, f"claude_exit_code={rc}")
+
+        try:
+            refreshed = sandbox_creds.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return (False, "refreshed_credentials_missing")
+        try:
+            new_token = (
+                (json.loads(refreshed).get("claudeAiOauth") or {}).get("accessToken")
+            ) or ""
+        except json.JSONDecodeError:
+            return (False, "refreshed_credentials_unparseable")
+
+        cache.write(refreshed)
+        if old_token and new_token and old_token == new_token:
+            return (True, "token_unchanged")
+        return (True, "token_refreshed")

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1572,6 +1572,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print bind address, allowed origins, and pairing status",
     ).set_defaults(func=cmd_api_status)
 
+    # macOS Keychain integration probes (no-op on Linux/Windows).
+    from .diagnostic import register_test_subcommands
+    register_test_subcommands(sub)
+
     return parser
 
 

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -68,10 +68,6 @@ REFRESH_POLL_SECONDS = 120
 REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 
-# Re-export from macos.keychain for callers that want the constant
-# without importing the macos package directly.
-from ..macos.keychain import KEYCHAIN_POLL_INTERVAL_SECONDS  # noqa: E402
-
 
 class RefreshOutcome(enum.Enum):
     """Result of a single backend refresh attempt."""
@@ -151,6 +147,11 @@ class FileBackend:
         ]
         started = time.time()
         try:
+            # cwd=host_home so claude's project-resolution doesn't
+            # drift into the daemon's launch directory (which is
+            # whatever the operator ran `puffo-agent start` from);
+            # the host home is the operator's normal claude
+            # working dir and matches single-process /login UX.
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -467,6 +468,12 @@ class CredentialRefresher:
         rotation. Runs as a sibling task to the main run_loop so the
         two cadences don't entangle (file-expiry poll = 2 min;
         external-rotation poll = 5 min)."""
+        # Lazy import — keeps the platform-agnostic module free of a
+        # hard dependency on the macos package, matching the pattern
+        # used inside ``KeychainBackend`` for every other macos
+        # touchpoint.
+        from ..macos.keychain import KEYCHAIN_POLL_INTERVAL_SECONDS
+
         interval = KEYCHAIN_POLL_INTERVAL_SECONDS
         while not stop_event.is_set():
             try:

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1,56 +1,62 @@
-"""PUF-221: daemon-owned Claude OAuth credential refresh.
+"""Daemon-owned Claude OAuth credential refresh.
 
 Replaces the per-agent ``refresh_ping`` from
 ``agent/adapters/base.py``. Every refresh of the on-disk Claude
-credentials file goes through ONE process — the puffo-agent
-daemon — so Anthropic's single-use refresh-token rotation can't
-be raced by N agent workers all reading the same disk RT and
-burning each other's in-memory copies.
+credentials file goes through ONE process — the puffo-agent daemon —
+so Anthropic's single-use refresh-token rotation can't be raced by N
+agent workers all reading the same disk RT and burning each other's
+in-memory copies.
 
-Implementation: the daemon owns one ``CredentialRefresher``
-instance. Its ``run_loop`` coroutine polls
-``~/.claude/.credentials.json`` every ``REFRESH_POLL_SECONDS``
-and triggers a refresh when ``expiresAt - now <
-REFRESH_SAFETY_MARGIN_SECONDS``, OR when something calls
-``notify_refresh_needed()``. Today's two callers: (a) the
-``puffo-agent agent refresh-token`` CLI subcommand, which drops
-a sentinel file the daemon's reconcile loop forwards into the
-in-process ``asyncio.Event``; (b) the per-worker
-``on_auth_failure`` hook fired from
-``worker._handle_suppressed_reply`` when an auth-class leak is
-detected in a turn reply. The event short-circuits the 2-minute
-poll so an operator- or agent-initiated refresh runs within ~1s.
+Backend abstraction
+-------------------
 
-The refresh itself shells out to ``claude --print "ok"`` with
-``HOME=<host_home>`` — mechanically identical to the cli-docker
-``_run_refresh_oneshot`` pattern that's been proven to work on
-Windows + macOS. Single-writer semantics: the daemon's mutex
-ensures only one ``claude --print`` is in flight at a time, so
-Anthropic's RT rotation can't be observed mid-write by another
-caller.
+The platform-agnostic ``CredentialRefresher`` owns the cross-cutting
+concerns: an ``asyncio.Lock`` (single-writer), an agent home registry,
+the ``_refresh_request`` event (notify_refresh_needed wake), the poll
+loop, and the per-tick fan-out to every registered agent. It delegates
+all platform specifics to a pluggable ``CredentialBackend``:
 
-After every successful refresh (or on every poll, as a safety
-net for the operator running ``claude /login`` externally on the
-device), the refresher fans out
-``state.link_host_credentials(host_home, agent_home)`` to each
-registered agent so per-agent symlinks / copy-mode copies stay
-in sync with the host file.
+  - ``FileBackend`` (Linux / Windows): host file
+    ``~/.claude/.credentials.json`` is the canonical store; refresh
+    spawns ``claude --print`` with ``HOME=host_home`` so the atomic
+    tmp+rename lands at the host file; per-agent sync is a symlink (or
+    copy fallback) via ``link_host_credentials``. External rotation
+    (operator running ``claude /login``) propagates atomically through
+    the symlink — no poll needed.
+  - ``KeychainBackend`` (macOS): Keychain is the canonical store
+    (Claude Code 2.x). The daemon maintains a cache at
+    ``~/.puffo-agent/run/claude-credentials.json``; refresh runs a
+    sandboxed ``claude --print`` so claude rotates the token against
+    Anthropic and writes it back; writeback to Keychain is best-effort
+    so the operator's main CLI / VS Code extension see the new token;
+    per-agent sync is a copy (Keychain ACL is keyed on UID + signing
+    identity, not HOME, so the per-agent HOME trick is moot). An extra
+    5-minute Keychain poll picks up rotations done by OTHER processes
+    (operator's main CLI, an agent's own claude self-refreshing on a
+    401) and fans them to running agents.
 
-Future: a follow-up PUF can replace the subprocess shell-out
-with a direct ``aiohttp.post`` to Anthropic's ``/oauth/token``
-endpoint once the endpoint + request shape are operator-
-verified. The subprocess path is safer to ship first because it
-re-uses the exact mechanism cli-docker already proves works.
+Public API (unchanged from the file-backend-only version):
+
+  - ``register_agent`` / ``unregister_agent`` — agent-home set
+  - ``notify_refresh_needed`` — in-process 401 trigger
+  - ``run_loop`` — the daemon's long-lived coroutine
+  - ``expires_in_seconds`` — diagnostics surface
+
+The refactor is invisible to the daemon's ``daemon.py`` wiring
+beyond the choice of backend at construction time.
 """
 
 from __future__ import annotations
 
 import asyncio
+import enum
 import json
 import logging
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional, Protocol
 
 from .state import link_host_credentials
 
@@ -62,36 +68,71 @@ REFRESH_POLL_SECONDS = 120
 REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 
+# Re-export from macos.keychain for callers that want the constant
+# without importing the macos package directly.
+from ..macos.keychain import KEYCHAIN_POLL_INTERVAL_SECONDS  # noqa: E402
 
-class CredentialRefresher:
-    """Daemon-level Claude credential refresh coordinator."""
 
-    def __init__(self, host_home: Path):
-        self.host_home = host_home
-        self.host_credentials = host_home / ".claude" / ".credentials.json"
-        self._refresh_request = asyncio.Event()
-        self._agent_homes: set[Path] = set()
-        self._lock = asyncio.Lock()
+class RefreshOutcome(enum.Enum):
+    """Result of a single backend refresh attempt."""
+    REFRESHED = "refreshed"
+    UNCHANGED = "unchanged"
+    FAILED = "failed"
 
-    def register_agent(self, agent_home: Path) -> None:
-        """Add an agent home to the view-sync fan-out list. Called
-        when each Worker starts so the daemon knows where to mirror
-        credentials after a refresh."""
-        self._agent_homes.add(Path(agent_home))
 
-    def unregister_agent(self, agent_home: Path) -> None:
-        self._agent_homes.discard(Path(agent_home))
+class CredentialBackend(Protocol):
+    """Platform adapter for credential storage + refresh.
 
-    def notify_refresh_needed(self) -> None:
-        """In-process trigger from an agent that just saw a 401. Wakes
-        the run_loop immediately rather than waiting for the next
-        2-minute poll. Safe to call from any coroutine; idempotent
-        within a single refresh cycle."""
-        self._refresh_request.set()
+    Implementations: ``FileBackend`` (Linux/Windows host file),
+    ``KeychainBackend`` (macOS Keychain + per-agent cache).
+    """
 
     def expires_in_seconds(self) -> int | None:
-        """Seconds until the disk access token expires (negative if
-        past). ``None`` if file unreadable / not OAuth."""
+        """Seconds until the canonical token expires (negative if
+        past). ``None`` if not readable / not OAuth."""
+        ...
+
+    async def refresh(self) -> RefreshOutcome:
+        """Run one refresh attempt. Must not be called concurrently —
+        the ``CredentialRefresher`` holds an ``asyncio.Lock`` around
+        every invocation."""
+        ...
+
+    def sync_to_agent(self, agent_home: Path) -> None:
+        """Mirror the canonical credentials to one agent's per-agent
+        ``.credentials.json``. Called by the refresher's fan-out after
+        every tick (refresh or not) so external rotation propagates."""
+        ...
+
+    async def bootstrap(self) -> tuple[bool, Optional[str]]:
+        """One-time setup at daemon start. ``FileBackend`` is a no-op;
+        ``KeychainBackend`` reads from Keychain to populate the cache
+        and installs the PATH shim."""
+        ...
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FileBackend — Linux / Windows
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class FileBackend:
+    """Host-file-canonical backend used on Linux and Windows. The host
+    ``~/.claude/.credentials.json`` is the single source of truth;
+    every agent's ``<agent_home>/.claude/.credentials.json`` is a
+    symlink (or copy fallback) onto it via ``link_host_credentials``.
+
+    External rotation (operator running ``claude /login``) propagates
+    atomically through the symlink, so no external-poll is needed
+    beyond the refresher's 2-minute ``expires_in`` poll.
+    """
+    host_home: Path
+
+    @property
+    def host_credentials(self) -> Path:
+        return self.host_home / ".claude" / ".credentials.json"
+
+    def expires_in_seconds(self) -> int | None:
         try:
             data = json.loads(self.host_credentials.read_text(encoding="utf-8"))
             expires_ms = int(data["claudeAiOauth"]["expiresAt"])
@@ -99,35 +140,351 @@ class CredentialRefresher:
             return None
         return int(expires_ms / 1000 - time.time())
 
+    async def refresh(self) -> RefreshOutcome:
+        before = self.expires_in_seconds()
+        env = {**os.environ, "HOME": str(self.host_home)}
+        cmd = [
+            "claude", "--dangerously-skip-permissions",
+            "--print", "--max-turns", "1",
+            "--output-format", "stream-json", "--verbose",
+            "ok",
+        ]
+        started = time.time()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                cwd=str(self.host_home),
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=REFRESH_ONESHOT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "credential refresh subprocess timed out after %ds",
+                REFRESH_ONESHOT_TIMEOUT_SECONDS,
+            )
+            return RefreshOutcome.FAILED
+        except FileNotFoundError:
+            logger.warning(
+                "credential refresh: claude binary missing on PATH"
+            )
+            return RefreshOutcome.FAILED
+        elapsed = time.time() - started
+        after = self.expires_in_seconds()
+        if proc.returncode != 0:
+            err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
+            out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
+            logger.warning(
+                "credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
+                proc.returncode, elapsed, out_tail, err_tail,
+            )
+            return RefreshOutcome.FAILED
+        if before is not None and after is not None and after <= before:
+            logger.error(
+                "credential refresh exit=0 but expiresAt didn't advance "
+                "(before=%ds, after=%ds) — claude may not be rewriting "
+                "credentials.json on this build; operator may need "
+                "`claude /login` to recover",
+                before, after,
+            )
+            return RefreshOutcome.UNCHANGED
+        logger.info(
+            "credential refresh ok in %.1fs (expires_in: %s -> %s)",
+            elapsed, before, after,
+        )
+        return RefreshOutcome.REFRESHED
+
+    def sync_to_agent(self, agent_home: Path) -> None:
+        link_host_credentials(self.host_home, agent_home)
+
+    async def bootstrap(self) -> tuple[bool, Optional[str]]:
+        return (True, "host_file_authoritative")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# KeychainBackend — macOS
+# ─────────────────────────────────────────────────────────────────────────────
+
+class KeychainBackend:
+    """macOS backend. The Keychain is the canonical store; the daemon
+    maintains a cache file and propagates rotations to every running
+    agent via per-agent file copies (Keychain ACL is keyed on UID +
+    signing identity, not HOME, so a symlink trick wouldn't help).
+
+    External-rotation poll: every ``KEYCHAIN_POLL_INTERVAL_SECONDS``
+    (5 min), re-read the Keychain (silent after the first
+    "Always Allow" grant) and compare to the last-known blob. On
+    change, write the cache and trigger a fan-out via the refresher's
+    ``notify_refresh_needed`` — this catches rotations performed by
+    the operator's main ``claude`` CLI or an agent's own subprocess
+    self-refreshing on a 401.
+    """
+
+    def __init__(
+        self,
+        home: Path,
+        cache,  # ..macos.keychain.CredentialCache
+        shim_dir: Path,
+    ):
+        self.home = home
+        self.cache = cache
+        self.shim_dir = shim_dir
+        # Last blob propagated to agents — cheap byte-equality key so
+        # the poll loop only fans out on real changes.
+        self._last_propagated_blob: Optional[str] = None
+
+    def expires_in_seconds(self) -> int | None:
+        """Pull expiry from the cache first (hot path; no subprocess).
+        Cache miss → fall back to a Keychain read so the daemon's
+        first-tick decision isn't blocked on bootstrap completion."""
+        # Lazy import to keep the module-level import graph light.
+        from ..macos.keychain import read_keychain_blob
+
+        expires_at = self.cache.expires_at_seconds()
+        if expires_at is not None:
+            return int(expires_at - time.time())
+        # Cache miss — try Keychain. Don't write the cache here; that's
+        # ``bootstrap``'s job. We only want a TTL value.
+        kr = read_keychain_blob()
+        if not kr.ok or not kr.blob:
+            return None
+        try:
+            data = json.loads(kr.blob)
+            ms = int((data.get("claudeAiOauth") or {}).get("expiresAt"))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        # Opportunistically warm the cache so subsequent ticks are fast.
+        try:
+            self.cache.write(kr.blob)
+        except OSError:
+            pass
+        return int(ms / 1000 - time.time())
+
+    async def refresh(self) -> RefreshOutcome:
+        from ..macos.keychain import (
+            refresh_via_oneshot,
+            writeback_to_keychain,
+        )
+
+        before = self.cache.read()
+        ok, reason = await refresh_via_oneshot(self.cache, self.shim_dir)
+        if not ok:
+            logger.warning(
+                "claude credential refresh failed: %s", reason,
+            )
+            return RefreshOutcome.FAILED
+        logger.info("claude credential refresh: %s", reason)
+        after = self.cache.read()
+        if after and after != before:
+            # Push the rotated blob back to Keychain best-effort so the
+            # operator's main CLI / VS Code extension see the new token.
+            wb_ok, wb_reason = writeback_to_keychain(after)
+            if wb_ok:
+                logger.info("claude credential writeback to keychain: ok")
+            else:
+                logger.info(
+                    "claude credential writeback to keychain skipped: %s",
+                    wb_reason,
+                )
+            self._last_propagated_blob = after
+            return RefreshOutcome.REFRESHED
+        return RefreshOutcome.UNCHANGED
+
+    def sync_to_agent(self, agent_home: Path) -> None:
+        """Atomic-write the cache blob to the agent's per-agent
+        ``.credentials.json``. No symlinking — Keychain ACL is on UID
+        + signing identity, not HOME, so a symlink to the host file
+        gives no benefit and the per-agent file diverges anyway when
+        claude self-refreshes inside the agent's process."""
+        blob = self.cache.read()
+        if not blob:
+            return
+        agent_claude = agent_home / ".claude"
+        try:
+            agent_claude.mkdir(parents=True, exist_ok=True)
+            target = agent_claude / ".credentials.json"
+            tmp = agent_claude / f".{target.name}.tmp.{os.getpid()}"
+            tmp.write_text(blob, encoding="utf-8")
+            try:
+                import stat as _stat
+                tmp.chmod(_stat.S_IRUSR | _stat.S_IWUSR)
+            except OSError:
+                pass
+            os.replace(tmp, target)
+        except OSError as exc:
+            logger.warning(
+                "keychain backend: sync to %s failed: %s",
+                agent_home, exc,
+            )
+
+    async def bootstrap(self) -> tuple[bool, Optional[str]]:
+        from ..macos.keychain import (
+            bootstrap_from_keychain,
+            install_path_shim,
+        )
+
+        install_path_shim(self.home)
+        ok, reason = bootstrap_from_keychain(self.cache)
+        if ok:
+            self._last_propagated_blob = self.cache.read()
+        return (ok, reason)
+
+    async def poll_external_rotation(self) -> bool:
+        """Read Keychain and compare to the last-propagated blob.
+        Returns True when a rotation was detected and the cache was
+        updated; the caller (``CredentialRefresher``) then fans the
+        new blob to every registered agent via ``_sync_views``.
+        """
+        from ..macos.keychain import read_keychain_blob
+
+        kr = read_keychain_blob()
+        if not kr.ok or not kr.blob:
+            logger.debug(
+                "keychain poll: read failed (%s); will retry next tick",
+                kr.error,
+            )
+            return False
+        if kr.blob == self._last_propagated_blob:
+            return False
+        self._last_propagated_blob = kr.blob
+        try:
+            self.cache.write(kr.blob)
+        except OSError as exc:
+            logger.warning("keychain poll: cache write failed: %s", exc)
+            return False
+        logger.info("keychain poll: token rotation detected; fanning out")
+        return True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CredentialRefresher — platform-agnostic owner of poll + fan-out
+# ─────────────────────────────────────────────────────────────────────────────
+
+class CredentialRefresher:
+    """Daemon-level Claude credential refresh coordinator.
+
+    Owns the cross-cutting concerns (lock, agent registry, poll loop,
+    fan-out) and delegates platform specifics to a ``CredentialBackend``.
+    """
+
+    def __init__(
+        self,
+        backend: CredentialBackend | None = None,
+        *,
+        host_home: Path | None = None,
+    ):
+        # Backwards-compat shim: callers that pass ``host_home=...``
+        # (the pre-backend constructor signature) get an implicit
+        # ``FileBackend``. This keeps existing tests pinning the
+        # old API working unchanged.
+        if backend is None:
+            if host_home is None:
+                raise TypeError(
+                    "CredentialRefresher requires either `backend` or `host_home`"
+                )
+            backend = FileBackend(host_home=host_home)
+        self.backend = backend
+        # FileBackend exposes the host_home; preserve the attribute so
+        # the existing test ``test_credential_refresher.py`` can read
+        # ``r.host_credentials`` if it wants to.
+        if isinstance(backend, FileBackend):
+            self.host_home = backend.host_home
+            self.host_credentials = backend.host_credentials
+        self._refresh_request = asyncio.Event()
+        self._agent_homes: set[Path] = set()
+        self._lock = asyncio.Lock()
+
+    def register_agent(self, agent_home: Path) -> None:
+        self._agent_homes.add(Path(agent_home))
+
+    def unregister_agent(self, agent_home: Path) -> None:
+        self._agent_homes.discard(Path(agent_home))
+
+    def notify_refresh_needed(self) -> None:
+        """In-process trigger from an agent that just saw a 401."""
+        self._refresh_request.set()
+
+    def expires_in_seconds(self) -> int | None:
+        return self.backend.expires_in_seconds()
+
     async def run_loop(self, stop_event: asyncio.Event) -> None:
         """Main daemon coroutine. Polls every REFRESH_POLL_SECONDS or
-        wakes early when an agent reports a 401."""
+        wakes early when an agent reports a 401. macOS backend also
+        runs an external-rotation poll on its own cadence as a sibling
+        task."""
         logger.info(
-            "credential refresher started (host=%s, poll=%ds, margin=%ds)",
-            self.host_credentials,
+            "credential refresher started (backend=%s, poll=%ds, margin=%ds)",
+            type(self.backend).__name__,
             REFRESH_POLL_SECONDS,
             REFRESH_SAFETY_MARGIN_SECONDS,
         )
+        # Optional bootstrap — primarily for ``KeychainBackend``.
+        try:
+            ok, reason = await self.backend.bootstrap()
+            if not ok:
+                logger.warning(
+                    "credential backend bootstrap reported not-ok: %s", reason,
+                )
+        except Exception as exc:
+            logger.warning("credential backend bootstrap errored: %s", exc)
+
+        # macOS-only sibling task: 5-min external-rotation poll. The
+        # ``CredentialRefresher`` itself stays platform-agnostic; we
+        # detect the capability via duck-typing on the backend so we
+        # don't import the macos module up here.
+        external_poll_task: asyncio.Task | None = None
+        if hasattr(self.backend, "poll_external_rotation"):
+            external_poll_task = asyncio.ensure_future(
+                self._external_rotation_loop(stop_event),
+            )
+
+        try:
+            while not stop_event.is_set():
+                triggered_by_agent = self._refresh_request.is_set()
+                self._refresh_request.clear()
+                try:
+                    await self._tick(triggered_by_agent=triggered_by_agent)
+                except Exception as exc:
+                    logger.warning("credential refresher tick errored: %s", exc)
+                if stop_event.is_set():
+                    break
+                await self._sleep_until_next_tick(stop_event)
+        finally:
+            if external_poll_task is not None:
+                external_poll_task.cancel()
+                try:
+                    await external_poll_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    async def _external_rotation_loop(self, stop_event: asyncio.Event) -> None:
+        """KeychainBackend-only: poll Keychain every
+        ``KEYCHAIN_POLL_INTERVAL_SECONDS``, fan out on detected
+        rotation. Runs as a sibling task to the main run_loop so the
+        two cadences don't entangle (file-expiry poll = 2 min;
+        external-rotation poll = 5 min)."""
+        interval = KEYCHAIN_POLL_INTERVAL_SECONDS
         while not stop_event.is_set():
-            # Capture and clear the agent-trigger atomically so a
-            # notification arriving mid-tick survives to the NEXT
-            # iteration rather than being consumed twice.
-            triggered_by_agent = self._refresh_request.is_set()
-            self._refresh_request.clear()
             try:
-                await self._tick(triggered_by_agent=triggered_by_agent)
-            except Exception as exc:
-                logger.warning("credential refresher tick errored: %s", exc)
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+                return
+            except asyncio.TimeoutError:
+                pass
             if stop_event.is_set():
-                break
-            await self._sleep_until_next_tick(stop_event)
+                return
+            try:
+                rotated = await self.backend.poll_external_rotation()
+            except Exception as exc:
+                logger.warning("external-rotation poll errored: %s", exc)
+                continue
+            if rotated:
+                self._sync_views()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
-        """Wait for poll interval, OR an agent's 401 notification,
-        OR daemon shutdown — whichever fires first. The event itself
-        stays set; the next loop iteration reads + clears it before
-        ``_tick`` so the notification isn't lost between sleep-wake
-        and tick-entry."""
         stop_task = asyncio.create_task(stop_event.wait())
         refresh_task = asyncio.create_task(self._refresh_request.wait())
         try:
@@ -142,7 +499,7 @@ class CredentialRefresher:
 
     async def _tick(self, *, triggered_by_agent: bool = False) -> None:
         """One refresh cycle: check expiry, refresh if needed, sync
-        views regardless so external ``claude /login`` propagates."""
+        views regardless so external rotation propagates."""
         expires_in = self.expires_in_seconds()
         if expires_in is None and not triggered_by_agent:
             self._sync_views()
@@ -152,16 +509,18 @@ class CredentialRefresher:
             and expires_in <= REFRESH_SAFETY_MARGIN_SECONDS
         )
         if should_refresh:
-            await self._refresh_now(expires_in=expires_in, by_agent=triggered_by_agent)
+            await self._refresh_now(
+                expires_in=expires_in, by_agent=triggered_by_agent,
+            )
         self._sync_views()
 
     async def _refresh_now(
         self, *, expires_in: int | None, by_agent: bool,
     ) -> None:
-        """Spawn ``claude --print "ok"`` with HOST_HOME so Claude
-        Code's internal OAuth refresh fires + writes back to disk
-        on exit. Serialized by ``self._lock`` so concurrent triggers
-        don't race."""
+        """Single-writer refresh through the backend. The
+        ``asyncio.Lock`` is what makes the rotating-RT race
+        unwinnable: a second caller can't see an in-flight rotation
+        mid-write."""
         async with self._lock:
             before = self.expires_in_seconds()
             if (
@@ -178,74 +537,16 @@ class CredentialRefresher:
                 "refreshing credentials (expires_in=%s, by_agent=%s)",
                 expires_in, by_agent,
             )
-            env = {**os.environ, "HOME": str(self.host_home)}
-            cmd = [
-                "claude", "--dangerously-skip-permissions",
-                "--print", "--max-turns", "1",
-                "--output-format", "stream-json", "--verbose",
-                "ok",
-            ]
-            started = time.time()
             try:
-                # cwd=host_home so claude's project-resolution doesn't
-                # drift into the daemon's launch directory (which is
-                # whatever the operator ran `puffo-agent start` from);
-                # the host home is the operator's normal claude
-                # working dir and matches single-process /login UX.
-                proc = await asyncio.create_subprocess_exec(
-                    *cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=env,
-                    cwd=str(self.host_home),
-                )
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(),
-                    timeout=REFRESH_ONESHOT_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "credential refresh subprocess timed out after %ds",
-                    REFRESH_ONESHOT_TIMEOUT_SECONDS,
-                )
-                return
-            except FileNotFoundError:
-                logger.warning(
-                    "credential refresh: claude binary missing on PATH"
-                )
-                return
-            elapsed = time.time() - started
-            after = self.expires_in_seconds()
-            if proc.returncode != 0:
-                err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
-                out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
-                logger.warning(
-                    "credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
-                    proc.returncode, elapsed, out_tail, err_tail,
-                )
-                return
-            if before is not None and after is not None and after <= before:
-                logger.error(
-                    "credential refresh exit=0 but expiresAt didn't advance "
-                    "(before=%ds, after=%ds) — claude may not be rewriting "
-                    "credentials.json on this build; operator may need "
-                    "`claude /login` to recover",
-                    before, after,
-                )
-                return
-            logger.info(
-                "credential refresh ok in %.1fs (expires_in: %s -> %s)",
-                elapsed, before, after,
-            )
+                await self.backend.refresh()
+            except Exception as exc:
+                logger.warning("backend refresh errored: %s", exc)
 
     def _sync_views(self) -> None:
-        """Mirror the host credentials to every registered agent's
-        per-agent home. Handles the case where the operator ran
-        ``claude /login`` externally on the device — host file
-        changed, agent views need to catch up."""
+        """Mirror canonical credentials to every registered agent."""
         for agent_home in self._agent_homes:
             try:
-                link_host_credentials(self.host_home, agent_home)
+                self.backend.sync_to_agent(agent_home)
             except Exception as exc:
                 logger.warning(
                     "credential view-sync failed for %s: %s",

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -18,8 +18,13 @@ import time
 
 from pathlib import Path
 
+from ..macos.keychain import CredentialCache, is_macos, shim_dir
 from .api import start_api_server, stop_api_server
-from .credential_refresh import CredentialRefresher
+from .credential_refresh import (
+    CredentialRefresher,
+    FileBackend,
+    KeychainBackend,
+)
 from .data_service import start_data_service, stop_data_service
 from .state import (
     AgentConfig,
@@ -56,9 +61,23 @@ class Daemon:
         # whole reconciler. The worker keeps retrying in the background.
         self._warm_serialise_timeout = 120.0
         # PUF-221: daemon owns Claude OAuth refresh — single writer to
-        # the host .credentials.json so Anthropic's single-use refresh
-        # token rotation can't be raced by N agent workers.
-        self.refresher = CredentialRefresher(host_home=Path.home())
+        # the canonical credential store so Anthropic's single-use
+        # refresh-token rotation can't be raced by N agent workers.
+        # Backend choice is platform-dependent:
+        #   - macOS: Keychain is canonical (Claude Code 2.x); cache +
+        #     PATH shim + per-agent file copies via KeychainBackend.
+        #   - Linux/Windows: host file ``~/.claude/.credentials.json``
+        #     is canonical; agent files are symlinks via FileBackend.
+        if is_macos():
+            home = home_dir()
+            backend = KeychainBackend(
+                home=home,
+                cache=CredentialCache.at(home),
+                shim_dir=shim_dir(home),
+            )
+        else:
+            backend = FileBackend(host_home=Path.home())
+        self.refresher = CredentialRefresher(backend=backend)
 
     async def run(self) -> None:
         logger.info("puffo-agent portal starting; home=%s", home_dir())

--- a/src/puffo_agent/portal/diagnostic.py
+++ b/src/puffo_agent/portal/diagnostic.py
@@ -1,7 +1,7 @@
 """``puffo-agent test ...`` — macOS Keychain integration probes.
 
 Designed to be run by a colleague on a real macOS host so we can
-verify the assumptions baked into ``puffo_agent.macos.credential_manager``
+verify the assumptions baked into ``puffo_agent.macos.keychain``
 *before* promoting v0.9.0a* from TestPyPI to PyPI. Each subcommand:
 
   - Returns a structured ``ProbeReport`` (markdown) on stdout.
@@ -249,6 +249,14 @@ def _run_sandboxed_claude_oneshot(
 
     The sandbox dir must already exist. On timeout / claude missing,
     returncode is -1 and stderr describes the failure mode.
+
+    ⚠️ **Keep in sync with** ``macos.keychain.refresh_via_oneshot`` +
+    ``_run_claude_oneshot``: this probe re-implements the same
+    sandbox-HOME dance (``HOME``/``USERPROFILE``/``CLAUDE_CONFIG_DIR``/
+    PATH-shim + identical claude args) synchronously so the diagnostic
+    can run without an asyncio event loop. The diagnostic's
+    load-bearing value evaporates the moment the two drift, so any env
+    or arg change to the production refresh **must** be mirrored here.
     """
     sandbox_claude_dir = sandbox / ".claude"
     sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
@@ -617,6 +625,14 @@ def probe_keychain_survives_token_env() -> ProbeReport:
     )
 
     def _run_oneshot(path_value: str) -> tuple[int, str]:
+        # The token is briefly visible to ``ps auxe`` (and any other
+        # process in the user's ps namespace) while this claude
+        # subprocess runs. Accepted because this probe's whole
+        # purpose is to reproduce anthropics/claude-code#37512,
+        # which only fires when ``CLAUDE_CODE_OAUTH_TOKEN`` is set
+        # — production refresh paths deliberately do NOT set it.
+        # Run on a personal macOS workstation, not a shared host /
+        # CI runner / dev container.
         env = {
             **os.environ,
             "CLAUDE_CODE_OAUTH_TOKEN": access_token,

--- a/src/puffo_agent/portal/diagnostic.py
+++ b/src/puffo_agent/portal/diagnostic.py
@@ -1,0 +1,856 @@
+"""``puffo-agent test ...`` — macOS Keychain integration probes.
+
+Designed to be run by a colleague on a real macOS host so we can
+verify the assumptions baked into ``puffo_agent.macos.credential_manager``
+*before* promoting v0.9.0a* from TestPyPI to PyPI. Each subcommand:
+
+  - Returns a structured ``ProbeReport`` (markdown) on stdout.
+  - Classifies each step as ``OK`` / ``FAIL`` / ``NEEDS_ATTENTION``.
+  - Redacts secrets aggressively — token strings are shown only as
+    ``len=NNN sha256_prefix=XXXXXXXX``, never raw.
+
+Cross-platform: every subcommand runs everywhere, but non-Darwin hosts
+get a ``skipped: not applicable`` body so Linux/Windows reviewers can
+also sanity-check the output format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from ..macos.keychain import (
+    KEYCHAIN_SERVICE,
+    install_path_shim,
+    is_macos,
+    read_keychain_blob,
+    shim_dir,
+    writeback_to_keychain,
+)
+from .state import home_dir
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Report structure
+# ─────────────────────────────────────────────────────────────────────────────
+
+VERDICT_OK = "OK"
+VERDICT_FAIL = "FAIL"
+VERDICT_NEEDS_ATTENTION = "NEEDS_ATTENTION"
+VERDICT_SKIPPED = "SKIPPED"
+
+
+@dataclass
+class ProbeStep:
+    name: str
+    verdict: str  # one of VERDICT_*
+    detail: str = ""
+
+
+@dataclass
+class ProbeReport:
+    title: str
+    steps: list[ProbeStep] = field(default_factory=list)
+    summary: str = ""
+
+    def add(self, name: str, verdict: str, detail: str = "") -> None:
+        self.steps.append(ProbeStep(name, verdict, detail))
+
+    def overall(self) -> str:
+        if any(s.verdict == VERDICT_FAIL for s in self.steps):
+            return VERDICT_FAIL
+        if any(s.verdict == VERDICT_NEEDS_ATTENTION for s in self.steps):
+            return VERDICT_NEEDS_ATTENTION
+        if all(s.verdict == VERDICT_SKIPPED for s in self.steps):
+            return VERDICT_SKIPPED
+        return VERDICT_OK
+
+    def render_markdown(self) -> str:
+        lines = [f"# {self.title}", ""]
+        lines.append(f"**Overall**: {self.overall()}")
+        lines.append("")
+        lines.append(f"- Platform: `{platform.system()} {platform.release()}`")
+        lines.append(f"- Python: `{sys.version.split()[0]}`")
+        lines.append(f"- claude on PATH: `{shutil.which('claude') or '(none)'}`")
+        lines.append("")
+        for s in self.steps:
+            lines.append(f"## {s.name} — {s.verdict}")
+            if s.detail:
+                lines.append("")
+                lines.append("```")
+                lines.append(s.detail)
+                lines.append("```")
+            lines.append("")
+        if self.summary:
+            lines.append("---")
+            lines.append("")
+            lines.append(f"_{self.summary}_")
+        return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Secret-safe printing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _redact_token(s: str) -> str:
+    """Show length + sha256 prefix, never raw token."""
+    if not s:
+        return "(empty)"
+    digest = hashlib.sha256(s.encode("utf-8")).hexdigest()[:12]
+    return f"len={len(s)} sha256_prefix={digest}"
+
+
+def _summarise_blob(raw: str) -> str:
+    """Pretty-print Claude Code's credential blob with token fields
+    redacted. Output goes to stdout so it MUST be safe to paste."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return f"(invalid JSON, length={len(raw)})"
+    oauth = (data.get("claudeAiOauth") or {}).copy()
+    if "accessToken" in oauth:
+        oauth["accessToken"] = _redact_token(oauth["accessToken"])
+    if "refreshToken" in oauth:
+        oauth["refreshToken"] = _redact_token(oauth["refreshToken"])
+    other_keys = sorted(k for k in data.keys() if k != "claudeAiOauth")
+    pretty = {"claudeAiOauth": oauth, "other_keys": other_keys}
+    return json.dumps(pretty, indent=2, sort_keys=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def probe_keychain_read() -> ProbeReport:
+    """Step 1: can we read the Keychain entry?"""
+    rpt = ProbeReport(title="puffo-agent test keychain-read")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+
+    rpt.add(
+        "command",
+        VERDICT_OK,
+        f"security find-generic-password -s '{KEYCHAIN_SERVICE}' -w",
+    )
+
+    started = time.time()
+    result = read_keychain_blob()
+    elapsed_ms = int((time.time() - started) * 1000)
+
+    if not result.ok:
+        # First-time ACL grant: stderr typically contains "user
+        # interaction is not allowed" if running under a non-TTY parent,
+        # or the result is just slow when the dialog is up.
+        rpt.add(
+            "read",
+            VERDICT_FAIL,
+            f"reason: {result.error}\nstderr: {result.stderr or '(none)'}\n"
+            f"elapsed_ms: {elapsed_ms}",
+        )
+        rpt.summary = (
+            "Reading Keychain failed. If this is the first time, you "
+            "may need to click 'Always Allow' on a system dialog."
+        )
+        return rpt
+
+    rpt.add(
+        "read",
+        VERDICT_OK,
+        f"got blob: {_summarise_blob(result.blob)}\nelapsed_ms: {elapsed_ms}",
+    )
+    rpt.summary = (
+        "Keychain read succeeded. Bootstrap path will work."
+    )
+    return rpt
+
+
+def probe_keychain_write() -> ProbeReport:
+    """Step 2: can we *write* to the Keychain (preserving content)?"""
+    rpt = ProbeReport(title="puffo-agent test keychain-write")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+
+    # Read existing.
+    read_result = read_keychain_blob()
+    if not read_result.ok:
+        rpt.add(
+            "prerequisite-read",
+            VERDICT_FAIL,
+            f"can't read keychain to back up: {read_result.error}; "
+            "run `puffo-agent test keychain-read` first.",
+        )
+        return rpt
+    rpt.add("prerequisite-read", VERDICT_OK, "backup captured in memory")
+
+    # Write the same value back via -U upsert.
+    started = time.time()
+    write_ok, write_reason = writeback_to_keychain(read_result.blob)
+    elapsed_ms = int((time.time() - started) * 1000)
+
+    if not write_ok:
+        rpt.add(
+            "write",
+            VERDICT_NEEDS_ATTENTION,
+            f"writeback failed: {write_reason}\nelapsed_ms: {elapsed_ms}\n"
+            "Daemon will still work — writeback is best-effort; this just "
+            "means user's main CLI won't see refreshed tokens.",
+        )
+        rpt.summary = (
+            "Keychain write was rejected. Operation will degrade "
+            "gracefully — agents still authenticated, but main CLI may "
+            "need re-login after long sessions."
+        )
+        return rpt
+    rpt.add("write", VERDICT_OK, f"elapsed_ms: {elapsed_ms}")
+
+    # Re-read to confirm Keychain entry survives.
+    reread = read_keychain_blob()
+    if not reread.ok:
+        rpt.add(
+            "verify-read",
+            VERDICT_FAIL,
+            f"after write, Keychain read FAILED: {reread.error}",
+        )
+        rpt.summary = "DANGER: write may have corrupted Keychain entry."
+        return rpt
+    if reread.blob == read_result.blob:
+        rpt.add("verify-read", VERDICT_OK, "post-write blob matches pre-write blob")
+        rpt.summary = "Keychain write+read roundtrip works."
+    else:
+        rpt.add(
+            "verify-read",
+            VERDICT_NEEDS_ATTENTION,
+            "post-write blob DIFFERS from pre-write blob — could be a "
+            "concurrent refresh by your main CLI.",
+        )
+        rpt.summary = "Roundtrip OK but content changed — likely benign."
+    return rpt
+
+
+def _run_sandboxed_claude_oneshot(
+    sandbox: Path, blob: str, shim_path: Path,
+) -> tuple[int, str, str, Optional[str]]:
+    """Stage ``blob`` into ``sandbox/.claude/.credentials.json``, run a
+    one-turn ``claude --print``, and return
+    ``(returncode, stdout_tail, stderr_tail, refreshed_blob_or_none)``.
+
+    The sandbox dir must already exist. On timeout / claude missing,
+    returncode is -1 and stderr describes the failure mode.
+    """
+    sandbox_claude_dir = sandbox / ".claude"
+    sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
+    sandbox_creds = sandbox_claude_dir / ".credentials.json"
+    sandbox_creds.write_text(blob, encoding="utf-8")
+
+    env = {
+        **os.environ,
+        "HOME": str(sandbox),
+        "USERPROFILE": str(sandbox),
+        "CLAUDE_CONFIG_DIR": str(sandbox_claude_dir),
+        "PATH": f"{shim_path}{os.pathsep}{os.environ.get('PATH', '')}",
+    }
+
+    try:
+        proc = subprocess.run(
+            [
+                "claude", "--dangerously-skip-permissions",
+                "--print", "--max-turns", "1",
+                "--output-format", "stream-json", "--verbose",
+                "ok",
+            ],
+            env=env, cwd=str(sandbox),
+            capture_output=True, text=True, timeout=90,
+        )
+    except subprocess.TimeoutExpired:
+        return (-1, "", "timeout after 90s", None)
+    except FileNotFoundError:
+        return (-1, "", "claude binary missing", None)
+
+    try:
+        refreshed = sandbox_creds.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        refreshed = None
+
+    return (
+        proc.returncode,
+        (proc.stdout or "")[-300:],
+        (proc.stderr or "")[-500:],
+        refreshed,
+    )
+
+
+def _access_token(blob: str) -> str:
+    try:
+        return (
+            (json.loads(blob).get("claudeAiOauth") or {}).get("accessToken")
+        ) or ""
+    except json.JSONDecodeError:
+        return ""
+
+
+def _force_expiry(blob: str, seconds_in_past: int = 60) -> Optional[str]:
+    """Return a copy of ``blob`` with ``expiresAt`` mutated to
+    ``now - seconds_in_past`` (milliseconds). ``None`` if the blob is
+    unparseable or doesn't have the expected shape."""
+    try:
+        data = json.loads(blob)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data.get("claudeAiOauth"), dict):
+        return None
+    data["claudeAiOauth"]["expiresAt"] = int(
+        (time.time() - seconds_in_past) * 1000,
+    )
+    return json.dumps(data)
+
+
+def probe_refresh_flush() -> ProbeReport:
+    """Step 3: does a sandboxed ``claude --print`` actually flush a
+    refreshed token to its ``.credentials.json``?
+
+    This is the **passive** variant — it stages the current blob and
+    just observes whether claude rotates the token naturally. When the
+    token is still well within its 8h TTL, claude won't rotate
+    (correctly), and we report NEEDS_ATTENTION with a note to rerun
+    with ``puffo-agent test refresh-flush-forced`` for definitive
+    confirmation.
+    """
+    rpt = ProbeReport(title="puffo-agent test refresh-flush")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+    if shutil.which("claude") is None:
+        rpt.add(
+            "prerequisite-claude",
+            VERDICT_FAIL,
+            "`claude` not on PATH — install Claude Code first.",
+        )
+        return rpt
+
+    read_result = read_keychain_blob()
+    if not read_result.ok:
+        rpt.add(
+            "prerequisite-keychain",
+            VERDICT_FAIL,
+            f"keychain read failed: {read_result.error}",
+        )
+        return rpt
+    rpt.add("prerequisite-keychain", VERDICT_OK, "blob in memory")
+
+    home = home_dir()
+    shim_path = install_path_shim(home)
+    old_token = _access_token(read_result.blob)
+
+    with tempfile.TemporaryDirectory(prefix="puffo-agent-test-refresh-") as sandbox:
+        started = time.time()
+        code, _, stderr_tail, refreshed = _run_sandboxed_claude_oneshot(
+            Path(sandbox), read_result.blob, shim_path,
+        )
+        elapsed_ms = int((time.time() - started) * 1000)
+
+        if code != 0:
+            rpt.add(
+                "claude-oneshot",
+                VERDICT_FAIL,
+                f"exit={code}, elapsed_ms={elapsed_ms}\n"
+                f"stderr (last 500): {stderr_tail}",
+            )
+            return rpt
+        rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
+
+        if refreshed is None:
+            rpt.add(
+                "credentials-file",
+                VERDICT_FAIL,
+                "sandbox .credentials.json was DELETED — flush failed",
+            )
+            return rpt
+
+        new_token = _access_token(refreshed)
+        rotated = bool(new_token) and old_token != new_token
+        rpt.add(
+            "credentials-file",
+            VERDICT_OK if rotated else VERDICT_NEEDS_ATTENTION,
+            "token rotated: {}\nold: {}\nnew: {}".format(
+                rotated, _redact_token(old_token), _redact_token(new_token),
+            ),
+        )
+
+    if rotated:
+        rpt.summary = "Refresh flush works — sandbox flush mechanism confirmed."
+    else:
+        rpt.summary = (
+            "Sandbox claude exited OK but the token wasn't rotated — "
+            "current token is still valid, so claude correctly skipped "
+            "the OAuth round-trip. To definitively confirm refresh-"
+            "on-expiry, run `puffo-agent test refresh-flush-forced` "
+            "(which mutates expiresAt to force the refresh path)."
+        )
+    return rpt
+
+
+def probe_refresh_flush_forced() -> ProbeReport:
+    """Step 3b (opt-in): force the refresh code path by mutating the
+    cached blob's ``expiresAt`` to a past timestamp.
+
+    **Has real side effects:** Anthropic rotates the refresh_token on
+    every successful refresh, so the user's pre-probe refresh_token is
+    invalidated as soon as claude succeeds. We write the freshly-issued
+    blob back to the Keychain so the user's main CLI / VS Code
+    extension stays authenticated. If that writeback fails, the user
+    is left in a degraded state where their main CLI will need a re-
+    login (the new tokens still live in our run-dir cache, but main
+    CLI doesn't know about them).
+
+    Designed for occasional manual verification, NOT for every
+    deploy. The natural ``refresh-flush`` is the everyday probe.
+    """
+    rpt = ProbeReport(title="puffo-agent test refresh-flush-forced")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+    if shutil.which("claude") is None:
+        rpt.add(
+            "prerequisite-claude",
+            VERDICT_FAIL,
+            "`claude` not on PATH — install Claude Code first.",
+        )
+        return rpt
+
+    read_result = read_keychain_blob()
+    if not read_result.ok:
+        rpt.add(
+            "prerequisite-keychain",
+            VERDICT_FAIL,
+            f"keychain read failed: {read_result.error}",
+        )
+        return rpt
+    rpt.add(
+        "prerequisite-keychain",
+        VERDICT_OK,
+        "original blob captured (will write back at the end to keep "
+        "main CLI alive)",
+    )
+
+    mutated = _force_expiry(read_result.blob, seconds_in_past=60)
+    if mutated is None:
+        rpt.add(
+            "force-expiry",
+            VERDICT_FAIL,
+            "could not mutate blob — unexpected shape; aborting "
+            "before doing anything destructive",
+        )
+        return rpt
+    rpt.add(
+        "force-expiry",
+        VERDICT_OK,
+        "set claudeAiOauth.expiresAt = now - 60s in sandbox copy "
+        "(Keychain entry untouched until writeback step)",
+    )
+
+    home = home_dir()
+    shim_path = install_path_shim(home)
+    old_token = _access_token(read_result.blob)
+
+    with tempfile.TemporaryDirectory(
+        prefix="puffo-agent-test-refresh-forced-",
+    ) as sandbox:
+        started = time.time()
+        code, _, stderr_tail, refreshed = _run_sandboxed_claude_oneshot(
+            Path(sandbox), mutated, shim_path,
+        )
+        elapsed_ms = int((time.time() - started) * 1000)
+
+        if code != 0:
+            rpt.add(
+                "claude-oneshot",
+                VERDICT_FAIL,
+                f"exit={code}, elapsed_ms={elapsed_ms}\n"
+                f"stderr (last 500): {stderr_tail}",
+            )
+            rpt.summary = (
+                "Forced refresh failed before completing. Anthropic "
+                "side-effect did not happen — Keychain untouched."
+            )
+            return rpt
+        rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
+
+        if refreshed is None:
+            rpt.add(
+                "credentials-file",
+                VERDICT_FAIL,
+                "sandbox .credentials.json was DELETED — flush failed",
+            )
+            return rpt
+
+        new_token = _access_token(refreshed)
+        rotated = bool(new_token) and old_token != new_token
+        rpt.add(
+            "credentials-file",
+            VERDICT_OK if rotated else VERDICT_FAIL,
+            "token rotated: {}\nold: {}\nnew: {}\n{}".format(
+                rotated,
+                _redact_token(old_token),
+                _redact_token(new_token),
+                (
+                    "claude saw the past expiresAt and refreshed."
+                    if rotated else
+                    "claude did NOT rotate despite forced expiry — "
+                    "the refresh code path is broken or behind a flag "
+                    "we don't set."
+                ),
+            ),
+        )
+
+        if not rotated:
+            rpt.summary = (
+                "Forced expiry did not trigger refresh. Investigate "
+                "before promoting — `refresh_via_oneshot` will silently "
+                "no-op in production."
+            )
+            return rpt
+
+        # Critical: writeback the freshly-rotated blob to Keychain so
+        # the user's main CLI doesn't get stranded with an invalid
+        # refresh_token. Anthropic invalidated the original
+        # refresh_token the moment they issued the new one.
+        wb_ok, wb_reason = writeback_to_keychain(refreshed)
+        if wb_ok:
+            rpt.add(
+                "keychain-writeback",
+                VERDICT_OK,
+                "freshly-rotated tokens written back to Keychain; "
+                "main CLI / VS Code extension will see them on next "
+                "use",
+            )
+            rpt.summary = (
+                "Forced refresh succeeded end-to-end: claude rotated "
+                "the token AND we synced the new value back to "
+                "Keychain. `refresh_via_oneshot` will work as "
+                "designed in production."
+            )
+        else:
+            rpt.add(
+                "keychain-writeback",
+                VERDICT_NEEDS_ATTENTION,
+                f"writeback failed: {wb_reason}\n"
+                "Main CLI's view of the credentials is now STALE. "
+                "Run `puffo-agent test keychain-write` to diagnose; "
+                "user may need to re-login via `claude` in a terminal "
+                "to recover.",
+            )
+            rpt.summary = (
+                "Forced refresh worked but writeback to Keychain "
+                "failed. Main CLI is now in a degraded state and may "
+                "need a manual re-login."
+            )
+
+    return rpt
+
+
+def probe_keychain_survives_token_env() -> ProbeReport:
+    """Step 4: does Claude Code still delete the Keychain entry when
+    ``CLAUDE_CODE_OAUTH_TOKEN`` is set? Reproduces github issue #37512.
+
+    If this comes back FAIL, the daemon MUST use the PATH shim to
+    block the deletion call (which it does by default).
+    """
+    rpt = ProbeReport(title="puffo-agent test keychain-survives-token-env")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+    if shutil.which("claude") is None:
+        rpt.add(
+            "prerequisite-claude",
+            VERDICT_FAIL,
+            "`claude` not on PATH — install Claude Code first.",
+        )
+        return rpt
+
+    pre = read_keychain_blob()
+    if not pre.ok:
+        rpt.add(
+            "prerequisite-keychain",
+            VERDICT_FAIL,
+            f"keychain read failed before probe: {pre.error}",
+        )
+        return rpt
+    rpt.add("prerequisite-keychain", VERDICT_OK, "Keychain entry exists pre-probe")
+
+    try:
+        access_token = (
+            (json.loads(pre.blob).get("claudeAiOauth") or {}).get("accessToken")
+        ) or ""
+    except json.JSONDecodeError:
+        rpt.add(
+            "prerequisite-keychain",
+            VERDICT_FAIL,
+            "Keychain blob is invalid JSON",
+        )
+        return rpt
+
+    home = home_dir()
+    shim_path = install_path_shim(home)
+
+    # First sub-probe: WITHOUT shim (baseline — should reproduce bug).
+    rpt.add(
+        "approach",
+        VERDICT_OK,
+        "Will run two claude oneshots back-to-back:\n"
+        "  A) PATH=$PATH (no shim), CLAUDE_CODE_OAUTH_TOKEN set\n"
+        "  B) PATH=<shim>:$PATH, CLAUDE_CODE_OAUTH_TOKEN set\n"
+        "Re-reads keychain after each. We expect A to delete (or be a\n"
+        "no-op if Anthropic fixed #37512), and B to never delete.",
+    )
+
+    def _run_oneshot(path_value: str) -> tuple[int, str]:
+        env = {
+            **os.environ,
+            "CLAUDE_CODE_OAUTH_TOKEN": access_token,
+            "PATH": path_value,
+        }
+        try:
+            proc = subprocess.run(
+                [
+                    "claude", "--dangerously-skip-permissions",
+                    "--print", "--max-turns", "1",
+                    "--output-format", "stream-json", "--verbose",
+                    "ok",
+                ],
+                env=env, capture_output=True, text=True, timeout=60,
+            )
+            return (proc.returncode, (proc.stderr or "")[-300:])
+        except subprocess.TimeoutExpired:
+            return (-1, "timeout")
+
+    # A: without shim
+    code_a, stderr_a = _run_oneshot(os.environ.get("PATH", ""))
+    post_a = read_keychain_blob()
+    if post_a.ok:
+        rpt.add(
+            "without-shim",
+            VERDICT_OK,
+            f"claude exit={code_a}; Keychain entry STILL PRESENT — "
+            "Anthropic may have fixed #37512, OR the deletion path "
+            "didn't trigger in this particular invocation.",
+        )
+    else:
+        rpt.add(
+            "without-shim",
+            VERDICT_NEEDS_ATTENTION,
+            f"claude exit={code_a}; Keychain entry DELETED after run "
+            f"(reason: {post_a.error})\nstderr tail: {stderr_a}\n"
+            "This reproduces #37512 — restoring entry before next "
+            "sub-probe.",
+        )
+        # Restore so the user doesn't lose their main-CLI auth.
+        writeback_to_keychain(pre.blob)
+
+    # B: with shim
+    code_b, stderr_b = _run_oneshot(
+        f"{shim_path}{os.pathsep}{os.environ.get('PATH', '')}"
+    )
+    post_b = read_keychain_blob()
+    if post_b.ok:
+        rpt.add(
+            "with-shim",
+            VERDICT_OK,
+            f"claude exit={code_b}; Keychain entry preserved. "
+            "Shim is doing its job.",
+        )
+    else:
+        rpt.add(
+            "with-shim",
+            VERDICT_FAIL,
+            f"claude exit={code_b}; Keychain entry DELETED EVEN WITH "
+            f"SHIM (reason: {post_b.error})\nstderr tail: {stderr_b}\n"
+            "The shim is NOT being honoured — check PATH ordering.",
+        )
+        writeback_to_keychain(pre.blob)
+
+    # Verdict summary.
+    pre_lost = not post_a.ok and not post_b.ok
+    if pre_lost:
+        rpt.summary = (
+            "Critical: shim did not protect Keychain. Investigate before "
+            "shipping."
+        )
+    elif not post_a.ok:
+        rpt.summary = (
+            "Bug #37512 still present in this Claude Code version; "
+            "shim protects against it. Ship-ready."
+        )
+    else:
+        rpt.summary = (
+            "Could not reproduce #37512 in this run. Shim is harmless "
+            "to leave in place; we keep it for safety against re-"
+            "regression."
+        )
+    return rpt
+
+
+def probe_full() -> ProbeReport:
+    """Run every probe end-to-end and return a single combined report."""
+    rpt = ProbeReport(title="puffo-agent test full-probe")
+    rpt.add(
+        "environment",
+        VERDICT_OK,
+        f"home_dir: {home_dir()}\nclaude: {shutil.which('claude')}\n"
+        f"shim_dir: {shim_dir(home_dir())}",
+    )
+
+    sub_reports = [
+        probe_keychain_read(),
+        probe_keychain_write(),
+        probe_refresh_flush(),
+        probe_keychain_survives_token_env(),
+    ]
+    for sub in sub_reports:
+        verdict = sub.overall()
+        rpt.add(
+            sub.title,
+            verdict,
+            "\n".join(f"  [{s.verdict}] {s.name}" for s in sub.steps)
+            + (f"\n\nsummary: {sub.summary}" if sub.summary else ""),
+        )
+
+    overall = rpt.overall()
+    if overall == VERDICT_OK:
+        rpt.summary = "All probes green. Ship 0.9.0 to PyPI."
+    elif overall == VERDICT_NEEDS_ATTENTION:
+        rpt.summary = (
+            "Some probes flagged NEEDS_ATTENTION — review each item "
+            "before promoting from TestPyPI."
+        )
+    else:
+        rpt.summary = "At least one probe FAILED. Do not promote."
+    return rpt
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI plumbing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _print_report(rpt: ProbeReport, *, save_to: Optional[Path] = None) -> int:
+    body = rpt.render_markdown()
+    print(body)
+    if save_to is not None:
+        try:
+            save_to.parent.mkdir(parents=True, exist_ok=True)
+            save_to.write_text(body, encoding="utf-8")
+            print(f"\n(report also saved to {save_to})")
+        except OSError as exc:
+            print(f"\n(warning: could not save report to {save_to}: {exc})")
+    return 0 if rpt.overall() in (VERDICT_OK, VERDICT_SKIPPED) else 1
+
+
+def cmd_test_keychain_read(args: argparse.Namespace) -> int:
+    return _print_report(probe_keychain_read())
+
+
+def cmd_test_keychain_write(args: argparse.Namespace) -> int:
+    return _print_report(probe_keychain_write())
+
+
+def cmd_test_refresh_flush(args: argparse.Namespace) -> int:
+    return _print_report(probe_refresh_flush())
+
+
+def cmd_test_refresh_flush_forced(args: argparse.Namespace) -> int:
+    if not getattr(args, "yes", False):
+        print(
+            "This probe rotates your real OAuth refresh_token by "
+            "mutating expiresAt and forcing Claude to refresh. Anthropic "
+            "invalidates the prior refresh_token on success; we write "
+            "the new value back to your Keychain to keep your main CLI "
+            "alive, but writeback can fail.\n\n"
+            "Re-run with `--yes` to acknowledge.",
+            file=sys.stderr,
+        )
+        return 2
+    return _print_report(probe_refresh_flush_forced())
+
+
+def cmd_test_keychain_survives_token_env(
+    args: argparse.Namespace,
+) -> int:
+    return _print_report(probe_keychain_survives_token_env())
+
+
+def cmd_test_full_probe(args: argparse.Namespace) -> int:
+    save_to = home_dir() / "probe-report.md"
+    return _print_report(probe_full(), save_to=save_to)
+
+
+def register_test_subcommands(sub) -> None:
+    """Wire the ``test`` command tree onto an argparse subparsers
+    object. Called from ``portal/cli.py``'s ``build_parser``.
+    """
+    test = sub.add_parser(
+        "test",
+        help="Diagnostic probes for macOS Keychain credential management",
+        description=(
+            "Run probes to validate the assumptions used by the "
+            "macOS-side claude credential manager. Designed to be run "
+            "by macOS users on a real host; non-Darwin platforms get "
+            "SKIPPED for each probe."
+        ),
+    )
+    test_sub = test.add_subparsers(dest="test_cmd", required=True)
+
+    test_sub.add_parser(
+        "keychain-read",
+        help="Check that `security find-generic-password` succeeds.",
+    ).set_defaults(func=cmd_test_keychain_read)
+
+    test_sub.add_parser(
+        "keychain-write",
+        help="Check `security add-generic-password -U` upsert works.",
+    ).set_defaults(func=cmd_test_keychain_write)
+
+    test_sub.add_parser(
+        "refresh-flush",
+        help="Run a sandboxed `claude --print` and check that the "
+        "OAuth token is rotated on the way out (passive; expects "
+        "current token to still be valid).",
+    ).set_defaults(func=cmd_test_refresh_flush)
+
+    forced = test_sub.add_parser(
+        "refresh-flush-forced",
+        help="Force the refresh code path by mutating the cached "
+        "blob's expiresAt to a past timestamp. HAS SIDE EFFECTS: "
+        "rotates the user's real refresh_token; requires --yes.",
+    )
+    forced.add_argument(
+        "--yes",
+        action="store_true",
+        help="Acknowledge that this probe will rotate your real "
+        "OAuth refresh_token.",
+    )
+    forced.set_defaults(func=cmd_test_refresh_flush_forced)
+
+    test_sub.add_parser(
+        "keychain-survives-token-env",
+        help="Reproduce GitHub issue #37512: does setting "
+        "CLAUDE_CODE_OAUTH_TOKEN delete the Keychain entry? Verify the "
+        "shim protects against it.",
+    ).set_defaults(func=cmd_test_keychain_survives_token_env)
+
+    test_sub.add_parser(
+        "full-probe",
+        help="Run every probe end-to-end and write a single "
+        "report to ~/.puffo-agent/probe-report.md.",
+    ).set_defaults(func=cmd_test_full_probe)

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -1,0 +1,692 @@
+"""Tests for ``puffo_agent.macos.keychain`` + the macOS-side
+``KeychainBackend`` plugged into ``CredentialRefresher``.
+
+We can't actually call the macOS ``security`` binary on a Linux / CI
+runner, so the keychain primitives are exercised via
+``subprocess.run`` / ``asyncio.create_subprocess_exec`` monkey-patches.
+The cache, shim, refresh-oneshot, and the end-to-end refresher fan-out
+are real code paths that run on every platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.macos import keychain as cm
+from puffo_agent.portal import credential_refresh as cr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+_BLOB = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-original-access",
+        "refreshToken": "rt-original",
+        "expiresAt": 9_999_999_000,
+    },
+})
+
+_REFRESHED_BLOB = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-NEW-access",
+        "refreshToken": "rt-new",
+        "expiresAt": 9_999_999_500,
+    },
+})
+
+
+def _force_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+
+
+def _disable_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CredentialCache
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_cache_write_then_read_roundtrip(tmp_path):
+    cache = cm.CredentialCache.at(tmp_path)
+    assert cache.read() is None
+    cache.write(_BLOB)
+    assert cache.read() == _BLOB
+    assert cache.access_token() == "sk-ant-original-access"
+
+
+def test_cache_write_is_atomic(tmp_path):
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+    assert cache.path.exists()
+    cache.write(_REFRESHED_BLOB)
+    # No leftover tmp files.
+    siblings = list(cache.path.parent.glob(".claude-credentials.json.tmp.*"))
+    assert siblings == []
+    assert cache.read() == _REFRESHED_BLOB
+
+
+def test_cache_access_token_handles_malformed_blob(tmp_path):
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.path.parent.mkdir(parents=True, exist_ok=True)
+    cache.path.write_text("not json {", encoding="utf-8")
+    assert cache.access_token() is None
+    assert cache.expires_at_seconds() is None
+
+
+def test_cache_expires_at_seconds(tmp_path):
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+    assert cache.expires_at_seconds() == 9_999_999.000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PATH shim
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_install_path_shim_writes_executable(tmp_path):
+    d = cm.install_path_shim(tmp_path)
+    binary = d / "security"
+    assert binary.exists()
+    body = binary.read_text(encoding="utf-8")
+    assert body.startswith("#!/bin/bash")
+    assert "delete-generic-password" in body
+    assert "Claude Code-credentials" in body
+    assert "/usr/bin/security" in body
+
+
+def test_install_path_shim_overwrites_existing(tmp_path):
+    d = cm.install_path_shim(tmp_path)
+    (d / "security").write_text("# manually edited", encoding="utf-8")
+    cm.install_path_shim(tmp_path)
+    assert "#!/bin/bash" in (d / "security").read_text(encoding="utf-8")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Keychain primitives — mocked subprocess
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_read_keychain_blob_success(monkeypatch):
+    _force_macos(monkeypatch)
+
+    def _fake_run(cmd, **kwargs):
+        assert cmd[0] == "security"
+        assert "find-generic-password" in cmd
+        assert "Claude Code-credentials" in cmd
+        return _FakeCompletedProcess(0, stdout=_BLOB)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = cm.read_keychain_blob()
+    assert result.ok is True
+    assert result.blob == _BLOB
+
+
+def test_read_keychain_blob_invalid_json(monkeypatch):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout="not a json"),
+    )
+    result = cm.read_keychain_blob()
+    assert result.ok is False
+    assert "invalid_json" in result.error
+
+
+def test_read_keychain_blob_nonzero_exit(monkeypatch):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(44, stderr="entry not found"),
+    )
+    result = cm.read_keychain_blob()
+    assert result.ok is False
+    assert "exit_code=44" in result.error
+    assert result.stderr == "entry not found"
+
+
+def test_read_keychain_blob_skipped_off_macos(monkeypatch):
+    _disable_macos(monkeypatch)
+    result = cm.read_keychain_blob()
+    assert result.ok is False
+    assert result.error == "not_macos"
+
+
+def test_writeback_to_keychain_passes_blob(monkeypatch):
+    _force_macos(monkeypatch)
+    captured = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeCompletedProcess(0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ok, reason = cm.writeback_to_keychain(_BLOB)
+    assert ok is True
+    assert reason is None
+    assert "add-generic-password" in captured["cmd"]
+    assert "-U" in captured["cmd"]
+    assert _BLOB in captured["cmd"]
+
+
+def test_writeback_to_keychain_reports_failure(monkeypatch):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(1, stderr="permission denied"),
+    )
+    ok, reason = cm.writeback_to_keychain(_BLOB)
+    assert ok is False
+    assert "permission denied" in reason
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bootstrap
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_bootstrap_writes_cache(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout=_BLOB),
+    )
+    cache = cm.CredentialCache.at(tmp_path)
+    ok, reason = cm.bootstrap_from_keychain(cache)
+    assert ok is True
+    assert reason == "bootstrapped"
+    assert cache.read() == _BLOB
+
+
+def test_bootstrap_skips_when_cache_warm(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+
+    def _fake_run(*a, **k):
+        raise AssertionError("should not have run security")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ok, reason = cm.bootstrap_from_keychain(cache)
+    assert ok is True
+    assert reason == "cache_already_warm"
+
+
+def test_bootstrap_propagates_read_error(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(44, stderr="missing"),
+    )
+    cache = cm.CredentialCache.at(tmp_path)
+    ok, reason = cm.bootstrap_from_keychain(cache)
+    assert ok is False
+    assert "exit_code=44" in reason
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Refresh oneshot — subprocess mocked
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _FakeAsyncProc:
+    def __init__(self, returncode: int):
+        self.returncode = returncode
+
+    async def communicate(self):
+        return (b"", b"")
+
+    def kill(self):
+        pass
+
+
+def test_refresh_via_oneshot_rotates_token(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+
+    sandbox_seen = {}
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        sandbox_seen["cwd"] = cwd
+        sandbox_seen["env"] = env
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is True
+    assert reason == "token_refreshed"
+    assert cache.access_token() == "sk-ant-NEW-access"
+    # Must NOT set CLAUDE_CODE_OAUTH_TOKEN — that env var triggers the
+    # bug #37512 Keychain-delete path on exit.
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in (sandbox_seen.get("env") or {})
+    # PATH must include the shim dir.
+    path_val = (sandbox_seen.get("env") or {}).get("PATH", "")
+    assert str(tmp_path / "shim") in path_val
+
+
+def test_refresh_via_oneshot_token_unchanged(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_BLOB, encoding="utf-8")
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is True
+    assert reason == "token_unchanged"
+
+
+def test_refresh_via_oneshot_handles_claude_exit_failure(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        return _FakeAsyncProc(1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is False
+    assert reason == "claude_exit_code=1"
+
+
+def test_refresh_via_oneshot_skipped_off_macos(monkeypatch, tmp_path):
+    _disable_macos(monkeypatch)
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is False
+    assert reason == "not_macos"
+
+
+def test_refresh_via_oneshot_skipped_when_claude_missing(monkeypatch, tmp_path):
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: None)
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is False
+    assert reason == "claude_binary_missing"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# KeychainBackend — plugged into CredentialRefresher
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_keychain_backend(home: Path) -> cr.KeychainBackend:
+    cache = cm.CredentialCache.at(home)
+    return cr.KeychainBackend(
+        home=home, cache=cache, shim_dir=home / "run" / "keychain-shim",
+    )
+
+
+def test_keychain_backend_bootstrap_installs_shim_and_reads_keychain(
+    monkeypatch, tmp_path,
+):
+    """``bootstrap`` should populate the cache from Keychain and
+    install the PATH shim. The refresher calls this once on
+    daemon-loop entry."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout=_BLOB),
+    )
+    backend = _make_keychain_backend(tmp_path)
+    ok, reason = asyncio.run(backend.bootstrap())
+    assert ok is True
+    assert reason == "bootstrapped"
+    # Cache materialised from the Keychain.
+    assert backend.cache.read() == _BLOB
+    # Shim installed.
+    assert (tmp_path / "run" / "keychain-shim" / "security").exists()
+    # Internal last-propagated marker populated so the external-poll
+    # loop has a baseline to diff against.
+    assert backend._last_propagated_blob == _BLOB
+
+
+def test_keychain_backend_expires_in_seconds_uses_cache(tmp_path, monkeypatch):
+    """Hot path: cache hit returns expiry without spawning a
+    subprocess."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    import time as _time
+    far_future_blob = json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "x",
+            "refreshToken": "y",
+            "expiresAt": int((_time.time() + 3600) * 1000),  # +1h
+        },
+    })
+    backend.cache.write(far_future_blob)
+    ttl = backend.expires_in_seconds()
+    assert ttl is not None
+    assert ttl > 0
+    assert 3590 <= ttl <= 3610
+
+
+def test_keychain_backend_expires_in_seconds_falls_back_to_keychain(
+    monkeypatch, tmp_path,
+):
+    """Cache miss → Keychain read → opportunistically warms cache."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout=_BLOB),
+    )
+    backend = _make_keychain_backend(tmp_path)
+    assert backend.cache.read() is None
+    ttl = backend.expires_in_seconds()
+    assert ttl is not None
+    # Side effect: cache now warm.
+    assert backend.cache.read() == _BLOB
+
+
+def test_keychain_backend_sync_to_agent_writes_per_agent_file(tmp_path, monkeypatch):
+    """The macOS sync path is a copy, not a symlink — Keychain ACL is
+    keyed on UID + signing identity, not HOME, so symlinking the
+    daemon cache into agent dirs gives no benefit (and would diverge
+    anyway when claude self-refreshes inside the agent process)."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+    agent_home = tmp_path / "agent-a"
+    agent_home.mkdir()
+    backend.sync_to_agent(agent_home)
+    agent_creds = agent_home / ".claude" / ".credentials.json"
+    assert agent_creds.exists()
+    assert not agent_creds.is_symlink()
+    assert agent_creds.read_text() == _BLOB
+
+
+def test_keychain_backend_sync_skips_when_cache_empty(tmp_path, monkeypatch):
+    """No cache → no per-agent file written. Avoids stamping an
+    empty-string file that claude would later read as "no auth"."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    agent_home = tmp_path / "agent-a"
+    agent_home.mkdir()
+    backend.sync_to_agent(agent_home)
+    assert not (agent_home / ".claude" / ".credentials.json").exists()
+
+
+def test_keychain_backend_refresh_returns_refreshed_on_token_rotation(
+    monkeypatch, tmp_path,
+):
+    """Backend refresh: cache → refresh oneshot → cache write →
+    writeback to Keychain (best-effort). Returns REFRESHED when the
+    access token actually rotated."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    writeback_calls: list = []
+
+    def _fake_writeback(blob, timeout=cm.SECURITY_TIMEOUT_SECONDS):
+        writeback_calls.append(blob)
+        return (True, None)
+
+    monkeypatch.setattr(cm, "writeback_to_keychain", _fake_writeback)
+
+    outcome = asyncio.run(backend.refresh())
+    assert outcome == cr.RefreshOutcome.REFRESHED
+    assert backend.cache.access_token() == "sk-ant-NEW-access"
+    assert writeback_calls == [_REFRESHED_BLOB]
+    assert backend._last_propagated_blob == _REFRESHED_BLOB
+
+
+def test_keychain_backend_refresh_returns_unchanged_when_token_stays(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_BLOB, encoding="utf-8")  # same blob back
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    outcome = asyncio.run(backend.refresh())
+    assert outcome == cr.RefreshOutcome.UNCHANGED
+
+
+def test_keychain_backend_refresh_returns_failed_on_claude_exit_failure(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        return _FakeAsyncProc(1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    outcome = asyncio.run(backend.refresh())
+    assert outcome == cr.RefreshOutcome.FAILED
+
+
+def test_keychain_backend_poll_external_rotation_detects_change(
+    monkeypatch, tmp_path,
+):
+    """Operator runs ``claude /login`` (or an agent's own claude
+    self-refreshes on 401) → Keychain has a new blob → poll returns
+    True so the refresher fans out to every running agent."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    backend._last_propagated_blob = _BLOB
+    backend.cache.write(_BLOB)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            True, _REFRESHED_BLOB, None, None,
+        ),
+    )
+    rotated = asyncio.run(backend.poll_external_rotation())
+    assert rotated is True
+    assert backend.cache.read() == _REFRESHED_BLOB
+    assert backend._last_propagated_blob == _REFRESHED_BLOB
+
+
+def test_keychain_backend_poll_external_rotation_no_change_returns_false(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    backend._last_propagated_blob = _BLOB
+    backend.cache.write(_BLOB)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            True, _BLOB, None, None,
+        ),
+    )
+    rotated = asyncio.run(backend.poll_external_rotation())
+    assert rotated is False
+
+
+def test_keychain_backend_poll_external_rotation_swallows_read_failure(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "security_timeout", None,
+        ),
+    )
+    rotated = asyncio.run(backend.poll_external_rotation())
+    assert rotated is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# End-to-end: CredentialRefresher + KeychainBackend fan-out
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_refresher_with_keychain_backend_fans_sync_to_registered_agents(
+    monkeypatch, tmp_path,
+):
+    """After a _tick on macOS, the refresher's fan-out calls
+    KeychainBackend.sync_to_agent for every registered agent — same
+    contract as the FileBackend's link_host_credentials path, just
+    plumbed through the backend abstraction."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+    refresher = cr.CredentialRefresher(backend=backend)
+
+    agent_a = tmp_path / "agent-a"
+    agent_b = tmp_path / "agent-b"
+    refresher.register_agent(agent_a)
+    refresher.register_agent(agent_b)
+
+    asyncio.run(refresher._tick())
+
+    assert (agent_a / ".claude" / ".credentials.json").read_text() == _BLOB
+    assert (agent_b / ".claude" / ".credentials.json").read_text() == _BLOB
+
+
+def test_refresher_with_keychain_backend_refreshes_when_close_to_expiry(
+    monkeypatch, tmp_path,
+):
+    """Cache blob expiring soon → refresher triggers
+    backend.refresh()."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+    backend = _make_keychain_backend(tmp_path)
+    # Seed with a blob expiring in 1 minute (well inside the 10-min margin).
+    import time as _time
+    soon_expiry = int((_time.time() + 60) * 1000)
+    near_expiry_blob = json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "soon-expiry",
+            "refreshToken": "rt",
+            "expiresAt": soon_expiry,
+        },
+    })
+    backend.cache.write(near_expiry_blob)
+
+    spawned: list = []
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        spawned.append(env)
+        # Pretend claude wrote a rotated blob.
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    monkeypatch.setattr(cm, "writeback_to_keychain", lambda *a, **k: (True, None))
+
+    refresher = cr.CredentialRefresher(backend=backend)
+    asyncio.run(refresher._tick())
+    assert spawned, "backend.refresh should have run claude --print"
+    # Refresh ran inside a sandbox HOME (not the operator's), so HOME
+    # must be a tempdir, not host_home.
+    env = spawned[0]
+    assert "HOME" in env
+    assert env["HOME"] != str(Path.home())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FD-leak regression — timeout path drains pipes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_timeout_path_kills_proc_and_drains_pipes(monkeypatch, tmp_path):
+    """The previous timeout path returned without awaiting proc.wait()
+    + pipe close, leaking 3 FDs (stdin/stdout/stderr) per timed-out
+    refresh. Under multi-agent load this surfaced as ``[Errno 24]
+    Too many open files``. Verify the helper kills + drains."""
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+
+    kill_called = {"value": False}
+    drain_calls = {"value": 0}
+
+    class _HangingProc:
+        returncode = None  # alive
+
+        async def communicate(self):
+            if drain_calls["value"] == 0:
+                drain_calls["value"] += 1
+                await asyncio.sleep(60)
+                return (b"", b"")
+            drain_calls["value"] += 1
+            self.returncode = -9
+            return (b"", b"")
+
+        def kill(self):
+            kill_called["value"] = True
+
+        async def wait(self):
+            self.returncode = -9
+
+    async def _fake_spawn(*args, **kwargs):
+        return _HangingProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    async def _drive():
+        return await cm._run_claude_oneshot(
+            env={}, cwd=str(tmp_path), timeout=0.1,
+        )
+
+    rc, err = asyncio.run(_drive())
+    assert rc is None
+    assert err == "refresh_oneshot_timeout"
+    assert kill_called["value"], "proc.kill() must run on timeout"
+    assert drain_calls["value"] == 2, (
+        "expected one wait_for'd communicate() + one drain communicate() "
+        "after kill — got %d" % drain_calls["value"]
+    )

--- a/tests/test_macos_diagnostic.py
+++ b/tests/test_macos_diagnostic.py
@@ -1,0 +1,226 @@
+"""Tests for ``puffo_agent.portal.diagnostic`` — the ``puffo-agent test``
+command tree.
+
+Most of the report content depends on real macOS Keychain state, which
+we can't have on a CI runner; these tests focus on:
+
+  * Report rendering (markdown shape, verdict propagation).
+  * Token redaction (no raw secrets in output).
+  * Off-macOS code path (every probe reports SKIPPED cleanly).
+  * On-macOS happy path with subprocess / keychain mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.macos import keychain as cm
+from puffo_agent.portal import diagnostic as diag
+
+
+_BLOB = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-AAAA",
+        "refreshToken": "rt-BBBB",
+        "expiresAt": 9_999_999_000,
+    },
+})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Report rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_report_overall_verdict_aggregation():
+    rpt = diag.ProbeReport(title="t")
+    rpt.add("a", diag.VERDICT_OK)
+    rpt.add("b", diag.VERDICT_OK)
+    assert rpt.overall() == diag.VERDICT_OK
+
+    rpt.add("c", diag.VERDICT_NEEDS_ATTENTION)
+    assert rpt.overall() == diag.VERDICT_NEEDS_ATTENTION
+
+    rpt.add("d", diag.VERDICT_FAIL)
+    assert rpt.overall() == diag.VERDICT_FAIL
+
+
+def test_report_all_skipped_overall():
+    rpt = diag.ProbeReport(title="t")
+    rpt.add("a", diag.VERDICT_SKIPPED)
+    rpt.add("b", diag.VERDICT_SKIPPED)
+    assert rpt.overall() == diag.VERDICT_SKIPPED
+
+
+def test_report_renders_markdown():
+    rpt = diag.ProbeReport(title="hello")
+    rpt.add("step-1", diag.VERDICT_OK, "detail line")
+    rpt.summary = "all good"
+    md = rpt.render_markdown()
+    assert md.startswith("# hello")
+    assert "## step-1 — OK" in md
+    assert "detail line" in md
+    assert "all good" in md
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Token redaction — the most important property
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_redact_token_omits_raw_value():
+    out = diag._redact_token("sk-ant-supersecret-9999")
+    assert "supersecret" not in out
+    assert "len=" in out
+    assert "sha256_prefix=" in out
+
+
+def test_summarise_blob_redacts_oauth_tokens():
+    summary = diag._summarise_blob(_BLOB)
+    assert "AAAA" not in summary
+    assert "BBBB" not in summary
+    assert "len=" in summary
+    assert "claudeAiOauth" in summary
+
+
+def test_summarise_blob_handles_invalid_json():
+    summary = diag._summarise_blob("not json")
+    assert "invalid JSON" in summary
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Off-macOS: every probe returns SKIPPED cleanly
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_keychain_read_skipped_off_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+    monkeypatch.setattr(diag, "is_macos", lambda: False)
+    rpt = diag.probe_keychain_read()
+    assert rpt.overall() == diag.VERDICT_SKIPPED
+
+
+def test_keychain_write_skipped_off_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+    monkeypatch.setattr(diag, "is_macos", lambda: False)
+    rpt = diag.probe_keychain_write()
+    assert rpt.overall() == diag.VERDICT_SKIPPED
+
+
+def test_refresh_flush_skipped_off_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+    monkeypatch.setattr(diag, "is_macos", lambda: False)
+    rpt = diag.probe_refresh_flush()
+    assert rpt.overall() == diag.VERDICT_SKIPPED
+
+
+def test_keychain_survives_token_env_skipped_off_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+    monkeypatch.setattr(diag, "is_macos", lambda: False)
+    rpt = diag.probe_keychain_survives_token_env()
+    assert rpt.overall() == diag.VERDICT_SKIPPED
+
+
+def test_full_probe_off_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+    monkeypatch.setattr(diag, "is_macos", lambda: False)
+    rpt = diag.probe_full()
+    # Sub-probes are skipped, but the env-step is always OK; that's
+    # acceptable — the operator sees skipped sub-reports.
+    assert rpt.overall() in (diag.VERDICT_OK, diag.VERDICT_SKIPPED)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# On-macOS: keychain-read happy path with mocked subprocess
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_keychain_read_success_includes_redacted_blob(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(diag, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout=_BLOB),
+    )
+    rpt = diag.probe_keychain_read()
+    assert rpt.overall() == diag.VERDICT_OK
+    body = rpt.render_markdown()
+    assert "AAAA" not in body
+    assert "BBBB" not in body
+
+
+def test_keychain_write_roundtrip_success(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(diag, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout=_BLOB),
+    )
+    rpt = diag.probe_keychain_write()
+    assert rpt.overall() == diag.VERDICT_OK
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Forced-expiry helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_force_expiry_mutates_expires_at():
+    import time
+    out = diag._force_expiry(_BLOB, seconds_in_past=120)
+    assert out is not None
+    parsed = json.loads(out)
+    expires_ms = parsed["claudeAiOauth"]["expiresAt"]
+    # expiresAt should now be in the past (within the last few seconds).
+    assert expires_ms < int(time.time() * 1000)
+    # accessToken and refreshToken should be preserved verbatim — we only
+    # touched expiresAt.
+    assert parsed["claudeAiOauth"]["accessToken"] == "sk-ant-AAAA"
+    assert parsed["claudeAiOauth"]["refreshToken"] == "rt-BBBB"
+
+
+def test_force_expiry_rejects_malformed_blob():
+    assert diag._force_expiry("not json") is None
+
+
+def test_force_expiry_rejects_missing_oauth_dict():
+    assert diag._force_expiry(json.dumps({"unrelated": 1})) is None
+
+
+def test_access_token_extraction():
+    assert diag._access_token(_BLOB) == "sk-ant-AAAA"
+    assert diag._access_token("not json") == ""
+    assert diag._access_token(json.dumps({})) == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# refresh-flush-forced subcommand
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_refresh_flush_forced_skipped_off_macos(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: False)
+    monkeypatch.setattr(diag, "is_macos", lambda: False)
+    rpt = diag.probe_refresh_flush_forced()
+    assert rpt.overall() == diag.VERDICT_SKIPPED
+
+
+def test_refresh_flush_forced_requires_yes_flag(monkeypatch, capsys):
+    """The forced subcommand has destructive side effects; without
+    --yes it must refuse and exit non-zero."""
+    import argparse
+    ns = argparse.Namespace(yes=False)
+    code = diag.cmd_test_refresh_flush_forced(ns)
+    assert code == 2
+    captured = capsys.readouterr()
+    assert "rotates" in captured.err.lower()
+    assert "--yes" in captured.err


### PR DESCRIPTION
## Summary

Daemon-owned OAuth credential lifecycle for macOS, layered on top of `main`'s 0.8.8 `CredentialRefresher` (PUF-221) via a pluggable backend abstraction so Linux/Windows and macOS share the lock + agent fan-out + 401-wake invariants and only diverge on storage.

Force-pushed over the previous 0.9.0a1 / 0.9.0a2 history — the parallel `CredentialManager` class + module-singleton design from those alpha iterations didn't compose cleanly with the post-PUF-221 state of `main`. Rebuilt from `main`@0.8.8 with one unified manager.

**This PR is NOT for merging yet.** Pre-release `0.9.0a3` published to TestPyPI so a macOS colleague can run the diagnostic probes and report back. Once verified, we'll cut 0.9.0 and merge.

## How to test (macOS colleague)

```bash
pip install --index-url https://test.pypi.org/simple/             --extra-index-url https://pypi.org/simple/             puffo-agent==0.9.0a3

puffo-agent test full-probe
```

The probe writes a structured markdown report to `~/.puffo-agent/probe-report.md`. Tokens are redacted (`len=N sha256_prefix=X`); the file is safe to paste back.

Probes:

| Probe | What it checks |
|---|---|
| `keychain-read` | `security find-generic-password` succeeds + parses |
| `keychain-write` | `security add-generic-password -U` roundtrip survives |
| `refresh-flush` | sandboxed `claude --print` actually rotates the cached token |
| `keychain-survives-token-env` | reproduces github.com/anthropics/claude-code#37512 with + without our PATH shim |
| `full-probe` | runs all of the above end-to-end |

## Architecture

`CredentialBackend` Protocol (`portal/credential_refresh.py`) with four methods: `expires_in_seconds`, `refresh` (async, returns `RefreshOutcome.{REFRESHED, UNCHANGED, FAILED}`), `sync_to_agent`, `bootstrap`.

- **`FileBackend`** — preserves bit-identical 0.8.8 behavior on Linux/Windows. Host `~/.claude/.credentials.json` is canonical; refresh runs `claude --print` with `HOME=host_home`; `sync_to_agent` is a symlink (or copy fallback) via `link_host_credentials`. External rotation propagates atomically through the symlink — no external-poll needed.

- **`KeychainBackend`** — macOS path. The Keychain is canonical; the daemon maintains a cache at `~/.puffo-agent/run/claude-credentials.json` (atomic-write JSON, chmod 600). Refresh runs a sandboxed `claude --print` under a tempdir `HOME` seeded from the cache so claude's native refresh path engages and writes the rotated blob back to the sandbox file (we then copy it to the cache). Writeback to Keychain is best-effort so the operator's main CLI sees the new token. `sync_to_agent` is a per-agent file copy (Keychain ACL is keyed on UID + signing identity, not HOME — symlinking the cache wouldn't help, since the per-agent `claude` process still goes through Keychain anyway).

- **`CredentialRefresher`** itself stays platform-agnostic: owns the `asyncio.Lock` (single-writer across all refreshes), the agent home registry, the `_refresh_request` event for the 401-wake (PUF-221 contract, wired via `Worker.__init__` callback — unchanged from main), the 2-minute file-expiry poll, and the post-tick fan-out that calls `backend.sync_to_agent(agent_home)` for every registered agent. Duck-types `poll_external_rotation` on the backend so macOS gets a sibling 5-min Keychain-poll task without `CredentialRefresher` needing to know about the macos module.

- **`daemon.py`** picks the backend at startup based on `is_macos()`. Backwards-compat: `CredentialRefresher(host_home=...)` still works (auto-builds a `FileBackend`) so the 12 `test_credential_refresher.py` tests pin the same contract unchanged.

## What changed vs 0.9.0a1/a2

- **Drops the parallel `CredentialManager` class** + the module-singleton pattern (`set_global_credential_manager` / `trigger_poll_now_if_macos` / `register_agent_home_if_macos` / `unregister_agent_home_if_macos`). On-401 trigger now goes through the same `notify_refresh_needed` callback on both platforms — uniform wiring through `Worker.__init__`, no globals.

- **Linux/Windows path is now the daemon-owned `CredentialRefresher` from PUF-221** (single writer to host `.credentials.json` → no rotating-RT race), not the per-agent `_run_refresh_oneshot` from the 0.9.0a2/a3 era.

- **PATH shim for issue #37512 preserved** in `macos/keychain.py` (verbatim from the previous branch): intercepts `security delete-generic-password "Claude Code-credentials"` while passing every other `security` call through to `/usr/bin/security`.

- **5-min external-rotation poll** + on-401 trigger preserved. Now implemented as a sibling task spawned by `CredentialRefresher.run_loop` when the backend exposes `poll_external_rotation`.

- **Diagnostic CLI (`puffo-agent test ...`)** ported verbatim — 5 probes, redacted markdown report.

## Test plan

- [x] Local unit tests: **726 passed / 7 skipped / 0 failed** on Windows (incl. 12 pre-existing `test_credential_refresher.py` pinned tests passing unchanged thanks to backwards-compat constructor; 34 new `test_macos_credential_manager.py` rewritten against the new shape; 18 new `test_macos_diagnostic.py`; 7 skipped are pre-existing symlink-not-available + permission-mode-pending entries, none new).
- [x] CLI surface compiles, `puffo-agent test --help` renders, `full-probe` on Windows correctly skips every macOS probe via `is_macos()` early-returns.
- [x] `python -c "import puffo_agent.portal.daemon; import puffo_agent.portal.credential_refresh; import puffo_agent.macos.keychain; import puffo_agent.portal.diagnostic"` clean on Windows.
- [ ] **macOS colleague runs `puffo-agent test full-probe` and reports back** ← gate for promotion to 0.9.0.

## Publishing to TestPyPI

After this PR's CI is green, go to Actions → "Publish to TestPyPI" → "Run workflow", select the `feat/macos-transparent-keychain` branch. Uses Trusted Publishing (no token), so the only manual step is clicking "Run workflow".

## History note (force-push)

This branch's force-pushed head (`5cfed64`) discards the previous 0.9.0a1 / 0.9.0a2 / refactor commits (`c3fbc63`, `a9a3dca`, `073dc6b`, `babd97c`, `a444918`, `75e0fa0`). Those are reachable via `git reflog` on the contributor's local machine if any of the prior alpha exploration needs to be revisited. Nothing was tagged or released from those commits — the only published artifact was `0.9.0a1` on TestPyPI, which remains downloadable but is now superseded.

## Related

- github.com/anthropics/claude-code/issues/37512 — unfixed, auto-closed in April 2026
- PUF-221 (`main` 0.8.8) — daemon-owned credential refresh; this PR extends its backend abstraction
- Internal: discussion thread about Keychain popup spam with macOS users

🤖 Generated with [Claude Code](https://claude.com/claude-code)