### PR TITLE
fix(PUF-202): coerce visibility back to true when body @-mentions a non-agent slug

### DIFF
--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -140,6 +140,7 @@ def puffo_core_mcp_env(
     data_service_url: str = "http://127.0.0.1:63386",
     runtime_kind: str = "",
     harness: str = "",
+    known_agent_slugs: set[str] | None = None,
 ) -> dict[str, str]:
     """Env dict for the puffo-core MCP subprocess.
 
@@ -148,6 +149,11 @@ def puffo_core_mcp_env(
     ``http://host.docker.internal:63386`` so the container can
     reach the host loopback. The MCP never opens ``messages.db``
     directly — the daemon is the sole owner.
+
+    ``known_agent_slugs`` (PUF-202) carries the operator's trusted
+    peer-agent slugs; an empty set means every @-mention coerces
+    visibility back to true. Wire-shape is comma-separated for the
+    ENV.
     """
     env: dict[str, str] = {
         "PUFFO_CORE_SLUG": slug,
@@ -171,6 +177,8 @@ def puffo_core_mcp_env(
         env["PUFFO_RUNTIME_KIND"] = runtime_kind
     if harness:
         env["PUFFO_HARNESS"] = harness
+    if known_agent_slugs:
+        env["PUFFO_KNOWN_AGENT_SLUGS"] = ",".join(sorted(known_agent_slugs))
     return env
 
 
@@ -184,6 +192,7 @@ def puffo_core_stdio_sdk_config(
     keystore_dir: str,
     workspace: str,
     agent_id: str,
+    known_agent_slugs: set[str] | None = None,
 ) -> dict:
     """Return the ``mcp_servers`` config dict for the SDK adapter."""
     return {
@@ -200,6 +209,7 @@ def puffo_core_stdio_sdk_config(
                 workspace=workspace,
                 agent_id=agent_id,
                 runtime_kind="sdk-local",
+                known_agent_slugs=known_agent_slugs,
             ),
         }
     }

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -180,6 +180,7 @@ def build_server(
     data_service_url: str,
     runtime_kind: str = "",
     harness: str = "",
+    known_agent_slugs: set[str] | None = None,
 ) -> FastMCP:
     ks = KeyStore(keystore_dir)
     http = PuffoCoreHttpClient(server_url, ks, slug)
@@ -196,6 +197,7 @@ def build_server(
         data_client=data,
         space_id=space_id,
         workspace=workspace,
+        known_agent_slugs=known_agent_slugs or set(),
     )
 
     mcp = FastMCP("puffo-core")
@@ -204,7 +206,7 @@ def build_server(
     return mcp
 
 
-def _cfg_from_env() -> dict[str, str]:
+def _cfg_from_env() -> dict[str, object]:
     required = {
         "slug": os.environ.get("PUFFO_CORE_SLUG", ""),
         "device_id": os.environ.get("PUFFO_CORE_DEVICE_ID", ""),
@@ -224,6 +226,12 @@ def _cfg_from_env() -> dict[str, str]:
     data_service_url = os.environ.get(
         "PUFFO_DATA_SERVICE_URL", "http://127.0.0.1:63386",
     )
+    # PUF-202: comma-separated peer-agent slugs the operator has
+    # opted into for invisibility. Empty / unset → empty set →
+    # every @-mention coerces. Worker writes this ENV var from
+    # daemon.yml / agent.yml at spawn time.
+    raw_peers = os.environ.get("PUFFO_KNOWN_AGENT_SLUGS", "")
+    known_agent_slugs = {s.strip().lower() for s in raw_peers.split(",") if s.strip()}
     return {
         **required,
         "space_id": os.environ.get("PUFFO_CORE_SPACE_ID", ""),
@@ -233,6 +241,7 @@ def _cfg_from_env() -> dict[str, str]:
         "data_service_url": data_service_url,
         "runtime_kind": os.environ.get("PUFFO_RUNTIME_KIND", ""),
         "harness": os.environ.get("PUFFO_HARNESS", ""),
+        "known_agent_slugs": known_agent_slugs,
     }
 
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import urllib.parse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -111,6 +112,15 @@ class PuffoCoreToolsConfig:
     # safety-resolve LLM-supplied relative paths (no ``..`` escape,
     # no absolutes).
     workspace: Optional[str] = None
+    # PUF-202: peer-agent slugs the daemon trusts as agents (per
+    # daemon.yml / agent.yml). The send-time visibility coercion
+    # at ``_coerce_root_visibility`` reads this set; any @-mention
+    # whose slug isn't here gets flagged as "probably a human" and
+    # coerces ``is_visible_to_human=false`` back to true. Cache is
+    # written into the module-level ``_KNOWN_AGENT_SLUGS`` at
+    # ``register_core_tools`` time so tests and the production path
+    # share the same source of truth.
+    known_agent_slugs: set[str] = field(default_factory=set)
 
 
 async def _fetch_device_keys(
@@ -155,29 +165,98 @@ async def _fetch_device_keys(
     return devices
 
 
-def _coerce_root_visibility(
-    is_visible_to_human: bool, root_id: str,
-) -> tuple[bool, str]:
-    """Root-level (non-threaded) messages can't fold in the human UI —
-    only threaded replies do. When an agent marks a root-level message
-    ``is_visible_to_human=false`` we coerce it back to visible (so the
-    message still goes out) and return a note to splice into the tool
-    response. The agent learns from the tool result on the spot,
-    rather than depending on the primer being current.
+# PUF-202: matches ``@<slug>`` tokens in a message body. Puffo slugs
+# are lowercase alphanumeric + hyphen, length >= 2 (e.g.
+# ``equation-7256-87f7``). The regex allows the @ to follow any
+# non-alphanumeric character — opening paren, leading-quote ``>``,
+# bullet ``-``, em-dash, etc. — so ``(@slug)``, ``> @slug ...``, and
+# ``- @slug`` all match. Slugs are extracted lowercased so a user
+# typing ``@Equation-7256-87f7`` matches the canonical form in the
+# known-agents cache.
+_AT_MENTION_RE = re.compile(r"(?:(?<=^)|(?<=[^A-Za-z0-9_]))@([a-z0-9][a-z0-9-]+)", re.IGNORECASE)
 
-    Returns ``(effective_visibility, note)`` — ``note`` is empty
-    unless a coercion happened.
+# PUF-202: module-level cache of slugs the operator has confirmed are
+# agents. Look-ups happen during ``_coerce_root_visibility``; misses
+# bias toward coercing-to-visible (the "right floor" per FB-130
+# recurrence rate: miss a human is worse than over-coerce a bot).
+#
+# Cache is empty by default — Tuesday's ship-day floor is "every
+# @-mention coerces visible." A follow-up PUF will populate this
+# from the cert-sync ``identity_type`` channel once that endpoint
+# carries the field.
+_KNOWN_AGENT_SLUGS: set[str] = set()
+
+
+def _set_known_agent_slugs(slugs: set[str]) -> None:
+    """Replace the module-level known-agents cache. Used by the
+    test suite and, eventually, by the worker on startup once a
+    runtime population path lands. Slugs are normalized to lowercase
+    so callers don't have to."""
+    _KNOWN_AGENT_SLUGS.clear()
+    _KNOWN_AGENT_SLUGS.update(s.strip().lower() for s in slugs if s.strip())
+
+
+def _extract_at_mentioned_slugs(body: str) -> list[str]:
+    """Return every ``@<slug>`` token from ``body`` (lowercased,
+    insertion order, duplicates preserved). Empty when the body has
+    no mentions or is empty/None-ish."""
+    if not body:
+        return []
+    return [m.group(1).lower() for m in _AT_MENTION_RE.finditer(body)]
+
+
+def _coerce_root_visibility(
+    is_visible_to_human: bool, root_id: str, body: str = "",
+) -> tuple[bool, str]:
+    """Coerce ``is_visible_to_human=false`` to true in two cases:
+
+    1. **Root-level** sends (no ``root_id``): folding only applies
+       to threaded replies; on a root post ``false`` is meaningless
+       and the message would be sent visible anyway.
+    2. **PUF-202** — body @-mentions a slug the local known-agents
+       cache hasn't tagged as another agent. Without this, an agent
+       posting ``@<human-slug> please do X`` with ``false`` would
+       fold the message and the human would never see instructions
+       explicitly addressed to them (the FB-130 family bug;
+       Sam/Sean/Tang Yan/Maoyi-Motrin case-studies).
+
+    Returns ``(effective_visibility, note)``. ``note`` is empty
+    when no coercion happened.
     """
-    if is_visible_to_human is False and not root_id.strip():
+    if is_visible_to_human is not False:
+        return is_visible_to_human, ""
+
+    if not root_id.strip():
         return True, (
             "\nnote: is_visible_to_human=false ignored — root-level "
             "messages can't fold; sent as visible. Use false only on "
             "threaded replies (pass root_id)."
         )
-    return is_visible_to_human, ""
+
+    mentioned = _extract_at_mentioned_slugs(body)
+    unknown = [s for s in mentioned if s not in _KNOWN_AGENT_SLUGS]
+    if unknown:
+        first = unknown[0]
+        return True, (
+            f"\nnote: is_visible_to_human=false coerced to true — "
+            f"body @-mentions {first}, not in the local known-agents "
+            "cache. If "
+            f"{first} is an agent your local cache hasn't seen yet, "
+            "subsequent sends should fold normally."
+        )
+
+    return False, ""
 
 
 def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
+
+    # PUF-202: prime the module-level known-agents cache from the
+    # config supplied by the worker/daemon. The cache is shared
+    # across registered tools and the visibility-coercion helper;
+    # writing it here keeps the production path (worker injects
+    # daemon-config seed list at startup) and the test path
+    # (``_set_known_agent_slugs`` directly) on the same wire.
+    _set_known_agent_slugs(cfg.known_agent_slugs)
 
     @mcp.tool()
     async def whoami() -> str:
@@ -301,7 +380,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         )
 
         effective_visible, fold_note = _coerce_root_visibility(
-            is_visible_to_human, root_id,
+            is_visible_to_human, root_id, body=text,
         )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
@@ -797,7 +876,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             "attachments": [m.to_dict() for m in attachment_metas],
         }
         effective_visible, fold_note = _coerce_root_visibility(
-            is_visible_to_human, root_id,
+            is_visible_to_human, root_id, body=caption,
         )
         inp = EncryptInput(
             envelope_kind=envelope_kind,

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -721,6 +721,14 @@ class DaemonConfig:
     # with a verbose primer.
     max_inline_message_chars: int = 4000
     segment_chars: int = 2000
+    # PUF-202: peer-agent slugs the operator opts into for the
+    # agent-to-agent invisibility rule. When an agent sends with
+    # ``is_visible_to_human=false`` and the body contains
+    # ``@<slug>``, that slug is checked against this list; any miss
+    # coerces the message back to visible (the FB-130 medical-harm
+    # bias — better to over-coerce a peer than miss a human). Empty
+    # default → every @-mention coerces.
+    known_agent_slugs: list[str] = field(default_factory=list)
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(
         default_factory=lambda: DataServiceConfig(),
@@ -744,6 +752,11 @@ class DaemonConfig:
             docker_memory_reservation=raw.get("docker_memory_reservation", "500m"),
             max_inline_message_chars=int(raw.get("max_inline_message_chars", 4000)),
             segment_chars=int(raw.get("segment_chars", 2000)),
+            known_agent_slugs=[
+                str(s).strip().lower()
+                for s in (raw.get("known_agent_slugs") or [])
+                if str(s).strip()
+            ],
         )
         for name in ("anthropic", "openai", "google"):
             p = raw.get(name) or {}
@@ -781,6 +794,7 @@ class DaemonConfig:
             "docker_memory_reservation": self.docker_memory_reservation,
             "max_inline_message_chars": self.max_inline_message_chars,
             "segment_chars": self.segment_chars,
+            "known_agent_slugs": list(self.known_agent_slugs),
             "anthropic": asdict(self.anthropic),
             "openai": asdict(self.openai),
             "google": asdict(self.google),

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -86,6 +86,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 keystore_dir=str(agent_dir(agent_cfg.id) / "keys"),
                 workspace=str(agent_cfg.resolve_workspace_dir()),
                 agent_id=agent_cfg.id,
+                known_agent_slugs=set(daemon_cfg.known_agent_slugs),
             )
         return adapter
 
@@ -154,6 +155,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 data_service_url="http://host.docker.internal:63386",
                 runtime_kind="cli-docker",
                 harness=agent_cfg.runtime.harness,
+                known_agent_slugs=set(daemon_cfg.known_agent_slugs),
             )
         return adapter
 
@@ -187,6 +189,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 keystore_dir=str(agent_dir(agent_cfg.id) / "keys"),
                 workspace=str(agent_cfg.resolve_workspace_dir()),
                 agent_id=agent_cfg.id,
+                known_agent_slugs=set(daemon_cfg.known_agent_slugs),
                 runtime_kind="cli-local",
                 harness=agent_cfg.runtime.harness,
             )

--- a/tests/test_coerce_root_visibility_at_mentions.py
+++ b/tests/test_coerce_root_visibility_at_mentions.py
@@ -1,0 +1,249 @@
+"""PUF-202: ``_coerce_root_visibility`` coerces ``false`` → ``true``
+when the body @-mentions a slug the local known-agents cache hasn't
+tagged as a peer agent. Default (empty cache) → all @-mentions
+coerce — the safe floor for the FB-130 family of bugs where an
+agent's ``@<human-slug> please do X`` got folded away from the human
+it explicitly addressed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from puffo_agent.mcp.puffo_core_tools import (
+    _AT_MENTION_RE,
+    _KNOWN_AGENT_SLUGS,
+    _coerce_root_visibility,
+    _extract_at_mentioned_slugs,
+    _set_known_agent_slugs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Cache is module-level state; reset between tests so cases
+    don't bleed into each other."""
+    _set_known_agent_slugs(set())
+    yield
+    _set_known_agent_slugs(set())
+
+
+# ── _extract_at_mentioned_slugs: regex behaviour ─────────────────
+
+
+def test_extract_finds_bare_at_mention():
+    assert _extract_at_mentioned_slugs("hi @bob-1234 please review") == ["bob-1234"]
+
+
+def test_extract_finds_mention_after_open_paren():
+    # Equation's edge case: the @ following punctuation should still match.
+    assert _extract_at_mentioned_slugs("see (@bob-1234) for context") == ["bob-1234"]
+
+
+def test_extract_finds_mention_after_quote_marker():
+    # Markdown blockquote / reply prefix.
+    assert _extract_at_mentioned_slugs("> @bob-1234 said earlier") == ["bob-1234"]
+
+
+def test_extract_finds_mention_after_bullet():
+    assert _extract_at_mentioned_slugs("- @bob-1234 owns this") == ["bob-1234"]
+
+
+def test_extract_case_insensitive_but_lowercases_output():
+    # Equation's edge case: case-mismatched at-mention should still
+    # match, and we should canonicalize to lowercase for cache lookup.
+    assert _extract_at_mentioned_slugs("hi @Equation-7256-87f7") == ["equation-7256-87f7"]
+    assert _extract_at_mentioned_slugs("hi @EQUATION-7256-87f7") == ["equation-7256-87f7"]
+
+
+def test_extract_finds_multiple_mentions_in_order():
+    assert _extract_at_mentioned_slugs(
+        "@alice-1 and @bob-2 — let's coordinate"
+    ) == ["alice-1", "bob-2"]
+
+
+def test_extract_ignores_email_address():
+    # ``foo@bar.com`` shouldn't trigger a mention — the @ here is in
+    # the middle of a word, not at a word boundary.
+    assert _extract_at_mentioned_slugs("ping me at foo@bar.com") == []
+
+
+def test_extract_ignores_lone_at_sign():
+    assert _extract_at_mentioned_slugs("price @ market") == []
+
+
+def test_extract_empty_body():
+    assert _extract_at_mentioned_slugs("") == []
+    assert _extract_at_mentioned_slugs(None) == []  # type: ignore[arg-type]
+
+
+# ── _coerce_root_visibility: PUF-200's original root-level rule ──
+
+
+def test_coerce_root_level_false_still_coerces():
+    """Pre-PUF-202 behaviour: ``is_visible_to_human=False`` on a
+    root-level send (empty ``root_id``) coerces to True with the
+    original "messages can't fold" note. PUF-202 must not regress."""
+    visible, note = _coerce_root_visibility(False, "")
+    assert visible is True
+    assert "can't fold" in note
+
+
+def test_coerce_visible_true_is_passthrough():
+    visible, note = _coerce_root_visibility(True, "msg_root", body="@bob hello")
+    assert visible is True
+    assert note == ""
+
+
+# ── PUF-202: body @-mention coercion ─────────────────────────────
+
+
+def test_coerce_threaded_false_no_mentions_passes_through():
+    """Threaded reply, no @-mentions, empty cache — original
+    semantics. False stays False, no coercion."""
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="Got it, will look.",
+    )
+    assert visible is False
+    assert note == ""
+
+
+def test_coerce_threaded_false_human_mention_coerces():
+    """The FB-130 medical-harm case: agent threads a reply, sets
+    visible=false, and @-mentions a human. Pre-fix the human
+    never saw the message. Post-PUF-202 we coerce visible."""
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="@sam-1234 please give Maoyi Motrin 7.5ml",
+    )
+    assert visible is True
+    assert "coerced to true" in note
+    assert "sam-1234" in note
+    assert "known-agents cache" in note
+
+
+def test_coerce_threaded_false_known_agent_does_not_coerce():
+    """If every @-mention is a known peer agent, leave the
+    visibility flag alone — preserves the operator's agent-to-agent
+    invisibility rule."""
+    _set_known_agent_slugs({"equation-7256-87f7"})
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="@equation-7256-87f7 ack",
+    )
+    assert visible is False
+    assert note == ""
+
+
+def test_coerce_threaded_false_mixed_known_unknown_coerces():
+    """If ANY @-mention is unknown, coerce. Better to err visible
+    when even one of the mentions might be a human."""
+    _set_known_agent_slugs({"equation-7256-87f7"})
+    visible, note = _coerce_root_visibility(
+        False, "msg_root",
+        body="@equation-7256-87f7 and @sam-1234 — both should see this",
+    )
+    assert visible is True
+    assert "coerced to true" in note
+    # The note names the *first* unknown slug as the trigger.
+    assert "sam-1234" in note
+
+
+def test_coerce_cache_miss_on_known_agent_still_coerces():
+    """Equation's specifically-asked test: in a fresh worker
+    session, the cert cache hasn't warmed up yet, so a peer-agent
+    @-mention coerces visible. That's the right safe-fail — the
+    note tells the agent the cache might catch up later."""
+    # Cache empty (no _set_known_agent_slugs call).
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="@equation-7256-87f7 see above",
+    )
+    assert visible is True
+    assert "coerced to true" in note
+    assert "subsequent sends should fold normally" in note
+
+
+def test_coerce_case_mismatched_at_mention_uses_canonical_lookup():
+    """Equation's edge case: ``@Equation-7256-87f7`` lowercases to
+    ``equation-7256-87f7`` for the cache lookup, so a properly-
+    cached peer agent isn't accidentally coerced."""
+    _set_known_agent_slugs({"equation-7256-87f7"})
+    visible, _ = _coerce_root_visibility(
+        False, "msg_root", body="hi @Equation-7256-87f7",
+    )
+    assert visible is False
+
+
+def test_coerce_at_mention_after_punctuation_still_triggers():
+    """Equation's edge case: ``(@slug)`` parens + leading-quote ``>``."""
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="(@sam-1234) — see this",
+    )
+    assert visible is True
+    assert "sam-1234" in note
+
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="> @sam-1234 said earlier",
+    )
+    assert visible is True
+    assert "sam-1234" in note
+
+
+def test_coerce_root_level_takes_precedence_over_mention_coercion():
+    """Empty root_id wins — gets the original 'can't fold' note,
+    not the new @-mention note. Saves the caller a meaningless
+    'this is a known agent so no coercion needed' path on a root
+    send where the flag was meaningless anyway."""
+    _set_known_agent_slugs({"equation-7256-87f7"})
+    visible, note = _coerce_root_visibility(
+        False, "", body="@equation-7256-87f7 hello",
+    )
+    assert visible is True
+    assert "can't fold" in note
+    # The PUF-202 note isn't included since the root-level rule
+    # already coerced.
+    assert "coerced to true" not in note
+
+
+def test_coerce_empty_body_passes_through():
+    """No body → no @-mentions → no PUF-202 coercion. False stays
+    False (assuming a threaded send)."""
+    visible, note = _coerce_root_visibility(False, "msg_root", body="")
+    assert visible is False
+    assert note == ""
+
+
+def test_coerce_email_in_body_does_not_trigger():
+    """An email address (e.g. ``foo@bar.com``) shouldn't trip the
+    coercion — the @ here is mid-word, not at a mention boundary."""
+    visible, note = _coerce_root_visibility(
+        False, "msg_root", body="reach me at foo@bar.com",
+    )
+    assert visible is False
+    assert note == ""
+
+
+# ── _set_known_agent_slugs: cache contract ────────────────────────
+
+
+def test_set_known_agent_slugs_replaces_state():
+    _set_known_agent_slugs({"alice-1"})
+    assert "alice-1" in _KNOWN_AGENT_SLUGS
+
+    _set_known_agent_slugs({"bob-2"})
+    assert "alice-1" not in _KNOWN_AGENT_SLUGS  # replaced, not appended
+    assert "bob-2" in _KNOWN_AGENT_SLUGS
+
+
+def test_set_known_agent_slugs_normalises_to_lowercase():
+    _set_known_agent_slugs({"Alice-1234", "BOB-5678"})
+    assert "alice-1234" in _KNOWN_AGENT_SLUGS
+    assert "bob-5678" in _KNOWN_AGENT_SLUGS
+
+
+def test_set_known_agent_slugs_ignores_empty_strings():
+    _set_known_agent_slugs({"", "  ", "alice-1"})
+    assert _KNOWN_AGENT_SLUGS == {"alice-1"}


### PR DESCRIPTION
## Summary

When an agent sends a threaded reply with `is_visible_to_human=false` AND the body `@<slug>` mentions a slug the operator hasn't tagged as another agent, coerce visibility back to true so the human sees a message that's explicitly addressed to them. Closes the FB-130 family — Sam / Sean / Tang Yan / Maoyi-Motrin case-studies where agent-to-human instructions got folded out of view because the agent (correctly) flagged the thread as agent-to-agent chatter and then explicitly @-mentioned a person in the body.

The known-agents check is config-driven (operator owns the list in `daemon.yml`'s `known_agent_slugs` top-level field). Empty list / unset = every `@<slug>` mention coerces, which is the safe-fail floor (better to over-coerce a peer than miss a human). A future PUF will populate the cache automatically from `/certs/sync`'s `identity_type` once that field ships.

Ticket: `/home/hanchen/.puffo-agent/shared/PUF-202.md`

## ⚠ Operator action required at deploy

Add the three known-peer slugs to your `daemon.yml` so agent-to-agent threaded chatter stays folded:

```yaml
known_agent_slugs:
  - calculatio-4282-36fa
  - solution-5805-d1be
  - equation-7256-87f7
```

Plus any other peer agents you run on your side (Han / Hetong / Matrix / etc). Without this, every `@<slug>` mention between Equation / Calculation / Solution will coerce to visible — flooding your feed with what the agent-invisibility rule was meant to hide. The wire-up is operator-controlled by design.

## Test plan

- [x] Full pytest: **606 passed / 1 intentional skip / 0 failed** (582 pre-existing + 24 new in `tests/test_coerce_root_visibility_at_mentions.py`).
- [x] **Regex matrix** (Equation's main risk-flag was overreach): bare `@bob-1234`, `(@bob-1234)`, `> @bob-1234`, `- @bob-1234`, case-mismatched `@Equation-7256-87f7`, multiple mentions in order, `foo@bar.com` does NOT match (preceded by `o`), empty/None body, lone `@` doesn't match.
- [x] **Coercion matrix**: root-level still works + takes precedence, visible=true is passthrough, threaded no-mentions passthrough, threaded human-mention coerces with new note text, all-known-agents leaves visible=false alone, mixed known+unknown coerces and names the first unknown, **cache-miss-on-known-agent edge case** (cold-start: empty cache → every `@<slug>` coerces → note says "subsequent sends should fold normally"), case-mismatched lookup, punctuation-prefix, empty body, email-in-text doesn't trip.
- [x] **Cache contract**: `_set_known_agent_slugs` replaces (not appends), lowercases, ignores empty/whitespace.
- [x] **Wire chain end-to-end**: `state.py::DaemonConfig.known_agent_slugs` → `worker.py` (all 3 runtime kinds) → `config.py::puffo_core_mcp_env` emits `PUFFO_KNOWN_AGENT_SLUGS=...` → `puffo_core_server.py::_cfg_from_env` reads + splits + lowercases → `register_core_tools` primes module-level cache.
- [x] Independent QA with no blocking findings.

## Known limit (intentional)

`@<own-slug>` (an agent @-mentioning itself) isn't specially handled — today's behavior is "coerce if not in cache, leave alone if in cache." Self-mention isn't a load-bearing case, so this is fine. If you want explicit self-mention pass-through, file a follow-up; the wiring is one extra branch in `_coerce_root_visibility`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)