### PR TITLE
fix(PUF-249): TTL-bounded restart-surviving throttle on operator-DM invite emit

### DIFF
--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -70,6 +70,19 @@ CREATE TABLE IF NOT EXISTS channel_space_map (
     space_id TEXT NOT NULL,
     learned_at INTEGER NOT NULL
 );
+
+-- PUF-249: TTL-bounded restart-surviving dedup for the operator-DM
+-- invite-emit path. The in-memory ``_processed_invite_ids`` set on
+-- ``PuffoCoreClient`` covers the within-process case; this table is
+-- the cross-process restart defense. Operator's PUF-240-B closure
+-- framing locked the fix shape to "throttling > full persistence":
+-- bounded TTL (default 24h) lets the gentle-reminder restart-re-emit
+-- still happen for a stale invite the operator forgot, but caps the
+-- frequency so 20-over-8-days never recurs.
+CREATE TABLE IF NOT EXISTS invite_emit_throttle (
+    invitation_event_id TEXT PRIMARY KEY,
+    last_emitted_at INTEGER NOT NULL
+);
 """
 
 
@@ -591,6 +604,50 @@ class MessageStore:
                VALUES (?, ?)
                ON CONFLICT(channel_id) DO NOTHING""",
             (channel_id, _now_ms()),
+        )
+        await db.commit()
+
+    async def was_invite_emitted_within(
+        self,
+        invitation_event_id: str,
+        ttl_ms: int,
+        *,
+        now_ms: int | None = None,
+    ) -> bool:
+        """True iff this ``invitation_event_id`` was emitted to the
+        operator within the last ``ttl_ms``. Survives daemon restart
+        (sqlite-backed). See PUF-249 + the ``invite_emit_throttle``
+        schema comment."""
+        if not invitation_event_id or ttl_ms <= 0:
+            return False
+        db = await self._ensure_db()
+        cutoff = (now_ms if now_ms is not None else _now_ms()) - ttl_ms
+        async with db.execute(
+            "SELECT last_emitted_at FROM invite_emit_throttle "
+            "WHERE invitation_event_id = ?",
+            (invitation_event_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return row is not None and row["last_emitted_at"] >= cutoff
+
+    async def record_invite_emit(
+        self,
+        invitation_event_id: str,
+        *,
+        now_ms: int | None = None,
+    ) -> None:
+        """Stamp the last-emit time for ``invitation_event_id``.
+        Idempotent (upsert)."""
+        if not invitation_event_id:
+            return
+        db = await self._ensure_db()
+        await db.execute(
+            """INSERT INTO invite_emit_throttle
+               (invitation_event_id, last_emitted_at)
+               VALUES (?, ?)
+               ON CONFLICT(invitation_event_id) DO UPDATE SET
+                   last_emitted_at = excluded.last_emitted_at""",
+            (invitation_event_id, now_ms if now_ms is not None else _now_ms()),
         )
         await db.commit()
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -61,6 +61,14 @@ PRIORITY_SYSTEM = 5
 # tool which force-refreshes regardless of TTL.
 _PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
+# PUF-249: cap operator-DM re-emit of the same still-pending invite
+# to once-per-window. Operator's PUF-240-B closure framing locked
+# the value to "same-invite-once-per-24h". Bounded TTL so a stale
+# invite the operator legitimately forgot still gets a gentle
+# reminder eventually (the "feature not bug" intent), just not 20×
+# in 8 days.
+_INVITE_EMIT_THROTTLE_TTL_SECONDS = 24 * 60 * 60
+
 
 @dataclass
 class _ThreadEntry:
@@ -1727,6 +1735,21 @@ class PuffoCoreMessageClient:
                     kind, inviter_slug, invitation_event_id,
                 )
         else:
+            # PUF-249: restart-surviving throttle. The auto-accept arm
+            # above always tries to drain the server-side pending row,
+            # so it stays uncapped; this arm is the operator-DM emit
+            # surface where 20-over-8-days happened on Sean's daemon.
+            ttl_ms = _INVITE_EMIT_THROTTLE_TTL_SECONDS * 1000
+            if await self.store.was_invite_emitted_within(
+                invitation_event_id, ttl_ms,
+            ):
+                self._log.info(
+                    "throttled operator-DM for %s (event_id=%s) — already emitted within %ss",
+                    kind, invitation_event_id,
+                    _INVITE_EMIT_THROTTLE_TTL_SECONDS,
+                )
+                self._processed_invite_ids.add(invitation_event_id)
+                return
             try:
                 await self._notify_operator_of_invite(
                     kind=kind,
@@ -1741,6 +1764,10 @@ class PuffoCoreMessageClient:
                 # Mark processed even on DM failure — the operator
                 # still sees the invite in their chat client.
                 self._processed_invite_ids.add(invitation_event_id)
+                # Stamp the throttle even on DM failure for the same
+                # reason: the operator saw the inbound either way, so
+                # a restart-retry within the TTL would be redundant.
+                await self.store.record_invite_emit(invitation_event_id)
 
     async def _inviter_is_operator(self, inviter_slug: str) -> bool:
         """True iff ``inviter_slug``'s root pubkey matches our

--- a/tests/test_invite_dedup_persistence.py
+++ b/tests/test_invite_dedup_persistence.py
@@ -76,6 +76,18 @@ def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, l
 
     client.http = _StubHttp()
 
+    # PUF-249 wires a throttle gate atop the operator-DM arm; this
+    # PUF-240 test harness doesn't exercise it, so a no-op stub keeps
+    # the in-memory dedup invariants the load-bearing assertion here.
+    class _NoThrottleStore:
+        async def was_invite_emitted_within(self, *args, **kwargs):
+            return False
+
+        async def record_invite_emit(self, *args, **kwargs):
+            return None
+
+    client.store = _NoThrottleStore()
+
     import logging
     client._log = logging.getLogger("test-puf-240")
     return client, sent

--- a/tests/test_invite_emit_throttle.py
+++ b/tests/test_invite_emit_throttle.py
@@ -1,0 +1,291 @@
+"""PUF-249: TTL-bounded restart-surviving throttle on operator-DM
+invite emit.
+
+Sean's daemon emitted the same Jeff→yolo invitation 20× across 8
+days because each daemon restart cleared the in-memory
+``_processed_invite_ids`` set, and the server-side pending-invite
+row never expires. PUF-240 fixed within-process reconnect-clearing;
+PUF-249 adds the cross-process restart layer via a sqlite-backed
+``invite_emit_throttle`` table on ``MessageStore``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import (
+    PuffoCoreMessageClient,
+    _INVITE_EMIT_THROTTLE_TTL_SECONDS,
+)
+
+
+_TTL_MS = _INVITE_EMIT_THROTTLE_TTL_SECONDS * 1000
+
+
+def _make_client(
+    store: MessageStore,
+    operator_slug: str = "op-1",
+) -> tuple[PuffoCoreMessageClient, list[dict]]:
+    """Bare client harness — same shape as
+    ``test_invite_dedup_persistence._make_client`` but wires a real
+    ``MessageStore`` so the throttle table is exercised end-to-end."""
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.operator_slug = operator_slug
+    client._processed_invite_ids = set()
+    client._pending_invite_dms = {}
+    client._operator_root_pubkey = b"op-root-pk"
+    client._inviter_root_cache = {}
+    client._invites_response = {"invites": []}
+    client.store = store
+
+    sent: list[dict] = []
+
+    async def _stub_send_dm(recipient_slug, text, root_id):
+        sent.append({"to": recipient_slug, "text": text, "root_id": root_id})
+        return {"envelope_id": f"env_dm_{len(sent)}"}
+
+    async def _stub_space_name(space_id):
+        return space_id
+
+    async def _stub_channel_name(*, space_id, channel_id):
+        return channel_id
+
+    async def _stub_display_name(slug):
+        return ""
+
+    async def _stub_inviter_pk(slug):
+        return b"non-operator-pk"
+
+    client._send_dm = _stub_send_dm  # type: ignore[assignment]
+    client._resolve_space_name = _stub_space_name  # type: ignore[assignment]
+    client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
+    client._fetch_display_name = _stub_display_name  # type: ignore[assignment]
+    client._fetch_inviter_root_pubkey = _stub_inviter_pk  # type: ignore[assignment]
+
+    class _StubHttp:
+        async def get(self, path):
+            if path.startswith("/invites"):
+                return client._invites_response
+            return {}
+
+    client.http = _StubHttp()
+    client._log = logging.getLogger("test-puf-249")
+    return client, sent
+
+
+def _invite_row(event_id: str = "ev_invite_1") -> dict:
+    return {
+        "invitation_event_id": event_id,
+        "scope": "channel",
+        "space_id": "sp_1",
+        "channel_id": "ch_1",
+        "inviter_slug": "non-op",
+        "space_name": "Team",
+        "channel_name": "general",
+    }
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path: Path):
+    s = MessageStore(tmp_path / "messages.db")
+    await s.open()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_store_records_and_reads_within_window(store: MessageStore):
+    """Direct store-layer pin: a stamped event reads as
+    ``was_emitted_within`` for any cutoff up to its stamp."""
+    await store.record_invite_emit("ev_1", now_ms=1_000_000)
+    assert await store.was_invite_emitted_within(
+        "ev_1", ttl_ms=_TTL_MS, now_ms=1_000_500,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_reports_false_after_ttl_expiry(store: MessageStore):
+    """Same stamp, now beyond the TTL: read returns False."""
+    await store.record_invite_emit("ev_1", now_ms=1_000_000)
+    assert not await store.was_invite_emitted_within(
+        "ev_1", ttl_ms=_TTL_MS, now_ms=1_000_000 + _TTL_MS + 1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_unknown_event_reports_false(store: MessageStore):
+    """Never-stamped event is always allowed."""
+    assert not await store.was_invite_emitted_within(
+        "ev_never_seen", ttl_ms=_TTL_MS, now_ms=1_000_000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_record_is_upsert(store: MessageStore):
+    """A later record_invite_emit overwrites the earlier stamp so
+    repeated emits don't grow the throttle row."""
+    await store.record_invite_emit("ev_1", now_ms=1_000_000)
+    await store.record_invite_emit("ev_1", now_ms=2_000_000)
+    # Old stamp gone — TTL window from now=2_000_500 still inside.
+    assert await store.was_invite_emitted_within(
+        "ev_1", ttl_ms=_TTL_MS, now_ms=2_000_500,
+    )
+
+
+@pytest.mark.asyncio
+async def test_throttle_survives_simulated_restart(tmp_path: Path):
+    """Sean's-symptom regression seal. Open the store, stamp an
+    event, close it, reopen at the same path, and assert the stamp
+    still reads as within-window. This is the cross-process restart
+    case PUF-240 didn't cover and PUF-249 is shipping."""
+    db_path = tmp_path / "messages.db"
+    store_a = MessageStore(db_path)
+    await store_a.open()
+    await store_a.record_invite_emit("ev_sean", now_ms=1_000_000)
+    await store_a.close()
+
+    store_b = MessageStore(db_path)
+    await store_b.open()
+    try:
+        assert await store_b.was_invite_emitted_within(
+            "ev_sean", ttl_ms=_TTL_MS, now_ms=1_000_500,
+        )
+    finally:
+        await store_b.close()
+
+
+@pytest.mark.asyncio
+async def test_first_poll_emits_and_stamps_throttle(store: MessageStore):
+    """End-to-end: first poll on a fresh invite fires the DM AND
+    records the throttle stamp so a subsequent restart-equivalent
+    won't re-emit."""
+    client, sent = _make_client(store)
+    client._invites_response = {"invites": [_invite_row("ev_a")]}
+
+    await client._poll_pending_invites()
+
+    assert len(sent) == 1
+    assert await store.was_invite_emitted_within("ev_a", ttl_ms=_TTL_MS)
+
+
+@pytest.mark.asyncio
+async def test_restart_within_ttl_does_not_re_emit(store: MessageStore):
+    """Sean's-symptom regression seal end-to-end. Process A stamps
+    the throttle; process B (new client instance, empty in-memory
+    dedup) sees the stamp via store and skips the DM."""
+    client_a, sent_a = _make_client(store)
+    client_a._invites_response = {"invites": [_invite_row("ev_x")]}
+    await client_a._poll_pending_invites()
+    assert len(sent_a) == 1
+
+    # Simulate a daemon restart: fresh client, empty in-memory dedup,
+    # same backing store. The same server row is still pending.
+    client_b, sent_b = _make_client(store)
+    client_b._invites_response = {"invites": [_invite_row("ev_x")]}
+    await client_b._poll_pending_invites()
+    assert sent_b == []
+    # And the throttle even adds it to the in-memory set on the
+    # skip-path so the next within-process poll is a fast no-op.
+    assert "ev_x" in client_b._processed_invite_ids
+
+
+@pytest.mark.asyncio
+async def test_restart_after_ttl_does_re_emit(store: MessageStore):
+    """The "gentle reminder" intent: 24h+ later, a still-pending
+    invite IS re-emitted. The throttle caps frequency, not lifetime."""
+    # Stamp at t0.
+    await store.record_invite_emit("ev_y", now_ms=1_000_000)
+
+    # Patch _now_ms used by was_invite_emitted_within indirectly: we
+    # pass an explicit now_ms via a thin wrapper on the store so the
+    # poll path sees "now" as t0 + TTL + 1.
+    original = store.was_invite_emitted_within
+
+    async def _was_after_ttl(event_id, ttl_ms):
+        return await original(
+            event_id, ttl_ms, now_ms=1_000_000 + _TTL_MS + 1,
+        )
+
+    store.was_invite_emitted_within = _was_after_ttl  # type: ignore[assignment]
+
+    client, sent = _make_client(store)
+    client._invites_response = {"invites": [_invite_row("ev_y")]}
+    await client._poll_pending_invites()
+
+    assert len(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_distinct_invites_each_get_one_prompt(store: MessageStore):
+    """Distinct event_ids dedup independently across restart — two
+    invites stamped in process A both skip in process B."""
+    client_a, sent_a = _make_client(store)
+    client_a._invites_response = {
+        "invites": [
+            _invite_row("ev_a"),
+            {**_invite_row("ev_b"), "channel_id": "ch_2"},
+        ],
+    }
+    await client_a._poll_pending_invites()
+    assert len(sent_a) == 2
+
+    client_b, sent_b = _make_client(store)
+    client_b._invites_response = {
+        "invites": [
+            _invite_row("ev_a"),
+            {**_invite_row("ev_b"), "channel_id": "ch_2"},
+        ],
+    }
+    await client_b._poll_pending_invites()
+    assert sent_b == []
+
+
+@pytest.mark.asyncio
+async def test_throttle_stamps_even_on_dm_failure(store: MessageStore):
+    """Mirrors PUF-240's "mark processed even on DM failure"
+    invariant — if the transport raised, the operator already saw
+    the inbound row in their chat client, so a restart-retry within
+    the TTL would be redundant noise."""
+    client, _ = _make_client(store)
+    client._invites_response = {"invites": [_invite_row("ev_fail")]}
+
+    async def _failing_send_dm(*args, **kwargs):
+        raise RuntimeError("simulated DM transport failure")
+
+    client._send_dm = _failing_send_dm  # type: ignore[assignment]
+
+    await client._poll_pending_invites()
+    assert await store.was_invite_emitted_within("ev_fail", ttl_ms=_TTL_MS)
+
+
+@pytest.mark.asyncio
+async def test_operator_auto_accept_is_unaffected_by_throttle(store: MessageStore):
+    """The throttle gates only the operator-DM emit arm. The auto-
+    accept arm (inviter == operator) is uncapped so a restart-retry
+    of a not-yet-accepted-by-server invite still tries to drain it."""
+    client, sent = _make_client(store, operator_slug="op-1")
+    client._invites_response = {
+        "invites": [{**_invite_row("ev_auto"), "inviter_slug": "op-1"}],
+    }
+
+    accept_calls: list[tuple] = []
+
+    async def _stub_accept_invite(kind, invitation_event_id, space_id, channel_id):
+        accept_calls.append((kind, invitation_event_id, space_id, channel_id))
+
+    client._accept_invite = _stub_accept_invite  # type: ignore[assignment]
+
+    await client._poll_pending_invites()
+    assert len(accept_calls) == 1
+    assert sent == []
+    # No throttle stamp on the auto-accept path — leaves the auto-
+    # accept arm uncapped across restarts.
+    assert not await store.was_invite_emitted_within(
+        "ev_auto", ttl_ms=_TTL_MS,
+    )


### PR DESCRIPTION
## Summary

Fixes the **20× re-emission over 8 days** of the same Jeff→yolo invitation on Sean's daemon (surfaced by Grande during PUF-247 bug-1 investigation; Tier-1 evidence in `PUF-249.md`).

**Discrimination via code-read (Calculation's Stage-3 trace, msg_064a529c):** (α)+(β) **joint-mechanism** — Sean's daemon restarts wiped the in-memory `_processed_invite_ids` dedup, and the server-side pending-invite row never expires, so each fresh process re-emitted on the next poll. (γ) ruled out (polling logic itself is correct). Neither fix alone is sufficient; both factors required for the symptom. Equation's endorsement at `msg_dc212f6a` captures the "structural-guarantee shape" framing.

**Fix:** **TTL-bounded restart-surviving throttle** at the operator-DM emit layer. Per operator's PUF-240-B framing ("throttling > persistence; same-invite-once-per-24h"), the throttle uses bounded 24h TTL so a stale invite the operator legitimately forgot still gets a gentle reminder eventually (the "feature not bug" intent preserved at PUF-240-B), just not 20× in 8 days.

## Architecture

```
operator-DM emit path
        │
        ▼
was_invite_emitted_within(event_id, 24h_ms)  ◄── PUF-249 (NEW)
        │
        ├─ true  → throttled, _processed_invite_ids.add, return
        │
        └─ false → emit to operator (existing path)
                            │
                            ▼
                    record_invite_emit(event_id)  ◄── stamp in finally
                            │ (stamps on BOTH success AND failure
                            │  — same "operator saw it either way"
                            │  rationale as PUF-240's
                            │  `_processed_invite_ids.add` in finally)
```

- **`invite_emit_throttle`** table mirrors the existing `channel_intro_prompted` shape next to it (established precedent, low review cognitive cost).
- **`_INVITE_EMIT_THROTTLE_TTL_SECONDS = 24 * 60 * 60`** — operator's exact PUF-240-B figure.
- **Auto-accept arm deliberately uncapped** — restart-retry of a not-yet-server-acked accept IS the correct behaviour (no operator-noise surface, just server-side state convergence).

## Test coverage

11 new cases in `tests/test_invite_emit_throttle.py` + 4 PUF-240 regression-seal updates in `test_invite_dedup_persistence.py`:

| Test | Pin |
|---|---|
| `store_records_and_reads_within_window` | Basic store-layer record/read |
| `store_reports_false_after_ttl_expiry` | TTL boundary at the store layer |
| `store_unknown_event_reports_false` | Empty / unknown event_id case |
| `store_record_is_upsert` | UPSERT idempotency on duplicate stamp |
| `throttle_survives_simulated_restart` | Direct store-layer cross-process check (same tmp_path, different MessageStore instances) |
| `first_poll_emits_and_stamps_throttle` | Happy path through `_process_invite` |
| **`restart_within_ttl_does_not_re_emit`** | **Sean's-symptom regression seal** — process A stamps, process B sees stamp + skips DM. `sent_b == []` |
| `restart_after_ttl_does_re_emit` | 24h+ gentle-reminder behavior preserved |
| `distinct_invites_each_get_one_prompt` | Different event_ids unaffected by throttle of other invites |
| `throttle_stamps_even_on_dm_failure` | Stamp on failure path (matches PUF-240 invariant) |
| `operator_auto_accept_is_unaffected_by_throttle` | Auto-accept arm uncapped guardrail — inviter==operator → `_accept_invite` runs, no throttle stamp |

**Local verification:**
- `pytest tests/test_invite_emit_throttle.py tests/test_invite_dedup_persistence.py` → **15/15**
- `pytest` (full suite) → **844 passed, 1 skipped** (expected — permission-proxy-modes test gated on bypassPermissions)

## Architectural alignment

- Operator's PUF-240-B framing (`msg_db70b6f0`) — *"throttling > persistence if 'too noisy' ever surfaces"* — Calculation's bounded-TTL persistence interpretation honors both the "no full persistence" rejection AND the "gentle reminder" preservation. Equation endorsed at `msg_dc212f6a` as the right read of operator's architectural intent.
- Schema mirrors `channel_intro_prompted` shape — established precedent in this module, low review surface for future archaeology.

## Known limits

- **(γ) polling-logic ruled out via code-read** — no test added since there's nothing to seal.
- **Server-side `pending_invites` row expiration** (defense-in-depth (β)) is out of scope. Future puffo-server ticket candidate (PUF-249-B) only if 24h client-side throttle proves insufficient at scale — highly unlikely for invite traffic.
- **TTL is event_id-based, not logical-key based.** If Jeff re-sends a NEW invite envelope (different `invitation_event_id`) for the same channel, it bypasses the throttle and emits. Defaulting to the simpler scope per Stage-3 trace; operator-overrideable post-deploy.

## Test plan

- [ ] Sean's-symptom regression seal: `pytest tests/test_invite_emit_throttle.py::test_restart_within_ttl_does_not_re_emit` → green.
- [ ] `pytest tests/test_invite_emit_throttle.py tests/test_invite_dedup_persistence.py` → 15/15.
- [ ] `pytest` full suite → 844 passed, 1 skipped.
- [ ] (Optional) Manual repro on Sean's host post-deploy: restart daemon repeatedly within 24h, confirm operator-DM emits once not N times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)