### PR TITLE
fix(mcp): channel→space resolves from event-driven cache, not space walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,13 +77,129 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   resolution stack for little real benefit given the server is
   authoritative for membership state anyway).
 
+### Changed
+
+- **MCP tool surface for channel discovery is now three explicit
+  tools instead of one implicitly-cross-space `list_channels`.**
+
+  - `list_spaces()` — every space the agent is a member of.
+    `GET /spaces` is server-filtered, so the result reflects
+    authoritative permissions: anything in the list is a space
+    the agent can write to.
+  - `list_channels_in_space(space_id)` — channels in one named
+    space. `space_id` is required (empty → MCP tool error) so
+    the LLM can't accidentally fall back on the legacy
+    `cfg.space_id` for routing.
+  - `list_channels_in_all_spaces()` — convenience: walks
+    `GET /spaces` plus one `GET /spaces/<sp>/channels` per
+    space, grouped output. Same behaviour as the old
+    `list_channels` cross-space rewrite, renamed for clarity.
+
+  The old `list_channels` walked `cfg.space_id`'s event stream
+  and returned `(no space configured)` when that field was
+  empty, both of which made it impossible for an agent
+  operating in multiple spaces to enumerate its true channel
+  surface. Three-tool split gives the LLM precise vocabulary
+  for "which spaces" vs "which channels in space X" and removes
+  the last MCP-surface dependency on `cfg.space_id`. Primer
+  (`shared_content.py`), tool allowlist (`mcp/config.py`), and
+  log-message tool-name examples (`local_cli.py` /
+  `docker_cli.py`) are all updated to point at the new names.
+
+### Hardened
+
+- **`send_fallback_message` no longer silently routes to
+  `self.space_id` on cache miss.** The daemon's reply-when-LLM-
+  skipped-`send_message` path used to fall back to the legacy
+  home space when the in-memory channel→space map didn't have
+  the inbound channel — under cross-space deployments or after
+  a kick/cascade that evicted the cache, that sent the reply
+  to the wrong space (server 403) or worse to a space the
+  agent had just been removed from. Now drops the reply with a
+  clear log line; legacy `self.space_id` slot stays in the
+  constructor but no code path consults it for routing.
+
+- **Membership-exit eviction now drops the persistent
+  `channel_space_map` rows too, not just the in-memory cache.**
+  The MCP subprocess reads `channel_space_map` via
+  `lookup_channel_space` to resolve `send_message` targets;
+  the 0.8.7 in-memory `_evict_*_caches` left those rows in
+  place, so after a kick/cascade the LLM would resolve a
+  channel it had been evicted from to the old space, pay a
+  round-trip, and get a 403. Added
+  `MessageStore.unmark_channel_space` and
+  `unmark_channel_space_for_space`; wired into both eviction
+  helpers (now async). Errors are logged + swallowed so a
+  transient DB hiccup never blocks the visible WS-handler
+  reaction.
+
+### Fixed
+
+- **`list_channel_members(channel)` returns the right space's
+  roster across cross-space membership.** Previously hardcoded
+  the URL with `cfg.space_id` regardless of where the channel
+  actually lived; cross-space callers got the wrong roster, a
+  404, or a 403. Now resolves the channel→space mapping from
+  the event-driven cache (see "Added" below) and round-trips
+  to the channel's actual parent space.
+
+- **`send_message` / `send_message_with_attachments` resolve the
+  target space from the event-driven cache, not a multi-call
+  walk over `/spaces` + `/spaces/<sp>/channels`.** The pre-fix
+  resolver was both slow (worst-case N+1 round-trips) and racy
+  (channel might not be in the per-space listing yet when the
+  AcceptChannelInvite has just been committed). Misses now
+  raise a clear MCP error rather than silently falling back to
+  `cfg.space_id`.
+
+### Added
+
+- **Membership events feed the channel→space cache so the agent
+  can address a freshly-joined channel before the first inbound
+  message lands on it.** `_handle_event` now records the
+  `(channel_id, space_id)` pair from `invite_to_channel` (when
+  the agent is the invitee), `accept_channel_invite` (when the
+  agent is the signer), and `create_channel` (always — the
+  server only fans `create_channel` to space members).
+  `_accept_invite` also writes the mapping synchronously after
+  posting the accept so the immediately-following intro-nudge
+  send doesn't race the WS echo back.
+
+- **Agent now reacts to space/channel membership-exit events on the
+  WS push.** Before this release the WS event router (`_handle_event`
+  in `puffo_core_client.py`) only handled `invite_to_space` /
+  `invite_to_channel` / the synthetic auto-accept
+  `accept_channel_invite`. Every other event kind was silently
+  dropped, so when the agent was removed from a space or kicked from
+  a channel its caches and outbound queues stayed stale until the
+  next reconnect / poll, and the operator got no notification about
+  what changed.
+
+  Pairs with `puffo-server` review/events (PR #74) which now
+  broadcasts these events to the affected slug too via the
+  `extra_ws_targets` union (otherwise the agent would never see
+  them — by the time the post-loop fan-out runs, the engine has
+  already removed it from the member set).
+
 ### Tests
 
-14 new pytest tests in `tests/test_membership_events.py` covering
-each handler's happy path, ignore-when-not-target, cache eviction
-contents, operator DM text, the synthetic-cascade re-check
-behavior (still-member / confirmed-gone / network-failure), and
-the `operator_slug = ""` early-provisioning case.
+40+ new pytest tests across:
+
+- `tests/test_membership_events.py` — 16 tests covering each
+  exit-event handler's happy path, ignore-when-not-target,
+  cache eviction contents (in-memory + persistent), operator
+  DM text, the synthetic-cascade re-check behavior, and the
+  `operator_slug = ""` early-provisioning case.
+- `tests/test_puffo_core_tools.py` — 10 tests for the new
+  three-tool surface plus the existing
+  `_handle_event` cache-admission tests (admission per event
+  kind + signer gate, `send_message` / `list_channel_members`
+  cache-miss raises).
+- `tests/test_channel_intro_nudge.py` — cache-admission tests
+  for the synthetic auto-accept path and the `create_channel`
+  / `invite_to_channel` mapping recording.
+- `tests/test_worker_integration.py` — pin
+  `send_fallback_message` drop-on-unknown-channel behavior.
 
 ## [0.8.6] — 2026-05-18
 

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -781,7 +781,7 @@ class DockerCLIAdapter(Adapter):
         logger.warning(
             "agent %s: cli-docker MCP tools unavailable — puffo_core is "
             "not configured. populate `puffo_core:` in agent.yml so "
-            "send_message / list_channels / etc. show up under "
+            "send_message / list_channels_in_all_spaces / etc. show up under "
             "claude-code's tool surface.",
             self.agent_id,
         )

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -457,7 +457,7 @@ class LocalCLIAdapter(Adapter):
         logger.warning(
             "agent %s: cli-local MCP tools unavailable — puffo_core is "
             "not configured. populate `puffo_core:` in agent.yml to "
-            "enable send_message / list_channels / etc.",
+            "enable send_message / list_channels_in_all_spaces / etc.",
             self.agent_id,
         )
         return []

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -268,6 +268,39 @@ class MessageStore:
         )
         await db.commit()
 
+    async def unmark_channel_space(self, channel_id: str) -> None:
+        """Drop a single channel→space mapping. Called by the per-
+        channel eviction path (``_on_kicked_from_channel`` /
+        ``_on_left_channel`` in puffo_core_client) so subsequent
+        MCP-tool resolution doesn't keep routing into a channel
+        we're no longer in. Idempotent — non-existent rows are
+        silently skipped."""
+        if not channel_id:
+            return
+        db = await self._ensure_db()
+        await db.execute(
+            "DELETE FROM channel_space_map WHERE channel_id = ?",
+            (channel_id,),
+        )
+        await db.commit()
+
+    async def unmark_channel_space_for_space(self, space_id: str) -> None:
+        """Per-space companion to ``unmark_channel_space`` — drops
+        every channel→space mapping whose space matches. Called by
+        the space-level eviction path (``_on_left_space`` /
+        ``_on_kicked_from_space``) when the agent has been removed
+        from a whole space, so MCP-tool resolution for any of that
+        space's channels fast-fails locally instead of round-tripping
+        the server for a guaranteed-403."""
+        if not space_id:
+            return
+        db = await self._ensure_db()
+        await db.execute(
+            "DELETE FROM channel_space_map WHERE space_id = ?",
+            (space_id,),
+        )
+        await db.commit()
+
     async def get_channel_history(
         self,
         channel_id: str,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1137,9 +1137,38 @@ class PuffoCoreMessageClient:
         To avoid bare-ID DMs we use the WS push as a trigger and
         defer to ``_poll_pending_invites``; the processed-id cache
         prevents the next periodic poll from double-acting.
+
+        Side effect: any event carrying a (channel_id, space_id)
+        pair gets recorded via ``store.mark_channel_space``. This
+        keeps the channel→space cache populated even for channels
+        the agent has just been added to but hasn't received a
+        message in yet — MCP tools (``send_message``,
+        ``list_channel_members``) read that cache to construct the
+        space-scoped server URLs and bail loudly on miss rather
+        than walking ``/spaces`` as a fallback (the FB-76 era
+        resolver was removed once events became authoritative).
         """
         kind = event.get("kind")
         payload = event.get("payload") or {}
+
+        # Cache channel→space from any membership event that carries
+        # the pair, before falling through to the kind-specific
+        # handlers. The conditions on which kinds + signers we trust
+        # are deliberately narrow: ``invite_to_channel`` is recorded
+        # only when WE are the invitee (the WS fans invites to every
+        # space member, but other people's invites tell us nothing
+        # about channels we can access); ``accept_channel_invite`` is
+        # recorded only when WE are the signer (the agent's own
+        # accept, or the server-emitted auto-accept synthetic which
+        # signs-as-us); ``create_channel`` is recorded unconditionally
+        # — the server only fans create_channel to space members, so
+        # if we see it we have access to the space.
+        try:
+            await self._maybe_cache_channel_space(kind, event, payload)
+        except Exception:
+            # Never let cache bookkeeping break the rest of event
+            # routing — invite polling / intro nudges must still run.
+            logger.exception("mark_channel_space from %s failed", kind)
 
         if kind in ("invite_to_space", "invite_to_channel"):
             if payload.get("invitee_slug") != self.slug:
@@ -1182,6 +1211,30 @@ class PuffoCoreMessageClient:
                     space_id, channel_id,
                 )
             return
+
+    async def _maybe_cache_channel_space(
+        self, kind: str | None, event: dict, payload: dict,
+    ) -> None:
+        """Record (channel_id, space_id) from events that authoritatively
+        prove the agent can reach the channel. See ``_handle_event``
+        for the rationale per kind."""
+        if not kind:
+            return
+        channel_id = payload.get("channel_id") or ""
+        space_id = payload.get("space_id") or ""
+        if not channel_id or not space_id:
+            return
+        if kind == "invite_to_channel":
+            if payload.get("invitee_slug") != self.slug:
+                return
+        elif kind == "accept_channel_invite":
+            if event.get("signer_slug") != self.slug:
+                return
+        elif kind == "create_channel":
+            pass  # always cache; server only fans to space members
+        else:
+            return
+        await self.store.mark_channel_space(channel_id, space_id)
 
     async def _poll_pending_invites(self) -> None:
         """Pull pending invites the agent hasn't acted on. Space
@@ -1472,6 +1525,22 @@ class PuffoCoreMessageClient:
             "/spaces/events",
             {"space_id": space_id, "events": [signed]},
         )
+
+        # Belt + suspenders: record the channel→space mapping
+        # synchronously here. The server fans the accept event back
+        # over WS and ``_handle_event`` records it too, but that's
+        # async — without this immediate write, the intro nudge's
+        # ``send_message`` call (queued right below) could race the
+        # WS echo and hit a cache miss on a channel the agent has
+        # just provably joined.
+        if kind == "invite_to_channel" and channel_id and space_id:
+            try:
+                await self.store.mark_channel_space(channel_id, space_id)
+            except Exception:
+                logger.exception(
+                    "mark_channel_space after manual accept failed "
+                    "(space=%s channel=%s)", space_id, channel_id,
+                )
 
         # Accepting an invite triggers a one-shot self-introduction
         # nudge: we enqueue a synthetic ``[puffo-agent system message]``

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1285,27 +1285,51 @@ class PuffoCoreMessageClient:
             return
         await self.store.mark_channel_space(channel_id, space_id)
 
-    def _evict_space_caches(self, space_id: str) -> None:
+    async def _evict_space_caches(self, space_id: str) -> None:
         """Drop every cached entry tied to a space we've left/been
-        kicked from. The membership server is authoritative so
-        we don't need this to stay correct — leaving stale entries
-        just risks the agent racing to send into a space it isn't
-        in (server 403s, worker logs a confusing failure). Reverse-
-        scans ``_channel_space`` for channels mapped to this space."""
+        kicked from. Two layers:
+
+          1. In-memory ``_channel_space`` / name caches consumed by
+             the daemon's send paths (e.g. ``send_fallback_message``).
+          2. The persistent ``channel_space_map`` table consumed by
+             the MCP subprocess via ``lookup_channel_space`` — without
+             evicting this too, the LLM's ``send_message`` would
+             happily resolve a channel we're no longer in and pay
+             one round-trip just to get the server's 403.
+
+        Reverse-scans ``_channel_space`` for the in-memory side;
+        the persistent layer takes a ``DELETE WHERE space_id = ?``."""
         if not space_id:
             return
         for cid in [c for c, s in self._channel_space.items() if s == space_id]:
             self._channel_space.pop(cid, None)
             self._channel_name_cache.pop(cid, None)
         self._space_name_cache.pop(space_id, None)
+        try:
+            await self.store.unmark_channel_space_for_space(space_id)
+        except Exception:
+            logger.exception(
+                "unmark_channel_space_for_space failed for sp=%s "
+                "(non-fatal — in-memory eviction already ran)",
+                space_id,
+            )
 
-    def _evict_channel_caches(self, channel_id: str) -> None:
+    async def _evict_channel_caches(self, channel_id: str) -> None:
         """Smaller-scope twin of ``_evict_space_caches`` for the
-        per-channel kick paths."""
+        per-channel kick paths. Same two-layer eviction (in-memory
+        + persistent map)."""
         if not channel_id:
             return
         self._channel_space.pop(channel_id, None)
         self._channel_name_cache.pop(channel_id, None)
+        try:
+            await self.store.unmark_channel_space(channel_id)
+        except Exception:
+            logger.exception(
+                "unmark_channel_space failed for ch=%s "
+                "(non-fatal — in-memory eviction already ran)",
+                channel_id,
+            )
 
     async def _dm_operator_membership_change(self, text: str) -> None:
         """Best-effort operator notification on membership exit. No-op
@@ -1354,7 +1378,7 @@ class PuffoCoreMessageClient:
             )
             return
         space_label = await self._resolve_space_name(space_id)
-        self._evict_space_caches(space_id)
+        await self._evict_space_caches(space_id)
         reason = (
             "your space exit cascaded to me"
             if synthetic else "I signed a LeaveSpace"
@@ -1397,7 +1421,7 @@ class PuffoCoreMessageClient:
         if not space_id:
             return
         space_label = await self._resolve_space_name(space_id)
-        self._evict_space_caches(space_id)
+        await self._evict_space_caches(space_id)
         kicker_display = (
             await self._fetch_display_name(kicker_slug) if kicker_slug else ""
         )
@@ -1415,7 +1439,7 @@ class PuffoCoreMessageClient:
         avoid noise. Cache cleanup still runs."""
         if not channel_id:
             return
-        self._evict_channel_caches(channel_id)
+        await self._evict_channel_caches(channel_id)
 
     async def _on_kicked_from_channel(
         self, *, channel_id: str, space_id: str, kicker_slug: str,
@@ -1427,7 +1451,7 @@ class PuffoCoreMessageClient:
             space_id=space_id, channel_id=channel_id,
         )
         space_label = await self._resolve_space_name(space_id) if space_id else ""
-        self._evict_channel_caches(channel_id)
+        await self._evict_channel_caches(channel_id)
         kicker_display = (
             await self._fetch_display_name(kicker_slug) if kicker_slug else ""
         )
@@ -2376,10 +2400,24 @@ class PuffoCoreMessageClient:
         )
 
         if channel_id:
-            # Channel reply — prefer the space learned from the inbound
-            # envelope (so cross-space channels work) and fall back to
-            # the configured home space.
-            target_space_id = self._channel_space.get(channel_id, self.space_id)
+            # Channel reply — resolve the space from the in-memory
+            # channel→space map (populated by inbound envelopes +
+            # membership events). No silent fallback to
+            # ``self.space_id``: the configured "home" space is
+            # legacy metadata that shouldn't decide where outbound
+            # messages route. If the cache misses, the agent either
+            # hasn't seen this channel yet or has been evicted from
+            # it; either way, sending blindly to a guessed space
+            # gets a 403 or worse (wrong-space cross-talk).
+            target_space_id = self._channel_space.get(channel_id)
+            if not target_space_id:
+                logger.warning(
+                    "send_fallback_message: no known space for channel %s — "
+                    "dropping (agent may have been removed, or the channel "
+                    "id is stale)",
+                    channel_id,
+                )
+                return
             members_resp = await self.http.get(
                 f"/spaces/{target_space_id}/channels/{channel_id}/members"
             )

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -176,7 +176,8 @@ Use `sender_type` and `mentions` to decide whether to reply:
   inside spaces you've been invited to.
 - **Channel:** a multi-user conversation inside a space, addressed
   by a `ch_<uuid>` id. There is no `#name` shortcut — you address
-  channels by id. Use `list_channels` to discover them.
+  channels by id. Use `list_channels_in_all_spaces` (or
+  `list_spaces` + `list_channels_in_space`) to discover them.
 - **Direct message (DM):** one-on-one. The wire envelope's
   `envelope_kind` is `dm` rather than `channel`; you reply by
   passing `@<slug>` to `send_message`.
@@ -233,8 +234,17 @@ for one doc per tool.
   thread.
 
 **Read / discovery tools:**
-- `mcp__puffo__list_channels()` — channels in your configured space,
-  derived from the space's event stream.
+- `mcp__puffo__list_spaces()` — every space you are a member of
+  (id + name). The list reflects authoritative server-side
+  permissions, so anything here is a space you can actually
+  send messages into.
+- `mcp__puffo__list_channels_in_space(space_id)` — channels in a
+  single named space. Pair with `list_spaces` for explicit,
+  one-space-at-a-time discovery.
+- `mcp__puffo__list_channels_in_all_spaces()` — channels across
+  every space you're in, grouped by space. One-shot full
+  picture; useful when you don't know which space a channel
+  lives in.
 - `mcp__puffo__list_channel_members(channel)` — slugs + roles.
 - `mcp__puffo__get_channel_history(channel, limit=20, since="", before=0, after=0)`
   — recent **root posts** in the channel, with the reply count
@@ -373,7 +383,7 @@ Post a message to a Puffo.ai channel or DM a user.
   - `"@<slug>"` to DM a user (e.g. `"@alice-1234"`)
   - a raw channel id (`"ch_<uuid>"`) for a channel post
   - the `#<name>` shortcut is **not** supported; call
-    `list_channels` to look up an id.
+    `list_channels_in_all_spaces` to look up an id.
 - `text` (required) — message body. Markdown is preserved on the
   wire; the client will render it when the formatting upgrade ships.
 - `is_visible_to_human` (required) — bool, no default. `true` for
@@ -535,7 +545,8 @@ store so you can catch up on the conversation before responding.
 
 **Arguments:**
 - `channel` (required) — channel id (`ch_<uuid>`). The `#name`
-  shortcut isn't supported; call `list_channels` to look up an id.
+  shortcut isn't supported; call `list_channels_in_all_spaces` to
+  look up an id.
 - `limit` (optional, default 20, max 200) — how many recent posts.
 
 **Output format:** one line per post in chronological order:

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -24,7 +24,9 @@ MCP_SERVER_NAME = "puffo"
 PUFFO_CORE_TOOL_NAMES = (
     "send_message",
     "send_message_with_attachments",
-    "list_channels",
+    "list_spaces",
+    "list_channels_in_all_spaces",
+    "list_channels_in_space",
     "list_channel_members",
     "get_channel_history",
     "get_thread_history",

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -32,65 +32,35 @@ from .data_client import DataClient, DataNotFound
 logger = logging.getLogger(__name__)
 
 
-async def _discover_channel_space(http_client: Any, channel_id: str) -> Optional[str]:
-    """Walk the agent's accessible spaces to find which one contains
-    ``channel_id``. Used as the second-stage resolver when the local
-    cache (``data_client.lookup_channel_space``) has no record of the
-    channel — typically because the agent was just added to it and
-    hasn't received an inbound message there yet.
+async def _resolve_channel_space(cfg: Any, channel_id: str) -> str:
+    """Resolve ``channel_id`` → ``space_id`` from the local cache.
 
-    Bounded by ``GET /spaces`` — only spaces the agent has access to
-    are scanned, so a hit also proves access. Returns ``None`` when
-    no accessible space contains the channel, or when ``/spaces`` is
-    unreachable; the caller (``send_message``) fails loud at that
-    point rather than guessing.
+    The cache is filled by ``puffo_core_client._handle_event`` for
+    every membership event the agent receives that carries both ids
+    (``invite_to_channel`` where we're the invitee,
+    ``accept_channel_invite`` where we're the signer, and
+    ``create_channel`` — server only fans those to space members).
+    ``mark_channel_space`` is also written synchronously inside
+    ``_accept_invite`` to close the WS-echo race.
 
-    Replaces an earlier silent fallback to ``cfg.space_id`` (the
-    agent's home space) that produced wrong-space members requests
-    when an unseen channel actually lived in a *different* accessible
-    space — the FB-76 root cause.
+    Raises ``RuntimeError`` (which propagates to the LLM as an MCP
+    tool error) on miss — that's the signal "agent has no way to
+    reach this channel; you may not be a member, or the id is
+    wrong." Earlier code walked ``GET /spaces`` as a fallback
+    resolver, but with events feeding the cache that fallback is
+    redundant and silently misleading (a hit there only proved
+    access to the space, not membership in the channel).
     """
-    try:
-        spaces_resp = await http_client.get("/spaces")
-    except Exception as exc:
-        logger.warning(
-            "discover_channel_space %s: GET /spaces failed: %s",
-            channel_id, exc,
+    space_id = await cfg.data_client.lookup_channel_space(channel_id)
+    if not space_id:
+        raise RuntimeError(
+            f"agent has no record of channel {channel_id} — it may not "
+            f"be a channel the agent belongs to, or the id may be "
+            f"wrong. Membership events are cached as they arrive over "
+            f"the WS, so a fresh channel becomes addressable as soon "
+            f"as the invite/accept/create event lands."
         )
-        return None
-    spaces = (
-        spaces_resp.get("spaces", [])
-        if isinstance(spaces_resp, dict)
-        else []
-    )
-    for space in spaces:
-        if not isinstance(space, dict):
-            continue
-        sp_id = space.get("space_id") or space.get("id")
-        if not sp_id:
-            continue
-        try:
-            channels_resp = await http_client.get(
-                f"/spaces/{urllib.parse.quote(sp_id, safe='')}/channels"
-            )
-        except Exception as exc:
-            logger.warning(
-                "discover_channel_space %s: GET /spaces/%s/channels failed: %s",
-                channel_id, sp_id, exc,
-            )
-            continue
-        channels = (
-            channels_resp.get("channels", [])
-            if isinstance(channels_resp, dict)
-            else []
-        )
-        for ch in channels:
-            if not isinstance(ch, dict):
-                continue
-            cid = ch.get("channel_id") or ch.get("id")
-            if cid == channel_id:
-                return sp_id
-    return None
+    return space_id
 
 
 def _ts_to_iso(ms: int) -> str:
@@ -244,39 +214,11 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             channel_id = channel_ref
             envelope_kind = "channel"
             recipient_slug = None
-            # Resolve which space this channel lives in. Two-stage:
-            # (1) local cache — inbound envelopes tag ``space_id`` in
-            # the message store, so any prior message in this channel
-            # gives the mapping for free. (2) On miss (channel never
-            # seen — typical right after the agent gets added) walk
-            # ``GET /spaces`` + ``GET /spaces/<sp>/channels`` for a
-            # definitive match across the agent's accessible spaces.
-            #
-            # Previously the cache miss fell back to ``cfg.space_id``
-            # (the agent's home space). When the channel actually
-            # lived in a *different* accessible space, the next call
-            # (``/spaces/<home>/channels/<ch>/members``) targeted the
-            # wrong space. The response in that case wasn't the
-            # expected 403/400 — it was a 2xx with a non-JSON body
-            # (proxy / gateway interstitial), which surfaced three
-            # layers up as ``'str' object has no attribute 'get'``.
-            # FB-76's root cause. We now fail loud when both stages
-            # miss rather than guessing.
-            send_space_id: Optional[str] = await cfg.data_client.lookup_channel_space(
-                channel_id,
-            )
-            if not send_space_id:
-                send_space_id = await _discover_channel_space(
-                    cfg.http_client, channel_id,
-                )
-            if not send_space_id:
-                raise RuntimeError(
-                    f"can't resolve which space channel {channel_id} belongs "
-                    f"to: the agent has no local record of it, and it doesn't "
-                    f"appear in any space the agent currently has access to. "
-                    f"The agent may need to be invited to that space first, "
-                    f"or the channel id may be wrong."
-                )
+            # The local cache (filled by membership events landing
+            # over the WS — see puffo_core_client._handle_event /
+            # _maybe_cache_channel_space) is authoritative for
+            # channels the agent can reach. Miss → bail loud.
+            send_space_id = await _resolve_channel_space(cfg, channel_id)
             members_resp = await cfg.http_client.get(
                 f"/spaces/{send_space_id}/channels/{channel_id}/members"
             )
@@ -487,14 +429,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "channel id directly."
             )
         channel_id = channel_ref
-        if not cfg.space_id:
-            raise RuntimeError(
-                "agent has no configured space_id — set "
-                "`puffo_core.space_id` in agent.yml."
-            )
+        # Resolve from the local channel→space cache (populated by
+        # membership events). Misses raise — the previous version
+        # silently used ``cfg.space_id`` (home space), which broke
+        # for any channel not in the agent's home space.
+        space_id = await _resolve_channel_space(cfg, channel_id)
 
         data = await cfg.http_client.get(
-            f"/spaces/{cfg.space_id}/channels/{channel_id}/members"
+            f"/spaces/{space_id}/channels/{channel_id}/members"
         )
         rows = []
         for m in data.get("members", []):
@@ -762,15 +704,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             channel_id = channel_ref
             envelope_kind = "channel"
             recipient_slug = None
-            send_space_id = (
-                await cfg.data_client.lookup_channel_space(channel_id)
-                or cfg.space_id
-            )
-            if not send_space_id:
-                raise RuntimeError(
-                    f"send_message_with_attachments: channel {channel_id} not seen before "
-                    "and the agent has no configured space_id"
-                )
+            # Same cache-only resolution as ``send_message`` — no
+            # silent fallback to ``cfg.space_id``, because targeting
+            # the wrong space produced FB-76 mismaps.
+            send_space_id = await _resolve_channel_space(cfg, channel_id)
             members_resp = await cfg.http_client.get(
                 f"/spaces/{send_space_id}/channels/{channel_id}/members"
             )

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -474,45 +474,55 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
 
     @mcp.tool()
     async def list_channels() -> str:
-        """List channels in the agent's configured space (id + name).
+        """List channels in every space the agent is a member of.
 
-        Channels are derived by replaying ``/spaces/<sp>/events`` and
-        surfacing every ``create_channel`` payload — there is no
-        direct ``/spaces/<sp>/channels`` endpoint.
+        Output is grouped by space::
+
+            Space sp_X (Team):
+              - ch_a  general
+              - ch_b  random
+            Space sp_Y (Other):
+              - ch_c  general
+
+        The legacy ``cfg.space_id`` is intentionally NOT consulted:
+        agents operate cross-space (an operator can invite the
+        agent into channels in any space they're also in) and the
+        LLM needs the full membership view to route ``send_message``
+        targets correctly. Walks one ``GET /spaces`` plus one
+        ``GET /spaces/<sp>/channels`` per space — both endpoints
+        are server-filtered to memberships the agent actually has,
+        so the result reflects authoritative permissions.
         """
-        if not cfg.space_id:
-            return "(no space configured)"
-        space_id = cfg.space_id
-        # cursor is ``<issued_at>:<signer_slug>:<event_id>``. Colons
-        # are legal in query strings but encode anyway for safety.
-        cursor: Optional[str] = None
-        prev_cursor: Optional[str] = None
-        channels: list[tuple[str, str]] = []
-        while True:
-            if cursor is not None:
-                path = (
-                    f"/spaces/{space_id}/events"
-                    f"?since={urllib.parse.quote(cursor, safe='')}"
-                )
-            else:
-                path = f"/spaces/{space_id}/events"
-            data = await cfg.http_client.get(path)
-            for entry in data.get("events", []):
-                if entry.get("kind") == "create_channel":
-                    payload = entry.get("payload", {}) or {}
-                    cid = payload.get("channel_id", "")
-                    name = payload.get("name", "")
-                    if cid:
-                        channels.append((cid, name))
-            if not data.get("has_more"):
-                break
-            prev_cursor = cursor
-            cursor = data.get("next_cursor")
-            if cursor is None or cursor == prev_cursor:
-                break
-        if not channels:
-            return "(no channels in this space)"
-        return "\n".join(f"- {cid}  {name}" for cid, name in channels)
+        spaces_data = await cfg.http_client.get("/spaces")
+        spaces_entries = (spaces_data or {}).get("spaces", []) or []
+        if not spaces_entries:
+            return "(no spaces — the agent is not a member of any space)"
+        lines: list[str] = []
+        for sp in spaces_entries:
+            space_id = sp.get("space_id", "")
+            space_name = sp.get("name", "") or space_id
+            if not space_id:
+                continue
+            ch_data = await cfg.http_client.get(
+                f"/spaces/{space_id}/channels"
+            )
+            # The endpoint returns the SPA-route HTML stub (decoded
+            # as ``str``) when called during a tight race against
+            # the materialiser. Treat that as "no channels yet";
+            # the agent will see them on the next call.
+            channels = (
+                ch_data.get("channels", []) if isinstance(ch_data, dict) else []
+            )
+            lines.append(f"Space {space_id} ({space_name}):")
+            if not channels:
+                lines.append("  (no channels)")
+                continue
+            for ch in channels:
+                cid = ch.get("channel_id", "")
+                name = ch.get("name", "") or cid
+                if cid:
+                    lines.append(f"  - {cid}  {name}")
+        return "\n".join(lines) if lines else "(no channels)"
 
     @mcp.tool()
     async def list_channel_members(channel: str) -> str:

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -269,8 +269,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         """Post a message to a Puffo.ai channel or DM a user.
 
         channel: '@<slug>' for a DM (e.g. '@alice-1234'), or a raw
-            channel id (e.g. 'ch_<uuid>'). Use ``list_channels`` to
-            discover ids — '#name' shortcuts are not supported.
+            channel id (e.g. 'ch_<uuid>'). Use
+            ``list_channels_in_all_spaces`` (or ``list_spaces`` +
+            ``list_channels_in_space``) to discover ids — '#name'
+            shortcuts are not supported.
         text: message body. Markdown preserved verbatim.
         is_visible_to_human: REQUIRED — decide whether a human should
             see this message inline. ``true`` for anything a person
@@ -290,7 +292,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             raise RuntimeError(
                 "'#<name>' channel addressing isn't supported; "
                 "use the channel id (e.g. 'ch_<uuid>') or call "
-                "list_channels to look one up."
+                "list_channels_in_all_spaces to look one up."
             )
 
         if channel_ref.startswith("@"):
@@ -473,7 +475,59 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
-    async def list_channels() -> str:
+    async def list_spaces() -> str:
+        """List spaces this agent is a member of (id + name).
+
+        ``GET /spaces`` is server-filtered to memberships the
+        agent actually has, so the result reflects authoritative
+        permissions — channels can be enumerated for any space
+        listed here via ``list_channels_in_space``."""
+        data = await cfg.http_client.get("/spaces")
+        spaces_entries = (data or {}).get("spaces", []) or []
+        if not spaces_entries:
+            return "(not a member of any space)"
+        lines: list[str] = []
+        for sp in spaces_entries:
+            sid = sp.get("space_id", "")
+            name = sp.get("name", "") or sid
+            if sid:
+                lines.append(f"- {sid}  {name}")
+        return "\n".join(lines) if lines else "(not a member of any space)"
+
+    @mcp.tool()
+    async def list_channels_in_space(space_id: str) -> str:
+        """List channels in a single space the agent is a member of.
+
+        ``GET /spaces/<space_id>/channels`` is server-filtered to the
+        agent's actual channel memberships; this tool just formats the
+        result. The legacy ``cfg.space_id`` is not consulted — pass
+        the explicit ``space_id`` to scope the query. Use
+        ``list_spaces`` to enumerate valid ``space_id``s first.
+
+        Tight-race note: just after AcceptSpaceInvite the endpoint can
+        briefly return the SPA-route HTML stub (decoded as ``str``)
+        while the materialiser commits. Treat that as "no channels yet"
+        rather than crashing the tool.
+        """
+        sid = (space_id or "").strip()
+        if not sid:
+            raise RuntimeError("space_id is required")
+        data = await cfg.http_client.get(f"/spaces/{sid}/channels")
+        channels = (
+            data.get("channels", []) if isinstance(data, dict) else []
+        ) or []
+        if not channels:
+            return "(no channels — agent may not be a member of this space yet)"
+        lines: list[str] = []
+        for ch in channels:
+            cid = ch.get("channel_id", "")
+            name = ch.get("name", "") or cid
+            if cid:
+                lines.append(f"- {cid}  {name}")
+        return "\n".join(lines) if lines else "(no channels)"
+
+    @mcp.tool()
+    async def list_channels_in_all_spaces() -> str:
         """List channels in every space the agent is a member of.
 
         Output is grouped by space::
@@ -484,19 +538,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             Space sp_Y (Other):
               - ch_c  general
 
-        The legacy ``cfg.space_id`` is intentionally NOT consulted:
-        agents operate cross-space (an operator can invite the
-        agent into channels in any space they're also in) and the
-        LLM needs the full membership view to route ``send_message``
-        targets correctly. Walks one ``GET /spaces`` plus one
-        ``GET /spaces/<sp>/channels`` per space — both endpoints
-        are server-filtered to memberships the agent actually has,
-        so the result reflects authoritative permissions.
-        """
+        Convenience over ``list_spaces`` + ``list_channels_in_space``
+        for the case where the LLM wants the full membership picture
+        in one tool call. Walks one ``GET /spaces`` plus one
+        ``GET /spaces/<sp>/channels`` per space."""
         spaces_data = await cfg.http_client.get("/spaces")
         spaces_entries = (spaces_data or {}).get("spaces", []) or []
         if not spaces_entries:
-            return "(no spaces — the agent is not a member of any space)"
+            return "(not a member of any space)"
         lines: list[str] = []
         for sp in spaces_entries:
             space_id = sp.get("space_id", "")
@@ -506,10 +555,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             ch_data = await cfg.http_client.get(
                 f"/spaces/{space_id}/channels"
             )
-            # The endpoint returns the SPA-route HTML stub (decoded
-            # as ``str``) when called during a tight race against
-            # the materialiser. Treat that as "no channels yet";
-            # the agent will see them on the next call.
             channels = (
                 ch_data.get("channels", []) if isinstance(ch_data, dict) else []
             )

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -642,3 +642,154 @@ async def test_handle_event_synthetic_accept_missing_ids_is_safe():
     assert client._queue.qsize() == 0
 
     await store.close()
+
+
+# ─── _handle_event: channel→space cache writes ────────────────────
+#
+# Membership events landing on the WS are the source of truth for
+# ``lookup_channel_space``; this lets ``send_message`` /
+# ``list_channel_members`` resolve any channel the agent has been
+# admitted to, without walking ``/spaces`` as a fallback. Each event
+# kind that carries the ``(channel_id, space_id)`` pair has its own
+# admission test below to lock the gate down.
+
+
+@pytest.mark.asyncio
+async def test_handle_event_synthetic_accept_records_channel_space():
+    """Server-emitted auto-accept synthetic event populates the
+    channel→space cache so the immediately-following intro-nudge
+    send (and any subsequent MCP tool call) can resolve the channel
+    without depending on inbound messages."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="sp_1", channel_id="ch_1",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert await store.lookup_channel_space("ch_1") == "sp_1"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_create_channel_records_mapping():
+    """``create_channel`` events fan to every space member, so seeing
+    one proves the agent has access to that space — record the
+    channel→space tuple unconditionally."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = {
+        "type": "signed_event",
+        "version": 1,
+        "event_id": "ev_create_1",
+        "kind": "create_channel",
+        "signer_slug": "alice-0001",
+        "signer_device_id": "dev_alice",
+        "signer_subkey_id": "sk_alice",
+        "signature": "fake-sig",
+        "payload": {
+            "space_id": "sp_team",
+            "channel_id": "ch_secret",
+            "name": "secret-room",
+            "is_public": False,
+        },
+    }
+    await client._handle_event(scope="sp_team", event=event)
+    assert await store.lookup_channel_space("ch_secret") == "sp_team"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_invite_to_channel_for_self_records_mapping(
+    monkeypatch,
+):
+    """Inviting *this agent* into a channel makes the channel
+    addressable even before the agent has accepted (the LLM might
+    look members up to decide whether to accept). The branch also
+    fires ``_poll_pending_invites``; stub it so the test stays
+    network-free."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+    polled = 0
+
+    async def _stub_poll() -> None:
+        nonlocal polled
+        polled += 1
+
+    client._poll_pending_invites = _stub_poll  # type: ignore[assignment]
+
+    event = {
+        "type": "signed_event",
+        "version": 1,
+        "event_id": "ev_invite_1",
+        "kind": "invite_to_channel",
+        "signer_slug": "alice-0001",
+        "signer_device_id": "dev_alice",
+        "signer_subkey_id": "sk_alice",
+        "signature": "fake-sig",
+        "payload": {
+            "space_id": "sp_team",
+            "channel_id": "ch_secret",
+            "invitee_slug": "agent-1",
+            "issued_at": 1_700_000_000_000,
+            "nonce": "n",
+        },
+    }
+    await client._handle_event(scope="sp_team", event=event)
+    assert await store.lookup_channel_space("ch_secret") == "sp_team"
+    assert polled == 1, "expected pending-invites poll to fire"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_invite_to_channel_for_other_skips_cache(
+    monkeypatch,
+):
+    """Server fans channel invites to every space member — when the
+    invitee is someone else, the cache must NOT pick up the
+    mapping (we don't know if we have access)."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    async def _stub_poll() -> None:
+        # Should never be called when invitee != self.
+        raise AssertionError("poll fired for someone else's invite")
+
+    client._poll_pending_invites = _stub_poll  # type: ignore[assignment]
+
+    event = {
+        "kind": "invite_to_channel",
+        "signer_slug": "alice-0001",
+        "payload": {
+            "space_id": "sp_team",
+            "channel_id": "ch_secret",
+            "invitee_slug": "someone-else",
+        },
+    }
+    await client._handle_event(scope="sp_team", event=event)
+    assert await store.lookup_channel_space("ch_secret") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_accept_signed_by_other_skips_cache():
+    """A ``accept_channel_invite`` signed by someone else (an admin
+    accepting on behalf of a peer, or just fan-out) does not prove
+    we have access. Cache must stay clean."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+
+    event = _synthetic_accept_event(
+        agent_slug="someone-else",  # signer != self.slug
+        space_id="sp_1", channel_id="ch_1",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+    assert await store.lookup_channel_space("ch_1") is None
+    await store.close()

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -54,6 +54,23 @@ def _make_client(
     client._processed_invite_ids = set()
     client._pending_invite_dms = {}
 
+    # _evict_*_caches now also drops persistent ``channel_space_map``
+    # rows so the MCP subprocess's send_message tool doesn't keep
+    # resolving channels we've been evicted from. The harness
+    # doesn't open a real MessageStore, so stub the two methods the
+    # eviction path uses and capture invocations for assertions.
+    unmark_calls: dict[str, list] = {"space": [], "channel": []}
+
+    class _StubStore:
+        async def unmark_channel_space(self, channel_id: str) -> None:
+            unmark_calls["channel"].append(channel_id)
+
+        async def unmark_channel_space_for_space(self, space_id: str) -> None:
+            unmark_calls["space"].append(space_id)
+
+    client.store = _StubStore()
+    client._unmark_calls = unmark_calls  # type: ignore[attr-defined]
+
     sent: list[dict] = []
 
     async def _stub_send_dm(recipient_slug: str, text: str, root_id: str) -> dict | None:
@@ -422,6 +439,55 @@ async def test_cancel_invite_with_no_outstanding_dm_is_noop():
 
 
 # ─── operator_slug unset ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_evict_space_caches_clears_persistent_channel_space_map():
+    """RemoveFromSpace / synthetic cascade evicts the persistent
+    ``channel_space_map`` rows too, not just the in-memory caches.
+    Without this the MCP subprocess's ``lookup_channel_space`` would
+    keep handing the LLM a space the agent's been evicted from."""
+    client, sent = _make_client()
+    client._channel_space["ch_1"] = "sp_1"
+    client._channel_space["ch_other"] = "sp_2"
+
+    event = {
+        "kind": "remove_from_space",
+        "signer_slug": "alice-0001",
+        "payload": {"space_id": "sp_1", "removed_slug": "agent-1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # In-memory + persistent both touched, scoped to sp_1.
+    assert "ch_1" not in client._channel_space
+    assert client._channel_space.get("ch_other") == "sp_2"
+    assert client._unmark_calls["space"] == ["sp_1"]
+    assert client._unmark_calls["channel"] == []
+
+
+@pytest.mark.asyncio
+async def test_evict_channel_caches_clears_single_persistent_row():
+    """RemoveFromChannel only drops the single channel's mapping,
+    leaving siblings in the same space alone."""
+    client, sent = _make_client()
+    client._channel_space["ch_priv"] = "sp_1"
+    client._channel_space["ch_other"] = "sp_1"
+
+    event = {
+        "kind": "remove_from_channel",
+        "signer_slug": "alice-0001",
+        "payload": {
+            "space_id": "sp_1",
+            "channel_id": "ch_priv",
+            "removed_slug": "agent-1",
+        },
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert "ch_priv" not in client._channel_space
+    assert client._channel_space.get("ch_other") == "sp_1"
+    assert client._unmark_calls["channel"] == ["ch_priv"]
+    assert client._unmark_calls["space"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -290,30 +290,18 @@ async def test_send_message_threaded_false_not_coerced():
 
 
 @pytest.mark.asyncio
-async def test_send_message_discovers_channel_in_other_space():
-    """When the channel id isn't in the local cache (no inbound seen
-    yet), send_message walks ``/spaces`` + ``/spaces/<sp>/channels``
-    for a definitive match — and aims the members call at the
-    *discovered* space, not at ``cfg.space_id``. Fixes FB-76: the
-    previous silent fallback to ``cfg.space_id`` produced wrong-space
-    members requests that surfaced as ``'str' object has no attribute
-    'get'`` three layers up."""
-    cfg, http, _ = _setup()
+async def test_send_message_uses_cached_space_for_cross_space_channel():
+    """send_message resolves channel→space from the local cache —
+    which is filled by membership events as they arrive over the WS
+    (see ``puffo_core_client._handle_event``). A channel that lives
+    in a non-home space must still get its members call routed to
+    the correct space, with no ``cfg.space_id`` fallback in sight.
+    """
+    cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
-    # cfg.space_id is "sp_test"; the channel actually lives in a
-    # DIFFERENT space the agent has access to.
-    http.responses["/spaces"] = {
-        "spaces": [
-            {"space_id": "sp_test", "name": "Home"},
-            {"space_id": "sp_other", "name": "Other Team"},
-        ],
-    }
-    http.responses["/spaces/sp_test/channels"] = {
-        "channels": [{"channel_id": "ch_home", "name": "general"}],
-    }
-    http.responses["/spaces/sp_other/channels"] = {
-        "channels": [{"channel_id": "ch_elsewhere", "name": "general"}],
-    }
+    # Pre-cache the mapping the way an ``accept_channel_invite`` /
+    # ``invite_to_channel`` / ``create_channel`` event would.
+    await ms.mark_channel_space("ch_elsewhere", "sp_other")
     http.responses["/spaces/sp_other/channels/ch_elsewhere/members"] = {
         "members": [{"slug": "alice-0001", "role": "member"}],
     }
@@ -337,9 +325,6 @@ async def test_send_message_discovers_channel_in_other_space():
         },
     )
     assert "posted" in result, f"expected success, got: {result}"
-    # Critical: the members call must target sp_other (correct), NOT
-    # sp_test (the previous wrong-space fallback) — that's the
-    # regression we're guarding against.
     members_paths = [
         path for method, path, _ in http.calls
         if method == "GET" and "ch_elsewhere/members" in path
@@ -350,20 +335,23 @@ async def test_send_message_discovers_channel_in_other_space():
     assert not any("/spaces/sp_test/" in p for p in members_paths), (
         f"must NOT hit sp_test (wrong-space fallback regression): {members_paths}"
     )
+    # And critically: no /spaces walking — the cache should be the
+    # only authority. (Pre-cache fix removed the FB-76-era resolver
+    # that walked /spaces + /spaces/<sp>/channels.)
+    assert not any(
+        path == "/spaces" for method, path, _ in http.calls
+        if method == "GET"
+    ), "no /spaces walk should occur — cache lookup is the only path"
 
 
 @pytest.mark.asyncio
-async def test_send_message_fails_loud_when_channel_not_in_any_space():
-    """When neither the local cache nor any accessible space contains
-    the channel, send_message raises a clear unresolved-channel error
-    instead of silently sending to the wrong space — FB-76 fix."""
+async def test_send_message_fails_loud_on_cache_miss():
+    """A channel the agent has no cached mapping for produces a
+    clear MCP error — no walking ``/spaces`` as a guess, no falling
+    back to ``cfg.space_id``. The agent's source of truth for
+    channel→space is the event stream; if no event fed the cache,
+    the agent isn't a member and shouldn't be sending."""
     cfg, http, _ = _setup()
-    http.responses["/spaces"] = {
-        "spaces": [{"space_id": "sp_test", "name": "Home"}],
-    }
-    http.responses["/spaces/sp_test/channels"] = {
-        "channels": [{"channel_id": "ch_known", "name": "general"}],
-    }
     mcp = _build_tools(cfg)
     with pytest.raises(Exception) as excinfo:
         await _call(
@@ -374,15 +362,32 @@ async def test_send_message_fails_loud_when_channel_not_in_any_space():
                 "is_visible_to_human": True,
             },
         )
-    assert "can't resolve which space" in str(excinfo.value), (
-        f"expected an unresolved-channel error, got: {excinfo.value}"
+    assert "no record of channel" in str(excinfo.value), (
+        f"expected a cache-miss error, got: {excinfo.value}"
     )
-    # And critically: no wrong-space members call was issued.
+    # No members call, no /spaces walk — the resolver bailed before
+    # any HTTP.
     assert not any(
-        "ch_nowhere/members" in path
+        "ch_nowhere/members" in path or path == "/spaces"
         for method, path, _ in http.calls
         if method == "GET"
-    ), "must not issue a members call when space resolution fails"
+    ), f"must not issue HTTP on cache miss; calls={http.calls}"
+
+
+@pytest.mark.asyncio
+async def test_list_channel_members_fails_loud_on_cache_miss():
+    """list_channel_members reads the cache too — miss = clear error,
+    no fallback to ``cfg.space_id``."""
+    cfg, http, _ = _setup()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "list_channel_members", {"channel": "ch_unknown"})
+    assert "no record of channel" in str(excinfo.value)
+    assert not any(
+        "ch_unknown/members" in path
+        for method, path, _ in http.calls
+        if method == "GET"
+    ), "must not issue a members call when cache misses"
 
 
 @pytest.mark.asyncio

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -560,94 +560,115 @@ async def test_get_thread_history_empty_window():
 
 
 @pytest.mark.asyncio
-async def test_list_channels():
-    """Channels come from ``/spaces/<sp>/events`` replay — there's no
-    standalone channels endpoint on puffo-server."""
+async def test_list_channels_enumerates_all_spaces():
+    """The tool now walks every space the agent is a member of, not
+    just ``cfg.space_id``. Server-filtered ``GET /spaces`` returns
+    the actual membership; per-space ``GET /spaces/<sp>/channels``
+    enumerates the channels with one round-trip each."""
     cfg, http, ms = _setup()
-    http.responses["/spaces/sp_test/events"] = {
-        "events": [
-            {"kind": "create_space", "payload": {"space_id": "sp_test", "name": "Test"}},
-            {"kind": "create_channel", "payload": {"channel_id": "ch_1", "name": "General"}},
-            {"kind": "create_channel", "payload": {"channel_id": "ch_2", "name": "Random"}},
-            {"kind": "invite_to_space", "payload": {"invitee_slug": "alice-0001"}},
+    http.responses["/spaces"] = {
+        "spaces": [
+            {"space_id": "sp_team", "name": "Team"},
+            {"space_id": "sp_other", "name": "Other"},
         ],
-        "has_more": False,
+    }
+    http.responses["/spaces/sp_team/channels"] = {
+        "channels": [
+            {"channel_id": "ch_g_team", "name": "General", "is_public": True},
+            {"channel_id": "ch_rand", "name": "Random", "is_public": False},
+        ],
+    }
+    http.responses["/spaces/sp_other/channels"] = {
+        "channels": [
+            {"channel_id": "ch_g_other", "name": "General", "is_public": True},
+        ],
     }
     mcp = _build_tools(cfg)
     result = await _call(mcp, "list_channels")
-    assert "General" in result
-    assert "Random" in result
-    assert "ch_1" in result
-    assert "ch_2" in result
+
+    # Both spaces named, grouped, with all their channels.
+    assert "sp_team" in result and "Team" in result
+    assert "sp_other" in result and "Other" in result
+    assert "ch_g_team" in result and "ch_rand" in result
+    assert "ch_g_other" in result
+    # One /spaces + one /spaces/<sp>/channels per space.
+    assert ("GET", "/spaces", None) in http.calls
+    assert ("GET", "/spaces/sp_team/channels", None) in http.calls
+    assert ("GET", "/spaces/sp_other/channels", None) in http.calls
 
 
 @pytest.mark.asyncio
-async def test_list_channels_paginates_via_since():
-    """``list_channels`` walks ``/spaces/<sp>/events`` page-by-page
-    using ``?since=<next_cursor>``. Guards against a regression of
-    the ``?cursor=`` bug — the server's axum extractor silently
-    ignored the wrong-named key, so paginated calls re-fetched the
-    first page forever and the tool never returned."""
+async def test_list_channels_returns_empty_message_with_no_spaces():
+    """Agent not in any space (new install, fully cascaded out) —
+    no /spaces/<sp>/channels round-trips at all."""
     cfg, http, ms = _setup()
-    # Page 1: one channel + cursor pointing at page 2.
-    http.responses["/spaces/sp_test/events"] = {
-        "events": [
-            {"kind": "create_channel", "payload": {"channel_id": "ch_1", "name": "General"}},
-        ],
-        "has_more": True,
-        "next_cursor": "cursor_page2",
-    }
-    # Page 2: second channel + end of stream. Registered against the
-    # exact ``?since=`` URL so a regression to ``?cursor=`` would miss
-    # this entry and fall back to page 1 (loop forever).
-    http.responses["/spaces/sp_test/events?since=cursor_page2"] = {
-        "events": [
-            {"kind": "create_channel", "payload": {"channel_id": "ch_2", "name": "Random"}},
-        ],
-        "has_more": False,
-    }
+    http.responses["/spaces"] = {"spaces": []}
     mcp = _build_tools(cfg)
     result = await _call(mcp, "list_channels")
 
-    assert "General" in result
-    assert "ch_1" in result
-    assert "Random" in result
-    assert "ch_2" in result
-
-    events_calls = [c for c in http.calls if c[1].startswith("/spaces/sp_test/events")]
-    # Exactly two requests: page 1 (no query) + page 2 (?since=).
-    assert len(events_calls) == 2, events_calls
-    assert events_calls[0][1] == "/spaces/sp_test/events"
-    assert "?since=cursor_page2" in events_calls[1][1]
+    assert "not a member" in result
+    # No per-space round-trip — bail after the empty /spaces list.
+    per_space_calls = [c for c in http.calls if "/channels" in c[1]]
+    assert per_space_calls == []
 
 
 @pytest.mark.asyncio
-async def test_list_channels_bails_on_stuck_cursor():
-    """If the server ever regresses and returns the same cursor it
-    was just sent, the tool must stop instead of spinning. Mirrors
-    the strict-advance guard in ``fetchChannelsFromEvents``
-    (web) and ``_resolve_channel_name`` (this package)."""
+async def test_list_channels_ignores_cfg_space_id():
+    """Req 3 / FB diagnostic: ``cfg.space_id`` is legacy metadata and
+    must not gate the LLM's view. An agent with ``cfg.space_id``
+    pointing at a space it IS NOT in must still see channels in the
+    spaces it IS in. Pre-fix would have walked
+    ``/spaces/sp_legacy/events`` (404 or empty) and returned
+    ``(no channels in this space)``."""
     cfg, http, ms = _setup()
-    # Both the initial and the ``?since=stuck`` request hand back
-    # the same ``next_cursor`` — a real regression would loop, the
-    # guarded loop bails after the second fetch.
-    page = {
-        "events": [
-            {"kind": "create_channel", "payload": {"channel_id": "ch_1", "name": "General"}},
-        ],
-        "has_more": True,
-        "next_cursor": "stuck",
+    cfg.space_id = "sp_legacy_not_a_member"  # explicit miss
+    http.responses["/spaces"] = {
+        "spaces": [{"space_id": "sp_real", "name": "Real"}],
     }
-    http.responses["/spaces/sp_test/events"] = page
-    http.responses["/spaces/sp_test/events?since=stuck"] = page
+    http.responses["/spaces/sp_real/channels"] = {
+        "channels": [
+            {"channel_id": "ch_only", "name": "general"},
+        ],
+    }
     mcp = _build_tools(cfg)
     result = await _call(mcp, "list_channels")
 
-    assert "General" in result
-    events_calls = [c for c in http.calls if c[1].startswith("/spaces/sp_test/events")]
-    # Two calls: initial, then one with ``?since=stuck`` whose
-    # ``next_cursor`` is also ``stuck`` — the guard breaks the loop.
-    assert len(events_calls) == 2, events_calls
+    assert "ch_only" in result
+    assert "sp_real" in result
+    # Never reached the legacy path.
+    legacy_calls = [
+        c for c in http.calls
+        if "sp_legacy_not_a_member" in c[1]
+    ]
+    assert legacy_calls == [], (
+        f"expected no calls into cfg.space_id, got {legacy_calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_channels_tolerates_per_space_string_response():
+    """Tight race after AcceptSpaceInvite: ``GET /spaces/<sp>/channels``
+    returns the SPA-route HTML stub (decoded as ``str``) before the
+    materialiser commits. Treat as "no channels yet" rather than
+    crashing the tool."""
+    cfg, http, ms = _setup()
+    http.responses["/spaces"] = {
+        "spaces": [
+            {"space_id": "sp_a", "name": "A"},
+            {"space_id": "sp_b", "name": "B"},
+        ],
+    }
+    http.responses["/spaces/sp_a/channels"] = ""  # racy / unhealthy
+    http.responses["/spaces/sp_b/channels"] = {
+        "channels": [{"channel_id": "ch_x", "name": "general"}],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels")
+
+    # sp_a present, but empty-channels marker; sp_b lists its channel.
+    assert "sp_a" in result
+    assert "(no channels)" in result
+    assert "ch_x" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -560,11 +560,87 @@ async def test_get_thread_history_empty_window():
 
 
 @pytest.mark.asyncio
-async def test_list_channels_enumerates_all_spaces():
-    """The tool now walks every space the agent is a member of, not
-    just ``cfg.space_id``. Server-filtered ``GET /spaces`` returns
-    the actual membership; per-space ``GET /spaces/<sp>/channels``
-    enumerates the channels with one round-trip each."""
+async def test_list_spaces_returns_server_filtered_memberships():
+    """``GET /spaces`` is server-filtered to memberships the agent
+    actually has; the tool just formats the result. Server-side
+    enforcement means "if it's in the list, the agent can write
+    there" — pair with ``list_channels_in_space`` for the channel
+    detail."""
+    cfg, http, ms = _setup()
+    http.responses["/spaces"] = {
+        "spaces": [
+            {"space_id": "sp_team", "name": "Team"},
+            {"space_id": "sp_other", "name": "Other"},
+        ],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_spaces")
+    assert "sp_team" in result and "Team" in result
+    assert "sp_other" in result and "Other" in result
+    # No per-space round-trips — list_spaces stays cheap.
+    per_space_calls = [c for c in http.calls if "/channels" in c[1]]
+    assert per_space_calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_spaces_returns_empty_marker_when_not_a_member():
+    cfg, http, ms = _setup()
+    http.responses["/spaces"] = {"spaces": []}
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_spaces")
+    assert "not a member" in result
+
+
+@pytest.mark.asyncio
+async def test_list_channels_in_space_scopes_to_one_space():
+    """``list_channels_in_space(space_id)`` round-trips exactly one
+    ``GET /spaces/<sp>/channels`` and formats the result. No
+    ``GET /spaces`` enumeration; no ``cfg.space_id`` consulting."""
+    cfg, http, ms = _setup()
+    cfg.space_id = "sp_legacy"  # must be irrelevant
+    http.responses["/spaces/sp_target/channels"] = {
+        "channels": [
+            {"channel_id": "ch_g", "name": "general"},
+            {"channel_id": "ch_r", "name": "random"},
+        ],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels_in_space", {"space_id": "sp_target"})
+
+    assert "ch_g" in result and "general" in result
+    assert "ch_r" in result and "random" in result
+    # Exactly one round-trip; never to cfg.space_id or /spaces.
+    assert ("GET", "/spaces/sp_target/channels", None) in http.calls
+    assert not any(c[1] == "/spaces" for c in http.calls)
+    assert not any("sp_legacy" in c[1] for c in http.calls)
+
+
+@pytest.mark.asyncio
+async def test_list_channels_in_space_requires_space_id():
+    """Missing ``space_id`` is a contract error — surface it as an
+    MCP tool error rather than silently using ``cfg.space_id``."""
+    cfg, http, ms = _setup()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception):
+        await _call(mcp, "list_channels_in_space", {"space_id": ""})
+
+
+@pytest.mark.asyncio
+async def test_list_channels_in_space_tolerates_string_response():
+    """Tight race after AcceptSpaceInvite: server briefly returns
+    the SPA HTML stub (``str``). Treat as "no channels yet"."""
+    cfg, http, ms = _setup()
+    http.responses["/spaces/sp_racy/channels"] = ""
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels_in_space", {"space_id": "sp_racy"})
+    assert "no channels" in result
+
+
+@pytest.mark.asyncio
+async def test_list_channels_in_all_spaces_enumerates_all_spaces():
+    """One ``GET /spaces`` + one ``GET /spaces/<sp>/channels`` per
+    space, grouped output. Convenience shortcut over ``list_spaces``
+    + per-space calls."""
     cfg, http, ms = _setup()
     http.responses["/spaces"] = {
         "spaces": [
@@ -584,7 +660,7 @@ async def test_list_channels_enumerates_all_spaces():
         ],
     }
     mcp = _build_tools(cfg)
-    result = await _call(mcp, "list_channels")
+    result = await _call(mcp, "list_channels_in_all_spaces")
 
     # Both spaces named, grouped, with all their channels.
     assert "sp_team" in result and "Team" in result
@@ -598,28 +674,25 @@ async def test_list_channels_enumerates_all_spaces():
 
 
 @pytest.mark.asyncio
-async def test_list_channels_returns_empty_message_with_no_spaces():
+async def test_list_channels_in_all_spaces_returns_empty_message_with_no_spaces():
     """Agent not in any space (new install, fully cascaded out) —
     no /spaces/<sp>/channels round-trips at all."""
     cfg, http, ms = _setup()
     http.responses["/spaces"] = {"spaces": []}
     mcp = _build_tools(cfg)
-    result = await _call(mcp, "list_channels")
+    result = await _call(mcp, "list_channels_in_all_spaces")
 
     assert "not a member" in result
-    # No per-space round-trip — bail after the empty /spaces list.
     per_space_calls = [c for c in http.calls if "/channels" in c[1]]
     assert per_space_calls == []
 
 
 @pytest.mark.asyncio
-async def test_list_channels_ignores_cfg_space_id():
-    """Req 3 / FB diagnostic: ``cfg.space_id`` is legacy metadata and
-    must not gate the LLM's view. An agent with ``cfg.space_id``
+async def test_list_channels_in_all_spaces_ignores_cfg_space_id():
+    """Req 3 anchor: ``cfg.space_id`` is legacy metadata and must
+    not gate the LLM's view. An agent with ``cfg.space_id``
     pointing at a space it IS NOT in must still see channels in the
-    spaces it IS in. Pre-fix would have walked
-    ``/spaces/sp_legacy/events`` (404 or empty) and returned
-    ``(no channels in this space)``."""
+    spaces it IS in."""
     cfg, http, ms = _setup()
     cfg.space_id = "sp_legacy_not_a_member"  # explicit miss
     http.responses["/spaces"] = {
@@ -631,11 +704,10 @@ async def test_list_channels_ignores_cfg_space_id():
         ],
     }
     mcp = _build_tools(cfg)
-    result = await _call(mcp, "list_channels")
+    result = await _call(mcp, "list_channels_in_all_spaces")
 
     assert "ch_only" in result
     assert "sp_real" in result
-    # Never reached the legacy path.
     legacy_calls = [
         c for c in http.calls
         if "sp_legacy_not_a_member" in c[1]
@@ -646,11 +718,9 @@ async def test_list_channels_ignores_cfg_space_id():
 
 
 @pytest.mark.asyncio
-async def test_list_channels_tolerates_per_space_string_response():
-    """Tight race after AcceptSpaceInvite: ``GET /spaces/<sp>/channels``
-    returns the SPA-route HTML stub (decoded as ``str``) before the
-    materialiser commits. Treat as "no channels yet" rather than
-    crashing the tool."""
+async def test_list_channels_in_all_spaces_tolerates_per_space_string_response():
+    """One space's ``/channels`` returns the SPA HTML stub (tight
+    race); other spaces still enumerate cleanly."""
     cfg, http, ms = _setup()
     http.responses["/spaces"] = {
         "spaces": [
@@ -663,9 +733,8 @@ async def test_list_channels_tolerates_per_space_string_response():
         "channels": [{"channel_id": "ch_x", "name": "general"}],
     }
     mcp = _build_tools(cfg)
-    result = await _call(mcp, "list_channels")
+    result = await _call(mcp, "list_channels_in_all_spaces")
 
-    # sp_a present, but empty-channels marker; sp_b lists its channel.
     assert "sp_a" in result
     assert "(no channels)" in result
     assert "ch_x" in result
@@ -1126,13 +1195,15 @@ async def test_send_message_with_attachments_auto_corrects_reply_as_root_id(
 
 
 @pytest.mark.asyncio
-async def test_all_9_tools_registered():
+async def test_core_tools_registered():
     cfg, _, _ = _setup()
     mcp = _build_tools(cfg)
     tool_names = {t.name for t in await mcp.list_tools()}
     expected = {
         "whoami", "send_message", "get_channel_history",
-        "list_channels", "list_channel_members", "get_user_info",
-        "get_post", "send_message_with_attachments", "fetch_channel_files",
+        "list_spaces", "list_channels_in_all_spaces",
+        "list_channels_in_space", "list_channel_members",
+        "get_user_info", "get_post", "send_message_with_attachments",
+        "fetch_channel_files",
     }
     assert expected.issubset(tool_names)

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -340,6 +340,12 @@ async def test_puffo_core_client_send_fallback_message_encrypts():
         http_client=http,
         message_store=ms,
     )
+    # Pre-seed the channel→space cache: ``send_fallback_message``
+    # no longer silently falls back to ``self.space_id`` (legacy
+    # home space) when the cache misses. Production fills this
+    # cache from inbound envelopes + membership events; the smoke
+    # test seeds it directly.
+    client._channel_space["ch_abc"] = "sp_test"
     await client.send_fallback_message("ch_abc", "hello world", root_id="")
 
     # Channel resolution: members endpoint -> /certs/sync.
@@ -366,4 +372,60 @@ async def test_puffo_core_client_send_fallback_message_encrypts():
     assert r["device_id"] == "dev_recipient"
     assert "hpke_enc" in r
     assert "wrapped_content_key" in r
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_send_fallback_message_drops_when_channel_space_unknown():
+    """Regression for the ``self.space_id`` silent-fallback at
+    line 2382 — the agent used to route an unknown-channel reply
+    to its legacy home space, which under cross-space deployments
+    (or after a kick / cascade that evicted the in-memory cache)
+    sent the reply to the wrong place or to a space the agent had
+    just been kicked from. Now the path drops the reply with a
+    clear log line instead."""
+    from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+    ks, ks_dir, d, kem_kp = _make_keystore()
+    db_path = os.path.join(d, "messages.db")
+    ms = MessageStore(db_path)
+    await ms.open()
+
+    class _NoHttp:
+        def __init__(self):
+            self.calls = []
+
+        async def get(self, path):
+            self.calls.append(("GET", path))
+            raise AssertionError(
+                f"send_fallback_message must NOT round-trip when "
+                f"channel→space is unknown; got GET {path}"
+            )
+
+        async def post(self, path, body=None):
+            self.calls.append(("POST", path))
+            raise AssertionError(
+                f"send_fallback_message must NOT POST when "
+                f"channel→space is unknown; got POST {path}"
+            )
+
+        async def _ensure_subkey(self):
+            pass
+
+    http = _NoHttp()
+    client = PuffoCoreMessageClient(
+        slug="bot-0001",
+        device_id="dev_test",
+        space_id="sp_legacy_home",  # ← used to be the silent fallback
+        keystore=ks,
+        http_client=http,
+        message_store=ms,
+    )
+    # Crucially: do NOT pre-seed ``_channel_space``. The pre-fix
+    # behaviour would have read ``self.space_id`` and routed to
+    # ``/spaces/sp_legacy_home/...``; the post-fix behaviour drops.
+    await client.send_fallback_message("ch_unknown", "reply", root_id="")
+
+    # No HTTP at all — the FakeHttp ``raise`` ensures it.
+    assert http.calls == []
     await ms.close()


### PR DESCRIPTION
## Symptom

Two related symptoms when an agent operates in a channel that isn't in its "home" \`cfg.space_id\`:

1. \`list_channel_members\` returns the wrong space's roster (or a 404 / 403) — the URL was hard-coded with \`cfg.space_id\` regardless of where the channel actually lived.
2. \`send_message\` to a freshly-joined channel either silently sent into the wrong space (pre-FB-76) or paid a multi-call walk over \`GET /spaces\` + \`/spaces/<sp>/channels\` (post-FB-76, slower / still racy).

The diagnostic thread is on the prior session — symptom 1 was reported on a brand-new user; symptom 2 was FB-76.

## Root cause

The channel→space cache that backs \`lookup_channel_space\` was only populated from inbound **messages**. Membership events carrying \`(channel_id, space_id)\` — \`accept_channel_invite\`, \`invite_to_channel\`, \`create_channel\` — landed on the WS but were never recorded. So a channel the agent had just been admitted to remained \"unknown\" until the first message arrived.

## Fix

\`puffo_core_client._handle_event\` now feeds the cache from every membership event that proves the agent can reach the channel:

| Event kind | Admission gate |
|---|---|
| \`invite_to_channel\` | \`payload.invitee_slug == self.slug\` |
| \`accept_channel_invite\` | \`event.signer_slug == self.slug\` |
| \`create_channel\` | always — server only fans these to space members |

\`_accept_invite\` also writes the mapping synchronously after posting the accept, so the immediately-following intro-nudge send doesn't race the WS echo back.

With events feeding the cache, the FB-76-era \`_discover_channel_space\` walker is unnecessary. Replaced by a thin \`_resolve_channel_space\` helper that's purely a cache lookup; on miss the MCP tool raises a clear \"agent has no record of channel\" error.

Three MCP tools simplified to the same cache-lookup-or-raise pattern:
- \`send_message\` — drops the two-stage resolver.
- \`send_message_with_attachments\` — drops the silent \`or cfg.space_id\` fallback.
- \`list_channel_members\` — drops the \`cfg.space_id\` hardcoding.

\`cfg.space_id\` is now genuinely just metadata for the agent's home space; no MCP code path falls back to it.

## Test plan

- [x] New: \`_handle_event\` cache admission tests per kind + signer gate
  - \`test_handle_event_synthetic_accept_records_channel_space\`
  - \`test_handle_event_create_channel_records_mapping\`
  - \`test_handle_event_invite_to_channel_for_self_records_mapping\`
  - \`test_handle_event_invite_to_channel_for_other_skips_cache\`
  - \`test_handle_event_accept_signed_by_other_skips_cache\`
- [x] Rewritten: cross-space \`send_message\` test pre-caches the mapping
- [x] New: \`send_message\` / \`list_channel_members\` cache-miss tests assert no HTTP at all
- [x] \`pytest tests/\` — 542 passed, 3 pre-existing skips (Docker / symlinks / permission-mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)