### PR TITLE
fix(PUF-227): pin per-message channel context in batch render

### DIFF
--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -127,12 +127,22 @@ class PuffoAgent:
         if not batch:
             return None
         for msg in batch:
+            # PUF-227: render each message with ITS OWN channel/space
+            # context, not the batch-level cached channel_meta. The
+            # admit-into-existing-batch path at puffo_core_client.py
+            # appends new messages without updating entry.channel_meta;
+            # if a thread root receives messages from two different
+            # channels in the same in-queue batch, channel_meta would
+            # carry the FIRST message's context for every subsequent
+            # render. Each msg dict already carries channel_id /
+            # channel_name / space_id / space_name from the envelope
+            # decode — use them.
             self._append_user(
-                channel_meta.get("channel_name", ""),
+                msg.get("channel_name", ""),
                 msg.get("sender_slug", ""),
                 msg.get("sender_email", ""),
                 msg.get("text", ""),
-                channel_id=channel_meta.get("channel_id", ""),
+                channel_id=msg.get("channel_id", ""),
                 root_id=root_id,
                 attachments=msg.get("attachments") or [],
                 sender_is_bot=msg.get("sender_is_bot", False),
@@ -140,8 +150,8 @@ class PuffoAgent:
                 post_id=msg.get("envelope_id", ""),
                 create_at=msg.get("sent_at", 0),
                 followups=None,
-                space_id=channel_meta.get("space_id", ""),
-                space_name=channel_meta.get("space_name", ""),
+                space_id=msg.get("space_id", ""),
+                space_name=msg.get("space_name", ""),
                 sender_display_name=msg.get("sender_display_name", ""),
                 is_visible_to_human=msg.get("is_visible_to_human", True),
             )
@@ -150,7 +160,7 @@ class PuffoAgent:
         # agent itself decides who to reply to.
         last_msg = batch[-1]
         return await self._run_turn_and_route(
-            channel_name=channel_meta.get("channel_name", ""),
+            channel_name=last_msg.get("channel_name", ""),
             sender=last_msg.get("sender_slug", ""),
             on_progress=on_progress,
         )
@@ -185,20 +195,22 @@ class PuffoAgent:
         # adapter API for a single user_message, so concatenate.
         fallback_chunks: list[str] = []
         for msg in fallback_batch:
+            # PUF-227: per-msg channel/space fields — symmetric with
+            # handle_message_batch.
             fallback_chunks.append(self._format_user_block(
-                channel_name=channel_meta.get("channel_name", ""),
+                channel_name=msg.get("channel_name", ""),
                 sender=msg.get("sender_slug", ""),
                 sender_email=msg.get("sender_email", ""),
                 text=msg.get("text", ""),
-                channel_id=channel_meta.get("channel_id", ""),
+                channel_id=msg.get("channel_id", ""),
                 root_id=root_id,
                 attachments=msg.get("attachments") or [],
                 sender_is_bot=msg.get("sender_is_bot", False),
                 mentions=msg.get("mentions") or [],
                 post_id=msg.get("envelope_id", ""),
                 create_at=msg.get("sent_at", 0),
-                space_id=channel_meta.get("space_id", ""),
-                space_name=channel_meta.get("space_name", ""),
+                space_id=msg.get("space_id", ""),
+                space_name=msg.get("space_name", ""),
                 sender_display_name=msg.get("sender_display_name", ""),
             ))
         fallback_text = "\n\n".join(fallback_chunks)
@@ -217,14 +229,17 @@ class PuffoAgent:
 
         # Route reply the same way as a normal turn so the consumer
         # picks up AgentAPIError again on consecutive rate-limit
-        # failures.
+        # failures. The assistant log entry's channel_name is a
+        # display label — use the LAST batch msg's channel so the
+        # tag matches what the agent is most likely replying about.
+        last_channel_name = (
+            fallback_batch[-1].get("channel_name", "") if fallback_batch else ""
+        )
         send_message_called = bool(result.metadata.get("send_message_targets"))
         text_parts: list[str] = result.metadata.get("assistant_text_parts") or []
         if send_message_called:
             if result.reply:
-                self._append_assistant(
-                    channel_meta.get("channel_name", ""), result.reply,
-                )
+                self._append_assistant(last_channel_name, result.reply)
             return None
         joined = "\n".join(text_parts) if text_parts else (result.reply or "")
         if "[SILENT]" in joined:
@@ -240,7 +255,7 @@ class PuffoAgent:
         if not text_parts and not result.reply:
             return None
         fallback = _format_assistant_fallback(text_parts, result.reply)
-        self._append_assistant(channel_meta.get("channel_name", ""), fallback)
+        self._append_assistant(last_channel_name, fallback)
         return fallback
 
     async def _run_turn_and_route(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -61,9 +61,16 @@ class _ThreadEntry:
     - ``in_queue`` flips False between successful dispatch and the
       next arrival on this root, so a later message reopens the
       entry cleanly instead of stacking into a stale batch.
-    - ``channel_meta`` is captured on the first enqueue and reused
-      on dispatch; the thread/channel/space context is invariant
-      for a given root.
+    - ``channel_meta`` is a batch-level summary captured when a
+      new batch opens (first enqueue OR reopen after dispatch). It
+      is NOT load-bearing for per-message rendering — PUF-227 moved
+      the per-message channel/space context into each ``msg_dict``
+      so the prompt block is pinned to the envelope, not to a
+      thread cache. Today's consumers (``handle_message_batch``,
+      ``handle_api_error_retry``) read channel/space fields off
+      each msg, so cross-channel admit on the same root_id (server
+      / UI bug or otherwise) can no longer leak one channel's
+      context into another envelope's rendered block.
     - ``dispatching_ids`` is the set of envelope_ids currently being
       sent to the agent (the batch the consumer just claimed but
       hasn't finished). A duplicate WS delivery that lands during

--- a/tests/test_core_handle_batch.py
+++ b/tests/test_core_handle_batch.py
@@ -1,0 +1,240 @@
+"""PUF-227: handle_message_batch / handle_api_error_retry render each
+message in a batch with ITS OWN channel/space fields, not the
+batch-level cached channel_meta.
+
+This is the load-bearing regression test for Scout's bug. Without
+the fix, a batch where messages came from different channels would
+render every message with the FIRST message's channel context
+(because ``entry.channel_meta`` is captured at first enqueue and the
+append branch in ``_admit_thread_message`` doesn't update it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from puffo_agent.agent.adapters import Adapter, TurnContext, TurnResult
+from puffo_agent.agent.core import PuffoAgent
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _CapturingAdapter(Adapter):
+    """Records every system_prompt + messages payload the adapter
+    sees so the test can inspect the rendered user blocks. Replies
+    with [SILENT] so the agent doesn't try to send a fallback."""
+
+    def __init__(self):
+        self.calls: list[TurnContext] = []
+
+    async def run_turn(self, ctx: TurnContext) -> TurnResult:
+        self.calls.append(ctx)
+        return TurnResult(reply="[SILENT]")
+
+
+def _msg(
+    *,
+    envelope_id: str,
+    sender: str = "sam-0001",
+    channel_id: str,
+    channel_name: str,
+    space_id: str = "sp_founders",
+    space_name: str = "Puffo Founders",
+    text: str = "hello",
+) -> dict:
+    return {
+        "envelope_id": envelope_id,
+        "sender_slug": sender,
+        "sender_email": "",
+        "text": text,
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "space_id": space_id,
+        "space_name": space_name,
+        "sent_at": 0,
+        "is_dm": False,
+        "attachments": [],
+        "sender_is_bot": False,
+        "mentions": [],
+        "is_visible_to_human": True,
+        "sender_display_name": "",
+    }
+
+
+def _agent(tmp_path) -> tuple[PuffoAgent, _CapturingAdapter]:
+    adapter = _CapturingAdapter()
+    agent = PuffoAgent(
+        adapter=adapter,
+        system_prompt="test bot",
+        memory_dir=str(tmp_path),
+    )
+    return agent, adapter
+
+
+# ── handle_message_batch: per-msg channel context wins ───────────
+
+
+def test_batch_renders_each_msg_with_own_channel_id(tmp_path):
+    """Scout's symptom shape, hoisted to the prompt-render layer.
+
+    A batch contains two messages from different channels (which
+    can happen via the in-queue append path on the same root_id).
+    The batch-level channel_meta carries channel-A's context.
+    Assert each rendered user block carries its OWN channel_id /
+    channel_name / space_id / space_name — NOT channel_meta's."""
+    agent, adapter = _agent(tmp_path)
+    batch = [
+        _msg(
+            envelope_id="env_general_1",
+            channel_id="ch_general",
+            channel_name="General",
+        ),
+        _msg(
+            envelope_id="env_gtm_1",
+            channel_id="ch_gtm",
+            channel_name="gtm",
+        ),
+    ]
+    # Stale batch-level channel_meta (the bug shape — first msg's
+    # channel got cached, second msg appended without updating it).
+    stale_channel_meta = {
+        "channel_id": "ch_general",
+        "channel_name": "General",
+        "space_id": "sp_founders",
+        "space_name": "Puffo Founders",
+        "is_dm": False,
+    }
+    _run(agent.handle_message_batch(
+        root_id="env_thread_root",
+        batch=batch,
+        channel_meta=stale_channel_meta,
+    ))
+    # The agent.log should now contain TWO user entries, one per msg.
+    user_entries = [e for e in agent.log if e.get("role") == "user"]
+    assert len(user_entries) == 2
+
+    block_a = user_entries[0]["content"]
+    block_b = user_entries[1]["content"]
+
+    # Block A carries #General's context (matches both the msg AND
+    # the stale channel_meta, so this assertion alone is necessary
+    # but not sufficient).
+    assert "channel: General" in block_a
+    assert "channel_id: ch_general" in block_a
+    assert "space: Puffo Founders" in block_a
+
+    # Block B carries #gtm's context — distinct from the stale
+    # channel_meta. This is the load-bearing assertion for PUF-227.
+    assert "channel: gtm" in block_b
+    assert "channel_id: ch_gtm" in block_b
+    # And critically, block B's render does NOT leak #General into
+    # the channel_id field.
+    assert "channel_id: ch_general" not in block_b
+
+
+def test_batch_uses_msg_channel_when_channel_meta_empty(tmp_path):
+    """Defense-in-depth: if a batch arrives with an empty
+    channel_meta dict (older callers, future refactor regressions),
+    per-msg fields still render correctly."""
+    agent, adapter = _agent(tmp_path)
+    batch = [_msg(
+        envelope_id="env_solo",
+        channel_id="ch_gtm",
+        channel_name="gtm",
+    )]
+    _run(agent.handle_message_batch(
+        root_id="env_solo",
+        batch=batch,
+        channel_meta={},  # empty — pre-PUF-227 this would render bare ids.
+    ))
+    user_entries = [e for e in agent.log if e.get("role") == "user"]
+    assert len(user_entries) == 1
+    block = user_entries[0]["content"]
+    assert "channel: gtm" in block
+    assert "channel_id: ch_gtm" in block
+
+
+def test_batch_route_log_uses_last_msg_channel(tmp_path):
+    """The post-batch route-log channel_name should reflect the
+    LAST message's channel (the trigger the agent is most likely
+    replying about), not the stale batch-level channel_meta."""
+    agent, adapter = _agent(tmp_path)
+    batch = [
+        _msg(envelope_id="env_a", channel_id="ch_general", channel_name="General"),
+        _msg(envelope_id="env_b", channel_id="ch_gtm", channel_name="gtm"),
+    ]
+    stale_channel_meta = {
+        "channel_id": "ch_general",
+        "channel_name": "General",
+        "space_id": "sp_founders",
+        "space_name": "Puffo Founders",
+        "is_dm": False,
+    }
+    _run(agent.handle_message_batch(
+        root_id="env_thread_root",
+        batch=batch,
+        channel_meta=stale_channel_meta,
+    ))
+    # _run_turn_and_route doesn't directly write a channel_name to
+    # the log, but the adapter saw exactly one turn run. The
+    # important post-condition is the user-block render correctness
+    # already asserted above. This case smoke-tests no crash on the
+    # divergent-channel-name path through _run_turn_and_route.
+    assert len(adapter.calls) == 1
+
+
+# ── handle_api_error_retry: symmetric per-msg rendering ──────────
+
+
+class _CapturingRetryAdapter(Adapter):
+    """Records the fallback text the retry path constructs so we
+    can assert per-msg fields landed in the rendered chunks."""
+
+    def __init__(self):
+        self.fallback_text = ""
+
+    async def run_turn(self, ctx: TurnContext) -> TurnResult:
+        return TurnResult(reply="[SILENT]")
+
+    async def run_retry_turn(
+        self, kick_text: str, fallback_user_message: str, ctx: TurnContext,
+    ) -> TurnResult:
+        self.fallback_text = fallback_user_message
+        return TurnResult(reply="[SILENT]")
+
+
+def test_api_error_retry_fallback_renders_each_msg_with_own_channel(tmp_path):
+    """The retry path builds a fallback payload by concatenating
+    per-msg _format_user_block calls. PUF-227 makes those reads
+    come from each msg, not from the stale channel_meta."""
+    adapter = _CapturingRetryAdapter()
+    agent = PuffoAgent(
+        adapter=adapter,
+        system_prompt="test bot",
+        memory_dir=str(tmp_path),
+    )
+    fallback_batch = [
+        _msg(envelope_id="env_a", channel_id="ch_general", channel_name="General"),
+        _msg(envelope_id="env_b", channel_id="ch_gtm", channel_name="gtm"),
+    ]
+    stale_channel_meta = {
+        "channel_id": "ch_general",
+        "channel_name": "General",
+        "space_id": "sp_founders",
+        "space_name": "Puffo Founders",
+        "is_dm": False,
+    }
+    _run(agent.handle_api_error_retry(
+        root_id="env_thread_root",
+        channel_meta=stale_channel_meta,
+        fallback_batch=fallback_batch,
+    ))
+    # Both per-msg channel ids must be visible in the fallback
+    # payload — the rate-limit retry must NOT leak channel-A's
+    # context onto envelope-B's render.
+    assert "channel: General" in adapter.fallback_text
+    assert "channel_id: ch_general" in adapter.fallback_text
+    assert "channel: gtm" in adapter.fallback_text
+    assert "channel_id: ch_gtm" in adapter.fallback_text

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -62,12 +62,21 @@ def _make_client_for_queue(store: MessageStore) -> PuffoCoreMessageClient:
     return client
 
 
-def _msg(envelope_id: str, sender: str = "alice-0001", sent_at: int | None = None) -> dict:
+def _msg(
+    envelope_id: str,
+    sender: str = "alice-0001",
+    sent_at: int | None = None,
+    *,
+    channel_id: str = "ch_1",
+    channel_name: str = "general",
+    space_id: str = "sp_1",
+    space_name: str = "Team",
+) -> dict:
     return {
-        "channel_id": "ch_1",
-        "channel_name": "general",
-        "space_id": "sp_1",
-        "space_name": "Team",
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "space_id": space_id,
+        "space_name": space_name,
         "sender_slug": sender,
         "sender_email": "",
         "text": f"hello from {envelope_id}",
@@ -81,12 +90,18 @@ def _msg(envelope_id: str, sender: str = "alice-0001", sent_at: int | None = Non
     }
 
 
-def _channel_meta() -> dict:
+def _channel_meta(
+    *,
+    channel_id: str = "ch_1",
+    channel_name: str = "general",
+    space_id: str = "sp_1",
+    space_name: str = "Team",
+) -> dict:
     return {
-        "channel_id": "ch_1",
-        "channel_name": "general",
-        "space_id": "sp_1",
-        "space_name": "Team",
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "space_id": space_id,
+        "space_name": space_name,
         "is_dm": False,
     }
 
@@ -894,4 +909,96 @@ async def test_pre_existing_cursor_blocks_redelivered_messages():
     assert await store.get_last_processed_sent_at("env_root") == 500
     # A fresh root has no entry → returns 0 → admits everything.
     assert await store.get_last_processed_sent_at("env_fresh") == 0
+    await store.close()
+
+
+# ─── PUF-227: cross-channel same-root admit ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admit_same_root_two_channels_preserves_per_msg_fields():
+    """Scout's PUF-227 symptom shape, isolated to the queue layer.
+
+    Two messages arrive on the SAME root_id but from DIFFERENT
+    channels (the canonical untested case the intake flagged).
+    The append-to-existing-batch path does NOT update
+    ``entry.channel_meta`` — so a batch-level read of the cached
+    channel_meta would inherit message-1's channel context for
+    message-2's render. PUF-227's fix moves per-message context
+    into each msg_dict; we assert that each msg in the resulting
+    batch still carries its OWN channel_id / channel_name /
+    space_id / space_name, regardless of the batch-level cache."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    msg_general = _msg(
+        "env_general_1",
+        channel_id="ch_general", channel_name="General",
+    )
+    msg_gtm = _msg(
+        "env_gtm_1",
+        channel_id="ch_gtm", channel_name="gtm",
+    )
+
+    await client._admit_thread_message(
+        root_id="env_thread_root",
+        priority=PRIORITY_MENTIONED_HUMAN,
+        msg_dict=msg_general,
+        channel_meta=_channel_meta(channel_id="ch_general", channel_name="General"),
+    )
+    await client._admit_thread_message(
+        root_id="env_thread_root",
+        priority=PRIORITY_MENTIONED_HUMAN,
+        msg_dict=msg_gtm,
+        channel_meta=_channel_meta(channel_id="ch_gtm", channel_name="gtm"),
+    )
+
+    entry = client._thread_state["env_thread_root"]
+    # Both messages landed in the same in-queue batch (append path).
+    assert len(entry.messages) == 2
+    # Each msg carries its OWN channel context — this is the
+    # source of truth handle_message_batch reads from per PUF-227.
+    assert entry.messages[0]["channel_id"] == "ch_general"
+    assert entry.messages[0]["channel_name"] == "General"
+    assert entry.messages[1]["channel_id"] == "ch_gtm"
+    assert entry.messages[1]["channel_name"] == "gtm"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_admit_same_root_reopen_resets_channel_meta_to_new_msg():
+    """Per the PUF-227 docstring update: ``entry.channel_meta`` is a
+    batch-level summary captured at first enqueue OR reopen after
+    dispatch. After the consumer drains a batch and a new message
+    arrives on the same root from a different channel, the reopen
+    path at puffo_core_client.py:821-839 overwrites channel_meta to
+    the NEW message's. We assert this for the docstring contract."""
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+
+    msg1 = _msg("env_1", channel_id="ch_general", channel_name="General")
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=msg1,
+        channel_meta=_channel_meta(channel_id="ch_general", channel_name="General"),
+    )
+    # Simulate the consumer claiming the batch (set in_queue=False).
+    entry = client._thread_state["env_root"]
+    entry.in_queue = False
+    entry.messages = []
+
+    msg2 = _msg("env_2", channel_id="ch_gtm", channel_name="gtm")
+    await client._admit_thread_message(
+        root_id="env_root",
+        priority=PRIORITY_HUMAN,
+        msg_dict=msg2,
+        channel_meta=_channel_meta(channel_id="ch_gtm", channel_name="gtm"),
+    )
+
+    entry = client._thread_state["env_root"]
+    # Reopen path reset the batch + updated channel_meta to NEW.
+    assert entry.in_queue is True
+    assert entry.messages == [msg2]
+    assert entry.channel_meta["channel_id"] == "ch_gtm"
     await store.close()


### PR DESCRIPTION
## Summary

- Fixes per-worker prompt-assembly metadata corruption where a thread queue's batch could render one envelope's `channel_id` / `channel_name` / `space_id` / `space_name` using a **stale batch-level cached `channel_meta`** captured at first enqueue.
- Root cause (`agent/core.py:127-146` pre-fix): `handle_message_batch` read every msg's channel/space fields from the batch-level `channel_meta` dict, ignoring per-msg fields already present in each envelope's decoded dict. When the queue's append-into-existing-batch path landed a second message on the same `root_id` from a DIFFERENT channel, the second envelope's prompt block carried the FIRST message's channel context.
- Three-step fix in `agent/core.py`: `handle_message_batch` + `handle_api_error_retry` now read every channel/space field off each `msg` dict directly. The post-batch route + assistant-log channel tag uses the LAST batch msg's channel_name (matches what the agent is most likely replying about).
- `agent/puffo_core_client.py:_ThreadEntry` docstring reconciliation: explicitly states `channel_meta` is a batch-level summary, NOT load-bearing for per-message rendering. Line 837 (`entry.channel_meta = channel_meta` on reopen-after-dispatch) stays — direction-of-corruption analysis showed it's not the load-bearing path; the old docstring just incorrectly claimed channel_meta was invariant for a root.
- Closes PUF-227.

## Architecture / decision notes

**Why per-msg fields are authoritative.** Each msg dict already carries `channel_id` / `channel_name` / `space_id` / `space_name` from the envelope decode (`puffo_core_client.py:722-728` builds them per-envelope). The pre-fix code was effectively a downgrade — choosing to read from a cached summary instead of the canonical per-envelope source.

**Why daemon-side render-from-msg over upstream "fix same-root-spanning-two-channels."** Daemon-side render-from-msg makes the agent robust regardless of how the root_id collision arises (server bug, UI bug, agent-reply-system, anything else upstream). Equation flagged the upstream investigation as a possible follow-up audit ticket if customers continue reporting cross-channel pollution after this lands.

## Test plan

- [x] **Load-bearing assertion** (`tests/test_core_handle_batch.py:test_batch_renders_each_msg_with_own_channel_id`) — reproduces Scout's exact symptom shape: batch with msg-A from `#General` and msg-B from `#gtm`, stale batch-level `channel_meta` pointing at `#General`. Asserts block-B carries `channel: gtm` + `channel_id: ch_gtm`, **and critically** that `channel_id: ch_general` does NOT leak into block-B. Pre-fix this assertion fails — that's what makes it load-bearing.
- [x] **Symmetric retry path** (`test_api_error_retry_fallback_renders_each_msg_with_own_channel`) — the rate-limit retry fallback chunks each go through `_format_user_block`; assert both channel ids appear in the assembled fallback text.
- [x] **Queue-layer source of truth** (`tests/test_thread_queue.py:test_admit_same_root_two_channels_preserves_per_msg_fields`) — the canonical untested case the intake flagged. Direct precondition for the prompt-layer fix to work.
- [x] **Docstring contract** (`tests/test_thread_queue.py:test_admit_same_root_reopen_resets_channel_meta_to_new_msg`) — pins behavior so future refactors can't accidentally invariant-make `channel_meta`.
- [x] **Full pytest suite**: **685 passed / 1 skipped / 0 failed** (was 679 on main → +6 net new tests; 1 skip is the pre-existing permission-proxy-mode entry, unrelated).
- [x] **Negative grep:** zero `channel_meta.get(` reads in `handle_message_batch` or `handle_api_error_retry` post-fix.
- [ ] **Live verification post-merge:** confirm Scout no longer corrupts cross-channel mentions; spot-check from the puffotest cluster.