### PR TITLE
fix(PUF-206): pre-check Python >= 3.11 at cli.py module load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,24 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   code 1 + version-in-message + presence of at least one of
   `pyenv` / `brew` / `python.org` upgrade hints. (PUF-206)
 
+- **PUF-217 test fixture: `os.rename` → `os.replace` + symlink-skip
+  guard for Windows.** The PUF-217 test fixture's fake-claude
+  subprocess used `os.rename(tmp_target, target)` to mimic Claude
+  CLI's atomic tmp+rename. On POSIX `os.rename` atomically replaces
+  an existing target, but on Windows it raises `FileExistsError`;
+  the cross-platform atomic-replace primitive is `os.replace`. Two
+  `os.rename` call sites in `test_refresh_oneshot_home_env.py`
+  swapped to `os.replace`. Additionally, the two tests that assert
+  on `agent_creds.is_symlink()` now gate on
+  `_symlinks_available(tmp_path)` and `pytest.skip` when the host
+  can't create symlinks — mirrors the existing pattern in
+  `test_host_credentials.py` (Windows without Developer Mode falls
+  through `link_host_credentials`'s copy-mode branch, so the
+  symlink-distribution invariant these tests assert on doesn't
+  apply there). Linux CI continues to exercise the full assertions;
+  Windows now skips cleanly instead of failing. Full suite:
+  **642 passed / 9 skipped / 0 failed**.
+
 ## [0.8.5] — 2026-05-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.6] — 2026-05-18
+
+### Fixed
+
+- **Python-version precheck moved to `puffo_agent/__init__.py` and
+  fires before any submodule of the package is parsed.** Users on
+  Python 3.9 / 3.10 used to see a deep `SyntaxError` / `ImportError`
+  from inside the submodule chain at `cli.py`'s import block — the
+  actual cause (wrong Python version) was buried under the
+  wrong-looking message, and users frequently mis-attributed it as
+  "my Python is broken" (Shiva, FB-149).
+
+  Initial fix (0.8.5-rc, PR #27) added the precheck at the top of
+  `cli.py`. That covered the dominant case but had a subtle
+  weakness: Python parses an entire module before executing any line,
+  so if `cli.py` itself ever used Python 3.11-only syntax (`match` /
+  `case`, PEP 604 unions in expression position, exception groups)
+  the file would fail at parse time **before** the precheck had a
+  chance to run, and the user would be back to "deep SyntaxError"
+  from inside `cli.py`.
+
+  Move it one layer up: `puffo_agent/__init__.py` runs first when
+  Python resolves any `puffo_agent.*` submodule import — including
+  the entry-point's `from puffo_agent.portal.cli import main`. The
+  precheck now fires **before `cli.py` is even parsed**, so a future
+  3.11-only edit to `cli.py` (or any other submodule) can't bypass
+  the guard. `puffo_agent/__init__.py` itself stays deliberately
+  parseable on Python 3.6+ (f-strings only, no PEP 604, no `match`)
+  — documented in the module docstring so the constraint isn't lost.
+
+  `pyproject.toml`'s `requires-python = ">=3.11"` remains the
+  canonical metadata gate; this is the runtime safety net for users
+  on venvs whose interpreter doesn't match the metadata (e.g.
+  installed with `--ignore-requires-python` or older pip).
+
+  Tests in `test_cli_python_version.py` updated to import
+  `_require_python_311` from `puffo_agent` instead of
+  `puffo_agent.portal.cli`. Same 4-case matrix (rejects 3.9.18 /
+  3.10.12, passes 3.11.0 / 3.14.4); each reject branch asserts exit
+  code 1 + version-in-message + presence of at least one of
+  `pyenv` / `brew` / `python.org` upgrade hints. (PUF-206)
+
 ## [0.8.5] — 2026-05-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.5"
+version = "0.8.6"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/__init__.py
+++ b/src/puffo_agent/__init__.py
@@ -1,0 +1,28 @@
+"""puffo-agent top-level package.
+
+The only thing the package-init does is the Python-version precheck
+— it runs *before* any submodule of ``puffo_agent`` is parsed, which
+means a user on Python 3.9 / 3.10 gets a clear, actionable message
+even if a downstream module happens to use 3.11-only syntax. The
+deliberate constraint on this file: keep it parseable on Python 3.6+
+(f-strings only, no PEP 604 unions in expression position, no
+``match/case``) so the precheck itself never trips before it runs.
+"""
+
+import sys
+
+
+def _require_python_311() -> None:
+    if sys.version_info < (3, 11):
+        v = sys.version_info
+        sys.stderr.write(
+            f"puffo-agent requires Python >= 3.11; you have "
+            f"{v.major}.{v.minor}.{v.micro}.\n"
+            f"Upgrade via pyenv (`pyenv install 3.12`), Homebrew "
+            f"(`brew install python@3.12`), or python.org/downloads, "
+            f"then re-run.\n"
+        )
+        raise SystemExit(1)
+
+
+_require_python_311()

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -11,18 +11,9 @@ import sys
 
 
 def _require_python_311() -> None:
-    """Bail with a clear, actionable message on Python <3.11.
-
-    ``pyproject.toml`` already pins ``requires-python = ">=3.11"`` so
-    pip refuses the install on 3.10 — but users hit this anyway when
-    the package landed in a venv they later run from the wrong
-    interpreter, or via a packaging tool that bypasses pip's
-    metadata check. Without this gate the next submodule import can
-    raise ``SyntaxError`` / ``ImportError`` deep in the call chain,
-    which users mis-attribute to "my Python is broken" (Shiva,
-    FB-149). Runs before any submodule import so the failure surfaces
-    as a clear version error, not something else.
-    """
+    """Bail with a clear, actionable message on Python <3.11. Runs
+    at module load so submodule imports never get a chance to raise
+    a downstream SyntaxError/ImportError that users mis-attribute."""
     if sys.version_info < (3, 11):
         v = sys.version_info
         sys.stderr.write(

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -7,28 +7,6 @@ Entry point: the ``puffo-agent`` console script, or
 
 from __future__ import annotations
 
-import sys
-
-
-def _require_python_311() -> None:
-    """Bail with a clear, actionable message on Python <3.11. Runs
-    at module load so submodule imports never get a chance to raise
-    a downstream SyntaxError/ImportError that users mis-attribute."""
-    if sys.version_info < (3, 11):
-        v = sys.version_info
-        sys.stderr.write(
-            f"puffo-agent requires Python >= 3.11; you have "
-            f"{v.major}.{v.minor}.{v.micro}.\n"
-            f"Upgrade via pyenv (`pyenv install 3.12`), Homebrew "
-            f"(`brew install python@3.12`), or python.org/downloads, "
-            f"then re-run.\n"
-        )
-        raise SystemExit(1)
-
-
-_require_python_311()
-
-
 import argparse
 import asyncio
 import io
@@ -36,6 +14,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -7,6 +7,37 @@ Entry point: the ``puffo-agent`` console script, or
 
 from __future__ import annotations
 
+import sys
+
+
+def _require_python_311() -> None:
+    """Bail with a clear, actionable message on Python <3.11.
+
+    ``pyproject.toml`` already pins ``requires-python = ">=3.11"`` so
+    pip refuses the install on 3.10 — but users hit this anyway when
+    the package landed in a venv they later run from the wrong
+    interpreter, or via a packaging tool that bypasses pip's
+    metadata check. Without this gate the next submodule import can
+    raise ``SyntaxError`` / ``ImportError`` deep in the call chain,
+    which users mis-attribute to "my Python is broken" (Shiva,
+    FB-149). Runs before any submodule import so the failure surfaces
+    as a clear version error, not something else.
+    """
+    if sys.version_info < (3, 11):
+        v = sys.version_info
+        sys.stderr.write(
+            f"puffo-agent requires Python >= 3.11; you have "
+            f"{v.major}.{v.minor}.{v.micro}.\n"
+            f"Upgrade via pyenv (`pyenv install 3.12`), Homebrew "
+            f"(`brew install python@3.12`), or python.org/downloads, "
+            f"then re-run.\n"
+        )
+        raise SystemExit(1)
+
+
+_require_python_311()
+
+
 import argparse
 import asyncio
 import io
@@ -14,7 +45,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import time
 from pathlib import Path
 

--- a/tests/test_cli_python_version.py
+++ b/tests/test_cli_python_version.py
@@ -1,9 +1,12 @@
-"""PUF-206: cli.py's runtime guard against Python <3.11.
+"""PUF-206: package-init runtime guard against Python <3.11.
 
-The check lives at module-level above any submodule import. We test
-the helper function directly with a mocked ``sys.version_info`` so
-the test doesn't reload the module (which would re-fire every
-submodule import + side-effect under our test harness).
+The check lives in ``puffo_agent/__init__.py`` so it fires *before*
+any submodule of the package is parsed — that way a 3.9 user gets
+the clear message even if some downstream module ever uses
+3.11-only syntax. We test the helper function directly with a mocked
+``sys.version_info`` so the test doesn't reload the module (which
+would re-fire every submodule import + side-effect under our test
+harness).
 """
 
 from __future__ import annotations
@@ -11,13 +14,12 @@ from __future__ import annotations
 import io
 import os
 import sys
-from unittest import mock
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from puffo_agent.portal.cli import _require_python_311
+from puffo_agent import _require_python_311
 
 
 class _VersionInfo(tuple):

--- a/tests/test_cli_python_version.py
+++ b/tests/test_cli_python_version.py
@@ -1,0 +1,68 @@
+"""PUF-206: cli.py's runtime guard against Python <3.11.
+
+The check lives at module-level above any submodule import. We test
+the helper function directly with a mocked ``sys.version_info`` so
+the test doesn't reload the module (which would re-fire every
+submodule import + side-effect under our test harness).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.portal.cli import _require_python_311
+
+
+class _VersionInfo(tuple):
+    """Minimal stand-in for ``sys.version_info`` that supports both
+    tuple comparison and named-attribute access (``major``, ``minor``,
+    ``micro``)."""
+
+    def __new__(cls, major: int, minor: int, micro: int):
+        obj = super().__new__(cls, (major, minor, micro, "final", 0))
+        obj.major = major
+        obj.minor = minor
+        obj.micro = micro
+        return obj
+
+
+def test_require_python_311_rejects_310(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", _VersionInfo(3, 10, 12))
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+    with pytest.raises(SystemExit) as exc:
+        _require_python_311()
+    assert exc.value.code == 1
+    msg = buf.getvalue()
+    assert ">= 3.11" in msg
+    assert "3.10.12" in msg
+    # At least one of the upgrade-path hints should be cited so the
+    # user has a concrete next step rather than just "go figure it
+    # out".
+    assert any(token in msg for token in ("pyenv", "brew", "python.org"))
+
+
+def test_require_python_311_rejects_old_3x(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", _VersionInfo(3, 9, 18))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    with pytest.raises(SystemExit):
+        _require_python_311()
+
+
+def test_require_python_311_passes_on_311(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", _VersionInfo(3, 11, 0))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    _require_python_311()
+
+
+def test_require_python_311_passes_on_312_and_later(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", _VersionInfo(3, 14, 4))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    _require_python_311()

--- a/tests/test_refresh_oneshot_home_env.py
+++ b/tests/test_refresh_oneshot_home_env.py
@@ -13,7 +13,31 @@ import shutil
 import time
 from pathlib import Path
 
+import pytest
+
 from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+
+
+def _symlinks_available(tmp_path: Path) -> bool:
+    """Probe: can this process create a symlink in ``tmp_path``?
+    Mirrors the helper in ``test_host_credentials.py`` — Windows
+    needs Developer Mode or admin to create symlinks, so the
+    symlink-distribution invariant these tests assert on doesn't
+    apply there."""
+    probe = tmp_path / "_probe_symlink"
+    target = tmp_path / "_probe_target"
+    target.write_text("x", encoding="utf-8")
+    try:
+        os.symlink(target, probe)
+        probe.unlink()
+        target.unlink()
+        return True
+    except (OSError, NotImplementedError):
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        return False
 
 
 class _FakeProc:
@@ -85,6 +109,8 @@ def test_refresh_oneshot_write_lands_at_host_path_visible_via_agent_symlink(
     .credentials.json surfaces the new value to puffo-agent's read
     path. Locks in the symlink-distribution contract this fix
     depends on."""
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
     host_home = tmp_path / "operator_home"
     agent_home = tmp_path / "agent_home"
     (host_home / ".claude").mkdir(parents=True)
@@ -110,7 +136,11 @@ def test_refresh_oneshot_write_lands_at_host_path_visible_via_agent_symlink(
         tmp_target.write_text(json.dumps({
             "claudeAiOauth": {"accessToken": "fresh", "expiresAt": fresh_expires_ms},
         }))
-        os.rename(tmp_target, target)
+        # ``os.replace`` not ``os.rename`` — POSIX ``os.rename``
+        # atomically replaces an existing target, but on Windows it
+        # raises ``FileExistsError``. ``os.replace`` is the
+        # cross-platform atomic-replace primitive.
+        os.replace(tmp_target, target)
         return _FakeProc()
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
@@ -147,6 +177,8 @@ def test_refresh_oneshot_does_not_create_regular_file_at_agent_path(
     end up with a regular file (which would let
     link_host_credentials's copy-mode clobber the fresh token with
     the stale host content)."""
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
     host_home = tmp_path / "operator_home"
     agent_home = tmp_path / "agent_home"
     (host_home / ".claude").mkdir(parents=True)
@@ -166,7 +198,11 @@ def test_refresh_oneshot_does_not_create_regular_file_at_agent_path(
         tmp_target.write_text(json.dumps({
             "claudeAiOauth": {"accessToken": "post-refresh", "expiresAt": fresh_expires_ms},
         }))
-        os.rename(tmp_target, target)
+        # ``os.replace`` not ``os.rename`` — POSIX ``os.rename``
+        # atomically replaces an existing target, but on Windows it
+        # raises ``FileExistsError``. ``os.replace`` is the
+        # cross-platform atomic-replace primitive.
+        os.replace(tmp_target, target)
         return _FakeProc()
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)


### PR DESCRIPTION
## Summary

Users running `puffo-agent` against Python 3.10 / 3.9 hit a deep `SyntaxError` / `ImportError` from inside the submodule chain at `cli.py:21-49` — the actual cause (wrong Python version) was buried under the wrong-looking message, and users frequently mis-attributed it as "my Python is broken" (Shiva, FB-149).

This PR adds a `_require_python_311()` precheck at the top of `cli.py`, called at module load between `from __future__ import annotations` and the first submodule import. On Python <3.11 it writes a single actionable line to stderr — naming the detected version + three concrete upgrade paths (pyenv / Homebrew / python.org) — and exits with code 1. On 3.11+ it returns silently and the rest of the module loads normally.

`pyproject.toml`'s `requires-python = ">=3.11"` is still the canonical gate; this is the runtime safety net for users on venvs whose interpreter doesn't match the metadata.

Ticket: `/home/hanchen/.puffo-agent/shared/PUF-206.md`

## Test plan

- [x] Full pytest: **586 passed / 1 intentional skip / 0 failed** (582 pre-existing + 4 new).
- [x] 4 new tests in `tests/test_cli_python_version.py` mock `sys.version_info` + `sys.stderr` and cover the matrix: rejects 3.9.18, rejects 3.10.12, passes 3.11.0, passes 3.14.4. Reject branches assert on exit code, version-in-message, and presence of at least one of the upgrade-path hints.
- [x] Error message is ASCII-only (`>= 3.11`, no `≥`) per Equation's Windows-terminal compatibility nit.
- [x] Independent QA with one iteration to slim the helper docstring.

## Out of scope

- Pre-install hook / install-script side: `pyproject.toml` already pins via `requires-python`; this is the runtime safety net.
- Auto-detect-and-suggest a `python3.12` on PATH: explicitly post-Tuesday per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)