### PR TITLE
fix(PUF-200): auto-correct non-root thread_root_id in send_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.5] — 2026-05-18
+
+### Fixed
+
+- **`mcp__puffo__send_message` (and `send_message_with_attachments`)
+  now auto-correct a non-root `root_id`.** When an agent passed the
+  envelope id of a *reply* (rather than the thread's true root) as
+  `root_id`, the message used to encrypt with that reply id as
+  `thread_root_id` and land in a sub-thread that human clients don't
+  surface — no failure signal returned to the agent. We hit this
+  twice live on 2026-05-18 (clone-report `msg_38364760` and
+  build-test-report `msg_9e8f1a83`, both threaded under root
+  `msg_610fec10`), and both messages vanished from the operator's
+  view.
+
+  New helper `_resolve_root_id(root_id, data_client)` runs alongside
+  `_coerce_root_visibility`: it looks the supplied envelope up in the
+  local message store and substitutes its own `thread_root_id`
+  before encrypting, then appends a correction note to the tool
+  response so the agent learns the rule from the result on the spot
+  rather than depending on the primer being current.
+
+  Failure-mode contract: lookup miss / transport error / `DataNotFound`
+  fall through with the original id plus a soft warning — the send
+  still completes (better to land in the wrong thread than drop the
+  message). Cycle in the chain or chain deeper than 4 levels is
+  treated as corrupt data: the helper preserves the original `root_id`
+  and surfaces a loud "could not resolve to a true root" warning
+  instead of auto-correcting to a value it can't trust.
+
+  Walk is capped at 4 levels with cycle detection — on healthy data
+  the walk terminates in one hop (per `message_store.py`'s schema,
+  `thread_root_id` always points at a true root); the multi-hop walk
+  is corruption defense for relay data shapes that shouldn't exist.
+
+  Tests in `test_puffo_core_tools.py`: 8 unit tests on `_resolve_root_id`
+  (empty/whitespace, true root unchanged, single-level + depth-2 walk,
+  lookup miss, transport error, real `DataNotFound`, cycle + depth-cap
+  preservation), plus 5 integration tests on `send_message` /
+  `send_message_with_attachments` — including the two real
+  2026-05-18 live-failure envelope IDs as parametrised cases for a
+  date-stamped regression anchor. Full suite: **596 passed / 1
+  skipped / 0 failed**. (PUF-200)
+
 ## [0.8.4] — 2026-05-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.4"
+version = "0.8.5"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -177,6 +177,97 @@ def _coerce_root_visibility(
     return is_visible_to_human, ""
 
 
+_RESOLVE_ROOT_MAX_DEPTH = 4
+
+
+async def _resolve_root_id(
+    root_id: str, data_client: Any,
+) -> tuple[Optional[str], str]:
+    """Resolve a caller-supplied ``root_id`` to the actual thread
+    root.
+
+    Agents sometimes pass an envelope's ``post_id`` (a specific reply)
+    as ``root_id`` expecting the new message to thread under that
+    reply. But ``thread_root_id`` on the wire must point at the *root*
+    of the thread — when it points at a non-root reply the resulting
+    message lands in a sub-thread or is dropped silently by the client
+    renderer. The bug is invisible to the agent: ``send_message``
+    returns success either way. We learned that the hard way during
+    the team's first hour on 2026-05-18.
+
+    Behaviour:
+    - Empty / whitespace ``root_id`` → ``(None, "")``. No lookup;
+      the envelope's ``thread_root_id`` stays ``None`` (root-level).
+    - Looked-up message's ``thread_root_id`` is ``None`` → the
+      supplied id IS a root → return ``(root_id, "")``.
+    - Looked-up message has a non-null ``thread_root_id`` → the
+      supplied id was itself a reply; substitute the real root and
+      return a correction note naming both ids so the agent learns.
+    - Defensive: if the substituted root is also a reply (malformed
+      data; should never happen for well-formed messages), walk one
+      more level. Capped at ``_RESOLVE_ROOT_MAX_DEPTH`` to prevent
+      infinite traversal on cycles.
+    - Lookup miss / transport failure → fall through with the
+      original ``root_id`` plus a soft-warning note. The send still
+      completes; the agent is told we couldn't verify the root.
+
+    Returns ``(resolved_root_or_None, note)``. ``note`` is empty
+    when no correction was needed (and no warning was emitted),
+    mirroring ``_coerce_root_visibility``'s shape.
+    """
+    if not root_id.strip():
+        return None, ""
+
+    current = root_id
+    seen: set[str] = set()
+    walked = False
+
+    for _ in range(_RESOLVE_ROOT_MAX_DEPTH):
+        if current in seen:
+            break
+        seen.add(current)
+        try:
+            msg = await data_client.get_message_by_envelope(current)
+        except DataNotFound:
+            msg = None
+        except Exception as exc:
+            logger.warning(
+                "resolve_root_id: lookup transport error for %s: %s",
+                current, exc,
+            )
+            return root_id, (
+                f"\nnote: could not verify root_id {root_id} is a thread "
+                "root (lookup failed); sent as-is. If this lands in the "
+                "wrong thread, pass the metadata block's thread_root_id, "
+                "not post_id."
+            )
+        if msg is None:
+            return root_id, (
+                f"\nnote: could not verify root_id {root_id} is a thread "
+                "root (message not in local store); sent as-is. If this "
+                "lands in the wrong thread, pass the metadata block's "
+                "thread_root_id, not post_id."
+            )
+        parent_root = msg.thread_root_id
+        if parent_root is None:
+            if walked:
+                return current, (
+                    f"\nnote: root_id {root_id} was a reply, not a root — "
+                    f"auto-corrected to {current}. Pass the metadata "
+                    "block's thread_root_id, not post_id."
+                )
+            return root_id, ""
+        walked = True
+        current = parent_root
+
+    return current, (
+        f"\nnote: root_id {root_id} was a reply, not a root — "
+        f"auto-corrected to {current} after walking "
+        f"{_RESOLVE_ROOT_MAX_DEPTH} levels. Pass the metadata block's "
+        "thread_root_id, not post_id."
+    )
+
+
 def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
 
     @mcp.tool()
@@ -303,6 +394,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
+        resolved_root, root_note = await _resolve_root_id(
+            root_id, cfg.data_client,
+        )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
             sender_slug=cfg.slug,
@@ -311,7 +405,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             space_id=send_space_id,
             channel_id=channel_id,
             recipient_slug=recipient_slug,
-            thread_root_id=root_id if root_id else None,
+            thread_root_id=resolved_root,
             content_type="text/plain",
             content=text,
             recipients=devices,
@@ -322,6 +416,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return (
             f"posted {envelope.get('envelope_id', '?')} to {channel}"
             f"{fold_note}"
+            f"{root_note}"
         )
 
     @mcp.tool()
@@ -799,6 +894,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
+        resolved_root, root_note = await _resolve_root_id(
+            root_id, cfg.data_client,
+        )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
             sender_slug=cfg.slug,
@@ -807,7 +905,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             space_id=send_space_id,
             channel_id=channel_id,
             recipient_slug=recipient_slug,
-            thread_root_id=root_id if root_id else None,
+            thread_root_id=resolved_root,
             content_type=ATTACHMENT_CONTENT_TYPE,
             content=body_content,
             recipients=devices,
@@ -815,12 +913,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         envelope = encrypt_message(inp, signing_key)
         await cfg.http_client.post("/messages", envelope)
         names = ", ".join(t.name for t in targets)
-        thread_note = f" in thread {root_id}" if root_id else ""
+        thread_display = resolved_root if resolved_root else root_id
+        thread_note = f" in thread {thread_display}" if thread_display else ""
         return (
             f"uploaded {len(targets)} file(s) [{names}] ({total_bytes} bytes "
             f"total) to {channel}{thread_note} "
             f"(envelope_id {envelope.get('envelope_id', '?')})"
             f"{fold_note}"
+            f"{root_note}"
         )
 
     @mcp.tool()

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -183,37 +183,16 @@ _RESOLVE_ROOT_MAX_DEPTH = 4
 async def _resolve_root_id(
     root_id: str, data_client: Any,
 ) -> tuple[Optional[str], str]:
-    """Resolve a caller-supplied ``root_id`` to the actual thread
-    root.
-
-    Agents sometimes pass an envelope's ``post_id`` (a specific reply)
-    as ``root_id`` expecting the new message to thread under that
-    reply. But ``thread_root_id`` on the wire must point at the *root*
-    of the thread — when it points at a non-root reply the resulting
-    message lands in a sub-thread or is dropped silently by the client
-    renderer. The bug is invisible to the agent: ``send_message``
-    returns success either way. We learned that the hard way during
-    the team's first hour on 2026-05-18.
-
-    Behaviour:
-    - Empty / whitespace ``root_id`` → ``(None, "")``. No lookup;
-      the envelope's ``thread_root_id`` stays ``None`` (root-level).
-    - Looked-up message's ``thread_root_id`` is ``None`` → the
-      supplied id IS a root → return ``(root_id, "")``.
-    - Looked-up message has a non-null ``thread_root_id`` → the
-      supplied id was itself a reply; substitute the real root and
-      return a correction note naming both ids so the agent learns.
-    - Defensive: if the substituted root is also a reply (malformed
-      data; should never happen for well-formed messages), walk one
-      more level. Capped at ``_RESOLVE_ROOT_MAX_DEPTH`` to prevent
-      infinite traversal on cycles.
-    - Lookup miss / transport failure → fall through with the
-      original ``root_id`` plus a soft-warning note. The send still
-      completes; the agent is told we couldn't verify the root.
+    """When an agent passes a reply's envelope id as ``root_id``,
+    look that envelope up and substitute its own ``thread_root_id``
+    so the new message threads under the real root instead of
+    silently disappearing into a sub-thread.
 
     Returns ``(resolved_root_or_None, note)``. ``note`` is empty
-    when no correction was needed (and no warning was emitted),
-    mirroring ``_coerce_root_visibility``'s shape.
+    unless a correction or warning happened — shape mirrors
+    ``_coerce_root_visibility``. Lookup miss / transport failure
+    falls through with the original id plus a soft warning so the
+    send still completes.
     """
     if not root_id.strip():
         return None, ""

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -188,8 +188,21 @@ async def _resolve_root_id(
     so the new message threads under the real root instead of
     silently disappearing into a sub-thread.
 
-    Returns ``(resolved_root_or_None, note)``. ``note`` is empty
-    unless a correction or warning happened — shape mirrors
+    Runs *after* ``_coerce_root_visibility`` — the visibility
+    decision is keyed off the agent's *intent* (a non-empty
+    ``root_id`` means "threaded reply"), so a hidden-visibility
+    reply whose ``root_id`` is auto-corrected stays hidden. This
+    helper only retargets which thread the message lands in.
+
+    On healthy data ``thread_root_id`` is always a true root
+    (its own ``thread_root_id IS NULL`` per ``message_store.py``'s
+    schema contract), so the loop terminates after at most one
+    hop. The multi-step walk + cycle break are corruption defense
+    for relay data shapes the schema shouldn't produce.
+
+    Returns ``(resolved_root_or_None, note)``. ``None`` is
+    returned only when ``root_id.strip()`` is empty. ``note`` is
+    empty unless a correction or warning happened — shape mirrors
     ``_coerce_root_visibility``. Lookup miss / transport failure
     falls through with the original id plus a soft warning so the
     send still completes.
@@ -200,9 +213,11 @@ async def _resolve_root_id(
     current = root_id
     seen: set[str] = set()
     walked = False
+    cycle = False
 
     for _ in range(_RESOLVE_ROOT_MAX_DEPTH):
         if current in seen:
+            cycle = True
             break
         seen.add(current)
         try:
@@ -239,11 +254,19 @@ async def _resolve_root_id(
         walked = True
         current = parent_root
 
-    return current, (
-        f"\nnote: root_id {root_id} was a reply, not a root — "
-        f"auto-corrected to {current} after walking "
-        f"{_RESOLVE_ROOT_MAX_DEPTH} levels. Pass the metadata block's "
-        "thread_root_id, not post_id."
+    # Corruption defense: ran out of depth or hit a cycle without
+    # finding a true root. Don't auto-correct to a value we can't
+    # trust — send to the original id and warn loudly.
+    reason = (
+        "cycle detected in thread chain"
+        if cycle
+        else f"chain deeper than {_RESOLVE_ROOT_MAX_DEPTH} levels"
+    )
+    return root_id, (
+        f"\nnote: could not resolve root_id {root_id} to a true thread "
+        f"root ({reason}); sent as-is. The relay's thread chain looks "
+        "corrupt — please flag this to the operator and pass the "
+        "metadata block's thread_root_id directly."
     )
 
 
@@ -892,8 +915,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         envelope = encrypt_message(inp, signing_key)
         await cfg.http_client.post("/messages", envelope)
         names = ", ".join(t.name for t in targets)
-        thread_display = resolved_root if resolved_root else root_id
-        thread_note = f" in thread {thread_display}" if thread_display else ""
+        thread_note = f" in thread {resolved_root}" if resolved_root else ""
         return (
             f"uploaded {len(targets)} file(s) [{names}] ({total_bytes} bytes "
             f"total) to {channel}{thread_note} "

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -743,18 +743,12 @@ async def test_fetch_channel_files_stub():
     assert "not yet implemented" in result
 
 
-# ───────────────────────── _resolve_root_id ──────────────────────────
-#
-# Guards PUF-200: agents that pass a non-root post_id as ``root_id``
-# used to silently land in a sub-thread invisible to the human. The
-# helper now resolves the supplied id back to the real thread root
-# before the envelope is encrypted, and tells the agent in the tool
-# response so the lesson sticks.
+# PUF-200: _resolve_root_id
 
 
 class _FakeDataClient:
-    """Minimal stand-in for ``DataClient`` — lets us seed thread_root_id
-    values and inject lookup failures without touching SQLite."""
+    """Stand-in for ``DataClient`` — seed thread_root_id values and
+    inject lookup failures without touching SQLite."""
 
     def __init__(self):
         self.messages: dict[str, object] = {}
@@ -844,6 +838,24 @@ async def test_resolve_root_id_transport_error_falls_through_with_warning():
 
 
 @pytest.mark.asyncio
+async def test_resolve_root_id_data_not_found_treated_as_lookup_miss():
+    """``DataClient.get_message_by_envelope`` raises ``DataNotFound``
+    (rather than returning None) when the data service is reachable
+    but the agent never recorded the envelope. The resolver should
+    treat that the same as a None return — fall through with the
+    "not in local store" warning, not the broader "lookup failed"
+    one."""
+    from puffo_agent.agent.message_store import DataNotFound
+    dc = _FakeDataClient()
+    dc.exc = DataNotFound("msg_only_on_server")
+    resolved, note = await _resolve_root_id("msg_only_on_server", dc)
+    assert resolved == "msg_only_on_server"
+    assert "could not verify" in note
+    assert "not in local store" in note
+    assert "lookup failed" not in note
+
+
+@pytest.mark.asyncio
 async def test_resolve_root_id_caps_walk_on_cycle():
     """Defensive: if the data is corrupt and a chain loops back on
     itself, the walk terminates and surfaces what it found rather
@@ -861,12 +873,9 @@ async def test_resolve_root_id_caps_walk_on_cycle():
 
 
 def _spy_encrypt_input(monkeypatch):
-    """Wrap ``encrypt_message`` so the test can read back the
-    ``EncryptInput`` the send path actually built. ``thread_root_id``
-    lives inside the encrypted payload, so checking the outer envelope
-    dict doesn't prove the auto-correction reached the wire — this
-    spy is the load-bearing assertion for the integration tests
-    below."""
+    """Capture the EncryptInput so tests can assert on the payload's
+    thread_root_id (which lives inside the ciphertext, not on the
+    outer envelope dict)."""
     import puffo_agent.mcp.puffo_core_tools as pct
     captured: dict = {}
     real = pct.encrypt_message
@@ -905,45 +914,60 @@ async def _seed_channel(ms, http, channel_id: str, space_id: str,
 
 
 @pytest.mark.asyncio
-async def test_send_message_auto_corrects_reply_as_root_id(monkeypatch):
-    """Pass a reply's post_id as root_id; the EncryptInput built by
-    the send path must carry the resolved real root, and the tool
-    response must include the correction note so the agent learns.
-    Mirrors the live failure Calculation hit on 2026-05-18."""
+@pytest.mark.parametrize(
+    "wrong_post_id, real_root_id, scenario",
+    [
+        # The two live failures we hit on 2026-05-18 with operator
+        # mingvase-8795 — the clone-report send (post_id of the
+        # operator's "please clone" message used as root_id) and
+        # the build-test report send (post_id of the operator's
+        # "ensure you can build/test" message used as root_id).
+        ("msg_38364760-cd04-408a-9daf-aad66a2487fc",
+         "msg_610fec10-122f-4fff-8dcb-498770809c84",
+         "clone-report-live-failure"),
+        ("msg_9e8f1a83-05ff-4775-8e07-b90999c61d53",
+         "msg_610fec10-122f-4fff-8dcb-498770809c84",
+         "build-test-report-live-failure"),
+    ],
+)
+async def test_send_message_auto_corrects_real_live_failures(
+    monkeypatch, wrong_post_id, real_root_id, scenario,
+):
+    """Each parameter is one of the two real failures we observed
+    on 2026-05-18 — operator's post is the thread root, the message
+    Calculation incorrectly passed as root_id is a reply in that
+    same thread. After the fix the EncryptInput must carry the real
+    root and the response must include the correction note."""
     cfg, http, ms = _setup()
     await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
-    # Local store: msg_root is the real root, msg_reply threads under
-    # it. Agent (incorrectly) passes msg_reply's id as root_id.
     await ms.store({
-        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "envelope_id": real_root_id, "envelope_kind": "channel",
         "sender_slug": "alice-0001", "channel_id": "ch_abc",
         "space_id": "sp_test", "content_type": "text/plain",
-        "content": "root post", "sent_at": _now_ms(),
+        "content": "real root", "sent_at": _now_ms(),
         "thread_root_id": None,
     })
     await ms.store({
-        "envelope_id": "msg_reply", "envelope_kind": "channel",
+        "envelope_id": wrong_post_id, "envelope_kind": "channel",
         "sender_slug": "alice-0001", "channel_id": "ch_abc",
         "space_id": "sp_test", "content_type": "text/plain",
-        "content": "first reply", "sent_at": _now_ms(),
-        "thread_root_id": "msg_root",
+        "content": f"reply in thread ({scenario})", "sent_at": _now_ms(),
+        "thread_root_id": real_root_id,
     })
     captured = _spy_encrypt_input(monkeypatch)
 
     mcp = _build_tools(cfg)
     result = await _call(mcp, "send_message", {
         "channel": "ch_abc",
-        "text": "agent thinks this is threading under msg_reply",
+        "text": f"replaying {scenario}",
         "is_visible_to_human": False,
-        "root_id": "msg_reply",
+        "root_id": wrong_post_id,
     })
 
     assert "posted" in result
     assert "auto-corrected" in result
-    assert "msg_reply" in result and "msg_root" in result
-    # The substituted root is what reaches the encrypted payload —
-    # not the original wrong id.
-    assert captured["inp"].thread_root_id == "msg_root"
+    assert wrong_post_id in result and real_root_id in result
+    assert captured["inp"].thread_root_id == real_root_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -15,6 +15,7 @@ from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
 from puffo_agent.mcp.puffo_core_tools import (
     PuffoCoreToolsConfig,
     _coerce_root_visibility,
+    _resolve_root_id,
     register_core_tools,
 )
 
@@ -64,6 +65,17 @@ class FakeHttpClient:
         if path in self.responses:
             return self.responses[path]
         return {"ok": True}
+
+    async def post_bytes(self, path, headers=None, data=None):
+        """``send_message_with_attachments`` uploads each file via
+        ``POST /blobs/upload`` before encrypting the message
+        envelope; the integration tests below need this stub so the
+        upload step doesn't AttributeError on the way to the
+        envelope path. Return the canned response when set."""
+        self.calls.append(("POST_BYTES", path, len(data) if data else 0))
+        if path in self.responses:
+            return self.responses[path]
+        return {"blob_id": "blob_stub", "ok": True}
 
     async def _ensure_subkey(self):
         pass
@@ -729,6 +741,323 @@ async def test_fetch_channel_files_stub():
     mcp = _build_tools(cfg)
     result = await _call(mcp, "fetch_channel_files", {"channel": "ch_1"})
     assert "not yet implemented" in result
+
+
+# ───────────────────────── _resolve_root_id ──────────────────────────
+#
+# Guards PUF-200: agents that pass a non-root post_id as ``root_id``
+# used to silently land in a sub-thread invisible to the human. The
+# helper now resolves the supplied id back to the real thread root
+# before the envelope is encrypted, and tells the agent in the tool
+# response so the lesson sticks.
+
+
+class _FakeDataClient:
+    """Minimal stand-in for ``DataClient`` — lets us seed thread_root_id
+    values and inject lookup failures without touching SQLite."""
+
+    def __init__(self):
+        self.messages: dict[str, object] = {}
+        self.exc: Exception | None = None
+        self.calls: list[str] = []
+
+    def add(self, envelope_id: str, thread_root_id: str | None) -> None:
+        class _Msg:
+            pass
+        m = _Msg()
+        m.envelope_id = envelope_id
+        m.thread_root_id = thread_root_id
+        self.messages[envelope_id] = m
+
+    async def get_message_by_envelope(self, envelope_id: str):
+        self.calls.append(envelope_id)
+        if self.exc is not None:
+            raise self.exc
+        return self.messages.get(envelope_id)
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_empty_skips_lookup():
+    dc = _FakeDataClient()
+    resolved, note = await _resolve_root_id("", dc)
+    assert resolved is None
+    assert note == ""
+    assert dc.calls == []
+    # Whitespace-only is also treated as empty.
+    resolved, note = await _resolve_root_id("   ", dc)
+    assert resolved is None and note == ""
+    assert dc.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_true_root_unchanged():
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None)
+    resolved, note = await _resolve_root_id("msg_root", dc)
+    assert resolved == "msg_root"
+    assert note == ""
+    assert dc.calls == ["msg_root"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_reply_auto_corrected():
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None)
+    dc.add("msg_reply", thread_root_id="msg_root")
+    resolved, note = await _resolve_root_id("msg_reply", dc)
+    assert resolved == "msg_root"
+    assert "auto-corrected" in note
+    assert "msg_reply" in note and "msg_root" in note
+    assert "thread_root_id" in note and "post_id" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_depth_two_chain_walks_to_root():
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None)
+    dc.add("msg_mid", thread_root_id="msg_root")
+    dc.add("msg_leaf", thread_root_id="msg_mid")
+    resolved, note = await _resolve_root_id("msg_leaf", dc)
+    assert resolved == "msg_root"
+    assert "auto-corrected" in note
+    assert dc.calls == ["msg_leaf", "msg_mid", "msg_root"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_lookup_miss_falls_through_with_warning():
+    dc = _FakeDataClient()
+    resolved, note = await _resolve_root_id("msg_unknown", dc)
+    assert resolved == "msg_unknown"
+    assert "could not verify" in note
+    assert "not in local store" in note
+    assert "thread_root_id" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_transport_error_falls_through_with_warning():
+    dc = _FakeDataClient()
+    dc.exc = RuntimeError("simulated transport blip")
+    resolved, note = await _resolve_root_id("msg_anything", dc)
+    assert resolved == "msg_anything"
+    assert "could not verify" in note
+    assert "lookup failed" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_caps_walk_on_cycle():
+    """Defensive: if the data is corrupt and a chain loops back on
+    itself, the walk terminates and surfaces what it found rather
+    than hanging."""
+    dc = _FakeDataClient()
+    # Cycle: A → B → A → ...
+    dc.add("msg_a", thread_root_id="msg_b")
+    dc.add("msg_b", thread_root_id="msg_a")
+    resolved, note = await _resolve_root_id("msg_a", dc)
+    # Resolved to whichever node the walk landed on when it detected
+    # the cycle / hit the depth cap — either is acceptable, but the
+    # call must complete and return a correction note.
+    assert resolved in ("msg_a", "msg_b")
+    assert "auto-corrected" in note
+
+
+def _spy_encrypt_input(monkeypatch):
+    """Wrap ``encrypt_message`` so the test can read back the
+    ``EncryptInput`` the send path actually built. ``thread_root_id``
+    lives inside the encrypted payload, so checking the outer envelope
+    dict doesn't prove the auto-correction reached the wire — this
+    spy is the load-bearing assertion for the integration tests
+    below."""
+    import puffo_agent.mcp.puffo_core_tools as pct
+    captured: dict = {}
+    real = pct.encrypt_message
+
+    def spy(inp, signing_key, **kw):
+        captured["inp"] = inp
+        return real(inp, signing_key, **kw)
+
+    monkeypatch.setattr(pct, "encrypt_message", spy)
+    return captured
+
+
+def _seed_recipient(http, recipient_slug: str):
+    recipient_kem = KemKeyPair.generate()
+    http.responses[f"/certs/sync?slugs={recipient_slug}"] = {
+        "entries": [{
+            "seq": 1, "kind": "device_cert", "slug": recipient_slug,
+            "cert": {
+                "device_id": f"dev_{recipient_slug}",
+                "kem_public_key": base64url_encode(
+                    recipient_kem.public_key_bytes()
+                ),
+            },
+        }],
+        "has_more": False,
+    }
+
+
+async def _seed_channel(ms, http, channel_id: str, space_id: str,
+                        recipient_slug: str):
+    await ms.mark_channel_space(channel_id, space_id)
+    http.responses[f"/spaces/{space_id}/channels/{channel_id}/members"] = {
+        "members": [{"slug": recipient_slug, "role": "owner"}],
+    }
+    _seed_recipient(http, recipient_slug)
+
+
+@pytest.mark.asyncio
+async def test_send_message_auto_corrects_reply_as_root_id(monkeypatch):
+    """Pass a reply's post_id as root_id; the EncryptInput built by
+    the send path must carry the resolved real root, and the tool
+    response must include the correction note so the agent learns.
+    Mirrors the live failure Calculation hit on 2026-05-18."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    # Local store: msg_root is the real root, msg_reply threads under
+    # it. Agent (incorrectly) passes msg_reply's id as root_id.
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root post", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+    await ms.store({
+        "envelope_id": "msg_reply", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "first reply", "sent_at": _now_ms(),
+        "thread_root_id": "msg_root",
+    })
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc",
+        "text": "agent thinks this is threading under msg_reply",
+        "is_visible_to_human": False,
+        "root_id": "msg_reply",
+    })
+
+    assert "posted" in result
+    assert "auto-corrected" in result
+    assert "msg_reply" in result and "msg_root" in result
+    # The substituted root is what reaches the encrypted payload —
+    # not the original wrong id.
+    assert captured["inp"].thread_root_id == "msg_root"
+
+
+@pytest.mark.asyncio
+async def test_send_message_keeps_real_root_id_unchanged(monkeypatch):
+    """Happy path: agent passes a real root id; no correction note,
+    EncryptInput's thread_root_id is the supplied id."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root post", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc",
+        "text": "correctly threaded reply",
+        "is_visible_to_human": False,
+        "root_id": "msg_root",
+    })
+
+    assert "posted" in result
+    assert "auto-corrected" not in result
+    assert "could not verify" not in result
+    assert captured["inp"].thread_root_id == "msg_root"
+
+
+@pytest.mark.asyncio
+async def test_send_message_unknown_root_id_falls_through_with_warning(monkeypatch):
+    """When the supplied root_id isn't in the local store at all
+    (could happen for very fresh messages), the send still completes
+    with the original id and the tool response carries a warning."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc",
+        "text": "racing the inbound write",
+        "is_visible_to_human": False,
+        "root_id": "msg_never_seen",
+    })
+
+    assert "posted" in result
+    assert "could not verify" in result
+    # Better to land in a wrong thread than to drop the message —
+    # the original id reaches the payload.
+    assert captured["inp"].thread_root_id == "msg_never_seen"
+
+
+@pytest.mark.asyncio
+async def test_send_message_root_level_send_skips_resolve(monkeypatch):
+    """No root_id → no lookup attempted, EncryptInput's thread_root_id
+    is None, no resolve-style note in the response."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "top-level", "is_visible_to_human": True,
+    })
+
+    assert "posted" in result
+    assert "auto-corrected" not in result
+    assert "could not verify" not in result
+    assert captured["inp"].thread_root_id is None
+
+
+@pytest.mark.asyncio
+async def test_send_message_with_attachments_auto_corrects_reply_as_root_id(
+    monkeypatch, tmp_path,
+):
+    """Same auto-correction behaviour on the attachments path."""
+    cfg, http, ms = _setup()
+    cfg.workspace = tmp_path
+    (tmp_path / "hello.txt").write_bytes(b"hello attachments")
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    http.responses["/blobs/upload"] = {"blob_id": "blob_xyz"}
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+    await ms.store({
+        "envelope_id": "msg_reply", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "reply", "sent_at": _now_ms(),
+        "thread_root_id": "msg_root",
+    })
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message_with_attachments", {
+        "paths": ["hello.txt"],
+        "channel": "ch_abc",
+        "is_visible_to_human": False,
+        "root_id": "msg_reply",
+        "caption": "files",
+    })
+
+    assert "uploaded" in result
+    assert "auto-corrected" in result
+    # Display string reflects the *resolved* thread, not the wrong id.
+    assert "in thread msg_root" in result
+    assert captured["inp"].thread_root_id == "msg_root"
 
 
 @pytest.mark.asyncio

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -856,20 +856,35 @@ async def test_resolve_root_id_data_not_found_treated_as_lookup_miss():
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_caps_walk_on_cycle():
-    """Defensive: if the data is corrupt and a chain loops back on
-    itself, the walk terminates and surfaces what it found rather
-    than hanging."""
+async def test_resolve_root_id_cycle_preserves_root_id_with_warning():
+    """Cycle is corrupt data — don't auto-correct to a node we
+    can't trust. Preserve the original ``root_id`` and surface a
+    loud warning so the operator can investigate."""
     dc = _FakeDataClient()
-    # Cycle: A → B → A → ...
     dc.add("msg_a", thread_root_id="msg_b")
     dc.add("msg_b", thread_root_id="msg_a")
     resolved, note = await _resolve_root_id("msg_a", dc)
-    # Resolved to whichever node the walk landed on when it detected
-    # the cycle / hit the depth cap — either is acceptable, but the
-    # call must complete and return a correction note.
-    assert resolved in ("msg_a", "msg_b")
-    assert "auto-corrected" in note
+    assert resolved == "msg_a"
+    assert "could not resolve" in note
+    assert "cycle detected" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_root_id_depth_cap_preserves_root_id_with_warning():
+    """Same corruption-defense path for a chain deeper than the
+    cap — preserve ``root_id``, warn loudly, don't auto-correct."""
+    dc = _FakeDataClient()
+    # Chain deeper than _RESOLVE_ROOT_MAX_DEPTH (4): leaf → l4 → l3 → l2 → l1 → root
+    dc.add("msg_leaf", thread_root_id="msg_l4")
+    dc.add("msg_l4", thread_root_id="msg_l3")
+    dc.add("msg_l3", thread_root_id="msg_l2")
+    dc.add("msg_l2", thread_root_id="msg_l1")
+    dc.add("msg_l1", thread_root_id="msg_root")
+    dc.add("msg_root", thread_root_id=None)
+    resolved, note = await _resolve_root_id("msg_leaf", dc)
+    assert resolved == "msg_leaf"
+    assert "could not resolve" in note
+    assert "deeper than" in note
 
 
 def _spy_encrypt_input(monkeypatch):


### PR DESCRIPTION
## Summary

Agents calling `mcp__puffo__send_message` (and `send_message_with_attachments`) with `root_id` set to a reply's envelope id — instead of the thread's true root — used to land in a sub-thread the human client doesn't surface, with no failure signal returned. We hit this twice live on 2026-05-18 (clone-report `msg_38364760` and build-test-report `msg_9e8f1a83`, both threaded under root `msg_610fec10`) and both messages vanished from the operator's view.

This PR adds a `_resolve_root_id(root_id, data_client)` helper next to `_coerce_root_visibility` that looks up the supplied envelope, walks to the real `thread_root_id` (capped at depth 4 with cycle detection), substitutes it before encrypting, and appends a correction note to the tool response so the agent learns the rule on the spot. Lookup miss / transport error falls through with a soft warning rather than failing the send.

Wired into both `send_message` (line 397) and `send_message_with_attachments` (line 894). The attachments-path display string ("in thread …") also reflects the resolved root, not the original wrong id.

Ticket: `/home/hanchen/.puffo-agent/shared/PUF-200.md`

## Test plan

- [x] Unit matrix on `_resolve_root_id` (8 tests): empty / whitespace, true root, single-level reply, depth-2 walk, lookup miss (None return), transport error, real `DataNotFound`, cycle defensive cap.
- [x] Integration on `send_message` parametrized over the **two real 2026-05-18 live failures** + 3 single-case integrations: real-root unchanged, unknown-root fall-through with warning, root-level skips lookup entirely.
- [x] Integration on `send_message_with_attachments`: same auto-correction; display string reflects the resolved root.
- [x] Full pytest in worktree: **596 passed / 1 intentional skip / 0 failed**.
- [x] Independent QA round 2 by Solution after iteration on docstring trim + DataNotFound coverage + parametrize ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)