### PR TITLE
feat(bridge): expose + edit runtime.harness via /v1/agents endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   summary alone. Older web clients that don't read the field are
   unaffected (extra JSON keys are ignored client-side).
 
+- **`harness` is now editable via `PATCH /v1/agents/<id>/runtime`.**
+  The endpoint previously rejected the `harness` key with a "not
+  editable here" comment — operators had to drop to `agent.yml` or
+  `puffo-agent agent runtime --harness` to switch a running agent
+  between codex and claude-code. With the web client gaining a
+  harness dropdown in the agent edit form (puffo-core-han-group
+  PR #130), the bridge accepts harness alongside the existing
+  fields. `validate_triple` continues to enforce kind/provider/
+  harness combo correctness — invalid combos return 400 before
+  save. The reconcile loop catches the change on its next tick and
+  respawns the worker on the new harness.
+
 ### Fixed
 
 - **PUF-227-A: strict same-channel cache validation on `thread_root_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,38 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   Older web clients that don't read the fields are unaffected
   (extra JSON keys are ignored client-side).
 
+- **Profile cache (display_name + avatar_url) is now TTL'd and
+  manually-refreshable via the MCP `get_user_info` tool.** The
+  per-slug `_display_name_cache` was previously session-lifetime —
+  an operator (or any other user) renaming themselves on
+  puffo-server meant the agent rendered the stale name in its
+  prompt forever (until daemon restart). Three fixes layered:
+
+  1. The cache itself becomes TTL'd at 10 min (`_PROFILE_CACHE_TTL_SECONDS`)
+     and now carries both display_name + avatar_url (was just the
+     name). Renames + avatar swaps propagate within the TTL window
+     without operator intervention.
+
+  2. `get_user_info` MCP tool fix: was reading `entry.get("username")`
+     which silently dropped the display_name (server returns
+     `display_name`). Now reads the right field, also surfaces
+     `avatar_url` in the tool response. Renamed the output keys
+     from `display:` / `avatar:` to `display_name:` / `avatar_url:`
+     to match the wire fields.
+
+  3. `get_user_info` now POSTs the just-fetched values back to
+     the daemon's profile cache via the new
+     `POST /v1/data/{agent_id}/profile-cache` data-service route.
+     The next render in the daemon picks up the fresh values
+     immediately — operators wanting "right now" don't have to
+     wait for the TTL. Mechanism: data-service holds a module-
+     level setter the daemon wires to its worker registry; setter
+     finds the agent's worker and calls
+     `Worker.set_profile_cache(slug, name, avatar)` →
+     `PuffoCoreMessageClient.set_profile(...)`. Best-effort —
+     transport failures don't break the tool's reply, the TTL
+     catches up regardless.
+
 - **In-memory `_channel_space` dict now mirrors the persistent
   `channel_space_map` table.** Previously `_maybe_cache_channel_space`
   only wrote to the persistent store (used by the MCP subprocess via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   summary alone. Older web clients that don't read the field are
   unaffected (extra JSON keys are ignored client-side).
 
+- **In-memory `_channel_space` dict now mirrors the persistent
+  `channel_space_map` table.** Previously `_maybe_cache_channel_space`
+  only wrote to the persistent store (used by the MCP subprocess via
+  `lookup_channel_space`), leaving the in-memory dict (used by
+  `send_fallback_message`) empty until the first real inbound
+  envelope landed in the channel. An agent auto-accepted into a
+  channel via the operator-trust synthetic `accept_channel_invite`
+  would drop fallback replies (`no known space for channel …`)
+  until that first envelope — including its own intro-nudge reply
+  if the LLM didn't use the MCP `send_message` tool.
+
+  Two layers fixed: (a) every successful `mark_channel_space` call
+  in `_maybe_cache_channel_space` now also mirrors into
+  `self._channel_space[channel_id] = space_id`; (b)
+  `send_fallback_message` falls back to `store.lookup_channel_space`
+  on in-memory miss and backfills the dict on hit. (b) also covers
+  the post-daemon-restart case where the in-memory dict is empty
+  but the persistent table has the mapping from a prior session.
+
 - **`harness` is now editable via `PATCH /v1/agents/<id>/runtime`.**
   The endpoint previously rejected the `harness` key with a "not
   editable here" comment — operators had to drop to `agent.yml` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   Older web clients that don't read the fields are unaffected
   (extra JSON keys are ignored client-side).
 
+- **Agent primer (`DEFAULT_SHARED_CLAUDE_MD` + skill cards) audited
+  and trimmed.** Cut ~45% by length (~17K → ~9.3K chars) while
+  closing 5 documentation gaps surfaced in 0.9.0 / 0.9.1 work:
+  (1) the PUF-227-A `root_id` cache-validation invariant is now
+  explicit in both the main primer and the `send_message` skill —
+  agents are told to pass the true thread root and warned that
+  cross-channel `root_id` gets wiped to null; (2) the
+  "Your two CLAUDE.md layers" + "Permission prompts" sections
+  explicitly call out the codex-agent equivalents (`AGENTS.md`,
+  daemon-trust auto-approval) so codex agents reading the shared
+  primer aren't told to look at files they don't have; (3) the
+  `get_user_info` skill + tool catalogue document the new
+  force-refresh behavior + the operator-rename trigger for calling
+  it; (4) the `refresh(model=...)` description lists the valid
+  Claude Code models (`claude-opus-4-7`, `claude-opus-4-6-1m`,
+  `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`); (5) the
+  workspace section adds a "credentials are daemon-managed" note so
+  agents don't try to write `~/.claude/.credentials.json` or
+  `~/.codex/auth.json` themselves. Section framework (14 headers in
+  the primer + 10 skill cards) is unchanged — only the prose got
+  tighter.
+
 - **Profile cache (display_name + avatar_url) is now TTL'd and
   manually-refreshable via the MCP `get_user_info` tool.** The
   per-slug `_display_name_cache` was previously session-lifetime —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.9.1] — 2026-05-20
 
+### Added
+
+- **`runtime_harness` field on `/v1/agents` summary response.** The
+  bridge's per-agent summary previously only exposed `runtime_kind`
+  (cli-local / cli-docker / chat-local / sdk-local). With codex
+  joining claude-code on the cli-local path, web clients couldn't
+  distinguish a codex agent from a claude-code agent without
+  fetching the full `/v1/agents/<id>` detail per card. Adds
+  `cfg.runtime.harness` to the items dict so the My-Agents grid can
+  label a card as "Codex · local" vs "Claude Code · local" from the
+  summary alone. Older web clients that don't read the field are
+  unaffected (extra JSON keys are ignored client-side).
+
 ### Fixed
 
 - **PUF-227-A: strict same-channel cache validation on `thread_root_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **`runtime_harness` field on `/v1/agents` summary response.** The
-  bridge's per-agent summary previously only exposed `runtime_kind`
-  (cli-local / cli-docker / chat-local / sdk-local). With codex
-  joining claude-code on the cli-local path, web clients couldn't
-  distinguish a codex agent from a claude-code agent without
-  fetching the full `/v1/agents/<id>` detail per card. Adds
-  `cfg.runtime.harness` to the items dict so the My-Agents grid can
-  label a card as "Codex · local" vs "Claude Code · local" from the
-  summary alone. Older web clients that don't read the field are
-  unaffected (extra JSON keys are ignored client-side).
+- **`runtime_harness` and `runtime_model` fields on `/v1/agents`
+  summary response.** The bridge's per-agent summary previously
+  only exposed `runtime_kind` (cli-local / cli-docker / chat-local /
+  sdk-local). With codex joining claude-code on the cli-local path,
+  web clients couldn't distinguish a codex agent from a claude-code
+  agent without fetching the full `/v1/agents/<id>` detail per
+  card. Adds `cfg.runtime.harness` so the My-Agents grid can label
+  a card as "Codex · local" vs "Claude Code · local" from the
+  summary alone, and `cfg.runtime.model` so the per-card edit form
+  can pre-fill the model dropdown without a per-card detail fetch.
+  Older web clients that don't read the fields are unaffected
+  (extra JSON keys are ignored client-side).
 
 - **In-memory `_channel_space` dict now mirrors the persistent
   `channel_space_map` table.** Previously `_maybe_cache_channel_space`

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Optional
 
@@ -35,6 +36,14 @@ PRIORITY_MENTIONED_BOT = 2
 PRIORITY_HUMAN = 3
 PRIORITY_BOT = 4
 PRIORITY_SYSTEM = 5
+
+# Per-slug profile cache TTL — keeps display_name + avatar_url
+# fresh enough that a rename / avatar change on puffo-server
+# propagates within ~10 min on the next render, without paying
+# a /identities/profiles HTTP round-trip on every inbound msg.
+# Operators wanting "right now" can fire the MCP get_user_profile
+# tool which force-refreshes regardless of TTL.
+_PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
 
 @dataclass
@@ -424,9 +433,14 @@ class PuffoCoreMessageClient:
         # slug → root_pubkey for inviters, to avoid hammering
         # /certs/sync on bursts of invites from the same person.
         self._inviter_root_cache: dict[str, bytes] = {}
-        # slug → display_name from /identities/profiles. Empty strings
-        # are cached too so unset display_names don't trigger re-fetch.
-        self._display_name_cache: dict[str, str] = {}
+        # slug → (display_name, avatar_url, fetched_at_monotonic) from
+        # /identities/profiles. TTL'd at _PROFILE_CACHE_TTL_SECONDS so
+        # operator name / avatar changes propagate without daemon
+        # restart (was previously session-lifetime, leaving the agent
+        # rendering the stale name forever). Empty fields are cached
+        # under the same TTL — transient lookup failures self-heal at
+        # the next tick instead of pinning a permanent "" miss.
+        self._profile_cache: dict[str, tuple[str, str, float]] = {}
         # Invitation event_ids the worker has already processed; per-
         # listen() (cleared on reconnect). Server-side state is the
         # durable record — this cache just avoids repeating work
@@ -1726,26 +1740,60 @@ class PuffoCoreMessageClient:
         return root_pk
 
     async def _fetch_display_name(self, slug: str) -> str:
-        """display_name via /identities/profiles, cached per session.
-        Empty string on miss/failure; caller falls back to ``@slug``."""
+        """display_name via the unified profile cache. Empty string
+        on miss/failure; caller falls back to ``@slug``. Thin wrapper
+        kept for source compat with the dozen call sites that only
+        care about the name."""
+        name, _ = await self._fetch_user_profile(slug)
+        return name
+
+    def set_profile(self, slug: str, display_name: str, avatar_url: str) -> None:
+        """Inject fresh values into the profile cache, bypassing TTL.
+        Used by the MCP ``get_user_info`` tool to share its just-
+        fetched values with the daemon's render path so the next
+        inbound envelope renders with the new display_name + avatar
+        without waiting for the cache to expire."""
         if not slug:
-            return ""
-        if slug in self._display_name_cache:
-            return self._display_name_cache[slug]
+            return
+        self._profile_cache[slug] = (display_name, avatar_url, time.monotonic())
+
+    async def _fetch_user_profile(
+        self, slug: str, *, force_refresh: bool = False,
+    ) -> tuple[str, str]:
+        """``(display_name, avatar_url)`` via /identities/profiles,
+        cached for ``_PROFILE_CACHE_TTL_SECONDS``. Empty strings on
+        miss/failure; same TTL applies so a transient lookup
+        failure doesn't pin a permanent miss.
+
+        ``force_refresh=True`` bypasses the cache for the read (the
+        MCP ``get_user_profile`` tool's path) but still writes back
+        so subsequent reads see the fresh value.
+        """
+        if not slug:
+            return ("", "")
+        now = time.monotonic()
+        if not force_refresh:
+            cached = self._profile_cache.get(slug)
+            if cached is not None and now - cached[2] < _PROFILE_CACHE_TTL_SECONDS:
+                return (cached[0], cached[1])
+        name = ""
+        avatar_url = ""
         try:
             data = await self.http.get(
                 f"/identities/profiles?slugs={slug}",
             )
-        except Exception:
-            self._display_name_cache[slug] = ""
-            return ""
-        for entry in data.get("profiles") or []:
-            if entry.get("slug") == slug:
-                name = (entry.get("display_name") or "").strip()
-                self._display_name_cache[slug] = name
-                return name
-        self._display_name_cache[slug] = ""
-        return ""
+            for entry in data.get("profiles") or []:
+                if entry.get("slug") == slug:
+                    name = (entry.get("display_name") or "").strip()
+                    avatar_url = (entry.get("avatar_url") or "").strip()
+                    break
+        except Exception as exc:
+            logger.debug(
+                "_fetch_user_profile: lookup failed for %s: %s",
+                slug, exc,
+            )
+        self._profile_cache[slug] = (name, avatar_url, now)
+        return (name, avatar_url)
 
     async def _validate_incoming_parent_id(
         self,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1311,6 +1311,14 @@ class PuffoCoreMessageClient:
         else:
             return
         await self.store.mark_channel_space(channel_id, space_id)
+        # Mirror to the in-memory dict that ``send_fallback_message``
+        # reads. Without this, an agent that's just joined a channel
+        # via a synthetic accept_channel_invite (operator-trust auto-
+        # accept) would drop fallback replies until the first real
+        # inbound envelope in that channel populated this dict via
+        # ``handle_envelope`` — including the intro nudge's own
+        # outbound, which never goes through handle_envelope.
+        self._channel_space[channel_id] = space_id
 
     async def _evict_space_caches(self, space_id: str) -> None:
         """Drop every cached entry tied to a space we've left/been
@@ -2487,6 +2495,22 @@ class PuffoCoreMessageClient:
             # it; either way, sending blindly to a guessed space
             # gets a 403 or worse (wrong-space cross-talk).
             target_space_id = self._channel_space.get(channel_id)
+            if not target_space_id:
+                # In-memory miss — try the persistent channel_space_map
+                # before giving up. Catches the post-daemon-restart
+                # case (in-memory dict empty until first inbound
+                # envelope) and any membership-event path that
+                # forgot to mirror to the dict. Backfill on hit so
+                # subsequent calls go through the fast path.
+                target_space_id = await self.store.lookup_channel_space(channel_id) or ""
+                if target_space_id:
+                    self._channel_space[channel_id] = target_space_id
+                    logger.info(
+                        "send_fallback_message: hydrated in-memory "
+                        "channel_space for %s from persistent store "
+                        "(sp=%s)",
+                        channel_id, target_space_id,
+                    )
             if not target_space_id:
                 logger.warning(
                     "send_fallback_message: no known space for channel %s — "

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -16,338 +16,234 @@ from pathlib import Path
 DEFAULT_SHARED_CLAUDE_MD = """\
 # Puffo.ai platform primer
 
-You are an AI agent running on the [Puffo.ai](https://puffo.ai)
-platform, hosted by the `puffo-agent` daemon on a human operator's
-machine. This primer is shared across every agent the operator runs;
-your specific role lives in the *Your role* section below.
-
-Puffo.ai uses end-to-end-encrypted messaging — your replies are
-sealed to each recipient's device key before they leave this host.
-You don't need to manage that; it's the runtime's job.
+You are an AI agent on Puffo.ai, hosted by `puffo-agent` on a human
+operator's machine. End-to-end encryption is handled by the runtime;
+you just produce replies. This primer is shared across every agent
+the operator runs; your specific role is in *Your role* below.
 
 ## How messages arrive
 
-Every user message is wrapped in a metadata block:
+Every user message carries a metadata block:
 
 ```
 - space: <space_name>            # absent for DMs
 - space_id: <sp_<uuid>>          # absent for DMs
-- channel: <channel_name>        # human-readable; "Direct message" for DMs
-- channel_id: <ch_<uuid>>        # pass as send_message(channel=...); absent for DMs
-- post_id: <env_<uuid>>          # the envelope_id of THIS message
-- thread_root_id: <env_<uuid>>   # pass as send_message(root_id=...)
+- channel: <channel_name>        # "Direct message" for DMs
+- channel_id: <ch_<uuid>>        # send_message(channel=...); absent for DMs
+- post_id: <env_<uuid>>          # this envelope's id
+- thread_root_id: <env_<uuid>>   # send_message(root_id=...) to reply in-thread
 - timestamp: <ISO-8601>
-- sender: <slug>                 # e.g. alice-1234, agent-5678
+- sender: <slug>
 - sender_type: human | bot
-- is_visible_to_human: true | false  # false = folded out of the human's view; agent-to-agent only
-- mentions:                      # present when the message @-mentions
+- is_visible_to_human: true | false
+- mentions:                      # only when @-mentions present
   - puffotest-19b1 (you)
   - alice-1234 (human)
-  - helper-bot-abcd (agent)
-- attachments:                   # only present when files are attached
+- attachments:                   # only when files attached
   - attachments/<envelope_id>/<filename>
 - message: <actual message text>
 ```
 
-Reply only to the `message:` field's content. Never echo the metadata
-block, field labels (`message:`), or bracketed prefixes in your
-response. Address users with `@<slug>` inline when needed.
+Reply to the `message:` content only — never echo metadata, labels,
+or `[bracket]` prefixes. Address users with `@<slug>`.
 
 ## `[puffo-agent system message]` lines
 
-Occasionally a user-role turn arrives whose body starts with the
-literal prefix:
+User-role turns starting with `[puffo-agent system message]` are
+runtime notes, not real users. Act on the instruction; don't reply
+to the system message itself.
 
-```
-[puffo-agent system message] <text>
-```
-
-These are **not** messages from a real Puffo.ai user — they're the
-runtime talking to you. They never carry a `post_id` /
-`thread_root_id` / `sender` block (or, if those fields are present,
-ignore them — they're just a side-effect of the same envelope
-shape). Treat each `[puffo-agent system message]` as an
-informational/control note from your operator's daemon and act on
-its instruction. Do not reply *to* the system message itself with
-`send_message`; respond to whatever real user content the
-instruction points at.
-
-Common examples:
-- `[puffo-agent system message] session errored on rate limiting,
-  please resume processing.` — the previous turn was interrupted by
-  a provider rate limit. Your previous user input is still in this
-  transcript; re-attempt your response now.
-- `[puffo-agent system message] inbound message was too long to
-  embed inline and has been redacted from this prompt ...` — the
-  user pasted a body larger than the daemon's prompt-budget cap.
-  The full text is still on disk in the agent's message store;
-  page it back one chunk at a time with
-  `mcp__puffo__get_post_segment(envelope_id=..., segment=N,
-  segment_size=...)` using the values the placeholder cites.
-  Fetch only the segments you actually need — the `preview:` line
-  in the placeholder is usually enough to decide. If you've seen
-  enough from the preview to reply, do so without paging.
+Common ones:
+- `session errored on rate limiting, please resume processing.` —
+  previous turn was interrupted; retry your reply now.
+- `inbound message was too long ... redacted from this prompt ...`
+  — page chunks back with `mcp__puffo__get_post_segment(envelope_id=...,
+  segment=N, segment_size=...)`. The placeholder's `preview:` is
+  usually enough; fetch only what you need.
 
 ## How to reply (read this carefully)
 
-There are exactly two ways to deliver a reply, and you must pick
-one explicitly on every turn:
+Two ways, pick one explicitly every turn:
 
-1. **`mcp__puffo__send_message(channel, text, is_visible_to_human, root_id="")`
-   — the default.** Use this for *every* user-visible reply,
-   including the obvious "answer the message I just received"
-   case. Pass the metadata's `channel_id` as `channel` and (if
-   you want to stay in the same thread) `thread_root_id` as
-   `root_id`. You may call it more than once per turn — for
-   example to reply in the originating channel AND notify another
-   channel in the same turn — and every send is treated as
-   intentional.
+1. **`mcp__puffo__send_message(channel, text, is_visible_to_human, root_id="")`**
+   — the default for every user-visible reply. Pass the metadata's
+   `channel_id` as `channel`, `thread_root_id` as `root_id` to stay
+   in-thread. Multiple calls per turn are fine (reply here + notify
+   elsewhere in the same turn).
 
-   `is_visible_to_human` is **required** — there is no default,
-   you decide on every call. Pass `true` for anything a human
-   should read: replies to people, status updates, anything an
-   operator would want in their feed. Pass `false` only for
-   agent-to-agent chatter a human watching the channel would find
-   pure noise — coordination handshakes between bots, payloads
-   addressed to another agent. When in doubt, pass `true`: a
-   visible message a human skims past is cheaper than a useful
-   one folded out of sight. Human clients collapse runs of
-   `false` messages behind a placeholder; they are still
-   delivered, searchable, and visible to other agents.
+   `is_visible_to_human` is **required**, no default:
+   - `true` — anything a human should read (replies, status updates,
+     operator pings). Default choice; when in doubt, `true`.
+   - `false` — agent-to-agent chatter humans would find noise. Only
+     effective on threaded replies (`root_id` set); on root posts
+     it's ignored and coerced to visible.
 
-   `false` only folds **threaded replies** (calls with `root_id`
-   set). A root-level message can't fold, so `false` on one is
-   ignored — the tool coerces it to visible and tells you so in
-   the response. If you want agent-to-agent chatter folded away,
-   keep it in a thread.
+   **Cache-validation (PUF-227-A).** The daemon verifies that
+   `root_id` points to a parent envelope in your local message store
+   AND in the same channel/space as your outbound. Otherwise it
+   wipes `root_id` to null + returns a warning note in the tool
+   response. Always pass the **true thread root** (the metadata's
+   `thread_root_id`), not an arbitrary reply id. Don't carry
+   `root_id` across channel switches.
 
-2. **`[SILENT]` in your `assistant.text`** — when no reply is
-   needed (the conversation is between other people, the
-   `mentions:` list doesn't include you, you're in a possible
-   bot-loop, etc). Write the literal token `[SILENT]` somewhere
-   in your assistant text; the runtime substring-matches and
-   posts nothing to puffo-core. Surrounding prose is fine — the
-   marker just signals "intentionally no reply".
+2. **`[SILENT]`** in your `assistant.text` — when no reply is needed
+   (conversation between others, you're not mentioned, possible
+   bot-loop). Substring-matched; surrounding prose is fine.
 
-If you do *neither* of those — no `send_message` call AND no
-`[SILENT]` marker — the runtime will fall back to assembling
-your `assistant.text` frames into a markdown bullet list and
-posting that as the reply. Treat the fallback as a safety net,
-not a target: it costs the operator a `[fallback] ...skipped
-both send_message and [SILENT] markers` warning in their daemon
-log, the bullet-list rendering rarely matches what you'd have
-written if you'd composed the reply directly, and the fallback
-posts with `is_visible_to_human=false` — so the human may never
-see it. Always prefer an explicit `send_message` call where you
-set visibility consciously.
+Skipping both produces a `[fallback]` warning posted as
+`is_visible_to_human=false` — humans may never see it. Don't rely
+on it.
 
-**Self-mention marker.** If a message @-mentions you, the shell
-rewrites your handle in the `message:` field as `@you(<your-slug>)`
-— e.g. if the operator types `@puffotest-19b1 please do X` and your
-slug is `puffotest-19b1`, you see `@you(puffotest-19b1) please do X`.
+**Self-mention marker.** If a message @-mentions you, your handle
+appears in the `message:` body as `@you(<your-slug>)`. Treat it as
+a direct mention; use the slug inside parens for self-reference,
+but don't echo `@you(...)` literally — it's incoming-only syntax.
+Other users' @-mentions appear unchanged.
 
-- `@you(...)` means *you are being addressed in this position*; treat
-  it exactly like a direct @-mention of yourself.
-- The slug inside the parens is your own puffo-core identity. Use it
-  when you need to self-reference (e.g., in a tool call), but don't
-  echo the literal `@you(...)` wrapper back in your reply — that's
-  incoming-only syntax.
-- Other users' `@-mentions` appear unchanged so you can see who else
-  was tagged in the same message.
-
-To **reply in the same thread**, pass `thread_root_id` as
-`send_message`'s `root_id` argument. To **start a new top-level
-message** in the same channel/DM, omit `root_id`.
-
-Use `sender_type` and `mentions` to decide whether to reply:
-- If `sender_type: bot`, you may be in a bot-to-bot loop — be
-  conservative and stay `[SILENT]` unless a human is clearly in the
-  loop.
-- If `mentions:` lists you (marked `(you)`) or the `message:`
-  contains `@you(...)`, you're being addressed directly — reply.
-- If the `mentions:` list names another human/agent but NOT you,
-  consider whether you're the right responder; often `[SILENT]` is
-  correct.
+**Deciding whether to reply** — check `sender_type` and `mentions`:
+- `sender_type: bot` → may be bot-loop; stay `[SILENT]` unless a
+  human is clearly in the loop.
+- `mentions` includes `(you)` or message has `@you(...)` → reply.
+- `mentions` names others but not you → often `[SILENT]`.
 
 ## Spaces, channels, DMs
 
-- **Space:** a top-level container with its own membership and event
-  log. You belong to one or more spaces; you only see channels
-  inside spaces you've been invited to.
-- **Channel:** a multi-user conversation inside a space, addressed
-  by a `ch_<uuid>` id. There is no `#name` shortcut — you address
-  channels by id. Use `list_channels_in_all_spaces` (or
-  `list_spaces` + `list_channels_in_space`) to discover them.
-- **Direct message (DM):** one-on-one. The wire envelope's
-  `envelope_kind` is `dm` rather than `channel`; you reply by
-  passing `@<slug>` to `send_message`.
+- **Space:** top-level container. You only see channels in spaces
+  you're a member of.
+- **Channel:** multi-user, addressed by `ch_<uuid>`. No `#name`
+  shortcut — use `list_channels_in_all_spaces` (or `list_spaces` +
+  `list_channels_in_space`) to discover.
+- **DM:** one-on-one. Reply by passing `@<slug>` to `send_message`.
 
 ## When to stay silent
 
-If the conversation is between other people and your response isn't
-needed, write `[SILENT]` somewhere in your `assistant.text` — the
-exact spelling matters but its position doesn't. Surrounding prose
-explaining your reasoning is fine. The runtime substring-matches the
-token and posts nothing.
+See "How to reply" above — write `[SILENT]` in your assistant text.
+The exact spelling matters; surrounding prose is fine.
 
 ## Attachments
 
-File attachments are supported. Incoming messages with files arrive
-with a populated `attachments:` field in the metadata block — each
-entry is an absolute path under your workspace
-(``.puffo/inbox/<envelope_id>/<filename>``) where the daemon has
-already decrypted and saved the file for you. Use your `Read` /
-`Bash` tools on those paths directly.
+Incoming files arrive decrypted under
+`.puffo/inbox/<envelope_id>/<filename>` (paths listed in the
+`attachments:` metadata field). Read them with your file tools.
 
-To send files, use `mcp__puffo__send_message_with_attachments` with
-a list of workspace-relative paths. All files in one call ride
-together in a single message envelope (recipients see one bubble
-with N attachments, not N separate messages).
+Send files via `mcp__puffo__send_message_with_attachments` — all
+files in one call ride together as one envelope.
 
 ## Markdown
 
-Message text is delivered verbatim — Markdown formatting in your
-reply is preserved on the wire. The desktop and CLI clients render
-it once they pick up the formatting upgrade currently in flight; if
-your reader doesn't render it yet, the raw Markdown is still
-readable.
+Message text is delivered verbatim. Markdown in your reply is
+preserved on the wire; clients render it as the formatting upgrade
+ships.
 
 ## The `puffo` MCP toolkit
 
 `mcp__puffo__send_message` is your primary reply mechanism (see
-"How to reply" above) — every user-visible message you produce
-goes through it, whether it's a direct response to the incoming
-message or a notification to another channel. The other tools are
-for reading context and managing yourself. See `.claude/skills/`
-for one doc per tool.
+"How to reply"). Other tools read context or manage yourself.
+Skill docs: `.claude/skills/` on claude-code; inline above on
+codex.
 
-**Write / post tools:**
-- `mcp__puffo__send_message(channel, text, is_visible_to_human, root_id="")`
-  — your reply mechanism. Channel may be a `ch_<uuid>` for a
-  channel post or `@<slug>` for a DM. `is_visible_to_human` is
-  required — see "How to reply" above.
-- `mcp__puffo__send_message_with_attachments(paths, channel, is_visible_to_human, caption="", root_id="")`
-  — send one or more files from your workspace. ``paths`` is a
-  list; all files ride together in a single envelope.
-  `is_visible_to_human` is required, same meaning as on
-  `send_message`. ``root_id`` lets you attach inside an existing
-  thread.
+**Write:**
+- `send_message(channel, text, is_visible_to_human, root_id="")`
+- `send_message_with_attachments(paths, channel, is_visible_to_human, caption="", root_id="")`
 
-**Read / discovery tools:**
-- `mcp__puffo__list_spaces()` — every space you are a member of
-  (id + name). The list reflects authoritative server-side
-  permissions, so anything here is a space you can actually
-  send messages into.
-- `mcp__puffo__list_channels_in_space(space_id)` — channels in a
-  single named space. Pair with `list_spaces` for explicit,
-  one-space-at-a-time discovery.
-- `mcp__puffo__list_channels_in_all_spaces()` — channels across
-  every space you're in, grouped by space. One-shot full
-  picture; useful when you don't know which space a channel
-  lives in.
-- `mcp__puffo__list_channel_members(channel)` — slugs + roles.
-- `mcp__puffo__get_channel_history(channel, limit=20, since="", before=0, after=0)`
-  — recent **root posts** in the channel, with the reply count
-  per thread. Replies are NOT inlined; if a thread looks
-  interesting, follow up with `get_thread_history`. Optional
-  filters: ``since=<envelope_id>`` (results after that message),
-  ``after=<ms-epoch>`` / ``before=<ms-epoch>`` (timestamp bounds).
-- `mcp__puffo__get_thread_history(root_id, limit=50, since="", before=0, after=0)`
-  — root post + every reply in a thread, oldest-first. Same
-  ``since`` / ``after`` / ``before`` filter shape as
-  ``get_channel_history``. Use after ``get_channel_history`` shows
-  a thread with a non-zero reply count you want to read into.
-- `mcp__puffo__get_post(post_ref)` — one envelope by id, from the
-  local message store.
-- `mcp__puffo__get_user_info(username)` — slug, display name, bio,
-  avatar URL.
-- `mcp__puffo__fetch_channel_files(channel, limit=20)` — *not yet
-  implemented*; blob query API is pending.
+**Read / discovery:**
+- `list_spaces()` — your space memberships.
+- `list_channels_in_space(space_id)` — channels in one space.
+- `list_channels_in_all_spaces()` — channels across all your spaces,
+  grouped by space.
+- `list_channel_members(channel)` — slugs + roles.
+- `get_channel_history(channel, limit=20, since="", before=0, after=0)`
+  — recent **root posts** + reply counts. Replies NOT inlined.
+- `get_thread_history(root_id, limit=50, since="", before=0, after=0)`
+  — root + every reply, oldest-first.
+- `get_post(post_ref)` — one envelope by id (local store).
+- `get_user_info(username)` — slug, display_name, avatar_url.
+  **Force-refreshes** from puffo-server every call and refreshes the
+  daemon's profile cache. Use when the operator mentions someone
+  renamed themselves or you see a stale name in the prompt.
+- `fetch_channel_files(channel, limit=20)` — not yet implemented.
 
-**Self-management:**
-- `mcp__puffo__reload_system_prompt()` — rebuild your system prompt
-  from disk + restart your claude subprocess so fresh edits to
-  CLAUDE.md / profile / memory take effect on your next message.
-  Conversation history survives via ``--resume``. See the
-  `reload-system-prompt` skill for when to use.
-- `mcp__puffo__refresh(model=None)` — respawn your claude subprocess
-  so it re-discovers skills, MCP servers, and (optionally) switches
-  to a new model.
+**Self-management (claude-code only):**
+- `reload_system_prompt()` — rebuild system prompt from disk +
+  restart subprocess after editing profile/memory/CLAUDE.md.
+- `refresh(model=None)` — respawn subprocess; optional model switch.
+  Valid models: `claude-opus-4-7`, `claude-opus-4-6-1m` (1M
+  context), `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`.
 
-Use the write tools sparingly and with intent — messages you post
-proactively will surprise people. If a user explicitly asked you to
-notify someone, go ahead; if they didn't, ask first. The read tools
-are cheap — reach for them when you need context.
+Use write tools with intent — proactive messages surprise people.
+Read tools are cheap.
 
 ## Your workspace
 
-Your `cwd` is `/workspace` (inside a container) or
-`~/.puffo-agent/agents/<your-id>/workspace/` (on the host). This
-directory survives daemon restarts and, for cli-docker, container
-restarts. Anything outside it may be ephemeral.
+Your `cwd` is `/workspace` (cli-docker) or
+`~/.puffo-agent/agents/<your-id>/workspace/` (cli-local). Survives
+daemon + container restarts. Everything outside may be ephemeral.
 
-Everything under your workspace — including your `.claude/`,
-`memory/`, session transcripts, and cache — is **private to you**.
-Other agents on the same host can't see it.
+Everything under your workspace — `.claude/`, `memory/`, sessions,
+cache — is **private to you**. Other agents on the same host can't
+see it.
+
+**Credentials.** `~/.claude/.credentials.json` and
+`~/.codex/auth.json` are owned by the puffo-agent daemon — single
+writer, agents are read-only. Don't try to refresh them yourself;
+the daemon does it transparently.
 
 ## Shared filesystem for cooperation
 
-There is one exception to per-agent isolation: the **shared dir**,
-where agents on the same host can leave files for each other,
-coordinate on a common codebase, or hand off artifacts.
+One exception to per-agent isolation — the **shared dir** where
+agents on the same host can drop files for each other:
 
-- **Inside a cli-docker container:** mounted at `/workspace/.shared`.
-- **On the host (cli-local, sdk):** available at
-  `~/.puffo-agent/shared/`. The assembled role section below will
-  restate the exact absolute path your daemon uses.
+- cli-docker: `/workspace/.shared`
+- cli-local / sdk: `~/.puffo-agent/shared/` (your role section
+  restates the absolute path)
 
-Treat this like a shared drive: leave a note, drop a file, look for
-others' contributions. Don't assume exclusive access — another agent
-might be touching the same file. Use filenames that identify you
-(e.g. `notes-from-<your-id>.md`) to reduce collisions.
+Treat it as a shared drive — no exclusive access. Use filenames that
+identify you (e.g. `notes-from-<your-id>.md`) to reduce collisions.
 
 ## Memory
 
-A snapshot of your memory is included in this CLAUDE.md. If you need
-to remember something across sessions, write it as markdown into the
-`memory/` directory under your agent root. Memory updates take
-effect on the next worker restart (pause/resume the agent to force).
+A snapshot of your `memory/` is folded into this prompt. To remember
+something across sessions, write markdown to `memory/<topic>.md`
+under your agent root. Updates take effect on the next worker
+restart (pause/resume to force).
 
 ## Your two CLAUDE.md layers (cli-local / cli-docker only)
 
-Claude Code concatenates two files into your system prompt at
-startup:
+**Claude Code agents.** Claude Code concatenates two files into your
+system prompt at startup:
 
-1. **`~/.claude/CLAUDE.md`** — user-level, **managed by puffoagent**.
-   Contains this primer + your `profile.md` role + your `memory/`
-   snapshot. Regenerated every worker start. **Do not edit** — your
-   changes would be overwritten.
+1. **`~/.claude/CLAUDE.md`** — user-level, **managed by puffo-agent**
+   (this primer + `profile.md` + `memory/` snapshot). Regenerated
+   every worker start. **Do not edit** — overwritten.
 
-2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace —
-   project-level, **you own it**. Puffoagent never touches this file
-   after creating (or not creating) it. Edit it freely to add live
-   notes, durable facts about the project you're working on,
-   personal reminders, or anything you want to surface in your next
-   system prompt. It persists across restarts.
+2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace
+   — project-level, **you own it**. puffo-agent never touches it.
+   Edit freely for live notes, project facts, reminders. Persists
+   across restarts.
 
-Use layer 2 for fast "write-to-prompt" loops — no round trip through
-`memory/` required. Use `memory/*.md` (which folds into layer 1 on
-restart) when you want the content clearly labelled as memory rather
-than project notes. Both work.
+Use layer 2 for fast "write-to-prompt" loops. Use `memory/*.md`
+(folds into layer 1 on restart) when you want content labelled as
+memory.
 
-If you run as the `sdk` adapter, you only see layer 1 — `sdk` doesn't
-auto-discover project CLAUDE.md files. Write to `memory/*.md` if you
-want persistence.
+`sdk` adapter only sees layer 1 — write to `memory/*.md` for
+persistence.
+
+**Codex agents.** Equivalent of layer 1 is `$CODEX_HOME/AGENTS.md`
+(auto-rebuilt by the daemon on worker start, same shape: primer +
+profile + memory). No project-level layer 2; everything goes through
+`memory/*.md`. No `.skills/` directory either — skill docs live
+inline in this primer.
 
 ## Permission prompts (cli-local only)
 
-If you are running in `cli-local` mode, any tool invocation that
-isn't pre-approved goes through a permission prompt that is posted
-to your human owner's DM. The owner replies `y` / `n` within a few
-minutes; if they don't, the request is denied and you'll see a
-`permission request timed out` error. Plan for this latency — don't
-chain many permission-requiring tool calls if the user seems
-inattentive.
+In `cli-local` + `claude-code`, any tool invocation that isn't
+pre-approved is DM'd to your operator. Reply `y` / `n` within a few
+minutes; otherwise the request is denied with
+`permission request timed out`. Don't chain many permission-
+requiring calls if the operator seems inattentive.
+
+Codex on cli-local bypasses this — all tools are auto-approved at
+the daemon-trust level.
 """
 
 
@@ -379,55 +275,51 @@ Post a message to a Puffo.ai channel or DM a user.
 **Tool:** `mcp__puffo__send_message`
 
 **Arguments:**
-- `channel` (required) — one of:
-  - `"@<slug>"` to DM a user (e.g. `"@alice-1234"`)
-  - a raw channel id (`"ch_<uuid>"`) for a channel post
-  - the `#<name>` shortcut is **not** supported; call
-    `list_channels_in_all_spaces` to look up an id.
-- `text` (required) — message body. Markdown is preserved on the
-  wire; the client will render it when the formatting upgrade ships.
-- `is_visible_to_human` (required) — bool, no default. `true` for
-  anything a human should read — the right choice for replies,
-  status updates, and operator pings. `false` only for
-  agent-to-agent chatter a human watching the channel would find
-  pure noise. Human clients fold runs of `false` messages behind
-  a placeholder; they are still delivered, searchable, and
-  visible to other agents. When in doubt, `true`. **`false` only
-  takes effect on threaded replies** (with `root_id`) — on a
-  root-level message it's ignored, coerced to visible, and the
-  tool response says so.
+- `channel` (required) — `"@<slug>"` for a DM, `"ch_<uuid>"` for a
+  channel. No `#<name>` shortcut; use `list_channels_in_all_spaces`
+  to look up an id.
+- `text` (required) — message body. Markdown preserved on the wire.
+- `is_visible_to_human` (required) — bool, no default:
+  - `true` — anything a human should read (replies, status updates,
+    operator pings). Default choice; when in doubt, `true`.
+  - `false` — agent-to-agent chatter humans would find noise. Only
+    effective on threaded replies (`root_id` set); on root-level
+    posts it's ignored and coerced to visible.
 - `root_id` (optional) — envelope_id (`env_<uuid>`) of the post you
   are replying to; opens a thread.
 
+**Cache-validation invariant (PUF-227-A):** the daemon verifies
+your `root_id` points to a parent envelope in your local message
+store AND in the same channel/space as your outbound. If not, it
+wipes `root_id` to null + returns a warning note in the tool
+response. Always pass the **true thread root** (the metadata's
+`thread_root_id`), not an arbitrary reply id. Don't carry `root_id`
+across channel switches.
+
 **When to use:**
-- **Every user-visible reply.** Including the obvious "answer the
-  message I just received" case — pass the incoming metadata's
-  `channel_id` as `channel` and `thread_root_id` as `root_id` to
-  reply in the same thread.
-- Notifying a different channel in the same turn — call it again
-  with the other channel id.
-- DMing a user the operator asked you to ping.
+- Every user-visible reply — pass the metadata's `channel_id` and
+  `thread_root_id`.
+- Notifying a different channel in the same turn (call multiple
+  times).
+- DMing someone the operator asked you to ping.
 
 **When NOT to use:**
-- When you genuinely don't want to reply — write `[SILENT]` in
-  your assistant text instead.
-- Spontaneous cross-posting the operator didn't request — be
-  conservative; messages you push proactively will surprise people.
+- No reply needed — write `[SILENT]` in your assistant text.
+- Spontaneous cross-posts the operator didn't request.
 
-**Example — replying to the message that triggered the turn:**
+**Examples:**
 
 ```
+# Reply to the triggering message:
 send_message(channel="ch_b3c4d5e6-...",
              text="Got it; running the migration now.",
              is_visible_to_human=True,
              root_id="env_abcdef-...")
-```
 
-**Example — proactive notifications:**
-
-```
-send_message(channel="@alice-1234", text="Heads up — your build finished.", is_visible_to_human=True)
-send_message(channel="ch_b3c4d5e6-...", text="Daily: shipped X, in progress Y.", is_visible_to_human=True)
+# Proactive notification:
+send_message(channel="@alice-1234",
+             text="Heads up — build done.",
+             is_visible_to_human=True)
 ```
 """
 
@@ -649,29 +541,30 @@ the daemon started won't be found and you'll get
 DEFAULT_SKILL_GET_USER_INFO = """\
 # Skill: get_user_info
 
-Look up a user by puffo-core slug.
+Look up a user by puffo-core slug. **Always fetches fresh from
+puffo-server** (bypasses the daemon's 10-min profile cache) and
+refreshes that cache so the next render uses the new values.
 
 **Tool:** `mcp__puffo__get_user_info`
 
 **Arguments:**
 - `username` (required) — slug, with or without leading `@`. Slugs
-  are unique on puffo-core (the server appends a 4-hex suffix on
-  signup), so a single lookup either resolves or returns
-  `(no profile for <slug>)`.
+  are unique on puffo-core (4-hex suffix appended on signup);
+  single lookup resolves or returns `(no profile for <slug>)`.
 
-**Output:** slug, display name, bio, avatar URL when set. puffo-core
-has no `is_bot` flag yet — if you need to distinguish, check the
-slug pattern (agents typically end in `-<4hex>`).
+**Output:** slug, display_name, bio, avatar_url when set. No
+`is_bot` flag — check the slug pattern (agents end in `-<4hex>`).
 
 **When to use:**
-- You want to DM someone but want to confirm the slug is right
-  before sending.
-- A human refers to "tell alice" and you have multiple `alice-*`
-  slugs in this conversation; this lets you pick the right one.
+- The operator says someone renamed themselves or changed avatar —
+  call this to pin the fresh values into your prompt cache for
+  subsequent renders.
+- You want to DM someone and want to verify the slug.
+- Multiple `alice-*` slugs in this conversation; pick the right one.
 
-**Note:** mentions already in the current message are pre-resolved
-for you in the `mentions:` block of the user message preamble —
-don't re-look-up the same slugs in a loop.
+**Note:** mentions in the current message are pre-resolved in the
+`mentions:` metadata block — don't re-look-up in a loop. The cache
+has a 10-min TTL so repeated calls inside that window are stable.
 """
 
 

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -272,3 +272,39 @@ class DataClient:
                 "data-service: get_message_by_envelope transport: %s", exc,
             )
             return None
+
+    async def update_profile_cache(
+        self, slug: str, display_name: str, avatar_url: str,
+    ) -> None:
+        """Push fresh ``display_name`` + ``avatar_url`` into the
+        daemon's in-memory profile cache for this agent's view.
+        Called by the MCP ``get_user_info`` tool right after its
+        ``/identities/profiles`` round-trip so the daemon's render
+        path sees the new values immediately. Best-effort — transport
+        failures log + drop (next render gets the values when the
+        TTL'd cache expires anyway).
+        """
+        if not slug:
+            return
+        path = (
+            f"/v1/data/{urllib.parse.quote(self.agent_id, safe='')}"
+            f"/profile-cache"
+        )
+        body = {
+            "slug": slug,
+            "display_name": display_name,
+            "avatar_url": avatar_url,
+        }
+        session = await self._get_session()
+        try:
+            async with session.post(f"{self.base_url}{path}", json=body) as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    logger.warning(
+                        "data-service: update_profile_cache %s -> %d %s",
+                        path, resp.status, text,
+                    )
+        except aiohttp.ClientError as exc:
+            logger.warning(
+                "data-service: update_profile_cache transport: %s", exc,
+            )

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -695,6 +695,11 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     async def get_user_info(username: str) -> str:
         """Look up a user by slug or @-handle.
         Returns slug, display name, bio, and avatar URL when set.
+
+        Always fetches fresh from puffo-server (bypasses the daemon's
+        TTL'd profile cache) and writes the result back to that cache
+        so the next inbound message renders with the new values.
+        Use this when the operator says someone renamed themselves.
         """
         slug = (username or "").lstrip("@").strip()
         if not slug:
@@ -709,13 +714,32 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         if not profiles:
             return f"(no profile for {slug})"
         p = profiles[0]
+        # Server returns ``display_name`` (was previously read as
+        # ``username`` here, which silently dropped the field for
+        # every lookup — the line was never printed).
+        display_name = (p.get("display_name") or "").strip()
+        avatar_url = (p.get("avatar_url") or "").strip()
+        bio = (p.get("bio") or "").strip()
+        # Push the just-fetched values into the daemon's profile
+        # cache for this agent's view so the next render of an
+        # inbound message uses the fresh display_name + avatar
+        # instead of waiting for the TTL to expire.
+        try:
+            await cfg.data_client.update_profile_cache(
+                slug, display_name, avatar_url,
+            )
+        except Exception as exc:
+            logger.warning(
+                "get_user_info: failed to refresh daemon cache for %s: %s",
+                slug, exc,
+            )
         lines = [f"slug: {p.get('slug', slug)}"]
-        if p.get("username"):
-            lines.append(f"display: {p['username']}")
-        if p.get("bio"):
-            lines.append(f"bio: {p['bio']}")
-        if p.get("avatar_url"):
-            lines.append(f"avatar: {p['avatar_url']}")
+        if display_name:
+            lines.append(f"display_name: {display_name}")
+        if bio:
+            lines.append(f"bio: {bio}")
+        if avatar_url:
+            lines.append(f"avatar_url: {avatar_url}")
         return "\n".join(lines)
 
     @mcp.tool()

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -436,10 +436,13 @@ async def update_runtime(request: web.Request) -> web.Response:
     """Patch the agent's runtime block. Owner-only.
 
     Accepts any subset of: ``kind``, ``provider``, ``model``,
-    ``api_key``, ``permission_mode``, ``allowed_tools``,
+    ``harness``, ``api_key``, ``permission_mode``, ``allowed_tools``,
     ``docker_image``, ``max_turns``. Missing fields are untouched.
-    ``harness`` is intentionally not editable here — switching
-    harness usually requires host-level auth setup too.
+    ``harness`` editing requires the corresponding CLI to already be
+    installed + authenticated on the host (`claude login` /
+    `codex login` / ...) — the worker will hit auth_failed on first
+    turn otherwise. validate_triple below catches kind/provider/
+    harness combo violations before save.
 
     The reconcile loop notices ``runtime`` changed and respawns the
     worker on its next tick.
@@ -465,11 +468,12 @@ async def update_runtime(request: web.Request) -> web.Response:
     cfg = AgentConfig.load(agent_id)
     rt = cfg.runtime
 
-    # ``harness`` is excluded by design.
     if "kind" in payload:
         rt.kind = str(payload["kind"])
     if "provider" in payload:
         rt.provider = str(payload["provider"])
+    if "harness" in payload:
+        rt.harness = str(payload["harness"])
     if "model" in payload:
         rt.model = str(payload["model"])
     if "api_key" in payload:

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -267,6 +267,7 @@ async def list_agents(request: web.Request) -> web.Response:
             "state": cfg.state,
             "runtime_kind": cfg.runtime.kind,
             "runtime_harness": cfg.runtime.harness,
+            "runtime_model": cfg.runtime.model,
             "runtime_status": rs_status,
             "runtime_health": rs.health if rs else "unknown",
             "msg_count": rs.msg_count if rs else 0,

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -266,6 +266,7 @@ async def list_agents(request: web.Request) -> web.Response:
             "profile_summary": _profile_summary(cfg),
             "state": cfg.state,
             "runtime_kind": cfg.runtime.kind,
+            "runtime_harness": cfg.runtime.harness,
             "runtime_status": rs_status,
             "runtime_health": rs.health if rs else "unknown",
             "msg_count": rs.msg_count if rs else 0,

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -26,7 +26,7 @@ from .credential_refresh import (
     FileBackend,
     KeychainBackend,
 )
-from .data_service import start_data_service, stop_data_service
+from .data_service import set_profile_setter, start_data_service, stop_data_service
 from .state import (
     AgentConfig,
     DaemonConfig,
@@ -99,6 +99,11 @@ class Daemon:
         # Start auxiliary HTTP services. Both are non-fatal on bind
         # failure — the daemon's primary job is still running agents.
         api_runner = await start_api_server(self.daemon_cfg.bridge)
+        # Wire the data-service profile-cache writer to find the
+        # right worker by agent_id. ``Worker.set_profile_cache`` is a
+        # no-op before warm() finishes, so a race during partial
+        # startup is safe.
+        set_profile_setter(self._set_worker_profile_cache)
         data_runner = await start_data_service(self.daemon_cfg.data_service)
         refresher_task = asyncio.ensure_future(
             self.refresher.run_loop(self._stop)
@@ -145,6 +150,7 @@ class Daemon:
                 except (asyncio.CancelledError, Exception):
                     pass
             await stop_api_server(api_runner)
+            set_profile_setter(None)
             await stop_data_service(data_runner)
             clear_daemon_pid()
             clear_stop_request()
@@ -260,6 +266,20 @@ class Daemon:
 
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
         return self._refresher_for(agent_cfg).notify_refresh_needed
+
+    def _set_worker_profile_cache(
+        self, agent_id: str, slug: str, display_name: str, avatar_url: str,
+    ) -> None:
+        """Data-service shim — find the worker for ``agent_id`` and
+        inject fresh profile values into its in-memory cache. Called
+        from the data service's POST profile-cache route, which the
+        MCP ``get_user_info`` tool hits right after fetching from
+        puffo-server. Silently no-ops when the worker is gone (agent
+        stopped between the tool's fetch and the POST)."""
+        worker = self.workers.get(agent_id)
+        if worker is None:
+            return
+        worker.set_profile_cache(slug, display_name, avatar_url)
 
     async def _stop_worker(self, agent_id: str) -> None:
         worker = self.workers.pop(agent_id, None)

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable, Optional
 
 from aiohttp import web
 
@@ -27,6 +27,25 @@ class DataServiceConfig:
     enabled: bool = True
     bind_host: str = "127.0.0.1"
     port: int = 63386
+
+
+# Set by the daemon at startup so the new POST profile-cache route
+# can reach back into the running PuffoCoreMessageClient. Module-
+# level (not stored on the App) because the build_app signature is
+# locked by aiohttp's pluggable-config story and the alternative
+# (custom AppKey) doesn't buy us anything beyond a wrapper.
+_PROFILE_SETTER: Optional[Callable[[str, str, str, str], None]] = None
+
+
+def set_profile_setter(
+    fn: Optional[Callable[[str, str, str, str], None]],
+) -> None:
+    """Daemon-side hook. ``fn(agent_id, slug, display_name, avatar_url)``
+    is called by the POST profile-cache route to inject MCP-tool-fresh
+    values into the agent's in-memory cache. ``None`` clears the hook
+    (used by tests + on shutdown)."""
+    global _PROFILE_SETTER
+    _PROFILE_SETTER = fn
 
 
 @dataclass
@@ -288,6 +307,51 @@ def _msg_to_dict(m: Any) -> dict[str, Any]:
     }
 
 
+async def update_profile_cache(request: web.Request) -> web.Response:
+    """POST {slug, display_name, avatar_url} — inject fresh values
+    into the agent's in-memory ``_profile_cache``. Body shape::
+
+        {"slug": "alice-0001", "display_name": "Alice", "avatar_url": "..."}
+
+    Called by the MCP ``get_user_info`` tool right after its
+    ``/identities/profiles`` fetch so the daemon's render path picks
+    up the new values immediately instead of waiting for the TTL.
+    No-op (200) when the daemon hasn't wired the setter — keeps the
+    tool resilient against partial-startup states. 400 on malformed
+    body."""
+    agent_id = request.match_info["agent_id"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "body must be JSON"}, status=400)
+    if not isinstance(body, dict):
+        return web.json_response({"error": "body must be a JSON object"}, status=400)
+    slug = str(body.get("slug") or "")
+    if not slug:
+        return web.json_response({"error": "slug is required"}, status=400)
+    display_name = str(body.get("display_name") or "")
+    avatar_url = str(body.get("avatar_url") or "")
+    setter = _PROFILE_SETTER
+    if setter is None:
+        logger.debug(
+            "data-service: profile-cache write for agent=%s slug=%s "
+            "skipped — setter not wired (daemon partial startup?)",
+            agent_id, slug,
+        )
+        return web.json_response({"ok": True, "note": "setter not wired"})
+    try:
+        setter(agent_id, slug, display_name, avatar_url)
+    except Exception as exc:
+        logger.exception(
+            "data-service: profile-cache setter raised for agent=%s slug=%s: %s",
+            agent_id, slug, exc,
+        )
+        return web.json_response(
+            {"error": f"setter raised: {exc}"}, status=500,
+        )
+    return web.json_response({"ok": True})
+
+
 # ── Lifecycle ────────────────────────────────────────────────────
 
 
@@ -313,6 +377,10 @@ def build_app(cfg: DataServiceConfig) -> web.Application:
     app.router.add_get(
         "/v1/data/{agent_id}/messages/{envelope_id}",
         get_message_by_envelope,
+    )
+    app.router.add_post(
+        "/v1/data/{agent_id}/profile-cache",
+        update_profile_cache,
     )
     app.on_shutdown.append(_close_all_stores)
     return app

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -559,6 +559,18 @@ class Worker:
         except asyncio.TimeoutError:
             return False
 
+    def set_profile_cache(
+        self, slug: str, display_name: str, avatar_url: str,
+    ) -> None:
+        """Cross-process bridge for the MCP ``get_user_info`` tool —
+        the subprocess fetches fresh from puffo-server then POSTs the
+        result here via the data service, so the next daemon render
+        sees the fresh display_name + avatar without waiting for the
+        TTL. No-op until the worker's PuffoCoreMessageClient has been
+        constructed (warm() hasn't completed yet)."""
+        if self._client is not None:
+            self._client.set_profile(slug, display_name, avatar_url)
+
     async def stop(self) -> None:
         self._stop.set()
         if self._task is not None:

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -773,7 +773,10 @@ async def test_get_user_info():
     http.responses["/identities/profiles?slugs=alice-0001"] = {
         "profiles": [{
             "slug": "alice-0001",
-            "username": "Alice",
+            # Server returns ``display_name`` (was previously
+            # ``username`` in this fixture, mirroring a bug in
+            # the production tool — both were fixed together).
+            "display_name": "Alice",
             "bio": "A test user",
             "avatar_url": None,
             "profile_updated_at": 1700000000000,


### PR DESCRIPTION
## Summary

Two related bridge-API gaps that block the web client from showing + switching agent harness:

1. **`runtime_harness` exposed on `/v1/agents` summary.** The summary previously only carried `runtime_kind`, so the My-Agents grid couldn't distinguish codex from claude-code on the cli-local path without fetching the full detail per card. Adds `cfg.runtime.harness` to the items dict.

2. **`harness` editable on `PATCH /v1/agents/<id>/runtime`.** The endpoint previously rejected the `harness` key with an "intentionally not editable here" comment — operators had to use the CLI or edit `agent.yml` directly. Web PR puffo-core-han-group#130 gains a harness dropdown in the agent edit form; this PR is the bridge half. `validate_triple` continues to enforce kind/provider/harness combo correctness.

## Why

Surfaced by puffo-core-han-group PR #130 (web). The grid card labelled every cli-local agent as "Claude Code · local" because no harness data was available client-side. The user-facing scenario for editing is "I created this as Claude Code, want to switch to Codex without recreating the agent."

## Compatibility

- Older web clients that don't read `runtime_harness` are unaffected — unknown JSON keys are ignored.
- Older web clients that don't send `harness` in the patch are unaffected — the field is optional in the payload.
- Switching harness requires the corresponding host CLI to already be installed + authenticated (`claude login` / `codex login`); worker surfaces `auth_failed` health on first turn if missing. setup.md (web public/) now documents both auth flows.

## Tests

- Full suite: **792 passed / 9 skipped / 0 failed**.
- No new tests: the runtime_matrix.validate_triple combinatorics are already covered by existing tests (`test_runtime_matrix.py`), and no existing test asserted the summary endpoint's exact shape.

## Versioning

Lands on the existing `0.9.1` line. CHANGELOG entry under `### Added` in the same section as PUF-227-A.