### PR TITLE
macOS credential refresh: mirror FileBackend, drop sandbox HOME

### DIFF
--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -22,10 +22,7 @@ import shutil
 import time
 from pathlib import Path
 
-from ...macos.keychain import (
-    is_macos,
-    shim_dir,
-)
+from ...macos.keychain import is_macos
 from ...mcp.config import (
     default_python_executable,
     write_cli_mcp_config,
@@ -345,32 +342,20 @@ class LocalCLIAdapter(Adapter):
           (which the daemon's ``KeychainBackend.sync_to_agent`` keeps
           fresh) rather than racing the operator's main CLI for the
           Keychain entry.
-        - ``PATH`` is prepended with the security-shim dir so the
-          buggy ``security delete-generic-password`` call from Claude
-          Code issue #37512 is intercepted before it can flush the
-          operator's main CLI auth.
 
         Deliberately does NOT set ``CLAUDE_CODE_OAUTH_TOKEN`` — that
-        env var triggers the same fallback-combiner cleanup path that
-        deletes the Keychain entry. We let claude read its token
-        from the per-agent ``.credentials.json`` like normal.
+        env var triggers the fallback-combiner cleanup path from Claude
+        Code issue #37512 that deletes the Keychain entry. We let
+        claude read its token from the per-agent ``.credentials.json``
+        like normal.
 
         Returns ``{}`` on non-macOS so the Linux/Windows spawn env is
         unchanged.
         """
         if not is_macos():
             return {}
-        # Just compute the shim path — ``KeychainBackend.bootstrap()``
-        # installed the actual script once at daemon start
-        # (credential_refresh.py → keychain.install_path_shim).
-        # Re-installing on every adapter spawn would be wasted I/O
-        # and would race on the same file path when two workers spawn
-        # concurrently.
-        shim_path = shim_dir(home_dir())
-        existing_path = os.environ.get("PATH", "")
         return {
             "CLAUDE_CONFIG_DIR": str(Path(self.agent_home_dir) / ".claude"),
-            "PATH": f"{shim_path}{os.pathsep}{existing_path}",
         }
 
     def _permission_hook_env(self) -> dict[str, str]:

--- a/src/puffo_agent/macos/__init__.py
+++ b/src/puffo_agent/macos/__init__.py
@@ -2,24 +2,19 @@
 
 The async ``CredentialRefresher`` lifecycle is platform-agnostic and
 lives in ``puffo_agent.portal.credential_refresh``; this package owns
-the macOS storage primitives (Keychain read/write, PATH shim,
-credential cache, refresh oneshot) it delegates to via
-``KeychainBackend``.
+the macOS storage primitives (Keychain read/write, credential cache)
+it delegates to via ``KeychainBackend``.
 """
 
 from .keychain import (
     CACHE_FILENAME,
     KEYCHAIN_POLL_INTERVAL_SECONDS,
     KEYCHAIN_SERVICE,
-    SHIM_FILENAME,
     CredentialCache,
     KeychainReadResult,
     bootstrap_from_keychain,
-    install_path_shim,
     is_macos,
     read_keychain_blob,
-    refresh_via_oneshot,
-    shim_dir,
     writeback_to_keychain,
 )
 
@@ -27,14 +22,10 @@ __all__ = [
     "CACHE_FILENAME",
     "KEYCHAIN_POLL_INTERVAL_SECONDS",
     "KEYCHAIN_SERVICE",
-    "SHIM_FILENAME",
     "CredentialCache",
     "KeychainReadResult",
     "bootstrap_from_keychain",
-    "install_path_shim",
     "is_macos",
     "read_keychain_blob",
-    "refresh_via_oneshot",
-    "shim_dir",
     "writeback_to_keychain",
 ]

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -334,6 +334,16 @@ async def refresh_via_oneshot(
 
     Returns (ok, reason_when_not_ok).
 
+    A non-zero claude exit code is **not** by itself a hard failure:
+    claude may rotate the OAuth token successfully (writing the new blob
+    to ``.credentials.json``) and then exit non-zero from a later,
+    unrelated step. Dropping the new blob in that case strands the user
+    with the prior refresh_token, which Anthropic has already
+    invalidated — main CLI then can't recover without ``claude login``.
+    So we always inspect the sandbox file after the process exits: if
+    it contains a rotated access_token, we accept it and report
+    ``"token_refreshed_rc=N"`` so the non-zero exit stays visible.
+
     ⚠️ **Keep in sync with** ``portal.diagnostic._run_sandboxed_claude_oneshot``:
     that probe is a sync mirror of this function so the diagnostic
     can run without an asyncio event loop. Any env / arg change here
@@ -369,22 +379,37 @@ async def refresh_via_oneshot(
         # mode would bypass storage entirely.
         rc, err = await _run_claude_oneshot(env, str(sandbox_path), timeout=timeout)
         if rc is None:
+            # Spawn/timeout — no sandbox state to salvage.
             return (False, err)
-        if rc != 0:
-            return (False, f"claude_exit_code={rc}")
 
+        # Always read sandbox creds, regardless of rc. Parse failures
+        # only matter as a fallback signal when rc != 0.
         try:
             refreshed = sandbox_creds.read_text(encoding="utf-8")
         except FileNotFoundError:
+            if rc != 0:
+                return (False, f"claude_exit_code={rc}")
             return (False, "refreshed_credentials_missing")
         try:
             new_token = (
                 (json.loads(refreshed).get("claudeAiOauth") or {}).get("accessToken")
             ) or ""
         except json.JSONDecodeError:
+            if rc != 0:
+                return (False, f"claude_exit_code={rc}")
             return (False, "refreshed_credentials_unparseable")
 
+        rotated = bool(new_token) and old_token != new_token
+
+        # rc != 0 with no rotation: real failure, nothing to salvage.
+        if rc != 0 and not rotated:
+            return (False, f"claude_exit_code={rc}")
+
         cache.write(refreshed)
-        if old_token and new_token and old_token == new_token:
+        if rc != 0:
+            # Salvage path: keep the rotation, surface the rc so the
+            # caller can log + investigate the non-zero exit separately.
+            return (True, f"token_refreshed_rc={rc}")
+        if not rotated:
             return (True, "token_unchanged")
         return (True, "token_refreshed")

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -205,12 +205,30 @@ class CredentialCache:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def bootstrap_from_keychain(cache: CredentialCache) -> tuple[bool, Optional[str]]:
-    """Materialise the cache from the Keychain if the cache is missing
-    or empty. Returns (ok, reason_when_not_ok)."""
-    if cache.exists() and cache.access_token():
-        return (True, "cache_already_warm")
+    """Materialise the cache from the Keychain on daemon start.
+
+    Always reads Keychain — Keychain is canonical, and while the daemon
+    was stopped the user (or anything else with the user's UID +
+    signing identity) may have rotated the token via interactive
+    ``claude /login``, the main CLI's own refresh-on-expiry, a VS Code
+    plugin write, etc. A warm-cache short-circuit here previously
+    caused the daemon to start with a stale RT, sync that stale RT to
+    every agent's per-agent ``.credentials.json``, and then the
+    spawned claude subprocesses immediately 401'd on Anthropic until
+    the auth-error wake-up eventually pulled the current token from
+    Keychain. The one extra ``security`` call per daemon start is
+    cheap insurance against that startup race.
+
+    If Keychain read fails *and* the cache still has a token, fall
+    back to the cache so the daemon at least limps along (the 5-min
+    external-rotation poll will keep trying Keychain).
+
+    Returns ``(ok, reason_when_not_ok)``.
+    """
     read = read_keychain_blob()
-    if not read.ok:
-        return (False, read.error)
-    cache.write(read.blob)
-    return (True, "bootstrapped")
+    if read.ok and read.blob:
+        cache.write(read.blob)
+        return (True, "bootstrapped")
+    if cache.exists() and cache.access_token():
+        return (True, f"keychain_read_failed_fell_back_to_cache: {read.error}")
+    return (False, read.error)

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -2,9 +2,21 @@
 
 Claude Code 2.x stores its OAuth token in the system Keychain
 (``"Claude Code-credentials"``). Per-agent ``$HOME`` overrides don't
-isolate Keychain access (Keychain ACL is keyed by user UID + signing
-identity, not by HOME), so the host's claude binary running under a
-puffo-agent worker can trigger an ACL re-prompt every spawn.
+isolate Keychain ACL access (Keychain ACL is keyed by user UID +
+signing identity, not by HOME), so the host's claude binary running
+under a puffo-agent worker can trigger an ACL re-prompt every spawn.
+
+BUT — and this caught us in production — HOME *does* affect the
+``security`` CLI's lookup of the user's login keychain file. The CLI
+constructs ``$HOME/Library/Keychains/login.keychain-db`` to find the
+default keychain. With a sandbox HOME and no such path, ``security``
+fires the ``loginKC:queryCreate`` authorization mechanism asking the
+user to create a brand-new login keychain. Users almost always dismiss
+that dialog, the keychain write fails, claude exits non-zero, and any
+freshly-rotated OAuth tokens are lost in flight (Anthropic has already
+invalidated the prior refresh_token by that point). The fix in this
+module: ``_stage_keychain_visibility`` symlinks the real
+``~/Library/Keychains`` into the sandbox HOME before claude runs.
 
 Also: GitHub issue anthropics/claude-code#37512 documents that setting
 ``CLAUDE_CODE_OAUTH_TOKEN`` causes the CLI to silently
@@ -179,6 +191,33 @@ fi
 
 exec "$REAL" "$@"
 """
+
+
+def _stage_keychain_visibility(sandbox: Path) -> Optional[str]:
+    """Symlink the user's ``~/Library/Keychains`` into the sandbox HOME
+    so the ``security`` CLI (and anything else doing
+    ``$HOME``-relative keychain lookup) reaches the real login keychain
+    instead of firing the ``loginKC:queryCreate`` authorization dialog.
+
+    See module docstring for the full incident description. Returns
+    ``None`` on success, or a short reason string on best-effort
+    failure — the refresh attempt still proceeds since claude *may*
+    succeed via the framework path even without this staging.
+    """
+    real_keychains = Path.home() / "Library" / "Keychains"
+    if not real_keychains.exists():
+        return "real_keychains_missing"
+    try:
+        sandbox_library = sandbox / "Library"
+        sandbox_library.mkdir(parents=True, exist_ok=True)
+        target = sandbox_library / "Keychains"
+        # Idempotent: a prior call already linked it.
+        if target.is_symlink() or target.exists():
+            return None
+        os.symlink(real_keychains, target)
+    except OSError as exc:
+        return f"symlink_failed: {exc}"
+    return None
 
 
 def shim_dir(home: Path) -> Path:
@@ -365,6 +404,14 @@ async def refresh_via_oneshot(
         sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
         sandbox_creds = sandbox_claude_dir / ".credentials.json"
         sandbox_creds.write_text(blob, encoding="utf-8")
+
+        stage_err = _stage_keychain_visibility(sandbox_path)
+        if stage_err is not None:
+            logger.info(
+                "refresh sandbox: keychain visibility staging skipped "
+                "(%s); claude may still succeed via framework path",
+                stage_err,
+            )
 
         env = {
             **os.environ,

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -1,60 +1,49 @@
 """macOS Keychain primitives for Claude Code OAuth credentials.
 
 Claude Code 2.x stores its OAuth token in the system Keychain
-(``"Claude Code-credentials"``). Per-agent ``$HOME`` overrides don't
-isolate Keychain ACL access (Keychain ACL is keyed by user UID +
-signing identity, not by HOME), so the host's claude binary running
-under a puffo-agent worker can trigger an ACL re-prompt every spawn.
-
-BUT — and this caught us in production — HOME *does* affect the
-``security`` CLI's lookup of the user's login keychain file. The CLI
-constructs ``$HOME/Library/Keychains/login.keychain-db`` to find the
-default keychain. With a sandbox HOME and no such path, ``security``
-fires the ``loginKC:queryCreate`` authorization mechanism asking the
-user to create a brand-new login keychain. Users almost always dismiss
-that dialog, the keychain write fails, claude exits non-zero, and any
-freshly-rotated OAuth tokens are lost in flight (Anthropic has already
-invalidated the prior refresh_token by that point). The fix in this
-module: ``_stage_keychain_visibility`` symlinks the real
-``~/Library/Keychains`` into the sandbox HOME before claude runs.
-
-Also: GitHub issue anthropics/claude-code#37512 documents that setting
-``CLAUDE_CODE_OAUTH_TOKEN`` causes the CLI to silently
-``security delete-generic-password "Claude Code-credentials"`` on exit
-via its fallback-combiner cleanup path — which kicks the user's main
-CLI / VS Code extension off. Anthropic did not fix it; the issue auto-
-closed in April 2026.
+(``"Claude Code-credentials"``). The Keychain is the canonical store on
+macOS; the daemon-side ``KeychainBackend`` (in
+``portal/credential_refresh.py``) just reads it for expiry inspection,
+triggers refresh by running ``claude --print ok`` exactly the way an
+interactive user does, and maintains an on-disk cache so each agent can
+read a per-agent ``.credentials.json`` without round-tripping through
+``security`` every read.
 
 This module provides the storage primitives only:
 
   - **Keychain read / write** via the ``security`` CLI.
-  - **PATH shim** that intercepts the buggy delete-generic-password
-    call from issue #37512.
   - **CredentialCache** — atomic-write JSON blob to
     ``~/.puffo-agent/run/claude-credentials.json``, daemon-owned.
   - **Bootstrap** — populate the cache from Keychain on first call.
-  - **Refresh oneshot** — run a sandboxed ``claude --print`` so claude
-    rotates the token and writes the new blob back to the cache.
 
-The async ``CredentialRefresher`` lifecycle (poll loop, agent fan-out,
-401-wake) lives in ``portal/credential_refresh.py`` and delegates here
-via the ``KeychainBackend`` adapter — this module stays
-synchronous-primitive-only so it's straightforward to unit-test off
-macOS.
+Refresh itself is *not* in this module. The previous design ran claude
+in a sandboxed ``$HOME`` with a forged ``.credentials.json`` seeded
+from the cache, then copied the resulting blob back; in production that
+turned out to be brittle: claude on macOS deleted the sandbox creds
+file on exit before flushing the rotated blob, sandboxing HOME caused
+``security`` to fire ``loginKC:queryCreate`` authorization prompts, and
+the only outcome was burning Anthropic refresh-tokens that we then
+couldn't capture. The current design runs claude with the user's real
+``$HOME`` (identical to the FileBackend on Linux/Windows) so claude's
+own refresh path writes straight to Keychain, exactly the way the user
+running ``claude`` interactively expects. The daemon picks the
+rotation up via cache expiry inspection and propagates it to agents.
+
+GitHub issue anthropics/claude-code#37512 documented that setting
+``CLAUDE_CODE_OAUTH_TOKEN`` caused the CLI to silently
+``security delete-generic-password "Claude Code-credentials"`` on exit
+via its fallback-combiner cleanup path. We never set that env var, and
+the real-HOME refresh path doesn't either, so the bug doesn't apply.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
 import platform
-import shutil
 import stat
 import subprocess
-import tempfile
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -67,20 +56,11 @@ logger = logging.getLogger(__name__)
 # #37512 and reproducible with ``security dump-keychain | grep``.
 KEYCHAIN_SERVICE = "Claude Code-credentials"
 
-# File names — picked deliberately short + obvious.
+# File name for the cache JSON blob — picked deliberately short + obvious.
 CACHE_FILENAME = "claude-credentials.json"
-SHIM_FILENAME = "security"
-
-# Refresh every 6h. Claude Code OAuth access tokens TTL is 8h, so the
-# 2h margin means a slow / failed refresh has a retry before tokens
-# actually expire.
-REFRESH_INTERVAL_SECONDS = 6 * 3600
 
 # How long we wait for a single ``security`` invocation.
 SECURITY_TIMEOUT_SECONDS = 60
-
-# Refresh oneshot timeout.
-REFRESH_ONESHOT_TIMEOUT_SECONDS = 90
 
 # How often the Keychain-poll loop wakes to detect tokens rotated by
 # OTHER processes (operator's main CLI, an agent's own claude
@@ -139,7 +119,12 @@ def read_keychain_blob(timeout: float = SECURITY_TIMEOUT_SECONDS) -> KeychainRea
 def writeback_to_keychain(
     blob: str, timeout: float = SECURITY_TIMEOUT_SECONDS,
 ) -> tuple[bool, Optional[str]]:
-    """Upsert the JSON blob into the Keychain entry. Best-effort."""
+    """Upsert the JSON blob into the Keychain entry. Best-effort.
+
+    Only used by external-rotation poll when we detect Keychain drifted
+    from cache for some reason; the canonical refresh path lets claude
+    itself update Keychain.
+    """
     if not is_macos():
         return (False, "not_macos")
     try:
@@ -158,87 +143,6 @@ def writeback_to_keychain(
     if result.returncode != 0:
         return (False, f"exit_code={result.returncode}; stderr={result.stderr.strip()!r}")
     return (True, None)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# PATH shim
-# ─────────────────────────────────────────────────────────────────────────────
-
-_SHIM_BODY = r"""#!/bin/bash
-# Auto-generated by puffo-agent. Intercepts
-# `security delete-generic-password "Claude Code-credentials"` and
-# silently no-ops it (Claude Code issue #37512), passing every other
-# `security` invocation through to the real binary.
-#
-# DO NOT EDIT — overwritten on daemon start.
-REAL=/usr/bin/security
-
-is_delete=0
-for arg in "$@"; do
-  if [ "$arg" = "delete-generic-password" ]; then
-    is_delete=1
-    break
-  fi
-done
-
-if [ "$is_delete" = "1" ]; then
-  for arg in "$@"; do
-    if [ "$arg" = "Claude Code-credentials" ]; then
-      exit 0
-    fi
-  done
-fi
-
-exec "$REAL" "$@"
-"""
-
-
-def _stage_keychain_visibility(sandbox: Path) -> Optional[str]:
-    """Symlink the user's ``~/Library/Keychains`` into the sandbox HOME
-    so the ``security`` CLI (and anything else doing
-    ``$HOME``-relative keychain lookup) reaches the real login keychain
-    instead of firing the ``loginKC:queryCreate`` authorization dialog.
-
-    See module docstring for the full incident description. Returns
-    ``None`` on success, or a short reason string on best-effort
-    failure — the refresh attempt still proceeds since claude *may*
-    succeed via the framework path even without this staging.
-    """
-    real_keychains = Path.home() / "Library" / "Keychains"
-    if not real_keychains.exists():
-        return "real_keychains_missing"
-    try:
-        sandbox_library = sandbox / "Library"
-        sandbox_library.mkdir(parents=True, exist_ok=True)
-        target = sandbox_library / "Keychains"
-        # Idempotent: a prior call already linked it.
-        if target.is_symlink() or target.exists():
-            return None
-        os.symlink(real_keychains, target)
-    except OSError as exc:
-        return f"symlink_failed: {exc}"
-    return None
-
-
-def shim_dir(home: Path) -> Path:
-    """Where the PATH shim binary lives. Inside daemon run dir so it
-    auto-cleans on uninstall."""
-    return home / "run" / "keychain-shim"
-
-
-def install_path_shim(home: Path) -> Path:
-    """Write the security-shim script and chmod it executable. Returns
-    the directory to prepend to ``PATH``. Idempotent."""
-    d = shim_dir(home)
-    d.mkdir(parents=True, exist_ok=True)
-    binary = d / SHIM_FILENAME
-    binary.write_text(_SHIM_BODY, encoding="utf-8")
-    binary.chmod(
-        stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
-        | stat.S_IRGRP | stat.S_IXGRP
-        | stat.S_IROTH | stat.S_IXOTH,
-    )
-    return d
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -297,7 +201,7 @@ class CredentialCache:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Bootstrap + Refresh
+# Bootstrap
 # ─────────────────────────────────────────────────────────────────────────────
 
 def bootstrap_from_keychain(cache: CredentialCache) -> tuple[bool, Optional[str]]:
@@ -310,153 +214,3 @@ def bootstrap_from_keychain(cache: CredentialCache) -> tuple[bool, Optional[str]
         return (False, read.error)
     cache.write(read.blob)
     return (True, "bootstrapped")
-
-
-async def _run_claude_oneshot(
-    env: dict[str, str],
-    cwd: str,
-    *,
-    timeout: float = REFRESH_ONESHOT_TIMEOUT_SECONDS,
-) -> tuple[Optional[int], str]:
-    """Spawn ``claude --print --max-turns 1 "ok"`` and wait. Returns
-    ``(returncode, error_reason)`` — ``returncode`` is None on
-    failure paths. Always cleans up the subprocess + pipe FDs even on
-    early-return paths (timeout / spawn error)."""
-    if shutil.which("claude") is None:
-        return (None, "claude_binary_missing")
-    proc: asyncio.subprocess.Process | None = None
-    try:
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "claude", "--dangerously-skip-permissions",
-                "--print", "--max-turns", "1",
-                "--output-format", "stream-json", "--verbose",
-                "ok",
-                env=env, cwd=cwd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-        except FileNotFoundError:
-            return (None, "claude_binary_missing")
-
-        try:
-            await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except asyncio.TimeoutError:
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            try:
-                await proc.communicate()
-            except Exception:
-                pass
-            return (None, "refresh_oneshot_timeout")
-        return (proc.returncode, "")
-    finally:
-        if proc is not None and proc.returncode is None:
-            try:
-                proc.kill()
-                await proc.wait()
-            except (ProcessLookupError, OSError):
-                pass
-
-
-async def refresh_via_oneshot(
-    cache: CredentialCache,
-    shim_dir_path: Path,
-    *,
-    timeout: float = REFRESH_ONESHOT_TIMEOUT_SECONDS,
-) -> tuple[bool, Optional[str]]:
-    """macOS path: run a one-turn ``claude --print`` in a sandbox $HOME
-    seeded from the cache. On exit, Claude has rewritten
-    ``.credentials.json`` with a fresh token; copy it back to the cache.
-
-    Returns (ok, reason_when_not_ok).
-
-    A non-zero claude exit code is **not** by itself a hard failure:
-    claude may rotate the OAuth token successfully (writing the new blob
-    to ``.credentials.json``) and then exit non-zero from a later,
-    unrelated step. Dropping the new blob in that case strands the user
-    with the prior refresh_token, which Anthropic has already
-    invalidated — main CLI then can't recover without ``claude login``.
-    So we always inspect the sandbox file after the process exits: if
-    it contains a rotated access_token, we accept it and report
-    ``"token_refreshed_rc=N"`` so the non-zero exit stays visible.
-
-    ⚠️ **Keep in sync with** ``portal.diagnostic._run_sandboxed_claude_oneshot``:
-    that probe is a sync mirror of this function so the diagnostic
-    can run without an asyncio event loop. Any env / arg change here
-    must be mirrored there or the probe stops validating prod.
-    """
-    if not is_macos():
-        return (False, "not_macos")
-    blob = cache.read()
-    if not blob:
-        return (False, "cache_empty")
-    try:
-        old_token = ((json.loads(blob).get("claudeAiOauth") or {}).get("accessToken")) or ""
-    except json.JSONDecodeError:
-        old_token = ""
-
-    with tempfile.TemporaryDirectory(prefix="puffo-agent-refresh-") as sandbox:
-        sandbox_path = Path(sandbox)
-        sandbox_claude_dir = sandbox_path / ".claude"
-        sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
-        sandbox_creds = sandbox_claude_dir / ".credentials.json"
-        sandbox_creds.write_text(blob, encoding="utf-8")
-
-        stage_err = _stage_keychain_visibility(sandbox_path)
-        if stage_err is not None:
-            logger.info(
-                "refresh sandbox: keychain visibility staging skipped "
-                "(%s); claude may still succeed via framework path",
-                stage_err,
-            )
-
-        env = {
-            **os.environ,
-            "HOME": str(sandbox_path),
-            "USERPROFILE": str(sandbox_path),
-            "CLAUDE_CONFIG_DIR": str(sandbox_claude_dir),
-            "PATH": f"{shim_dir_path}{os.pathsep}{os.environ.get('PATH', '')}",
-        }
-        # Deliberately NO ``CLAUDE_CODE_OAUTH_TOKEN``: we want claude's
-        # native refresh path to engage (read .credentials.json → if
-        # expired refresh against Anthropic → write back). The env-var
-        # mode would bypass storage entirely.
-        rc, err = await _run_claude_oneshot(env, str(sandbox_path), timeout=timeout)
-        if rc is None:
-            # Spawn/timeout — no sandbox state to salvage.
-            return (False, err)
-
-        # Always read sandbox creds, regardless of rc. Parse failures
-        # only matter as a fallback signal when rc != 0.
-        try:
-            refreshed = sandbox_creds.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            if rc != 0:
-                return (False, f"claude_exit_code={rc}")
-            return (False, "refreshed_credentials_missing")
-        try:
-            new_token = (
-                (json.loads(refreshed).get("claudeAiOauth") or {}).get("accessToken")
-            ) or ""
-        except json.JSONDecodeError:
-            if rc != 0:
-                return (False, f"claude_exit_code={rc}")
-            return (False, "refreshed_credentials_unparseable")
-
-        rotated = bool(new_token) and old_token != new_token
-
-        # rc != 0 with no rotation: real failure, nothing to salvage.
-        if rc != 0 and not rotated:
-            return (False, f"claude_exit_code={rc}")
-
-        cache.write(refreshed)
-        if rc != 0:
-            # Salvage path: keep the rotation, surface the rc so the
-            # caller can log + investigate the non-zero exit separately.
-            return (True, f"token_refreshed_rc={rc}")
-        if not rotated:
-            return (True, "token_unchanged")
-        return (True, "token_refreshed")

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -379,6 +379,15 @@ class KeychainBackend:
     agent via per-agent file copies (Keychain ACL is keyed on UID +
     signing identity, not HOME, so a symlink trick wouldn't help).
 
+    Refresh strategy: identical to ``FileBackend`` — run
+    ``claude --print "ok"`` with the *real* user HOME and let claude's
+    own OAuth path read Keychain, rotate against Anthropic if expired,
+    and write the rotated blob back to Keychain. This is exactly what
+    the operator's interactive ``claude`` invocation does, so we share
+    its battle-tested refresh code path instead of reinventing it via
+    sandbox + cache-seeding (which proved fragile: see the keychain.py
+    module docstring for the failure modes).
+
     External-rotation poll: every ``KEYCHAIN_POLL_INTERVAL_SECONDS``
     (5 min), re-read the Keychain (silent after the first
     "Always Allow" grant) and compare to the last-known blob. On
@@ -392,11 +401,9 @@ class KeychainBackend:
         self,
         home: Path,
         cache,  # ..macos.keychain.CredentialCache
-        shim_dir: Path,
     ):
         self.home = home
         self.cache = cache
-        self.shim_dir = shim_dir
         # Last blob propagated to agents — cheap byte-equality key so
         # the poll loop only fans out on real changes.
         self._last_propagated_blob: Optional[str] = None
@@ -429,34 +436,99 @@ class KeychainBackend:
         return int(ms / 1000 - time.time())
 
     async def refresh(self) -> RefreshOutcome:
-        from ..macos.keychain import (
-            refresh_via_oneshot,
-            writeback_to_keychain,
-        )
+        from ..macos.keychain import read_keychain_blob
 
-        before = self.cache.read()
-        ok, reason = await refresh_via_oneshot(self.cache, self.shim_dir)
-        if not ok:
+        # Snapshot Keychain before claude runs so we can byte-compare
+        # after. Cache.read() is not enough — agent processes may have
+        # rotated Keychain externally between ticks and the cache is a
+        # lagging mirror.
+        kr_before = read_keychain_blob()
+        before_blob = kr_before.blob if kr_before.ok else None
+
+        # Real user HOME — claude reads Keychain, refreshes if expired,
+        # writes back to Keychain. Identical pattern to FileBackend.
+        # cwd=host_home so claude's project-resolution lands in the
+        # operator's normal working dir (matches single-process /login
+        # UX) instead of wherever the daemon was launched from.
+        host_home = Path.home()
+        env = {**os.environ, "HOME": str(host_home)}
+        cmd = [
+            "claude", "--dangerously-skip-permissions",
+            "--print", "--max-turns", "1",
+            "--output-format", "stream-json", "--verbose",
+            "ok",
+        ]
+        started = time.time()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                cwd=str(host_home),
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=REFRESH_ONESHOT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
             logger.warning(
-                "claude credential refresh failed: %s", reason,
+                "claude credential refresh timed out after %ds",
+                REFRESH_ONESHOT_TIMEOUT_SECONDS,
             )
             return RefreshOutcome.FAILED
-        logger.info("claude credential refresh: %s", reason)
-        after = self.cache.read()
-        if after and after != before:
-            # Push the rotated blob back to Keychain best-effort so the
-            # operator's main CLI / VS Code extension see the new token.
-            wb_ok, wb_reason = writeback_to_keychain(after)
-            if wb_ok:
-                logger.info("claude credential writeback to keychain: ok")
-            else:
-                logger.info(
-                    "claude credential writeback to keychain skipped: %s",
-                    wb_reason,
-                )
-            self._last_propagated_blob = after
-            return RefreshOutcome.REFRESHED
-        return RefreshOutcome.UNCHANGED
+        except FileNotFoundError:
+            logger.warning(
+                "claude credential refresh: claude binary missing on PATH"
+            )
+            return RefreshOutcome.FAILED
+        elapsed = time.time() - started
+
+        if proc.returncode != 0:
+            err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
+            out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
+            logger.warning(
+                "claude credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
+                proc.returncode, elapsed, out_tail, err_tail,
+            )
+            return RefreshOutcome.FAILED
+
+        # Pull the post-refresh blob straight from Keychain — that's
+        # where claude wrote it. Then sync our cache so agent fan-out
+        # has fresh bytes.
+        kr_after = read_keychain_blob()
+        if not kr_after.ok or not kr_after.blob:
+            logger.warning(
+                "claude credential refresh exit=0 but Keychain re-read "
+                "failed (%s); cache untouched",
+                kr_after.error,
+            )
+            return RefreshOutcome.FAILED
+        try:
+            self.cache.write(kr_after.blob)
+        except OSError as exc:
+            logger.warning(
+                "claude credential refresh: cache write failed: %s", exc,
+            )
+
+        # Byte-compare the Keychain blob before and after. Anything
+        # else (e.g. comparing int(expires_in_seconds)) loses
+        # sub-second resolution to time.time()'s fractional part.
+        if before_blob is not None and before_blob == kr_after.blob:
+            logger.info(
+                "claude credential refresh ok in %.1fs but Keychain "
+                "unchanged — token was still fresh; claude skipped the "
+                "OAuth round-trip",
+                elapsed,
+            )
+            return RefreshOutcome.UNCHANGED
+
+        self._last_propagated_blob = kr_after.blob
+        logger.info(
+            "claude credential refresh ok in %.1fs (Keychain rotated)",
+            elapsed,
+        )
+        return RefreshOutcome.REFRESHED
 
     def sync_to_agent(self, agent_home: Path) -> None:
         """Atomic-write the cache blob to the agent's per-agent
@@ -486,12 +558,8 @@ class KeychainBackend:
             )
 
     async def bootstrap(self) -> tuple[bool, Optional[str]]:
-        from ..macos.keychain import (
-            bootstrap_from_keychain,
-            install_path_shim,
-        )
+        from ..macos.keychain import bootstrap_from_keychain
 
-        install_path_shim(self.home)
         ok, reason = bootstrap_from_keychain(self.cache)
         if ok:
             self._last_propagated_blob = self.cache.read()

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -18,7 +18,7 @@ import time
 
 from pathlib import Path
 
-from ..macos.keychain import CredentialCache, is_macos, shim_dir
+from ..macos.keychain import CredentialCache, is_macos
 from .api import start_api_server, stop_api_server
 from .credential_refresh import (
     CodexFileBackend,
@@ -66,7 +66,7 @@ class Daemon:
         # refresh-token rotation can't be raced by N agent workers.
         # Backend choice is platform-dependent:
         #   - macOS: Keychain is canonical (Claude Code 2.x); cache +
-        #     PATH shim + per-agent file copies via KeychainBackend.
+        #     per-agent file copies via KeychainBackend.
         #   - Linux/Windows: host file ``~/.claude/.credentials.json``
         #     is canonical; agent files are symlinks via FileBackend.
         if is_macos():
@@ -74,7 +74,6 @@ class Daemon:
             backend = KeychainBackend(
                 home=home,
                 cache=CredentialCache.at(home),
-                shim_dir=shim_dir(home),
             )
         else:
             backend = FileBackend(host_home=Path.home())

--- a/src/puffo_agent/portal/diagnostic.py
+++ b/src/puffo_agent/portal/diagnostic.py
@@ -32,6 +32,7 @@ from typing import Optional
 
 from ..macos.keychain import (
     KEYCHAIN_SERVICE,
+    _stage_keychain_visibility,
     install_path_shim,
     is_macos,
     read_keychain_blob,
@@ -262,6 +263,10 @@ def _run_sandboxed_claude_oneshot(
     sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
     sandbox_creds = sandbox_claude_dir / ".credentials.json"
     sandbox_creds.write_text(blob, encoding="utf-8")
+
+    # Mirror production: symlink real ~/Library/Keychains in so the
+    # security CLI doesn't ask the user to create a new login keychain.
+    _stage_keychain_visibility(sandbox)
 
     env = {
         **os.environ,

--- a/src/puffo_agent/portal/diagnostic.py
+++ b/src/puffo_agent/portal/diagnostic.py
@@ -1,8 +1,8 @@
 """``puffo-agent test ...`` — macOS Keychain integration probes.
 
 Designed to be run by a colleague on a real macOS host so we can
-verify the assumptions baked into ``puffo_agent.macos.keychain``
-*before* promoting v0.9.0a* from TestPyPI to PyPI. Each subcommand:
+verify the assumptions baked into ``puffo_agent.macos.keychain``. Each
+subcommand:
 
   - Returns a structured ``ProbeReport`` (markdown) on stdout.
   - Classifies each step as ``OK`` / ``FAIL`` / ``NEEDS_ATTENTION``.
@@ -24,7 +24,6 @@ import platform
 import shutil
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -32,12 +31,8 @@ from typing import Optional
 
 from ..macos.keychain import (
     KEYCHAIN_SERVICE,
-    _stage_keychain_visibility,
-    install_path_shim,
     is_macos,
     read_keychain_blob,
-    shim_dir,
-    writeback_to_keychain,
 )
 from .state import home_dir
 
@@ -113,195 +108,18 @@ def _redact_token(s: str) -> str:
 
 
 def _summarise_blob(raw: str) -> str:
-    """Pretty-print Claude Code's credential blob with token fields
-    redacted. Output goes to stdout so it MUST be safe to paste."""
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
-        return f"(invalid JSON, length={len(raw)})"
-    oauth = (data.get("claudeAiOauth") or {}).copy()
-    if "accessToken" in oauth:
-        oauth["accessToken"] = _redact_token(oauth["accessToken"])
-    if "refreshToken" in oauth:
-        oauth["refreshToken"] = _redact_token(oauth["refreshToken"])
-    other_keys = sorted(k for k in data.keys() if k != "claudeAiOauth")
-    pretty = {"claudeAiOauth": oauth, "other_keys": other_keys}
-    return json.dumps(pretty, indent=2, sort_keys=True)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Probes
-# ─────────────────────────────────────────────────────────────────────────────
-
-def probe_keychain_read() -> ProbeReport:
-    """Step 1: can we read the Keychain entry?"""
-    rpt = ProbeReport(title="puffo-agent test keychain-read")
-    if not is_macos():
-        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
-        return rpt
-
-    rpt.add(
-        "command",
-        VERDICT_OK,
-        f"security find-generic-password -s '{KEYCHAIN_SERVICE}' -w",
-    )
-
-    started = time.time()
-    result = read_keychain_blob()
-    elapsed_ms = int((time.time() - started) * 1000)
-
-    if not result.ok:
-        # First-time ACL grant: stderr typically contains "user
-        # interaction is not allowed" if running under a non-TTY parent,
-        # or the result is just slow when the dialog is up.
-        rpt.add(
-            "read",
-            VERDICT_FAIL,
-            f"reason: {result.error}\nstderr: {result.stderr or '(none)'}\n"
-            f"elapsed_ms: {elapsed_ms}",
-        )
-        rpt.summary = (
-            "Reading Keychain failed. If this is the first time, you "
-            "may need to click 'Always Allow' on a system dialog."
-        )
-        return rpt
-
-    rpt.add(
-        "read",
-        VERDICT_OK,
-        f"got blob: {_summarise_blob(result.blob)}\nelapsed_ms: {elapsed_ms}",
-    )
-    rpt.summary = (
-        "Keychain read succeeded. Bootstrap path will work."
-    )
-    return rpt
-
-
-def probe_keychain_write() -> ProbeReport:
-    """Step 2: can we *write* to the Keychain (preserving content)?"""
-    rpt = ProbeReport(title="puffo-agent test keychain-write")
-    if not is_macos():
-        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
-        return rpt
-
-    # Read existing.
-    read_result = read_keychain_blob()
-    if not read_result.ok:
-        rpt.add(
-            "prerequisite-read",
-            VERDICT_FAIL,
-            f"can't read keychain to back up: {read_result.error}; "
-            "run `puffo-agent test keychain-read` first.",
-        )
-        return rpt
-    rpt.add("prerequisite-read", VERDICT_OK, "backup captured in memory")
-
-    # Write the same value back via -U upsert.
-    started = time.time()
-    write_ok, write_reason = writeback_to_keychain(read_result.blob)
-    elapsed_ms = int((time.time() - started) * 1000)
-
-    if not write_ok:
-        rpt.add(
-            "write",
-            VERDICT_NEEDS_ATTENTION,
-            f"writeback failed: {write_reason}\nelapsed_ms: {elapsed_ms}\n"
-            "Daemon will still work — writeback is best-effort; this just "
-            "means user's main CLI won't see refreshed tokens.",
-        )
-        rpt.summary = (
-            "Keychain write was rejected. Operation will degrade "
-            "gracefully — agents still authenticated, but main CLI may "
-            "need re-login after long sessions."
-        )
-        return rpt
-    rpt.add("write", VERDICT_OK, f"elapsed_ms: {elapsed_ms}")
-
-    # Re-read to confirm Keychain entry survives.
-    reread = read_keychain_blob()
-    if not reread.ok:
-        rpt.add(
-            "verify-read",
-            VERDICT_FAIL,
-            f"after write, Keychain read FAILED: {reread.error}",
-        )
-        rpt.summary = "DANGER: write may have corrupted Keychain entry."
-        return rpt
-    if reread.blob == read_result.blob:
-        rpt.add("verify-read", VERDICT_OK, "post-write blob matches pre-write blob")
-        rpt.summary = "Keychain write+read roundtrip works."
-    else:
-        rpt.add(
-            "verify-read",
-            VERDICT_NEEDS_ATTENTION,
-            "post-write blob DIFFERS from pre-write blob — could be a "
-            "concurrent refresh by your main CLI.",
-        )
-        rpt.summary = "Roundtrip OK but content changed — likely benign."
-    return rpt
-
-
-def _run_sandboxed_claude_oneshot(
-    sandbox: Path, blob: str, shim_path: Path,
-) -> tuple[int, str, str, Optional[str]]:
-    """Stage ``blob`` into ``sandbox/.claude/.credentials.json``, run a
-    one-turn ``claude --print``, and return
-    ``(returncode, stdout_tail, stderr_tail, refreshed_blob_or_none)``.
-
-    The sandbox dir must already exist. On timeout / claude missing,
-    returncode is -1 and stderr describes the failure mode.
-
-    ⚠️ **Keep in sync with** ``macos.keychain.refresh_via_oneshot`` +
-    ``_run_claude_oneshot``: this probe re-implements the same
-    sandbox-HOME dance (``HOME``/``USERPROFILE``/``CLAUDE_CONFIG_DIR``/
-    PATH-shim + identical claude args) synchronously so the diagnostic
-    can run without an asyncio event loop. The diagnostic's
-    load-bearing value evaporates the moment the two drift, so any env
-    or arg change to the production refresh **must** be mirrored here.
-    """
-    sandbox_claude_dir = sandbox / ".claude"
-    sandbox_claude_dir.mkdir(parents=True, exist_ok=True)
-    sandbox_creds = sandbox_claude_dir / ".credentials.json"
-    sandbox_creds.write_text(blob, encoding="utf-8")
-
-    # Mirror production: symlink real ~/Library/Keychains in so the
-    # security CLI doesn't ask the user to create a new login keychain.
-    _stage_keychain_visibility(sandbox)
-
-    env = {
-        **os.environ,
-        "HOME": str(sandbox),
-        "USERPROFILE": str(sandbox),
-        "CLAUDE_CONFIG_DIR": str(sandbox_claude_dir),
-        "PATH": f"{shim_path}{os.pathsep}{os.environ.get('PATH', '')}",
-    }
-
-    try:
-        proc = subprocess.run(
-            [
-                "claude", "--dangerously-skip-permissions",
-                "--print", "--max-turns", "1",
-                "--output-format", "stream-json", "--verbose",
-                "ok",
-            ],
-            env=env, cwd=str(sandbox),
-            capture_output=True, text=True, timeout=90,
-        )
-    except subprocess.TimeoutExpired:
-        return (-1, "", "timeout after 90s", None)
-    except FileNotFoundError:
-        return (-1, "", "claude binary missing", None)
-
-    try:
-        refreshed = sandbox_creds.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        refreshed = None
-
+        return f"invalid JSON (len={len(raw)})"
+    oauth = data.get("claudeAiOauth") or {}
+    access = oauth.get("accessToken") or ""
+    refresh = oauth.get("refreshToken") or ""
+    expires = oauth.get("expiresAt")
     return (
-        proc.returncode,
-        (proc.stdout or "")[-300:],
-        (proc.stderr or "")[-500:],
-        refreshed,
+        f"claudeAiOauth.accessToken: {_redact_token(access)}\n"
+        f"claudeAiOauth.refreshToken: {_redact_token(refresh)}\n"
+        f"claudeAiOauth.expiresAt: {expires}"
     )
 
 
@@ -314,335 +132,105 @@ def _access_token(blob: str) -> str:
         return ""
 
 
-def _force_expiry(blob: str, seconds_in_past: int = 60) -> Optional[str]:
-    """Return a copy of ``blob`` with ``expiresAt`` mutated to
-    ``now - seconds_in_past`` (milliseconds). ``None`` if the blob is
-    unparseable or doesn't have the expected shape."""
-    try:
-        data = json.loads(blob)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(data.get("claudeAiOauth"), dict):
-        return None
-    data["claudeAiOauth"]["expiresAt"] = int(
-        (time.time() - seconds_in_past) * 1000,
+# ─────────────────────────────────────────────────────────────────────────────
+# Probes
+# ─────────────────────────────────────────────────────────────────────────────
+
+def probe_keychain_read() -> ProbeReport:
+    """Step 1: can the daemon read the Keychain entry?"""
+    rpt = ProbeReport(title="puffo-agent test keychain-read")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+    rpt.add(
+        "command",
+        VERDICT_OK,
+        f"$ security find-generic-password -s {KEYCHAIN_SERVICE!r} -w",
     )
-    return json.dumps(data)
+    result = read_keychain_blob()
+    if not result.ok:
+        rpt.add(
+            "read",
+            VERDICT_FAIL,
+            f"reason: {result.error}\n"
+            f"stderr: {result.stderr or '(none)'}\n"
+            "→ if 'exit_code=44', the entry doesn't exist; run "
+            "`claude` interactively to populate the Keychain.\n"
+            "→ if 'timeout', an ACL prompt is pending — accept "
+            "'Always Allow' so future calls are non-interactive.",
+        )
+        rpt.summary = "Keychain read failed — daemon cannot bootstrap."
+        return rpt
+    rpt.add("read", VERDICT_OK, _summarise_blob(result.blob))
+    rpt.summary = "Keychain read succeeded. Bootstrap path will work."
+    return rpt
+
+
+def probe_keychain_write() -> ProbeReport:
+    """Step 2: can the daemon round-trip a writeback?
+
+    Writes the existing blob back to itself (so the user's auth state
+    is preserved) and re-reads to confirm the upsert worked.
+    """
+    rpt = ProbeReport(title="puffo-agent test keychain-write")
+    if not is_macos():
+        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
+        return rpt
+    from ..macos.keychain import writeback_to_keychain
+
+    pre = read_keychain_blob()
+    if not pre.ok:
+        rpt.add(
+            "prerequisite-read",
+            VERDICT_FAIL,
+            f"can't read existing blob to roundtrip: {pre.error}",
+        )
+        return rpt
+    rpt.add("prerequisite-read", VERDICT_OK, "captured existing blob")
+
+    ok, reason = writeback_to_keychain(pre.blob)
+    if not ok:
+        rpt.add("write", VERDICT_FAIL, f"upsert failed: {reason}")
+        return rpt
+    rpt.add("write", VERDICT_OK, "upsert succeeded (-U)")
+
+    post = read_keychain_blob()
+    if not post.ok:
+        rpt.add(
+            "verify-read",
+            VERDICT_FAIL,
+            f"re-read after write failed: {post.error}",
+        )
+        return rpt
+    if post.blob != pre.blob:
+        rpt.add(
+            "verify-read",
+            VERDICT_FAIL,
+            "post-write blob differs from pre — upsert corrupted the entry",
+        )
+        return rpt
+    rpt.add("verify-read", VERDICT_OK, "post-write blob matches pre")
+    rpt.summary = "Keychain write+read roundtrip works."
+    return rpt
 
 
 def probe_refresh_flush() -> ProbeReport:
-    """Step 3: does a sandboxed ``claude --print`` actually flush a
-    refreshed token to its ``.credentials.json``?
+    """Step 3: does ``claude --print "ok"`` against the real Keychain
+    actually flush a refreshed token?
 
-    This is the **passive** variant — it stages the current blob and
-    just observes whether claude rotates the token naturally. When the
-    token is still well within its 8h TTL, claude won't rotate
-    (correctly), and we report NEEDS_ATTENTION with a note to rerun
-    with ``puffo-agent test refresh-flush-forced`` for definitive
-    confirmation.
+    Mirrors production: real user HOME, no sandbox. claude reads
+    Keychain, refreshes if expired, writes the rotated blob back to
+    Keychain. We compare the access_token before/after.
+
+    Passive only — when the token is still well within its TTL, claude
+    won't rotate (correctly), and we report NEEDS_ATTENTION explaining
+    the token is fresh. There's no longer a forced variant: in the
+    real-HOME design we can't lie to claude about expiry without
+    mutating the user's Keychain entry, and the production refresh
+    path is exercised every time the daemon's poll triggers a refresh
+    against a naturally-expiring token.
     """
     rpt = ProbeReport(title="puffo-agent test refresh-flush")
-    if not is_macos():
-        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
-        return rpt
-    if shutil.which("claude") is None:
-        rpt.add(
-            "prerequisite-claude",
-            VERDICT_FAIL,
-            "`claude` not on PATH — install Claude Code first.",
-        )
-        return rpt
-
-    read_result = read_keychain_blob()
-    if not read_result.ok:
-        rpt.add(
-            "prerequisite-keychain",
-            VERDICT_FAIL,
-            f"keychain read failed: {read_result.error}",
-        )
-        return rpt
-    rpt.add("prerequisite-keychain", VERDICT_OK, "blob in memory")
-
-    home = home_dir()
-    shim_path = install_path_shim(home)
-    old_token = _access_token(read_result.blob)
-
-    with tempfile.TemporaryDirectory(prefix="puffo-agent-test-refresh-") as sandbox:
-        started = time.time()
-        code, _, stderr_tail, refreshed = _run_sandboxed_claude_oneshot(
-            Path(sandbox), read_result.blob, shim_path,
-        )
-        elapsed_ms = int((time.time() - started) * 1000)
-
-        if code != 0:
-            rpt.add(
-                "claude-oneshot",
-                VERDICT_FAIL,
-                f"exit={code}, elapsed_ms={elapsed_ms}\n"
-                f"stderr (last 500): {stderr_tail}",
-            )
-            return rpt
-        rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
-
-        if refreshed is None:
-            rpt.add(
-                "credentials-file",
-                VERDICT_FAIL,
-                "sandbox .credentials.json was DELETED — flush failed",
-            )
-            return rpt
-
-        new_token = _access_token(refreshed)
-        rotated = bool(new_token) and old_token != new_token
-        rpt.add(
-            "credentials-file",
-            VERDICT_OK if rotated else VERDICT_NEEDS_ATTENTION,
-            "token rotated: {}\nold: {}\nnew: {}".format(
-                rotated, _redact_token(old_token), _redact_token(new_token),
-            ),
-        )
-
-    if rotated:
-        rpt.summary = "Refresh flush works — sandbox flush mechanism confirmed."
-    else:
-        rpt.summary = (
-            "Sandbox claude exited OK but the token wasn't rotated — "
-            "current token is still valid, so claude correctly skipped "
-            "the OAuth round-trip. To definitively confirm refresh-"
-            "on-expiry, run `puffo-agent test refresh-flush-forced` "
-            "(which mutates expiresAt to force the refresh path)."
-        )
-    return rpt
-
-
-def probe_refresh_flush_forced() -> ProbeReport:
-    """Step 3b (opt-in): force the refresh code path by mutating the
-    cached blob's ``expiresAt`` to a past timestamp.
-
-    **Has real side effects:** Anthropic rotates the refresh_token on
-    every successful refresh, so the user's pre-probe refresh_token is
-    invalidated as soon as claude succeeds. We always reconcile the
-    Keychain state at the end so the user's main CLI / VS Code extension
-    keeps a working token.
-
-    Rotation may happen via two paths and we must handle both:
-
-      1. ``claude`` rewrites the sandbox ``.credentials.json`` — we
-         writeback to Keychain ourselves.
-      2. ``claude`` writes the new blob directly to the user's real
-         Keychain. On macOS, ``$HOME`` does NOT isolate Keychain access
-         (ACL is keyed on UID + signing identity, not HOME), so the
-         sandbox claude reaches the real Keychain anyway and writes
-         there itself. No writeback needed.
-
-    Critically, ``rc != 0`` does **not** mean "Anthropic side-effect
-    didn't happen": claude can rotate successfully and then exit non-
-    zero from a later unrelated step. We always re-read Keychain + the
-    sandbox file after the run and decide writeback from observed
-    state, not from rc.
-
-    Designed for occasional manual verification, NOT for every
-    deploy. The natural ``refresh-flush`` is the everyday probe.
-    """
-    rpt = ProbeReport(title="puffo-agent test refresh-flush-forced")
-    if not is_macos():
-        rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
-        return rpt
-    if shutil.which("claude") is None:
-        rpt.add(
-            "prerequisite-claude",
-            VERDICT_FAIL,
-            "`claude` not on PATH — install Claude Code first.",
-        )
-        return rpt
-
-    read_result = read_keychain_blob()
-    if not read_result.ok:
-        rpt.add(
-            "prerequisite-keychain",
-            VERDICT_FAIL,
-            f"keychain read failed: {read_result.error}",
-        )
-        return rpt
-    rpt.add(
-        "prerequisite-keychain",
-        VERDICT_OK,
-        "original blob captured; will reconcile Keychain against actual "
-        "post-run state (claude in sandbox can write the real Keychain "
-        "directly because $HOME doesn't isolate it on macOS)",
-    )
-
-    mutated = _force_expiry(read_result.blob, seconds_in_past=60)
-    if mutated is None:
-        rpt.add(
-            "force-expiry",
-            VERDICT_FAIL,
-            "could not mutate blob — unexpected shape; aborting "
-            "before doing anything destructive",
-        )
-        return rpt
-    rpt.add(
-        "force-expiry",
-        VERDICT_OK,
-        "set claudeAiOauth.expiresAt = now - 60s in sandbox copy "
-        "(Keychain entry will be re-read after the sandbox run)",
-    )
-
-    home = home_dir()
-    shim_path = install_path_shim(home)
-    old_token = _access_token(read_result.blob)
-
-    with tempfile.TemporaryDirectory(
-        prefix="puffo-agent-test-refresh-forced-",
-    ) as sandbox:
-        started = time.time()
-        code, _, stderr_tail, refreshed = _run_sandboxed_claude_oneshot(
-            Path(sandbox), mutated, shim_path,
-        )
-        elapsed_ms = int((time.time() - started) * 1000)
-
-        # Re-read Keychain regardless of rc: claude may have written
-        # straight to the real Keychain (HOME doesn't isolate it), so
-        # the rc alone doesn't tell us whether rotation happened.
-        post_read = read_keychain_blob()
-        keychain_after_blob = post_read.blob if post_read.ok else None
-        keychain_after_token = _access_token(keychain_after_blob or "")
-        sandbox_token = _access_token(refreshed or "")
-
-        sandbox_rotated = bool(sandbox_token) and sandbox_token != old_token
-        keychain_rotated = (
-            bool(keychain_after_token) and keychain_after_token != old_token
-        )
-
-        if code == 0:
-            rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
-        else:
-            # rc != 0 is only a real failure if NOTHING rotated. If
-            # something did rotate, surface it as NEEDS_ATTENTION so
-            # the operator investigates the exit code separately.
-            verdict = (
-                VERDICT_NEEDS_ATTENTION
-                if (sandbox_rotated or keychain_rotated)
-                else VERDICT_FAIL
-            )
-            rpt.add(
-                "claude-oneshot",
-                verdict,
-                f"exit={code}, elapsed_ms={elapsed_ms}\n"
-                f"stderr (last 500): {stderr_tail}\n"
-                "(continuing: inspecting Keychain + sandbox creds for "
-                "partial rotation regardless of rc)",
-            )
-
-        # Decide from observed state, not rc.
-        if not sandbox_rotated and not keychain_rotated:
-            rpt.add(
-                "rotation-outcome",
-                VERDICT_FAIL,
-                "neither sandbox creds nor Keychain show a new "
-                "access_token. claude did not reach Anthropic's refresh "
-                "endpoint, or the refresh failed. Keychain unchanged — "
-                "main CLI is safe.\n"
-                f"old:           {_redact_token(old_token)}\n"
-                f"sandbox after: {_redact_token(sandbox_token)}\n"
-                f"keychain after: {_redact_token(keychain_after_token)}",
-            )
-            rpt.summary = (
-                "Forced expiry did not produce a rotation. No Anthropic "
-                "side-effect; Keychain untouched."
-            )
-            return rpt
-
-        rpt.add(
-            "rotation-outcome",
-            VERDICT_OK,
-            "rotation detected: sandbox_rotated={}, keychain_rotated={}\n"
-            "old:           {}\n"
-            "sandbox after: {}\n"
-            "keychain after: {}".format(
-                sandbox_rotated,
-                keychain_rotated,
-                _redact_token(old_token),
-                _redact_token(sandbox_token),
-                _redact_token(keychain_after_token),
-            ),
-        )
-
-        # Reconcile Keychain. Writeback only when Keychain doesn't
-        # already hold the rotated blob — naively writing the original
-        # back on any failure path would clobber a token claude just
-        # rotated into Keychain itself, leaving the user with an
-        # Anthropic-invalidated refresh_token.
-        if (
-            keychain_rotated
-            and sandbox_rotated
-            and keychain_after_token == sandbox_token
-        ):
-            rpt.add(
-                "keychain-writeback",
-                VERDICT_OK,
-                "Keychain already holds the rotated token (claude wrote "
-                "it directly); no writeback needed.",
-            )
-        elif keychain_rotated and not sandbox_rotated:
-            rpt.add(
-                "keychain-writeback",
-                VERDICT_OK,
-                "Keychain holds a new token from claude's direct write; "
-                "sandbox creds file was not updated. Trusting Keychain "
-                "as canonical — no writeback needed.",
-            )
-        elif sandbox_rotated and refreshed is not None:
-            # Either Keychain wasn't rotated (we must writeback) or
-            # there's a disagreement between sandbox and Keychain (we
-            # prefer the sandbox blob since it's the one we definitively
-            # observed claude write during this run).
-            wb_ok, wb_reason = writeback_to_keychain(refreshed)
-            if wb_ok:
-                rpt.add(
-                    "keychain-writeback",
-                    VERDICT_OK,
-                    "rotated sandbox blob written back to Keychain; "
-                    "main CLI / VS Code extension will see it on next "
-                    "use.",
-                )
-            else:
-                rpt.add(
-                    "keychain-writeback",
-                    VERDICT_NEEDS_ATTENTION,
-                    f"writeback failed: {wb_reason}\n"
-                    "Main CLI's view of the credentials is now STALE. "
-                    "Run `puffo-agent test keychain-write` to diagnose; "
-                    "user may need to re-login via `claude` in a "
-                    "terminal to recover.",
-                )
-
-        if code == 0:
-            rpt.summary = (
-                "Forced refresh succeeded end-to-end: claude rotated "
-                "the token and the new value is live in Keychain. "
-                "`refresh_via_oneshot` will work as designed in "
-                "production."
-            )
-        else:
-            rpt.summary = (
-                f"Forced refresh: claude exited {code} but Anthropic-"
-                "side rotation DID happen and Keychain is reconciled. "
-                "Refresh mechanism is effective; investigate the non-"
-                "zero exit code separately."
-            )
-
-    return rpt
-
-
-def probe_keychain_survives_token_env() -> ProbeReport:
-    """Step 4: does Claude Code still delete the Keychain entry when
-    ``CLAUDE_CODE_OAUTH_TOKEN`` is set? Reproduces github issue #37512.
-
-    If this comes back FAIL, the daemon MUST use the PATH shim to
-    block the deletion call (which it does by default).
-    """
-    rpt = ProbeReport(title="puffo-agent test keychain-survives-token-env")
     if not is_macos():
         rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
         return rpt
@@ -659,127 +247,73 @@ def probe_keychain_survives_token_env() -> ProbeReport:
         rpt.add(
             "prerequisite-keychain",
             VERDICT_FAIL,
-            f"keychain read failed before probe: {pre.error}",
+            f"keychain read failed: {pre.error}",
         )
         return rpt
     rpt.add("prerequisite-keychain", VERDICT_OK, "Keychain entry exists pre-probe")
+    old_token = _access_token(pre.blob)
 
+    host_home = Path.home()
+    env = {**os.environ, "HOME": str(host_home)}
+    started = time.time()
     try:
-        access_token = (
-            (json.loads(pre.blob).get("claudeAiOauth") or {}).get("accessToken")
-        ) or ""
-    except json.JSONDecodeError:
+        proc = subprocess.run(
+            [
+                "claude", "--dangerously-skip-permissions",
+                "--print", "--max-turns", "1",
+                "--output-format", "stream-json", "--verbose",
+                "ok",
+            ],
+            env=env, cwd=str(host_home),
+            capture_output=True, text=True, timeout=90,
+        )
+        code = proc.returncode
+        stderr_tail = (proc.stderr or "")[-500:]
+    except subprocess.TimeoutExpired:
+        rpt.add("claude-oneshot", VERDICT_FAIL, "claude oneshot timed out after 90s")
+        return rpt
+    elapsed_ms = int((time.time() - started) * 1000)
+
+    if code != 0:
         rpt.add(
-            "prerequisite-keychain",
+            "claude-oneshot",
             VERDICT_FAIL,
-            "Keychain blob is invalid JSON",
+            f"exit={code}, elapsed_ms={elapsed_ms}\n"
+            f"stderr (last 500): {stderr_tail}",
         )
         return rpt
+    rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
 
-    home = home_dir()
-    shim_path = install_path_shim(home)
-
-    # First sub-probe: WITHOUT shim (baseline — should reproduce bug).
-    rpt.add(
-        "approach",
-        VERDICT_OK,
-        "Will run two claude oneshots back-to-back:\n"
-        "  A) PATH=$PATH (no shim), CLAUDE_CODE_OAUTH_TOKEN set\n"
-        "  B) PATH=<shim>:$PATH, CLAUDE_CODE_OAUTH_TOKEN set\n"
-        "Re-reads keychain after each. We expect A to delete (or be a\n"
-        "no-op if Anthropic fixed #37512), and B to never delete.",
-    )
-
-    def _run_oneshot(path_value: str) -> tuple[int, str]:
-        # The token is briefly visible to ``ps auxe`` (and any other
-        # process in the user's ps namespace) while this claude
-        # subprocess runs. Accepted because this probe's whole
-        # purpose is to reproduce anthropics/claude-code#37512,
-        # which only fires when ``CLAUDE_CODE_OAUTH_TOKEN`` is set
-        # — production refresh paths deliberately do NOT set it.
-        # Run on a personal macOS workstation, not a shared host /
-        # CI runner / dev container.
-        env = {
-            **os.environ,
-            "CLAUDE_CODE_OAUTH_TOKEN": access_token,
-            "PATH": path_value,
-        }
-        try:
-            proc = subprocess.run(
-                [
-                    "claude", "--dangerously-skip-permissions",
-                    "--print", "--max-turns", "1",
-                    "--output-format", "stream-json", "--verbose",
-                    "ok",
-                ],
-                env=env, capture_output=True, text=True, timeout=60,
-            )
-            return (proc.returncode, (proc.stderr or "")[-300:])
-        except subprocess.TimeoutExpired:
-            return (-1, "timeout")
-
-    # A: without shim
-    code_a, stderr_a = _run_oneshot(os.environ.get("PATH", ""))
-    post_a = read_keychain_blob()
-    if post_a.ok:
+    post = read_keychain_blob()
+    if not post.ok:
         rpt.add(
-            "without-shim",
-            VERDICT_OK,
-            f"claude exit={code_a}; Keychain entry STILL PRESENT — "
-            "Anthropic may have fixed #37512, OR the deletion path "
-            "didn't trigger in this particular invocation.",
-        )
-    else:
-        rpt.add(
-            "without-shim",
-            VERDICT_NEEDS_ATTENTION,
-            f"claude exit={code_a}; Keychain entry DELETED after run "
-            f"(reason: {post_a.error})\nstderr tail: {stderr_a}\n"
-            "This reproduces #37512 — restoring entry before next "
-            "sub-probe.",
-        )
-        # Restore so the user doesn't lose their main-CLI auth.
-        writeback_to_keychain(pre.blob)
-
-    # B: with shim
-    code_b, stderr_b = _run_oneshot(
-        f"{shim_path}{os.pathsep}{os.environ.get('PATH', '')}"
-    )
-    post_b = read_keychain_blob()
-    if post_b.ok:
-        rpt.add(
-            "with-shim",
-            VERDICT_OK,
-            f"claude exit={code_b}; Keychain entry preserved. "
-            "Shim is doing its job.",
-        )
-    else:
-        rpt.add(
-            "with-shim",
+            "keychain-after",
             VERDICT_FAIL,
-            f"claude exit={code_b}; Keychain entry DELETED EVEN WITH "
-            f"SHIM (reason: {post_b.error})\nstderr tail: {stderr_b}\n"
-            "The shim is NOT being honoured — check PATH ordering.",
+            f"re-read after claude oneshot failed: {post.error}",
         )
-        writeback_to_keychain(pre.blob)
+        return rpt
+    new_token = _access_token(post.blob)
+    rotated = bool(new_token) and old_token != new_token
+    rpt.add(
+        "keychain-after",
+        VERDICT_OK if rotated else VERDICT_NEEDS_ATTENTION,
+        "token rotated: {}\nold: {}\nnew: {}".format(
+            rotated, _redact_token(old_token), _redact_token(new_token),
+        ),
+    )
 
-    # Verdict summary.
-    pre_lost = not post_a.ok and not post_b.ok
-    if pre_lost:
+    if rotated:
         rpt.summary = (
-            "Critical: shim did not protect Keychain. Investigate before "
-            "shipping."
-        )
-    elif not post_a.ok:
-        rpt.summary = (
-            "Bug #37512 still present in this Claude Code version; "
-            "shim protects against it. Ship-ready."
+            "Refresh flush works — claude rotated the token and the new "
+            "value is live in Keychain."
         )
     else:
         rpt.summary = (
-            "Could not reproduce #37512 in this run. Shim is harmless "
-            "to leave in place; we keep it for safety against re-"
-            "regression."
+            "claude exited OK but the token wasn't rotated — current "
+            "token is still valid, so claude correctly skipped the "
+            "OAuth round-trip. The production refresh path is "
+            "exercised whenever the daemon's poll hits a "
+            "naturally-expiring token (within ~10 min of expiresAt)."
         )
     return rpt
 
@@ -790,15 +324,13 @@ def probe_full() -> ProbeReport:
     rpt.add(
         "environment",
         VERDICT_OK,
-        f"home_dir: {home_dir()}\nclaude: {shutil.which('claude')}\n"
-        f"shim_dir: {shim_dir(home_dir())}",
+        f"home_dir: {home_dir()}\nclaude: {shutil.which('claude')}",
     )
 
     sub_reports = [
         probe_keychain_read(),
         probe_keychain_write(),
         probe_refresh_flush(),
-        probe_keychain_survives_token_env(),
     ]
     for sub in sub_reports:
         verdict = sub.overall()
@@ -811,14 +343,13 @@ def probe_full() -> ProbeReport:
 
     overall = rpt.overall()
     if overall == VERDICT_OK:
-        rpt.summary = "All probes green. Ship 0.9.0 to PyPI."
+        rpt.summary = "All probes green."
     elif overall == VERDICT_NEEDS_ATTENTION:
         rpt.summary = (
-            "Some probes flagged NEEDS_ATTENTION — review each item "
-            "before promoting from TestPyPI."
+            "Some probes flagged NEEDS_ATTENTION — review each item."
         )
     else:
-        rpt.summary = "At least one probe FAILED. Do not promote."
+        rpt.summary = "At least one probe FAILED."
     return rpt
 
 
@@ -849,27 +380,6 @@ def cmd_test_keychain_write(args: argparse.Namespace) -> int:
 
 def cmd_test_refresh_flush(args: argparse.Namespace) -> int:
     return _print_report(probe_refresh_flush())
-
-
-def cmd_test_refresh_flush_forced(args: argparse.Namespace) -> int:
-    if not getattr(args, "yes", False):
-        print(
-            "This probe rotates your real OAuth refresh_token by "
-            "mutating expiresAt and forcing Claude to refresh. Anthropic "
-            "invalidates the prior refresh_token on success; we write "
-            "the new value back to your Keychain to keep your main CLI "
-            "alive, but writeback can fail.\n\n"
-            "Re-run with `--yes` to acknowledge.",
-            file=sys.stderr,
-        )
-        return 2
-    return _print_report(probe_refresh_flush_forced())
-
-
-def cmd_test_keychain_survives_token_env(
-    args: argparse.Namespace,
-) -> int:
-    return _print_report(probe_keychain_survives_token_env())
 
 
 def cmd_test_full_probe(args: argparse.Namespace) -> int:
@@ -905,31 +415,10 @@ def register_test_subcommands(sub) -> None:
 
     test_sub.add_parser(
         "refresh-flush",
-        help="Run a sandboxed `claude --print` and check that the "
-        "OAuth token is rotated on the way out (passive; expects "
-        "current token to still be valid).",
+        help="Run `claude --print` against the real Keychain and check "
+        "whether the OAuth token rotates on the way out (passive; "
+        "expects current token to still be valid).",
     ).set_defaults(func=cmd_test_refresh_flush)
-
-    forced = test_sub.add_parser(
-        "refresh-flush-forced",
-        help="Force the refresh code path by mutating the cached "
-        "blob's expiresAt to a past timestamp. HAS SIDE EFFECTS: "
-        "rotates the user's real refresh_token; requires --yes.",
-    )
-    forced.add_argument(
-        "--yes",
-        action="store_true",
-        help="Acknowledge that this probe will rotate your real "
-        "OAuth refresh_token.",
-    )
-    forced.set_defaults(func=cmd_test_refresh_flush_forced)
-
-    test_sub.add_parser(
-        "keychain-survives-token-env",
-        help="Reproduce GitHub issue #37512: does setting "
-        "CLAUDE_CODE_OAUTH_TOKEN delete the Keychain entry? Verify the "
-        "shim protects against it.",
-    ).set_defaults(func=cmd_test_keychain_survives_token_env)
 
     test_sub.add_parser(
         "full-probe",

--- a/src/puffo_agent/portal/diagnostic.py
+++ b/src/puffo_agent/portal/diagnostic.py
@@ -416,12 +416,25 @@ def probe_refresh_flush_forced() -> ProbeReport:
 
     **Has real side effects:** Anthropic rotates the refresh_token on
     every successful refresh, so the user's pre-probe refresh_token is
-    invalidated as soon as claude succeeds. We write the freshly-issued
-    blob back to the Keychain so the user's main CLI / VS Code
-    extension stays authenticated. If that writeback fails, the user
-    is left in a degraded state where their main CLI will need a re-
-    login (the new tokens still live in our run-dir cache, but main
-    CLI doesn't know about them).
+    invalidated as soon as claude succeeds. We always reconcile the
+    Keychain state at the end so the user's main CLI / VS Code extension
+    keeps a working token.
+
+    Rotation may happen via two paths and we must handle both:
+
+      1. ``claude`` rewrites the sandbox ``.credentials.json`` — we
+         writeback to Keychain ourselves.
+      2. ``claude`` writes the new blob directly to the user's real
+         Keychain. On macOS, ``$HOME`` does NOT isolate Keychain access
+         (ACL is keyed on UID + signing identity, not HOME), so the
+         sandbox claude reaches the real Keychain anyway and writes
+         there itself. No writeback needed.
+
+    Critically, ``rc != 0`` does **not** mean "Anthropic side-effect
+    didn't happen": claude can rotate successfully and then exit non-
+    zero from a later unrelated step. We always re-read Keychain + the
+    sandbox file after the run and decide writeback from observed
+    state, not from rc.
 
     Designed for occasional manual verification, NOT for every
     deploy. The natural ``refresh-flush`` is the everyday probe.
@@ -449,8 +462,9 @@ def probe_refresh_flush_forced() -> ProbeReport:
     rpt.add(
         "prerequisite-keychain",
         VERDICT_OK,
-        "original blob captured (will write back at the end to keep "
-        "main CLI alive)",
+        "original blob captured; will reconcile Keychain against actual "
+        "post-run state (claude in sandbox can write the real Keychain "
+        "directly because $HOME doesn't isolate it on macOS)",
     )
 
     mutated = _force_expiry(read_result.blob, seconds_in_past=60)
@@ -466,7 +480,7 @@ def probe_refresh_flush_forced() -> ProbeReport:
         "force-expiry",
         VERDICT_OK,
         "set claudeAiOauth.expiresAt = now - 60s in sandbox copy "
-        "(Keychain entry untouched until writeback step)",
+        "(Keychain entry will be re-read after the sandbox run)",
     )
 
     home = home_dir()
@@ -482,88 +496,135 @@ def probe_refresh_flush_forced() -> ProbeReport:
         )
         elapsed_ms = int((time.time() - started) * 1000)
 
-        if code != 0:
+        # Re-read Keychain regardless of rc: claude may have written
+        # straight to the real Keychain (HOME doesn't isolate it), so
+        # the rc alone doesn't tell us whether rotation happened.
+        post_read = read_keychain_blob()
+        keychain_after_blob = post_read.blob if post_read.ok else None
+        keychain_after_token = _access_token(keychain_after_blob or "")
+        sandbox_token = _access_token(refreshed or "")
+
+        sandbox_rotated = bool(sandbox_token) and sandbox_token != old_token
+        keychain_rotated = (
+            bool(keychain_after_token) and keychain_after_token != old_token
+        )
+
+        if code == 0:
+            rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
+        else:
+            # rc != 0 is only a real failure if NOTHING rotated. If
+            # something did rotate, surface it as NEEDS_ATTENTION so
+            # the operator investigates the exit code separately.
+            verdict = (
+                VERDICT_NEEDS_ATTENTION
+                if (sandbox_rotated or keychain_rotated)
+                else VERDICT_FAIL
+            )
             rpt.add(
                 "claude-oneshot",
-                VERDICT_FAIL,
+                verdict,
                 f"exit={code}, elapsed_ms={elapsed_ms}\n"
-                f"stderr (last 500): {stderr_tail}",
+                f"stderr (last 500): {stderr_tail}\n"
+                "(continuing: inspecting Keychain + sandbox creds for "
+                "partial rotation regardless of rc)",
+            )
+
+        # Decide from observed state, not rc.
+        if not sandbox_rotated and not keychain_rotated:
+            rpt.add(
+                "rotation-outcome",
+                VERDICT_FAIL,
+                "neither sandbox creds nor Keychain show a new "
+                "access_token. claude did not reach Anthropic's refresh "
+                "endpoint, or the refresh failed. Keychain unchanged — "
+                "main CLI is safe.\n"
+                f"old:           {_redact_token(old_token)}\n"
+                f"sandbox after: {_redact_token(sandbox_token)}\n"
+                f"keychain after: {_redact_token(keychain_after_token)}",
             )
             rpt.summary = (
-                "Forced refresh failed before completing. Anthropic "
-                "side-effect did not happen — Keychain untouched."
-            )
-            return rpt
-        rpt.add("claude-oneshot", VERDICT_OK, f"exit=0, elapsed_ms={elapsed_ms}")
-
-        if refreshed is None:
-            rpt.add(
-                "credentials-file",
-                VERDICT_FAIL,
-                "sandbox .credentials.json was DELETED — flush failed",
+                "Forced expiry did not produce a rotation. No Anthropic "
+                "side-effect; Keychain untouched."
             )
             return rpt
 
-        new_token = _access_token(refreshed)
-        rotated = bool(new_token) and old_token != new_token
         rpt.add(
-            "credentials-file",
-            VERDICT_OK if rotated else VERDICT_FAIL,
-            "token rotated: {}\nold: {}\nnew: {}\n{}".format(
-                rotated,
+            "rotation-outcome",
+            VERDICT_OK,
+            "rotation detected: sandbox_rotated={}, keychain_rotated={}\n"
+            "old:           {}\n"
+            "sandbox after: {}\n"
+            "keychain after: {}".format(
+                sandbox_rotated,
+                keychain_rotated,
                 _redact_token(old_token),
-                _redact_token(new_token),
-                (
-                    "claude saw the past expiresAt and refreshed."
-                    if rotated else
-                    "claude did NOT rotate despite forced expiry — "
-                    "the refresh code path is broken or behind a flag "
-                    "we don't set."
-                ),
+                _redact_token(sandbox_token),
+                _redact_token(keychain_after_token),
             ),
         )
 
-        if not rotated:
-            rpt.summary = (
-                "Forced expiry did not trigger refresh. Investigate "
-                "before promoting — `refresh_via_oneshot` will silently "
-                "no-op in production."
-            )
-            return rpt
-
-        # Critical: writeback the freshly-rotated blob to Keychain so
-        # the user's main CLI doesn't get stranded with an invalid
-        # refresh_token. Anthropic invalidated the original
-        # refresh_token the moment they issued the new one.
-        wb_ok, wb_reason = writeback_to_keychain(refreshed)
-        if wb_ok:
+        # Reconcile Keychain. Writeback only when Keychain doesn't
+        # already hold the rotated blob — naively writing the original
+        # back on any failure path would clobber a token claude just
+        # rotated into Keychain itself, leaving the user with an
+        # Anthropic-invalidated refresh_token.
+        if (
+            keychain_rotated
+            and sandbox_rotated
+            and keychain_after_token == sandbox_token
+        ):
             rpt.add(
                 "keychain-writeback",
                 VERDICT_OK,
-                "freshly-rotated tokens written back to Keychain; "
-                "main CLI / VS Code extension will see them on next "
-                "use",
+                "Keychain already holds the rotated token (claude wrote "
+                "it directly); no writeback needed.",
             )
-            rpt.summary = (
-                "Forced refresh succeeded end-to-end: claude rotated "
-                "the token AND we synced the new value back to "
-                "Keychain. `refresh_via_oneshot` will work as "
-                "designed in production."
-            )
-        else:
+        elif keychain_rotated and not sandbox_rotated:
             rpt.add(
                 "keychain-writeback",
-                VERDICT_NEEDS_ATTENTION,
-                f"writeback failed: {wb_reason}\n"
-                "Main CLI's view of the credentials is now STALE. "
-                "Run `puffo-agent test keychain-write` to diagnose; "
-                "user may need to re-login via `claude` in a terminal "
-                "to recover.",
+                VERDICT_OK,
+                "Keychain holds a new token from claude's direct write; "
+                "sandbox creds file was not updated. Trusting Keychain "
+                "as canonical — no writeback needed.",
             )
+        elif sandbox_rotated and refreshed is not None:
+            # Either Keychain wasn't rotated (we must writeback) or
+            # there's a disagreement between sandbox and Keychain (we
+            # prefer the sandbox blob since it's the one we definitively
+            # observed claude write during this run).
+            wb_ok, wb_reason = writeback_to_keychain(refreshed)
+            if wb_ok:
+                rpt.add(
+                    "keychain-writeback",
+                    VERDICT_OK,
+                    "rotated sandbox blob written back to Keychain; "
+                    "main CLI / VS Code extension will see it on next "
+                    "use.",
+                )
+            else:
+                rpt.add(
+                    "keychain-writeback",
+                    VERDICT_NEEDS_ATTENTION,
+                    f"writeback failed: {wb_reason}\n"
+                    "Main CLI's view of the credentials is now STALE. "
+                    "Run `puffo-agent test keychain-write` to diagnose; "
+                    "user may need to re-login via `claude` in a "
+                    "terminal to recover.",
+                )
+
+        if code == 0:
             rpt.summary = (
-                "Forced refresh worked but writeback to Keychain "
-                "failed. Main CLI is now in a degraded state and may "
-                "need a manual re-login."
+                "Forced refresh succeeded end-to-end: claude rotated "
+                "the token and the new value is live in Keychain. "
+                "`refresh_via_oneshot` will work as designed in "
+                "production."
+            )
+        else:
+            rpt.summary = (
+                f"Forced refresh: claude exited {code} but Anthropic-"
+                "side rotation DID happen and Keychain is reconciled. "
+                "Refresh mechanism is effective; investigate the non-"
+                "zero exit code separately."
             )
 
     return rpt

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -305,6 +305,60 @@ def test_refresh_via_oneshot_token_unchanged(monkeypatch, tmp_path):
     assert reason == "token_unchanged"
 
 
+def test_stage_keychain_visibility_creates_symlink(monkeypatch, tmp_path):
+    """The helper must symlink the real ~/Library/Keychains into the
+    sandbox so the security CLI's HOME-relative lookup finds the user's
+    login keychain instead of asking to create a new one."""
+    real_home = tmp_path / "real_home"
+    real_keychains = real_home / "Library" / "Keychains"
+    real_keychains.mkdir(parents=True)
+    (real_keychains / "login.keychain-db").write_bytes(b"")
+    monkeypatch.setattr(cm.Path, "home", classmethod(lambda cls: real_home))
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    err = cm._stage_keychain_visibility(sandbox)
+    assert err is None
+    target = sandbox / "Library" / "Keychains"
+    assert target.is_symlink()
+    assert (target / "login.keychain-db").exists()
+
+
+def test_stage_keychain_visibility_is_idempotent(monkeypatch, tmp_path):
+    """Calling twice on the same sandbox must not error and must not
+    end up with a nested or broken symlink."""
+    real_home = tmp_path / "real_home"
+    (real_home / "Library" / "Keychains").mkdir(parents=True)
+    monkeypatch.setattr(cm.Path, "home", classmethod(lambda cls: real_home))
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    assert cm._stage_keychain_visibility(sandbox) is None
+    assert cm._stage_keychain_visibility(sandbox) is None
+    target = sandbox / "Library" / "Keychains"
+    assert target.is_symlink()
+    # Symlink target should still be the real dir, not a recursive link.
+    assert target.resolve() == (real_home / "Library" / "Keychains").resolve()
+
+
+def test_stage_keychain_visibility_missing_real_keychains(monkeypatch, tmp_path):
+    """If the real ~/Library/Keychains doesn't exist (unusual but
+    possible in CI / fresh accounts), return a reason instead of
+    crashing — the caller treats this as best-effort."""
+    real_home = tmp_path / "real_home"
+    real_home.mkdir()  # no Library/Keychains under it
+    monkeypatch.setattr(cm.Path, "home", classmethod(lambda cls: real_home))
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    err = cm._stage_keychain_visibility(sandbox)
+    assert err == "real_keychains_missing"
+    assert not (sandbox / "Library" / "Keychains").exists()
+
+
 def test_refresh_via_oneshot_handles_claude_exit_failure(monkeypatch, tmp_path):
     _force_macos(monkeypatch)
     monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -192,21 +192,50 @@ def test_bootstrap_writes_cache(monkeypatch, tmp_path):
     assert cache.read() == _BLOB
 
 
-def test_bootstrap_skips_when_cache_warm(monkeypatch, tmp_path):
+def test_bootstrap_overwrites_stale_cache_with_keychain(monkeypatch, tmp_path):
+    """Regression: daemon restart with a stale cache (e.g. the user
+    /login'd while the daemon was off) MUST pull the canonical blob
+    from Keychain on bootstrap, not blindly trust the cache. Otherwise
+    the daemon sync_to_agent fans out the stale RT, the spawned claude
+    workers immediately 401, and the user sees auth errors until the
+    401-wake recovers."""
+    _force_macos(monkeypatch)
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)  # stale cache from a previous daemon session
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(0, stdout=_REFRESHED_BLOB),
+    )
+    ok, reason = cm.bootstrap_from_keychain(cache)
+    assert ok is True
+    assert reason == "bootstrapped"
+    # Cache now reflects the canonical Keychain blob, not the stale one.
+    assert cache.read() == _REFRESHED_BLOB
+
+
+def test_bootstrap_falls_back_to_cache_when_keychain_read_fails(
+    monkeypatch, tmp_path,
+):
+    """Transient Keychain read failure shouldn't crash the daemon if
+    the cache has plausibly-current credentials — the 5-min external-
+    rotation poll will keep trying. Degraded-mode boot."""
     _force_macos(monkeypatch)
     cache = cm.CredentialCache.at(tmp_path)
     cache.write(_BLOB)
-
-    def _fake_run(*a, **k):
-        raise AssertionError("should not have run security")
-
-    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompletedProcess(1, stderr="transient"),
+    )
     ok, reason = cm.bootstrap_from_keychain(cache)
     assert ok is True
-    assert reason == "cache_already_warm"
+    assert "fell_back_to_cache" in reason
+    # Cache untouched.
+    assert cache.read() == _BLOB
 
 
-def test_bootstrap_propagates_read_error(monkeypatch, tmp_path):
+def test_bootstrap_propagates_read_error_when_no_cache(monkeypatch, tmp_path):
+    """No cache + Keychain unreadable → daemon can't bootstrap. Fail
+    cleanly so the operator sees the cause."""
     _force_macos(monkeypatch)
     monkeypatch.setattr(
         subprocess, "run",

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -322,6 +322,64 @@ def test_refresh_via_oneshot_handles_claude_exit_failure(monkeypatch, tmp_path):
     assert reason == "claude_exit_code=1"
 
 
+def test_refresh_via_oneshot_salvages_rotation_on_nonzero_exit(
+    monkeypatch, tmp_path,
+):
+    """claude can rotate the OAuth token successfully and then exit
+    non-zero from a later unrelated step. The pre-fix behaviour dropped
+    the rotated blob in that case, leaving Anthropic to invalidate the
+    refresh_token while the user's main CLI was stuck on it — needing
+    a manual ``claude login`` to recover. Now we always read the
+    sandbox file and accept the rotation regardless of rc."""
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        # claude wrote a fresh blob, THEN died.
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
+        return _FakeAsyncProc(1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is True
+    assert reason == "token_refreshed_rc=1"
+    # The rotated blob must be in the cache so writeback can pick it up.
+    assert cache.access_token() == "sk-ant-NEW-access"
+
+
+def test_refresh_via_oneshot_failure_with_unchanged_blob_still_fails(
+    monkeypatch, tmp_path,
+):
+    """If claude exits non-zero AND the sandbox file shows no rotation
+    (claude wrote it back identical, or failed before reaching the
+    refresh path), the refresh is a real failure — don't pretend
+    success."""
+    _force_macos(monkeypatch)
+    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+    cache = cm.CredentialCache.at(tmp_path)
+    cache.write(_BLOB)
+
+    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
+        # Sandbox file contains the same token as the input.
+        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
+        sandbox_creds.write_text(_BLOB, encoding="utf-8")
+        return _FakeAsyncProc(7)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    ok, reason = asyncio.run(
+        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
+    )
+    assert ok is False
+    assert reason == "claude_exit_code=7"
+    # Cache must remain on the original blob.
+    assert cache.access_token() == "sk-ant-original-access"
+
+
 def test_refresh_via_oneshot_skipped_off_macos(monkeypatch, tmp_path):
     _disable_macos(monkeypatch)
     cache = cm.CredentialCache.at(tmp_path)

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -4,8 +4,8 @@
 We can't actually call the macOS ``security`` binary on a Linux / CI
 runner, so the keychain primitives are exercised via
 ``subprocess.run`` / ``asyncio.create_subprocess_exec`` monkey-patches.
-The cache, shim, refresh-oneshot, and the end-to-end refresher fan-out
-are real code paths that run on every platform.
+The cache, refresh path, and end-to-end refresher fan-out are real
+code paths that run on every platform.
 """
 
 from __future__ import annotations
@@ -71,7 +71,6 @@ def test_cache_write_is_atomic(tmp_path):
     cache.write(_BLOB)
     assert cache.path.exists()
     cache.write(_REFRESHED_BLOB)
-    # No leftover tmp files.
     siblings = list(cache.path.parent.glob(".claude-credentials.json.tmp.*"))
     assert siblings == []
     assert cache.read() == _REFRESHED_BLOB
@@ -80,37 +79,16 @@ def test_cache_write_is_atomic(tmp_path):
 def test_cache_access_token_handles_malformed_blob(tmp_path):
     cache = cm.CredentialCache.at(tmp_path)
     cache.path.parent.mkdir(parents=True, exist_ok=True)
-    cache.path.write_text("not json {", encoding="utf-8")
+    cache.path.write_text("not json", encoding="utf-8")
     assert cache.access_token() is None
-    assert cache.expires_at_seconds() is None
 
 
 def test_cache_expires_at_seconds(tmp_path):
     cache = cm.CredentialCache.at(tmp_path)
     cache.write(_BLOB)
-    assert cache.expires_at_seconds() == 9_999_999.000
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# PATH shim
-# ─────────────────────────────────────────────────────────────────────────────
-
-def test_install_path_shim_writes_executable(tmp_path):
-    d = cm.install_path_shim(tmp_path)
-    binary = d / "security"
-    assert binary.exists()
-    body = binary.read_text(encoding="utf-8")
-    assert body.startswith("#!/bin/bash")
-    assert "delete-generic-password" in body
-    assert "Claude Code-credentials" in body
-    assert "/usr/bin/security" in body
-
-
-def test_install_path_shim_overwrites_existing(tmp_path):
-    d = cm.install_path_shim(tmp_path)
-    (d / "security").write_text("# manually edited", encoding="utf-8")
-    cm.install_path_shim(tmp_path)
-    assert "#!/bin/bash" in (d / "security").read_text(encoding="utf-8")
+    expires = cache.expires_at_seconds()
+    assert expires is not None
+    assert expires == 9_999_999_000 / 1000.0
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -241,239 +219,30 @@ def test_bootstrap_propagates_read_error(monkeypatch, tmp_path):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Refresh oneshot — subprocess mocked
+# KeychainBackend — plugged into CredentialRefresher
 # ─────────────────────────────────────────────────────────────────────────────
 
 class _FakeAsyncProc:
-    def __init__(self, returncode: int):
+    def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b""):
         self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
 
     async def communicate(self):
-        return (b"", b"")
+        return (self._stdout, self._stderr)
 
     def kill(self):
         pass
 
 
-def test_refresh_via_oneshot_rotates_token(monkeypatch, tmp_path):
-    _force_macos(monkeypatch)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-
-    sandbox_seen = {}
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        sandbox_seen["cwd"] = cwd
-        sandbox_seen["env"] = env
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
-        return _FakeAsyncProc(0)
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is True
-    assert reason == "token_refreshed"
-    assert cache.access_token() == "sk-ant-NEW-access"
-    # Must NOT set CLAUDE_CODE_OAUTH_TOKEN — that env var triggers the
-    # bug #37512 Keychain-delete path on exit.
-    assert "CLAUDE_CODE_OAUTH_TOKEN" not in (sandbox_seen.get("env") or {})
-    # PATH must include the shim dir.
-    path_val = (sandbox_seen.get("env") or {}).get("PATH", "")
-    assert str(tmp_path / "shim") in path_val
-
-
-def test_refresh_via_oneshot_token_unchanged(monkeypatch, tmp_path):
-    _force_macos(monkeypatch)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_BLOB, encoding="utf-8")
-        return _FakeAsyncProc(0)
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is True
-    assert reason == "token_unchanged"
-
-
-def test_stage_keychain_visibility_creates_symlink(monkeypatch, tmp_path):
-    """The helper must symlink the real ~/Library/Keychains into the
-    sandbox so the security CLI's HOME-relative lookup finds the user's
-    login keychain instead of asking to create a new one."""
-    real_home = tmp_path / "real_home"
-    real_keychains = real_home / "Library" / "Keychains"
-    real_keychains.mkdir(parents=True)
-    (real_keychains / "login.keychain-db").write_bytes(b"")
-    monkeypatch.setattr(cm.Path, "home", classmethod(lambda cls: real_home))
-
-    sandbox = tmp_path / "sandbox"
-    sandbox.mkdir()
-
-    err = cm._stage_keychain_visibility(sandbox)
-    assert err is None
-    target = sandbox / "Library" / "Keychains"
-    assert target.is_symlink()
-    assert (target / "login.keychain-db").exists()
-
-
-def test_stage_keychain_visibility_is_idempotent(monkeypatch, tmp_path):
-    """Calling twice on the same sandbox must not error and must not
-    end up with a nested or broken symlink."""
-    real_home = tmp_path / "real_home"
-    (real_home / "Library" / "Keychains").mkdir(parents=True)
-    monkeypatch.setattr(cm.Path, "home", classmethod(lambda cls: real_home))
-
-    sandbox = tmp_path / "sandbox"
-    sandbox.mkdir()
-
-    assert cm._stage_keychain_visibility(sandbox) is None
-    assert cm._stage_keychain_visibility(sandbox) is None
-    target = sandbox / "Library" / "Keychains"
-    assert target.is_symlink()
-    # Symlink target should still be the real dir, not a recursive link.
-    assert target.resolve() == (real_home / "Library" / "Keychains").resolve()
-
-
-def test_stage_keychain_visibility_missing_real_keychains(monkeypatch, tmp_path):
-    """If the real ~/Library/Keychains doesn't exist (unusual but
-    possible in CI / fresh accounts), return a reason instead of
-    crashing — the caller treats this as best-effort."""
-    real_home = tmp_path / "real_home"
-    real_home.mkdir()  # no Library/Keychains under it
-    monkeypatch.setattr(cm.Path, "home", classmethod(lambda cls: real_home))
-
-    sandbox = tmp_path / "sandbox"
-    sandbox.mkdir()
-
-    err = cm._stage_keychain_visibility(sandbox)
-    assert err == "real_keychains_missing"
-    assert not (sandbox / "Library" / "Keychains").exists()
-
-
-def test_refresh_via_oneshot_handles_claude_exit_failure(monkeypatch, tmp_path):
-    _force_macos(monkeypatch)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        return _FakeAsyncProc(1)
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is False
-    assert reason == "claude_exit_code=1"
-
-
-def test_refresh_via_oneshot_salvages_rotation_on_nonzero_exit(
-    monkeypatch, tmp_path,
-):
-    """claude can rotate the OAuth token successfully and then exit
-    non-zero from a later unrelated step. The pre-fix behaviour dropped
-    the rotated blob in that case, leaving Anthropic to invalidate the
-    refresh_token while the user's main CLI was stuck on it — needing
-    a manual ``claude login`` to recover. Now we always read the
-    sandbox file and accept the rotation regardless of rc."""
-    _force_macos(monkeypatch)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        # claude wrote a fresh blob, THEN died.
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
-        return _FakeAsyncProc(1)
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is True
-    assert reason == "token_refreshed_rc=1"
-    # The rotated blob must be in the cache so writeback can pick it up.
-    assert cache.access_token() == "sk-ant-NEW-access"
-
-
-def test_refresh_via_oneshot_failure_with_unchanged_blob_still_fails(
-    monkeypatch, tmp_path,
-):
-    """If claude exits non-zero AND the sandbox file shows no rotation
-    (claude wrote it back identical, or failed before reaching the
-    refresh path), the refresh is a real failure — don't pretend
-    success."""
-    _force_macos(monkeypatch)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        # Sandbox file contains the same token as the input.
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_BLOB, encoding="utf-8")
-        return _FakeAsyncProc(7)
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is False
-    assert reason == "claude_exit_code=7"
-    # Cache must remain on the original blob.
-    assert cache.access_token() == "sk-ant-original-access"
-
-
-def test_refresh_via_oneshot_skipped_off_macos(monkeypatch, tmp_path):
-    _disable_macos(monkeypatch)
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is False
-    assert reason == "not_macos"
-
-
-def test_refresh_via_oneshot_skipped_when_claude_missing(monkeypatch, tmp_path):
-    _force_macos(monkeypatch)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: None)
-    cache = cm.CredentialCache.at(tmp_path)
-    cache.write(_BLOB)
-    ok, reason = asyncio.run(
-        cm.refresh_via_oneshot(cache, tmp_path / "shim"),
-    )
-    assert ok is False
-    assert reason == "claude_binary_missing"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# KeychainBackend — plugged into CredentialRefresher
-# ─────────────────────────────────────────────────────────────────────────────
-
 def _make_keychain_backend(home: Path) -> cr.KeychainBackend:
     cache = cm.CredentialCache.at(home)
-    return cr.KeychainBackend(
-        home=home, cache=cache, shim_dir=home / "run" / "keychain-shim",
-    )
+    return cr.KeychainBackend(home=home, cache=cache)
 
 
-def test_keychain_backend_bootstrap_installs_shim_and_reads_keychain(
-    monkeypatch, tmp_path,
-):
-    """``bootstrap`` should populate the cache from Keychain and
-    install the PATH shim. The refresher calls this once on
-    daemon-loop entry."""
+def test_keychain_backend_bootstrap_reads_keychain(monkeypatch, tmp_path):
+    """``bootstrap`` should populate the cache from Keychain. The
+    refresher calls this once on daemon-loop entry."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
     monkeypatch.setattr(
         subprocess, "run",
@@ -483,10 +252,7 @@ def test_keychain_backend_bootstrap_installs_shim_and_reads_keychain(
     ok, reason = asyncio.run(backend.bootstrap())
     assert ok is True
     assert reason == "bootstrapped"
-    # Cache materialised from the Keychain.
     assert backend.cache.read() == _BLOB
-    # Shim installed.
-    assert (tmp_path / "run" / "keychain-shim" / "security").exists()
     # Internal last-propagated marker populated so the external-poll
     # loop has a baseline to diff against.
     assert backend._last_propagated_blob == _BLOB
@@ -557,56 +323,70 @@ def test_keychain_backend_sync_skips_when_cache_empty(tmp_path, monkeypatch):
     assert not (agent_home / ".claude" / ".credentials.json").exists()
 
 
-def test_keychain_backend_refresh_returns_refreshed_on_token_rotation(
-    monkeypatch, tmp_path,
-):
-    """Backend refresh: cache → refresh oneshot → cache write →
-    writeback to Keychain (best-effort). Returns REFRESHED when the
-    access token actually rotated."""
-    monkeypatch.setattr(cm, "is_macos", lambda: True)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
+def _stub_keychain_sequence(monkeypatch, blobs):
+    """Stub ``cm.read_keychain_blob`` to return successive blobs from
+    ``blobs`` on each call (last one repeats if exhausted)."""
+    queue = list(blobs)
 
-    backend = _make_keychain_backend(tmp_path)
-    backend.cache.write(_BLOB)
+    def fake_read(timeout=cm.SECURITY_TIMEOUT_SECONDS):
+        blob = queue.pop(0) if len(queue) > 1 else queue[0]
+        return cm.KeychainReadResult(True, blob, None, None)
+
+    monkeypatch.setattr(cm, "read_keychain_blob", fake_read)
+
+
+def test_keychain_backend_refresh_uses_real_home(monkeypatch, tmp_path):
+    """KeychainBackend.refresh must spawn ``claude --print`` with the
+    user's real HOME (NOT a sandbox HOME) — mirrors FileBackend so
+    claude's own OAuth path writes Keychain directly the same way the
+    user's interactive ``claude`` invocation does."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+
+    spawned = {}
 
     async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
+        spawned["env"] = env
+        spawned["cwd"] = cwd
+        spawned["argv"] = args
         return _FakeAsyncProc(0)
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    # First Keychain read returns the pre-refresh blob; second returns
+    # the post-refresh (rotated) blob.
+    _stub_keychain_sequence(monkeypatch, [_BLOB, _REFRESHED_BLOB])
 
-    writeback_calls: list = []
-
-    def _fake_writeback(blob, timeout=cm.SECURITY_TIMEOUT_SECONDS):
-        writeback_calls.append(blob)
-        return (True, None)
-
-    monkeypatch.setattr(cm, "writeback_to_keychain", _fake_writeback)
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
 
     outcome = asyncio.run(backend.refresh())
     assert outcome == cr.RefreshOutcome.REFRESHED
-    assert backend.cache.access_token() == "sk-ant-NEW-access"
-    assert writeback_calls == [_REFRESHED_BLOB]
+    # HOME = real user HOME, not a sandbox tempdir.
+    assert spawned["env"]["HOME"] == str(Path.home())
+    assert spawned["cwd"] == str(Path.home())
+    # Sentinel against #37512 regression — must never set this env var.
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in spawned["env"]
+    # Cache is now synced to the rotated blob (read straight from Keychain).
+    assert backend.cache.read() == _REFRESHED_BLOB
     assert backend._last_propagated_blob == _REFRESHED_BLOB
 
 
-def test_keychain_backend_refresh_returns_unchanged_when_token_stays(
+def test_keychain_backend_refresh_returns_unchanged_when_token_stays_fresh(
     monkeypatch, tmp_path,
 ):
+    """When claude sees the token isn't close to expiring, it skips
+    the OAuth round-trip and Keychain stays put. Backend reports
+    UNCHANGED, not FAILED."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
 
-    backend = _make_keychain_backend(tmp_path)
-    backend.cache.write(_BLOB)
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_BLOB, encoding="utf-8")  # same blob back
+    async def _fake_spawn(*args, **kwargs):
         return _FakeAsyncProc(0)
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    # Same blob both reads → Keychain unchanged.
+    _stub_keychain_sequence(monkeypatch, [_BLOB, _BLOB])
 
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
     outcome = asyncio.run(backend.refresh())
     assert outcome == cr.RefreshOutcome.UNCHANGED
 
@@ -615,18 +395,43 @@ def test_keychain_backend_refresh_returns_failed_on_claude_exit_failure(
     monkeypatch, tmp_path,
 ):
     monkeypatch.setattr(cm, "is_macos", lambda: True)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
 
-    backend = _make_keychain_backend(tmp_path)
-    backend.cache.write(_BLOB)
-
-    async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
-        return _FakeAsyncProc(1)
+    async def _fake_spawn(*args, **kwargs):
+        return _FakeAsyncProc(1, stderr=b"boom")
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
 
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
     outcome = asyncio.run(backend.refresh())
     assert outcome == cr.RefreshOutcome.FAILED
+
+
+def test_keychain_backend_refresh_returns_failed_on_post_keychain_read_failure(
+    monkeypatch, tmp_path,
+):
+    """claude exits 0 but the post-refresh Keychain re-read fails (e.g.
+    transient permission issue). Don't poison the cache — return
+    FAILED so the daemon retries on the next tick."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+
+    async def _fake_spawn(*args, **kwargs):
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "exit_code=44", None,
+        ),
+    )
+
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome == cr.RefreshOutcome.FAILED
+    # Cache must not have been clobbered.
+    assert backend.cache.read() == _BLOB
 
 
 def test_keychain_backend_poll_external_rotation_detects_change(
@@ -696,7 +501,20 @@ def test_refresher_with_keychain_backend_fans_sync_to_registered_agents(
     plumbed through the backend abstraction."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
     backend = _make_keychain_backend(tmp_path)
-    backend.cache.write(_BLOB)
+    # Seed with a blob whose expiresAt is comfortably outside the
+    # refresh safety margin, so _tick goes straight to _sync_views
+    # without trying to spawn claude — otherwise the test would either
+    # spawn the real binary (polluting tester credentials!) or need a
+    # subprocess monkeypatch we don't care about here.
+    import time as _time
+    far_future_blob = json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "x",
+            "refreshToken": "y",
+            "expiresAt": int((_time.time() + 24 * 3600) * 1000),  # +24h
+        },
+    })
+    backend.cache.write(far_future_blob)
     refresher = cr.CredentialRefresher(backend=backend)
 
     agent_a = tmp_path / "agent-a"
@@ -706,19 +524,17 @@ def test_refresher_with_keychain_backend_fans_sync_to_registered_agents(
 
     asyncio.run(refresher._tick())
 
-    assert (agent_a / ".claude" / ".credentials.json").read_text() == _BLOB
-    assert (agent_b / ".claude" / ".credentials.json").read_text() == _BLOB
+    assert (agent_a / ".claude" / ".credentials.json").read_text() == far_future_blob
+    assert (agent_b / ".claude" / ".credentials.json").read_text() == far_future_blob
 
 
 def test_refresher_with_keychain_backend_refreshes_when_close_to_expiry(
     monkeypatch, tmp_path,
 ):
     """Cache blob expiring soon → refresher triggers
-    backend.refresh()."""
+    backend.refresh() with real HOME (mirror FileBackend)."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
     backend = _make_keychain_backend(tmp_path)
-    # Seed with a blob expiring in 1 minute (well inside the 10-min margin).
     import time as _time
     soon_expiry = int((_time.time() + 60) * 1000)
     near_expiry_blob = json.dumps({
@@ -734,71 +550,19 @@ def test_refresher_with_keychain_backend_refreshes_when_close_to_expiry(
 
     async def _fake_spawn(*args, env=None, cwd=None, **kwargs):
         spawned.append(env)
-        # Pretend claude wrote a rotated blob.
-        sandbox_creds = Path(cwd) / ".claude" / ".credentials.json"
-        sandbox_creds.write_text(_REFRESHED_BLOB, encoding="utf-8")
         return _FakeAsyncProc(0)
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-    monkeypatch.setattr(cm, "writeback_to_keychain", lambda *a, **k: (True, None))
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            True, _REFRESHED_BLOB, None, None,
+        ),
+    )
 
     refresher = cr.CredentialRefresher(backend=backend)
     asyncio.run(refresher._tick())
     assert spawned, "backend.refresh should have run claude --print"
-    # Refresh ran inside a sandbox HOME (not the operator's), so HOME
-    # must be a tempdir, not host_home.
+    # Refresh uses real HOME — same model as FileBackend.
     env = spawned[0]
-    assert "HOME" in env
-    assert env["HOME"] != str(Path.home())
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# FD-leak regression — timeout path drains pipes
-# ─────────────────────────────────────────────────────────────────────────────
-
-def test_timeout_path_kills_proc_and_drains_pipes(monkeypatch, tmp_path):
-    """The previous timeout path returned without awaiting proc.wait()
-    + pipe close, leaking 3 FDs (stdin/stdout/stderr) per timed-out
-    refresh. Under multi-agent load this surfaced as ``[Errno 24]
-    Too many open files``. Verify the helper kills + drains."""
-    monkeypatch.setattr(cm.shutil, "which", lambda b: "/usr/local/bin/claude")
-
-    kill_called = {"value": False}
-    drain_calls = {"value": 0}
-
-    class _HangingProc:
-        returncode = None  # alive
-
-        async def communicate(self):
-            if drain_calls["value"] == 0:
-                drain_calls["value"] += 1
-                await asyncio.sleep(60)
-                return (b"", b"")
-            drain_calls["value"] += 1
-            self.returncode = -9
-            return (b"", b"")
-
-        def kill(self):
-            kill_called["value"] = True
-
-        async def wait(self):
-            self.returncode = -9
-
-    async def _fake_spawn(*args, **kwargs):
-        return _HangingProc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-
-    async def _drive():
-        return await cm._run_claude_oneshot(
-            env={}, cwd=str(tmp_path), timeout=0.1,
-        )
-
-    rc, err = asyncio.run(_drive())
-    assert rc is None
-    assert err == "refresh_oneshot_timeout"
-    assert kill_called["value"], "proc.kill() must run on timeout"
-    assert drain_calls["value"] == 2, (
-        "expected one wait_for'd communicate() + one drain communicate() "
-        "after kill — got %d" % drain_calls["value"]
-    )
+    assert env["HOME"] == str(Path.home())

--- a/tests/test_macos_diagnostic.py
+++ b/tests/test_macos_diagnostic.py
@@ -224,3 +224,156 @@ def test_refresh_flush_forced_requires_yes_flag(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "rotates" in captured.err.lower()
     assert "--yes" in captured.err
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# refresh-flush-forced — rc-vs-rotation reconciliation
+#
+# The probe must decide writeback + verdict from the observed Keychain
+# and sandbox-creds state after the run, not from claude's exit code.
+# Pre-fix it took an rc-based early return and either dropped a real
+# rotation (stranding the user with an Anthropic-invalidated RT) or
+# falsely reported "Keychain untouched" when claude had already updated
+# the Keychain via its own native write.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_BLOB_NEW = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-NEW",
+        "refreshToken": "rt-NEW",
+        "expiresAt": 9_999_999_500,
+    },
+})
+
+
+def _force_macos_for_probe(monkeypatch):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(diag, "is_macos", lambda: True)
+    monkeypatch.setattr(diag.shutil, "which", lambda b: "/usr/local/bin/claude")
+    monkeypatch.setattr(diag, "install_path_shim", lambda home: home / "shim")
+
+
+def _stub_keychain_reads(monkeypatch, prerequisite_blob, post_blob):
+    """Stub ``read_keychain_blob`` so the prerequisite read returns one
+    blob and the post-sandbox read returns another."""
+    calls = {"n": 0}
+
+    def fake_read():
+        calls["n"] += 1
+        blob = prerequisite_blob if calls["n"] == 1 else post_blob
+        return cm.KeychainReadResult(True, blob, None, None)
+
+    monkeypatch.setattr(diag, "read_keychain_blob", fake_read)
+
+
+def _stub_subprocess(monkeypatch, *, sandbox_after_blob, rc):
+    """Stub ``subprocess.run`` so the sandbox claude appears to write
+    the given blob (or nothing, if None) and exits with ``rc``."""
+    def fake_run(*args, cwd=None, **kwargs):
+        if sandbox_after_blob is not None:
+            Path(cwd, ".claude", ".credentials.json").write_text(
+                sandbox_after_blob, encoding="utf-8",
+            )
+        return _FakeCompletedProcess(rc, stdout="", stderr="downstream boom")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+def test_forced_rc_nonzero_but_sandbox_rotated_triggers_writeback(monkeypatch):
+    """claude rotated, wrote the new blob to the sandbox file, then
+    exited non-zero. Keychain still holds the original (claude didn't
+    rewrite it). Probe MUST writeback so main CLI doesn't get stranded
+    on the Anthropic-invalidated RT."""
+    _force_macos_for_probe(monkeypatch)
+    # Prerequisite read + post read both return the original — claude
+    # only updated the sandbox file, not Keychain.
+    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
+    _stub_subprocess(monkeypatch, sandbox_after_blob=_BLOB_NEW, rc=1)
+
+    written = []
+    monkeypatch.setattr(
+        diag, "writeback_to_keychain",
+        lambda blob: (written.append(blob) or (True, None)),
+    )
+
+    rpt = diag.probe_refresh_flush_forced()
+    body = rpt.render_markdown()
+
+    # Salvaged rotation → overall NEEDS_ATTENTION, not FAIL.
+    assert rpt.overall() == diag.VERDICT_NEEDS_ATTENTION, body
+    assert "rotation detected" in body
+    assert "written back to Keychain" in body
+    # Writeback was called with the rotated blob.
+    assert len(written) == 1
+    assert json.loads(written[0])["claudeAiOauth"]["accessToken"] == "sk-ant-NEW"
+
+
+def test_forced_rc_nonzero_with_keychain_rotated_skips_writeback(monkeypatch):
+    """claude wrote the new blob directly into the real Keychain (HOME
+    doesn't isolate Keychain) and then exited non-zero without updating
+    the sandbox file. Keychain is already correct; writeback would be a
+    no-op at best and a clobber at worst — must NOT be called."""
+    _force_macos_for_probe(monkeypatch)
+    # Prerequisite read returns original; post read returns rotated.
+    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB_NEW)
+    # Sandbox file unchanged from the mutated blob.
+    _stub_subprocess(monkeypatch, sandbox_after_blob=None, rc=1)
+
+    written = []
+    monkeypatch.setattr(
+        diag, "writeback_to_keychain",
+        lambda blob: (written.append(blob) or (True, None)),
+    )
+
+    rpt = diag.probe_refresh_flush_forced()
+    body = rpt.render_markdown()
+
+    assert rpt.overall() == diag.VERDICT_NEEDS_ATTENTION, body
+    assert "claude wrote it directly" in body or "claude's direct write" in body
+    assert written == [], (
+        "writeback must NOT be called when Keychain already has the "
+        "rotated token — would clobber a fresh blob with stale data"
+    )
+
+
+def test_forced_rc_nonzero_with_no_rotation_is_real_failure(monkeypatch):
+    """claude exited non-zero AND neither Keychain nor sandbox file
+    shows rotation. Real failure; Keychain unchanged; main CLI safe.
+    Must report FAIL without any writeback."""
+    _force_macos_for_probe(monkeypatch)
+    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
+    _stub_subprocess(monkeypatch, sandbox_after_blob=None, rc=1)
+
+    written = []
+    monkeypatch.setattr(
+        diag, "writeback_to_keychain",
+        lambda blob: (written.append(blob) or (True, None)),
+    )
+
+    rpt = diag.probe_refresh_flush_forced()
+    body = rpt.render_markdown()
+
+    assert rpt.overall() == diag.VERDICT_FAIL, body
+    assert "did not produce a rotation" in body or "Keychain unchanged" in body
+    assert written == []
+
+
+def test_forced_rc_zero_happy_path_writes_back(monkeypatch):
+    """Sanity: the original happy path (claude exits 0, sandbox file
+    has a rotated token, Keychain still on the original) still works
+    end-to-end with writeback."""
+    _force_macos_for_probe(monkeypatch)
+    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
+    _stub_subprocess(monkeypatch, sandbox_after_blob=_BLOB_NEW, rc=0)
+
+    written = []
+    monkeypatch.setattr(
+        diag, "writeback_to_keychain",
+        lambda blob: (written.append(blob) or (True, None)),
+    )
+
+    rpt = diag.probe_refresh_flush_forced()
+    body = rpt.render_markdown()
+
+    assert rpt.overall() == diag.VERDICT_OK, body
+    assert len(written) == 1
+    assert json.loads(written[0])["claudeAiOauth"]["accessToken"] == "sk-ant-NEW"

--- a/tests/test_macos_diagnostic.py
+++ b/tests/test_macos_diagnostic.py
@@ -34,6 +34,14 @@ _BLOB = json.dumps({
     },
 })
 
+_BLOB_NEW = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-ant-NEW",
+        "refreshToken": "rt-NEW",
+        "expiresAt": 9_999_999_500,
+    },
+})
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Report rendering
@@ -94,6 +102,12 @@ def test_summarise_blob_handles_invalid_json():
     assert "invalid JSON" in summary
 
 
+def test_access_token_extraction():
+    assert diag._access_token(_BLOB) == "sk-ant-AAAA"
+    assert diag._access_token("not json") == ""
+    assert diag._access_token(json.dumps({})) == ""
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Off-macOS: every probe returns SKIPPED cleanly
 # ─────────────────────────────────────────────────────────────────────────────
@@ -119,13 +133,6 @@ def test_refresh_flush_skipped_off_macos(monkeypatch):
     assert rpt.overall() == diag.VERDICT_SKIPPED
 
 
-def test_keychain_survives_token_env_skipped_off_macos(monkeypatch):
-    monkeypatch.setattr(cm, "is_macos", lambda: False)
-    monkeypatch.setattr(diag, "is_macos", lambda: False)
-    rpt = diag.probe_keychain_survives_token_env()
-    assert rpt.overall() == diag.VERDICT_SKIPPED
-
-
 def test_full_probe_off_macos(monkeypatch):
     monkeypatch.setattr(cm, "is_macos", lambda: False)
     monkeypatch.setattr(diag, "is_macos", lambda: False)
@@ -136,7 +143,7 @@ def test_full_probe_off_macos(monkeypatch):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# On-macOS: keychain-read happy path with mocked subprocess
+# On-macOS: keychain-read / keychain-write happy path with mocked subprocess
 # ─────────────────────────────────────────────────────────────────────────────
 
 class _FakeCompletedProcess:
@@ -172,93 +179,28 @@ def test_keychain_write_roundtrip_success(monkeypatch):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Forced-expiry helpers
-# ─────────────────────────────────────────────────────────────────────────────
-
-def test_force_expiry_mutates_expires_at():
-    import time
-    out = diag._force_expiry(_BLOB, seconds_in_past=120)
-    assert out is not None
-    parsed = json.loads(out)
-    expires_ms = parsed["claudeAiOauth"]["expiresAt"]
-    # expiresAt should now be in the past (within the last few seconds).
-    assert expires_ms < int(time.time() * 1000)
-    # accessToken and refreshToken should be preserved verbatim — we only
-    # touched expiresAt.
-    assert parsed["claudeAiOauth"]["accessToken"] == "sk-ant-AAAA"
-    assert parsed["claudeAiOauth"]["refreshToken"] == "rt-BBBB"
-
-
-def test_force_expiry_rejects_malformed_blob():
-    assert diag._force_expiry("not json") is None
-
-
-def test_force_expiry_rejects_missing_oauth_dict():
-    assert diag._force_expiry(json.dumps({"unrelated": 1})) is None
-
-
-def test_access_token_extraction():
-    assert diag._access_token(_BLOB) == "sk-ant-AAAA"
-    assert diag._access_token("not json") == ""
-    assert diag._access_token(json.dumps({})) == ""
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# refresh-flush-forced subcommand
-# ─────────────────────────────────────────────────────────────────────────────
-
-def test_refresh_flush_forced_skipped_off_macos(monkeypatch):
-    monkeypatch.setattr(cm, "is_macos", lambda: False)
-    monkeypatch.setattr(diag, "is_macos", lambda: False)
-    rpt = diag.probe_refresh_flush_forced()
-    assert rpt.overall() == diag.VERDICT_SKIPPED
-
-
-def test_refresh_flush_forced_requires_yes_flag(monkeypatch, capsys):
-    """The forced subcommand has destructive side effects; without
-    --yes it must refuse and exit non-zero."""
-    import argparse
-    ns = argparse.Namespace(yes=False)
-    code = diag.cmd_test_refresh_flush_forced(ns)
-    assert code == 2
-    captured = capsys.readouterr()
-    assert "rotates" in captured.err.lower()
-    assert "--yes" in captured.err
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# refresh-flush-forced — rc-vs-rotation reconciliation
+# refresh-flush — passive probe over real HOME
 #
-# The probe must decide writeback + verdict from the observed Keychain
-# and sandbox-creds state after the run, not from claude's exit code.
-# Pre-fix it took an rc-based early return and either dropped a real
-# rotation (stranding the user with an Anthropic-invalidated RT) or
-# falsely reported "Keychain untouched" when claude had already updated
-# the Keychain via its own native write.
+# Pre-fix the probe ran claude in a sandbox HOME with a seeded
+# .credentials.json and inspected the sandbox file after; that turned
+# out to be fragile (claude deletes the sandbox file on exit, security
+# CLI's HOME-relative keychain lookup fires loginKC:queryCreate). The
+# new design mirrors production: real HOME, then re-read Keychain to
+# see if the access_token rotated.
 # ─────────────────────────────────────────────────────────────────────────────
-
-_BLOB_NEW = json.dumps({
-    "claudeAiOauth": {
-        "accessToken": "sk-ant-NEW",
-        "refreshToken": "rt-NEW",
-        "expiresAt": 9_999_999_500,
-    },
-})
-
 
 def _force_macos_for_probe(monkeypatch):
     monkeypatch.setattr(cm, "is_macos", lambda: True)
     monkeypatch.setattr(diag, "is_macos", lambda: True)
     monkeypatch.setattr(diag.shutil, "which", lambda b: "/usr/local/bin/claude")
-    monkeypatch.setattr(diag, "install_path_shim", lambda home: home / "shim")
 
 
 def _stub_keychain_reads(monkeypatch, prerequisite_blob, post_blob):
     """Stub ``read_keychain_blob`` so the prerequisite read returns one
-    blob and the post-sandbox read returns another."""
+    blob and the post-claude-run read returns another."""
     calls = {"n": 0}
 
-    def fake_read():
+    def fake_read(timeout=cm.SECURITY_TIMEOUT_SECONDS):
         calls["n"] += 1
         blob = prerequisite_blob if calls["n"] == 1 else post_blob
         return cm.KeychainReadResult(True, blob, None, None)
@@ -266,114 +208,51 @@ def _stub_keychain_reads(monkeypatch, prerequisite_blob, post_blob):
     monkeypatch.setattr(diag, "read_keychain_blob", fake_read)
 
 
-def _stub_subprocess(monkeypatch, *, sandbox_after_blob, rc):
-    """Stub ``subprocess.run`` so the sandbox claude appears to write
-    the given blob (or nothing, if None) and exits with ``rc``."""
-    def fake_run(*args, cwd=None, **kwargs):
-        if sandbox_after_blob is not None:
-            Path(cwd, ".claude", ".credentials.json").write_text(
-                sandbox_after_blob, encoding="utf-8",
-            )
-        return _FakeCompletedProcess(rc, stdout="", stderr="downstream boom")
+def _stub_subprocess(monkeypatch, *, rc, env_captured=None):
+    """Stub the ``claude --print`` subprocess to exit with the given
+    rc. Optionally capture the env dict it was launched with."""
+    def fake_run(*args, env=None, cwd=None, **kwargs):
+        if env_captured is not None:
+            env_captured["env"] = env
+            env_captured["cwd"] = cwd
+        return _FakeCompletedProcess(rc, stdout="", stderr="")
     monkeypatch.setattr(subprocess, "run", fake_run)
 
 
-def test_forced_rc_nonzero_but_sandbox_rotated_triggers_writeback(monkeypatch):
-    """claude rotated, wrote the new blob to the sandbox file, then
-    exited non-zero. Keychain still holds the original (claude didn't
-    rewrite it). Probe MUST writeback so main CLI doesn't get stranded
-    on the Anthropic-invalidated RT."""
+def test_refresh_flush_reports_rotation_on_token_change(monkeypatch):
     _force_macos_for_probe(monkeypatch)
-    # Prerequisite read + post read both return the original — claude
-    # only updated the sandbox file, not Keychain.
-    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
-    _stub_subprocess(monkeypatch, sandbox_after_blob=_BLOB_NEW, rc=1)
-
-    written = []
-    monkeypatch.setattr(
-        diag, "writeback_to_keychain",
-        lambda blob: (written.append(blob) or (True, None)),
-    )
-
-    rpt = diag.probe_refresh_flush_forced()
-    body = rpt.render_markdown()
-
-    # Salvaged rotation → overall NEEDS_ATTENTION, not FAIL.
-    assert rpt.overall() == diag.VERDICT_NEEDS_ATTENTION, body
-    assert "rotation detected" in body
-    assert "written back to Keychain" in body
-    # Writeback was called with the rotated blob.
-    assert len(written) == 1
-    assert json.loads(written[0])["claudeAiOauth"]["accessToken"] == "sk-ant-NEW"
-
-
-def test_forced_rc_nonzero_with_keychain_rotated_skips_writeback(monkeypatch):
-    """claude wrote the new blob directly into the real Keychain (HOME
-    doesn't isolate Keychain) and then exited non-zero without updating
-    the sandbox file. Keychain is already correct; writeback would be a
-    no-op at best and a clobber at worst — must NOT be called."""
-    _force_macos_for_probe(monkeypatch)
-    # Prerequisite read returns original; post read returns rotated.
     _stub_keychain_reads(monkeypatch, _BLOB, _BLOB_NEW)
-    # Sandbox file unchanged from the mutated blob.
-    _stub_subprocess(monkeypatch, sandbox_after_blob=None, rc=1)
+    captured = {}
+    _stub_subprocess(monkeypatch, rc=0, env_captured=captured)
 
-    written = []
-    monkeypatch.setattr(
-        diag, "writeback_to_keychain",
-        lambda blob: (written.append(blob) or (True, None)),
-    )
-
-    rpt = diag.probe_refresh_flush_forced()
-    body = rpt.render_markdown()
-
-    assert rpt.overall() == diag.VERDICT_NEEDS_ATTENTION, body
-    assert "claude wrote it directly" in body or "claude's direct write" in body
-    assert written == [], (
-        "writeback must NOT be called when Keychain already has the "
-        "rotated token — would clobber a fresh blob with stale data"
-    )
-
-
-def test_forced_rc_nonzero_with_no_rotation_is_real_failure(monkeypatch):
-    """claude exited non-zero AND neither Keychain nor sandbox file
-    shows rotation. Real failure; Keychain unchanged; main CLI safe.
-    Must report FAIL without any writeback."""
-    _force_macos_for_probe(monkeypatch)
-    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
-    _stub_subprocess(monkeypatch, sandbox_after_blob=None, rc=1)
-
-    written = []
-    monkeypatch.setattr(
-        diag, "writeback_to_keychain",
-        lambda blob: (written.append(blob) or (True, None)),
-    )
-
-    rpt = diag.probe_refresh_flush_forced()
-    body = rpt.render_markdown()
-
-    assert rpt.overall() == diag.VERDICT_FAIL, body
-    assert "did not produce a rotation" in body or "Keychain unchanged" in body
-    assert written == []
-
-
-def test_forced_rc_zero_happy_path_writes_back(monkeypatch):
-    """Sanity: the original happy path (claude exits 0, sandbox file
-    has a rotated token, Keychain still on the original) still works
-    end-to-end with writeback."""
-    _force_macos_for_probe(monkeypatch)
-    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
-    _stub_subprocess(monkeypatch, sandbox_after_blob=_BLOB_NEW, rc=0)
-
-    written = []
-    monkeypatch.setattr(
-        diag, "writeback_to_keychain",
-        lambda blob: (written.append(blob) or (True, None)),
-    )
-
-    rpt = diag.probe_refresh_flush_forced()
+    rpt = diag.probe_refresh_flush()
     body = rpt.render_markdown()
 
     assert rpt.overall() == diag.VERDICT_OK, body
-    assert len(written) == 1
-    assert json.loads(written[0])["claudeAiOauth"]["accessToken"] == "sk-ant-NEW"
+    assert "token rotated: True" in body
+    # Must use real HOME — mirror production.
+    assert captured["env"]["HOME"] == str(Path.home())
+
+
+def test_refresh_flush_reports_needs_attention_when_token_stays(monkeypatch):
+    """Token is still fresh, so claude correctly skips OAuth. Report
+    NEEDS_ATTENTION (not FAIL) with an explanation."""
+    _force_macos_for_probe(monkeypatch)
+    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
+    _stub_subprocess(monkeypatch, rc=0)
+
+    rpt = diag.probe_refresh_flush()
+    body = rpt.render_markdown()
+
+    assert rpt.overall() == diag.VERDICT_NEEDS_ATTENTION, body
+    assert "token rotated: False" in body
+    assert "current token is still valid" in body
+
+
+def test_refresh_flush_reports_fail_on_claude_nonzero_exit(monkeypatch):
+    _force_macos_for_probe(monkeypatch)
+    _stub_keychain_reads(monkeypatch, _BLOB, _BLOB)
+    _stub_subprocess(monkeypatch, rc=1)
+
+    rpt = diag.probe_refresh_flush()
+    assert rpt.overall() == diag.VERDICT_FAIL


### PR DESCRIPTION
## What

Replace the macOS sandbox-HOME refresh path with the same real-HOME model the FileBackend uses on Linux/Windows.

## Why

The original macOS design ran `claude --print "ok"` in a tempdir sandbox with a seeded `.credentials.json`, then copied the rotated blob back. In practice that wedged in three independent ways — each surfacing as "the user's main Claude Code CLI got logged out after the daemon's refresh tick fired":

1. **Sandbox HOME broke `security` CLI lookup** → "Keychain cannot be found to store '$USER'" popup → user dismissed → `authd -60008` ("Caller dismissed") → claude failed → no rotation (lucky).
2. **Even after symlinking `~/Library/Keychains` into the sandbox** (intermediate fix in this PR), claude would call Anthropic, write the rotated blob *directly to the real Keychain* (HOME doesn't isolate Keychain ACL access at all), and then exit non-zero from a downstream step before flushing to the sandbox file. Daemon couldn't tell rotation happened; Anthropic had already invalidated the prior `refresh_token` → main CLI 401.
3. **Even when claude didn't crash**, its on-exit cleanup path deleted the sandbox `.credentials.json` before the daemon could read it back.

All three are caused by trying to hide claude's refresh behind our own sandbox. None exist on Linux/Windows, because FileBackend just lets claude do its thing with the real HOME — the same code path that runs every time the user types `claude` interactively.

This PR walks back to that model.

## PR history (4 commits)

The first three commits were attempts to patch the sandbox approach; the fourth realises the approach is fundamentally fragile and removes it. Kept as separate commits so the reasoning trail is visible.

1. `a5d98cc` — `refresh_via_oneshot`: read sandbox creds on `rc != 0`; probe: re-read Keychain before exits, decide writeback from observed state not rc.
2. `b6bfd11` — Symlink real `~/Library/Keychains` into sandbox HOME to fix "loginKC:queryCreate" popup.
3. `f969f7e` — **Drop sandbox entirely; mirror FileBackend.**

The final state of this PR is best read as `f969f7e`: all the sandbox machinery (including the symlink fix added one commit prior) is removed.

## What `f969f7e` does

- `KeychainBackend.refresh` runs `claude --print "ok"` with `HOME=Path.home()`, exactly like `FileBackend.refresh`. claude reads Keychain, refreshes if expired, writes the new blob back to Keychain. The daemon re-reads Keychain and byte-compares before/after to decide `REFRESHED` vs `UNCHANGED`.
- Deleted: `_stage_keychain_visibility`, `install_path_shim`, `_run_claude_oneshot`, `refresh_via_oneshot`, `_run_sandboxed_claude_oneshot`, `_force_expiry`, `probe_refresh_flush_forced`, `probe_keychain_survives_token_env`.
- `probe_refresh_flush` rewritten to mirror production (real HOME, compare Keychain before/after).
- `LocalCLIAdapter._macos_credential_env` drops the PATH shim, keeps `CLAUDE_CONFIG_DIR` isolation (which is the part that actually matters for agents).

The 5-minute Keychain poll (which catches rotations performed by anyone — main CLI, agent subprocesses self-refreshing on 401) is unchanged and is now the only macOS-specific path in the refresher.

**Net diff: -1071 lines, behaviour parity with FileBackend.**

## Test plan

- [x] `pytest tests/test_macos_credential_manager.py tests/test_macos_diagnostic.py tests/test_credential_refresher.py` → 55 passed.
- [x] Full suite: 783 passed + 7 pre-existing failures in `tests/test_host_credentials.py` (verified present on `main` without these edits).
- [x] `puffo-agent test refresh-flush` smoke (passive — no RT burned).
- [ ] **Soak test: run `puffo-agent start` for ~8h and observe the natural refresh tick when the token approaches `expiresAt - 10min`.** This is the behaviour-equivalent verification of the production path; no synthetic forced-expiry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)