### PR TITLE
feat(agent): react to space/channel membership-exit events (0.8.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,87 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.7] — 2026-05-19
+
+### Added
+
+- **Agent now reacts to space/channel membership-exit events on the
+  WS push.** Before this release the WS event router (`_handle_event`
+  in `puffo_core_client.py`) only handled `invite_to_space` /
+  `invite_to_channel` / the synthetic auto-accept
+  `accept_channel_invite`. Every other event kind was silently
+  dropped, so when the agent was removed from a space or kicked from
+  a channel its caches and outbound queues stayed stale until the
+  next reconnect / poll, and the operator got no notification about
+  what changed.
+
+  Pairs with `puffo-server` review/events (PR #74) which now
+  broadcasts these events to the affected slug too via the
+  `extra_ws_targets` union (otherwise the agent would never see
+  them — by the time the post-loop fan-out runs, the engine has
+  already removed it from the member set).
+
+  New handlers:
+
+  - `leave_space` (signer = self) — fires on both a self-signed
+    `LeaveSpace` and the puffo-server #74 synthetic cascade emitted
+    when an operator leaves (`signature ==
+    "server-auto:agent-cascade-leave-space"`). Evicts
+    `_channel_space` / `_channel_name_cache` / `_space_name_cache`
+    for the space; DMs the operator with reason-specific wording.
+
+  - `remove_from_space` (target = self) — same cache eviction; DM
+    names the kicker so the operator knows who removed their agent.
+
+  - `leave_channel` (signer = self) — voluntary channel exit; cache
+    eviction only, no DM (operator-initiated, they already know).
+
+  - `remove_from_channel` (target = self) — per-channel eviction; DM
+    references both the channel and its parent space.
+
+  - `cancel_space_invite` / `cancel_channel_invite` — if the agent
+    DM'd the operator a `y`/`n` prompt for the now-withdrawn invite,
+    send a follow-up in the same thread so the operator doesn't
+    reply `y` to nothing (server would return InviteNotFound 400).
+    No-op when no prompt was outstanding (auto-accepted, never
+    DM'd).
+
+### Hardened
+
+- **Synthetic cascade `LeaveSpace` events are re-verified against
+  `/spaces` before any visible side effect.** The synthetic events
+  puffo-server emits for agent-operator cascades carry a server-set
+  marker signature (`"server-auto:agent-cascade-leave-space"`) —
+  not a real ed25519 signature — so they aren't
+  cryptographically authenticatable on the wire. Trusting them
+  blindly meant a buggy server, WS redelivery on reconnect, or a
+  malicious server could trick the agent into evicting caches and
+  DMing the operator about a membership change that never
+  happened.
+
+  Fix: before applying the visible side effects of a synthetic
+  cascade event, re-confirm with `GET /spaces` (authoritative
+  membership API). The check returns `True` (still listed —
+  contradicts cascade, bail), `False` (confirmed gone — proceed),
+  or `None` (network error — fall through to permissive cleanup so
+  a transient flake doesn't strand the agent in a space it's been
+  cascaded out of).
+
+  Scoped to the one event kind where this defense matters; real
+  signed events skip the recheck (the server-side engine already
+  verified the signature before broadcasting, and re-verifying on
+  the agent side would need a full ed25519-verify + cert-chain
+  resolution stack for little real benefit given the server is
+  authoritative for membership state anyway).
+
+### Tests
+
+14 new pytest tests in `tests/test_membership_events.py` covering
+each handler's happy path, ignore-when-not-target, cache eviction
+contents, operator DM text, the synthetic-cascade re-check
+behavior (still-member / confirmed-gone / network-failure), and
+the `operator_slug = ""` early-provisioning case.
+
 ## [0.8.6] — 2026-05-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.8.6"
+version = "0.8.7"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1183,6 +1183,226 @@ class PuffoCoreMessageClient:
                 )
             return
 
+        # Membership-exit events. Pair-wise: the kick path
+        # (RemoveFromSpace / RemoveFromChannel) is target-addressed
+        # via ``removed_slug``; the leave path (LeaveSpace /
+        # LeaveChannel) is signer-addressed. The synthetic LeaveSpace
+        # the server emits when an operator leaves (puffo-server #74
+        # agent-cascade) is signed-as-the-agent — same predicate as
+        # a real self-signed leave, so it lands in the same branch.
+        if kind == "leave_space" and event.get("signer_slug") == self.slug:
+            await self._on_left_space(
+                space_id=payload.get("space_id") or "",
+                synthetic=str(event.get("signature") or "").startswith(
+                    "server-auto:agent-cascade-leave-space"
+                ),
+            )
+            return
+
+        if kind == "remove_from_space" and payload.get("removed_slug") == self.slug:
+            await self._on_kicked_from_space(
+                space_id=payload.get("space_id") or "",
+                kicker_slug=event.get("signer_slug") or "",
+            )
+            return
+
+        if kind == "leave_channel" and event.get("signer_slug") == self.slug:
+            await self._on_left_channel(
+                channel_id=payload.get("channel_id") or "",
+            )
+            return
+
+        if kind == "remove_from_channel" and payload.get("removed_slug") == self.slug:
+            await self._on_kicked_from_channel(
+                channel_id=payload.get("channel_id") or "",
+                space_id=payload.get("space_id") or "",
+                kicker_slug=event.get("signer_slug") or "",
+            )
+            return
+
+        # Invite-withdrawn paths. The server emits the cancel to the
+        # invitee's session too (puffo-server review/events: invitee
+        # added to ``extra_ws_targets`` for cancel/reject). If the
+        # operator is still holding an un-answered y/n DM, follow up
+        # so they don't reply ``y`` to a dead invite.
+        if kind in ("cancel_space_invite", "cancel_channel_invite"):
+            await self._on_invite_canceled(
+                invitation_event_id=payload.get("invitation_event_id") or "",
+                scope="space" if kind == "cancel_space_invite" else "channel",
+            )
+            return
+
+    def _evict_space_caches(self, space_id: str) -> None:
+        """Drop every cached entry tied to a space we've left/been
+        kicked from. The membership server is authoritative so
+        we don't need this to stay correct — leaving stale entries
+        just risks the agent racing to send into a space it isn't
+        in (server 403s, worker logs a confusing failure). Reverse-
+        scans ``_channel_space`` for channels mapped to this space."""
+        if not space_id:
+            return
+        for cid in [c for c, s in self._channel_space.items() if s == space_id]:
+            self._channel_space.pop(cid, None)
+            self._channel_name_cache.pop(cid, None)
+        self._space_name_cache.pop(space_id, None)
+
+    def _evict_channel_caches(self, channel_id: str) -> None:
+        """Smaller-scope twin of ``_evict_space_caches`` for the
+        per-channel kick paths."""
+        if not channel_id:
+            return
+        self._channel_space.pop(channel_id, None)
+        self._channel_name_cache.pop(channel_id, None)
+
+    async def _dm_operator_membership_change(self, text: str) -> None:
+        """Best-effort operator notification on membership exit. No-op
+        when ``operator_slug`` isn't configured (early provisioning,
+        smoke fixtures); exception suppression matches the existing
+        invite-DM helpers so a failed DM never crashes the WS handler."""
+        if not self.operator_slug:
+            logger.info(
+                "membership change but no operator_slug; not DMing: %s", text,
+            )
+            return
+        try:
+            await self._send_dm(self.operator_slug, text, root_id="")
+        except Exception:
+            logger.exception(
+                "failed to DM operator about membership change: %s", text,
+            )
+
+    async def _on_left_space(self, *, space_id: str, synthetic: bool) -> None:
+        """Agent exited a space — either signed LeaveSpace itself, or
+        was cascaded out by the server when its operator left
+        (puffo-server #74 emits a synthetic ``LeaveSpace`` per agent
+        with ``signature = "server-auto:agent-cascade-leave-space"``).
+        Either way, clean caches and tell the operator why."""
+        if not space_id:
+            return
+        space_label = await self._resolve_space_name(space_id)
+        self._evict_space_caches(space_id)
+        reason = (
+            "your space exit cascaded to me"
+            if synthetic else "I signed a LeaveSpace"
+        )
+        await self._dm_operator_membership_change(
+            f"Removed from space **{space_label}**({space_id}) — {reason}."
+        )
+
+    async def _on_kicked_from_space(
+        self, *, space_id: str, kicker_slug: str,
+    ) -> None:
+        """Owner (or owner-cascade synthetic from puffo-server review/events)
+        removed us from a space. Different wording from
+        ``_on_left_space`` so the operator can tell apart "I left it"
+        from "they kicked me"."""
+        if not space_id:
+            return
+        space_label = await self._resolve_space_name(space_id)
+        self._evict_space_caches(space_id)
+        kicker_display = (
+            await self._fetch_display_name(kicker_slug) if kicker_slug else ""
+        )
+        kicker_label = (
+            f"**{kicker_display}**(@{kicker_slug})"
+            if kicker_display else f"@{kicker_slug}" if kicker_slug else "the space owner"
+        )
+        await self._dm_operator_membership_change(
+            f"Removed from space **{space_label}**({space_id}) by {kicker_label}."
+        )
+
+    async def _on_left_channel(self, *, channel_id: str) -> None:
+        """Voluntary channel exit (agent signed LeaveChannel itself).
+        Operator-initiated tooling already knows; skip the DM to
+        avoid noise. Cache cleanup still runs."""
+        if not channel_id:
+            return
+        self._evict_channel_caches(channel_id)
+
+    async def _on_kicked_from_channel(
+        self, *, channel_id: str, space_id: str, kicker_slug: str,
+    ) -> None:
+        """Owner kicked us out of a private channel."""
+        if not channel_id:
+            return
+        channel_label = await self._resolve_channel_name(
+            space_id=space_id, channel_id=channel_id,
+        )
+        space_label = await self._resolve_space_name(space_id) if space_id else ""
+        self._evict_channel_caches(channel_id)
+        kicker_display = (
+            await self._fetch_display_name(kicker_slug) if kicker_slug else ""
+        )
+        kicker_label = (
+            f"**{kicker_display}**(@{kicker_slug})"
+            if kicker_display else f"@{kicker_slug}" if kicker_slug else "the space owner"
+        )
+        location = f"channel **{channel_label}**({channel_id})"
+        if space_id:
+            location += f" in space **{space_label}**({space_id})"
+        await self._dm_operator_membership_change(
+            f"Removed from {location} by {kicker_label}."
+        )
+
+    async def _on_invite_canceled(
+        self, *, invitation_event_id: str, scope: str,
+    ) -> None:
+        """A pending invite for us was withdrawn. If we DM'd the
+        operator a y/n prompt for it, follow up so they know not to
+        reply ``y`` (would 400 against an InviteNotFound at the
+        server). No-op when we either auto-accepted, never DM'd,
+        or already cleaned up — matched by ``_pending_invite_dms``
+        absence."""
+        if not invitation_event_id:
+            return
+        target_env_id: str | None = None
+        for env_id, meta in self._pending_invite_dms.items():
+            if meta.get("invitation_event_id") == invitation_event_id:
+                target_env_id = env_id
+                break
+        if target_env_id is None:
+            return
+        meta = self._pending_invite_dms.pop(target_env_id)
+        # Add to processed-set too so a stale pending-invite poll
+        # response (server-side cache lag) can't re-fire the DM.
+        self._processed_invite_ids.add(invitation_event_id)
+
+        inviter_slug = meta.get("inviter_slug") or ""
+        space_id = meta.get("space_id") or ""
+        channel_id = meta.get("channel_id") or ""
+        space_name = meta.get("space_name") or None
+        channel_name = meta.get("channel_name") or None
+        space_label = (
+            f"**{space_name}**({space_id})" if space_name else space_id
+        )
+        inviter_display = (
+            await self._fetch_display_name(inviter_slug) if inviter_slug else ""
+        )
+        inviter_label = (
+            f"**{inviter_display}**(@{inviter_slug})"
+            if inviter_display else f"@{inviter_slug}" if inviter_slug else "the inviter"
+        )
+        if scope == "channel":
+            channel_label = (
+                f"**{channel_name}**({channel_id})" if channel_name else channel_id
+            )
+            target = f"channel {channel_label} in space {space_label}"
+        else:
+            target = f"space {space_label}"
+        text = (
+            f"{inviter_label} withdrew the invite to {target} — "
+            f"ignore my earlier prompt."
+        )
+        try:
+            await self._send_dm(
+                self.operator_slug, text, root_id=target_env_id,
+            )
+        except Exception:
+            logger.exception(
+                "failed to DM operator about canceled invite (event_id=%s)",
+                invitation_event_id,
+            )
+
     async def _poll_pending_invites(self) -> None:
         """Pull pending invites the agent hasn't acted on. Space
         invites only arrive via this poll (WS doesn't fan to non-

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1276,8 +1276,29 @@ class PuffoCoreMessageClient:
         was cascaded out by the server when its operator left
         (puffo-server #74 emits a synthetic ``LeaveSpace`` per agent
         with ``signature = "server-auto:agent-cascade-leave-space"``).
-        Either way, clean caches and tell the operator why."""
+        Either way, clean caches and tell the operator why.
+
+        Synthetic events aren't cryptographically signed — the
+        ``signature`` field is a server-set marker — so before
+        applying the visible side effect (operator DM), verify the
+        cascade actually happened by asking the server's authoritative
+        membership API. Defends against buggy server emits, WS
+        redelivery on reconnect, and a malicious server crafting a
+        cascade event the agent has no way to refute on the wire.
+        Real signed LeaveSpace events skip the check (the agent itself
+        signed it; server-side engine already verified the signer)."""
         if not space_id:
+            return
+        # ``_still_member_of_space`` returns True / False / None.
+        # We only ignore the cascade on a definitive "still a member";
+        # ``None`` (network error) falls through to the permissive path
+        # so a transient /spaces flake can't block legitimate cleanup.
+        if synthetic and await self._still_member_of_space(space_id) is True:
+            logger.warning(
+                "synthetic LeaveSpace for sp=%s but /spaces still lists "
+                "us — ignoring (likely server bug or WS redelivery)",
+                space_id,
+            )
             return
         space_label = await self._resolve_space_name(space_id)
         self._evict_space_caches(space_id)
@@ -1288,6 +1309,30 @@ class PuffoCoreMessageClient:
         await self._dm_operator_membership_change(
             f"Removed from space **{space_label}**({space_id}) — {reason}."
         )
+
+    async def _still_member_of_space(self, space_id: str) -> bool | None:
+        """Authoritative membership check via ``GET /spaces``.
+
+        Returns:
+          * ``True``  — server still lists us as a member (cascade event
+                        contradicts authoritative state, caller should ignore).
+          * ``False`` — server does NOT list us (cascade matches reality,
+                        caller should proceed with cleanup).
+          * ``None``  — request failed; caller falls through to the
+                        permissive path rather than blocking on a flake.
+        """
+        try:
+            data = await self.http.get("/spaces")
+        except Exception:
+            logger.exception(
+                "membership re-check for sp=%s failed — falling through",
+                space_id,
+            )
+            return None
+        for entry in data.get("spaces") or []:
+            if entry.get("space_id") == space_id:
+                return True
+        return False
 
     async def _on_kicked_from_space(
         self, *, space_id: str, kicker_slug: str,

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -25,7 +25,11 @@ from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
 # ─── Fixture ───────────────────────────────────────────────────────
 
 
-def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, list[dict]]:
+def _make_client(
+    operator_slug: str = "op-1",
+    spaces_response: dict | None = None,
+    spaces_raises: bool = False,
+) -> tuple[PuffoCoreMessageClient, list[dict]]:
     """Bare client with just enough state to exercise the WS router.
 
     Stubs:
@@ -33,6 +37,11 @@ def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, l
       * ``_resolve_space_name`` / ``_resolve_channel_name`` /
         ``_fetch_display_name`` return canonical labels so DM text
         assertions don't depend on /spaces or /identities lookups.
+      * ``self.http`` stubs ``GET /spaces`` per ``spaces_response``
+        (or raises when ``spaces_raises=True``) — drives the
+        ``_still_member_of_space`` check in the synthetic-cascade
+        path. Default returns an empty member list, so by default
+        synthetic-cascade tests see "confirmed gone" and proceed.
 
     Returns the client + a list the stubbed ``_send_dm`` appends to.
     """
@@ -64,6 +73,16 @@ def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, l
     client._resolve_space_name = _stub_space_name  # type: ignore[assignment]
     client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
     client._fetch_display_name = _stub_display_name  # type: ignore[assignment]
+
+    class _StubHttp:
+        async def get(self, path: str):
+            if spaces_raises:
+                raise RuntimeError("simulated /spaces failure")
+            if path == "/spaces":
+                return spaces_response or {"spaces": []}
+            return {}
+
+    client.http = _StubHttp()
     return client, sent
 
 
@@ -119,6 +138,85 @@ async def test_leave_space_self_signed_dm_mentions_self_action():
     await client._handle_event(scope="sp_1", event=event)
     assert len(sent) == 1
     assert "signed a LeaveSpace" in sent[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_leave_space_synthetic_cascade_ignored_when_still_member():
+    """Defence-in-depth: synthetic events have a server-set marker
+    signature, not a real ed25519 signature. If the server emits a
+    cascade but ``GET /spaces`` still lists us as a member, the
+    cascade contradicts authoritative state — bail out without
+    DMing the operator or evicting caches. Catches buggy server
+    emits, WS redelivery on reconnect, and a malicious server
+    crafting a fake cascade."""
+    client, sent = _make_client(
+        spaces_response={"spaces": [{"space_id": "sp_1", "name": "Team"}]},
+    )
+    client._channel_space["ch_1"] = "sp_1"
+    client._space_name_cache["sp_1"] = "Team"
+
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "agent-1",
+        "signature": "server-auto:agent-cascade-leave-space",
+        "payload": {"space_id": "sp_1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # Authoritative state wins — caches preserved, operator not DM'd.
+    assert client._channel_space.get("ch_1") == "sp_1"
+    assert "sp_1" in client._space_name_cache
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_leave_space_synthetic_cascade_proceeds_when_spaces_lookup_fails():
+    """The membership re-check is best-effort. If ``GET /spaces``
+    blows up (network, server down), the agent falls through to the
+    normal cleanup rather than blocking on a flake — better to risk
+    a redundant DM than strand the agent in a space it's been
+    cascaded out of."""
+    client, sent = _make_client(spaces_raises=True)
+    client._channel_space["ch_1"] = "sp_1"
+
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "agent-1",
+        "signature": "server-auto:agent-cascade-leave-space",
+        "payload": {"space_id": "sp_1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # Eviction + DM happen — None ≠ True so the gate falls through.
+    assert "ch_1" not in client._channel_space
+    assert len(sent) == 1
+    assert "cascaded" in sent[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_leave_space_real_signed_self_skips_membership_recheck():
+    """Real (non-synthetic) self-signed LeaveSpace doesn't need the
+    authoritative re-check — the agent's own key signed it, so we
+    aren't second-guessing the server. Wire-shape test: stubbing
+    ``GET /spaces`` to STILL list us would block the path if the
+    check ran; this asserts it doesn't."""
+    client, sent = _make_client(
+        spaces_response={"spaces": [{"space_id": "sp_1", "name": "Team"}]},
+    )
+    client._channel_space["ch_1"] = "sp_1"
+
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "agent-1",
+        "signature": "real-ed25519-sig",
+        "payload": {"space_id": "sp_1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # Cleanup + DM still fire — the membership re-check is gated on
+    # ``synthetic``.
+    assert "ch_1" not in client._channel_space
+    assert len(sent) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -1,0 +1,346 @@
+"""WS routing for space/channel membership-exit events.
+
+Pairs with ``puffo-server`` review/events PR #74: the server now
+broadcasts ``leave_space`` / ``remove_from_space`` /
+``leave_channel`` / ``remove_from_channel`` / ``cancel_space_invite``
+/ ``cancel_channel_invite`` to the agent's own session even after
+the agent is no longer in the space's member set (``extra_ws_targets``
+union for the removed slug + each cascaded agent). These tests pin
+the agent-side reactions: cache eviction, operator-DM notification,
+and "not for me" no-ops.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+
+# ─── Fixture ───────────────────────────────────────────────────────
+
+
+def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, list[dict]]:
+    """Bare client with just enough state to exercise the WS router.
+
+    Stubs:
+      * ``_send_dm`` records calls in ``sent`` instead of round-tripping.
+      * ``_resolve_space_name`` / ``_resolve_channel_name`` /
+        ``_fetch_display_name`` return canonical labels so DM text
+        assertions don't depend on /spaces or /identities lookups.
+
+    Returns the client + a list the stubbed ``_send_dm`` appends to.
+    """
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.operator_slug = operator_slug
+    client._channel_space = {}
+    client._space_name_cache = {}
+    client._channel_name_cache = {}
+    client._processed_invite_ids = set()
+    client._pending_invite_dms = {}
+
+    sent: list[dict] = []
+
+    async def _stub_send_dm(recipient_slug: str, text: str, root_id: str) -> dict | None:
+        sent.append({"to": recipient_slug, "text": text, "root_id": root_id})
+        return {"envelope_id": f"env_response_{len(sent)}"}
+
+    async def _stub_space_name(space_id: str) -> str:
+        return {"sp_1": "Team", "sp_2": "Other"}.get(space_id, space_id)
+
+    async def _stub_channel_name(*, space_id: str, channel_id: str) -> str:
+        return {"ch_1": "general", "ch_priv": "secrets"}.get(channel_id, channel_id)
+
+    async def _stub_display_name(slug: str) -> str:
+        return {"alice-0001": "Alice", "op-1": "Operator"}.get(slug, "")
+
+    client._send_dm = _stub_send_dm  # type: ignore[assignment]
+    client._resolve_space_name = _stub_space_name  # type: ignore[assignment]
+    client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
+    client._fetch_display_name = _stub_display_name  # type: ignore[assignment]
+    return client, sent
+
+
+# ─── leave_space (synthetic cascade + self-signed) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_leave_space_synthetic_cascade_evicts_caches_and_dms_operator():
+    """puffo-server #74 emits a synthetic LeaveSpace per cascaded
+    agent when its operator leaves. ``signature`` is the audit marker.
+    Agent must evict per-space caches AND DM operator explaining the
+    cascade."""
+    client, sent = _make_client()
+    client._channel_space["ch_1"] = "sp_1"
+    client._channel_space["ch_other"] = "sp_2"  # unrelated; survives
+    client._channel_name_cache["ch_1"] = "general"
+    client._space_name_cache["sp_1"] = "Team"
+
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "agent-1",
+        "signature": "server-auto:agent-cascade-leave-space",
+        "payload": {"space_id": "sp_1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # Per-space caches gone, unrelated space untouched.
+    assert "ch_1" not in client._channel_space
+    assert "ch_1" not in client._channel_name_cache
+    assert "sp_1" not in client._space_name_cache
+    assert client._channel_space.get("ch_other") == "sp_2"
+
+    # One operator DM, mentions the cascade reason.
+    assert len(sent) == 1
+    assert sent[0]["to"] == "op-1"
+    assert "Team" in sent[0]["text"]
+    assert "sp_1" in sent[0]["text"]
+    assert "cascaded" in sent[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_leave_space_self_signed_dm_mentions_self_action():
+    """Non-synthetic LeaveSpace signed by the agent itself — different
+    wording so the operator doesn't see "cascaded" when there was no
+    cascade."""
+    client, sent = _make_client()
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "agent-1",
+        "signature": "real-ed25519-sig",
+        "payload": {"space_id": "sp_1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+    assert len(sent) == 1
+    assert "signed a LeaveSpace" in sent[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_leave_space_for_other_slug_is_noop():
+    """Someone else's LeaveSpace gets fanned out to the agent too
+    (the agent is still a space member at fan-out time). Must NOT
+    fire the DM."""
+    client, sent = _make_client()
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "bob-0001",
+        "signature": "real-ed25519-sig",
+        "payload": {"space_id": "sp_1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+    assert sent == []
+
+
+# ─── remove_from_space ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remove_from_space_evicts_caches_and_dms_with_kicker():
+    client, sent = _make_client()
+    client._channel_space["ch_1"] = "sp_1"
+    client._channel_name_cache["ch_1"] = "general"
+    client._space_name_cache["sp_1"] = "Team"
+
+    event = {
+        "kind": "remove_from_space",
+        "signer_slug": "alice-0001",
+        "payload": {"space_id": "sp_1", "removed_slug": "agent-1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert "ch_1" not in client._channel_space
+    assert "sp_1" not in client._space_name_cache
+    assert len(sent) == 1
+    text = sent[0]["text"]
+    assert "Team" in text
+    assert "Alice" in text  # _fetch_display_name resolved
+    assert "alice-0001" in text
+
+
+@pytest.mark.asyncio
+async def test_remove_from_space_other_target_is_noop():
+    """Owner kicked some OTHER member; we got the WS push as a
+    surviving member of the space. No-op."""
+    client, sent = _make_client()
+    client._channel_space["ch_1"] = "sp_1"
+    event = {
+        "kind": "remove_from_space",
+        "signer_slug": "alice-0001",
+        "payload": {"space_id": "sp_1", "removed_slug": "bob-0001"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+    assert sent == []
+    assert client._channel_space.get("ch_1") == "sp_1"
+
+
+# ─── remove_from_channel / leave_channel ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remove_from_channel_evicts_caches_and_dms():
+    client, sent = _make_client()
+    client._channel_space["ch_priv"] = "sp_1"
+    client._channel_name_cache["ch_priv"] = "secrets"
+
+    event = {
+        "kind": "remove_from_channel",
+        "signer_slug": "alice-0001",
+        "payload": {
+            "space_id": "sp_1",
+            "channel_id": "ch_priv",
+            "removed_slug": "agent-1",
+        },
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert "ch_priv" not in client._channel_space
+    assert "ch_priv" not in client._channel_name_cache
+    assert len(sent) == 1
+    text = sent[0]["text"]
+    assert "secrets" in text
+    assert "ch_priv" in text
+    assert "Team" in text  # parent space label is included
+    assert "Alice" in text
+
+
+@pytest.mark.asyncio
+async def test_leave_channel_self_evicts_caches_no_dm():
+    """Voluntary channel exit signed by the agent itself: clean up
+    caches but don't DM (operator-initiated, they already know)."""
+    client, sent = _make_client()
+    client._channel_space["ch_priv"] = "sp_1"
+    client._channel_name_cache["ch_priv"] = "secrets"
+
+    event = {
+        "kind": "leave_channel",
+        "signer_slug": "agent-1",
+        "payload": {"space_id": "sp_1", "channel_id": "ch_priv"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert "ch_priv" not in client._channel_space
+    assert "ch_priv" not in client._channel_name_cache
+    assert sent == []
+
+
+# ─── cancel_space_invite / cancel_channel_invite ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_space_invite_dms_operator_when_dm_was_outstanding():
+    """Operator was DM'd a y/n prompt for the invite; the invite is
+    now withdrawn. Send a follow-up DM in the same thread so the
+    operator doesn't reply ``y`` to nothing."""
+    client, sent = _make_client()
+    client._pending_invite_dms["env_invite_dm"] = {
+        "kind": "invite_to_space",
+        "invitation_event_id": "ev_invite_1",
+        "inviter_slug": "alice-0001",
+        "space_id": "sp_1",
+        "channel_id": "",
+        "space_name": "Team",
+        "channel_name": None,
+    }
+
+    event = {
+        "kind": "cancel_space_invite",
+        "signer_slug": "alice-0001",
+        "payload": {
+            "space_id": "sp_1",
+            "invitation_event_id": "ev_invite_1",
+        },
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # Outstanding DM is dropped; processed-set seeded so a stale
+    # /invites poll can't re-fire.
+    assert "env_invite_dm" not in client._pending_invite_dms
+    assert "ev_invite_1" in client._processed_invite_ids
+
+    # Follow-up DM threaded to the original prompt.
+    assert len(sent) == 1
+    assert sent[0]["to"] == "op-1"
+    assert sent[0]["root_id"] == "env_invite_dm"
+    assert "withdrew" in sent[0]["text"]
+    assert "Team" in sent[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_channel_invite_dms_operator_when_dm_was_outstanding():
+    """Same as the space cancel path but for an outstanding channel
+    invite DM — the follow-up text references the channel label."""
+    client, sent = _make_client()
+    client._pending_invite_dms["env_chan_dm"] = {
+        "kind": "invite_to_channel",
+        "invitation_event_id": "ev_invite_2",
+        "inviter_slug": "alice-0001",
+        "space_id": "sp_1",
+        "channel_id": "ch_priv",
+        "space_name": "Team",
+        "channel_name": "secrets",
+    }
+
+    event = {
+        "kind": "cancel_channel_invite",
+        "signer_slug": "alice-0001",
+        "payload": {
+            "space_id": "sp_1",
+            "channel_id": "ch_priv",
+            "invitation_event_id": "ev_invite_2",
+        },
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert "env_chan_dm" not in client._pending_invite_dms
+    assert len(sent) == 1
+    text = sent[0]["text"]
+    assert "secrets" in text
+    assert "channel" in text
+
+
+@pytest.mark.asyncio
+async def test_cancel_invite_with_no_outstanding_dm_is_noop():
+    """If the agent auto-accepted or never DM'd the operator, there's
+    no outstanding y/n prompt — silently no-op rather than DMing a
+    confusing "invite was withdrawn" with no prior context."""
+    client, sent = _make_client()
+    event = {
+        "kind": "cancel_space_invite",
+        "signer_slug": "alice-0001",
+        "payload": {
+            "space_id": "sp_1",
+            "invitation_event_id": "ev_unknown",
+        },
+    }
+    await client._handle_event(scope="sp_1", event=event)
+    assert sent == []
+    assert "ev_unknown" not in client._processed_invite_ids
+
+
+# ─── operator_slug unset ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_membership_change_with_no_operator_slug_logs_but_doesnt_crash():
+    """Early-provisioning agents have no operator_slug yet. Cache
+    eviction must still happen; the DM is skipped without erroring."""
+    client, sent = _make_client(operator_slug="")
+    client._channel_space["ch_1"] = "sp_1"
+
+    event = {
+        "kind": "remove_from_space",
+        "signer_slug": "alice-0001",
+        "payload": {"space_id": "sp_1", "removed_slug": "agent-1"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    # Eviction still ran.
+    assert "ch_1" not in client._channel_space
+    # No DM attempted.
+    assert sent == []


### PR DESCRIPTION
## Summary

Teaches the agent's WS event router (`_handle_event` in `puffo_core_client.py`) to react to the six space/channel membership-exit event kinds that were previously silently dropped. Pairs with [puffo-server review/events PR #74](https://github.com/puffo-ai/puffo-server/pull/74) which now broadcasts these events to the affected slug so the agent actually sees them.

Before this change, when an agent was kicked from a space (or cascaded out by its operator leaving), it kept stale ``_channel_space`` entries, retried sends that 403'd at the server, and left the operator holding an obsolete y/n invite prompt after a withdrawn invite. The operator got zero notification about what changed.

## What's new

- **`leave_space` (signer = self)** — handles both self-signed LeaveSpace and the puffo-server #74 synthetic agent cascade (`signature = "server-auto:agent-cascade-leave-space"`). Evicts per-space caches; DMs operator with case-specific wording.
- **`remove_from_space` (target = self)** — same cache eviction; DM names the kicker.
- **`remove_from_channel` (target = self)** — per-channel eviction; DM references channel + parent space.
- **`leave_channel` (signer = self)** — voluntary channel exit; cache eviction only, no DM noise.
- **`cancel_space_invite` / `cancel_channel_invite`** — if an operator y/n prompt is outstanding, send a follow-up in the same thread so they don't reply `y` to a dead invite.

## Hardening

Synthetic cascade events have a server-set marker signature, not a real ed25519 sig — they aren't cryptographically authenticatable on the wire. Before applying the visible side effects (operator DM), the agent re-confirms cascade with `GET /spaces`. Returns ``True`` / ``False`` / ``None`` (still / gone / unknown) and only bails on a definitive "still a member" — transient network failures fall through to permissive cleanup. Real (signed) events skip this re-check because the server-side engine already verified them.

## Tests

14 new tests in `tests/test_membership_events.py`. Full suite 671/671 passing.

## Test plan

- [ ] CI green
- [ ] Manual smoke: operator leaves a space → DM lands "your space exit cascaded to me"
- [ ] Manual smoke: owner kicks operator → cascade DM from the agent
- [ ] Manual smoke: owner kicks agent directly → "Removed from space X by Y"
- [ ] Manual smoke: invite to non-operator → operator gets y/n prompt → operator cancels → agent DMs follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)