### PR TITLE
fix(PUF-258): clear runtime.health="auth_failed" on credential refresh-success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **PUF-258: ``runtime.health = "auth_failed"`` no longer sticky after
+  credential refresh-success.** The daemon set the flag in
+  ``_handle_suppressed_reply`` (PUF-221) but nothing cleared it
+  anywhere — once flipped it stayed until process restart, leaving
+  ``audit.log`` dishonest about post-recovery agent state.
+
+  ``CredentialRefresher`` now exposes
+  ``register_on_refresh_success(cb)`` /
+  ``unregister_on_refresh_success(cb)`` and fires after both regular
+  ``_refresh_now`` success AND ``_external_rotation_loop`` detected
+  rotation. Fire happens outside the refresh lock so callbacks can't
+  deadlock the next cycle; gated on
+  ``outcome is RefreshOutcome.REFRESHED`` so PUF-265's UNCHANGED
+  case (exit=0 but token didn't actually rotate) doesn't oscillate
+  ``auth_failed → ok → auth_failed``. Callbacks isolated — a
+  subscriber raising logs at WARNING and the loop continues.
+
+  ``Worker._clear_auth_failed_if_recoverable`` (lifted staticmethod
+  matching PUF-255's pattern) flips ``"auth_failed" → "ok"`` and
+  clears ``runtime.error``. Leaves ``api_error_abandoned`` to
+  PUF-255's ``on_turn_success`` lane (symmetric partition). Optimistic
+  semantics: if the agent's next request still 401s,
+  ``_handle_suppressed_reply`` re-flips on the next leak detection.
+
 - **PUF-264: request-too-large no longer infinite-retries + no longer
   leaks the raw Anthropic API error to chat.** When a user uploaded
   10 PDFs (msg_a42f8cbb), the agent inlined all of them into one

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -628,11 +628,6 @@ class CredentialRefresher:
             self.host_credentials = backend.host_credentials
         self._refresh_request = asyncio.Event()
         self._agent_homes: set[Path] = set()
-        # PUF-258: per-Worker callbacks fired after a successful refresh
-        # (regular tick OR external-rotation detection) so each Worker
-        # can clear its ``runtime.health == "auth_failed"`` optimistically.
-        # Mirrors the ``register_agent`` shape but operates on the
-        # in-memory Worker reference instead of a disk path.
         self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
 
@@ -643,13 +638,6 @@ class CredentialRefresher:
         self._agent_homes.discard(Path(agent_home))
 
     def register_on_refresh_success(self, callback: Callable[[], None]) -> None:
-        """PUF-258: subscribe to refresh-success notifications.
-
-        Fired after every successful refresh OR external-rotation
-        detection so subscribers (Workers) can clear an
-        ``auth_failed`` flag optimistically. Callbacks are sync; any
-        exception is caught + logged so a buggy subscriber doesn't
-        break the refresh loop."""
         self._on_refresh_success.append(callback)
 
     def unregister_on_refresh_success(self, callback: Callable[[], None]) -> None:
@@ -659,12 +647,7 @@ class CredentialRefresher:
             pass
 
     def _fire_refresh_success(self) -> None:
-        """Dispatch refresh-success to every registered subscriber.
-
-        Callback exceptions are swallowed + logged -- the refresh
-        loop has already done its real work (rotated credentials,
-        synced views); a Worker callback raising here mustn't
-        cascade into the daemon's refresh cadence."""
+        # list(...) defensive copy: callback may (un)register during dispatch.
         for cb in list(self._on_refresh_success):
             try:
                 cb()
@@ -758,10 +741,6 @@ class CredentialRefresher:
                 continue
             if rotated:
                 self._sync_views()
-                # PUF-258: external rotation = credentials are fresh
-                # without us calling refresh, so still notify Workers
-                # to clear ``auth_failed`` -- next request sees the
-                # rotated cred via _sync_views above.
                 self._fire_refresh_success()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
@@ -797,17 +776,10 @@ class CredentialRefresher:
     async def _refresh_now(
         self, *, expires_in: int | None, by_agent: bool,
     ) -> None:
-        """Single-writer refresh through the backend. The
-        ``asyncio.Lock`` is what makes the rotating-RT race
-        unwinnable: a second caller can't see an in-flight rotation
-        mid-write.
-
-        Fire ``_fire_refresh_success`` only when the backend reports
-        ``RefreshOutcome.REFRESHED`` (PR #48 review): UNCHANGED /
-        FAILED outcomes mean the on-disk token didn't actually
-        rotate, so optimistically clearing ``auth_failed`` on those
-        would oscillate ``auth_failed → ok → auth_failed`` every
-        poll cycle until the underlying refresh recovers."""
+        """Single-writer refresh through the backend; the lock makes
+        the rotating-RT race unwinnable."""
+        # Fire only on REFRESHED: UNCHANGED / FAILED leave the on-disk
+        # token unchanged, so clearing auth_failed would oscillate.
         outcome: RefreshOutcome | None = None
         async with self._lock:
             before = self.expires_in_seconds()

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -802,11 +802,13 @@ class CredentialRefresher:
         unwinnable: a second caller can't see an in-flight rotation
         mid-write.
 
-        PUF-258: on successful refresh fires
-        ``_fire_refresh_success`` so registered Workers clear an
-        ``auth_failed`` flag optimistically. Failure path stays
-        silent (the flag rightly persists until next attempt)."""
-        refreshed = False
+        Fire ``_fire_refresh_success`` only when the backend reports
+        ``RefreshOutcome.REFRESHED`` (PR #48 review): UNCHANGED /
+        FAILED outcomes mean the on-disk token didn't actually
+        rotate, so optimistically clearing ``auth_failed`` on those
+        would oscillate ``auth_failed → ok → auth_failed`` every
+        poll cycle until the underlying refresh recovers."""
+        outcome: RefreshOutcome | None = None
         async with self._lock:
             before = self.expires_in_seconds()
             if (
@@ -824,11 +826,11 @@ class CredentialRefresher:
                 expires_in, by_agent,
             )
             try:
-                await self.backend.refresh()
-                refreshed = True
+                outcome = await self.backend.refresh()
             except Exception as exc:
                 logger.warning("backend refresh errored: %s", exc)
-        if refreshed:
+                outcome = RefreshOutcome.FAILED
+        if outcome is RefreshOutcome.REFRESHED:
             self._fire_refresh_success()
 
     def _sync_views(self) -> None:

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -56,7 +56,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Callable, Optional, Protocol
 
 from .state import link_host_codex_auth, link_host_credentials
 
@@ -628,6 +628,12 @@ class CredentialRefresher:
             self.host_credentials = backend.host_credentials
         self._refresh_request = asyncio.Event()
         self._agent_homes: set[Path] = set()
+        # PUF-258: per-Worker callbacks fired after a successful refresh
+        # (regular tick OR external-rotation detection) so each Worker
+        # can clear its ``runtime.health == "auth_failed"`` optimistically.
+        # Mirrors the ``register_agent`` shape but operates on the
+        # in-memory Worker reference instead of a disk path.
+        self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
 
     def register_agent(self, agent_home: Path) -> None:
@@ -635,6 +641,37 @@ class CredentialRefresher:
 
     def unregister_agent(self, agent_home: Path) -> None:
         self._agent_homes.discard(Path(agent_home))
+
+    def register_on_refresh_success(self, callback: Callable[[], None]) -> None:
+        """PUF-258: subscribe to refresh-success notifications.
+
+        Fired after every successful refresh OR external-rotation
+        detection so subscribers (Workers) can clear an
+        ``auth_failed`` flag optimistically. Callbacks are sync; any
+        exception is caught + logged so a buggy subscriber doesn't
+        break the refresh loop."""
+        self._on_refresh_success.append(callback)
+
+    def unregister_on_refresh_success(self, callback: Callable[[], None]) -> None:
+        try:
+            self._on_refresh_success.remove(callback)
+        except ValueError:
+            pass
+
+    def _fire_refresh_success(self) -> None:
+        """Dispatch refresh-success to every registered subscriber.
+
+        Callback exceptions are swallowed + logged -- the refresh
+        loop has already done its real work (rotated credentials,
+        synced views); a Worker callback raising here mustn't
+        cascade into the daemon's refresh cadence."""
+        for cb in list(self._on_refresh_success):
+            try:
+                cb()
+            except Exception as exc:
+                logger.warning(
+                    "credential refresh-success callback raised: %s", exc,
+                )
 
     def notify_refresh_needed(self) -> None:
         """In-process trigger from an agent that just saw a 401."""
@@ -721,6 +758,11 @@ class CredentialRefresher:
                 continue
             if rotated:
                 self._sync_views()
+                # PUF-258: external rotation = credentials are fresh
+                # without us calling refresh, so still notify Workers
+                # to clear ``auth_failed`` -- next request sees the
+                # rotated cred via _sync_views above.
+                self._fire_refresh_success()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
         stop_task = asyncio.create_task(stop_event.wait())
@@ -758,7 +800,13 @@ class CredentialRefresher:
         """Single-writer refresh through the backend. The
         ``asyncio.Lock`` is what makes the rotating-RT race
         unwinnable: a second caller can't see an in-flight rotation
-        mid-write."""
+        mid-write.
+
+        PUF-258: on successful refresh fires
+        ``_fire_refresh_success`` so registered Workers clear an
+        ``auth_failed`` flag optimistically. Failure path stays
+        silent (the flag rightly persists until next attempt)."""
+        refreshed = False
         async with self._lock:
             before = self.expires_in_seconds()
             if (
@@ -777,8 +825,11 @@ class CredentialRefresher:
             )
             try:
                 await self.backend.refresh()
+                refreshed = True
             except Exception as exc:
                 logger.warning("backend refresh errored: %s", exc)
+        if refreshed:
+            self._fire_refresh_success()
 
     def _sync_views(self) -> None:
         """Mirror canonical credentials to every registered agent."""

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -263,10 +263,6 @@ class Daemon:
     ) -> None:
         refresher = self._refresher_for(agent_cfg)
         refresher.register_agent(agent_home_dir(agent_cfg.id))
-        # PUF-258: subscribe to refresh-success so the Worker can clear
-        # ``runtime.health = "auth_failed"`` optimistically when the
-        # daemon finishes a credential rotation. Callback identity is
-        # stashed on the worker so ``_stop_worker`` can unregister it.
         agent_id = agent_cfg.id
 
         def on_refresh_success() -> None:
@@ -275,6 +271,7 @@ class Daemon:
             )
 
         refresher.register_on_refresh_success(on_refresh_success)
+        # Stash callback identity for _stop_worker's unregister.
         worker._refresh_success_callback = on_refresh_success
 
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
@@ -302,9 +299,6 @@ class Daemon:
             home = agent_home_dir(agent_id)
             self.refresher.unregister_agent(home)
             self.codex_refresher.unregister_agent(home)
-            # PUF-258: unregister the refresh-success callback from
-            # whichever refresher was registered with. Same
-            # idempotent-on-both pattern as ``unregister_agent``.
             cb = getattr(worker, "_refresh_success_callback", None)
             if cb is not None:
                 self.refresher.unregister_on_refresh_success(cb)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -222,7 +222,7 @@ class Daemon:
                         notify_refresh_needed=self._notify_refresh_for(agent_cfg),
                     )
                     self.workers[agent_id] = worker
-                    self._register_with_refresher(agent_cfg)
+                    self._register_with_refresher(agent_cfg, worker)
                     worker.start()
                     # Serialise heavy startup: ``adapter.warm()`` reads
                     # the persisted session into Node's heap, so N
@@ -238,7 +238,7 @@ class Daemon:
                         notify_refresh_needed=self._notify_refresh_for(agent_cfg),
                     )
                     self.workers[agent_id] = worker
-                    self._register_with_refresher(agent_cfg)
+                    self._register_with_refresher(agent_cfg, worker)
                     worker.start()
                     await worker.wait_warm(timeout=self._warm_serialise_timeout)
                 else:
@@ -258,10 +258,24 @@ class Daemon:
             return self.codex_refresher
         return self.refresher
 
-    def _register_with_refresher(self, agent_cfg: AgentConfig) -> None:
-        self._refresher_for(agent_cfg).register_agent(
-            agent_home_dir(agent_cfg.id),
-        )
+    def _register_with_refresher(
+        self, agent_cfg: AgentConfig, worker: Worker,
+    ) -> None:
+        refresher = self._refresher_for(agent_cfg)
+        refresher.register_agent(agent_home_dir(agent_cfg.id))
+        # PUF-258: subscribe to refresh-success so the Worker can clear
+        # ``runtime.health = "auth_failed"`` optimistically when the
+        # daemon finishes a credential rotation. Callback identity is
+        # stashed on the worker so ``_stop_worker`` can unregister it.
+        agent_id = agent_cfg.id
+
+        def on_refresh_success() -> None:
+            Worker._clear_auth_failed_if_recoverable(
+                worker.runtime, agent_id, logger,
+            )
+
+        refresher.register_on_refresh_success(on_refresh_success)
+        worker._refresh_success_callback = on_refresh_success
 
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
         return self._refresher_for(agent_cfg).notify_refresh_needed
@@ -288,6 +302,13 @@ class Daemon:
             home = agent_home_dir(agent_id)
             self.refresher.unregister_agent(home)
             self.codex_refresher.unregister_agent(home)
+            # PUF-258: unregister the refresh-success callback from
+            # whichever refresher was registered with. Same
+            # idempotent-on-both pattern as ``unregister_agent``.
+            cb = getattr(worker, "_refresh_success_callback", None)
+            if cb is not None:
+                self.refresher.unregister_on_refresh_success(cb)
+                self.codex_refresher.unregister_on_refresh_success(cb)
             await worker.stop()
 
     async def _stop_all_workers(self) -> None:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1074,13 +1074,17 @@ class RuntimeState:
     last_event_at: int = 0
     error: str = ""
     # Worker-side health, independent of ``status``. Values:
-    #   "ok"                  — refresh-ping passed, or a turn cleared a
-    #                           prior abandon
-    #   "auth_failed"         — adapter saw 401 / authentication_error;
-    #                           cleared only by the CredentialRefresher
-    #                           success-ping (PUF-221's lane)
+    #   "ok"                  — refresh-ping passed, a turn cleared a
+    #                           prior abandon, or a credential refresh
+    #                           cleared a prior auth_failed
+    #   "auth_failed"         — adapter saw 401 / authentication_error
+    #                           (set in worker._handle_suppressed_reply);
+    #                           cleared by the CredentialRefresher's
+    #                           refresh-success callback (PUF-258 wired
+    #                           the clear; PUF-221 owns the set lane)
     #   "api_error_abandoned" — kick-retry exhausted, batch silently
     #                           abandoned; cleared on next successful turn
+    #                           (PUF-255's on_turn_success lane)
     #   "unknown"             — no probe yet
     health: str = "unknown"  # ok | auth_failed | api_error_abandoned | unknown
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -550,30 +550,9 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """PUF-258: clear ``runtime.health = "auth_failed"`` back to
-        ``"ok"`` after the daemon's CredentialRefresher reports a
-        successful refresh (or detects external rotation). Mirrors
-        PUF-255's recovery-clear pattern but at the refresh-success
-        event boundary instead of the turn-success boundary.
-
-        Only clears the ``auth_failed`` state.
-        ``api_error_abandoned`` is owned by PUF-255's
-        ``on_turn_success`` lane (recovery there happens via a
-        successful turn, not a credential refresh); leaving that
-        alone keeps the two health-state lifecycles cleanly
-        partitioned.
-
-        No-op when ``runtime.health`` is already ``"ok"`` /
-        ``"unknown"`` -- avoids needless ``runtime.save`` churn on
-        the steady-state hot path.
-
-        Optimistic-clear semantics: if the refresh succeeds but the
-        agent's next request still 401s (e.g., upstream revocation
-        beyond the refresh's scope), ``_handle_suppressed_reply``
-        re-flips ``runtime.health`` back to ``auth_failed`` on the
-        next leak detection. Same shape as PUF-255's optimistic
-        clear-on-turn-success.
-        """
+        # Symmetric to _clear_api_error_abandoned_if_recoverable but
+        # fired on refresh-success (not turn-success). Optimistic: if
+        # the next request still 401s, _handle_suppressed_reply re-sets.
         if runtime.health != "auth_failed":
             return
         runtime.health = "ok"

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -544,6 +544,47 @@ class Worker:
             agent_id, root_id,
         )
 
+    @staticmethod
+    def _clear_auth_failed_if_recoverable(
+        runtime: "RuntimeState",
+        agent_id: str,
+        log: logging.Logger,
+    ) -> None:
+        """PUF-258: clear ``runtime.health = "auth_failed"`` back to
+        ``"ok"`` after the daemon's CredentialRefresher reports a
+        successful refresh (or detects external rotation). Mirrors
+        PUF-255's recovery-clear pattern but at the refresh-success
+        event boundary instead of the turn-success boundary.
+
+        Only clears the ``auth_failed`` state.
+        ``api_error_abandoned`` is owned by PUF-255's
+        ``on_turn_success`` lane (recovery there happens via a
+        successful turn, not a credential refresh); leaving that
+        alone keeps the two health-state lifecycles cleanly
+        partitioned.
+
+        No-op when ``runtime.health`` is already ``"ok"`` /
+        ``"unknown"`` -- avoids needless ``runtime.save`` churn on
+        the steady-state hot path.
+
+        Optimistic-clear semantics: if the refresh succeeds but the
+        agent's next request still 401s (e.g., upstream revocation
+        beyond the refresh's scope), ``_handle_suppressed_reply``
+        re-flips ``runtime.health`` back to ``auth_failed`` on the
+        next leak detection. Same shape as PUF-255's optimistic
+        clear-on-turn-success.
+        """
+        if runtime.health != "auth_failed":
+            return
+        runtime.health = "ok"
+        runtime.error = ""
+        runtime.save(agent_id)
+        log.info(
+            "agent %s: credential-refresh-success; "
+            "runtime.health cleared from auth_failed back to ok",
+            agent_id,
+        )
+
     def __init__(
         self,
         daemon_cfg: DaemonConfig,

--- a/tests/test_credential_refresh_clears_auth_failed.py
+++ b/tests/test_credential_refresh_clears_auth_failed.py
@@ -288,3 +288,177 @@ async def test_refresh_now_skip_branch_does_not_fire(tmp_path, monkeypatch):
     )
     assert refresh_called["n"] == 0
     assert fired == []
+
+
+@pytest.mark.asyncio
+async def test_external_rotation_loop_fires_on_detected_rotation(
+    tmp_path, monkeypatch,
+):
+    """When ``backend.poll_external_rotation`` returns True (Keychain
+    rotated externally), the loop fires ``_fire_refresh_success`` after
+    syncing views. Pins the second ``_fire_refresh_success`` site so a
+    future regression that drops it from the rotated-branch breaks the
+    test rather than silently regressing the macOS Keychain-rotation
+    path."""
+    _write_creds(tmp_path, expires_in_seconds=600)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    # Shrink the poll interval so wait_for times out promptly. The
+    # constant lives in ``..macos.keychain`` and is imported lazily
+    # inside ``_external_rotation_loop`` -- patch at the module path
+    # the loop reads from.
+    from puffo_agent.macos import keychain as _kc
+    monkeypatch.setattr(_kc, "KEYCHAIN_POLL_INTERVAL_SECONDS", 0.01)
+
+    # Stub poll_external_rotation to return True once then False.
+    poll_calls = {"n": 0}
+
+    async def fake_poll() -> bool:
+        poll_calls["n"] += 1
+        return poll_calls["n"] == 1
+
+    # FileBackend doesn't natively have poll_external_rotation (it's
+    # KeychainBackend-only); attach it for the test via raising=False.
+    monkeypatch.setattr(
+        r.backend, "poll_external_rotation", fake_poll, raising=False,
+    )
+    # Stub _sync_views to a no-op (the disk-mirror logic isn't what
+    # we're pinning here -- the fire-after-sync ordering is).
+    sync_calls = {"n": 0}
+    monkeypatch.setattr(
+        r, "_sync_views", lambda: sync_calls.__setitem__("n", sync_calls["n"] + 1),
+    )
+
+    fired: list[str] = []
+    r.register_on_refresh_success(lambda: fired.append("ok"))
+
+    stop = asyncio.Event()
+    loop_task = asyncio.create_task(r._external_rotation_loop(stop))
+    # Let the loop iterate at least once on the rotated-branch.
+    await asyncio.sleep(0.05)
+    stop.set()
+    try:
+        await asyncio.wait_for(loop_task, timeout=1.0)
+    except asyncio.TimeoutError:
+        loop_task.cancel()
+        try:
+            await loop_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    assert poll_calls["n"] >= 1
+    assert sync_calls["n"] >= 1
+    assert fired == ["ok"]
+
+
+# ── Daemon-side wiring tests (register/unregister roundtrip) ────────────────
+
+
+class _FakeAgentCfg:
+    """Minimal stand-in for ``AgentConfig`` -- daemon's
+    ``_refresher_for`` reads ``runtime.harness`` to route to the
+    claude vs codex refresher."""
+
+    def __init__(self, agent_id: str, harness: str = "claude-code"):
+        self.id = agent_id
+
+        class _R:
+            def __init__(self_inner, h):
+                self_inner.harness = h
+
+        self.runtime = _R(harness)
+
+
+def _make_fake_worker():
+    """Stand-in Worker -- only the ``runtime`` attribute is touched
+    when the bound callback fires. ``_clear_auth_failed_if_recoverable``
+    accepts a fake runtime since it's a staticmethod."""
+    worker = type("FakeWorker", (), {})()
+    worker.runtime = _FakeRuntime(health="auth_failed")
+    worker.runtime.error = "pre-refresh auth error"
+    return worker
+
+
+def _make_daemon_stub(tmp_path):
+    """Build a Daemon-shaped stub by bypassing ``__init__`` (which
+    reads ``Path.home()`` + builds real backends) and stitching in
+    minimal attributes the wiring methods touch."""
+    from puffo_agent.portal.daemon import Daemon
+
+    daemon = Daemon.__new__(Daemon)
+    _write_creds(tmp_path, expires_in_seconds=600)
+    daemon.refresher = CredentialRefresher(host_home=tmp_path)
+    daemon.codex_refresher = CredentialRefresher(host_home=tmp_path)
+    daemon.workers = {}
+    return daemon
+
+
+def test_daemon_register_with_refresher_binds_callback_to_worker_runtime(tmp_path):
+    """``_register_with_refresher`` registers an
+    ``on_refresh_success`` callback that, when fired, clears the
+    Worker's ``runtime.health = "auth_failed"`` flag. Pins the
+    binding so a future refactor that forgets to wire
+    worker.runtime breaks the test."""
+    daemon = _make_daemon_stub(tmp_path)
+    agent_cfg = _FakeAgentCfg("agent-A", harness="claude-code")
+    worker = _make_fake_worker()
+    daemon.workers["agent-A"] = worker
+
+    daemon._register_with_refresher(agent_cfg, worker)
+
+    # Callback stashed on worker for unregister symmetry.
+    assert hasattr(worker, "_refresh_success_callback")
+    # Callback registered on the claude refresher (not codex).
+    assert len(daemon.refresher._on_refresh_success) == 1
+    assert len(daemon.codex_refresher._on_refresh_success) == 0
+
+    # Firing it clears the worker's auth_failed flag.
+    daemon.refresher._fire_refresh_success()
+    assert worker.runtime.health == "ok"
+    assert worker.runtime.error == ""
+
+
+def test_daemon_register_codex_harness_routes_to_codex_refresher(tmp_path):
+    """Codex-harness agents route to ``codex_refresher`` per
+    ``_refresher_for``'s branch. Pins the codex side has independent
+    callback registration -- if a refactor accidentally always uses
+    ``self.refresher``, this breaks."""
+    daemon = _make_daemon_stub(tmp_path)
+    agent_cfg = _FakeAgentCfg("agent-codex-A", harness="codex")
+    worker = _make_fake_worker()
+    daemon.workers["agent-codex-A"] = worker
+
+    daemon._register_with_refresher(agent_cfg, worker)
+
+    assert len(daemon.refresher._on_refresh_success) == 0
+    assert len(daemon.codex_refresher._on_refresh_success) == 1
+
+
+@pytest.mark.asyncio
+async def test_daemon_stop_worker_unregisters_callback_from_both_refreshers(
+    tmp_path,
+):
+    """``_stop_worker`` unregisters the on_refresh_success callback
+    from both claude AND codex refreshers (idempotent on both, same
+    pattern as ``unregister_agent``). This defends the cross-refresher
+    cleanup against a future single-side regression."""
+    daemon = _make_daemon_stub(tmp_path)
+    agent_cfg = _FakeAgentCfg("agent-A", harness="claude-code")
+    worker = _make_fake_worker()
+
+    # Hand-build the worker.stop coroutine so _stop_worker can await it.
+    async def fake_stop():
+        return None
+    worker.stop = fake_stop
+
+    daemon.workers["agent-A"] = worker
+    daemon._register_with_refresher(agent_cfg, worker)
+    assert len(daemon.refresher._on_refresh_success) == 1
+
+    await daemon._stop_worker("agent-A")
+    # Callback removed from claude refresher.
+    assert len(daemon.refresher._on_refresh_success) == 0
+    # Codex refresher unchanged (was already empty, unregister is no-op).
+    assert len(daemon.codex_refresher._on_refresh_success) == 0
+    # Worker popped from registry.
+    assert "agent-A" not in daemon.workers

--- a/tests/test_credential_refresh_clears_auth_failed.py
+++ b/tests/test_credential_refresh_clears_auth_failed.py
@@ -1,0 +1,290 @@
+"""PUF-258: auth_failed sticky state-machine fix.
+
+PUF-252 + PUF-255 established the symmetric ENTER/EXIT pattern for
+``runtime.health = "api_error_abandoned"`` (PUF-252 sets on
+kick-retry exhaustion; PUF-255 clears on next successful turn).
+PUF-258 extends the same pattern to ``runtime.health = "auth_failed"``:
+the daemon's ``CredentialRefresher`` fires registered
+``on_refresh_success`` callbacks after a successful refresh OR
+external rotation, and ``Worker._clear_auth_failed_if_recoverable``
+flips the flag back to ``"ok"``.
+
+Tests cover (1) the helper's policy contract directly + (2) the
+CredentialRefresher's register/fire/unregister wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.portal.credential_refresh import (
+    REFRESH_SAFETY_MARGIN_SECONDS,
+    CredentialRefresher,
+)
+from puffo_agent.portal.worker import Worker
+
+
+_LOG = logging.getLogger("test-puf-258")
+
+
+# ── Helper-policy tests (Worker._clear_auth_failed_if_recoverable) ──────────
+
+
+class _FakeRuntime:
+    """Stand-in for ``RuntimeState`` -- the helper only touches
+    ``.health`` + ``.error`` + ``.save(agent_id)``."""
+
+    def __init__(self, health: str = "ok"):
+        self.health = health
+        self.error = ""
+        self.saved_count = 0
+        self.last_saved_agent: str | None = None
+
+    def save(self, agent_id: str):
+        self.saved_count += 1
+        self.last_saved_agent = agent_id
+
+
+def _call(runtime: _FakeRuntime) -> None:
+    Worker._clear_auth_failed_if_recoverable(
+        runtime, "agent-X", _LOG,  # type: ignore[arg-type]
+    )
+
+
+def test_clear_flips_auth_failed_to_ok():
+    """Operator's scenario: agent in ``auth_failed`` -> credential
+    refresh succeeds -> health flips to ``ok`` + error cleared +
+    runtime saved (so puffo-server sees the transition via the
+    existing heartbeat reporter / next status read)."""
+    runtime = _FakeRuntime(health="auth_failed")
+    runtime.error = "Worker emitted an auth-error string..."
+    _call(runtime)
+    assert runtime.health == "ok"
+    assert runtime.error == ""
+    assert runtime.saved_count == 1
+    assert runtime.last_saved_agent == "agent-X"
+
+
+def test_clear_no_op_on_ok():
+    """Steady-state hot-path: most refresh cycles happen while
+    ``runtime.health == "ok"`` already (regular token rotations
+    pre-expiry). The helper should NOT write to runtime each
+    cycle -- skip the save."""
+    runtime = _FakeRuntime(health="ok")
+    _call(runtime)
+    assert runtime.health == "ok"
+    assert runtime.saved_count == 0
+
+
+def test_clear_leaves_api_error_abandoned_alone():
+    """PUF-255's ``on_turn_success`` lane owns the
+    ``api_error_abandoned`` lifecycle. PUF-258's refresh-success
+    hook is for the auth class only -- don't accidentally clear an
+    api-error-abandoned just because credentials rotated (the
+    abandoned batch is still stuck until a fresh turn succeeds);
+    leave it to the turn-success callback. Symmetric partition to
+    PUF-255's leaves-auth-failed-alone."""
+    runtime = _FakeRuntime(health="api_error_abandoned")
+    runtime.error = "Worker abandoned a batch..."
+    _call(runtime)
+    assert runtime.health == "api_error_abandoned"
+    assert runtime.error == "Worker abandoned a batch..."
+    assert runtime.saved_count == 0
+
+
+def test_clear_no_op_on_unknown():
+    """Boot-time / uninstrumented state. No refresh-success
+    transition is meaningful from ``unknown`` -- bootstrap probe
+    will set health to ok on its own once the auth-check runs."""
+    runtime = _FakeRuntime(health="unknown")
+    _call(runtime)
+    assert runtime.health == "unknown"
+    assert runtime.saved_count == 0
+
+
+def test_optimistic_clear_then_re_set_on_next_401():
+    """Optimistic-clear semantics: if the refresh succeeds but the
+    agent's next request still 401s (e.g., upstream revocation
+    beyond the refresh's scope), the auth_failed flag re-sets when
+    ``_handle_suppressed_reply`` fires next time. Pin via a
+    sequencing test on the runtime alone -- the
+    re-set is owned by worker code we don't touch in PUF-258."""
+    runtime = _FakeRuntime(health="auth_failed")
+    _call(runtime)
+    assert runtime.health == "ok"
+    # Simulate the worker's next auth-error leak detection re-setting
+    # the flag (this is the existing PUF-214 + PUF-221 path).
+    runtime.health = "auth_failed"
+    runtime.error = "fresh-401-after-refresh"
+    # The next refresh-success cycle would clear it again.
+    _call(runtime)
+    assert runtime.health == "ok"
+    assert runtime.error == ""
+    assert runtime.saved_count == 2  # initial clear + post-re-set clear
+
+
+# ── CredentialRefresher wiring tests ────────────────────────────────────────
+
+
+def _write_creds(host_home: Path, *, expires_in_seconds: int) -> Path:
+    creds_path = host_home / ".claude" / ".credentials.json"
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat01-test",
+            "refreshToken": "sk-ant-ort01-test",
+            "expiresAt": int((time.time() + expires_in_seconds) * 1000),
+            "scopes": ["user:inference"],
+            "subscriptionType": "max",
+        }
+    }
+    creds_path.write_text(json.dumps(payload))
+    return creds_path
+
+
+def test_register_and_unregister_on_refresh_success(tmp_path):
+    """``register_on_refresh_success`` adds the callback;
+    ``unregister_on_refresh_success`` removes it. Both are idempotent
+    on unknown identities (mirrors ``register_agent`` shape)."""
+    _write_creds(tmp_path, expires_in_seconds=600)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    calls: list[str] = []
+
+    def cb() -> None:
+        calls.append("fired")
+
+    r.register_on_refresh_success(cb)
+    r._fire_refresh_success()
+    assert calls == ["fired"]
+
+    r.unregister_on_refresh_success(cb)
+    r._fire_refresh_success()
+    assert calls == ["fired"]  # no further fires after unregister
+
+    # Unregistering an already-removed callback is a no-op.
+    r.unregister_on_refresh_success(cb)
+
+
+def test_fire_refresh_success_dispatches_to_multiple_subscribers(tmp_path):
+    """Multiple workers registered: all get the callback. Order
+    matches registration order (list semantics)."""
+    _write_creds(tmp_path, expires_in_seconds=600)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    fired: list[int] = []
+    r.register_on_refresh_success(lambda: fired.append(1))
+    r.register_on_refresh_success(lambda: fired.append(2))
+    r.register_on_refresh_success(lambda: fired.append(3))
+    r._fire_refresh_success()
+    assert fired == [1, 2, 3]
+
+
+def test_callback_exception_does_not_break_refresh_loop(tmp_path, caplog):
+    """A buggy subscriber raising must not cascade into the refresh
+    loop. The exception is caught + logged at WARNING."""
+    _write_creds(tmp_path, expires_in_seconds=600)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    fired: list[str] = []
+
+    def good_cb() -> None:
+        fired.append("good")
+
+    def bad_cb() -> None:
+        raise RuntimeError("subscriber boom")
+
+    r.register_on_refresh_success(good_cb)
+    r.register_on_refresh_success(bad_cb)
+    r.register_on_refresh_success(good_cb)  # double-register for the
+                                            # post-bad ordering check
+    with caplog.at_level(logging.WARNING, logger="puffo_agent"):
+        r._fire_refresh_success()
+    # Good callback fires before AND after the bad one -- exception
+    # didn't short-circuit the loop.
+    assert fired == ["good", "good"]
+    # And the warning was logged.
+    assert any(
+        "refresh-success callback raised" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
+    """End-to-end: ``_refresh_now`` -> backend.refresh succeeds ->
+    callbacks fire after the lock is released. Pins the wiring
+    between the rotation success path and the new event."""
+    _write_creds(tmp_path, expires_in_seconds=10)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    refresh_called = {"n": 0}
+
+    async def fake_refresh() -> None:
+        refresh_called["n"] += 1
+        # Simulate the backend writing a fresh expiry.
+        _write_creds(tmp_path, expires_in_seconds=3600)
+
+    monkeypatch.setattr(r.backend, "refresh", fake_refresh)
+
+    fired: list[str] = []
+    r.register_on_refresh_success(lambda: fired.append("ok"))
+
+    await r._refresh_now(expires_in=10, by_agent=True)
+    assert refresh_called["n"] == 1
+    assert fired == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_now_does_not_fire_on_failure(tmp_path, monkeypatch):
+    """If ``backend.refresh`` raises, no callbacks fire -- the
+    auth_failed flag rightly persists until the next successful
+    refresh attempt."""
+    _write_creds(tmp_path, expires_in_seconds=10)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def failing_refresh() -> None:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(r.backend, "refresh", failing_refresh)
+
+    fired: list[str] = []
+    r.register_on_refresh_success(lambda: fired.append("ok"))
+
+    # Should NOT raise -- _refresh_now catches the exception.
+    await r._refresh_now(expires_in=10, by_agent=True)
+    assert fired == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_now_skip_branch_does_not_fire(tmp_path, monkeypatch):
+    """Non-agent-triggered refresh that finds ``before`` still
+    within the safety margin returns early without rotating
+    credentials. No callbacks fire (the credentials didn't actually
+    change)."""
+    # Plenty of TTL so the skip-branch fires.
+    _write_creds(tmp_path, expires_in_seconds=REFRESH_SAFETY_MARGIN_SECONDS + 600)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    refresh_called = {"n": 0}
+
+    async def fake_refresh() -> None:
+        refresh_called["n"] += 1
+
+    monkeypatch.setattr(r.backend, "refresh", fake_refresh)
+
+    fired: list[str] = []
+    r.register_on_refresh_success(lambda: fired.append("ok"))
+
+    await r._refresh_now(
+        expires_in=REFRESH_SAFETY_MARGIN_SECONDS + 600,
+        by_agent=False,
+    )
+    assert refresh_called["n"] == 0
+    assert fired == []

--- a/tests/test_credential_refresh_clears_auth_failed.py
+++ b/tests/test_credential_refresh_clears_auth_failed.py
@@ -1,17 +1,4 @@
-"""PUF-258: auth_failed sticky state-machine fix.
-
-PUF-252 + PUF-255 established the symmetric ENTER/EXIT pattern for
-``runtime.health = "api_error_abandoned"`` (PUF-252 sets on
-kick-retry exhaustion; PUF-255 clears on next successful turn).
-PUF-258 extends the same pattern to ``runtime.health = "auth_failed"``:
-the daemon's ``CredentialRefresher`` fires registered
-``on_refresh_success`` callbacks after a successful refresh OR
-external rotation, and ``Worker._clear_auth_failed_if_recoverable``
-flips the flag back to ``"ok"``.
-
-Tests cover (1) the helper's policy contract directly + (2) the
-CredentialRefresher's register/fire/unregister wiring.
-"""
+"""PUF-258: clear runtime.health=auth_failed on credential refresh-success."""
 
 from __future__ import annotations
 
@@ -38,9 +25,6 @@ _LOG = logging.getLogger("test-puf-258")
 
 
 class _FakeRuntime:
-    """Stand-in for ``RuntimeState`` -- the helper only touches
-    ``.health`` + ``.error`` + ``.save(agent_id)``."""
-
     def __init__(self, health: str = "ok"):
         self.health = health
         self.error = ""
@@ -59,10 +43,6 @@ def _call(runtime: _FakeRuntime) -> None:
 
 
 def test_clear_flips_auth_failed_to_ok():
-    """Operator's scenario: agent in ``auth_failed`` -> credential
-    refresh succeeds -> health flips to ``ok`` + error cleared +
-    runtime saved (so puffo-server sees the transition via the
-    existing heartbeat reporter / next status read)."""
     runtime = _FakeRuntime(health="auth_failed")
     runtime.error = "Worker emitted an auth-error string..."
     _call(runtime)
@@ -73,10 +53,6 @@ def test_clear_flips_auth_failed_to_ok():
 
 
 def test_clear_no_op_on_ok():
-    """Steady-state hot-path: most refresh cycles happen while
-    ``runtime.health == "ok"`` already (regular token rotations
-    pre-expiry). The helper should NOT write to runtime each
-    cycle -- skip the save."""
     runtime = _FakeRuntime(health="ok")
     _call(runtime)
     assert runtime.health == "ok"
@@ -84,13 +60,8 @@ def test_clear_no_op_on_ok():
 
 
 def test_clear_leaves_api_error_abandoned_alone():
-    """PUF-255's ``on_turn_success`` lane owns the
-    ``api_error_abandoned`` lifecycle. PUF-258's refresh-success
-    hook is for the auth class only -- don't accidentally clear an
-    api-error-abandoned just because credentials rotated (the
-    abandoned batch is still stuck until a fresh turn succeeds);
-    leave it to the turn-success callback. Symmetric partition to
-    PUF-255's leaves-auth-failed-alone."""
+    # PUF-255's on_turn_success lane owns api_error_abandoned. PUF-258
+    # must not over-step into it.
     runtime = _FakeRuntime(health="api_error_abandoned")
     runtime.error = "Worker abandoned a batch..."
     _call(runtime)
@@ -100,9 +71,6 @@ def test_clear_leaves_api_error_abandoned_alone():
 
 
 def test_clear_no_op_on_unknown():
-    """Boot-time / uninstrumented state. No refresh-success
-    transition is meaningful from ``unknown`` -- bootstrap probe
-    will set health to ok on its own once the auth-check runs."""
     runtime = _FakeRuntime(health="unknown")
     _call(runtime)
     assert runtime.health == "unknown"
@@ -110,24 +78,16 @@ def test_clear_no_op_on_unknown():
 
 
 def test_optimistic_clear_then_re_set_on_next_401():
-    """Optimistic-clear semantics: if the refresh succeeds but the
-    agent's next request still 401s (e.g., upstream revocation
-    beyond the refresh's scope), the auth_failed flag re-sets when
-    ``_handle_suppressed_reply`` fires next time. Pin via a
-    sequencing test on the runtime alone -- the
-    re-set is owned by worker code we don't touch in PUF-258."""
     runtime = _FakeRuntime(health="auth_failed")
     _call(runtime)
     assert runtime.health == "ok"
-    # Simulate the worker's next auth-error leak detection re-setting
-    # the flag (this is the existing PUF-214 + PUF-221 path).
+    # Simulate worker's _handle_suppressed_reply re-flipping on next 401.
     runtime.health = "auth_failed"
     runtime.error = "fresh-401-after-refresh"
-    # The next refresh-success cycle would clear it again.
     _call(runtime)
     assert runtime.health == "ok"
     assert runtime.error == ""
-    assert runtime.saved_count == 2  # initial clear + post-re-set clear
+    assert runtime.saved_count == 2
 
 
 # ── CredentialRefresher wiring tests ────────────────────────────────────────
@@ -150,9 +110,6 @@ def _write_creds(host_home: Path, *, expires_in_seconds: int) -> Path:
 
 
 def test_register_and_unregister_on_refresh_success(tmp_path):
-    """``register_on_refresh_success`` adds the callback;
-    ``unregister_on_refresh_success`` removes it. Both are idempotent
-    on unknown identities (mirrors ``register_agent`` shape)."""
     _write_creds(tmp_path, expires_in_seconds=600)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -167,15 +124,13 @@ def test_register_and_unregister_on_refresh_success(tmp_path):
 
     r.unregister_on_refresh_success(cb)
     r._fire_refresh_success()
-    assert calls == ["fired"]  # no further fires after unregister
+    assert calls == ["fired"]
 
     # Unregistering an already-removed callback is a no-op.
     r.unregister_on_refresh_success(cb)
 
 
 def test_fire_refresh_success_dispatches_to_multiple_subscribers(tmp_path):
-    """Multiple workers registered: all get the callback. Order
-    matches registration order (list semantics)."""
     _write_creds(tmp_path, expires_in_seconds=600)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -188,8 +143,6 @@ def test_fire_refresh_success_dispatches_to_multiple_subscribers(tmp_path):
 
 
 def test_callback_exception_does_not_break_refresh_loop(tmp_path, caplog):
-    """A buggy subscriber raising must not cascade into the refresh
-    loop. The exception is caught + logged at WARNING."""
     _write_creds(tmp_path, expires_in_seconds=600)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -201,27 +154,43 @@ def test_callback_exception_does_not_break_refresh_loop(tmp_path, caplog):
     def bad_cb() -> None:
         raise RuntimeError("subscriber boom")
 
+    # Double-register good_cb to verify the loop continues PAST the bad one.
     r.register_on_refresh_success(good_cb)
     r.register_on_refresh_success(bad_cb)
-    r.register_on_refresh_success(good_cb)  # double-register for the
-                                            # post-bad ordering check
+    r.register_on_refresh_success(good_cb)
     with caplog.at_level(logging.WARNING, logger="puffo_agent"):
         r._fire_refresh_success()
-    # Good callback fires before AND after the bad one -- exception
-    # didn't short-circuit the loop.
     assert fired == ["good", "good"]
-    # And the warning was logged.
     assert any(
         "refresh-success callback raised" in rec.message
         for rec in caplog.records
     )
 
 
+def test_fire_is_safe_under_concurrent_register(tmp_path):
+    # Defensive copy via list(...) means a callback that registers
+    # another callback mid-dispatch doesn't IndexError or cause the
+    # new callback to fire in the same dispatch.
+    _write_creds(tmp_path, expires_in_seconds=600)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    fired: list[str] = []
+
+    def first_cb() -> None:
+        fired.append("first")
+        r.register_on_refresh_success(lambda: fired.append("late"))
+
+    r.register_on_refresh_success(first_cb)
+    r._fire_refresh_success()
+    # "late" not in fired — registered after dispatch copy was taken.
+    assert fired == ["first"]
+    # But it IS in the list for the next fire.
+    r._fire_refresh_success()
+    assert fired == ["first", "first", "late"]
+
+
 @pytest.mark.asyncio
 async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
-    """End-to-end: ``_refresh_now`` -> backend.refresh succeeds ->
-    callbacks fire after the lock is released. Pins the wiring
-    between the rotation success path and the new event."""
     _write_creds(tmp_path, expires_in_seconds=10)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -229,9 +198,6 @@ async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
 
     async def fake_refresh() -> RefreshOutcome:
         refresh_called["n"] += 1
-        # Simulate the backend writing a fresh expiry + reporting
-        # the canonical REFRESHED outcome (per PR #48 review:
-        # callbacks fire ONLY on this outcome, not on UNCHANGED).
         _write_creds(tmp_path, expires_in_seconds=3600)
         return RefreshOutcome.REFRESHED
 
@@ -247,11 +213,8 @@ async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_refresh_now_does_not_fire_on_unchanged(tmp_path, monkeypatch):
-    """PR #48 review: UNCHANGED outcome (the PUF-265 case where claude
-    exited 0 but expiresAt didn't advance) must NOT fire refresh-success
-    callbacks -- credentials didn't actually rotate, so optimistically
-    clearing auth_failed would oscillate auth_failed -> ok -> auth_failed
-    every poll cycle until the underlying refresh recovers."""
+    # PR #48 review: UNCHANGED (PUF-265 case) must not fire — would
+    # oscillate auth_failed → ok → auth_failed each 2-min poll.
     _write_creds(tmp_path, expires_in_seconds=10)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -269,9 +232,6 @@ async def test_refresh_now_does_not_fire_on_unchanged(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_refresh_now_does_not_fire_on_failed_outcome(tmp_path, monkeypatch):
-    """Same shape as the exception path but at the outcome level:
-    a backend that returns FAILED (rc!=0 from the subprocess) must
-    NOT trigger callbacks."""
     _write_creds(tmp_path, expires_in_seconds=10)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -289,9 +249,7 @@ async def test_refresh_now_does_not_fire_on_failed_outcome(tmp_path, monkeypatch
 
 @pytest.mark.asyncio
 async def test_refresh_now_does_not_fire_on_failure(tmp_path, monkeypatch):
-    """If ``backend.refresh`` raises, no callbacks fire -- the
-    auth_failed flag rightly persists until the next successful
-    refresh attempt."""
+    # backend.refresh raises (network down, subprocess crash, etc).
     _write_creds(tmp_path, expires_in_seconds=10)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -303,18 +261,12 @@ async def test_refresh_now_does_not_fire_on_failure(tmp_path, monkeypatch):
     fired: list[str] = []
     r.register_on_refresh_success(lambda: fired.append("ok"))
 
-    # Should NOT raise -- _refresh_now catches the exception.
     await r._refresh_now(expires_in=10, by_agent=True)
     assert fired == []
 
 
 @pytest.mark.asyncio
 async def test_refresh_now_skip_branch_does_not_fire(tmp_path, monkeypatch):
-    """Non-agent-triggered refresh that finds ``before`` still
-    within the safety margin returns early without rotating
-    credentials. No callbacks fire (the credentials didn't actually
-    change)."""
-    # Plenty of TTL so the skip-branch fires.
     _write_creds(tmp_path, expires_in_seconds=REFRESH_SAFETY_MARGIN_SECONDS + 600)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -340,36 +292,21 @@ async def test_refresh_now_skip_branch_does_not_fire(tmp_path, monkeypatch):
 async def test_external_rotation_loop_fires_on_detected_rotation(
     tmp_path, monkeypatch,
 ):
-    """When ``backend.poll_external_rotation`` returns True (Keychain
-    rotated externally), the loop fires ``_fire_refresh_success`` after
-    syncing views. Pins the second ``_fire_refresh_success`` site so a
-    future regression that drops it from the rotated-branch breaks the
-    test rather than silently regressing the macOS Keychain-rotation
-    path."""
     _write_creds(tmp_path, expires_in_seconds=600)
     r = CredentialRefresher(host_home=tmp_path)
 
-    # Shrink the poll interval so wait_for times out promptly. The
-    # constant lives in ``..macos.keychain`` and is imported lazily
-    # inside ``_external_rotation_loop`` -- patch at the module path
-    # the loop reads from.
     from puffo_agent.macos import keychain as _kc
     monkeypatch.setattr(_kc, "KEYCHAIN_POLL_INTERVAL_SECONDS", 0.01)
 
-    # Stub poll_external_rotation to return True once then False.
     poll_calls = {"n": 0}
 
     async def fake_poll() -> bool:
         poll_calls["n"] += 1
         return poll_calls["n"] == 1
 
-    # FileBackend doesn't natively have poll_external_rotation (it's
-    # KeychainBackend-only); attach it for the test via raising=False.
     monkeypatch.setattr(
         r.backend, "poll_external_rotation", fake_poll, raising=False,
     )
-    # Stub _sync_views to a no-op (the disk-mirror logic isn't what
-    # we're pinning here -- the fire-after-sync ordering is).
     sync_calls = {"n": 0}
     monkeypatch.setattr(
         r, "_sync_views", lambda: sync_calls.__setitem__("n", sync_calls["n"] + 1),
@@ -380,7 +317,6 @@ async def test_external_rotation_loop_fires_on_detected_rotation(
 
     stop = asyncio.Event()
     loop_task = asyncio.create_task(r._external_rotation_loop(stop))
-    # Let the loop iterate at least once on the rotated-branch.
     await asyncio.sleep(0.05)
     stop.set()
     try:
@@ -397,14 +333,10 @@ async def test_external_rotation_loop_fires_on_detected_rotation(
     assert fired == ["ok"]
 
 
-# ── Daemon-side wiring tests (register/unregister roundtrip) ────────────────
+# ── Daemon-side wiring tests ────────────────────────────────────────────────
 
 
 class _FakeAgentCfg:
-    """Minimal stand-in for ``AgentConfig`` -- daemon's
-    ``_refresher_for`` reads ``runtime.harness`` to route to the
-    claude vs codex refresher."""
-
     def __init__(self, agent_id: str, harness: str = "claude-code"):
         self.id = agent_id
 
@@ -416,9 +348,6 @@ class _FakeAgentCfg:
 
 
 def _make_fake_worker():
-    """Stand-in Worker -- only the ``runtime`` attribute is touched
-    when the bound callback fires. ``_clear_auth_failed_if_recoverable``
-    accepts a fake runtime since it's a staticmethod."""
     worker = type("FakeWorker", (), {})()
     worker.runtime = _FakeRuntime(health="auth_failed")
     worker.runtime.error = "pre-refresh auth error"
@@ -426,9 +355,6 @@ def _make_fake_worker():
 
 
 def _make_daemon_stub(tmp_path):
-    """Build a Daemon-shaped stub by bypassing ``__init__`` (which
-    reads ``Path.home()`` + builds real backends) and stitching in
-    minimal attributes the wiring methods touch."""
     from puffo_agent.portal.daemon import Daemon
 
     daemon = Daemon.__new__(Daemon)
@@ -440,11 +366,6 @@ def _make_daemon_stub(tmp_path):
 
 
 def test_daemon_register_with_refresher_binds_callback_to_worker_runtime(tmp_path):
-    """``_register_with_refresher`` registers an
-    ``on_refresh_success`` callback that, when fired, clears the
-    Worker's ``runtime.health = "auth_failed"`` flag. Pins the
-    binding so a future refactor that forgets to wire
-    worker.runtime breaks the test."""
     daemon = _make_daemon_stub(tmp_path)
     agent_cfg = _FakeAgentCfg("agent-A", harness="claude-code")
     worker = _make_fake_worker()
@@ -452,23 +373,16 @@ def test_daemon_register_with_refresher_binds_callback_to_worker_runtime(tmp_pat
 
     daemon._register_with_refresher(agent_cfg, worker)
 
-    # Callback stashed on worker for unregister symmetry.
     assert hasattr(worker, "_refresh_success_callback")
-    # Callback registered on the claude refresher (not codex).
     assert len(daemon.refresher._on_refresh_success) == 1
     assert len(daemon.codex_refresher._on_refresh_success) == 0
 
-    # Firing it clears the worker's auth_failed flag.
     daemon.refresher._fire_refresh_success()
     assert worker.runtime.health == "ok"
     assert worker.runtime.error == ""
 
 
 def test_daemon_register_codex_harness_routes_to_codex_refresher(tmp_path):
-    """Codex-harness agents route to ``codex_refresher`` per
-    ``_refresher_for``'s branch. Pins the codex side has independent
-    callback registration -- if a refactor accidentally always uses
-    ``self.refresher``, this breaks."""
     daemon = _make_daemon_stub(tmp_path)
     agent_cfg = _FakeAgentCfg("agent-codex-A", harness="codex")
     worker = _make_fake_worker()
@@ -484,15 +398,10 @@ def test_daemon_register_codex_harness_routes_to_codex_refresher(tmp_path):
 async def test_daemon_stop_worker_unregisters_callback_from_both_refreshers(
     tmp_path,
 ):
-    """``_stop_worker`` unregisters the on_refresh_success callback
-    from both claude AND codex refreshers (idempotent on both, same
-    pattern as ``unregister_agent``). This defends the cross-refresher
-    cleanup against a future single-side regression."""
     daemon = _make_daemon_stub(tmp_path)
     agent_cfg = _FakeAgentCfg("agent-A", harness="claude-code")
     worker = _make_fake_worker()
 
-    # Hand-build the worker.stop coroutine so _stop_worker can await it.
     async def fake_stop():
         return None
     worker.stop = fake_stop
@@ -502,9 +411,50 @@ async def test_daemon_stop_worker_unregisters_callback_from_both_refreshers(
     assert len(daemon.refresher._on_refresh_success) == 1
 
     await daemon._stop_worker("agent-A")
-    # Callback removed from claude refresher.
     assert len(daemon.refresher._on_refresh_success) == 0
-    # Codex refresher unchanged (was already empty, unregister is no-op).
     assert len(daemon.codex_refresher._on_refresh_success) == 0
-    # Worker popped from registry.
     assert "agent-A" not in daemon.workers
+
+
+@pytest.mark.asyncio
+async def test_daemon_stop_worker_no_callback_does_not_crash(tmp_path):
+    # Edge: worker was registered as agent but somehow lacks the callback
+    # attribute (e.g., partial init failure). _stop_worker must not raise.
+    daemon = _make_daemon_stub(tmp_path)
+    worker = _make_fake_worker()
+
+    async def fake_stop():
+        return None
+    worker.stop = fake_stop
+
+    daemon.workers["agent-A"] = worker
+    # No _register_with_refresher → no _refresh_success_callback attr.
+    assert not hasattr(worker, "_refresh_success_callback")
+
+    await daemon._stop_worker("agent-A")
+    assert "agent-A" not in daemon.workers
+
+
+def test_two_workers_both_get_auth_failed_cleared_on_one_refresh(tmp_path):
+    # End-to-end fan-out: two workers registered on the same refresher
+    # both clear their auth_failed flags from a single _fire_refresh_success.
+    daemon = _make_daemon_stub(tmp_path)
+    worker_a = _make_fake_worker()
+    worker_b = _make_fake_worker()
+    daemon.workers["agent-A"] = worker_a
+    daemon.workers["agent-B"] = worker_b
+
+    daemon._register_with_refresher(
+        _FakeAgentCfg("agent-A", harness="claude-code"), worker_a,
+    )
+    daemon._register_with_refresher(
+        _FakeAgentCfg("agent-B", harness="claude-code"), worker_b,
+    )
+
+    assert worker_a.runtime.health == "auth_failed"
+    assert worker_b.runtime.health == "auth_failed"
+
+    daemon.refresher._fire_refresh_success()
+
+    assert worker_a.runtime.health == "ok"
+    assert worker_b.runtime.health == "ok"

--- a/tests/test_credential_refresh_clears_auth_failed.py
+++ b/tests/test_credential_refresh_clears_auth_failed.py
@@ -26,6 +26,7 @@ import pytest
 from puffo_agent.portal.credential_refresh import (
     REFRESH_SAFETY_MARGIN_SECONDS,
     CredentialRefresher,
+    RefreshOutcome,
 )
 from puffo_agent.portal.worker import Worker
 
@@ -226,10 +227,13 @@ async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
 
     refresh_called = {"n": 0}
 
-    async def fake_refresh() -> None:
+    async def fake_refresh() -> RefreshOutcome:
         refresh_called["n"] += 1
-        # Simulate the backend writing a fresh expiry.
+        # Simulate the backend writing a fresh expiry + reporting
+        # the canonical REFRESHED outcome (per PR #48 review:
+        # callbacks fire ONLY on this outcome, not on UNCHANGED).
         _write_creds(tmp_path, expires_in_seconds=3600)
+        return RefreshOutcome.REFRESHED
 
     monkeypatch.setattr(r.backend, "refresh", fake_refresh)
 
@@ -239,6 +243,48 @@ async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
     await r._refresh_now(expires_in=10, by_agent=True)
     assert refresh_called["n"] == 1
     assert fired == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_now_does_not_fire_on_unchanged(tmp_path, monkeypatch):
+    """PR #48 review: UNCHANGED outcome (the PUF-265 case where claude
+    exited 0 but expiresAt didn't advance) must NOT fire refresh-success
+    callbacks -- credentials didn't actually rotate, so optimistically
+    clearing auth_failed would oscillate auth_failed -> ok -> auth_failed
+    every poll cycle until the underlying refresh recovers."""
+    _write_creds(tmp_path, expires_in_seconds=10)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def unchanged_refresh() -> RefreshOutcome:
+        return RefreshOutcome.UNCHANGED
+
+    monkeypatch.setattr(r.backend, "refresh", unchanged_refresh)
+
+    fired: list[str] = []
+    r.register_on_refresh_success(lambda: fired.append("ok"))
+
+    await r._refresh_now(expires_in=10, by_agent=True)
+    assert fired == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_now_does_not_fire_on_failed_outcome(tmp_path, monkeypatch):
+    """Same shape as the exception path but at the outcome level:
+    a backend that returns FAILED (rc!=0 from the subprocess) must
+    NOT trigger callbacks."""
+    _write_creds(tmp_path, expires_in_seconds=10)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def failed_refresh() -> RefreshOutcome:
+        return RefreshOutcome.FAILED
+
+    monkeypatch.setattr(r.backend, "refresh", failed_refresh)
+
+    fired: list[str] = []
+    r.register_on_refresh_success(lambda: fired.append("ok"))
+
+    await r._refresh_now(expires_in=10, by_agent=True)
+    assert fired == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Wires the EXIT edge for ``runtime.health = "auth_failed"`` — symmetric to PUF-255's ``on_turn_success`` clear-path for ``api_error_abandoned``, but at the credential-refresh-success event boundary instead of the turn-success boundary.

Pre-PUF-258 the daemon set ``runtime.health = "auth_failed"`` (worker.py:479, PUF-221's lane) but **nothing in the codebase cleared it**. Once flipped, the flag stayed sticky until process restart, which made ``audit.log`` misleading for power-users / operators checking agent health post-recovery (operator surfaced the gap via the PR #45 grep observation).

## Changes

- ``CredentialRefresher`` gets ``register_on_refresh_success(cb)`` / ``unregister_on_refresh_success(cb)`` callbacks
- ``_refresh_now`` fires after ``backend.refresh()`` succeeds (lock released first so callbacks can't deadlock the next refresh)
- ``_external_rotation_loop`` fires after detected rotation + ``_sync_views`` (covers the macOS Keychain external-rotation path)
- Failure path stays silent — no fire on ``backend.refresh()`` raising
- Daemon ``_register_with_refresher(agent_cfg, worker)`` wires Worker's ``_clear_auth_failed_if_recoverable`` staticmethod; callback identity stashed on ``worker._refresh_success_callback`` so ``_stop_worker`` can unregister symmetrically from both refreshers
- ``Worker._clear_auth_failed_if_recoverable`` lifted staticmethod (mirrors PUF-255's ``_clear_api_error_abandoned_if_recoverable``):
  - Only clears ``auth_failed``. Leaves ``api_error_abandoned`` alone (PUF-255's lane; symmetric partition)
  - No-op on ``ok`` / ``unknown`` to skip the save churn on the steady-state hot path
  - **Optimistic-clear**: if refresh succeeds but the next request still 401s, ``_handle_suppressed_reply`` re-flips on the next leak detection
- ``state.py`` docstring updated to reflect the now-symmetric ENTER/EXIT lifecycles for both ``api_error_abandoned`` (PUF-252 set / PUF-255 clear) and ``auth_failed`` (PUF-221 set / PUF-258 clear)

## Tests

15 new tests in ``tests/test_credential_refresh_clears_auth_failed.py``:

**Helper-policy (5):**
- flips ``auth_failed`` → ``ok``; no-op on ``ok``; no-op on ``unknown``; leaves ``api_error_abandoned`` alone (symmetric partition); optimistic-clear-then-re-set sequence

**CredentialRefresher wiring (6):**
- register/unregister roundtrip; multi-subscriber fan-out (order preserved); callback-exception isolation with caplog at WARNING; ``_refresh_now`` fires on success; ``_refresh_now`` does NOT fire on failure; skip-branch (sufficient TTL) doesn't fire

**External-rotation E2E (1):**
- Monkeypatches ``backend.poll_external_rotation`` + shrinks ``KEYCHAIN_POLL_INTERVAL_SECONDS`` + runs ``_external_rotation_loop`` briefly; asserts ``_sync_views`` called AND callback fired. Pins the rotated-branch ``_fire_refresh_success`` site so a macOS Keychain regression breaks the test.

**Daemon-side wiring (3):**
- ``_register_with_refresher`` binds callback to ``worker.runtime`` (closure-binding pinned)
- Codex-harness routes to ``codex_refresher`` (not ``self.refresher``)
- ``_stop_worker`` unregisters from both refreshers (cross-refresher cleanup symmetry)

**Test count:** 883 passed, 1 skipped (was 879 pre-PR; +15 across both commits; usual permission-mode skip).

## Scope & discipline

- **PR-256 close discipline preserved:** PUF-258 does NOT add a new propagation surface to puffo-server / UI. The ``runtime.health`` field stays local-honest. Per the user-action-invariance pre-check: this is owner-side cleanup of the local field PUF-256 closed as not-worth-propagating. Audit.log diagnostic value justifies the work per the "observability-for-operators IS legitimate" edge-case.
- **Symmetric partition with PUF-255:** each helper's first line guards on its own ``runtime.health`` value; pinned by ``test_clear_leaves_api_error_abandoned_alone``.
- **Ship-to-host:** daemon-side fix; agent restart picks it up. No server schema changes, no client changes.

## Out of scope

- Per-thread granularity for ``runtime.error`` (same coarseness as PUF-255; PUF-253 design lane)
- Central state-machine registry (Nova's "(1)-vs-(3) scope-choice" confirmed-out by Equation intake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)