### PR TITLE
feat(PUF-238): fill /v1/agents/{id}/log to read audit.log with tail + since

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   both an initial-paint mode and a delta-polling mode:
 
   1. **Tail mode** (default, or explicit `?tail=N`): returns the
-     last `N` lines, default 200, capped at 2000. Implemented via
-     reverse-seek in 64 KB chunks off the file end (`_read_tail_bytes`)
+     last `N` lines, default 30 (web UI Logs tab budget — ~1000
+     chars total), capped at 2000 for operator-driven investigation.
+     Implemented via reverse-seek in 64 KB chunks off the file end
+     (`_read_tail_bytes`)
      rather than `read_bytes()` — `audit.log` has no rotation at
      the writer side yet, so for a long-lived agent the file can
      grow to hundreds of MB and a full-file read would scale badly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.4] — 2026-05-22
+
+### Added
+
+- **`GET /v1/agents/{id}/log` now reads the agent's audit log.** The
+  route was scaffolded but the handler was a stub returning
+  `{lines: []}`. It now reads NDJSON from `~/.puffo-agent/agents/
+  <agent_id>/workspace/.puffo-agent/audit.log` (the same file
+  `cli_session.AuditLog.write` appends to on every turn) and exposes
+  both an initial-paint mode and a delta-polling mode:
+
+  1. **Tail mode** (default, or explicit `?tail=N`): returns the
+     last `N` lines, default 200, capped at 2000. Implemented via
+     reverse-seek in 64 KB chunks off the file end (`_read_tail_bytes`)
+     rather than `read_bytes()` — `audit.log` has no rotation at
+     the writer side yet, so for a long-lived agent the file can
+     grow to hundreds of MB and a full-file read would scale badly.
+     The reverse-seek bounds memory at roughly `tail × avg_line_size`
+     regardless of total file length.
+  2. **Delta mode** (`?since=<byte-offset>`): returns lines written
+     after the caller's previous cursor for cheap polling, capped
+     at 256 KB per response (`_LOG_MAX_DELTA_BYTES`). When the cap
+     hits, the response trims back to the previous newline (no
+     truncated JSON record) and `next_cursor` advances to the
+     partial offset so the next poll picks up the rest. Two-page
+     coverage is covered by
+     `test_log_delta_partial_cursor_drives_next_poll_to_completion`.
+
+  **Rotation safety**: a `since` cursor past current `file_size`
+  (file shrunk because the operator rotated/archived `audit.log` out
+  of band) resets to 0 so the next response carries a fresh initial
+  tail instead of returning empty and leaving the client stuck.
+
+  **Mutually exclusive query params**: passing both `tail` and
+  `since` is a `400` (`tail and since are mutually exclusive`)
+  rather than a silent precedence rule — small enough surface that
+  explicit-is-better-than-implicit pays for itself in debug time.
+
+  **Malformed-line preservation**: lines that don't parse as JSON
+  are surfaced as `{event: "_raw", ts: <ingestion time>, msg: <raw
+  text, truncated to 1024 bytes>}` instead of being dropped. `ts`
+  is synthesized from `datetime.now(timezone.utc)` at parse time so
+  a future UI sorting by timestamp doesn't bunch every `_raw` event
+  at top-of-list because of an empty string.
+
+  **Distinct empty states** via a new `state` field on the response
+  so the client can branch on a stable signal:
+  - `never_written` (`note: "audit log not yet created"`) — the
+    `.puffo-agent/audit.log` doesn't exist yet on disk.
+  - `up_to_date` (`note: "no new entries since cursor"`) — delta
+    mode returned nothing because the caller is already at EOF.
+  - `empty` (`note: "audit log is empty"`) — file exists but has
+    no content (rare; the writer touches the file on first run).
+
+  Response shape: `{agent_id, lines, next_cursor, state?, note?}`.
+  `lines[i]` is the parsed NDJSON record per line, or the `_raw`
+  wrapper described above. `next_cursor` is a byte-offset suitable
+  for the next `?since=` call.
+
+  Auth: unchanged — the existing pairing middleware
+  (`portal/api/auth.py`) rejects unsigned-paired callers with 401
+  before the handler runs.
+
+  Closes the server half of PUF-238.
+
+### Tests
+
+- `tests/test_log_endpoint.py` — 15 tests covering:
+  missing-file empty state + `state="never_written"`; tail default
+  (200), explicit, cap at 2000, invalid-int fallback; `since` delta
+  after cursor; `since` at EOF (empty + `state="up_to_date"`);
+  `since` past EOF resets to 0 (rotation safety); malformed line
+  preserved as `_raw` event; reverse-seek correctness on a 3000-row
+  file larger than the 64 KB chunk size; delta cap + partial cursor
+  + two-page completion; `tail`+`since` combo returns 400; unknown
+  agent id → 404; unpaired caller → 401.
+
 ## [0.9.3] — 2026-05-22
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.9.3"
+version = "0.9.4"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -10,8 +10,10 @@ are allowed.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -1000,6 +1002,17 @@ _LOG_DEFAULT_TAIL = 200
 # Hard cap on ``tail`` — protects against accidental huge fetches
 # from a chatty agent. 2000 lines * ~300 bytes / line ≈ 600 KB.
 _LOG_MAX_TAIL = 2000
+# Cap on bytes returned in delta mode. Prevents a busy agent + slow
+# poller combination from delivering a multi-MB response in one
+# tick. When the delta exceeds this, we serve a partial window +
+# advance ``next_cursor`` to the partial offset so the client picks
+# up the rest on the next poll.
+_LOG_MAX_DELTA_BYTES = 256 * 1024
+# Reverse-seek chunk size — read this many bytes per pass off the
+# end of the file when building a tail response. Keeps memory
+# bounded for unbounded ``audit.log`` files until rotation lands
+# at the writer side.
+_LOG_TAIL_CHUNK_BYTES = 64 * 1024
 # Marker event used when a line in audit.log can't be parsed as
 # JSON. Surfaces the raw text so the operator can still see what
 # the agent emitted instead of dropping the line silently.
@@ -1009,28 +1022,82 @@ _LOG_MALFORMED_EVENT = "_raw"
 def _parse_log_line(raw: str) -> dict[str, Any]:
     """Decode one NDJSON line from audit.log. Falls back to a
     ``_raw`` event wrapper if the line isn't valid JSON so the
-    client can still display the bytes."""
-    import json
+    client can still display the bytes. Synthesizes ``ts`` at the
+    ingestion moment so future sort-by-ts in the UI doesn't bunch
+    every ``_raw`` event at top-of-list because of an empty
+    timestamp."""
     try:
         return json.loads(raw)
     except (json.JSONDecodeError, ValueError):
-        return {"ts": "", "event": _LOG_MALFORMED_EVENT, "msg": raw[:1024]}
+        return {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "event": _LOG_MALFORMED_EVENT,
+            "msg": raw[:1024],
+        }
+
+
+def _read_tail_bytes(path: Path, file_size: int, target_lines: int) -> bytes:
+    """Reverse-seek the last ``target_lines + 1`` newlines off the
+    end of ``path``. Reads in ``_LOG_TAIL_CHUNK_BYTES`` chunks until
+    enough newlines are visible (or BOF is reached) so memory stays
+    bounded on a multi-MB audit.log. Returns the suffix bytes
+    starting at the byte after the (target_lines+1)-th-from-last
+    newline — enough to capture ``target_lines`` full lines (the
+    +1 ensures we don't accidentally start mid-line)."""
+    if file_size == 0:
+        return b""
+    with path.open("rb") as f:
+        # ``newlines_needed`` is the number of ``\n`` markers that
+        # delimit ``target_lines`` full lines from the back of the
+        # file. We need one more newline than lines to land on the
+        # start of a line cleanly; absent that extra newline (file
+        # starts with a partial line at BOF) we just return from the
+        # earliest read offset.
+        newlines_needed = target_lines + 1
+        offset = file_size
+        buf = b""
+        while offset > 0:
+            chunk_size = min(_LOG_TAIL_CHUNK_BYTES, offset)
+            offset -= chunk_size
+            f.seek(offset)
+            buf = f.read(chunk_size) + buf
+            if buf.count(b"\n") >= newlines_needed:
+                break
+        # Slice off everything before the (newlines_needed)-th-from-
+        # last newline so the result starts at a clean line boundary.
+        # If we didn't accumulate that many newlines (whole file
+        # smaller than tail window), return what we have.
+        if buf.count(b"\n") >= newlines_needed:
+            # ``rfind`` newline_needed times from the end.
+            pos = len(buf)
+            for _ in range(newlines_needed):
+                pos = buf.rfind(b"\n", 0, pos)
+                if pos == -1:
+                    break
+            if pos != -1:
+                buf = buf[pos + 1:]
+        return buf
 
 
 async def get_log(request: web.Request) -> web.Response:
     """Return the agent's per-agent audit.log entries.
 
     Query params:
-      * ``tail`` (default 200, max 2000) — last N lines.
+      * ``tail`` (default 200, max 2000) — last N lines. Mutually
+        exclusive with ``since``; passing both is a 400.
       * ``since`` (optional, int byte-offset) — return lines written
-        after this point for delta polling. When the file has
-        shrunk below ``since`` (rotation / archive) the cursor
-        resets to 0.
+        after this point for delta polling, capped at
+        ``_LOG_MAX_DELTA_BYTES`` per response (the cursor advances
+        partially so the client picks up the rest on the next poll).
+        When the file has shrunk below ``since`` (rotation / archive)
+        the cursor resets to 0.
 
-    Response: ``{agent_id, lines, next_cursor, note?}``. ``note`` is
-    populated when the agent has no log content yet so the client
-    can distinguish "never wrote" from "wrote and then we polled
-    deltas since".
+    Response: ``{agent_id, lines, next_cursor, note?, state?}``.
+    ``state`` is populated when ``lines`` is empty so the client
+    can distinguish "never wrote" vs "caught up via delta":
+    ``"never_written"`` (audit.log doesn't exist yet) or
+    ``"up_to_date"`` (delta returned nothing). ``note`` carries the
+    matching human-readable explanation.
     """
     agent_id = request.match_info["id"]
     if not agent_yml_path(agent_id).exists():
@@ -1039,19 +1106,29 @@ async def get_log(request: web.Request) -> web.Response:
     cfg = AgentConfig.load(agent_id)
     log_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "audit.log"
 
+    raw_tail = request.query.get("tail")
+    raw_since = request.query.get("since")
+    if raw_tail is not None and raw_since is not None:
+        # 400 instead of silently picking one — silent precedence
+        # masks confused callers and the surface is small enough
+        # that explicit-is-better-than-implicit wins.
+        return web.json_response(
+            {"error": "tail and since are mutually exclusive"},
+            status=400,
+        )
+
     try:
-        tail = int(request.query.get("tail", _LOG_DEFAULT_TAIL))
+        tail = int(raw_tail) if raw_tail is not None else _LOG_DEFAULT_TAIL
     except ValueError:
         tail = _LOG_DEFAULT_TAIL
     tail = max(1, min(_LOG_MAX_TAIL, tail))
 
-    since_raw = request.query.get("since")
     since: int | None
-    if since_raw is None:
+    if raw_since is None:
         since = None
     else:
         try:
-            since = max(0, int(since_raw))
+            since = max(0, int(raw_since))
         except ValueError:
             since = None
 
@@ -1060,7 +1137,8 @@ async def get_log(request: web.Request) -> web.Response:
             "agent_id": agent_id,
             "lines": [],
             "next_cursor": 0,
-            "note": "no log entries yet",
+            "state": "never_written",
+            "note": "audit log not yet created",
         })
 
     file_size = log_path.stat().st_size
@@ -1070,20 +1148,36 @@ async def get_log(request: web.Request) -> web.Response:
         # Delta mode — read from the caller's last cursor. A file
         # that's shrunk (rotated / archived) below the cursor
         # resets to 0 so the next response carries the full window.
+        # Cap the per-response byte count so a slow-poller + busy-
+        # agent combination can't trigger multi-MB allocations.
         offset = since if since <= file_size else 0
         with log_path.open("rb") as f:
             f.seek(offset)
-            content = f.read()
+            content = f.read(_LOG_MAX_DELTA_BYTES)
+        # Defensive trim: if the cap landed mid-line, drop the
+        # partial trailing chunk so the client doesn't see a
+        # truncated JSON record. The dropped bytes are still
+        # before ``next_cursor`` (advancement is based on slice
+        # length); a future patch could try a smarter mid-line
+        # backtrack, but truncate-at-newline is the cheap-correct
+        # default.
+        if len(content) == _LOG_MAX_DELTA_BYTES:
+            last_nl = content.rfind(b"\n")
+            if last_nl > 0:
+                content = content[: last_nl + 1]
         next_cursor = offset + len(content)
         for raw in content.decode("utf-8", errors="replace").splitlines():
             if raw.strip():
                 lines.append(_parse_log_line(raw))
     else:
-        # Tail mode — read the whole file (the MAX_TAIL bound on
-        # the response makes the memory hit predictable) and slice
-        # the last N lines. NDJSON files in practice stay small
-        # (rotation lives at the daemon layer, not here).
-        decoded = log_path.read_bytes().decode("utf-8", errors="replace")
+        # Tail mode — reverse-seek off the end of the file rather
+        # than loading the whole thing. ``audit.log`` has no
+        # rotation today (``cli_session.AuditLog.write`` just
+        # appends), so unbounded growth is realistic and a
+        # full-file ``read_bytes()`` would scale badly for a
+        # long-lived agent.
+        suffix = _read_tail_bytes(log_path, file_size, tail)
+        decoded = suffix.decode("utf-8", errors="replace")
         all_lines = [line for line in decoded.splitlines() if line.strip()]
         for raw in all_lines[-tail:]:
             lines.append(_parse_log_line(raw))
@@ -1095,7 +1189,16 @@ async def get_log(request: web.Request) -> web.Response:
         "next_cursor": next_cursor,
     }
     if not lines:
-        body["note"] = "no log entries yet"
+        # Distinct empty-state signals — the client uses ``state`` to
+        # pick the right copy + the matching ``note`` is the
+        # human-readable form. Missing-file is handled above before
+        # we reach this branch.
+        if since is not None:
+            body["state"] = "up_to_date"
+            body["note"] = "no new entries since cursor"
+        else:
+            body["state"] = "empty"
+            body["note"] = "audit log is empty"
     return web.json_response(body)
 
 

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -996,9 +996,11 @@ async def archive_agent(request: web.Request) -> web.Response:
 
 
 # Default number of trailing lines returned when no ``tail`` query
-# param is supplied. 200 is plenty for the on-mount paint without
-# blowing the wire response size on a busy agent.
-_LOG_DEFAULT_TAIL = 200
+# param is supplied. The web UI's Logs tab caps total displayed text
+# at ~1000 chars (no scroll history), so 30 lines at ~80 chars each
+# is the right initial-paint budget. Operators investigating an
+# incident can still request up to ``_LOG_MAX_TAIL`` explicitly.
+_LOG_DEFAULT_TAIL = 30
 # Hard cap on ``tail`` — protects against accidental huge fetches
 # from a chatty agent. 2000 lines * ~300 bytes / line ≈ 600 KB.
 _LOG_MAX_TAIL = 2000

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -993,21 +993,110 @@ async def archive_agent(request: web.Request) -> web.Response:
 # ────────────────────────────────────────────────────────────────────
 
 
+# Default number of trailing lines returned when no ``tail`` query
+# param is supplied. 200 is plenty for the on-mount paint without
+# blowing the wire response size on a busy agent.
+_LOG_DEFAULT_TAIL = 200
+# Hard cap on ``tail`` — protects against accidental huge fetches
+# from a chatty agent. 2000 lines * ~300 bytes / line ≈ 600 KB.
+_LOG_MAX_TAIL = 2000
+# Marker event used when a line in audit.log can't be parsed as
+# JSON. Surfaces the raw text so the operator can still see what
+# the agent emitted instead of dropping the line silently.
+_LOG_MALFORMED_EVENT = "_raw"
+
+
+def _parse_log_line(raw: str) -> dict[str, Any]:
+    """Decode one NDJSON line from audit.log. Falls back to a
+    ``_raw`` event wrapper if the line isn't valid JSON so the
+    client can still display the bytes."""
+    import json
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {"ts": "", "event": _LOG_MALFORMED_EVENT, "msg": raw[:1024]}
+
+
 async def get_log(request: web.Request) -> web.Response:
-    """Stub — per-agent log capture is not implemented yet. The
-    daemon currently writes a single combined stderr stream.
+    """Return the agent's per-agent audit.log entries.
+
+    Query params:
+      * ``tail`` (default 200, max 2000) — last N lines.
+      * ``since`` (optional, int byte-offset) — return lines written
+        after this point for delta polling. When the file has
+        shrunk below ``since`` (rotation / archive) the cursor
+        resets to 0.
+
+    Response: ``{agent_id, lines, next_cursor, note?}``. ``note`` is
+    populated when the agent has no log content yet so the client
+    can distinguish "never wrote" from "wrote and then we polled
+    deltas since".
     """
     agent_id = request.match_info["id"]
     if not agent_yml_path(agent_id).exists():
         return _not_found("agent not found")
-    return web.json_response({
+
+    cfg = AgentConfig.load(agent_id)
+    log_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "audit.log"
+
+    try:
+        tail = int(request.query.get("tail", _LOG_DEFAULT_TAIL))
+    except ValueError:
+        tail = _LOG_DEFAULT_TAIL
+    tail = max(1, min(_LOG_MAX_TAIL, tail))
+
+    since_raw = request.query.get("since")
+    since: int | None
+    if since_raw is None:
+        since = None
+    else:
+        try:
+            since = max(0, int(since_raw))
+        except ValueError:
+            since = None
+
+    if not log_path.exists():
+        return web.json_response({
+            "agent_id": agent_id,
+            "lines": [],
+            "next_cursor": 0,
+            "note": "no log entries yet",
+        })
+
+    file_size = log_path.stat().st_size
+
+    lines: list[dict[str, Any]] = []
+    if since is not None:
+        # Delta mode — read from the caller's last cursor. A file
+        # that's shrunk (rotated / archived) below the cursor
+        # resets to 0 so the next response carries the full window.
+        offset = since if since <= file_size else 0
+        with log_path.open("rb") as f:
+            f.seek(offset)
+            content = f.read()
+        next_cursor = offset + len(content)
+        for raw in content.decode("utf-8", errors="replace").splitlines():
+            if raw.strip():
+                lines.append(_parse_log_line(raw))
+    else:
+        # Tail mode — read the whole file (the MAX_TAIL bound on
+        # the response makes the memory hit predictable) and slice
+        # the last N lines. NDJSON files in practice stay small
+        # (rotation lives at the daemon layer, not here).
+        decoded = log_path.read_bytes().decode("utf-8", errors="replace")
+        all_lines = [line for line in decoded.splitlines() if line.strip()]
+        for raw in all_lines[-tail:]:
+            lines.append(_parse_log_line(raw))
+        next_cursor = file_size
+
+    body: dict[str, Any] = {
         "agent_id": agent_id,
-        "lines": [],
-        "note": (
-            "per-agent log capture is not implemented yet — daemon "
-            "currently writes a single combined stream. follow-up PR."
-        ),
-    })
+        "lines": lines,
+        "next_cursor": next_cursor,
+    }
+    if not lines:
+        body["note"] = "no log entries yet"
+    return web.json_response(body)
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_log_endpoint.py
+++ b/tests/test_log_endpoint.py
@@ -1,0 +1,277 @@
+"""PUF-238: /v1/agents/{id}/log endpoint — reads audit.log, tail +
+since delta polling, missing-file empty state, malformed-line
+preservation, MAX_TAIL cap."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from _bridge_support import (
+    isolated_home, make_user, pair_request_body, signed_headers,
+    write_test_agent,
+)
+from puffo_agent.portal.api.server import build_app
+from puffo_agent.portal.state import DaemonConfig
+
+pytestmark = pytest.mark.asyncio
+
+_HOST = {"Host": "127.0.0.1:63387"}
+
+
+@pytest_asyncio.fixture
+async def client():
+    isolated_home()
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        yield c
+
+
+async def _pair(client, user):
+    body = pair_request_body(user)
+    h = signed_headers(user, "POST", "/v1/pair", body); h.update(_HOST)
+    r = await client.post("/v1/pair", data=body, headers=h)
+    assert r.status == 200, await r.text()
+
+
+def _audit_log_path(home: str, agent_id: str) -> Path:
+    return Path(home) / "agents" / agent_id / "workspace" / ".puffo-agent" / "audit.log"
+
+
+def _write_audit_lines(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        for ev in events:
+            f.write(json.dumps(ev) + "\n")
+
+
+# ────────────────────────────────────────────────────────────────────
+# Missing-file empty state
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_log_missing_file_returns_empty_with_note(client):
+    user = make_user()
+    await _pair(client, user)
+    write_test_agent(os.environ["PUFFO_AGENT_HOME"], "agt-fresh")
+    h = signed_headers(user, "GET", "/v1/agents/agt-fresh/log"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-fresh/log", headers=h)
+    assert r.status == 200
+    j = await r.json()
+    assert j["agent_id"] == "agt-fresh"
+    assert j["lines"] == []
+    assert j["next_cursor"] == 0
+    assert "note" in j
+
+
+# ────────────────────────────────────────────────────────────────────
+# Tail mode (default)
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_log_tail_returns_last_n_lines(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-tail")
+    log_path = _audit_log_path(home, "agt-tail")
+    _write_audit_lines(log_path, [
+        {"ts": f"2026-05-22T00:00:0{i}Z", "agent": "agt-tail", "event": "turn", "n": i}
+        for i in range(10)
+    ])
+
+    h = signed_headers(user, "GET", "/v1/agents/agt-tail/log?tail=3"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-tail/log?tail=3", headers=h)
+    j = await r.json()
+    assert len(j["lines"]) == 3
+    # Last 3 events: 7, 8, 9 (zero-indexed).
+    assert [line["n"] for line in j["lines"]] == [7, 8, 9]
+    assert j["next_cursor"] == log_path.stat().st_size
+
+
+async def test_log_default_tail_is_200(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-default")
+    log_path = _audit_log_path(home, "agt-default")
+    _write_audit_lines(log_path, [
+        {"ts": "t", "agent": "agt-default", "event": "e", "n": i}
+        for i in range(250)
+    ])
+
+    h = signed_headers(user, "GET", "/v1/agents/agt-default/log"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-default/log", headers=h)
+    j = await r.json()
+    assert len(j["lines"]) == 200
+    # Last 200 of 250 → events 50..249.
+    assert j["lines"][0]["n"] == 50
+    assert j["lines"][-1]["n"] == 249
+
+
+async def test_log_tail_capped_at_max(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-cap")
+    log_path = _audit_log_path(home, "agt-cap")
+    _write_audit_lines(log_path, [
+        {"ts": "t", "agent": "agt-cap", "event": "e", "n": i}
+        for i in range(2500)
+    ])
+
+    # Request 5000 — should be capped to 2000.
+    h = signed_headers(user, "GET", "/v1/agents/agt-cap/log?tail=5000"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-cap/log?tail=5000", headers=h)
+    j = await r.json()
+    assert len(j["lines"]) == 2000
+
+
+async def test_log_invalid_tail_falls_back_to_default(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-bad-tail")
+    log_path = _audit_log_path(home, "agt-bad-tail")
+    _write_audit_lines(log_path, [
+        {"ts": "t", "agent": "agt-bad-tail", "event": "e", "n": i}
+        for i in range(5)
+    ])
+
+    h = signed_headers(user, "GET", "/v1/agents/agt-bad-tail/log?tail=banana"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-bad-tail/log?tail=banana", headers=h)
+    j = await r.json()
+    # Bad tail param → default 200; only 5 lines on disk, so all 5.
+    assert len(j["lines"]) == 5
+
+
+# ────────────────────────────────────────────────────────────────────
+# Since (delta polling)
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_log_since_returns_delta_after_cursor(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-delta")
+    log_path = _audit_log_path(home, "agt-delta")
+
+    # Initial state: 3 events.
+    _write_audit_lines(log_path, [
+        {"ts": "t", "agent": "agt-delta", "event": "first", "n": i}
+        for i in range(3)
+    ])
+    h1 = signed_headers(user, "GET", "/v1/agents/agt-delta/log"); h1.update(_HOST)
+    r1 = await client.get("/v1/agents/agt-delta/log", headers=h1)
+    j1 = await r1.json()
+    cursor = j1["next_cursor"]
+    assert len(j1["lines"]) == 3
+
+    # Append 2 more events.
+    _write_audit_lines(log_path, [
+        {"ts": "t", "agent": "agt-delta", "event": "later", "n": i}
+        for i in range(3, 5)
+    ])
+
+    h2 = signed_headers(user, "GET", f"/v1/agents/agt-delta/log?since={cursor}")
+    h2.update(_HOST)
+    r2 = await client.get(f"/v1/agents/agt-delta/log?since={cursor}", headers=h2)
+    j2 = await r2.json()
+    # Delta returns only the 2 new lines.
+    assert len(j2["lines"]) == 2
+    assert all(line["event"] == "later" for line in j2["lines"])
+    # Cursor advances to current EOF.
+    assert j2["next_cursor"] == log_path.stat().st_size
+
+
+async def test_log_since_empty_when_caller_at_eof(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-eof")
+    log_path = _audit_log_path(home, "agt-eof")
+    _write_audit_lines(log_path, [{"ts": "t", "agent": "agt-eof", "event": "x"}])
+    size = log_path.stat().st_size
+
+    h = signed_headers(user, "GET", f"/v1/agents/agt-eof/log?since={size}")
+    h.update(_HOST)
+    r = await client.get(f"/v1/agents/agt-eof/log?since={size}", headers=h)
+    j = await r.json()
+    assert j["lines"] == []
+    assert j["next_cursor"] == size
+    # Empty delta still gets the empty-state note so the client can
+    # render distinctly from "haven't loaded yet."
+    assert "note" in j
+
+
+async def test_log_since_past_eof_resets_to_zero(client):
+    # Rotation / archive simulation: file shrinks below the cursor.
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-rotate")
+    log_path = _audit_log_path(home, "agt-rotate")
+    _write_audit_lines(log_path, [{"ts": "t", "agent": "agt-rotate", "event": "post-rotation"}])
+
+    # Caller cursor pretends a much larger file.
+    h = signed_headers(user, "GET", "/v1/agents/agt-rotate/log?since=999999")
+    h.update(_HOST)
+    r = await client.get("/v1/agents/agt-rotate/log?since=999999", headers=h)
+    j = await r.json()
+    # Cursor was past EOF → reset to 0; full file returned.
+    assert len(j["lines"]) == 1
+    assert j["lines"][0]["event"] == "post-rotation"
+
+
+# ────────────────────────────────────────────────────────────────────
+# Malformed lines + auth
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_log_malformed_line_preserved_as_raw_event(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-malformed")
+    log_path = _audit_log_path(home, "agt-malformed")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    # One valid JSON line + one bare text line that JSON can't parse.
+    log_path.write_text(
+        json.dumps({"ts": "t", "agent": "agt-malformed", "event": "good"}) + "\n"
+        + "this is not JSON\n",
+        encoding="utf-8",
+    )
+
+    h = signed_headers(user, "GET", "/v1/agents/agt-malformed/log"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-malformed/log", headers=h)
+    j = await r.json()
+    assert len(j["lines"]) == 2
+    assert j["lines"][0]["event"] == "good"
+    assert j["lines"][1]["event"] == "_raw"
+    assert "this is not JSON" in j["lines"][1]["msg"]
+
+
+async def test_log_unknown_agent_returns_404(client):
+    user = make_user()
+    await _pair(client, user)
+    h = signed_headers(user, "GET", "/v1/agents/agt-nope/log"); h.update(_HOST)
+    r = await client.get("/v1/agents/agt-nope/log", headers=h)
+    assert r.status == 404
+
+
+async def test_log_unpaired_caller_returns_401(client):
+    # No /v1/pair first — middleware should reject unsigned-paired calls.
+    write_test_agent(os.environ["PUFFO_AGENT_HOME"], "agt-noauth")
+    r = await client.get(
+        "/v1/agents/agt-noauth/log",
+        headers={**_HOST},
+    )
+    assert r.status == 401

--- a/tests/test_log_endpoint.py
+++ b/tests/test_log_endpoint.py
@@ -68,7 +68,10 @@ async def test_log_missing_file_returns_empty_with_note(client):
     assert j["agent_id"] == "agt-fresh"
     assert j["lines"] == []
     assert j["next_cursor"] == 0
-    assert "note" in j
+    # PUF-238 polish: distinct state + note from the "up_to_date"
+    # delta case so the client can branch on a stable signal.
+    assert j["state"] == "never_written"
+    assert j["note"] == "audit log not yet created"
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -207,9 +210,10 @@ async def test_log_since_empty_when_caller_at_eof(client):
     j = await r.json()
     assert j["lines"] == []
     assert j["next_cursor"] == size
-    # Empty delta still gets the empty-state note so the client can
-    # render distinctly from "haven't loaded yet."
-    assert "note" in j
+    # PUF-238 polish: "up_to_date" is the empty-delta signal,
+    # distinct from "never_written" (audit log doesn't exist yet).
+    assert j["state"] == "up_to_date"
+    assert j["note"] == "no new entries since cursor"
 
 
 async def test_log_since_past_eof_resets_to_zero(client):
@@ -257,6 +261,139 @@ async def test_log_malformed_line_preserved_as_raw_event(client):
     assert j["lines"][0]["event"] == "good"
     assert j["lines"][1]["event"] == "_raw"
     assert "this is not JSON" in j["lines"][1]["msg"]
+    # PUF-238 polish: synthesized ts on _raw events should be a
+    # non-empty ISO-8601 string so sort-by-ts in the client doesn't
+    # bunch every malformed row at top-of-list.
+    raw_ts = j["lines"][1]["ts"]
+    assert raw_ts, "synthesized ts must be non-empty"
+    # ISO format is "YYYY-MM-DDTHH:MM:SS+00:00" (or similar with TZ).
+    from datetime import datetime
+    parsed = datetime.fromisoformat(raw_ts)
+    assert parsed is not None
+
+
+# ────────────────────────────────────────────────────────────────────
+# Polish (PR #39 review)
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_log_tail_and_since_mutually_exclusive_returns_400(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-conflict")
+    _write_audit_lines(
+        _audit_log_path(home, "agt-conflict"),
+        [{"ts": "t", "agent": "agt-conflict", "event": "x"}],
+    )
+
+    h = signed_headers(
+        user, "GET", "/v1/agents/agt-conflict/log?tail=10&since=0",
+    ); h.update(_HOST)
+    r = await client.get(
+        "/v1/agents/agt-conflict/log?tail=10&since=0", headers=h,
+    )
+    assert r.status == 400
+    j = await r.json()
+    assert "mutually exclusive" in j["error"]
+
+
+async def test_log_delta_caps_at_max_bytes_and_advances_partial_cursor(client):
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-big-delta")
+    log_path = _audit_log_path(home, "agt-big-delta")
+    # Write a single very-long-line file so the response would hit
+    # the cap. Each line is ~400 bytes; 1000 lines ≈ 400 KB > the
+    # 256 KB delta cap → response must truncate + cursor advances
+    # partially.
+    payload = "z" * 380
+    _write_audit_lines(
+        log_path,
+        [
+            {"ts": f"2026-05-22T00:00:{i % 60:02d}Z", "event": "fill", "n": i, "p": payload}
+            for i in range(1000)
+        ],
+    )
+
+    h = signed_headers(user, "GET", "/v1/agents/agt-big-delta/log?since=0")
+    h.update(_HOST)
+    r = await client.get("/v1/agents/agt-big-delta/log?since=0", headers=h)
+    j = await r.json()
+    # Returned partial — fewer than the full 1000 lines.
+    assert len(j["lines"]) < 1000
+    # Cursor advanced to where the partial read stopped, NOT to EOF.
+    assert j["next_cursor"] < log_path.stat().st_size
+    # Cursor still strictly positive (we didn't refuse to read
+    # anything).
+    assert j["next_cursor"] > 0
+
+
+async def test_log_delta_partial_cursor_drives_next_poll_to_completion(client):
+    # Belt-and-braces: pass the partial cursor from poll 1 back as
+    # ``since`` on poll 2; verify it picks up where the first one
+    # left off. This is the operator's described client behaviour —
+    # if it fails, the cap is a footgun.
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-paged")
+    log_path = _audit_log_path(home, "agt-paged")
+    payload = "z" * 380
+    _write_audit_lines(
+        log_path,
+        [
+            {"ts": "t", "event": "fill", "n": i, "p": payload}
+            for i in range(1000)
+        ],
+    )
+
+    h1 = signed_headers(user, "GET", "/v1/agents/agt-paged/log?since=0")
+    h1.update(_HOST)
+    r1 = await client.get("/v1/agents/agt-paged/log?since=0", headers=h1)
+    j1 = await r1.json()
+    cursor = j1["next_cursor"]
+    first_count = len(j1["lines"])
+
+    h2 = signed_headers(user, "GET", f"/v1/agents/agt-paged/log?since={cursor}")
+    h2.update(_HOST)
+    r2 = await client.get(f"/v1/agents/agt-paged/log?since={cursor}", headers=h2)
+    j2 = await r2.json()
+    # Together the two pages cover everything written; no overlap
+    # (the cursor advances exclusively).
+    assert first_count + len(j2["lines"]) == 1000
+
+
+async def test_log_tail_uses_reverse_seek_on_a_large_file(client):
+    # Smoke test for the reverse-seek path. We can't easily measure
+    # memory in a unit test, but we can verify correctness on a
+    # file that's larger than the chunk size — the tail-200 result
+    # must contain the last 200 rows in order regardless of
+    # how many chunks the seek had to load.
+    user = make_user()
+    await _pair(client, user)
+    home = os.environ["PUFFO_AGENT_HOME"]
+    write_test_agent(home, "agt-large")
+    log_path = _audit_log_path(home, "agt-large")
+    # 3000 ~80-byte rows ≈ 240 KB — comfortably larger than the
+    # 64 KB chunk size so the reverse-seek loop runs at least twice.
+    _write_audit_lines(
+        log_path,
+        [
+            {"ts": "t", "agent": "agt-large", "event": "row", "n": i}
+            for i in range(3000)
+        ],
+    )
+
+    h = signed_headers(user, "GET", "/v1/agents/agt-large/log?tail=200")
+    h.update(_HOST)
+    r = await client.get("/v1/agents/agt-large/log?tail=200", headers=h)
+    j = await r.json()
+    assert len(j["lines"]) == 200
+    # Last 200 of 3000 → rows 2800..2999, in order.
+    assert j["lines"][0]["n"] == 2800
+    assert j["lines"][-1]["n"] == 2999
 
 
 async def test_log_unknown_agent_returns_404(client):

--- a/tests/test_log_endpoint.py
+++ b/tests/test_log_endpoint.py
@@ -99,7 +99,7 @@ async def test_log_tail_returns_last_n_lines(client):
     assert j["next_cursor"] == log_path.stat().st_size
 
 
-async def test_log_default_tail_is_200(client):
+async def test_log_default_tail_is_30(client):
     user = make_user()
     await _pair(client, user)
     home = os.environ["PUFFO_AGENT_HOME"]
@@ -113,9 +113,10 @@ async def test_log_default_tail_is_200(client):
     h = signed_headers(user, "GET", "/v1/agents/agt-default/log"); h.update(_HOST)
     r = await client.get("/v1/agents/agt-default/log", headers=h)
     j = await r.json()
-    assert len(j["lines"]) == 200
-    # Last 200 of 250 → events 50..249.
-    assert j["lines"][0]["n"] == 50
+    # Default tail = 30 (web UI's Logs tab budget — ~1000 chars total).
+    assert len(j["lines"]) == 30
+    # Last 30 of 250 → events 220..249.
+    assert j["lines"][0]["n"] == 220
     assert j["lines"][-1]["n"] == 249
 
 


### PR DESCRIPTION
## Summary

Fills the pre-existing `GET /v1/agents/{id}/log` stub that was returning `{lines: []}` since the route was scaffolded.

- Reads NDJSON `~/.puffo-agent/agents/<agent_id>/workspace/.puffo-agent/audit.log` (populated by `local_cli.py` / `docker_cli.py`).
- Query params: `tail=N` (default 200, capped at `_LOG_MAX_TAIL=2000`); `since=<byte-offset>` for delta polling.
- Malformed JSON lines surface as `{event: "_raw", msg: <raw text>}` so the operator can still see what the agent emitted instead of silently dropping.
- Missing audit.log → empty `lines` + `note` so the client can distinguish "agent hasn't written yet" from "agent wrote then we caught up via delta."
- **Cursor past EOF resets to 0** — rotation-safe (file shrunk below `since` means the audit.log was rotated/archived; client gets a fresh initial tail on next poll).
- Auth middleware (paired identity) was already in place — non-paired callers get 401.
- Server-first ship order per intake. Client back-compat: old client polling against new endpoint works; new client polling against old daemon also works (stub returned `{lines: [], note}` previously).
- Closes server half of PUF-238.

## Test plan

- [x] **`tests/test_log_endpoint.py` (11 new):** missing-file, tail (basic), tail-default (200), tail capped at `_LOG_MAX_TAIL`, invalid `tail` (non-numeric / negative) → fallback to default, `since` byte-offset delta, `since` at EOF → empty delta, `since` past EOF → reset to 0 (rotation safe), malformed JSON line → `_raw` event wrapper, unknown agent_id → 404, unpaired caller → 401.
- [x] **Full pytest:** **819 passed / 1 skipped / 0 failed** (was 808 → +11 new).

## Related

- **PUF-238** — agent logs tab feature.
- **Client side**: `puffo-core-han-group#<TBD>` (PR opening in parallel).