### PR TITLE
fix(0.9.3): resolve codex / claude binaries beyond $PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.3] — 2026-05-22
+
+### Fixed
+
+- **Codex / Claude binary resolution now searches beyond `$PATH`.**
+  Operators who installed Codex via the desktop app (binary at
+  ``/Applications/Codex.app/Contents/Resources/codex``) hit
+  ``[Errno 2] No such file or directory: 'codex'`` when the daemon
+  spawned ``codex app-server``, because the LaunchAgent ``PATH``
+  excludes both ``/opt/homebrew/bin`` and the ``.app`` bundle. The
+  bug surfaced as the agent reporting ``runtime=running`` but never
+  replying — the spawn error fell to an unhandled exception in
+  ``handle_message_batch``.
+
+  Added ``puffo_agent.agent.cli_bin`` with ``resolve_codex_bin()`` /
+  ``resolve_claude_bin()`` that try, in order:
+  1. ``$PUFFO_CODEX_BIN`` / ``$PUFFO_CLAUDE_BIN`` (operator override).
+  2. ``shutil.which(...)`` (npm / brew / scoop install).
+  3. OS-specific bundle paths: ``Codex.app`` on macOS;
+     ``%LOCALAPPDATA%\Programs\codex`` / ``%PROGRAMFILES%\Codex``
+     on Windows; ``/opt/Codex`` and ``/usr/lib/codex`` on Linux.
+     Symmetric defensive paths for ``claude``.
+
+  Every existing call site (codex session spawn, credential refresh,
+  preflight diagnostic, macOS keychain probe) routes through the
+  new resolver, so the lookup order is uniform across the daemon.
+
+  When the resolver returns ``None``, the codex session spawn now
+  raises a clear ``RuntimeError`` naming both the env-var override
+  and the install steps, instead of letting ``FileNotFoundError``
+  bubble up from ``create_subprocess_exec``.
+
 ## [0.9.2] — 2026-05-22
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.9.2"
+version = "0.9.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -42,6 +42,7 @@ from ...portal.state import (
     sync_host_plugins,
     sync_host_skills,
 )
+from ..cli_bin import resolve_claude_bin, resolve_codex_bin
 from .base import Adapter, TurnContext, TurnResult
 from .cli_session import AuditLog, ClaudeSession
 from .codex_session import CodexSession
@@ -287,11 +288,21 @@ class LocalCLIAdapter(Adapter):
         )
         # Subprocess argv — ``codex app-server`` is the documented entry
         # point for embedding codex as a long-running agent. Resolve
-        # the binary via shutil.which so npm-installed shims like
-        # ``codex.cmd`` (Windows) work: asyncio.create_subprocess_exec
-        # goes through CreateProcess and does NOT honour PATHEXT, so
-        # the bare name ``codex`` fails to find ``codex.cmd``.
-        codex_bin = shutil.which("codex") or "codex"
+        # via the shared resolver so PATH + ``PUFFO_CODEX_BIN`` env
+        # override + macOS / Windows / Linux .app bundle paths all
+        # work. LaunchAgent on macOS has a narrow PATH that misses
+        # both ``/opt/homebrew/bin`` and the Codex.app bundle, so the
+        # plain ``shutil.which`` would fail even when the operator
+        # has Codex installed via the desktop app.
+        codex_bin = resolve_codex_bin()
+        if codex_bin is None:
+            raise RuntimeError(
+                "codex binary not found. Tried $PUFFO_CODEX_BIN, "
+                "$PATH, and the Codex.app / Windows / Linux bundle "
+                "paths. Install the Codex CLI (`npm install -g "
+                "@openai/codex`), Codex.app, or set "
+                "``PUFFO_CODEX_BIN=/abs/path/to/codex``."
+            )
         argv = [codex_bin, "app-server"]
 
         self._codex_session = CodexSession(
@@ -529,11 +540,12 @@ class LocalCLIAdapter(Adapter):
             # touching ~/.claude/* for a codex agent would be confusing.
             self._verified = True
             return
-        if shutil.which("claude") is None:
+        if resolve_claude_bin() is None:
             raise RuntimeError(
-                "claude binary not found on PATH. install the Claude Code CLI "
-                "(`npm install -g @anthropic-ai/claude-code`) to use runtime "
-                "kind 'cli-local'."
+                "claude binary not found. Tried $PUFFO_CLAUDE_BIN, "
+                "$PATH, and known bundle paths. Install the Claude "
+                "Code CLI (`npm install -g @anthropic-ai/claude-code`) "
+                "or set ``PUFFO_CLAUDE_BIN=/abs/path/to/claude``."
             )
         # Seed the per-agent virtual $HOME on first use (settings,
         # .claude.json). Credentials are handled separately via

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -1,0 +1,101 @@
+"""Resolve ``codex`` and ``claude`` binaries with broader-than-PATH
+search.
+
+LaunchAgent (macOS) and Windows service contexts run with a narrow
+PATH that misses ``/opt/homebrew/bin`` (Apple Silicon Homebrew) and
+ignores ``.app`` bundles entirely. Operators who installed Codex via
+the desktop app (binary tucked inside
+``/Applications/Codex.app/Contents/Resources/codex``) hit
+``[Errno 2] No such file or directory: 'codex'`` even though the
+binary exists.
+
+The resolver layers three lookups so the operator doesn't need to
+fiddle with ``launchd`` plists or symlink the binary into ``/usr/local/bin``:
+
+1. ``$PUFFO_<NAME>_BIN`` env var — explicit operator override.
+2. ``shutil.which(<name>)`` — npm / brew / scoop install.
+3. OS-specific bundle paths — Codex.app on macOS, %LOCALAPPDATA%
+   on Windows, /opt on Linux.
+
+Returns absolute path on hit, ``None`` on full miss. Callers
+distinguish "binary missing" (raise / report to status) from
+"resolver hit" (use returned path).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def resolve_codex_bin() -> str | None:
+    """Return the absolute path of the ``codex`` binary, or ``None``."""
+    return _resolve("codex", "PUFFO_CODEX_BIN", _codex_bundle_paths())
+
+
+def resolve_claude_bin() -> str | None:
+    """Return the absolute path of the ``claude`` binary, or ``None``."""
+    return _resolve("claude", "PUFFO_CLAUDE_BIN", _claude_bundle_paths())
+
+
+def _resolve(name: str, env_var: str, bundle_paths: list[Path]) -> str | None:
+    env_override = os.environ.get(env_var)
+    if env_override:
+        p = Path(env_override).expanduser()
+        if p.is_file():
+            return str(p)
+    on_path = shutil.which(name)
+    if on_path:
+        return on_path
+    for cand in bundle_paths:
+        if cand.is_file():
+            return str(cand)
+    return None
+
+
+def _codex_bundle_paths() -> list[Path]:
+    if sys.platform == "darwin":
+        return _expand(
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "~/Applications/Codex.app/Contents/Resources/codex",
+        )
+    if sys.platform == "win32":
+        return _expand(
+            r"%LOCALAPPDATA%\Programs\codex\codex.exe",
+            r"%LOCALAPPDATA%\Programs\Codex\codex.exe",
+            r"%PROGRAMFILES%\Codex\codex.exe",
+        )
+    # Linux — common bundled-app install roots.
+    return _expand(
+        "/opt/Codex/codex",
+        "/opt/codex/codex",
+        "/usr/lib/codex/codex",
+    )
+
+
+def _claude_bundle_paths() -> list[Path]:
+    # Anthropic doesn't currently ship a desktop app that bundles the
+    # ``claude`` CLI the way Codex.app does; defensive paths cover
+    # the case where they start to.
+    if sys.platform == "darwin":
+        return _expand(
+            "/Applications/Claude.app/Contents/Resources/claude",
+            "~/Applications/Claude.app/Contents/Resources/claude",
+        )
+    if sys.platform == "win32":
+        return _expand(
+            r"%LOCALAPPDATA%\Programs\claude\claude.exe",
+            r"%LOCALAPPDATA%\Programs\Claude\claude.exe",
+            r"%PROGRAMFILES%\Claude\claude.exe",
+        )
+    return _expand(
+        "/opt/Claude/claude",
+        "/opt/claude/claude",
+        "/usr/lib/claude/claude",
+    )
+
+
+def _expand(*paths: str) -> list[Path]:
+    return [Path(os.path.expandvars(p)).expanduser() for p in paths]

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -283,13 +283,15 @@ async def _run_claude_oneshot(
     ``(returncode, error_reason)`` — ``returncode`` is None on
     failure paths. Always cleans up the subprocess + pipe FDs even on
     early-return paths (timeout / spawn error)."""
-    if shutil.which("claude") is None:
+    from ..agent.cli_bin import resolve_claude_bin
+    claude_bin = resolve_claude_bin()
+    if claude_bin is None:
         return (None, "claude_binary_missing")
     proc: asyncio.subprocess.Process | None = None
     try:
         try:
             proc = await asyncio.create_subprocess_exec(
-                "claude", "--dangerously-skip-permissions",
+                claude_bin, "--dangerously-skip-permissions",
                 "--print", "--max-turns", "1",
                 "--output-format", "stream-json", "--verbose",
                 "ok",

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -360,13 +360,13 @@ class CodexFileBackend:
 
 
 def _resolve_codex_bin() -> str | None:
-    """Resolve the ``codex`` executable. On Windows, npm-installed
-    shims like ``codex.cmd`` aren't found by ``CreateProcess`` from a
-    bare ``"codex"`` argv; ``shutil.which`` honours PATHEXT so the
-    ``.cmd`` is reachable from the daemon's subprocess.
-    """
-    import shutil
-    return shutil.which("codex")
+    """Resolve the ``codex`` executable via the shared resolver
+    (``agent.cli_bin``). Covers PATH + ``PUFFO_CODEX_BIN`` env
+    override + macOS / Windows / Linux bundle paths so a LaunchAgent
+    PATH that misses ``/opt/homebrew/bin`` or ``Codex.app`` still
+    finds the binary the operator installed."""
+    from ..agent.cli_bin import resolve_codex_bin as _resolver
+    return _resolver()
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/puffo_agent/portal/diagnostic.py
+++ b/src/puffo_agent/portal/diagnostic.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from ..agent.cli_bin import resolve_claude_bin
 from ..macos.keychain import (
     KEYCHAIN_SERVICE,
     install_path_shim,
@@ -82,7 +83,7 @@ class ProbeReport:
         lines.append("")
         lines.append(f"- Platform: `{platform.system()} {platform.release()}`")
         lines.append(f"- Python: `{sys.version.split()[0]}`")
-        lines.append(f"- claude on PATH: `{shutil.which('claude') or '(none)'}`")
+        lines.append(f"- claude resolved: `{resolve_claude_bin() or '(none)'}`")
         lines.append("")
         for s in self.steps:
             lines.append(f"## {s.name} — {s.verdict}")
@@ -340,11 +341,12 @@ def probe_refresh_flush() -> ProbeReport:
     if not is_macos():
         rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
         return rpt
-    if shutil.which("claude") is None:
+    if resolve_claude_bin() is None:
         rpt.add(
             "prerequisite-claude",
             VERDICT_FAIL,
-            "`claude` not on PATH — install Claude Code first.",
+            "`claude` not resolvable via $PUFFO_CLAUDE_BIN, PATH, or "
+            "known bundle paths — install Claude Code first.",
         )
         return rpt
 
@@ -430,11 +432,12 @@ def probe_refresh_flush_forced() -> ProbeReport:
     if not is_macos():
         rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
         return rpt
-    if shutil.which("claude") is None:
+    if resolve_claude_bin() is None:
         rpt.add(
             "prerequisite-claude",
             VERDICT_FAIL,
-            "`claude` not on PATH — install Claude Code first.",
+            "`claude` not resolvable via $PUFFO_CLAUDE_BIN, PATH, or "
+            "known bundle paths — install Claude Code first.",
         )
         return rpt
 
@@ -580,11 +583,12 @@ def probe_keychain_survives_token_env() -> ProbeReport:
     if not is_macos():
         rpt.add("platform-check", VERDICT_SKIPPED, "not Darwin — probe skipped")
         return rpt
-    if shutil.which("claude") is None:
+    if resolve_claude_bin() is None:
         rpt.add(
             "prerequisite-claude",
             VERDICT_FAIL,
-            "`claude` not on PATH — install Claude Code first.",
+            "`claude` not resolvable via $PUFFO_CLAUDE_BIN, PATH, or "
+            "known bundle paths — install Claude Code first.",
         )
         return rpt
 
@@ -724,7 +728,7 @@ def probe_full() -> ProbeReport:
     rpt.add(
         "environment",
         VERDICT_OK,
-        f"home_dir: {home_dir()}\nclaude: {shutil.which('claude')}\n"
+        f"home_dir: {home_dir()}\nclaude: {resolve_claude_bin()}\n"
         f"shim_dir: {shim_dir(home_dir())}",
     )
 

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``puffo_agent.agent.cli_bin``."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent import cli_bin
+
+
+def _make_exe(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_text("#!/bin/sh\n")
+    p.chmod(0o755)
+    return p
+
+
+def test_env_override_wins(tmp_path, monkeypatch):
+    """``$PUFFO_CODEX_BIN`` beats PATH + bundle paths."""
+    fake = _make_exe(tmp_path, "fake_codex")
+    monkeypatch.setenv("PUFFO_CODEX_BIN", str(fake))
+    monkeypatch.setattr("shutil.which", lambda _name: "/some/other/codex")
+    assert cli_bin.resolve_codex_bin() == str(fake)
+
+
+def test_env_override_ignored_when_file_missing(tmp_path, monkeypatch):
+    """A pointer to a non-existent file is treated as "not set" and
+    falls through to PATH — protects against stale env vars."""
+    bogus = tmp_path / "nope" / "codex"
+    monkeypatch.setenv("PUFFO_CODEX_BIN", str(bogus))
+    monkeypatch.setattr("shutil.which", lambda _name: "/from/path/codex")
+    assert cli_bin.resolve_codex_bin() == "/from/path/codex"
+
+
+def test_path_used_when_env_unset(monkeypatch):
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/codex")
+    assert cli_bin.resolve_codex_bin() == "/usr/local/bin/codex"
+
+
+def test_bundle_path_hit_when_env_and_path_miss(tmp_path, monkeypatch):
+    """The Mac LaunchAgent case: PATH misses Codex.app, but the
+    bundle path resolves the binary."""
+    bundled = _make_exe(tmp_path, "codex_bundled")
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [bundled])
+    assert cli_bin.resolve_codex_bin() == str(bundled)
+
+
+def test_returns_none_on_full_miss(monkeypatch):
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [])
+    assert cli_bin.resolve_codex_bin() is None
+
+
+def test_claude_resolver_uses_its_own_env(tmp_path, monkeypatch):
+    """``resolve_claude_bin`` reads ``PUFFO_CLAUDE_BIN``, not
+    ``PUFFO_CODEX_BIN`` — make sure the namespacing is correct."""
+    fake_claude = _make_exe(tmp_path, "fake_claude")
+    monkeypatch.setenv("PUFFO_CLAUDE_BIN", str(fake_claude))
+    monkeypatch.setenv("PUFFO_CODEX_BIN", "/should/not/leak")
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr(cli_bin, "_claude_bundle_paths", lambda: [])
+    assert cli_bin.resolve_claude_bin() == str(fake_claude)
+
+
+@pytest.mark.parametrize("platform_value,want_first", [
+    ("darwin", "/Applications/Codex.app/Contents/Resources/codex"),
+    ("win32", "codex.exe"),  # contains-check
+])
+def test_bundle_paths_per_platform(platform_value, want_first, monkeypatch):
+    """Each platform contributes the right first-priority bundle
+    path — protects against accidental cross-platform regressions."""
+    monkeypatch.setattr(cli_bin.sys, "platform", platform_value)
+    paths = cli_bin._codex_bundle_paths()
+    assert paths, f"no candidates for platform {platform_value!r}"
+    if platform_value == "darwin":
+        # Use as_posix() so the comparison works regardless of the
+        # host OS running the test (pathlib normalises separators
+        # to the host's, even on a literal POSIX-shaped input).
+        assert paths[0].as_posix() == want_first
+    else:
+        assert want_first in str(paths[0]).lower()


### PR DESCRIPTION
## Summary

User report: a Mac operator created a codex-harness agent successfully, but it `runtime=running` while never replying. Daemon log:

```
spawning codex app-server (argv=codex app-server)
handle_message_batch error: `codex` binary not on PATH: [Errno 2] No such file or directory: 'codex'
RuntimeError: `codex` binary not on PATH
```

**Root cause**: operator installed Codex via the desktop app (`Codex.app`), which ships the binary at `/Applications/Codex.app/Contents/Resources/codex`. The puffo-agent LaunchAgent PATH excludes both the `.app` bundle and Apple Silicon Homebrew (`/opt/homebrew/bin`), so `shutil.which("codex")` returned `None` and `local_cli.py:294` fell back to the literal string `"codex"` which `create_subprocess_exec` failed to find.

The user worked around it by symlinking `/opt/homebrew/bin/codex -> /Applications/Codex.app/Contents/Resources/codex` and resuming the agent. This PR makes the workaround unnecessary.

## Files

- **NEW** `src/puffo_agent/agent/cli_bin.py` — `resolve_codex_bin()` / `resolve_claude_bin()`. Three-tier lookup:
  1. `$PUFFO_CODEX_BIN` / `$PUFFO_CLAUDE_BIN` (operator override).
  2. `shutil.which(...)` (npm / brew / scoop install — unchanged from before).
  3. OS-specific bundle paths — `Codex.app` on macOS, `%LOCALAPPDATA%\Programs\codex` / `%PROGRAMFILES%\Codex` on Windows, `/opt/Codex` / `/usr/lib/codex` on Linux. Symmetric defensive paths for `claude` (Anthropic doesn't ship a CLI-bundling desktop app today; the paths are defensive against future shape changes).
- `src/puffo_agent/agent/adapters/local_cli.py` — codex session spawn + claude preflight now route through the resolver. Codex session raises a clear `RuntimeError` when the resolver returns `None`, naming the env var + install steps, instead of letting `FileNotFoundError` from `create_subprocess_exec` silently kill the batch handler.
- `src/puffo_agent/portal/credential_refresh.py` — `_resolve_codex_bin` delegates to the shared resolver (was a bare `shutil.which`).
- `src/puffo_agent/portal/diagnostic.py` — 4 sites (preflight probes + report header + `puffo-agent test full-probe`) use the resolver.
- `src/puffo_agent/macos/keychain.py` — 1 site (one-shot claude refresh probe) uses the resolver.
- **NEW** `tests/test_cli_bin.py` — 8 unit tests covering the 3-tier order, env-var-pointing-at-missing-file fall-through, the `null` everywhere case, and per-platform bundle paths.

## Smoke (Windows local env)

```
platform = 'win32'
==> resolve_codex_bin() = 'C:\Program Files\nodejs\codex.CMD'
==> resolve_claude_bin() = 'C:\Users\hello\.local\bin\claude.EXE'
```

PATH resolution unchanged for users with npm-global installs; `.CMD` shim resolved via `shutil.which` (which honors `PATHEXT`).

Env-var override + bogus-env fallthrough also verified manually.

## Test plan

- [x] Full suite: 800 passed, 9 skipped (+8 new in `test_cli_bin.py`).
- [x] Local resolver smoke on Windows (npm-global install): PATH hits, returns correct .CMD shim.
- [x] Bogus `PUFFO_CODEX_BIN` falls through to PATH (verified manually).
- [ ] Live macOS smoke with Codex.app installed, LaunchAgent PATH stripped: resolver should pick the bundle path, agent should reply. Need to test on the operator's actual setup.
- [ ] Live error path: `mv codex` / unset `PUFFO_CODEX_BIN` → spawn raises a clean `RuntimeError`, status reporter surfaces it as `error` (with the PUF-232 classifier landing on `generic` / `auth`-ish since "binary missing" isn't yet a classified subclass).

## Out of scope (for a follow-up)

- **Status reporter classification for "binary missing"**: PUF-232's `classifyError` doesn't have a dedicated sub-label for missing CLI binary — falls into `generic`. Could add a `tooling_missing` class if we see this case in the wild.
- **Auto-symlink to `/opt/homebrew/bin`**: tempting but invasive; the env-var override is the right escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)