### PR TITLE
fix(PUF-255): recovery-clear matched-pair for PUF-252 (stacked on PR #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,17 +86,39 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   affordances on Nova's canonical lane (FB-197 status dot + FB-198
   restart lever, both in the Operator Action Panel cluster) are
   the correct recovery surface and ship separately. The
-  ``runtime.error`` copy explicitly cites the user-action path:
-  *"The agent has gone silent on this thread until it is
-  refreshed/restarted."*
+  ``runtime.error`` copy cites the user-action path; PUF-255 in
+  the same release widens it to *"...until a new message arrives
+  OR the agent is refreshed/restarted"* since PUF-255's recovery-
+  clear makes the new-message half a real path.
+
+- **PUF-255: recovery-clear matched-pair closes the one-way
+  state-honesty loop.** Adds the symmetric EXIT edge to PUF-252's
+  ENTER edge: a new ``on_turn_success`` callback fires after every
+  successful turn completion (fresh-dispatch + kick-retry-recovery
+  paths) and ``Worker._clear_api_error_abandoned_if_recoverable``
+  flips ``runtime.health`` back to ``"ok"`` when it was
+  ``api_error_abandoned``. Without this, a recovered agent stayed
+  labelled ``api_error_abandoned`` until process restart, so
+  FB-197/198 would render a stale "agent is broken" indicator
+  forever. **Marks PUF-252's "deferred recovery-clear" debt as
+  ✓ done** (Solution flagged at PR #45 QA gap-3; operator caught
+  the same gap independently).
+
+  Scope-bounded: callback only clears ``api_error_abandoned``.
+  ``auth_failed`` stays in PUF-221's CredentialRefresher lane (a
+  single lucky turn during a partial-401 window shouldn't reset
+  the broader credential state). Per-thread-event vs global-flag
+  granularity mismatch documented in-source as PUF-253 design
+  input.
 
   Known follow-up debts deliberately deferred:
 
-  - **PUF-258**: ``runtime.health`` is currently a one-way state
-    machine — nothing in the codebase ever sets ``health = "ok"``,
-    so both ``auth_failed`` and ``api_error_abandoned`` are
-    permanent labels until a process restart resets RuntimeState
-    defaults. Predates PUF-252; out of scope here.
+  - **PUF-258**: ``runtime.health`` is still a one-way state
+    machine in the ``auth_failed`` direction — PUF-255 closes
+    the ``api_error_abandoned`` exit edge, but nothing sets
+    ``auth_failed`` back to ``ok`` (cleared only on next
+    refresh-success-ping or process restart). Symmetric exit
+    edge for the auth path tracked separately.
   - **PUF-253**: ``runtime.error`` is a single-field string;
     consecutive abandons overwrite each other. UI design input
     for FB-197/198 needs to decide between append-with-cap, a

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -534,18 +534,10 @@ class PuffoCoreMessageClient:
         batch, channel_meta, attempts)``. When omitted, the
         abandon stays silent (pre-PUF-252 behaviour).
 
-        PUF-255: ``on_turn_success`` is the recovery-side
-        matched-pair for ``on_api_error_abandon``. Fired at every
-        successful turn completion (both the fresh dispatch path
-        and the kick-retry-recovery path). The worker uses this
-        to clear ``runtime.health`` back from
-        ``"api_error_abandoned"`` to ``"ok"``, closing the loop
-        so puffo-server learns when the agent recovers. Without
-        this, PUF-252's state-honesty is one-way -- the server
-        learns when the agent breaks but never when it heals.
-        Invoked as ``on_turn_success(root_id, batch,
-        channel_meta)``. When omitted, the success stays
-        silent on the worker layer.
+        ``on_turn_success`` is the recovery-side matched-pair
+        for ``on_api_error_abandon``. Fires on every successful
+        turn exit (fresh dispatch AND kick-retry recovery).
+        Invoked as ``on_turn_success(root_id, batch, channel_meta)``.
         """
         identity = self.keystore.load_identity(self.slug)
         kem_kp = KemKeyPair.from_secret_bytes(
@@ -1073,11 +1065,6 @@ class PuffoCoreMessageClient:
                     "agent thread %s recovered after kick-retry %d/%d",
                     root_id, attempt, self.MAX_API_ERROR_RETRIES,
                 )
-                # PUF-255: the kick-retry path is the OTHER success
-                # exit (vs the fresh-dispatch path in ``_consume_queue``).
-                # Both fire the turn-success hook so the worker can
-                # clear ``api_error_abandoned`` regardless of which
-                # success path got us here.
                 await self._fire_turn_success(
                     on_turn_success=on_turn_success,
                     root_id=root_id,
@@ -1154,24 +1141,14 @@ class PuffoCoreMessageClient:
         batch: list[dict],
         channel_meta: dict,
     ) -> None:
-        """PUF-255: recovery-side matched-pair for
-        ``_fire_api_error_abandon``. Fired on every successful turn
-        exit (both the fresh-dispatch path in ``_consume_queue`` and
-        the kick-retry-recovery path in ``_do_api_error_retries``).
-        The worker callback decides whether the success is a
-        recovery (clear ``runtime.health = "api_error_abandoned"``)
-        or a normal turn (no-op). Callback exceptions are caught +
-        logged -- the turn itself stands; this is purely
-        observational."""
+        """Recovery-side matched-pair for ``_fire_api_error_abandon``."""
         if on_turn_success is None:
             return
         try:
             await on_turn_success(root_id, batch, channel_meta)
         except Exception:
             self._log.exception(
-                "on_turn_success callback raised for thread %s; "
-                "the turn-success itself stands -- the callback's job "
-                "is purely observational",
+                "on_turn_success callback raised for thread %s",
                 root_id,
             )
 
@@ -1326,11 +1303,6 @@ class PuffoCoreMessageClient:
             # dispatching_ids set has done its job and can be released.
             entry.dispatching_ids = set()
 
-            # PUF-255: turn-success hook. Fires after every successful
-            # fresh-dispatch turn so the worker can clear a previous
-            # ``api_error_abandoned`` state. The consumer stays
-            # worker-state-agnostic; the worker callback decides
-            # whether the success is a recovery or just a normal turn.
             await self._fire_turn_success(
                 on_turn_success=on_turn_success,
                 root_id=root_id,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -506,6 +506,7 @@ class PuffoCoreMessageClient:
         on_message: Callable[..., Coroutine[Any, Any, Any]],
         on_api_error_retry: Callable[..., Coroutine[Any, Any, Any]] | None = None,
         on_api_error_abandon: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        on_turn_success: Callable[..., Coroutine[Any, Any, Any]] | None = None,
     ) -> None:
         """``on_message`` is the thread-batch callback. Despite the
         legacy parameter name kept for caller compatibility, it's
@@ -532,6 +533,19 @@ class PuffoCoreMessageClient:
         invisible. Invoked as ``on_api_error_abandon(root_id,
         batch, channel_meta, attempts)``. When omitted, the
         abandon stays silent (pre-PUF-252 behaviour).
+
+        PUF-255: ``on_turn_success`` is the recovery-side
+        matched-pair for ``on_api_error_abandon``. Fired at every
+        successful turn completion (both the fresh dispatch path
+        and the kick-retry-recovery path). The worker uses this
+        to clear ``runtime.health`` back from
+        ``"api_error_abandoned"`` to ``"ok"``, closing the loop
+        so puffo-server learns when the agent recovers. Without
+        this, PUF-252's state-honesty is one-way -- the server
+        learns when the agent breaks but never when it heals.
+        Invoked as ``on_turn_success(root_id, batch,
+        channel_meta)``. When omitted, the success stays
+        silent on the worker layer.
         """
         identity = self.keystore.load_identity(self.slug)
         kem_kp = KemKeyPair.from_secret_bytes(
@@ -844,7 +858,7 @@ class PuffoCoreMessageClient:
         self._queue_seq = 0
         self._thread_state: dict[str, _ThreadEntry] = {}
         consumer_task = asyncio.ensure_future(
-            self._consume_queue(on_message, on_api_error_retry, on_api_error_abandon),
+            self._consume_queue(on_message, on_api_error_retry, on_api_error_abandon, on_turn_success),
         )
         invite_poll_task = asyncio.ensure_future(self._invite_poll_loop())
         # Fire-and-forget; the WS subscribe below doesn't wait for
@@ -980,6 +994,7 @@ class PuffoCoreMessageClient:
         channel_meta: dict,
         on_api_error_retry: Optional[Callable[..., Coroutine[Any, Any, Any]]],
         on_api_error_abandon: Optional[Callable[..., Coroutine[Any, Any, Any]]],
+        on_turn_success: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None,
         last_envelope: str,
     ) -> None:
         """Loop the API-Error kick-retry path until the agent
@@ -1058,6 +1073,17 @@ class PuffoCoreMessageClient:
                     "agent thread %s recovered after kick-retry %d/%d",
                     root_id, attempt, self.MAX_API_ERROR_RETRIES,
                 )
+                # PUF-255: the kick-retry path is the OTHER success
+                # exit (vs the fresh-dispatch path in ``_consume_queue``).
+                # Both fire the turn-success hook so the worker can
+                # clear ``api_error_abandoned`` regardless of which
+                # success path got us here.
+                await self._fire_turn_success(
+                    on_turn_success=on_turn_success,
+                    root_id=root_id,
+                    batch=batch,
+                    channel_meta=channel_meta,
+                )
                 return
             except AgentAPIError:
                 # Still rate-limited; loop with another backoff.
@@ -1120,11 +1146,41 @@ class PuffoCoreMessageClient:
                 root_id,
             )
 
+    async def _fire_turn_success(
+        self,
+        *,
+        on_turn_success: Optional[Callable[..., Coroutine[Any, Any, Any]]],
+        root_id: str,
+        batch: list[dict],
+        channel_meta: dict,
+    ) -> None:
+        """PUF-255: recovery-side matched-pair for
+        ``_fire_api_error_abandon``. Fired on every successful turn
+        exit (both the fresh-dispatch path in ``_consume_queue`` and
+        the kick-retry-recovery path in ``_do_api_error_retries``).
+        The worker callback decides whether the success is a
+        recovery (clear ``runtime.health = "api_error_abandoned"``)
+        or a normal turn (no-op). Callback exceptions are caught +
+        logged -- the turn itself stands; this is purely
+        observational."""
+        if on_turn_success is None:
+            return
+        try:
+            await on_turn_success(root_id, batch, channel_meta)
+        except Exception:
+            self._log.exception(
+                "on_turn_success callback raised for thread %s; "
+                "the turn-success itself stands -- the callback's job "
+                "is purely observational",
+                root_id,
+            )
+
     async def _consume_queue(
         self,
         on_message_batch: Callable[..., Coroutine[Any, Any, Any]],
         on_api_error_retry: Callable[..., Coroutine[Any, Any, Any]] | None = None,
         on_api_error_abandon: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        on_turn_success: Callable[..., Coroutine[Any, Any, Any]] | None = None,
     ) -> None:
         """Drain the priority queue serially. One turn at a time so
         the underlying session keeps a coherent conversation history;
@@ -1233,6 +1289,7 @@ class PuffoCoreMessageClient:
                     channel_meta=channel_meta,
                     on_api_error_retry=on_api_error_retry,
                     on_api_error_abandon=on_api_error_abandon,
+                    on_turn_success=on_turn_success,
                     last_envelope=last_envelope,
                 )
                 continue
@@ -1268,6 +1325,18 @@ class PuffoCoreMessageClient:
             # cursor check from this point on, so the in-memory
             # dispatching_ids set has done its job and can be released.
             entry.dispatching_ids = set()
+
+            # PUF-255: turn-success hook. Fires after every successful
+            # fresh-dispatch turn so the worker can clear a previous
+            # ``api_error_abandoned`` state. The consumer stays
+            # worker-state-agnostic; the worker callback decides
+            # whether the success is a recovery or just a normal turn.
+            await self._fire_turn_success(
+                on_turn_success=on_turn_success,
+                root_id=root_id,
+                batch=batch,
+                channel_meta=channel_meta,
+            )
 
     async def _invite_poll_loop(self) -> None:
         """Poll ``/invites`` to catch invites the WS can't reach (the

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1075,13 +1075,21 @@ class RuntimeState:
     error: str = ""
     # Worker-side health, independent of ``status``. Values:
     #   "ok"                      — last refresh-ping smoke test passed
+    #                               OR PUF-255 cleared an abandoned state
+    #                               after a successful turn recovery
     #   "auth_failed"             — adapter saw 401 / authentication_error
+    #                               (PUF-221's CredentialRefresher lane;
+    #                               cleared by refresh-success-ping, not
+    #                               by PUF-255's turn-success hook)
     #   "api_error_abandoned"     — kick-retry exhausted on rate-limit /
     #                               API-error class, batch silently
-    #                               abandoned. PUF-252 ships this as the
-    #                               data layer; FB-197 (status dot) +
-    #                               FB-198 (restart lever) on Nova's
-    #                               canonical lane consume it on the UI.
+    #                               abandoned. PUF-252 ships the enter
+    #                               edge; PUF-255 ships the exit edge
+    #                               (recovery-clear on next successful
+    #                               turn). FB-197 (status dot) + FB-198
+    #                               (restart lever) on Nova's canonical
+    #                               lane consume the resulting
+    #                               bidirectional signal on the UI.
     #   "unknown"                 — no probe yet
     health: str = "unknown"  # ok | auth_failed | api_error_abandoned | unknown
 

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1074,23 +1074,14 @@ class RuntimeState:
     last_event_at: int = 0
     error: str = ""
     # Worker-side health, independent of ``status``. Values:
-    #   "ok"                      — last refresh-ping smoke test passed
-    #                               OR PUF-255 cleared an abandoned state
-    #                               after a successful turn recovery
-    #   "auth_failed"             — adapter saw 401 / authentication_error
-    #                               (PUF-221's CredentialRefresher lane;
-    #                               cleared by refresh-success-ping, not
-    #                               by PUF-255's turn-success hook)
-    #   "api_error_abandoned"     — kick-retry exhausted on rate-limit /
-    #                               API-error class, batch silently
-    #                               abandoned. PUF-252 ships the enter
-    #                               edge; PUF-255 ships the exit edge
-    #                               (recovery-clear on next successful
-    #                               turn). FB-197 (status dot) + FB-198
-    #                               (restart lever) on Nova's canonical
-    #                               lane consume the resulting
-    #                               bidirectional signal on the UI.
-    #   "unknown"                 — no probe yet
+    #   "ok"                  — refresh-ping passed, or a turn cleared a
+    #                           prior abandon
+    #   "auth_failed"         — adapter saw 401 / authentication_error;
+    #                           cleared only by the CredentialRefresher
+    #                           success-ping (PUF-221's lane)
+    #   "api_error_abandoned" — kick-retry exhausted, batch silently
+    #                           abandoned; cleared on next successful turn
+    #   "unknown"             — no probe yet
     health: str = "unknown"  # ok | auth_failed | api_error_abandoned | unknown
 
     @classmethod

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -514,6 +514,62 @@ def _handle_suppressed_reply(
 class Worker:
     """Runs a single AI agent inside the daemon event loop."""
 
+    @staticmethod
+    def _clear_api_error_abandoned_if_recoverable(
+        runtime: "RuntimeState",
+        agent_id: str,
+        root_id: str,
+        log: logging.Logger,
+    ) -> None:
+        """PUF-255: recovery-side matched-pair for
+        ``on_api_error_abandon``. Called from the
+        ``on_turn_success`` closure on every successful turn exit
+        (fresh dispatch + kick-retry recovery). Clears
+        ``runtime.health = "api_error_abandoned"`` back to
+        ``"ok"`` so puffo-server learns when the agent recovers --
+        closes the bidirectional state-honesty loop PUF-252
+        opened (server learned about breakage but never about
+        healing pre-PUF-255).
+
+        Only clears the ``api_error_abandoned`` state.
+        ``auth_failed`` is owned by PUF-221's credential-refresh
+        lane (recovery there happens via the
+        CredentialRefresher's success-ping, not via a turn
+        completing); leaving that alone keeps the two
+        health-state lifecycles cleanly partitioned.
+
+        No-op when ``runtime.health`` is already ``"ok"`` /
+        ``"unknown"`` -- avoids needless ``runtime.save`` churn
+        on the steady-state hot path.
+
+        **Known granularity mismatch (PUF-253 design input):**
+        ``api_error_abandoned`` is a thread-level event (thread A
+        abandoned its batch) but ``runtime.health`` is an
+        agent-global flag. A successful turn on thread B clears
+        the flag globally even though thread A's batch may
+        still be stuck. Current behaviour is last-write-wins;
+        the per-thread error history that would let the recovery
+        be thread-scoped is tracked separately as PUF-253's
+        design constraint for the eventual ``runtime.error``
+        list shape. UI consumers (FB-197/198) should expect this
+        coarseness until PUF-253 design lands.
+
+        Lifted from the local closure so tests exercise the real
+        function rather than a re-implemented stub -- a future
+        change here actually breaks the tests that pin its
+        contract.
+        """
+        if runtime.health != "api_error_abandoned":
+            return
+        runtime.health = "ok"
+        runtime.error = ""
+        runtime.save(agent_id)
+        log.info(
+            "agent %s: api-error-recovery on thread %s; "
+            "runtime.health cleared back to ok",
+            agent_id, root_id,
+        )
+
     def __init__(
         self,
         daemon_cfg: DaemonConfig,
@@ -971,35 +1027,8 @@ class Worker:
             batch: list[dict],
             channel_meta: dict,
         ):
-            """PUF-255: recovery-side matched-pair for
-            ``on_api_error_abandon``. Fires on every successful
-            turn exit (fresh dispatch + kick-retry recovery).
-            Clears ``runtime.health = "api_error_abandoned"`` back
-            to ``"ok"`` so puffo-server learns when the agent
-            recovers -- closes the bidirectional state-honesty
-            loop PUF-252 opened (server learned about breakage
-            but never about healing pre-PUF-255).
-
-            Only clears the ``api_error_abandoned`` state.
-            ``auth_failed`` is owned by PUF-221's credential-
-            refresh lane (recovery there happens via the
-            CredentialRefresher's success-ping, not via a turn
-            completing); leaving that alone keeps the two
-            health-state lifecycles cleanly partitioned.
-
-            No-op when ``runtime.health`` is already ``"ok"`` /
-            ``"unknown"`` -- avoids needless ``runtime.save``
-            churn on the steady-state hot path.
-            """
-            if self.runtime.health != "api_error_abandoned":
-                return
-            self.runtime.health = "ok"
-            self.runtime.error = ""
-            self.runtime.save(agent_id)
-            logger.info(
-                "agent %s: api-error-recovery on thread %s; "
-                "runtime.health cleared back to ok",
-                agent_id, root_id,
+            Worker._clear_api_error_abandoned_if_recoverable(
+                self.runtime, agent_id, root_id, logger,
             )
 
         async def heartbeat():

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -957,13 +957,49 @@ class Worker:
             self.runtime.error = (
                 f"Worker abandoned a batch on thread {root_id} after "
                 f"{attempts} rate-limit kick-retries. The agent has "
-                "gone silent on this thread until it is refreshed/"
-                "restarted."
+                "gone silent on this thread until a new message "
+                "arrives OR the agent is refreshed/restarted."
             )
             self.runtime.save(agent_id)
             logger.warning(
                 "agent %s: api-error-abandon on thread %s (attempts=%d)",
                 agent_id, root_id, attempts,
+            )
+
+        async def on_turn_success(
+            root_id: str,
+            batch: list[dict],
+            channel_meta: dict,
+        ):
+            """PUF-255: recovery-side matched-pair for
+            ``on_api_error_abandon``. Fires on every successful
+            turn exit (fresh dispatch + kick-retry recovery).
+            Clears ``runtime.health = "api_error_abandoned"`` back
+            to ``"ok"`` so puffo-server learns when the agent
+            recovers -- closes the bidirectional state-honesty
+            loop PUF-252 opened (server learned about breakage
+            but never about healing pre-PUF-255).
+
+            Only clears the ``api_error_abandoned`` state.
+            ``auth_failed`` is owned by PUF-221's credential-
+            refresh lane (recovery there happens via the
+            CredentialRefresher's success-ping, not via a turn
+            completing); leaving that alone keeps the two
+            health-state lifecycles cleanly partitioned.
+
+            No-op when ``runtime.health`` is already ``"ok"`` /
+            ``"unknown"`` -- avoids needless ``runtime.save``
+            churn on the steady-state hot path.
+            """
+            if self.runtime.health != "api_error_abandoned":
+                return
+            self.runtime.health = "ok"
+            self.runtime.error = ""
+            self.runtime.save(agent_id)
+            logger.info(
+                "agent %s: api-error-recovery on thread %s; "
+                "runtime.health cleared back to ok",
+                agent_id, root_id,
             )
 
         async def heartbeat():
@@ -1009,6 +1045,7 @@ class Worker:
                         on_message=on_message_batch,
                         on_api_error_retry=on_api_error_retry,
                         on_api_error_abandon=on_api_error_abandon,
+                        on_turn_success=on_turn_success,
                     )
                 except asyncio.CancelledError:
                     raise

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -521,43 +521,17 @@ class Worker:
         root_id: str,
         log: logging.Logger,
     ) -> None:
-        """PUF-255: recovery-side matched-pair for
-        ``on_api_error_abandon``. Called from the
-        ``on_turn_success`` closure on every successful turn exit
-        (fresh dispatch + kick-retry recovery). Clears
-        ``runtime.health = "api_error_abandoned"`` back to
-        ``"ok"`` so puffo-server learns when the agent recovers --
-        closes the bidirectional state-honesty loop PUF-252
-        opened (server learned about breakage but never about
-        healing pre-PUF-255).
+        """Clear ``runtime.health = "api_error_abandoned"`` back to
+        ``"ok"`` on the next successful turn. ``auth_failed`` is
+        deliberately left alone — PUF-221's CredentialRefresher
+        owns that lifecycle and a single lucky turn shouldn't
+        substitute for the refresh-success-ping.
 
-        Only clears the ``api_error_abandoned`` state.
-        ``auth_failed`` is owned by PUF-221's credential-refresh
-        lane (recovery there happens via the
-        CredentialRefresher's success-ping, not via a turn
-        completing); leaving that alone keeps the two
-        health-state lifecycles cleanly partitioned.
-
-        No-op when ``runtime.health`` is already ``"ok"`` /
-        ``"unknown"`` -- avoids needless ``runtime.save`` churn
-        on the steady-state hot path.
-
-        **Known granularity mismatch (PUF-253 design input):**
-        ``api_error_abandoned`` is a thread-level event (thread A
-        abandoned its batch) but ``runtime.health`` is an
-        agent-global flag. A successful turn on thread B clears
-        the flag globally even though thread A's batch may
-        still be stuck. Current behaviour is last-write-wins;
-        the per-thread error history that would let the recovery
-        be thread-scoped is tracked separately as PUF-253's
-        design constraint for the eventual ``runtime.error``
-        list shape. UI consumers (FB-197/198) should expect this
-        coarseness until PUF-253 design lands.
-
-        Lifted from the local closure so tests exercise the real
-        function rather than a re-implemented stub -- a future
-        change here actually breaks the tests that pin its
-        contract.
+        Known granularity mismatch (PUF-253 design input):
+        ``api_error_abandoned`` is a thread-level event but
+        ``runtime.health`` is an agent-global flag, so a success
+        on thread B clears it even if thread A is still stuck.
+        Last-write-wins until ``runtime.error`` becomes a list.
         """
         if runtime.health != "api_error_abandoned":
             return

--- a/tests/test_api_error_recovery_state.py
+++ b/tests/test_api_error_recovery_state.py
@@ -1,0 +1,344 @@
+"""PUF-255 (recovery-clear matched-pair for PUF-252).
+
+PUF-252 (PR #45) shipped the ENTER-error hook
+``on_api_error_abandon`` that flips
+``runtime.health = "api_error_abandoned"`` on kick-retry exhaustion.
+PUF-255 ships the symmetric EXIT-error hook ``on_turn_success``
+fired on every successful turn completion (both fresh-dispatch and
+kick-retry-recovery paths). The worker's callback clears the
+abandoned state back to ``"ok"`` so puffo-server learns when the
+agent has healed -- without this, PUF-252's state-honesty is
+one-way and the server permanently believes the agent is broken.
+
+Tests mirror PUF-252's ``test_api_error_abandon_state.py`` shape
+for symmetry + add the bidirectional cycle test Solution flagged
+at PR #45 QA gap-3 + the ticket's validation-plan "synthetic edge."
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.agent.core import AgentAPIError
+
+
+def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
+    """Bare client harness — bypass ``__init__`` so we don't need
+    keystore / identity / WS. Only the fields ``_fire_turn_success``
+    + ``_do_api_error_retries`` actually touch are stubbed."""
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "tester-1234"
+    client._log = logging.getLogger("test-puf-255")
+    client.MAX_API_ERROR_RETRIES = max_retries  # type: ignore[attr-defined]
+
+    class _StubStore:
+        async def mark_thread_processed(self, *args, **kwargs):
+            return None
+
+    client.store = _StubStore()  # type: ignore[assignment]
+    return client
+
+
+def _make_entry():
+    class _Entry:
+        dispatching_ids: set[str] = set()
+
+    return _Entry()
+
+
+@pytest.mark.asyncio
+async def test_recovery_callback_fires_on_kick_retry_success():
+    """When a kick-retry succeeds, the recovery callback fires
+    alongside ``mark_thread_processed``. Mirrors operator's
+    verbatim scenario: agent rate-limited → new message arrives →
+    kick-retry recovers → recovery callback fires."""
+    client = _make_client(max_retries=2)
+
+    retry_calls = {"n": 0}
+
+    async def kick_first_fails_then_succeeds(root_id, batch, channel_meta):
+        retry_calls["n"] += 1
+        if retry_calls["n"] == 1:
+            raise AgentAPIError("still rate-limited")
+        return None
+
+    success_calls: list[tuple[Any, ...]] = []
+
+    async def on_success(root_id, batch, channel_meta):
+        success_calls.append((root_id, list(batch), dict(channel_meta)))
+
+    real_sleep = asyncio.sleep
+    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
+    try:
+        await client._do_api_error_retries(  # type: ignore[arg-type]
+            root_id="root_rec",
+            entry=_make_entry(),  # type: ignore[arg-type]
+            batch=[{"envelope_id": "env_1", "sent_at": 100}],
+            channel_meta={"channel_id": "ch_x"},
+            on_api_error_retry=kick_first_fails_then_succeeds,
+            on_api_error_abandon=None,
+            on_turn_success=on_success,
+            last_envelope="env_1",
+        )
+    finally:
+        asyncio.sleep = real_sleep  # type: ignore[assignment]
+
+    assert len(success_calls) == 1
+    root_id, batch, channel_meta = success_calls[0]
+    assert root_id == "root_rec"
+    assert batch == [{"envelope_id": "env_1", "sent_at": 100}]
+    assert channel_meta == {"channel_id": "ch_x"}
+
+
+@pytest.mark.asyncio
+async def test_recovery_callback_does_not_fire_on_kick_retry_exhaustion():
+    """The recovery callback is for the SUCCESS path. When every
+    kick-retry fails and the batch is abandoned, recovery doesn't
+    fire (the abandon callback does — that's PUF-252's lane)."""
+    client = _make_client(max_retries=1)
+
+    async def always_fail(root_id, batch, channel_meta):
+        raise AgentAPIError("still rate-limited")
+
+    success_calls: list[tuple[Any, ...]] = []
+
+    async def on_success(root_id, batch, channel_meta):
+        success_calls.append((root_id,))
+
+    real_sleep = asyncio.sleep
+    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
+    try:
+        await client._do_api_error_retries(  # type: ignore[arg-type]
+            root_id="root_exhaust",
+            entry=_make_entry(),  # type: ignore[arg-type]
+            batch=[{"envelope_id": "env_1"}],
+            channel_meta={},
+            on_api_error_retry=always_fail,
+            on_api_error_abandon=None,
+            on_turn_success=on_success,
+            last_envelope="env_1",
+        )
+    finally:
+        asyncio.sleep = real_sleep  # type: ignore[assignment]
+
+    assert success_calls == []
+
+
+@pytest.mark.asyncio
+async def test_recovery_callback_exception_does_not_propagate():
+    """Observational hook — if the callback raises, the turn
+    itself stands. Same robustness invariant as
+    ``_fire_api_error_abandon``."""
+    client = _make_client(max_retries=1)
+
+    async def kick_succeeds(root_id, batch, channel_meta):
+        return None
+
+    async def on_success_raises(root_id, batch, channel_meta):
+        raise RuntimeError("callback boom")
+
+    real_sleep = asyncio.sleep
+    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
+    try:
+        # Should NOT raise.
+        await client._do_api_error_retries(  # type: ignore[arg-type]
+            root_id="root_swallow",
+            entry=_make_entry(),  # type: ignore[arg-type]
+            batch=[{"envelope_id": "env_1"}],
+            channel_meta={},
+            on_api_error_retry=kick_succeeds,
+            on_api_error_abandon=None,
+            on_turn_success=on_success_raises,
+            last_envelope="env_1",
+        )
+    finally:
+        asyncio.sleep = real_sleep  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_recovery_callback_omitted_does_not_break_backwards_compat():
+    """Pre-PUF-255 callers don't pass ``on_turn_success``. The
+    kick-recovery path should silently no-op the callback fire."""
+    client = _make_client(max_retries=1)
+
+    async def kick_succeeds(root_id, batch, channel_meta):
+        return None
+
+    real_sleep = asyncio.sleep
+    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
+    try:
+        # Should NOT raise.
+        await client._do_api_error_retries(  # type: ignore[arg-type]
+            root_id="root_noop",
+            entry=_make_entry(),  # type: ignore[arg-type]
+            batch=[{"envelope_id": "env_1"}],
+            channel_meta={},
+            on_api_error_retry=kick_succeeds,
+            on_api_error_abandon=None,
+            on_turn_success=None,
+            last_envelope="env_1",
+        )
+    finally:
+        asyncio.sleep = real_sleep  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_fire_turn_success_passes_batch_and_meta_unchanged():
+    """The helper just relays the tuple to the callback — no
+    mutation, no filtering. Pin so a future refactor that adds
+    filtering at the helper layer surfaces immediately."""
+    client = _make_client()
+
+    captured: list[Any] = []
+
+    async def on_success(root_id, batch, channel_meta):
+        captured.append((root_id, batch, channel_meta))
+
+    sample_batch = [{"envelope_id": "env_a"}, {"envelope_id": "env_b"}]
+    sample_meta = {"channel_id": "ch_q", "channel_name": "qa"}
+    await client._fire_turn_success(  # type: ignore[arg-type]
+        on_turn_success=on_success,
+        root_id="root_relay",
+        batch=sample_batch,
+        channel_meta=sample_meta,
+    )
+
+    assert len(captured) == 1
+    root_id, batch, channel_meta = captured[0]
+    assert root_id == "root_relay"
+    # Identity NOT preserved is the right contract (callers can
+    # mutate freely); but content should match.
+    assert batch == sample_batch
+    assert channel_meta == sample_meta
+
+
+# ── Worker callback unit tests ──────────────────────────────────────────────
+#
+# The worker defines ``on_turn_success`` as a local closure inside
+# ``Worker.run()``. To test it standalone we replicate the closure's
+# behavior via a tiny fake worker. Tests pin the
+# "clears api_error_abandoned, leaves auth_failed alone, no-op on ok"
+# contract that the comment block in worker.py documents.
+
+
+class _FakeRuntime:
+    """In-memory stand-in for ``RuntimeState`` -- the worker's
+    closure only touches ``.health`` + ``.error`` + ``.save(agent_id)``."""
+
+    def __init__(self, health: str = "ok"):
+        self.health = health
+        self.error = ""
+        self.saved_count = 0
+
+    def save(self, _agent_id: str):
+        self.saved_count += 1
+
+
+def _make_worker_recovery_callback(runtime: _FakeRuntime):
+    """Replicates the worker's ``on_turn_success`` closure shape
+    so we can test it without standing up the full Worker."""
+
+    async def on_turn_success(root_id, batch, channel_meta):
+        if runtime.health != "api_error_abandoned":
+            return
+        runtime.health = "ok"
+        runtime.error = ""
+        runtime.save("agent-X")
+
+    return on_turn_success
+
+
+@pytest.mark.asyncio
+async def test_worker_callback_clears_api_error_abandoned_to_ok():
+    """Operator's verbatim scenario: agent in
+    ``api_error_abandoned`` → new turn succeeds → health flips to
+    ``ok`` + error cleared + runtime saved (so puffo-server sees the
+    transition via the existing heartbeat reporter)."""
+    runtime = _FakeRuntime(health="api_error_abandoned")
+    runtime.error = "Worker abandoned a batch ..."
+    callback = _make_worker_recovery_callback(runtime)
+    await callback("root_x", [], {})
+    assert runtime.health == "ok"
+    assert runtime.error == ""
+    assert runtime.saved_count == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_callback_no_op_on_ok():
+    """Steady-state hot-path: most turns happen while
+    ``runtime.health == "ok"`` already. The callback should NOT
+    write to runtime each turn -- skip the save."""
+    runtime = _FakeRuntime(health="ok")
+    callback = _make_worker_recovery_callback(runtime)
+    await callback("root_x", [], {})
+    assert runtime.health == "ok"
+    assert runtime.saved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_worker_callback_leaves_auth_failed_alone():
+    """PUF-221's CredentialRefresher owns the ``auth_failed``
+    lifecycle. PUF-255's recovery hook is for the api-error class
+    only -- don't accidentally clear a 401 just because a turn
+    succeeded (the auth failure may persist after a single lucky
+    success); leave it to the refresh-success-ping."""
+    runtime = _FakeRuntime(health="auth_failed")
+    runtime.error = "auth-error"
+    callback = _make_worker_recovery_callback(runtime)
+    await callback("root_x", [], {})
+    assert runtime.health == "auth_failed"
+    assert runtime.error == "auth-error"
+    assert runtime.saved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_worker_callback_no_op_on_unknown():
+    """Boot-time / uninstrumented state. No turn-success transition
+    is meaningful from ``unknown`` -- the worker's other hooks
+    (health-ping, etc.) own that bootstrap transition."""
+    runtime = _FakeRuntime(health="unknown")
+    callback = _make_worker_recovery_callback(runtime)
+    await callback("root_x", [], {})
+    assert runtime.health == "unknown"
+    assert runtime.saved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_bidirectional_state_cycle():
+    """The matched-pair regression seal Solution flagged at PR #45
+    QA gap-3 + the ticket's validation-plan "synthetic edge":
+    error → recovery → error → recovery cycles correctly with the
+    last-write-wins semantics implied by ``runtime.save`` per
+    transition."""
+    runtime = _FakeRuntime(health="ok")
+    recovery_callback = _make_worker_recovery_callback(runtime)
+
+    # Simulate PUF-252's enter-error path setting state.
+    def enter_error(reason: str):
+        runtime.health = "api_error_abandoned"
+        runtime.error = reason
+        runtime.save("agent-X")
+
+    # Cycle 1: enter error, recover, verify
+    enter_error("first abandon")
+    assert runtime.health == "api_error_abandoned"
+    await recovery_callback("root_1", [], {})
+    assert runtime.health == "ok"
+    assert runtime.error == ""
+
+    # Cycle 2: enter error again, recover again
+    enter_error("second abandon")
+    assert runtime.health == "api_error_abandoned"
+    assert runtime.error == "second abandon"
+    await recovery_callback("root_2", [], {})
+    assert runtime.health == "ok"
+    assert runtime.error == ""
+
+    # Sanity: saves fired 4 times (2 enters + 2 recoveries).
+    assert runtime.saved_count == 4

--- a/tests/test_api_error_recovery_state.py
+++ b/tests/test_api_error_recovery_state.py
@@ -12,7 +12,7 @@ one-way and the server permanently believes the agent is broken.
 
 Tests mirror PUF-252's ``test_api_error_abandon_state.py`` shape
 for symmetry + add the bidirectional cycle test Solution flagged
-at PR #45 QA gap-3 + the ticket's validation-plan "synthetic edge."
+at PR #45 QA gap-3 + the ticket's validation-plan "synthetic edge".
 """
 
 from __future__ import annotations
@@ -20,16 +20,31 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
 from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
 from puffo_agent.agent.core import AgentAPIError
+from puffo_agent.portal.worker import Worker
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    """Mirror PR #45 polish: monkeypatch ``asyncio.sleep`` for the
+    test's lifetime via pytest's fixture so the patch is per-test
+    and reverts cleanly. Process-global ``asyncio.sleep = ...``
+    assignment + try/finally was brittle under pytest-xdist /
+    concurrent event-loop tests."""
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
 
 
 def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
-    """Bare client harness — bypass ``__init__`` so we don't need
+    """Bare client harness -- bypass ``__init__`` so we don't need
     keystore / identity / WS. Only the fields ``_fire_turn_success``
     + ``_do_api_error_retries`` actually touch are stubbed."""
     client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
@@ -46,8 +61,14 @@ def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
 
 
 def _make_entry():
+    """Tiny stand-in for ``_ThreadEntry``. Only ``dispatching_ids``
+    is touched by ``_do_api_error_retries`` (cleared on entry).
+    Initialised in ``__init__`` so each entry owns its own set --
+    mirrors PR #45 polish on the analogous PUF-252 test fixture."""
+
     class _Entry:
-        dispatching_ids: set[str] = set()
+        def __init__(self):
+            self.dispatching_ids: set[str] = set()
 
     return _Entry()
 
@@ -56,8 +77,8 @@ def _make_entry():
 async def test_recovery_callback_fires_on_kick_retry_success():
     """When a kick-retry succeeds, the recovery callback fires
     alongside ``mark_thread_processed``. Mirrors operator's
-    verbatim scenario: agent rate-limited → new message arrives →
-    kick-retry recovers → recovery callback fires."""
+    verbatim scenario: agent rate-limited -> new message arrives ->
+    kick-retry recovers -> recovery callback fires."""
     client = _make_client(max_retries=2)
 
     retry_calls = {"n": 0}
@@ -73,21 +94,16 @@ async def test_recovery_callback_fires_on_kick_retry_success():
     async def on_success(root_id, batch, channel_meta):
         success_calls.append((root_id, list(batch), dict(channel_meta)))
 
-    real_sleep = asyncio.sleep
-    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
-    try:
-        await client._do_api_error_retries(  # type: ignore[arg-type]
-            root_id="root_rec",
-            entry=_make_entry(),  # type: ignore[arg-type]
-            batch=[{"envelope_id": "env_1", "sent_at": 100}],
-            channel_meta={"channel_id": "ch_x"},
-            on_api_error_retry=kick_first_fails_then_succeeds,
-            on_api_error_abandon=None,
-            on_turn_success=on_success,
-            last_envelope="env_1",
-        )
-    finally:
-        asyncio.sleep = real_sleep  # type: ignore[assignment]
+    await client._do_api_error_retries(  # type: ignore[arg-type]
+        root_id="root_rec",
+        entry=_make_entry(),  # type: ignore[arg-type]
+        batch=[{"envelope_id": "env_1", "sent_at": 100}],
+        channel_meta={"channel_id": "ch_x"},
+        on_api_error_retry=kick_first_fails_then_succeeds,
+        on_api_error_abandon=None,
+        on_turn_success=on_success,
+        last_envelope="env_1",
+    )
 
     assert len(success_calls) == 1
     root_id, batch, channel_meta = success_calls[0]
@@ -100,7 +116,7 @@ async def test_recovery_callback_fires_on_kick_retry_success():
 async def test_recovery_callback_does_not_fire_on_kick_retry_exhaustion():
     """The recovery callback is for the SUCCESS path. When every
     kick-retry fails and the batch is abandoned, recovery doesn't
-    fire (the abandon callback does — that's PUF-252's lane)."""
+    fire (the abandon callback does -- that's PUF-252's lane)."""
     client = _make_client(max_retries=1)
 
     async def always_fail(root_id, batch, channel_meta):
@@ -111,30 +127,27 @@ async def test_recovery_callback_does_not_fire_on_kick_retry_exhaustion():
     async def on_success(root_id, batch, channel_meta):
         success_calls.append((root_id,))
 
-    real_sleep = asyncio.sleep
-    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
-    try:
-        await client._do_api_error_retries(  # type: ignore[arg-type]
-            root_id="root_exhaust",
-            entry=_make_entry(),  # type: ignore[arg-type]
-            batch=[{"envelope_id": "env_1"}],
-            channel_meta={},
-            on_api_error_retry=always_fail,
-            on_api_error_abandon=None,
-            on_turn_success=on_success,
-            last_envelope="env_1",
-        )
-    finally:
-        asyncio.sleep = real_sleep  # type: ignore[assignment]
+    await client._do_api_error_retries(  # type: ignore[arg-type]
+        root_id="root_exhaust",
+        entry=_make_entry(),  # type: ignore[arg-type]
+        batch=[{"envelope_id": "env_1"}],
+        channel_meta={},
+        on_api_error_retry=always_fail,
+        on_api_error_abandon=None,
+        on_turn_success=on_success,
+        last_envelope="env_1",
+    )
 
     assert success_calls == []
 
 
 @pytest.mark.asyncio
-async def test_recovery_callback_exception_does_not_propagate():
-    """Observational hook — if the callback raises, the turn
+async def test_recovery_callback_exception_does_not_propagate(caplog):
+    """Observational hook -- if the callback raises, the turn
     itself stands. Same robustness invariant as
-    ``_fire_api_error_abandon``."""
+    ``_fire_api_error_abandon``. ``caplog`` pins that the swallow
+    is logged via ``log.exception`` so a future regression that
+    silently passes instead of logging breaks the test."""
     client = _make_client(max_retries=1)
 
     async def kick_succeeds(root_id, batch, channel_meta):
@@ -143,9 +156,7 @@ async def test_recovery_callback_exception_does_not_propagate():
     async def on_success_raises(root_id, batch, channel_meta):
         raise RuntimeError("callback boom")
 
-    real_sleep = asyncio.sleep
-    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
-    try:
+    with caplog.at_level(logging.ERROR, logger="test-puf-255"):
         # Should NOT raise.
         await client._do_api_error_retries(  # type: ignore[arg-type]
             root_id="root_swallow",
@@ -157,8 +168,15 @@ async def test_recovery_callback_exception_does_not_propagate():
             on_turn_success=on_success_raises,
             last_envelope="env_1",
         )
-    finally:
-        asyncio.sleep = real_sleep  # type: ignore[assignment]
+
+    matching = [
+        r for r in caplog.records
+        if r.levelno == logging.ERROR and r.exc_info is not None
+    ]
+    assert matching, (
+        "expected log.exception() to fire when the recovery callback "
+        "raised; caplog saw no ERROR record with exc_info"
+    )
 
 
 @pytest.mark.asyncio
@@ -170,27 +188,22 @@ async def test_recovery_callback_omitted_does_not_break_backwards_compat():
     async def kick_succeeds(root_id, batch, channel_meta):
         return None
 
-    real_sleep = asyncio.sleep
-    asyncio.sleep = (lambda _s: real_sleep(0))  # type: ignore[assignment]
-    try:
-        # Should NOT raise.
-        await client._do_api_error_retries(  # type: ignore[arg-type]
-            root_id="root_noop",
-            entry=_make_entry(),  # type: ignore[arg-type]
-            batch=[{"envelope_id": "env_1"}],
-            channel_meta={},
-            on_api_error_retry=kick_succeeds,
-            on_api_error_abandon=None,
-            on_turn_success=None,
-            last_envelope="env_1",
-        )
-    finally:
-        asyncio.sleep = real_sleep  # type: ignore[assignment]
+    # Should NOT raise.
+    await client._do_api_error_retries(  # type: ignore[arg-type]
+        root_id="root_noop",
+        entry=_make_entry(),  # type: ignore[arg-type]
+        batch=[{"envelope_id": "env_1"}],
+        channel_meta={},
+        on_api_error_retry=kick_succeeds,
+        on_api_error_abandon=None,
+        on_turn_success=None,
+        last_envelope="env_1",
+    )
 
 
 @pytest.mark.asyncio
 async def test_fire_turn_success_passes_batch_and_meta_unchanged():
-    """The helper just relays the tuple to the callback — no
+    """The helper just relays the tuple to the callback -- no
     mutation, no filtering. Pin so a future refactor that adds
     filtering at the helper layer surfaces immediately."""
     client = _make_client()
@@ -218,106 +231,155 @@ async def test_fire_turn_success_passes_batch_and_meta_unchanged():
     assert channel_meta == sample_meta
 
 
+@pytest.mark.asyncio
+async def test_fresh_dispatch_success_path_fires_recovery_callback():
+    """The fresh-dispatch happy path through ``_consume_queue``
+    fires ``_fire_turn_success`` after ``mark_thread_processed``.
+
+    Without this test, removing the ``_fire_turn_success(...)``
+    call at the success branch of ``_consume_queue`` (line ~1334)
+    would slip past CI -- every other test exercises the
+    kick-retry-recovery path via ``_do_api_error_retries``. This
+    test stands up a minimal queue + thread_state + store mock and
+    drives one happy-path turn through the consumer.
+    """
+    from puffo_agent.agent.puffo_core_client import _ThreadEntry
+
+    client = _make_client(max_retries=1)
+    client._queue = asyncio.PriorityQueue()
+    client._thread_state = {}
+
+    root_id = "root_fresh"
+    batch = [{"envelope_id": "env_1", "sent_at": 100}]
+    entry = _ThreadEntry(
+        messages=list(batch),
+        channel_meta={"channel_id": "ch_x"},
+        current_priority=0,
+        current_seq=1,
+        in_queue=True,
+    )
+    client._thread_state[root_id] = entry
+    await client._queue.put((0, 1, root_id))
+
+    async def on_message_batch(_root_id, _batch, _meta):
+        return None
+
+    success_calls: list[tuple[Any, ...]] = []
+    done = asyncio.Event()
+
+    async def on_turn_success(_root_id, _batch, _meta):
+        success_calls.append((_root_id, list(_batch), dict(_meta)))
+        done.set()
+
+    task = asyncio.create_task(
+        client._consume_queue(  # type: ignore[arg-type]
+            on_message_batch=on_message_batch,
+            on_turn_success=on_turn_success,
+        )
+    )
+    try:
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert len(success_calls) == 1
+    fired_root, fired_batch, fired_meta = success_calls[0]
+    assert fired_root == root_id
+    assert fired_batch == batch
+    assert fired_meta == {"channel_id": "ch_x"}
+
+
 # ── Worker callback unit tests ──────────────────────────────────────────────
 #
-# The worker defines ``on_turn_success`` as a local closure inside
-# ``Worker.run()``. To test it standalone we replicate the closure's
-# behavior via a tiny fake worker. Tests pin the
-# "clears api_error_abandoned, leaves auth_failed alone, no-op on ok"
-# contract that the comment block in worker.py documents.
+# Tests call ``Worker._clear_api_error_abandoned_if_recoverable``
+# directly (the lifted staticmethod) so they pin the production
+# function's contract -- a change to the closure body actually
+# breaks the test rather than drifting against a re-implemented
+# stub. This is per operator's PR #46 review item 3 (path b
+# refactor).
 
 
 class _FakeRuntime:
-    """In-memory stand-in for ``RuntimeState`` -- the worker's
-    closure only touches ``.health`` + ``.error`` + ``.save(agent_id)``."""
+    """In-memory stand-in for ``RuntimeState`` -- the recovery
+    helper only touches ``.health`` + ``.error`` + ``.save(agent_id)``."""
 
     def __init__(self, health: str = "ok"):
         self.health = health
         self.error = ""
         self.saved_count = 0
+        self.last_saved_agent: str | None = None
 
-    def save(self, _agent_id: str):
+    def save(self, agent_id: str):
         self.saved_count += 1
+        self.last_saved_agent = agent_id
 
 
-def _make_worker_recovery_callback(runtime: _FakeRuntime):
-    """Replicates the worker's ``on_turn_success`` closure shape
-    so we can test it without standing up the full Worker."""
-
-    async def on_turn_success(root_id, batch, channel_meta):
-        if runtime.health != "api_error_abandoned":
-            return
-        runtime.health = "ok"
-        runtime.error = ""
-        runtime.save("agent-X")
-
-    return on_turn_success
+_WORKER_LOG = logging.getLogger("test-puf-255-worker")
 
 
-@pytest.mark.asyncio
-async def test_worker_callback_clears_api_error_abandoned_to_ok():
+def _call_recovery_helper(runtime: _FakeRuntime, root_id: str = "root_x") -> None:
+    Worker._clear_api_error_abandoned_if_recoverable(
+        runtime, "agent-X", root_id, _WORKER_LOG,  # type: ignore[arg-type]
+    )
+
+
+def test_worker_callback_clears_api_error_abandoned_to_ok():
     """Operator's verbatim scenario: agent in
-    ``api_error_abandoned`` → new turn succeeds → health flips to
-    ``ok`` + error cleared + runtime saved (so puffo-server sees the
-    transition via the existing heartbeat reporter)."""
+    ``api_error_abandoned`` -> new turn succeeds -> health flips to
+    ``ok`` + error cleared + runtime saved."""
     runtime = _FakeRuntime(health="api_error_abandoned")
     runtime.error = "Worker abandoned a batch ..."
-    callback = _make_worker_recovery_callback(runtime)
-    await callback("root_x", [], {})
+    _call_recovery_helper(runtime)
     assert runtime.health == "ok"
     assert runtime.error == ""
     assert runtime.saved_count == 1
+    assert runtime.last_saved_agent == "agent-X"
 
 
-@pytest.mark.asyncio
-async def test_worker_callback_no_op_on_ok():
+def test_worker_callback_no_op_on_ok():
     """Steady-state hot-path: most turns happen while
-    ``runtime.health == "ok"`` already. The callback should NOT
+    ``runtime.health == "ok"`` already. The helper should NOT
     write to runtime each turn -- skip the save."""
     runtime = _FakeRuntime(health="ok")
-    callback = _make_worker_recovery_callback(runtime)
-    await callback("root_x", [], {})
+    _call_recovery_helper(runtime)
     assert runtime.health == "ok"
     assert runtime.saved_count == 0
 
 
-@pytest.mark.asyncio
-async def test_worker_callback_leaves_auth_failed_alone():
+def test_worker_callback_leaves_auth_failed_alone():
     """PUF-221's CredentialRefresher owns the ``auth_failed``
     lifecycle. PUF-255's recovery hook is for the api-error class
     only -- don't accidentally clear a 401 just because a turn
-    succeeded (the auth failure may persist after a single lucky
-    success); leave it to the refresh-success-ping."""
+    succeeded; leave it to the refresh-success-ping."""
     runtime = _FakeRuntime(health="auth_failed")
     runtime.error = "auth-error"
-    callback = _make_worker_recovery_callback(runtime)
-    await callback("root_x", [], {})
+    _call_recovery_helper(runtime)
     assert runtime.health == "auth_failed"
     assert runtime.error == "auth-error"
     assert runtime.saved_count == 0
 
 
-@pytest.mark.asyncio
-async def test_worker_callback_no_op_on_unknown():
+def test_worker_callback_no_op_on_unknown():
     """Boot-time / uninstrumented state. No turn-success transition
-    is meaningful from ``unknown`` -- the worker's other hooks
-    (health-ping, etc.) own that bootstrap transition."""
+    is meaningful from ``unknown`` -- the worker's other hooks own
+    that bootstrap transition."""
     runtime = _FakeRuntime(health="unknown")
-    callback = _make_worker_recovery_callback(runtime)
-    await callback("root_x", [], {})
+    _call_recovery_helper(runtime)
     assert runtime.health == "unknown"
     assert runtime.saved_count == 0
 
 
-@pytest.mark.asyncio
-async def test_bidirectional_state_cycle():
+def test_bidirectional_state_cycle():
     """The matched-pair regression seal Solution flagged at PR #45
     QA gap-3 + the ticket's validation-plan "synthetic edge":
-    error → recovery → error → recovery cycles correctly with the
-    last-write-wins semantics implied by ``runtime.save`` per
+    error -> recovery -> error -> recovery cycles correctly with
+    the last-write-wins semantics implied by ``runtime.save`` per
     transition."""
     runtime = _FakeRuntime(health="ok")
-    recovery_callback = _make_worker_recovery_callback(runtime)
 
     # Simulate PUF-252's enter-error path setting state.
     def enter_error(reason: str):
@@ -328,7 +390,7 @@ async def test_bidirectional_state_cycle():
     # Cycle 1: enter error, recover, verify
     enter_error("first abandon")
     assert runtime.health == "api_error_abandoned"
-    await recovery_callback("root_1", [], {})
+    _call_recovery_helper(runtime, root_id="root_1")
     assert runtime.health == "ok"
     assert runtime.error == ""
 
@@ -336,7 +398,7 @@ async def test_bidirectional_state_cycle():
     enter_error("second abandon")
     assert runtime.health == "api_error_abandoned"
     assert runtime.error == "second abandon"
-    await recovery_callback("root_2", [], {})
+    _call_recovery_helper(runtime, root_id="root_2")
     assert runtime.health == "ok"
     assert runtime.error == ""
 

--- a/tests/test_api_error_recovery_state.py
+++ b/tests/test_api_error_recovery_state.py
@@ -1,19 +1,4 @@
-"""PUF-255 (recovery-clear matched-pair for PUF-252).
-
-PUF-252 (PR #45) shipped the ENTER-error hook
-``on_api_error_abandon`` that flips
-``runtime.health = "api_error_abandoned"`` on kick-retry exhaustion.
-PUF-255 ships the symmetric EXIT-error hook ``on_turn_success``
-fired on every successful turn completion (both fresh-dispatch and
-kick-retry-recovery paths). The worker's callback clears the
-abandoned state back to ``"ok"`` so puffo-server learns when the
-agent has healed -- without this, PUF-252's state-honesty is
-one-way and the server permanently believes the agent is broken.
-
-Tests mirror PUF-252's ``test_api_error_abandon_state.py`` shape
-for symmetry + add the bidirectional cycle test Solution flagged
-at PR #45 QA gap-3 + the ticket's validation-plan "synthetic edge".
-"""
+"""PUF-255: regression coverage for ``on_turn_success`` recovery-clear."""
 
 from __future__ import annotations
 
@@ -30,11 +15,7 @@ from puffo_agent.portal.worker import Worker
 
 @pytest.fixture(autouse=True)
 def _fast_sleep(monkeypatch):
-    """Mirror PR #45 polish: monkeypatch ``asyncio.sleep`` for the
-    test's lifetime via pytest's fixture so the patch is per-test
-    and reverts cleanly. Process-global ``asyncio.sleep = ...``
-    assignment + try/finally was brittle under pytest-xdist /
-    concurrent event-loop tests."""
+    """Per-test ``asyncio.sleep`` patch via monkeypatch."""
     real_sleep = asyncio.sleep
 
     async def fast_sleep(_seconds):
@@ -44,9 +25,6 @@ def _fast_sleep(monkeypatch):
 
 
 def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
-    """Bare client harness -- bypass ``__init__`` so we don't need
-    keystore / identity / WS. Only the fields ``_fire_turn_success``
-    + ``_do_api_error_retries`` actually touch are stubbed."""
     client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
     client.slug = "tester-1234"
     client._log = logging.getLogger("test-puf-255")
@@ -61,11 +39,6 @@ def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
 
 
 def _make_entry():
-    """Tiny stand-in for ``_ThreadEntry``. Only ``dispatching_ids``
-    is touched by ``_do_api_error_retries`` (cleared on entry).
-    Initialised in ``__init__`` so each entry owns its own set --
-    mirrors PR #45 polish on the analogous PUF-252 test fixture."""
-
     class _Entry:
         def __init__(self):
             self.dispatching_ids: set[str] = set()
@@ -75,10 +48,6 @@ def _make_entry():
 
 @pytest.mark.asyncio
 async def test_recovery_callback_fires_on_kick_retry_success():
-    """When a kick-retry succeeds, the recovery callback fires
-    alongside ``mark_thread_processed``. Mirrors operator's
-    verbatim scenario: agent rate-limited -> new message arrives ->
-    kick-retry recovers -> recovery callback fires."""
     client = _make_client(max_retries=2)
 
     retry_calls = {"n": 0}
@@ -114,9 +83,6 @@ async def test_recovery_callback_fires_on_kick_retry_success():
 
 @pytest.mark.asyncio
 async def test_recovery_callback_does_not_fire_on_kick_retry_exhaustion():
-    """The recovery callback is for the SUCCESS path. When every
-    kick-retry fails and the batch is abandoned, recovery doesn't
-    fire (the abandon callback does -- that's PUF-252's lane)."""
     client = _make_client(max_retries=1)
 
     async def always_fail(root_id, batch, channel_meta):
@@ -143,11 +109,7 @@ async def test_recovery_callback_does_not_fire_on_kick_retry_exhaustion():
 
 @pytest.mark.asyncio
 async def test_recovery_callback_exception_does_not_propagate(caplog):
-    """Observational hook -- if the callback raises, the turn
-    itself stands. Same robustness invariant as
-    ``_fire_api_error_abandon``. ``caplog`` pins that the swallow
-    is logged via ``log.exception`` so a future regression that
-    silently passes instead of logging breaks the test."""
+    """``caplog`` pins that the swallow is logged via ``log.exception``."""
     client = _make_client(max_retries=1)
 
     async def kick_succeeds(root_id, batch, channel_meta):
@@ -181,8 +143,6 @@ async def test_recovery_callback_exception_does_not_propagate(caplog):
 
 @pytest.mark.asyncio
 async def test_recovery_callback_omitted_does_not_break_backwards_compat():
-    """Pre-PUF-255 callers don't pass ``on_turn_success``. The
-    kick-recovery path should silently no-op the callback fire."""
     client = _make_client(max_retries=1)
 
     async def kick_succeeds(root_id, batch, channel_meta):
@@ -203,9 +163,8 @@ async def test_recovery_callback_omitted_does_not_break_backwards_compat():
 
 @pytest.mark.asyncio
 async def test_fire_turn_success_passes_batch_and_meta_unchanged():
-    """The helper just relays the tuple to the callback -- no
-    mutation, no filtering. Pin so a future refactor that adds
-    filtering at the helper layer surfaces immediately."""
+    """Pin so a future refactor that adds filtering at the helper
+    layer surfaces immediately."""
     client = _make_client()
 
     captured: list[Any] = []
@@ -225,24 +184,14 @@ async def test_fire_turn_success_passes_batch_and_meta_unchanged():
     assert len(captured) == 1
     root_id, batch, channel_meta = captured[0]
     assert root_id == "root_relay"
-    # Identity NOT preserved is the right contract (callers can
-    # mutate freely); but content should match.
     assert batch == sample_batch
     assert channel_meta == sample_meta
 
 
 @pytest.mark.asyncio
 async def test_fresh_dispatch_success_path_fires_recovery_callback():
-    """The fresh-dispatch happy path through ``_consume_queue``
-    fires ``_fire_turn_success`` after ``mark_thread_processed``.
-
-    Without this test, removing the ``_fire_turn_success(...)``
-    call at the success branch of ``_consume_queue`` (line ~1334)
-    would slip past CI -- every other test exercises the
-    kick-retry-recovery path via ``_do_api_error_retries``. This
-    test stands up a minimal queue + thread_state + store mock and
-    drives one happy-path turn through the consumer.
-    """
+    """Seals the ``_consume_queue`` success branch (every other
+    test exercises only the kick-retry-recovery path)."""
     from puffo_agent.agent.puffo_core_client import _ThreadEntry
 
     client = _make_client(max_retries=1)
@@ -293,20 +242,10 @@ async def test_fresh_dispatch_success_path_fires_recovery_callback():
     assert fired_meta == {"channel_id": "ch_x"}
 
 
-# ── Worker callback unit tests ──────────────────────────────────────────────
-#
-# Tests call ``Worker._clear_api_error_abandoned_if_recoverable``
-# directly (the lifted staticmethod) so they pin the production
-# function's contract -- a change to the closure body actually
-# breaks the test rather than drifting against a re-implemented
-# stub. This is per operator's PR #46 review item 3 (path b
-# refactor).
+# ── Worker callback unit tests (drive the lifted staticmethod) ───
 
 
 class _FakeRuntime:
-    """In-memory stand-in for ``RuntimeState`` -- the recovery
-    helper only touches ``.health`` + ``.error`` + ``.save(agent_id)``."""
-
     def __init__(self, health: str = "ok"):
         self.health = health
         self.error = ""
@@ -328,9 +267,6 @@ def _call_recovery_helper(runtime: _FakeRuntime, root_id: str = "root_x") -> Non
 
 
 def test_worker_callback_clears_api_error_abandoned_to_ok():
-    """Operator's verbatim scenario: agent in
-    ``api_error_abandoned`` -> new turn succeeds -> health flips to
-    ``ok`` + error cleared + runtime saved."""
     runtime = _FakeRuntime(health="api_error_abandoned")
     runtime.error = "Worker abandoned a batch ..."
     _call_recovery_helper(runtime)
@@ -341,9 +277,7 @@ def test_worker_callback_clears_api_error_abandoned_to_ok():
 
 
 def test_worker_callback_no_op_on_ok():
-    """Steady-state hot-path: most turns happen while
-    ``runtime.health == "ok"`` already. The helper should NOT
-    write to runtime each turn -- skip the save."""
+    """Steady-state hot path skips the runtime.save."""
     runtime = _FakeRuntime(health="ok")
     _call_recovery_helper(runtime)
     assert runtime.health == "ok"
@@ -351,10 +285,7 @@ def test_worker_callback_no_op_on_ok():
 
 
 def test_worker_callback_leaves_auth_failed_alone():
-    """PUF-221's CredentialRefresher owns the ``auth_failed``
-    lifecycle. PUF-255's recovery hook is for the api-error class
-    only -- don't accidentally clear a 401 just because a turn
-    succeeded; leave it to the refresh-success-ping."""
+    """auth_failed belongs to the CredentialRefresher lane."""
     runtime = _FakeRuntime(health="auth_failed")
     runtime.error = "auth-error"
     _call_recovery_helper(runtime)
@@ -364,9 +295,6 @@ def test_worker_callback_leaves_auth_failed_alone():
 
 
 def test_worker_callback_no_op_on_unknown():
-    """Boot-time / uninstrumented state. No turn-success transition
-    is meaningful from ``unknown`` -- the worker's other hooks own
-    that bootstrap transition."""
     runtime = _FakeRuntime(health="unknown")
     _call_recovery_helper(runtime)
     assert runtime.health == "unknown"
@@ -374,27 +302,20 @@ def test_worker_callback_no_op_on_unknown():
 
 
 def test_bidirectional_state_cycle():
-    """The matched-pair regression seal Solution flagged at PR #45
-    QA gap-3 + the ticket's validation-plan "synthetic edge":
-    error -> recovery -> error -> recovery cycles correctly with
-    the last-write-wins semantics implied by ``runtime.save`` per
-    transition."""
+    """Regression seal: error -> recovery -> error -> recovery cycles."""
     runtime = _FakeRuntime(health="ok")
 
-    # Simulate PUF-252's enter-error path setting state.
     def enter_error(reason: str):
         runtime.health = "api_error_abandoned"
         runtime.error = reason
         runtime.save("agent-X")
 
-    # Cycle 1: enter error, recover, verify
     enter_error("first abandon")
     assert runtime.health == "api_error_abandoned"
     _call_recovery_helper(runtime, root_id="root_1")
     assert runtime.health == "ok"
     assert runtime.error == ""
 
-    # Cycle 2: enter error again, recover again
     enter_error("second abandon")
     assert runtime.health == "api_error_abandoned"
     assert runtime.error == "second abandon"
@@ -402,5 +323,4 @@ def test_bidirectional_state_cycle():
     assert runtime.health == "ok"
     assert runtime.error == ""
 
-    # Sanity: saves fired 4 times (2 enters + 2 recoveries).
     assert runtime.saved_count == 4


### PR DESCRIPTION
## Summary

**Stacked PR on top of PR #45 (PUF-252).** Closes the bidirectional state-honesty loop PUF-252 opened: server learned about agent breakage (`runtime.health = "api_error_abandoned"`), but never about healing. PUF-255 ships the recovery-clear matched-pair so a healed agent reports `runtime.health = "ok"` back to puffo-server when a turn completes successfully.

**Direct response to my own PR #45 QA gap-3** at `msg_1f0ff9af`: *"Recovery path — when bug-2 restart lever fires, what resets `runtime.health` back to 'ok' / 'unknown'?"* Operator's DM observation at `msg_15870364` + my QA gap converged from different angles; PUF-255 closes both.

GitHub will auto-retarget this PR's base to `main` when PR #45 merges.

## What changed

- **`agent/puffo_core_client.py`** — symmetric `on_turn_success` callback (mirrors PUF-252's `on_api_error_abandon`). Fires on both successful turn exits: fresh-dispatch via `_consume_queue` AND kick-retry-recovery via `_do_api_error_retries`. Routed through `_fire_turn_success` helper.
- **`portal/worker.py`** — callback policy with explicit state-lifecycle partition:
  - Early return when `runtime.health != "api_error_abandoned"` (no-op on `"ok"` / `"unknown"` keeps steady-state hot path write-free)
  - Explicitly leaves `"auth_failed"` alone (PUF-221's CredentialRefresher lane owns that lifecycle; recovery there is via success-ping, not turn-completion)
  - Clears `runtime.health = "ok"` + `runtime.error = ""` + `runtime.save(agent_id)` + INFO log
- **`portal/state.py`** — formalize the cleared shape with explicit comment trail.

## Test coverage

10 cases in `tests/test_api_error_recovery_state.py`, all passing:

| Test | Pin |
|---|---|
| `recovery_callback_fires_on_kick_retry_success` | Operator's verbatim scenario — kick-retry recovers → callback fires |
| `recovery_callback_does_not_fire_on_kick_retry_exhaustion` | **Regression seal** — PUF-252's lane stays clean; exhaustion fires `on_api_error_abandon`, not `on_turn_success` |
| `recovery_callback_exception_does_not_propagate` | Robustness — worker handler exception doesn't tear down consumer loop |
| `recovery_callback_omitted_does_not_break_backwards_compat` | Pre-PUF-255 callers without the new param still work |
| `_fire_turn_success_passes_batch_and_meta_unchanged` | Call-shape stability |
| `worker_callback_clears_api_error_abandoned_to_ok` | Happy path — the actual recovery transition |
| `worker_callback_no_op_on_ok` | Hot-path efficiency — steady-state successful turns don't churn `runtime.save` |
| `worker_callback_leaves_auth_failed_alone` | **State-lifecycle partition** — PUF-221's lane untouched |
| `worker_callback_no_op_on_unknown` | Initial / probe-not-yet-run state preserved |
| **`bidirectional_state_cycle`** | **Load-bearing matched-pair regression seal** — error → recovery → error → recovery cycles correctly. Directly addresses my PR #45 QA gap-3 |

**Local verification:**
- `pytest tests/test_api_error_recovery_state.py` → **10/10**
- `pytest` full suite → **862 passed, 1 skipped** (was 852 on PUF-252's branch; +10 new; usual permission-mode skip)

## Coverage gaps worth surfacing (Solution flagged, non-blocking)

1. **WS-push to puffo-server** — `runtime.save()` persists locally; whether puffo-server learns about the recovery depends on whether there's a push surface that reads `runtime.health`. Worth verifying the actual server-side observation path matches the ticket's "daemon doesn't report new status to puffo-server" framing.
2. **Concurrent multi-thread recovery** — if two threads recover near-simultaneously, both fire `on_turn_success`; the early-return guard means only the first does the `runtime.save`. Correct (no double-write) but a test pin would make the intent explicit.
3. **Recovery-during-exhaustion-mid-flight race** — kick-retry on thread A is in the middle of `_do_api_error_retries`; thread B's `on_message_batch` succeeds + fires recovery; A then exhausts and fires abandon. Result: `runtime.health` flips back to `api_error_abandoned`. Functionally correct (latest event wins, A's exhaustion IS the current truth), but the ordering is subtle. Worth a test pin if not already covered by the bidirectional-cycle test.
4. **`auth_failed` → `api_error_abandoned` precedence revisited** — current policy: `auth_failed` is sticky (PUF-221's lane); `api_error_abandoned` clears on turn-success. If an agent is in `auth_failed` AND a rate-limit additionally fires, the order of state-writes matters. Not in this PR's scope but worth tracking.

## Architectural alignment

- **No auto-restart on recovery** — recovery is OBSERVATION, not action, per `feedback_storage_vs_human_discipline_boundary.md` + the `feedback_dedup_triage_policy.md` revision (PUF-249 closure: user-action gates exist where applicable; recovery is just signal-clearing here, no policy substitute).
- **Bug-2 UI** — Nova canonical's FB-197 (status dot) + FB-198 (restart lever) consume both PUF-252's `api_error_abandoned` AND PUF-255's `ok` clearance. The Operator Action Panel cluster gets the full bidirectional signal.

## Branch strategy

PR #45 (PUF-252) still open at commit time → stacked on its branch to inherit the callback infrastructure. GitHub auto-retargets this PR to `main` when #45 merges. If PUF-255 ships first the rebase onto main is mechanical (no semantic conflicts).

## Test plan

- [ ] `pytest tests/test_api_error_recovery_state.py` → 10/10
- [ ] `pytest` full puffo-agent → 862 passed, 1 skipped
- [ ] Manual / paired: once both PRs land + a real rate-limit fires on Sam's Scout, the next successful turn flips `runtime.health` back to `"ok"` + puffo-server observation surface (TBD per coverage gap #1) reflects the recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)