### PR TITLE
fix: drain .codex/tmp/ before archive/delete to dodge Windows .lock race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.6] — unreleased
+
+### Fixed
+
+- **Codex agent archive/delete failing with ``Permission denied`` on
+  ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an
+  exclusive file lock on ``.codex/tmp/arg0/codex-<id>/.lock`` for the
+  lifetime of the subprocess; on Windows, file-handle release can lag
+  the subprocess exit by several hundred milliseconds, so
+  ``_archive_on_flag`` /``_delete_on_flag``'s ``shutil.move`` /
+  ``shutil.rmtree`` firing immediately after ``_stop_worker`` returned
+  saw the ``.lock`` as still-locked and raised
+  ``[Errno 13] Permission denied``. The existing next-tick retry
+  could not recover because the ``.codex/tmp/`` tree is regenerated on
+  every codex start, so each reconciler tick hit the same lock on a
+  freshly-named tmp dir.
+
+  Daemon now pre-cleans ``.codex/tmp/`` via ``_drain_codex_tmp`` (5×
+  500ms retries, falls back to ``shutil.rmtree(ignore_errors=True)``)
+  before the outer move/rmtree walks the agent dir. The tmp dir is
+  ephemeral codex scratch — codex regenerates it on next start, so
+  there's nothing worth archiving inside it. Fix applies to both the
+  WS-cascade archive path and the operator-initiated delete path.
+
 ## [0.9.5] — 2026-05-26
 
 ### Fixed

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -307,6 +307,7 @@ class Daemon:
         src = agent_dir(agent_id)
         if not src.exists():
             return
+        await _drain_codex_tmp(src)
         archived_dir().mkdir(parents=True, exist_ok=True)
         stamp = time.strftime("%Y%m%d-%H%M%S")
         dest = archived_dir() / f"{agent_id}-ws-{stamp}"
@@ -332,6 +333,7 @@ class Daemon:
         src = agent_dir(agent_id)
         if not src.exists():
             return
+        await _drain_codex_tmp(src)
         try:
             shutil.rmtree(src)
             logger.info("agent %s: deleted", agent_id)
@@ -340,6 +342,25 @@ class Daemon:
                 "agent %s: delete failed: %s (flag still present — will retry next tick)",
                 agent_id, exc,
             )
+
+
+async def _drain_codex_tmp(src: Path) -> None:
+    """Pre-clean codex CLI's ephemeral ``.codex/tmp/`` so a still-held
+    ``.lock`` (Windows: file-handle release lags subprocess exit by
+    a few hundred ms) doesn't block the surrounding shutil.move /
+    shutil.rmtree. Best-effort with brief retries; a surviving lock
+    is left in place and the outer try/except + next reconciler tick
+    handle the eventual failure."""
+    codex_tmp = src / ".codex" / "tmp"
+    if not codex_tmp.exists():
+        return
+    for _ in range(5):
+        try:
+            shutil.rmtree(codex_tmp)
+            return
+        except OSError:
+            await asyncio.sleep(0.5)
+    shutil.rmtree(codex_tmp, ignore_errors=True)
 
 
 async def _log_outdated_version_warning() -> None:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -345,12 +345,8 @@ class Daemon:
 
 
 async def _drain_codex_tmp(src: Path) -> None:
-    """Pre-clean codex CLI's ephemeral ``.codex/tmp/`` so a still-held
-    ``.lock`` (Windows: file-handle release lags subprocess exit by
-    a few hundred ms) doesn't block the surrounding shutil.move /
-    shutil.rmtree. Best-effort with brief retries; a surviving lock
-    is left in place and the outer try/except + next reconciler tick
-    handle the eventual failure."""
+    """Windows: codex's .lock in .codex/tmp/ can outlive the subprocess
+    by a few hundred ms; pre-clean so the outer move/rmtree doesn't trip."""
     codex_tmp = src / ".codex" / "tmp"
     if not codex_tmp.exists():
         return

--- a/tests/test_archive_codex_tmp_drain.py
+++ b/tests/test_archive_codex_tmp_drain.py
@@ -1,0 +1,116 @@
+"""PUF-archive-tmp: regression seal for ``_drain_codex_tmp``.
+
+The codex CLI holds an exclusive lock on
+``.codex/tmp/arg0/codex-<id>/.lock``. On Windows the file handle
+can lag the subprocess exit by several hundred milliseconds, so a
+shutil.move/rmtree firing immediately after worker shutdown sees
+the .lock as locked and raises Permission denied. The helper
+drains the throwaway tmp dir with brief retries before the outer
+move/rmtree walks the tree."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.portal.daemon import _drain_codex_tmp
+
+
+def _seed_codex_tmp(root: Path) -> Path:
+    """Lay down a representative ``.codex/tmp/arg0/codex-<id>/.lock``
+    plus a sibling file so the helper has something non-trivial
+    to walk."""
+    nested = root / ".codex" / "tmp" / "arg0" / "codex-arg0AAA"
+    nested.mkdir(parents=True)
+    (nested / ".lock").write_text("", encoding="utf-8")
+    (nested / "state.json").write_text("{}", encoding="utf-8")
+    return root / ".codex" / "tmp"
+
+
+@pytest.mark.asyncio
+async def test_drain_removes_codex_tmp_on_clean_path(tmp_path: Path):
+    codex_tmp = _seed_codex_tmp(tmp_path)
+    assert codex_tmp.exists()
+    await _drain_codex_tmp(tmp_path)
+    assert not codex_tmp.exists()
+    assert (tmp_path / ".codex").exists()
+
+
+@pytest.mark.asyncio
+async def test_drain_is_noop_when_codex_tmp_missing(tmp_path: Path):
+    (tmp_path / ".codex").mkdir()
+    await _drain_codex_tmp(tmp_path)
+    assert (tmp_path / ".codex").exists()
+
+
+@pytest.mark.asyncio
+async def test_drain_is_noop_when_codex_dir_missing(tmp_path: Path):
+    await _drain_codex_tmp(tmp_path)
+    assert not (tmp_path / ".codex").exists()
+
+
+@pytest.mark.asyncio
+async def test_drain_retries_then_succeeds(monkeypatch, tmp_path: Path):
+    """First rmtree raises (simulating a still-locked .lock); the
+    second succeeds. Helper must not propagate the transient error."""
+    codex_tmp = _seed_codex_tmp(tmp_path)
+
+    real_rmtree = shutil.rmtree
+    calls = {"n": 0}
+
+    def flaky_rmtree(path, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "still locked", str(path))
+        return real_rmtree(path, *args, **kwargs)
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr("puffo_agent.portal.daemon.shutil.rmtree", flaky_rmtree)
+    monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
+
+    await _drain_codex_tmp(tmp_path)
+
+    assert calls["n"] == 2
+    assert not codex_tmp.exists()
+
+
+@pytest.mark.asyncio
+async def test_drain_falls_back_to_ignore_errors_after_exhaustion(
+    monkeypatch, tmp_path: Path,
+):
+    """If every retry fails, the final call swallows errors so the
+    caller's outer try/except can still attempt the surrounding
+    shutil.move / shutil.rmtree (a permanently-stuck lock is rare
+    and gets retried next reconciler tick anyway)."""
+    _seed_codex_tmp(tmp_path)
+
+    calls = {"n": 0, "ignore_errors_seen": False}
+
+    def always_fail(path, *args, **kwargs):
+        calls["n"] += 1
+        if kwargs.get("ignore_errors"):
+            calls["ignore_errors_seen"] = True
+            return
+        raise PermissionError(13, "stuck", str(path))
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_seconds):
+        await real_sleep(0)
+
+    monkeypatch.setattr("puffo_agent.portal.daemon.shutil.rmtree", always_fail)
+    monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
+
+    # Should NOT raise.
+    await _drain_codex_tmp(tmp_path)
+
+    # 5 retries + 1 final ignore_errors call.
+    assert calls["n"] == 6
+    assert calls["ignore_errors_seen"] is True

--- a/tests/test_archive_codex_tmp_drain.py
+++ b/tests/test_archive_codex_tmp_drain.py
@@ -1,12 +1,4 @@
-"""PUF-archive-tmp: regression seal for ``_drain_codex_tmp``.
-
-The codex CLI holds an exclusive lock on
-``.codex/tmp/arg0/codex-<id>/.lock``. On Windows the file handle
-can lag the subprocess exit by several hundred milliseconds, so a
-shutil.move/rmtree firing immediately after worker shutdown sees
-the .lock as locked and raises Permission denied. The helper
-drains the throwaway tmp dir with brief retries before the outer
-move/rmtree walks the tree."""
+"""Regression seal for _drain_codex_tmp."""
 
 from __future__ import annotations
 
@@ -20,9 +12,6 @@ from puffo_agent.portal.daemon import _drain_codex_tmp
 
 
 def _seed_codex_tmp(root: Path) -> Path:
-    """Lay down a representative ``.codex/tmp/arg0/codex-<id>/.lock``
-    plus a sibling file so the helper has something non-trivial
-    to walk."""
     nested = root / ".codex" / "tmp" / "arg0" / "codex-arg0AAA"
     nested.mkdir(parents=True)
     (nested / ".lock").write_text("", encoding="utf-8")
@@ -54,8 +43,6 @@ async def test_drain_is_noop_when_codex_dir_missing(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_drain_retries_then_succeeds(monkeypatch, tmp_path: Path):
-    """First rmtree raises (simulating a still-locked .lock); the
-    second succeeds. Helper must not propagate the transient error."""
     codex_tmp = _seed_codex_tmp(tmp_path)
 
     real_rmtree = shutil.rmtree
@@ -85,10 +72,6 @@ async def test_drain_retries_then_succeeds(monkeypatch, tmp_path: Path):
 async def test_drain_falls_back_to_ignore_errors_after_exhaustion(
     monkeypatch, tmp_path: Path,
 ):
-    """If every retry fails, the final call swallows errors so the
-    caller's outer try/except can still attempt the surrounding
-    shutil.move / shutil.rmtree (a permanently-stuck lock is rare
-    and gets retried next reconciler tick anyway)."""
     _seed_codex_tmp(tmp_path)
 
     calls = {"n": 0, "ignore_errors_seen": False}
@@ -108,9 +91,7 @@ async def test_drain_falls_back_to_ignore_errors_after_exhaustion(
     monkeypatch.setattr("puffo_agent.portal.daemon.shutil.rmtree", always_fail)
     monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
 
-    # Should NOT raise.
     await _drain_codex_tmp(tmp_path)
 
-    # 5 retries + 1 final ignore_errors call.
     assert calls["n"] == 6
     assert calls["ignore_errors_seen"] is True


### PR DESCRIPTION
## Summary

- Codex CLI holds an exclusive lock on `.codex/tmp/arg0/codex-<id>/.lock` for the lifetime of the subprocess. On Windows, file-handle release lags subprocess exit by several hundred ms, so `_archive_on_flag`'s `shutil.move` (and `_delete_on_flag`'s `shutil.rmtree`) firing right after `_stop_worker` returned saw the `.lock` as still-locked and raised `[Errno 13] Permission denied`.
- Existing next-tick retry could not recover — `.codex/tmp/` is regenerated on each codex start, so every tick hit a freshly-named tmp dir holding a fresh lock. Only workaround for the operator was switching the agent to claude-code + restarting the runtime.
- New `_drain_codex_tmp(src)` helper pre-cleans the throwaway tmp dir with 5×500ms `rmtree` retries, falling back to `ignore_errors=True`. Wired into both archive and delete paths.

## Root cause reproducer (from production log)

```
WARNING agent smoke-agent-v2-4b0a: archive.flag detected, stopping worker + archiving
ERROR   agent smoke-agent-v2-4b0a: archive failed: [('...\.codex\tmp\arg0\codex-arg0uHEZ3b\.lock', '...archived...\.lock', '[Errno 13] Permission denied')] (flag still present — will retry next tick)
```

The 3-tuple shape confirms `shutil.move` fell back to `copytree+rmtree` on the same filesystem; `copytree` opened `.lock` for read → Permission denied because codex's `fs2::try_lock_exclusive` opens it `FILE_SHARE_NONE` on Windows.

## Why pre-clean (not retry-the-move, not exclude-via-copy)

- `.codex/tmp/` is ephemeral codex scratch; codex regenerates it on next start. Nothing in there is worth archiving.
- Pre-clean avoids touching `shutil.move`'s contract (atomic-or-copytree) and avoids leaving a half-populated `archived/` dest on retry-the-move.
- `_delete_on_flag`'s `shutil.rmtree` has the same bug; same helper fixes both.

## Test plan

- [x] `tests/test_archive_codex_tmp_drain.py` — 5 new tests:
  - removes `.codex/tmp/` cleanly when nothing is locked
  - no-op when `.codex/tmp/` is absent
  - no-op when `.codex/` itself is absent
  - flaky-then-succeeds: first rmtree raises PermissionError, second succeeds (2 calls, dir gone)
  - exhausted-then-ignore-errors fallback: all 5 retries fail, helper calls `rmtree(ignore_errors=True)` and returns without raising
- [x] `tests/test_pause_resume_archive.py` (sibling integration tests) still pass — 11/11

## Out of scope

- Bumping pyproject `version = "0.9.5"` → `"0.9.6"` is deferred to release-cut commit, matching the existing `[x.y.z] — unreleased` pattern in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)