### PR TITLE
fix(PUF-208 v2): cap profile_summary at 10000 UTF-8 bytes on the bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **PUF-208 v2: ``profile_summary`` capped at 10000 UTF-8 bytes on
-  the bridge.** Pairs with the web client's 6000-byte typing cap +
-  10000-byte ``soul.md`` upload — the daemon-side
-  ``MAX_PROFILE_SUMMARY_BYTES`` is the load-bearing storage cap so
-  any caller (web, CLI, future automation) is rejected with 400 if
-  the post-strip payload exceeds the cap. Byte count rather than
-  codepoints so the cap matches what gets written to ``profile.md``
-  and read back off disk; CJK-heavy souls fit ~3000-3300 characters.
-  Out of scope per operator spec: the ``create_agent`` write path —
-  capping it would need to parse the full ``profile.md`` payload to
-  isolate the soul section, so a stale UI / CLI hitting
-  ``create_agent`` with a 50KB ``profile`` field still bypasses this
-  cap on first-create. Acknowledged gap.
+  the bridge.** The web client shares one 10000-byte ceiling across
+  textarea typing, ``soul.md`` upload, and Edit; the daemon-side
+  ``MAX_PROFILE_SUMMARY_BYTES`` is the load-bearing storage cap, so
+  any caller (web, CLI, future automation) is 400'd if the
+  post-strip payload exceeds it. Byte count rather than codepoints
+  so the cap matches what gets written to ``profile.md`` and read
+  back off disk; CJK-heavy souls fit ~3000-3300 characters. Out of
+  scope per operator spec: the ``create_agent`` write path — capping
+  it would need to parse the full ``profile.md`` payload to isolate
+  the soul section, so a stale UI / CLI hitting ``create_agent``
+  with a 50KB ``profile`` field still bypasses this cap on first-
+  create. Acknowledged gap.
 
 - **PUF-263: ``/v1/agents/export`` enforces paused-only.** A running
   agent may be mid-write (memory updates, ``cli_session.json``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **PUF-208 v2: ``profile_summary`` capped at 10000 UTF-8 bytes on
+  the bridge.** Pairs with the web client's 6000-byte typing cap +
+  10000-byte ``soul.md`` upload — the daemon-side
+  ``MAX_PROFILE_SUMMARY_BYTES`` is the load-bearing storage cap so
+  any caller (web, CLI, future automation) is rejected with 400 if
+  the post-strip payload exceeds the cap. Byte count rather than
+  codepoints so the cap matches what gets written to ``profile.md``
+  and read back off disk; CJK-heavy souls fit ~3000-3300 characters.
+  Out of scope per operator spec: the ``create_agent`` write path —
+  capping it would need to parse the full ``profile.md`` payload to
+  isolate the soul section, so a stale UI / CLI hitting
+  ``create_agent`` with a 50KB ``profile`` field still bypasses this
+  cap on first-create. Acknowledged gap.
+
 - **Codex agent archive/delete failing with ``Permission denied`` on
   ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an
   exclusive file lock on ``.codex/tmp/arg0/codex-<id>/.lock`` for the

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -652,14 +652,19 @@ async def update_profile(request: web.Request) -> web.Response:
     if isinstance(new_profile_summary, str):
         # PUF-208 v2: cap before write so a stale UI / future automation
         # client can't drop a multi-megabyte soul on disk + into the
-        # next CLAUDE.md sync. UTF-8 byte count matches storage.
-        summary_bytes = len(new_profile_summary.encode("utf-8"))
+        # next CLAUDE.md sync. UTF-8 byte count matches storage. Cap
+        # the STRIPPED payload so the gate sees what storage actually
+        # writes — otherwise 10010 bytes of content surrounded by
+        # whitespace (strips to 9990) would 400 even though the disk
+        # write would have landed under the cap.
+        stripped_summary = new_profile_summary.strip()
+        summary_bytes = len(stripped_summary.encode("utf-8"))
         if summary_bytes > MAX_PROFILE_SUMMARY_BYTES:
             return _bad(
                 f"profile_summary is {summary_bytes} bytes; cap is "
                 f"{MAX_PROFILE_SUMMARY_BYTES}"
             )
-        _update_profile_summary(cfg, new_profile_summary.strip())
+        _update_profile_summary(cfg, stripped_summary)
 
     # Write agent.yml last so local state reflects what we asked
     # the server for, even if the sync warned.

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -528,6 +528,14 @@ async def update_runtime(request: web.Request) -> web.Response:
 MAX_ROLE_LEN = 140
 MAX_ROLE_SHORT_LEN = 32
 
+# PUF-208 v2: server-side cap on soul / profile_summary content.
+# Web UI types up to 6000 + supports a .md upload up to 10000; this
+# is the load-bearing storage cap that any caller (web, CLI, future
+# automation) must respect. UTF-8 byte count rather than codepoints
+# so the cap matches what gets written to profile.md and read back
+# off disk — CJK-heavy souls fit about 3000-3300 characters.
+MAX_PROFILE_SUMMARY_BYTES = 10000
+
 
 async def update_profile(request: web.Request) -> web.Response:
     """Patch the agent's display_name + avatar_url + role. Owner-only.
@@ -642,6 +650,15 @@ async def update_profile(request: web.Request) -> web.Response:
 
     new_profile_summary = payload.get("profile_summary")
     if isinstance(new_profile_summary, str):
+        # PUF-208 v2: cap before write so a stale UI / future automation
+        # client can't drop a multi-megabyte soul on disk + into the
+        # next CLAUDE.md sync. UTF-8 byte count matches storage.
+        summary_bytes = len(new_profile_summary.encode("utf-8"))
+        if summary_bytes > MAX_PROFILE_SUMMARY_BYTES:
+            return _bad(
+                f"profile_summary is {summary_bytes} bytes; cap is "
+                f"{MAX_PROFILE_SUMMARY_BYTES}"
+            )
         _update_profile_summary(cfg, new_profile_summary.strip())
 
     # Write agent.yml last so local state reflects what we asked

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -366,3 +366,35 @@ async def test_update_profile_caps_on_utf8_bytes_not_codepoints():
         h["content-type"] = "application/json"
         r = await c.patch("/v1/agents/soul-bot/profile", data=body, headers=h)
         assert r.status == 400, await r.text()
+
+
+async def test_update_profile_caps_post_strip():
+    # PR #51 review item 2: the cap must check the same payload that
+    # storage writes. A user sending MAX + 20 bytes of content where
+    # the leading/trailing whitespace strips to exactly MAX bytes
+    # must be accepted — pre-fix, this was 400'd because the cap ran
+    # on the RAW payload while storage ran on the STRIPPED payload.
+    from puffo_agent.portal.api.handlers import MAX_PROFILE_SUMMARY_BYTES
+
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "soul-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    # Pad with whitespace so strip() lands exactly at the cap.
+    summary = " " * 10 + ("x" * MAX_PROFILE_SUMMARY_BYTES) + " " * 10
+    assert len(summary.encode("utf-8")) == MAX_PROFILE_SUMMARY_BYTES + 20
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        body = json.dumps({"profile_summary": summary}).encode("utf-8")
+        h = signed_headers(user, "PATCH", "/v1/agents/soul-bot/profile", body)
+        h.update(_HOST)
+        h["content-type"] = "application/json"
+        r = await c.patch("/v1/agents/soul-bot/profile", data=body, headers=h)
+        assert r.status == 200, await r.text()

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -271,3 +271,98 @@ async def test_read_file_caps_size():
         h = signed_headers(user, "GET", "/v1/agents/files-bot/files/raw?path=big.txt"); h.update(_HOST)
         r = await c.get("/v1/agents/files-bot/files/raw?path=big.txt", headers=h)
         assert r.status == 413
+
+
+# ────────────────────────────────────────────────────────────────────
+# PUF-208 v2: profile_summary byte-cap on PATCH /v1/agents/{id}/profile
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_update_profile_accepts_summary_at_cap():
+    # Exactly MAX_PROFILE_SUMMARY_BYTES (10000) UTF-8 bytes must pass.
+    # The cap is byte-counted so the on-disk profile.md size matches
+    # what the server enforced.
+    from puffo_agent.portal.api.handlers import MAX_PROFILE_SUMMARY_BYTES
+
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "soul-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    summary = "x" * MAX_PROFILE_SUMMARY_BYTES
+    assert len(summary.encode("utf-8")) == MAX_PROFILE_SUMMARY_BYTES
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        body = json.dumps({"profile_summary": summary}).encode("utf-8")
+        h = signed_headers(user, "PATCH", "/v1/agents/soul-bot/profile", body)
+        h.update(_HOST)
+        h["content-type"] = "application/json"
+        r = await c.patch("/v1/agents/soul-bot/profile", data=body, headers=h)
+        assert r.status == 200, await r.text()
+
+
+async def test_update_profile_rejects_summary_over_cap():
+    # MAX + 1 byte must reject with 400 + a body that fingers the
+    # offending byte count + the configured cap, so the UI can map
+    # the message without re-parsing.
+    from puffo_agent.portal.api.handlers import MAX_PROFILE_SUMMARY_BYTES
+
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "soul-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    summary = "x" * (MAX_PROFILE_SUMMARY_BYTES + 1)
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        body = json.dumps({"profile_summary": summary}).encode("utf-8")
+        h = signed_headers(user, "PATCH", "/v1/agents/soul-bot/profile", body)
+        h.update(_HOST)
+        h["content-type"] = "application/json"
+        r = await c.patch("/v1/agents/soul-bot/profile", data=body, headers=h)
+        assert r.status == 400, await r.text()
+        body_json = await r.json()
+        assert str(MAX_PROFILE_SUMMARY_BYTES) in body_json["error"]
+        assert str(MAX_PROFILE_SUMMARY_BYTES + 1) in body_json["error"]
+
+
+async def test_update_profile_caps_on_utf8_bytes_not_codepoints():
+    # CJK characters take 3 UTF-8 bytes each. 3334 CJK characters =
+    # 10002 bytes → rejected. (Even though 3334 codepoints is well
+    # under any plausible codepoint cap.)
+    from puffo_agent.portal.api.handlers import MAX_PROFILE_SUMMARY_BYTES
+
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "soul-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    # 3334 × 3 bytes = 10002 (just over the 10000 cap).
+    summary = "字" * 3334
+    assert len(summary.encode("utf-8")) > MAX_PROFILE_SUMMARY_BYTES
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        body = json.dumps({"profile_summary": summary}).encode("utf-8")
+        h = signed_headers(user, "PATCH", "/v1/agents/soul-bot/profile", body)
+        h.update(_HOST)
+        h["content-type"] = "application/json"
+        r = await c.patch("/v1/agents/soul-bot/profile", data=body, headers=h)
+        assert r.status == 400, await r.text()


### PR DESCRIPTION
## Summary

Operator P2 directive (msg_f231740f): paired with the web-side 6000-byte typing cap + 10000-byte file-upload, the daemon needs its own load-bearing cap so a stale UI, CLI, or future automation client can't drop a multi-megabyte soul onto disk + into the next CLAUDE.md sync.

Supersedes the older PR #123 (closed; was UI-only with a 12000-byte file cap).

## Changes

`src/puffo_agent/portal/api/handlers.py`:
- New `MAX_PROFILE_SUMMARY_BYTES = 10000` constant next to the existing `MAX_ROLE_LEN` / `MAX_ROLE_SHORT_LEN`
- In `PATCH /v1/agents/{id}/profile`, before delegating to `_update_profile_summary`, measure `len(summary.encode("utf-8"))` and 400 if it exceeds the cap
- **UTF-8 byte count** rather than codepoints — matches what gets written to profile.md + read back off disk. CJK-heavy souls fit ~3000-3300 characters
- Reuses existing `_bad` helper for shape parity with other input-validation errors
- Error body fingers both the offending count + the configured cap so the UI can render a specific message

## Tests

3 new pytest cases:
- `test_update_profile_accepts_summary_at_cap` — exactly 10000 bytes round-trips
- `test_update_profile_rejects_summary_over_cap` — 10001 bytes rejected; error body carries both counts
- `test_update_profile_caps_on_utf8_bytes_not_codepoints` — 3334 CJK characters (10002 UTF-8 bytes) rejected; defends byte-not-codepoint semantics against a future refactor

**Test results:** 3/3 focused + 871 passed, 1 skipped (unrelated permission-mode test) full suite.

## Paired client PR

https://github.com/puffo-ai/puffo-core-han-group/pull/ — bumps `MAX_DESC` 3000→6000 on the textarea + adds soul.md file upload (10000B cap, contract-pinned to this server cap). Ship server first.

## Out of scope (per operator's spec)

- Cap NOT added to the `create_agent` handler — operator spec scoped to the bridge soul-update path specifically. The web modal submits full profile.md via create_agent (not just the soul); a soul-cap there would need profile-section parsing. Worth a follow-up if operator wants belt-and-suspenders on all write paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)