### PR TITLE
feat(portal): multi-agent export/import with device migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,87 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.4] — 2026-05-17
+
+### Added
+
+- **Multi-agent `export` / `import` with device migration.** An
+  operator can pack N agents on the old machine into a single
+  encrypted `.puffoagent` bundle and recover them on the new machine
+  with the *same* slug — outside observers see the same agent, the
+  same channel/space memberships, the same profile; only the
+  underlying device key rotates and the old device is auto-revoked.
+
+  Architecture is enrollment-style, not key-copy: `device_id ↔
+  device_pubkey` is 1:1, so copying keys verbatim would make the old
+  and new daemon share an identity and a `/devices/{id}/revoke` call
+  would lock out both. Instead, import preserves `root_secret_key`
+  + `identity_cert` + `slug_binding` (the root identity), generates a
+  fresh `device_signing_key` + KEM key, calls the existing
+  `/devices/enroll/init` + `/devices/enroll/{nonce}/complete` to
+  register the new device, then signs a `device_revocation` with the
+  root key and POSTs it to `/devices/{old_device_id}/revoke`.
+  Best-effort revoke: if the new device is registered but the revoke
+  call 5xx's, a `pending_revoke.json` marker is written and the
+  separate `revoke-pending` command can retry without re-running
+  import.
+
+  **No server-side changes.** Uses `/devices/subkeys` (which accepts
+  device-key direct signing via `DeviceOrSubkeyAuth`) to register a
+  temporary subkey on the old device so it can sign the enrollment
+  completion, and again on the new device for the revoke call.
+
+  **Bundle format** — `.puffoagent`: 16-byte magic
+  (`PUFFO-AGENT-V1\x00\x00`) + 16-byte scrypt salt + 12-byte AES-GCM
+  nonce + AES-256-GCM-encrypted inner zip. AEAD AAD covers
+  `magic + salt` so header tampering fails decryption. Inner zip is
+  `manifest.json` + `agents/<id>/...` per agent. Password-required at
+  both ends; wrong password fails with a clean
+  `"decryption failed"` rather than a vague tag error.
+
+  **Crash safety.** Each agent imports through
+  `agents/.import-staging/<id>/` and only `shutil.move`s onto
+  `agents/<id>/` once enrollment is committed on the server. Daemon
+  startup sweeps any leftover `.import-staging/` from a prior crash.
+  Per-agent skip if the live agent dir already exists, so re-running
+  `import` on the same bundle is idempotent.
+
+  **Sanitisation.** The export drops files that are device-bound to
+  the source machine and don't carry forward: `runtime.json`,
+  `cli_session.json`, `messages.db`, `.puffo-agent/*.flag`,
+  `.puffo-agent/current_turn.json`, `workspace/.claude/.credentials.json`.
+  `messages.db` is deliberately dropped — its records are sealed
+  under the *old* KEM key, which the new device can't decrypt;
+  history that needs to survive a migration should be preserved
+  server-side.
+
+  **CLI.**
+  - `puffo-agent agent export <id>... --dest <path>` — prompts for a
+    password twice; auto-corrects `.puffoagent` extension; refuses
+    overwrite without `--force`.
+  - `puffo-agent agent import <src>` — prompts once; prints
+    per-agent `OK / PARTIAL / SKIP / FAIL` lines plus a summary.
+  - `puffo-agent agent revoke-pending [id]` — retries one agent's
+    pending revoke, or sweeps all when called without an id.
+
+  **Bridge HTTP.**
+  - `POST /v1/agents/export` — JSON
+    `{agent_ids, password}` → `application/octet-stream` blob.
+  - `POST /v1/agents/import` — JSON
+    `{bundle_b64, password}` → JSON `ImportReport`.
+  - `POST /v1/agents/{id}/revoke-pending` — owner-gated retry.
+
+  `BRIDGE_MAX_REQUEST_BYTES` raised to 64 MiB so the bridge can
+  accept a base64-wrapped multi-agent bundle.
+
+  24 new tests across `test_export_module.py`,
+  `test_import_module.py` (3-phase flow against a mocked
+  puffo-server, enrollment-failure cleanup, revoke-failure pending
+  marker, retry happy path), and `test_bridge_export_import.py`
+  (full HTTP roundtrip: export → fresh home → import →
+  verify new `device_id` replaced old; wrong-password rejection;
+  owner-gated revoke-pending). Full suite: 576 passed, 7 skipped.
+
 ## [0.8.3] — 2026-05-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.3"
+version = "0.8.4"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -1475,3 +1475,120 @@ def _bad(msg: str) -> web.Response:
 
 def _not_found(msg: str) -> web.Response:
     return web.json_response({"error": msg}, status=404)
+
+
+# ────────────────────────────────────────────────────────────────────
+# /v1/agents/export, /v1/agents/import, /v1/agents/{id}/revoke-pending
+# Multi-agent migration. See ``portal/export.py`` and
+# ``portal/import_agents.py`` for the on-disk + server-side flow.
+# ────────────────────────────────────────────────────────────────────
+
+
+async def agents_export(request: web.Request) -> web.Response:
+    from .. import export as exp
+
+    try:
+        payload = await request.json()
+    except Exception:
+        return _bad("body must be JSON")
+    if not isinstance(payload, dict):
+        return _bad("body must be a JSON object")
+
+    raw_ids = payload.get("agent_ids")
+    if not isinstance(raw_ids, list) or not raw_ids or not all(isinstance(a, str) for a in raw_ids):
+        return _bad("agent_ids must be a non-empty list of strings")
+    password = payload.get("password")
+    if not isinstance(password, str) or not password:
+        return _bad("password must be a non-empty string")
+    for aid in raw_ids:
+        if not is_valid_agent_id(aid):
+            return _bad(f"invalid agent id: {aid!r}")
+
+    try:
+        blob = exp.pack(raw_ids, password, exported_by_slug=request.get("paired_slug", ""))
+    except exp.ExportError as exc:
+        return _bad(str(exc))
+
+    logger.info("bridge: export packed agents=%s bytes=%d", raw_ids, len(blob))
+    return web.Response(
+        body=blob,
+        content_type="application/octet-stream",
+        headers={"content-disposition": 'attachment; filename="agents.puffoagent"'},
+    )
+
+
+async def agents_import(request: web.Request) -> web.Response:
+    from .. import export as exp
+    from .. import import_agents as imp
+
+    try:
+        payload = await request.json()
+    except Exception:
+        return _bad("body must be JSON")
+    if not isinstance(payload, dict):
+        return _bad("body must be a JSON object")
+
+    bundle_b64 = payload.get("bundle_b64")
+    password = payload.get("password")
+    if not isinstance(bundle_b64, str) or not bundle_b64:
+        return _bad("bundle_b64 must be a non-empty base64url string")
+    if not isinstance(password, str) or not password:
+        return _bad("password must be a non-empty string")
+
+    try:
+        blob = base64url_decode(bundle_b64)
+    except Exception as exc:
+        return _bad(f"bundle_b64 decode failed: {exc}")
+
+    try:
+        report = await imp.import_bundle(blob, password)
+    except exp.ImportPackError as exc:
+        return _bad(str(exc))
+
+    body = {
+        "total": report.total,
+        "imported": report.imported,
+        "skipped": report.skipped,
+        "failed": report.failed,
+        "pending_revokes": report.pending_revokes,
+        "results": [
+            {
+                "agent_id": r.agent_id,
+                "status": r.status,
+                "detail": r.detail,
+                "new_device_id": r.new_device_id,
+                "old_device_id": r.old_device_id,
+            }
+            for r in report.results
+        ],
+    }
+    logger.info(
+        "bridge: import done total=%d imported=%d skipped=%d failed=%d pending_revokes=%d",
+        report.total, report.imported, report.skipped, report.failed, report.pending_revokes,
+    )
+    return web.json_response(body)
+
+
+async def agent_revoke_pending(request: web.Request) -> web.Response:
+    from .. import import_agents as imp
+
+    agent_id = request.match_info["id"]
+    if not is_valid_agent_id(agent_id):
+        return _bad("invalid agent id")
+    if not agent_yml_path(agent_id).exists():
+        return _not_found("agent not found")
+    paired_root = request["paired_root_pubkey"]
+    if not is_owner(agent_id, paired_root):
+        return web.json_response(
+            {"error": "only the agent's operator can retry its revoke"},
+            status=403,
+        )
+    result = await imp.revoke_pending(agent_id)
+    body = {
+        "agent_id": result.agent_id,
+        "status": result.status,
+        "detail": result.detail,
+        "old_device_id": result.old_device_id,
+    }
+    status = 200 if result.status in ("imported", "skipped") else 502
+    return web.json_response(body, status=status)

--- a/src/puffo_agent/portal/api/server.py
+++ b/src/puffo_agent/portal/api/server.py
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 
 
 # aiohttp's default 1 MiB cap is below ``MAX_AVATAR_BYTES`` (4 MiB
-# raw → ~5.4 MiB after base64 + JSON envelope). 8 MiB covers the
-# avatar with headroom for identity-bundle bodies. Per-handler caps
-# still apply on top.
-BRIDGE_MAX_REQUEST_BYTES = 8 * 1024 * 1024
+# raw → ~5.4 MiB after base64 + JSON envelope). The ``import`` endpoint
+# also POSTs base64-encoded bundles that can hold N agents' workspaces,
+# so the cap is sized generously. Per-handler caps still apply on top.
+BRIDGE_MAX_REQUEST_BYTES = 64 * 1024 * 1024
 
 
 def build_app(cfg: BridgeConfig) -> web.Application:
@@ -52,6 +52,9 @@ def build_app(cfg: BridgeConfig) -> web.Application:
     app.router.add_get("/v1/agents/{id}/files", h.list_files)
     app.router.add_get("/v1/agents/{id}/files/raw", h.read_file)
     app.router.add_get("/v1/agents/{id}/claude-md", h.get_claude_md)
+    app.router.add_post("/v1/agents/export", h.agents_export)
+    app.router.add_post("/v1/agents/import", h.agents_import)
+    app.router.add_post("/v1/agents/{id}/revoke-pending", h.agent_revoke_pending)
     return app
 
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -16,7 +16,6 @@ import shutil
 import subprocess
 import sys
 import time
-import zipfile
 from pathlib import Path
 
 from .api.pairing import clear_pairing, load_pairing
@@ -1107,24 +1106,135 @@ def cmd_api_status(args: argparse.Namespace) -> int:
 
 
 def cmd_agent_export(args: argparse.Namespace) -> int:
-    agent_id = args.id
-    src = agent_dir(agent_id)
-    if not src.exists():
-        print(f"error: agent {agent_id!r} not found", file=sys.stderr)
+    from . import export as exp
+
+    agent_ids: list[str] = args.ids
+    missing = [a for a in agent_ids if not agent_dir(a).exists()]
+    if missing:
+        print(f"error: agent(s) not found: {', '.join(missing)}", file=sys.stderr)
         return 2
     dest = Path(args.dest)
-    if dest.suffix.lower() != ".zip":
-        dest = dest.with_suffix(".zip")
-    with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for path in src.rglob("*"):
-            if path.is_file():
-                # Skip any tmp files mid-write.
-                if path.suffix == ".tmp":
-                    continue
-                arcname = Path(agent_id) / path.relative_to(src)
-                zf.write(path, arcname=str(arcname))
-    print(f"exported {agent_id!r} → {dest}")
+    if dest.suffix.lower() != ".puffoagent":
+        dest = dest.with_suffix(".puffoagent")
+    if dest.exists() and not args.force:
+        print(f"error: {dest} already exists (pass --force to overwrite)", file=sys.stderr)
+        return 2
+
+    password = _prompt_password_twice("Set export password: ")
+    if password is None:
+        return 130
+
+    try:
+        blob = exp.pack(agent_ids, password)
+    except exp.ExportError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    dest.write_bytes(blob)
+    print(f"exported {len(agent_ids)} agent(s) → {dest} ({len(blob):,} bytes)")
     return 0
+
+
+def cmd_agent_import(args: argparse.Namespace) -> int:
+    from . import export as exp
+    from . import import_agents
+
+    src = Path(args.src)
+    if not src.is_file():
+        print(f"error: {src} not found", file=sys.stderr)
+        return 2
+    try:
+        blob = src.read_bytes()
+    except OSError as e:
+        print(f"error: cannot read {src}: {e}", file=sys.stderr)
+        return 2
+
+    password = _prompt_password_once("Import password: ")
+    if password is None:
+        return 130
+
+    try:
+        report = asyncio.run(import_agents.import_bundle(blob, password))
+    except exp.ImportPackError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    width = max((len(r.agent_id) for r in report.results), default=10)
+    for r in report.results:
+        tag = {
+            "imported": "OK     ",
+            "imported_pending_revoke": "PARTIAL",
+            "skipped": "SKIP   ",
+            "failed": "FAIL   ",
+        }.get(r.status, r.status)
+        line = f"  [{tag}] {r.agent_id.ljust(width)}"
+        if r.detail:
+            line += f"  — {r.detail}"
+        print(line)
+
+    print(
+        f"\nsummary: {report.imported} imported "
+        f"({report.pending_revokes} pending revoke), "
+        f"{report.skipped} skipped, {report.failed} failed"
+    )
+    return 0 if report.failed == 0 else 1
+
+
+def cmd_agent_revoke_pending(args: argparse.Namespace) -> int:
+    from . import import_agents
+
+    if args.id:
+        result = asyncio.run(import_agents.revoke_pending(args.id))
+        if result.status == "imported":
+            print(f"OK: revoked {result.old_device_id} for agent {result.agent_id}")
+            return 0
+        if result.status == "skipped":
+            print(f"skip: {result.detail}")
+            return 0
+        print(f"FAIL: {result.detail}", file=sys.stderr)
+        return 1
+
+    pending = import_agents.list_pending_revokes()
+    if not pending:
+        print("no pending revokes")
+        return 0
+    print(f"{len(pending)} pending revoke(s):")
+    for agent_id, old_device_id in pending:
+        result = asyncio.run(import_agents.revoke_pending(agent_id))
+        tag = "OK  " if result.status == "imported" else "FAIL"
+        print(f"  [{tag}] {agent_id}  old={old_device_id}  {result.detail}")
+    return 0
+
+
+def _prompt_password_once(prompt: str) -> str | None:
+    import getpass
+
+    try:
+        pw = getpass.getpass(prompt)
+    except (KeyboardInterrupt, EOFError):
+        print(file=sys.stderr)
+        return None
+    if not pw:
+        print("error: empty password", file=sys.stderr)
+        return None
+    return pw
+
+
+def _prompt_password_twice(prompt: str) -> str | None:
+    import getpass
+
+    try:
+        pw = getpass.getpass(prompt)
+        confirm = getpass.getpass("Confirm password:    ")
+    except (KeyboardInterrupt, EOFError):
+        print(file=sys.stderr)
+        return None
+    if not pw:
+        print("error: empty password", file=sys.stderr)
+        return None
+    if pw != confirm:
+        print("error: passwords do not match", file=sys.stderr)
+        return None
+    return pw
 
 
 def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
@@ -1466,10 +1576,33 @@ def build_parser() -> argparse.ArgumentParser:
     )
     rename.set_defaults(func=cmd_agent_rename)
 
-    export = agent_sub.add_parser("export", help="Export agent profile + memory + config as a zip")
-    export.add_argument("id")
-    export.add_argument("dest", help="Destination .zip file")
+    export = agent_sub.add_parser(
+        "export",
+        help="Encrypted export of N agents into a .puffoagent bundle",
+    )
+    export.add_argument("ids", nargs="+", metavar="agent_id", help="agent id(s) to export")
+    export.add_argument("--dest", required=True, help="Destination .puffoagent file")
+    export.add_argument("--force", action="store_true", help="Overwrite dest if it exists")
     export.set_defaults(func=cmd_agent_export)
+
+    imp = agent_sub.add_parser(
+        "import",
+        help="Restore agents from a .puffoagent bundle on this daemon",
+    )
+    imp.add_argument("src", help="Path to the .puffoagent file")
+    imp.set_defaults(func=cmd_agent_import)
+
+    revoke_pending = agent_sub.add_parser(
+        "revoke-pending",
+        help="Retry the post-import revocation of an old device",
+    )
+    revoke_pending.add_argument(
+        "id",
+        nargs="?",
+        default=None,
+        help="agent id to retry (omit to retry all pending)",
+    )
+    revoke_pending.set_defaults(func=cmd_agent_revoke_pending)
 
     reset_primer = agent_sub.add_parser(
         "reset-primer",

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -287,6 +287,9 @@ async def run_daemon() -> int:
     home_dir().mkdir(parents=True, exist_ok=True)
     agents_dir().mkdir(parents=True, exist_ok=True)
 
+    from .import_agents import cleanup_staging_dir
+    cleanup_staging_dir()
+
     daemon_cfg = DaemonConfig.load()
     write_daemon_pid(os.getpid())
 

--- a/src/puffo_agent/portal/export.py
+++ b/src/puffo_agent/portal/export.py
@@ -1,0 +1,227 @@
+"""Multi-agent export: zip N agent dirs + manifest + scrypt+AES-GCM encrypt.
+
+Wire layout::
+
+    magic       16 bytes  b"PUFFO-AGENT-V1\x00\x00"
+    kdf_salt    16 bytes
+    aead_nonce  12 bytes
+    ciphertext  rest      AES-256-GCM(scrypt(password, salt) || zip-bytes)
+
+Inner zip::
+
+    manifest.json
+    agents/<id>/...  (full agent dir, *.tmp skipped)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import secrets
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+from .state import agent_dir, agent_yml_path
+
+MAGIC = b"PUFFO-AGENT-V1\x00\x00"
+SALT_LEN = 16
+NONCE_LEN = 12
+KEY_LEN = 32
+
+SCRYPT_N = 2**15
+SCRYPT_R = 8
+SCRYPT_P = 1
+
+
+class ExportError(Exception):
+    pass
+
+
+class ImportPackError(Exception):
+    """Raised by ``unpack`` on bad password / corrupt header / bad zip."""
+
+
+@dataclass(frozen=True)
+class AgentManifestEntry:
+    id: str
+    slug: str
+    display_name: str
+    old_device_id: str
+
+
+def derive_key(password: str, salt: bytes) -> bytes:
+    return Scrypt(salt=salt, length=KEY_LEN, n=SCRYPT_N, r=SCRYPT_R, p=SCRYPT_P).derive(
+        password.encode("utf-8")
+    )
+
+
+def pack(agent_ids: Iterable[str], password: str, *, exported_by_slug: str = "") -> bytes:
+    ids = list(agent_ids)
+    if not ids:
+        raise ExportError("at least one agent id required")
+    if not password:
+        raise ExportError("password is required")
+
+    missing = [a for a in ids if not agent_yml_path(a).exists()]
+    if missing:
+        raise ExportError(f"agent(s) not found: {', '.join(missing)}")
+
+    inner = io.BytesIO()
+    manifest_entries: list[dict] = []
+    with zipfile.ZipFile(inner, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for agent_id in ids:
+            entry = _add_agent(zf, agent_id)
+            manifest_entries.append(entry)
+        manifest = {
+            "format_version": 1,
+            "exported_at": int(time.time() * 1000),
+            "exported_by_slug": exported_by_slug,
+            "agents": manifest_entries,
+        }
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+
+    zip_bytes = inner.getvalue()
+    salt = secrets.token_bytes(SALT_LEN)
+    nonce = secrets.token_bytes(NONCE_LEN)
+    key = derive_key(password, salt)
+    aad = MAGIC + salt
+    ciphertext = AESGCM(key).encrypt(nonce, zip_bytes, aad)
+    return MAGIC + salt + nonce + ciphertext
+
+
+def _add_agent(zf: zipfile.ZipFile, agent_id: str) -> dict:
+    src = agent_dir(agent_id)
+    slug = ""
+    display_name = ""
+    old_device_id = ""
+    try:
+        from .state import AgentConfig
+
+        cfg = AgentConfig.load(agent_id)
+        slug = cfg.puffo_core.slug
+        display_name = cfg.display_name
+        old_device_id = cfg.puffo_core.device_id
+    except Exception:
+        pass
+    for path in src.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix == ".tmp":
+            continue
+        arcname = f"agents/{agent_id}/{path.relative_to(src).as_posix()}"
+        zf.write(path, arcname=arcname)
+    return {
+        "id": agent_id,
+        "slug": slug,
+        "display_name": display_name,
+        "old_device_id": old_device_id,
+    }
+
+
+@dataclass(frozen=True)
+class UnpackedBundle:
+    manifest: dict
+    agents: dict[str, dict[str, bytes]]
+
+
+def unpack(blob: bytes, password: str) -> UnpackedBundle:
+    if len(blob) < len(MAGIC) + SALT_LEN + NONCE_LEN + 16:
+        raise ImportPackError("archive too short to be a puffo-agent export")
+    if blob[: len(MAGIC)] != MAGIC:
+        raise ImportPackError("not a puffo-agent export (bad magic)")
+    off = len(MAGIC)
+    salt = blob[off : off + SALT_LEN]
+    off += SALT_LEN
+    nonce = blob[off : off + NONCE_LEN]
+    off += NONCE_LEN
+    ciphertext = blob[off:]
+    if not password:
+        raise ImportPackError("password is required")
+    key = derive_key(password, salt)
+    aad = MAGIC + salt
+    try:
+        zip_bytes = AESGCM(key).decrypt(nonce, ciphertext, aad)
+    except Exception:
+        raise ImportPackError("decryption failed (wrong password or corrupted archive)")
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes), "r")
+    except zipfile.BadZipFile as exc:
+        raise ImportPackError(f"inner archive is not a valid zip: {exc}")
+
+    names = set(zf.namelist())
+    if "manifest.json" not in names:
+        raise ImportPackError("archive missing manifest.json")
+    manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+    if not isinstance(manifest, dict) or manifest.get("format_version") != 1:
+        raise ImportPackError("unsupported manifest format")
+    declared = manifest.get("agents") or []
+    if not isinstance(declared, list) or not declared:
+        raise ImportPackError("manifest declares no agents")
+
+    agents: dict[str, dict[str, bytes]] = {}
+    for entry in declared:
+        if not isinstance(entry, dict) or not entry.get("id"):
+            raise ImportPackError("manifest entry missing id")
+        agent_id = entry["id"]
+        prefix = f"agents/{agent_id}/"
+        files: dict[str, bytes] = {}
+        for name in names:
+            if not name.startswith(prefix) or name.endswith("/"):
+                continue
+            files[name[len(prefix) :]] = zf.read(name)
+        if not files:
+            raise ImportPackError(f"archive missing files for agent {agent_id!r}")
+        if "agent.yml" not in files:
+            raise ImportPackError(f"agent {agent_id!r} missing agent.yml")
+        if "profile.md" not in files:
+            raise ImportPackError(f"agent {agent_id!r} missing profile.md")
+        agents[agent_id] = files
+
+    return UnpackedBundle(manifest=manifest, agents=agents)
+
+
+def write_unpacked_to_dir(files: dict[str, bytes], dest: Path) -> None:
+    """Materialise an unpacked agent's files into ``dest`` (which must
+    not exist). Used by import after decryption + validation."""
+    if dest.exists():
+        raise ExportError(f"destination already exists: {dest}")
+    dest.mkdir(parents=True)
+    for rel, data in files.items():
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "wb") as f:
+            f.write(data)
+
+
+SANITIZE_PATHS = (
+    "runtime.json",
+    "cli_session.json",
+    "messages.db",
+    ".puffo-agent/reload.flag",
+    ".puffo-agent/refresh.flag",
+    ".puffo-agent/restart.flag",
+    ".puffo-agent/archive.flag",
+    ".puffo-agent/delete.flag",
+    ".puffo-agent/current_turn.json",
+    "workspace/.claude/.credentials.json",
+)
+
+
+def sanitize_staged_agent(staging_dir: Path) -> None:
+    """Drop files that are device-bound to the source machine. Mutates
+    the staging dir in place. Idempotent."""
+    for rel in SANITIZE_PATHS:
+        target = staging_dir / rel
+        if target.exists() and target.is_file():
+            try:
+                os.unlink(target)
+            except OSError:
+                pass

--- a/src/puffo_agent/portal/import_agents.py
+++ b/src/puffo_agent/portal/import_agents.py
@@ -1,0 +1,503 @@
+"""Multi-agent import with enrollment-style device migration.
+
+Each agent goes through three phases on the new daemon:
+
+1. **stage** — decrypt + write files to ``agents/.import-staging/<id>/``
+   + sanitize device-bound files.
+2. **enrol + revoke** — talk to puffo-server (signed by the OLD
+   device's subkey, derived from the imported bundle): submit an
+   enrollment for a freshly-generated device key + KEM key, then
+   revoke the OLD device id. Revoke is best-effort; on failure we
+   leave a ``pending_revoke.json`` marker for ``revoke_pending``
+   retry.
+3. **commit** — atomic rename staging → ``agents/<id>/``.
+
+Phase 2 is the commit point: once the server has registered the new
+device, the daemon writes the new keys to staging. Phase 3 makes it
+visible to the reconciler. Re-running ``import`` is idempotent — if
+the agent dir already exists it's skipped; pending revokes are
+handled by the separate ``revoke_pending`` helper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import aiohttp
+
+from ..crypto.certs import create_subkey_cert
+from ..crypto.encoding import base64url_decode, base64url_encode
+from ..crypto.http_auth import sign_request
+from ..crypto.keystore import KeyStore, StoredIdentity, decode_secret, encode_secret
+from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
+from .export import (
+    ImportPackError,
+    UnpackedBundle,
+    sanitize_staged_agent,
+    unpack,
+    write_unpacked_to_dir,
+)
+from .migration_certs import (
+    build_root_key_envelope,
+    create_device_cert,
+    create_device_revocation,
+    create_slug_binding,
+)
+from .state import agent_dir, agent_yml_path, agents_dir
+
+logger = logging.getLogger(__name__)
+
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=20)
+
+
+class ImportError(Exception):
+    pass
+
+
+@dataclass
+class AgentImportResult:
+    agent_id: str
+    status: str  # "imported" | "skipped" | "failed" | "imported_pending_revoke"
+    detail: str = ""
+    new_device_id: str = ""
+    old_device_id: str = ""
+
+
+@dataclass
+class ImportReport:
+    results: list[AgentImportResult]
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def imported(self) -> int:
+        return sum(1 for r in self.results if r.status.startswith("imported"))
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for r in self.results if r.status == "failed")
+
+    @property
+    def skipped(self) -> int:
+        return sum(1 for r in self.results if r.status == "skipped")
+
+    @property
+    def pending_revokes(self) -> int:
+        return sum(1 for r in self.results if r.status == "imported_pending_revoke")
+
+
+def staging_dir(agent_id: str) -> Path:
+    return agents_dir() / ".import-staging" / agent_id
+
+
+def pending_revoke_path(agent_id: str) -> Path:
+    return agent_dir(agent_id) / ".puffo-agent" / "pending_revoke.json"
+
+
+async def import_bundle(blob: bytes, password: str) -> ImportReport:
+    bundle: UnpackedBundle = unpack(blob, password)
+    results: list[AgentImportResult] = []
+    for agent_id, files in bundle.agents.items():
+        try:
+            results.append(await _import_one(agent_id, files))
+        except Exception as exc:
+            logger.exception("import: agent=%s unexpected error", agent_id)
+            _cleanup_staging(agent_id)
+            results.append(
+                AgentImportResult(agent_id=agent_id, status="failed", detail=str(exc))
+            )
+    return ImportReport(results=results)
+
+
+async def _import_one(agent_id: str, files: dict[str, bytes]) -> AgentImportResult:
+    if agent_yml_path(agent_id).exists():
+        detail = "agent already exists on this daemon"
+        if pending_revoke_path(agent_id).exists():
+            detail += " — pending revoke; run `puffo-agent agent revoke-pending`"
+        return AgentImportResult(agent_id=agent_id, status="skipped", detail=detail)
+
+    _cleanup_staging(agent_id)
+    stage_dir = staging_dir(agent_id)
+    write_unpacked_to_dir(files, stage_dir)
+    sanitize_staged_agent(stage_dir)
+
+    old_identity = _load_old_identity(stage_dir)
+    server_url = old_identity.server_url
+    if not server_url:
+        _cleanup_staging(agent_id)
+        return AgentImportResult(
+            agent_id=agent_id, status="failed", detail="bundle missing server_url",
+        )
+
+    new_signing = Ed25519KeyPair.generate()
+    new_kem = KemKeyPair.generate()
+
+    try:
+        await _enroll_new_device(server_url, old_identity, new_signing, new_kem)
+    except Exception as exc:
+        _cleanup_staging(agent_id)
+        return AgentImportResult(
+            agent_id=agent_id, status="failed", detail=f"enrollment failed: {exc}",
+        )
+
+    new_device_id = _device_id_from_pk(new_signing.public_key_bytes())
+    _write_new_identity(stage_dir, old_identity, new_signing, new_kem, new_device_id)
+    _commit_staging(agent_id, stage_dir)
+
+    revoke_ok = False
+    revoke_err = ""
+    try:
+        await _revoke_old_device(
+            server_url=server_url,
+            slug=old_identity.slug,
+            new_device_id=new_device_id,
+            new_signing_key=new_signing,
+            root_signing_key=Ed25519KeyPair.from_secret_bytes(
+                decode_secret(old_identity.root_secret_key)
+            ),
+            old_device_id=old_identity.device_id,
+        )
+        revoke_ok = True
+    except Exception as exc:
+        revoke_err = str(exc)
+        _write_pending_revoke(agent_id, old_identity.device_id, revoke_err)
+        logger.warning(
+            "import: agent=%s old device revoke failed: %s (left pending_revoke.json)",
+            agent_id, revoke_err,
+        )
+
+    return AgentImportResult(
+        agent_id=agent_id,
+        status="imported" if revoke_ok else "imported_pending_revoke",
+        new_device_id=new_device_id,
+        old_device_id=old_identity.device_id,
+        detail="" if revoke_ok else f"new device active; old revoke failed: {revoke_err}",
+    )
+
+
+def _load_old_identity(stage_dir: Path) -> StoredIdentity:
+    keys_dir = stage_dir / "keys"
+    if not keys_dir.is_dir():
+        raise ImportError("bundle missing keys/ directory")
+    json_files = [p for p in keys_dir.iterdir() if p.suffix == ".json" and ".session" not in p.name]
+    if len(json_files) != 1:
+        raise ImportError(f"expected exactly one identity JSON in keys/, found {len(json_files)}")
+    raw = json.loads(json_files[0].read_text(encoding="utf-8"))
+    return StoredIdentity(
+        slug=raw["slug"],
+        device_id=raw["device_id"],
+        root_secret_key=raw["root_secret_key"],
+        device_signing_secret_key=raw["device_signing_secret_key"],
+        kem_secret_key=raw["kem_secret_key"],
+        server_url=raw["server_url"],
+        slug_binding_json=raw.get("slug_binding_json"),
+        identity_cert_json=raw.get("identity_cert_json"),
+        identity_profile_json=raw.get("identity_profile_json"),
+    )
+
+
+def _device_id_from_pk(signing_pk: bytes) -> str:
+    from ..crypto.certs import derive_public_key_id
+
+    return derive_public_key_id("dev", signing_pk)
+
+
+def _write_new_identity(
+    stage_dir: Path,
+    old_identity: StoredIdentity,
+    new_signing: Ed25519KeyPair,
+    new_kem: KemKeyPair,
+    new_device_id: str,
+) -> None:
+    new_identity = StoredIdentity(
+        slug=old_identity.slug,
+        device_id=new_device_id,
+        root_secret_key=old_identity.root_secret_key,
+        device_signing_secret_key=encode_secret(new_signing.secret_bytes()),
+        kem_secret_key=encode_secret(new_kem.secret_bytes()),
+        server_url=old_identity.server_url,
+        slug_binding_json=old_identity.slug_binding_json,
+        identity_cert_json=old_identity.identity_cert_json,
+        identity_profile_json=old_identity.identity_profile_json,
+    )
+    keys_dir = stage_dir / "keys"
+    for path in list(keys_dir.iterdir()):
+        if path.is_file() and path.name != "registered-agents.json":
+            path.unlink()
+    out_path = keys_dir / f"{old_identity.slug}.json"
+    out_path.write_text(json.dumps(new_identity.to_dict(), indent=2), encoding="utf-8")
+
+    _patch_agent_yml_device_id(stage_dir / "agent.yml", new_device_id)
+
+
+def _patch_agent_yml_device_id(yml_path: Path, new_device_id: str) -> None:
+    import yaml
+
+    raw = yaml.safe_load(yml_path.read_text(encoding="utf-8")) or {}
+    pc = raw.get("puffo_core") or {}
+    pc["device_id"] = new_device_id
+    raw["puffo_core"] = pc
+    yml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+
+
+def _commit_staging(agent_id: str, stage_dir: Path) -> None:
+    target = agent_dir(agent_id)
+    if target.exists():
+        raise ImportError(f"agent dir appeared during import: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(stage_dir), str(target))
+
+
+def _cleanup_staging(agent_id: str) -> None:
+    stage = staging_dir(agent_id)
+    if stage.exists():
+        shutil.rmtree(stage, ignore_errors=True)
+
+
+def _write_pending_revoke(agent_id: str, old_device_id: str, last_error: str) -> None:
+    path = pending_revoke_path(agent_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "old_device_id": old_device_id,
+                "last_error": last_error,
+                "attempted_at": int(time.time() * 1000),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+async def _signed_post(
+    session: aiohttp.ClientSession,
+    *,
+    server_url: str,
+    path: str,
+    signer_key: Ed25519KeyPair,
+    signer_id: str,
+    slug: str,
+    body_dict: dict,
+) -> None:
+    body_bytes = json.dumps(body_dict, separators=(",", ":")).encode("utf-8")
+    headers = sign_request(
+        signing_key=signer_key,
+        slug=slug,
+        signer_id=signer_id,
+        method="POST",
+        path=path,
+        body=body_bytes,
+    ).to_dict()
+    async with session.post(
+        f"{server_url.rstrip('/')}{path}",
+        data=body_bytes,
+        headers=headers,
+    ) as resp:
+        if resp.status >= 400:
+            text = await resp.text()
+            raise ImportError(f"{path} {resp.status}: {text}")
+
+
+async def _register_subkey_via_device(
+    session: aiohttp.ClientSession,
+    *,
+    server_url: str,
+    slug: str,
+    device_id: str,
+    device_signing_key: Ed25519KeyPair,
+) -> tuple[Ed25519KeyPair, dict]:
+    subkey = Ed25519KeyPair.generate()
+    cert = create_subkey_cert(device_signing_key, device_id, subkey.public_key_bytes())
+    await _signed_post(
+        session,
+        server_url=server_url,
+        path="/devices/subkeys",
+        signer_key=device_signing_key,
+        signer_id=device_id,
+        slug=slug,
+        body_dict={"subkey_cert": cert},
+    )
+    return subkey, cert
+
+
+async def _enroll_new_device(
+    server_url: str,
+    old_identity: StoredIdentity,
+    new_signing: Ed25519KeyPair,
+    new_kem: KemKeyPair,
+) -> None:
+    import secrets
+
+    if not old_identity.identity_cert_json or not old_identity.slug_binding_json:
+        raise ImportError("bundle missing identity_cert or slug_binding")
+
+    root_signing = Ed25519KeyPair.from_secret_bytes(decode_secret(old_identity.root_secret_key))
+    old_device_signing = Ed25519KeyPair.from_secret_bytes(
+        decode_secret(old_identity.device_signing_secret_key)
+    )
+    new_signing_pk = new_signing.public_key_bytes()
+    new_kem_pk = new_kem.public_key_bytes()
+    signing_pk_b64 = base64url_encode(new_signing_pk)
+    kem_pk_b64 = base64url_encode(new_kem_pk)
+    nonce = base64url_encode(secrets.token_bytes(32))
+
+    async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
+        old_subkey, old_subkey_cert = await _register_subkey_via_device(
+            session,
+            server_url=server_url,
+            slug=old_identity.slug,
+            device_id=old_identity.device_id,
+            device_signing_key=old_device_signing,
+        )
+
+        async with session.post(
+            f"{server_url.rstrip('/')}/devices/enroll/init",
+            json={
+                "nonce": nonce,
+                "device_signing_public_key": signing_pk_b64,
+                "device_kem_public_key": kem_pk_b64,
+                "fingerprint": f"{signing_pk_b64[:8]}..{kem_pk_b64[:8]}",
+            },
+        ) as resp:
+            if resp.status >= 400:
+                text = await resp.text()
+                raise ImportError(f"enroll/init {resp.status}: {text}")
+
+        device_cert = create_device_cert(root_signing, new_signing_pk, new_kem_pk)
+        root_envelope = build_root_key_envelope(
+            decode_secret(old_identity.root_secret_key), nonce, new_kem_pk,
+        )
+        body_dict = {
+            "device_cert": device_cert,
+            "root_key_envelope": root_envelope,
+            "slug_binding": json.loads(old_identity.slug_binding_json),
+            "identity_cert": json.loads(old_identity.identity_cert_json),
+            "identity_profile": (
+                json.loads(old_identity.identity_profile_json)
+                if old_identity.identity_profile_json
+                else None
+            ),
+        }
+        await _signed_post(
+            session,
+            server_url=server_url,
+            path=f"/devices/enroll/{nonce}/complete",
+            signer_key=old_subkey,
+            signer_id=old_subkey_cert["subkey_id"],
+            slug=old_identity.slug,
+            body_dict=body_dict,
+        )
+
+
+async def _revoke_old_device(
+    *,
+    server_url: str,
+    slug: str,
+    new_device_id: str,
+    new_signing_key: Ed25519KeyPair,
+    root_signing_key: Ed25519KeyPair,
+    old_device_id: str,
+) -> None:
+    revocation = create_device_revocation(root_signing_key, old_device_id)
+    async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
+        new_subkey, new_subkey_cert = await _register_subkey_via_device(
+            session,
+            server_url=server_url,
+            slug=slug,
+            device_id=new_device_id,
+            device_signing_key=new_signing_key,
+        )
+        await _signed_post(
+            session,
+            server_url=server_url,
+            path=f"/devices/{old_device_id}/revoke",
+            signer_key=new_subkey,
+            signer_id=new_subkey_cert["subkey_id"],
+            slug=slug,
+            body_dict=revocation,
+        )
+
+
+async def revoke_pending(agent_id: str) -> AgentImportResult:
+    if not agent_yml_path(agent_id).exists():
+        return AgentImportResult(
+            agent_id=agent_id, status="failed", detail="agent not found",
+        )
+    path = pending_revoke_path(agent_id)
+    if not path.exists():
+        return AgentImportResult(
+            agent_id=agent_id, status="skipped", detail="no pending revoke",
+        )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    old_device_id = payload["old_device_id"]
+
+    from .state import AgentConfig
+
+    cfg = AgentConfig.load(agent_id)
+    identity = KeyStore.for_agent(agent_id).load_identity(cfg.puffo_core.slug)
+    root_signing = Ed25519KeyPair.from_secret_bytes(decode_secret(identity.root_secret_key))
+    new_signing = Ed25519KeyPair.from_secret_bytes(
+        decode_secret(identity.device_signing_secret_key)
+    )
+
+    try:
+        await _revoke_old_device(
+            server_url=identity.server_url,
+            slug=identity.slug,
+            new_device_id=identity.device_id,
+            new_signing_key=new_signing,
+            root_signing_key=root_signing,
+            old_device_id=old_device_id,
+        )
+    except Exception as exc:
+        _write_pending_revoke(agent_id, old_device_id, str(exc))
+        return AgentImportResult(
+            agent_id=agent_id,
+            status="failed",
+            detail=f"revoke retry failed: {exc}",
+            old_device_id=old_device_id,
+        )
+    try:
+        path.unlink()
+    except OSError:
+        pass
+    return AgentImportResult(
+        agent_id=agent_id, status="imported", old_device_id=old_device_id,
+    )
+
+
+def list_pending_revokes() -> list[tuple[str, str]]:
+    """Scan all agent dirs for pending_revoke.json. Returns
+    [(agent_id, old_device_id), ...]."""
+    out: list[tuple[str, str]] = []
+    root = agents_dir()
+    if not root.exists():
+        return out
+    for child in root.iterdir():
+        if not child.is_dir() or child.name == ".import-staging":
+            continue
+        marker = pending_revoke_path(child.name)
+        if marker.exists():
+            try:
+                payload = json.loads(marker.read_text(encoding="utf-8"))
+                out.append((child.name, payload.get("old_device_id", "")))
+            except Exception:
+                pass
+    return out
+
+
+def cleanup_staging_dir() -> None:
+    """Sweep any leftover ``.import-staging/`` entries from a previous
+    crashed import. Safe to call at daemon startup."""
+    root = agents_dir() / ".import-staging"
+    if root.exists():
+        shutil.rmtree(root, ignore_errors=True)

--- a/src/puffo_agent/portal/migration_certs.py
+++ b/src/puffo_agent/portal/migration_certs.py
@@ -1,0 +1,115 @@
+"""Cert + envelope builders used by import-side migration.
+
+Mirrors the TypeScript reference in
+``puffo-core-han-group/client/web/src/enrollment/certs.ts`` and
+``enroll.ts``. Byte layouts must match core-v2 — see the
+``puffo/rke-hpke/v1`` / ``puffo/root-key-envelope/v1`` constants
+below.
+"""
+
+from __future__ import annotations
+
+import time
+
+from ..crypto.canonical import canonicalize_for_signing
+from ..crypto.certs import derive_public_key_id
+from ..crypto.encoding import base64url_encode
+from ..crypto.fingerprint import root_public_key_fingerprint
+from ..crypto.primitives import Ed25519KeyPair, hpke_seal
+from ..crypto.v2_aad import compute_root_key_envelope_aad
+
+ROOT_KEY_ENVELOPE_HPKE_INFO = b"puffo/rke-hpke/v1"
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def create_device_cert(
+    root_signing_key: Ed25519KeyPair,
+    device_signing_pk: bytes,
+    device_kem_pk: bytes,
+    *,
+    issued_at_ms: int | None = None,
+) -> dict:
+    cert = {
+        "type": "device_cert",
+        "version": 1,
+        "device_id": derive_public_key_id("dev", device_signing_pk),
+        "root_public_key": base64url_encode(root_signing_key.public_key_bytes()),
+        "keys": {
+            "signing": {"algorithm": "ed25519", "public_key": base64url_encode(device_signing_pk)},
+            "encryption": {"algorithm": "x25519", "public_key": base64url_encode(device_kem_pk)},
+        },
+        "issued_at": issued_at_ms if issued_at_ms is not None else _now_ms(),
+        "expires_at": None,
+        "signature": "",
+    }
+    sig = root_signing_key.sign(canonicalize_for_signing(cert))
+    cert["signature"] = base64url_encode(sig)
+    return cert
+
+
+def create_slug_binding(
+    root_signing_key: Ed25519KeyPair, slug: str, *, issued_at_ms: int | None = None,
+) -> dict:
+    binding = {
+        "type": "slug_binding",
+        "version": 1,
+        "root_public_key": base64url_encode(root_signing_key.public_key_bytes()),
+        "slug": slug,
+        "issued_at": issued_at_ms if issued_at_ms is not None else _now_ms(),
+        "self_signature": "",
+    }
+    sig = root_signing_key.sign(canonicalize_for_signing(binding))
+    binding["self_signature"] = base64url_encode(sig)
+    return binding
+
+
+def create_device_revocation(
+    root_signing_key: Ed25519KeyPair,
+    device_id: str,
+    *,
+    effective_from_ms: int | None = None,
+    issued_at_ms: int | None = None,
+) -> dict:
+    now = _now_ms()
+    rev = {
+        "type": "device_revocation",
+        "version": 1,
+        "device_id": device_id,
+        "root_public_key": base64url_encode(root_signing_key.public_key_bytes()),
+        "effective_from": effective_from_ms if effective_from_ms is not None else now,
+        "issued_at": issued_at_ms if issued_at_ms is not None else now,
+        "signature": "",
+    }
+    sig = root_signing_key.sign(canonicalize_for_signing(rev))
+    rev["signature"] = base64url_encode(sig)
+    return rev
+
+
+def build_root_key_envelope(
+    root_secret_key: bytes,
+    enrollment_nonce: str,
+    new_device_kem_pk: bytes,
+) -> dict:
+    nonce_bytes = _base64url_decode(enrollment_nonce)
+    root_pk = Ed25519KeyPair.from_secret_bytes(root_secret_key).public_key_bytes()
+    fingerprint = root_public_key_fingerprint(root_pk)
+    aad = compute_root_key_envelope_aad(nonce_bytes, new_device_kem_pk, fingerprint)
+    hpke_out = hpke_seal(new_device_kem_pk, ROOT_KEY_ENVELOPE_HPKE_INFO, aad, root_secret_key)
+    combined = hpke_out.enc + hpke_out.ciphertext
+    return {
+        "type": "root_key_envelope",
+        "version": 1,
+        "enrollment_nonce": enrollment_nonce,
+        "recipient_kem_public_key": base64url_encode(new_device_kem_pk),
+        "hpke_ciphertext": base64url_encode(combined),
+        "root_public_key_fingerprint": base64url_encode(fingerprint),
+    }
+
+
+def _base64url_decode(s: str) -> bytes:
+    from ..crypto.encoding import base64url_decode as _d
+
+    return _d(s)

--- a/tests/test_bridge_export_import.py
+++ b/tests/test_bridge_export_import.py
@@ -1,0 +1,262 @@
+"""End-to-end test of the bridge ``/v1/agents/export``,
+``/v1/agents/import``, and ``/v1/agents/{id}/revoke-pending``
+endpoints. Drives the full flow through the same HTTP signing path
+the web client uses."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from _bridge_support import (
+    isolated_home, make_user, pair_request_body, signed_headers,
+)
+
+from puffo_agent.crypto.canonical import canonicalize_for_signing
+from puffo_agent.crypto.certs import derive_public_key_id
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.keystore import StoredIdentity, encode_secret
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+from puffo_agent.portal.api.server import build_app
+from puffo_agent.portal.state import DaemonConfig
+
+pytestmark = pytest.mark.asyncio
+
+_HOST = {"Host": "127.0.0.1:63387"}
+
+
+@pytest_asyncio.fixture
+async def mock_puffo_server():
+    """Stub of puffo-server that always 200s the enrollment + revoke
+    endpoints the import flow calls."""
+    state = {"calls": []}
+    app = web.Application()
+
+    async def record(request):
+        state["calls"].append(request.path)
+        return web.json_response({"ok": True})
+
+    app.router.add_post("/devices/subkeys", record)
+    app.router.add_post("/devices/enroll/init", record)
+    app.router.add_post("/devices/enroll/{nonce}/complete", record)
+    app.router.add_post("/devices/{device_id}/revoke", record)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        yield server, state
+    finally:
+        await server.close()
+
+
+@pytest_asyncio.fixture
+async def bridge_client():
+    isolated_home()
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        yield c
+
+
+async def _pair(client, user):
+    body = pair_request_body(user)
+    h = signed_headers(user, "POST", "/v1/pair", body)
+    h.update(_HOST)
+    r = await client.post("/v1/pair", data=body, headers=h)
+    assert r.status == 200, await r.text()
+
+
+def _seed_agent(home: str, agent_id: str, slug: str, server_url: str) -> str:
+    import yaml
+
+    root = Ed25519KeyPair.generate()
+    device_signing = Ed25519KeyPair.generate()
+    kem = KemKeyPair.generate()
+    old_device_id = derive_public_key_id("dev", device_signing.public_key_bytes())
+
+    adir = Path(home) / "agents" / agent_id
+    adir.mkdir(parents=True, exist_ok=True)
+    (adir / "memory").mkdir(exist_ok=True)
+    (adir / "keys").mkdir(exist_ok=True)
+    (adir / "profile.md").write_text("# profile\n", encoding="utf-8")
+    cfg = {
+        "id": agent_id, "state": "running", "display_name": agent_id,
+        "puffo_core": {
+            "server_url": server_url, "slug": slug,
+            "device_id": old_device_id, "space_id": "sp_test",
+        },
+        "runtime": {
+            "kind": "chat-local", "provider": "anthropic",
+            "model": "claude-sonnet-4-6", "api_key": "sk-test",
+            "harness": "claude-code", "permission_mode": "bypassPermissions",
+        },
+        "profile": "profile.md", "memory_dir": "memory",
+        "workspace_dir": "workspace",
+        "triggers": {"on_mention": True, "on_dm": True},
+    }
+    (adir / "agent.yml").write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    identity_cert = {
+        "type": "identity_cert", "version": 1,
+        "root_public_key": base64url_encode(root.public_key_bytes()),
+        "identity_type": "human", "declared_operator_public_key": None,
+    }
+    identity_cert["self_signature"] = base64url_encode(
+        root.sign(canonicalize_for_signing(identity_cert))
+    )
+    slug_binding = {
+        "type": "slug_binding", "version": 1,
+        "root_public_key": base64url_encode(root.public_key_bytes()),
+        "slug": slug, "issued_at": int(time.time() * 1000),
+    }
+    slug_binding["self_signature"] = base64url_encode(
+        root.sign(canonicalize_for_signing(slug_binding))
+    )
+    identity = StoredIdentity(
+        slug=slug, device_id=old_device_id,
+        root_secret_key=encode_secret(root.secret_bytes()),
+        device_signing_secret_key=encode_secret(device_signing.secret_bytes()),
+        kem_secret_key=encode_secret(kem.secret_bytes()),
+        server_url=server_url,
+        slug_binding_json=json.dumps(slug_binding),
+        identity_cert_json=json.dumps(identity_cert),
+    )
+    (adir / "keys" / f"{slug}.json").write_text(
+        json.dumps(identity.to_dict(), indent=2), encoding="utf-8"
+    )
+    return old_device_id
+
+
+async def test_bridge_export_returns_binary_blob(bridge_client):
+    user = make_user()
+    await _pair(bridge_client, user)
+    _seed_agent(os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", "http://unused")
+
+    body = json.dumps({"agent_ids": ["alpha"], "password": "hunter2"}).encode("utf-8")
+    h = signed_headers(user, "POST", "/v1/agents/export", body)
+    h.update(_HOST)
+    h["content-type"] = "application/json"
+    r = await bridge_client.post("/v1/agents/export", data=body, headers=h)
+    assert r.status == 200, await r.text()
+    assert r.headers["content-type"] == "application/octet-stream"
+    blob = await r.read()
+    from puffo_agent.portal import export as exp
+    assert blob.startswith(exp.MAGIC)
+    bundle = exp.unpack(blob, "hunter2")
+    assert "alpha" in bundle.agents
+
+
+async def test_bridge_export_rejects_invalid_input(bridge_client):
+    user = make_user()
+    await _pair(bridge_client, user)
+    body = json.dumps({"agent_ids": [], "password": "x"}).encode("utf-8")
+    h = signed_headers(user, "POST", "/v1/agents/export", body); h.update(_HOST)
+    h["content-type"] = "application/json"
+    r = await bridge_client.post("/v1/agents/export", data=body, headers=h)
+    assert r.status == 400
+
+
+async def test_bridge_import_roundtrip(bridge_client, mock_puffo_server):
+    user = make_user()
+    await _pair(bridge_client, user)
+    puffo, calls_state = mock_puffo_server
+    url = str(puffo.make_url("/")).rstrip("/")
+    _seed_agent(os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", url)
+
+    # Export through the bridge.
+    body = json.dumps({"agent_ids": ["alpha"], "password": "hunter2"}).encode("utf-8")
+    h = signed_headers(user, "POST", "/v1/agents/export", body); h.update(_HOST)
+    h["content-type"] = "application/json"
+    r = await bridge_client.post("/v1/agents/export", data=body, headers=h)
+    assert r.status == 200
+    blob = await r.read()
+
+    # Wipe local state to simulate the new machine, then re-pair so
+    # we're authed against the fresh home.
+    isolated_home()
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c2:
+        await _pair(c2, user)
+        import_body = json.dumps({
+            "bundle_b64": base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii"),
+            "password": "hunter2",
+        }).encode("utf-8")
+        h2 = signed_headers(user, "POST", "/v1/agents/import", import_body); h2.update(_HOST)
+        h2["content-type"] = "application/json"
+        r2 = await c2.post("/v1/agents/import", data=import_body, headers=h2)
+        assert r2.status == 200, await r2.text()
+        report = await r2.json()
+        assert report["imported"] == 1
+        assert report["results"][0]["agent_id"] == "alpha"
+        # The mock server saw the enrollment + revoke calls.
+        assert any(p == "/devices/enroll/init" for p in calls_state["calls"])
+        assert any(p.endswith("/revoke") for p in calls_state["calls"])
+
+
+async def test_bridge_import_wrong_password(bridge_client):
+    user = make_user()
+    await _pair(bridge_client, user)
+
+    # Build any valid bundle (no agents exist yet, so seed one + pack).
+    _seed_agent(os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", "http://unused")
+    from puffo_agent.portal import export as exp
+    blob = exp.pack(["alpha"], password="hunter2")
+    import shutil
+    shutil.rmtree(Path(os.environ["PUFFO_AGENT_HOME"]) / "agents" / "alpha")
+
+    body = json.dumps({
+        "bundle_b64": base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii"),
+        "password": "wrong",
+    }).encode("utf-8")
+    h = signed_headers(user, "POST", "/v1/agents/import", body); h.update(_HOST)
+    h["content-type"] = "application/json"
+    r = await bridge_client.post("/v1/agents/import", data=body, headers=h)
+    assert r.status == 400
+
+
+async def test_bridge_revoke_pending_no_marker(bridge_client):
+    user = make_user()
+    user_root_pk = base64url_encode(user.root_key.public_key_bytes())
+    home = isolated_home()
+
+    # Re-pair against the fresh home.
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        from _bridge_support import write_test_agent
+        write_test_agent(home, "alpha", owner_root_pubkey=user_root_pk)
+        h = signed_headers(user, "POST", "/v1/agents/alpha/revoke-pending", b"")
+        h.update(_HOST)
+        r = await c.post("/v1/agents/alpha/revoke-pending", data=b"", headers=h)
+        assert r.status == 200, await r.text()
+        body = await r.json()
+        assert body["status"] == "skipped"
+
+
+async def test_bridge_revoke_pending_requires_owner(bridge_client):
+    user = make_user()
+    other_root_pk = base64url_encode(b"\x99" * 32)
+    home = isolated_home()
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        from _bridge_support import write_test_agent
+        write_test_agent(home, "alpha", owner_root_pubkey=other_root_pk)
+        h = signed_headers(user, "POST", "/v1/agents/alpha/revoke-pending", b"")
+        h.update(_HOST)
+        r = await c.post("/v1/agents/alpha/revoke-pending", data=b"", headers=h)
+        assert r.status == 403

--- a/tests/test_export_module.py
+++ b/tests/test_export_module.py
@@ -1,0 +1,151 @@
+"""Unit tests for portal.export — pack/unpack roundtrip + AES-GCM
+auth + sanitize + missing-agent errors."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from _bridge_support import isolated_home, write_test_agent
+
+
+@pytest.fixture(autouse=True)
+def fresh_home():
+    home = isolated_home()
+    yield home
+
+
+def _seed(home: str, agent_id: str, extra_files: dict[str, str] | None = None) -> Path:
+    workspace = write_test_agent(home, agent_id)
+    adir = Path(home) / "agents" / agent_id
+    for rel, contents in (extra_files or {}).items():
+        target = adir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(contents.encode("utf-8"))
+    return adir
+
+
+def test_pack_requires_agents():
+    from puffo_agent.portal import export as exp
+
+    with pytest.raises(exp.ExportError):
+        exp.pack([], password="hunter2")
+
+
+def test_pack_requires_password():
+    from puffo_agent.portal import export as exp
+
+    _seed(os.environ["PUFFO_AGENT_HOME"], "alpha")
+    with pytest.raises(exp.ExportError):
+        exp.pack(["alpha"], password="")
+
+
+def test_pack_missing_agent_lists_them():
+    from puffo_agent.portal import export as exp
+
+    _seed(os.environ["PUFFO_AGENT_HOME"], "alpha")
+    with pytest.raises(exp.ExportError, match="ghost"):
+        exp.pack(["alpha", "ghost"], password="hunter2")
+
+
+def test_pack_unpack_roundtrip_single():
+    from puffo_agent.portal import export as exp
+
+    _seed(
+        os.environ["PUFFO_AGENT_HOME"],
+        "alpha",
+        extra_files={"memory/notes.md": "hello-memory"},
+    )
+    blob = exp.pack(["alpha"], password="hunter2", exported_by_slug="op-1")
+    assert blob.startswith(exp.MAGIC)
+    bundle = exp.unpack(blob, password="hunter2")
+    assert bundle.manifest["format_version"] == 1
+    assert bundle.manifest["exported_by_slug"] == "op-1"
+    assert [e["id"] for e in bundle.manifest["agents"]] == ["alpha"]
+    assert "agent.yml" in bundle.agents["alpha"]
+    assert bundle.agents["alpha"]["memory/notes.md"] == b"hello-memory"
+
+
+def test_pack_unpack_roundtrip_multi():
+    from puffo_agent.portal import export as exp
+
+    _seed(os.environ["PUFFO_AGENT_HOME"], "alpha")
+    _seed(os.environ["PUFFO_AGENT_HOME"], "beta")
+    blob = exp.pack(["alpha", "beta"], password="hunter2")
+    bundle = exp.unpack(blob, password="hunter2")
+    assert set(bundle.agents.keys()) == {"alpha", "beta"}
+
+
+def test_unpack_wrong_password():
+    from puffo_agent.portal import export as exp
+
+    _seed(os.environ["PUFFO_AGENT_HOME"], "alpha")
+    blob = exp.pack(["alpha"], password="hunter2")
+    with pytest.raises(exp.ImportPackError, match="decryption"):
+        exp.unpack(blob, password="wrong")
+
+
+def test_unpack_bad_magic():
+    from puffo_agent.portal import export as exp
+
+    with pytest.raises(exp.ImportPackError, match="too short|bad magic"):
+        exp.unpack(b"not-a-puffo-bundle", password="hunter2")
+    junk = b"X" * (len(exp.MAGIC) + exp.SALT_LEN + exp.NONCE_LEN + 32)
+    with pytest.raises(exp.ImportPackError, match="bad magic"):
+        exp.unpack(junk, password="hunter2")
+
+
+def test_unpack_tampered_header():
+    from puffo_agent.portal import export as exp
+
+    _seed(os.environ["PUFFO_AGENT_HOME"], "alpha")
+    blob = bytearray(exp.pack(["alpha"], password="hunter2"))
+    # Flip a byte in the salt — AEAD AAD covers it, so decrypt fails.
+    blob[len(exp.MAGIC)] ^= 0xFF
+    with pytest.raises(exp.ImportPackError):
+        exp.unpack(bytes(blob), password="hunter2")
+
+
+def test_sanitize_drops_device_bound_files():
+    from puffo_agent.portal import export as exp
+
+    home = os.environ["PUFFO_AGENT_HOME"]
+    adir = _seed(home, "alpha", extra_files={
+        "runtime.json": '{"status":"running"}',
+        "cli_session.json": '{"id":"x"}',
+        "messages.db": "binary-blob",
+        ".puffo-agent/restart.flag": "requested",
+        "workspace/.claude/.credentials.json": "{}",
+        "workspace/skills/keep.md": "skill",
+    })
+    with tempfile.TemporaryDirectory() as td:
+        stage = Path(td) / "stage"
+        stage.mkdir()
+        for src in adir.rglob("*"):
+            if src.is_file():
+                rel = src.relative_to(adir)
+                target = stage / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(src.read_bytes())
+        exp.sanitize_staged_agent(stage)
+        assert not (stage / "runtime.json").exists()
+        assert not (stage / "cli_session.json").exists()
+        assert not (stage / "messages.db").exists()
+        assert not (stage / ".puffo-agent" / "restart.flag").exists()
+        assert not (stage / "workspace" / ".claude" / ".credentials.json").exists()
+        assert (stage / "workspace" / "skills" / "keep.md").exists()
+        assert (stage / "agent.yml").exists()
+
+
+def test_unpack_rejects_missing_agent_yml():
+    from puffo_agent.portal import export as exp
+
+    home = os.environ["PUFFO_AGENT_HOME"]
+    _seed(home, "alpha")
+    # Tamper: delete agent.yml after seeding, before packing.
+    (Path(home) / "agents" / "alpha" / "agent.yml").unlink()
+    with pytest.raises(exp.ExportError):
+        exp.pack(["alpha"], password="hunter2")

--- a/tests/test_import_module.py
+++ b/tests/test_import_module.py
@@ -1,0 +1,328 @@
+"""Unit tests for portal.import_agents — 3-phase flow against a
+mocked puffo-server, including happy path, revoke failure, and the
+revoke_pending retry."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from _bridge_support import isolated_home
+
+from puffo_agent.crypto.canonical import canonicalize_for_signing
+from puffo_agent.crypto.certs import derive_public_key_id
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.keystore import StoredIdentity, encode_secret
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+pytestmark = pytest.mark.asyncio
+
+
+# ────────────────────────────────────────────────────────────────────
+# Mock puffo-server. Records every request so tests can assert what
+# the import flow sent. Each route can be flipped to fail via
+# ``state["fail"]``.
+# ────────────────────────────────────────────────────────────────────
+
+
+def _make_mock_server_state():
+    return {
+        "calls": [],
+        "fail": set(),  # path strings or "revoke" sentinel
+    }
+
+
+def _make_mock_app(state):
+    app = web.Application()
+
+    async def record(request):
+        path = request.path
+        state["calls"].append((request.method, path))
+        if path in state["fail"] or any(p in path for p in state["fail"] if isinstance(p, str)):
+            return web.json_response({"error": "induced failure"}, status=500)
+        return web.json_response({"ok": True})
+
+    app.router.add_post("/devices/subkeys", record)
+    app.router.add_post("/devices/enroll/init", record)
+    app.router.add_post("/devices/enroll/{nonce}/complete", record)
+    app.router.add_post("/devices/{device_id}/revoke", record)
+    return app
+
+
+@pytest_asyncio.fixture
+async def mock_server():
+    state = _make_mock_server_state()
+    server = TestServer(_make_mock_app(state))
+    await server.start_server()
+    try:
+        yield server, state
+    finally:
+        await server.close()
+
+
+@pytest.fixture(autouse=True)
+def fresh_home():
+    isolated_home()
+    yield
+
+
+# ────────────────────────────────────────────────────────────────────
+# Builders: a realistic .puffoagent bundle pointing at the mock URL.
+# ────────────────────────────────────────────────────────────────────
+
+
+def _build_signed_identity_cert(root: Ed25519KeyPair) -> dict:
+    cert = {
+        "type": "identity_cert",
+        "version": 1,
+        "root_public_key": base64url_encode(root.public_key_bytes()),
+        "identity_type": "human",
+        "declared_operator_public_key": None,
+    }
+    cert["self_signature"] = base64url_encode(
+        root.sign(canonicalize_for_signing(cert))
+    )
+    return cert
+
+
+def _build_signed_slug_binding(root: Ed25519KeyPair, slug: str) -> dict:
+    sb = {
+        "type": "slug_binding",
+        "version": 1,
+        "root_public_key": base64url_encode(root.public_key_bytes()),
+        "slug": slug,
+        "issued_at": int(time.time() * 1000),
+    }
+    sb["self_signature"] = base64url_encode(
+        root.sign(canonicalize_for_signing(sb))
+    )
+    return sb
+
+
+def _seed_source_agent(home: str, agent_id: str, slug: str, server_url: str) -> dict:
+    """Materialise an agent dir as it would exist on the *source*
+    machine — with full keys, agent.yml pointing at the mock server.
+    Returns dict with the generated key material for assertions."""
+    import yaml
+
+    root = Ed25519KeyPair.generate()
+    device_signing = Ed25519KeyPair.generate()
+    kem = KemKeyPair.generate()
+    old_device_id = derive_public_key_id("dev", device_signing.public_key_bytes())
+
+    adir = Path(home) / "agents" / agent_id
+    adir.mkdir(parents=True, exist_ok=True)
+    (adir / "memory").mkdir(exist_ok=True)
+    (adir / "keys").mkdir(exist_ok=True)
+    (adir / "profile.md").write_text("# profile\n", encoding="utf-8")
+
+    cfg = {
+        "id": agent_id,
+        "state": "running",
+        "display_name": agent_id,
+        "puffo_core": {
+            "server_url": server_url,
+            "slug": slug,
+            "device_id": old_device_id,
+            "space_id": "sp_test",
+        },
+        "runtime": {
+            "kind": "chat-local",
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "api_key": "sk-test",
+            "harness": "claude-code",
+            "permission_mode": "bypassPermissions",
+        },
+        "profile": "profile.md",
+        "memory_dir": "memory",
+        "workspace_dir": "workspace",
+        "triggers": {"on_mention": True, "on_dm": True},
+    }
+    (adir / "agent.yml").write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    identity = StoredIdentity(
+        slug=slug,
+        device_id=old_device_id,
+        root_secret_key=encode_secret(root.secret_bytes()),
+        device_signing_secret_key=encode_secret(device_signing.secret_bytes()),
+        kem_secret_key=encode_secret(kem.secret_bytes()),
+        server_url=server_url,
+        slug_binding_json=json.dumps(_build_signed_slug_binding(root, slug)),
+        identity_cert_json=json.dumps(_build_signed_identity_cert(root)),
+    )
+    (adir / "keys" / f"{slug}.json").write_text(
+        json.dumps(identity.to_dict(), indent=2), encoding="utf-8"
+    )
+    return {
+        "root": root,
+        "device_signing": device_signing,
+        "kem": kem,
+        "old_device_id": old_device_id,
+        "slug": slug,
+        "agent_id": agent_id,
+    }
+
+
+def _build_bundle(server_url: str, password: str = "hunter2") -> tuple[bytes, dict]:
+    from puffo_agent.portal import export as exp
+
+    info = _seed_source_agent(os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", server_url)
+    blob = exp.pack(["alpha"], password=password, exported_by_slug="op-source")
+    # Drop the source agent dir so import doesn't hit the skip-existing branch.
+    import shutil
+    shutil.rmtree(Path(os.environ["PUFFO_AGENT_HOME"]) / "agents" / "alpha")
+    return blob, info
+
+
+# ────────────────────────────────────────────────────────────────────
+# Tests
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_import_happy_path(mock_server):
+    from puffo_agent.portal import import_agents as imp
+    from puffo_agent.portal.state import AgentConfig
+
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    blob, info = _build_bundle(url)
+
+    report = await imp.import_bundle(blob, password="hunter2")
+    assert report.failed == 0
+    assert report.imported == 1
+    result = report.results[0]
+    assert result.status == "imported"
+    assert result.new_device_id != info["old_device_id"]
+    assert result.old_device_id == info["old_device_id"]
+
+    # Bundle decrypted onto disk + agent.yml device_id rewritten.
+    cfg = AgentConfig.load("alpha")
+    assert cfg.puffo_core.device_id == result.new_device_id
+    assert cfg.puffo_core.slug == "alpha-bot"
+
+    # Server saw the expected sequence (subkey x2, init, complete, revoke).
+    paths = [p for _, p in state["calls"]]
+    assert paths.count("/devices/subkeys") == 2
+    assert "/devices/enroll/init" in paths
+    assert any(p.startswith("/devices/enroll/") and p.endswith("/complete") for p in paths)
+    assert any(p.endswith("/revoke") for p in paths)
+
+
+async def test_import_skips_existing(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    blob, _info = _build_bundle(url)
+
+    first = await imp.import_bundle(blob, password="hunter2")
+    assert first.imported == 1
+
+    pre = len(state["calls"])
+    second = await imp.import_bundle(blob, password="hunter2")
+    assert second.imported == 0
+    assert second.skipped == 1
+    # No additional server calls on skip.
+    assert len(state["calls"]) == pre
+
+
+async def test_import_enrollment_failure_cleans_staging(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    state["fail"] = {"/devices/enroll/init"}
+    url = str(server.make_url("/")).rstrip("/")
+    blob, _ = _build_bundle(url)
+
+    report = await imp.import_bundle(blob, password="hunter2")
+    assert report.failed == 1
+    assert report.imported == 0
+    # Staging dir should be gone, no live agent dir created.
+    assert not imp.staging_dir("alpha").exists()
+    assert not Path(os.environ["PUFFO_AGENT_HOME"], "agents", "alpha").exists()
+
+
+async def test_import_revoke_failure_leaves_pending(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    state["fail"] = {"revoke"}  # matches by substring in path
+    url = str(server.make_url("/")).rstrip("/")
+    blob, info = _build_bundle(url)
+
+    report = await imp.import_bundle(blob, password="hunter2")
+    assert report.failed == 0
+    assert report.pending_revokes == 1
+    r = report.results[0]
+    assert r.status == "imported_pending_revoke"
+    pending = imp.pending_revoke_path("alpha")
+    assert pending.exists()
+    payload = json.loads(pending.read_text(encoding="utf-8"))
+    assert payload["old_device_id"] == info["old_device_id"]
+
+
+async def test_revoke_pending_succeeds_on_retry(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    state["fail"] = {"revoke"}
+    url = str(server.make_url("/")).rstrip("/")
+    blob, info = _build_bundle(url)
+    await imp.import_bundle(blob, password="hunter2")
+
+    # Server is healthy now; retry should succeed and clear the marker.
+    state["fail"] = set()
+    result = await imp.revoke_pending("alpha")
+    assert result.status == "imported"
+    assert not imp.pending_revoke_path("alpha").exists()
+
+
+async def test_revoke_pending_no_marker():
+    from puffo_agent.portal import import_agents as imp
+    from _bridge_support import write_test_agent
+
+    write_test_agent(os.environ["PUFFO_AGENT_HOME"], "alpha")
+    result = await imp.revoke_pending("alpha")
+    assert result.status == "skipped"
+
+
+async def test_revoke_pending_agent_not_found():
+    from puffo_agent.portal import import_agents as imp
+
+    result = await imp.revoke_pending("ghost")
+    assert result.status == "failed"
+
+
+async def test_list_pending_revokes_and_cleanup_staging():
+    from puffo_agent.portal import import_agents as imp
+    from puffo_agent.portal.state import agents_dir
+
+    # Drop a fake pending marker on disk.
+    a = agents_dir() / "alpha"
+    (a / ".puffo-agent").mkdir(parents=True, exist_ok=True)
+    (a / "agent.yml").write_text("id: alpha\n", encoding="utf-8")
+    (a / ".puffo-agent" / "pending_revoke.json").write_text(
+        json.dumps({"old_device_id": "dev_old", "last_error": "boom",
+                    "attempted_at": 0}),
+        encoding="utf-8",
+    )
+    found = imp.list_pending_revokes()
+    assert ("alpha", "dev_old") in found
+
+    # Staging cleanup is a no-op when nothing's there, and removes
+    # an existing .import-staging tree otherwise.
+    imp.cleanup_staging_dir()
+    staging = agents_dir() / ".import-staging" / "x"
+    staging.mkdir(parents=True, exist_ok=True)
+    (staging / "f").write_text("x")
+    assert staging.exists()
+    imp.cleanup_staging_dir()
+    assert not (agents_dir() / ".import-staging").exists()


### PR DESCRIPTION
## Summary
- Encrypted `.puffoagent` bundle (scrypt + AES-256-GCM) packs N agent dirs with a manifest.
- Enrollment-style import: stage → register new device + revoke old via existing puffo-server endpoints → atomic commit. Keeps slug + identity stable, swaps device key.
- Bridge HTTP: `POST /v1/agents/export`, `POST /v1/agents/import`, `POST /v1/agents/{id}/revoke-pending`. CLI mirrors all three.
- Crash safety: staging dir + atomic rename; `pending_revoke.json` marker lets the revoke step retry independently if the new device is registered but the revoke 5xx'd.
- Sanitises device-bound files on the way out (`runtime.json`, `cli_session.json`, `messages.db`, `.puffo-agent/*.flag`, `workspace/.claude/.credentials.json`). `messages.db` is dropped since its old KEM key can't decrypt under the new device.
- No server-side changes — uses existing `/devices/subkeys` (DeviceOrSubkeyAuth lets the old device key directly register a temp subkey), `/devices/enroll/init` + `/devices/enroll/{nonce}/complete`, and `/devices/{id}/revoke`.

## Test plan
- [x] `tests/test_export_module.py` — pack/unpack roundtrip (single + multi), wrong password, tampered AEAD header, sanitize drops device-bound files, missing-agent error, empty input.
- [x] `tests/test_import_module.py` — full 3-phase import against a mocked puffo-server; skip-existing; enrollment failure cleans staging; revoke failure leaves `pending_revoke.json`; `revoke_pending` retry succeeds; `list_pending_revokes` + `cleanup_staging_dir`.
- [x] `tests/test_bridge_export_import.py` — full HTTP roundtrip on the bridge: export → fresh home → import via base64; wrong-password rejection; owner-gated revoke-pending (403 for non-owner).
- [x] Full suite: `576 passed, 7 skipped` (skips are pre-existing host-platform / feature-flag gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)