### PR TITLE
fix(PUF-240-B): disk-persist invite dedup across daemon restarts

### DIFF
--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -6,11 +6,14 @@ and encrypted reply posting.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 import random
 import re
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Coroutine, Optional
 
 from ..crypto.encoding import base64url_decode
@@ -464,18 +467,23 @@ class PuffoCoreMessageClient:
         # the next tick instead of pinning a permanent "" miss.
         self._profile_cache: dict[str, tuple[str, str, float]] = {}
         # Invitation event_ids the worker has already processed.
-        # PUF-240: persisted across reconnects (was reset per
-        # ``listen()`` call; that wiped the dedup every WS cycle
-        # and the next 30s ``_poll_pending_invites`` re-emitted
-        # the operator-confirm prompt for every still-pending
-        # invite — N reconnects ⇒ N duplicate prompts in the
-        # operator's confirm thread). Server-side ``pending_invites``
-        # rows stay until the operator acts, so the only thing
-        # holding off re-emission is this set. Initialised once on
-        # ``__init__`` and never cleared inside ``listen()``.
-        # In-memory only across daemon restarts — disk-persist is
-        # a follow-up if restart-driven multi-emit surfaces.
+        # PUF-240: persisted across reconnects AND across daemon
+        # restarts. Was reset per ``listen()`` call (wiped on every
+        # WS cycle), so the next 30s ``_poll_pending_invites`` re-
+        # emitted the operator-confirm prompt for every still-
+        # pending invite — N reconnects ⇒ N duplicate prompts in
+        # the operator's confirm thread. Server-side
+        # ``pending_invites`` rows stay until the operator acts, so
+        # the only thing holding off re-emission is this set.
+        #
+        # In-memory: initialised on ``__init__`` and never cleared
+        # inside ``listen()``. On disk: hydrated at construct time
+        # from ``<workspace>/.puffo-agent/processed_invites.json``,
+        # appended via ``_persist_processed_invite`` after each add
+        # so a daemon restart between invite-and-act doesn't
+        # multi-emit either.
         self._processed_invite_ids: set[str] = set()
+        self._processed_invite_ids.update(self._load_processed_invites())
         # When the worker DMs the operator about a non-auto-acceptable
         # invite, the DM's envelope_id lives here so a ``y``/``n``
         # reply in that thread can be intercepted inside the daemon.
@@ -834,16 +842,18 @@ class PuffoCoreMessageClient:
         self._queue = asyncio.PriorityQueue()
         self._queue_seq = 0
         self._thread_state: dict[str, _ThreadEntry] = {}
-        # PUF-240: ``_processed_invite_ids`` initialisation moved to
-        # ``__init__`` (line 470) and intentionally NOT cleared here.
-        # The prior comment "auto-accept is idempotent against
-        # server-side state" only justified safety for the
-        # auto-accept branch; the operator-DM branch is NOT
-        # idempotent (each call sends a new DM), and resetting the
-        # dedup on every reconnect was producing the ~10× duplicate
-        # prompt symptom Sam reported. Server-side ``pending_invites``
-        # remains the source of truth; the in-memory set only avoids
-        # repeating work the agent already did in this process.
+        # PUF-240: ``_processed_invite_ids`` is owned by ``__init__``
+        # and intentionally NOT cleared here. The prior comment
+        # "auto-accept is idempotent against server-side state" only
+        # justified safety for the auto-accept branch; the operator-
+        # DM branch is NOT idempotent (each call sends a new DM), and
+        # resetting the dedup on every reconnect was producing the
+        # ~10× duplicate prompt symptom Sam reported. The set is now
+        # also disk-persisted at
+        # ``<workspace>/.puffo-agent/processed_invites.json`` so a
+        # daemon restart between invite-and-act doesn't re-emit
+        # either. Server-side ``pending_invites`` remains the source
+        # of truth.
         consumer_task = asyncio.ensure_future(
             self._consume_queue(on_message, on_api_error_retry),
         )
@@ -1610,6 +1620,7 @@ class PuffoCoreMessageClient:
         # Add to processed-set too so a stale pending-invite poll
         # response (server-side cache lag) can't re-fire the DM.
         self._processed_invite_ids.add(invitation_event_id)
+        self._persist_processed_invite(invitation_event_id)
 
         inviter_slug = meta.get("inviter_slug") or ""
         space_id = meta.get("space_id") or ""
@@ -1645,6 +1656,65 @@ class PuffoCoreMessageClient:
             self._log.exception(
                 "failed to DM operator about canceled invite (event_id=%s)",
                 invitation_event_id,
+            )
+
+    def _processed_invites_path(self) -> Path | None:
+        """Sidecar where ``_processed_invite_ids`` persists across
+        daemon restarts. Mirrors ``cron_state.py``'s sidecar shape
+        (PUF-239) — ``<workspace>/.puffo-agent/processed_invites.json``.
+        Returns ``None`` when no workspace is configured (test
+        harnesses construct the client with ``workspace=""``); in
+        that case persistence is a no-op and the in-memory dedup
+        still works."""
+        if not self.workspace:
+            return None
+        return Path(self.workspace) / ".puffo-agent" / "processed_invites.json"
+
+    def _load_processed_invites(self) -> set[str]:
+        """Hydrate the persisted dedup set from disk. Returns an
+        empty set on missing-file / corrupt-JSON / unreadable-row —
+        the scheduler shouldn't crash on a malformed sidecar, and
+        the worst case is one batch of legitimate re-emit while the
+        operator acts."""
+        path = self._processed_invites_path()
+        if path is None or not path.exists():
+            return set()
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            self._log.warning(
+                "processed_invites.json unreadable (%s); starting empty",
+                exc,
+            )
+            return set()
+        if not isinstance(raw, dict):
+            return set()
+        ids = raw.get("processed_invite_ids")
+        if not isinstance(ids, list):
+            return set()
+        return {str(x) for x in ids if isinstance(x, str) and x}
+
+    def _persist_processed_invite(self, invitation_event_id: str) -> None:
+        """Append ``invitation_event_id`` to the on-disk dedup
+        sidecar. Best-effort: a write failure logs + leaves the
+        in-memory set unchanged. Atomic-write via temp-file +
+        ``os.replace`` so a crash mid-write doesn't corrupt the
+        file."""
+        path = self._processed_invites_path()
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "processed_invite_ids": sorted(self._processed_invite_ids),
+            }
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+        except OSError as exc:
+            self._log.warning(
+                "failed to persist processed_invites (event_id=%s): %s",
+                invitation_event_id, exc,
             )
 
     async def _poll_pending_invites(self) -> None:
@@ -1737,6 +1807,7 @@ class PuffoCoreMessageClient:
                     kind, inviter_slug, invitation_event_id,
                 )
                 self._processed_invite_ids.add(invitation_event_id)
+                self._persist_processed_invite(invitation_event_id)
             except Exception:
                 self._log.exception(
                     "failed to auto-accept %s from operator %s (event_id=%s)",
@@ -1757,6 +1828,7 @@ class PuffoCoreMessageClient:
                 # Mark processed even on DM failure — the operator
                 # still sees the invite in their chat client.
                 self._processed_invite_ids.add(invitation_event_id)
+                self._persist_processed_invite(invitation_event_id)
 
     async def _inviter_is_operator(self, inviter_slug: str) -> bool:
         """True iff ``inviter_slug``'s root pubkey matches our

--- a/tests/test_invite_dedup_persistence.py
+++ b/tests/test_invite_dedup_persistence.py
@@ -18,12 +18,18 @@ processed invite even when fed the same server response twice.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
 
 
-def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, list[dict]]:
+def _make_client(
+    operator_slug: str = "op-1",
+    workspace: str = "",
+) -> tuple[PuffoCoreMessageClient, list[dict]]:
     """Bare client harness mirroring ``test_membership_events.py``.
 
     Stubs ``_send_dm`` (captures into ``sent``), the name-resolution
@@ -32,11 +38,22 @@ def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, l
     round-trip — keeps every test on the operator-DM branch), and
     ``http.get`` for ``/invites?direction=received`` so the poll
     loop returns whatever the test sets via ``_invites_response``.
+
+    ``workspace`` lets a test point the client at a real on-disk
+    dir so ``_persist_processed_invite`` / ``_load_processed_invites``
+    exercise the sidecar. Defaults to ``""`` — persistence becomes a
+    no-op (``_processed_invites_path`` returns ``None``) and only
+    the in-memory dedup is tested.
     """
+    import logging
+
     client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
     client.slug = "agent-1"
     client.operator_slug = operator_slug
+    client.workspace = workspace
+    client._log = logging.getLogger("test-puf-240")
     client._processed_invite_ids = set()
+    client._processed_invite_ids.update(client._load_processed_invites())
     client._pending_invite_dms = {}
     client._operator_root_pubkey = b"op-root-pk"
     client._inviter_root_cache = {}
@@ -76,8 +93,6 @@ def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, l
 
     client.http = _StubHttp()
 
-    import logging
-    client._log = logging.getLogger("test-puf-240")
     return client, sent
 
 
@@ -182,3 +197,35 @@ async def test_dedup_persists_across_failed_dm_attempt():
     client._send_dm = _capturing_send_dm  # type: ignore[assignment]
     await client._poll_pending_invites()
     assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_dedup_survives_daemon_restart(tmp_path: Path):
+    """PUF-240 daemon-restart class. The in-memory dedup is now also
+    sidecar-persisted to ``<workspace>/.puffo-agent/processed_invites.json``
+    so a daemon restart between invite-and-act doesn't multi-emit
+    either. Simulate the restart by constructing a SECOND client
+    pointed at the same workspace — its ``_load_processed_invites``
+    should rehydrate the set and the next poll should NOT re-fire
+    the operator DM."""
+    workspace = str(tmp_path)
+    client_a, sent_a = _make_client(workspace=workspace)
+    client_a._invites_response = {"invites": [_invite_row("ev_restart")]}
+
+    # First daemon lifetime: emit + persist.
+    await client_a._poll_pending_invites()
+    assert len(sent_a) == 1
+    sidecar = tmp_path / ".puffo-agent" / "processed_invites.json"
+    assert sidecar.exists()
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert "ev_restart" in payload["processed_invite_ids"]
+
+    # Simulate daemon restart — fresh PuffoCoreMessageClient instance,
+    # same workspace dir. Server-side pending_invites still returns
+    # the same row (the operator hasn't acted yet).
+    client_b, sent_b = _make_client(workspace=workspace)
+    client_b._invites_response = {"invites": [_invite_row("ev_restart")]}
+
+    assert "ev_restart" in client_b._processed_invite_ids
+    await client_b._poll_pending_invites()
+    assert sent_b == []

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -48,6 +48,7 @@ def _make_client(
     client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
     client.slug = "agent-1"
     client.operator_slug = operator_slug
+    client.workspace = ""
     client._channel_space = {}
     client._space_name_cache = {}
     client._channel_name_cache = {}


### PR DESCRIPTION
## Summary

Stacked on top of PR #40 (PUF-240). Closes the **daemon-restart-survives** invariant — distinct from PR #40's **reconnect-survives** invariant.

PR #40 keeps `_processed_invite_ids` alive across WS reconnects within one daemon process. A `kill -9` + restart between invite-arrival-and-operator-action still re-emits the operator-confirm DM today, because the set is purely in-memory.

This PR adds a sidecar at `<workspace>/.puffo-agent/processed_invites.json` (mirrors PUF-239's `.crons.json` shape) so the set hydrates on `__init__` + persists on every add. Atomic-write via temp-file + `os.replace` keeps a crash mid-write from corrupting the file.

- **NEW helpers** in `puffo_core_client.py`: `_processed_invites_path()` (returns sidecar path or `None` when workspace unset — handles test isolation), `_load_processed_invites()` (hydrates set; tolerant of missing-file / corrupt-JSON / unreadable-row → empty set + warn), `_persist_processed_invite(event_id)` (atomic write).
- `__init__` field initialiser now calls `self._processed_invite_ids.update(self._load_processed_invites())`.
- All 3 `_processed_invite_ids.add(...)` sites (cancel handler, auto-accept, operator-DM finally) paired with `_persist_processed_invite(event_id)`.
- Closes PUF-240-B.

## Branch / base note

This branch is stacked on `PUF-240-invite-dedup-persist` (PR #40's tip, commit `0012017`). PR base set accordingly so review surface shows ONLY the disk-persist changes. Once PR #40 merges, GitHub auto-retargets this PR's base to `main`; the diff re-narrows naturally.

## Test plan

- [x] **`test_dedup_survives_daemon_restart`**: tmp_path workspace; client-A polls (writes sidecar); construct client-B against same workspace; assert `_processed_invite_ids` rehydrated and B's poll emits zero DMs. **Load-bearing.**
- [x] Harness extended with `workspace` kwarg; `test_membership_events.py` updated to exercise the cancel-handler persist call site.
- [x] **Full pytest (`-p no:randomly`):** **819 passed** (+1 net new on top of PUF-240's 4); 1 skipped pre-existing unrelated.
- [x] **PUF-240 regression**: original 4 tests still pass.

## Known limit (operator's call on follow-up)

No LRU/TTL cap on the on-disk set. At expected scale (~few invites/week per agent) this stays well under "fancy" threshold. Add a cap in a follow-up if usage grows.

## Related

- **PUF-240 (PR #40)** — reconnect-survives invariant. Stack base.
- **PUF-239** — `.crons.json` sidecar pattern referenced as the shape for `processed_invites.json`.