### PR TITLE
fix(PUF-265): capture RefreshOutcome + flip runtime.health=refresh_broken on streak [P0 defensive]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,31 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   + raw API error. No ``api_error_abandoned`` flip — request-too-large
   is a permanent input-side failure class, not a transient.
 
+- **PUF-265: ``CredentialRefresher`` no longer silently runs on a dead
+  refresh mechanism.** ``_refresh_now`` used to call
+  ``await self.backend.refresh()`` without capturing the returned
+  ``RefreshOutcome``, so the "claude exited 0 but expiresAt didn't
+  advance" case (UNCHANGED) fell through unnoticed. The daemon went
+  back to its 2-minute poll loop, ``runtime.health`` stayed
+  ``"unknown"`` fleet-wide, and operators only noticed once individual
+  agents 401'd hours later.
+
+  ``_refresh_now`` now captures the outcome (exception → ``FAILED``)
+  and feeds ``_propagate_outcome``, which tracks a consecutive
+  non-success streak. After ``REFRESH_BROKEN_THRESHOLD = 2`` ticks
+  (~4 min @ 120s poll), every registered agent's ``runtime.health``
+  flips to ``"refresh_broken"`` with an operator-actionable error
+  (``"Run `claude /login` then `puffo-agent agent resume <id>`"``).
+  Cleared unconditionally on the next REFRESHED tick — daemon
+  restarts can still unstick agents stuck on the previous instance's
+  flipped state. Does not overwrite ``"auth_failed"`` /
+  ``"api_error_abandoned"`` (stronger downstream signals; same
+  operator recovery). ``agent list`` surfaces ``[refresh_broken]``.
+
+  ``FileBackend``'s UNCHANGED branch dumps stdout + stderr tails
+  (400 chars each) at ERROR level for forensic discrimination of the
+  underlying root cause.
+
 - **Codex agent archive/delete failing with ``Permission denied`` on
   ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an
   exclusive file lock on ``.codex/tmp/arg0/codex-<id>/.lock`` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,21 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   (400 chars each) at ERROR level for forensic discrimination of the
   underlying root cause.
 
+  v2 hardening (post-2026-05-29 09:08 UTC Anthropic-side rate-limit
+  incident): the refresh probe is now pinned to ``claude-haiku-4-5``
+  via ``--model`` (Haiku has higher per-model limits than the
+  operator's interactive Opus/Sonnet default, so the probe stops
+  fighting model-specific rate windows). A new
+  ``RefreshOutcome.RATE_LIMITED`` variant is returned when the
+  probe's stderr/stdout matches a canonical Anthropic rate-limit
+  signature (six anchored patterns: 429 / "temporarily limiting
+  requests" / ``rate_limit_error`` / 5h-quota / 529 overloaded).
+  RATE_LIMITED counts toward the refresh_broken streak (same as
+  FAILED — the rotation really didn't happen) AND schedules a
+  randomised ``[5, 15]`` s fast retry via ``_refresh_request.set()``
+  instead of parking on the natural 120s poll. Back-to-back
+  rate-limit hits coalesce into one pending retry task.
+
 - **Codex agent archive/delete failing with ``Permission denied`` on
   ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an
   exclusive file lock on ``.codex/tmp/arg0/codex-<id>/.lock`` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   instead of parking on the natural 120s poll. Back-to-back
   rate-limit hits coalesce into one pending retry task.
 
+  Model deprecation defence: a hardcoded ``REFRESH_PROBE_MODEL``
+  would silently break the day Anthropic retires Haiku 4.5. A
+  ``_probe_model_disabled`` module-level latch detects four
+  ``model_not_found`` surfaces in the probe stderr/stdout
+  (``"type":"not_found_error"`` + ``model`` / ``model not found`` /
+  ``model_not_found`` / ``invalid model`` / ``model X does not exist
+  | is not available | unknown``) and on first hit drops ``--model``
+  from subsequent probes, letting claude pick its current default.
+  The first tick after a deprecation counts as FAILED (streak=1),
+  the next tick succeeds with the default and resets — no spurious
+  ``refresh_broken`` flip. Operator can also override the constant
+  via ``PUFFO_AGENT_REFRESH_MODEL`` env var without a release.
+
 - **Codex agent archive/delete failing with ``Permission denied`` on
   ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an
   exclusive file lock on ``.codex/tmp/arg0/codex-<id>/.lock`` for the

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -528,7 +528,9 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
         # Surface non-ok health alongside lifecycle status so the
         # operator can see at a glance which agents need
         # re-auth or refresh/restart.
-        if rs is not None and rs.health in ("auth_failed", "api_error_abandoned"):
+        if rs is not None and rs.health in (
+            "auth_failed", "api_error_abandoned", "refresh_broken",
+        ):
             runtime = f"{runtime} [{rs.health}]"
         # Truncate display_name for table alignment.
         display = (ac.display_name or aid)

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -68,6 +68,13 @@ REFRESH_POLL_SECONDS = 120
 REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 
+# PUF-265: how many consecutive non-success refresh outcomes
+# (UNCHANGED | FAILED) before flipping registered agents'
+# ``runtime.health`` to ``"refresh_broken"``. 2 = ~4 min of dead refresh
+# at the 120s poll cadence; small enough to surface fast, large enough
+# that a single transient subprocess hiccup doesn't false-positive.
+REFRESH_BROKEN_THRESHOLD = 2
+
 # Codex's OAuth access_token is a JWT — the only authoritative expiry
 # is the ``exp`` claim inside the token. Codex's own ``last_refresh``
 # field uses an ~8-day staleness heuristic that's too coarse for our
@@ -213,12 +220,18 @@ class FileBackend:
             )
             return RefreshOutcome.FAILED
         if before is not None and after is not None and after <= before:
+            # PUF-265: dump stdout/stderr on UNCHANGED so the real-fix
+            # PR can discriminate sub-hypothesis 2a (claude CLI stopped
+            # rotating under --print) from 2b (Linux-specific writeback
+            # path failure) from a single in-the-wild event.
+            err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
+            out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
             logger.error(
                 "credential refresh exit=0 but expiresAt didn't advance "
-                "(before=%ds, after=%ds) — claude may not be rewriting "
-                "credentials.json on this build; operator may need "
-                "`claude /login` to recover",
-                before, after,
+                "(before=%ds, after=%ds) in %.1fs — claude may not be "
+                "rewriting credentials.json on this build; operator may "
+                "need `claude /login` to recover | stdout: %s | stderr: %s",
+                before, after, elapsed, out_tail, err_tail,
             )
             return RefreshOutcome.UNCHANGED
         logger.info(
@@ -630,6 +643,11 @@ class CredentialRefresher:
         self._agent_homes: set[Path] = set()
         self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
+        # PUF-265: consecutive UNCHANGED|FAILED outcome streak. Resets
+        # on the next REFRESHED outcome. Used to gate the
+        # ``runtime.health="refresh_broken"`` flip so a single
+        # transient hiccup doesn't false-positive registered agents.
+        self._consecutive_non_success = 0
 
     def register_agent(self, agent_home: Path) -> None:
         self._agent_homes.add(Path(agent_home))
@@ -802,8 +820,86 @@ class CredentialRefresher:
             except Exception as exc:
                 logger.warning("backend refresh errored: %s", exc)
                 outcome = RefreshOutcome.FAILED
+            self._propagate_outcome(outcome)
         if outcome is RefreshOutcome.REFRESHED:
             self._fire_refresh_success()
+
+    def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
+        """PUF-265: track consecutive non-success outcomes and surface
+        ``runtime.health="refresh_broken"`` on every registered agent
+        once the streak hits ``REFRESH_BROKEN_THRESHOLD``. Cleared by
+        the next REFRESHED outcome. Does not overwrite ``auth_failed``
+        / ``api_error_abandoned`` — those are stronger downstream
+        signals and the operator's recovery action (``claude /login``
+        then ``agent resume``) is identical."""
+        if outcome is RefreshOutcome.REFRESHED:
+            if self._consecutive_non_success > 0:
+                logger.info(
+                    "credential refresh recovered after %d non-success "
+                    "tick(s) — clearing refresh_broken health on "
+                    "registered agents",
+                    self._consecutive_non_success,
+                )
+                self._clear_refresh_broken()
+            self._consecutive_non_success = 0
+            return
+        self._consecutive_non_success += 1
+        if self._consecutive_non_success >= REFRESH_BROKEN_THRESHOLD:
+            self._flip_refresh_broken(outcome)
+
+    def _flip_refresh_broken(self, outcome: RefreshOutcome) -> None:
+        from .state import RuntimeState
+        msg = (
+            f"daemon CredentialRefresher saw {self._consecutive_non_success} "
+            f"consecutive {outcome.value} outcome(s); on-disk token isn't "
+            f"advancing. Run `claude /login` then "
+            f"`puffo-agent agent resume <id>` to recover."
+        )
+        for agent_home in self._agent_homes:
+            agent_id = Path(agent_home).name
+            try:
+                rs = RuntimeState.load(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "refresh_broken flip: failed to load runtime for %s: %s",
+                    agent_id, exc,
+                )
+                continue
+            if rs is None:
+                continue
+            if rs.health in ("auth_failed", "api_error_abandoned"):
+                continue
+            if rs.health == "refresh_broken":
+                continue
+            rs.health = "refresh_broken"
+            rs.error = msg
+            try:
+                rs.save(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "refresh_broken flip: failed to save runtime for %s: %s",
+                    agent_id, exc,
+                )
+
+    def _clear_refresh_broken(self) -> None:
+        from .state import RuntimeState
+        for agent_home in self._agent_homes:
+            agent_id = Path(agent_home).name
+            try:
+                rs = RuntimeState.load(agent_id)
+            except Exception:
+                continue
+            if rs is None or rs.health != "refresh_broken":
+                continue
+            rs.health = "ok"
+            rs.error = ""
+            try:
+                rs.save(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "refresh_broken clear: failed to save runtime for %s: %s",
+                    agent_id, exc,
+                )
 
     def _sync_views(self) -> None:
         """Mirror canonical credentials to every registered agent."""

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -53,6 +53,8 @@ import enum
 import json
 import logging
 import os
+import random
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -69,8 +71,53 @@ REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 
 # 2 ticks ≈ 4 min @ 120s poll: surfaces fast, doesn't false-positive on
-# a single transient subprocess hiccup.
+# a single transient subprocess hiccup. RATE_LIMITED also contributes.
 REFRESH_BROKEN_THRESHOLD = 2
+
+# PUF-265 v2: refresh probe model. The refresh subprocess just needs
+# to make ANY successful API call so Anthropic's auth layer rotates
+# the OAuth token; the model doesn't matter for the rotation itself.
+# Defaulting to the cheapest current model (Haiku 4.5) instead of the
+# operator's interactive default (typically Opus) makes the probe
+# (a) cheaper per call, and (b) less likely to hit per-model rate
+# limits during high-usage windows.
+REFRESH_PROBE_MODEL = "claude-haiku-4-5"
+
+# PUF-265 v2: when the refresh probe fails specifically because
+# Anthropic rate-limited us, the normal 120s poll wait is wasteful —
+# rate limits typically clear in seconds, not minutes. Wake the
+# refresher loop after a short randomised delay so we re-try sooner
+# without hammering. Window is small (5-15s) so we don't synchronise
+# multiple post-rate-limit retries across the fleet.
+RATE_LIMIT_FAST_RETRY_MIN_SECONDS = 5.0
+RATE_LIMIT_FAST_RETRY_MAX_SECONDS = 15.0
+
+# Patterns matched against the refresh subprocess's stderr+stdout
+# tails. Verbatim canonical Anthropic rate-limit signals + the
+# Claude Code wrapper's most-common surfaces. Anchored / unambiguous
+# tokens only — avoid generic "429" / "limit" which would false-
+# positive on legitimate model output (Haiku probe replies are short
+# but not infallibly clean).
+_RATE_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bAPI Error: Request rejected \(429\)", re.IGNORECASE),
+    re.compile(r"\bServer is temporarily limiting requests\b", re.IGNORECASE),
+    re.compile(r"\brate[_ -]limit[_ -]error\b", re.IGNORECASE),
+    re.compile(r'"type"\s*:\s*"rate_limit_error"', re.IGNORECASE),
+    re.compile(r"\bYou've hit your\b.*?\blimit\b", re.IGNORECASE),
+    re.compile(r"\bRepeated 529 Overloaded errors\b", re.IGNORECASE),
+)
+
+
+def _looks_like_rate_limit(out_tail: str, err_tail: str) -> bool:
+    """True iff the refresh subprocess output matches one of the
+    canonical Anthropic rate-limit signatures. Drives the fast-retry
+    path so a transient rate-limit doesn't park the refresher on a
+    full 120s wait."""
+    combined = f"{out_tail}\n{err_tail}"
+    for pattern in _RATE_LIMIT_PATTERNS:
+        if pattern.search(combined):
+            return True
+    return False
 
 # Codex's OAuth access_token is a JWT — the only authoritative expiry
 # is the ``exp`` claim inside the token. Codex's own ``last_refresh``
@@ -106,6 +153,16 @@ class RefreshOutcome(enum.Enum):
     REFRESHED = "refreshed"
     UNCHANGED = "unchanged"
     FAILED = "failed"
+    # PUF-265 v2: ``FAILED`` whose stderr/stdout matches a canonical
+    # Anthropic rate-limit signature. Counts toward the
+    # ``refresh_broken`` streak the same as ``FAILED`` (the refresh
+    # really didn't happen) but additionally schedules a fast retry
+    # via ``RATE_LIMIT_FAST_RETRY_{MIN,MAX}_SECONDS`` rather than
+    # parking on the full ``REFRESH_POLL_SECONDS`` wait — rate limits
+    # typically clear in seconds, and the refresher waking back up
+    # within 5-15s rather than 2 min materially shrinks the
+    # operator-observable outage when a momentary throttle clears.
+    RATE_LIMITED = "rate_limited"
 
 
 class CredentialBackend(Protocol):
@@ -171,8 +228,15 @@ class FileBackend:
     async def refresh(self) -> RefreshOutcome:
         before = self.expires_in_seconds()
         env = {**os.environ, "HOME": str(self.host_home)}
+        # PUF-265 v2: ``--model`` pins the probe to the cheapest current
+        # Claude (Haiku 4.5) so it doesn't fight per-model rate limits on
+        # the operator's interactive default (Opus / Sonnet) during
+        # high-usage windows. Any successful response refreshes the
+        # OAuth token regardless of model — model choice is a probe-cost
+        # decision, not a correctness one.
         cmd = [
             "claude", "--dangerously-skip-permissions",
+            "--model", REFRESH_PROBE_MODEL,
             "--print", "--max-turns", "1",
             "--output-format", "stream-json", "--verbose",
             "ok",
@@ -211,6 +275,13 @@ class FileBackend:
         if proc.returncode != 0:
             err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
             out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
+            if _looks_like_rate_limit(out_tail, err_tail):
+                logger.warning(
+                    "credential refresh rate-limited rc=%d in %.1fs | "
+                    "stdout: %s | stderr: %s",
+                    proc.returncode, elapsed, out_tail, err_tail,
+                )
+                return RefreshOutcome.RATE_LIMITED
             logger.warning(
                 "credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
                 proc.returncode, elapsed, out_tail, err_tail,
@@ -458,8 +529,11 @@ class KeychainBackend:
         # UX) instead of wherever the daemon was launched from.
         host_home = Path.home()
         env = {**os.environ, "HOME": str(host_home)}
+        # PUF-265 v2: same model-pin rationale as ``FileBackend.refresh``
+        # — Haiku to dodge per-model rate-limit windows on Opus/Sonnet.
         cmd = [
             "claude", "--dangerously-skip-permissions",
+            "--model", REFRESH_PROBE_MODEL,
             "--print", "--max-turns", "1",
             "--output-format", "stream-json", "--verbose",
             "ok",
@@ -493,6 +567,13 @@ class KeychainBackend:
         if proc.returncode != 0:
             err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
             out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
+            if _looks_like_rate_limit(out_tail, err_tail):
+                logger.warning(
+                    "claude credential refresh rate-limited rc=%d in %.1fs "
+                    "| stdout: %s | stderr: %s",
+                    proc.returncode, elapsed, out_tail, err_tail,
+                )
+                return RefreshOutcome.RATE_LIMITED
             logger.warning(
                 "claude credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
                 proc.returncode, elapsed, out_tail, err_tail,
@@ -637,6 +718,9 @@ class CredentialRefresher:
         self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
+        # In-flight fast-retry task spawned on a RATE_LIMITED outcome.
+        # Tracked so back-to-back hits coalesce (no pile-up).
+        self._rate_limit_retry_task: asyncio.Task | None = None
 
     def register_agent(self, agent_home: Path) -> None:
         self._agent_homes.add(Path(agent_home))
@@ -814,6 +898,9 @@ class CredentialRefresher:
             self._fire_refresh_success()
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
+        # RATE_LIMITED counts toward the refresh_broken streak (same
+        # as FAILED) AND schedules a fast retry so the loop doesn't
+        # park on the full 120s wait when the throttle clears.
         if outcome is RefreshOutcome.REFRESHED:
             if self._consecutive_non_success > 0:
                 logger.info(
@@ -832,6 +919,44 @@ class CredentialRefresher:
         self._consecutive_non_success += 1
         if self._consecutive_non_success >= REFRESH_BROKEN_THRESHOLD:
             self._flip_refresh_broken(outcome)
+        if outcome is RefreshOutcome.RATE_LIMITED:
+            self._schedule_rate_limit_retry()
+
+    def _schedule_rate_limit_retry(self) -> None:
+        """Spawn a background task that pings ``_refresh_request`` after
+        a randomised ``[5, 15]`` s delay so the next refresh attempt
+        fires before the natural 120s poll deadline. Multiple
+        concurrent rate-limit hits coalesce into one pending retry —
+        we don't pile up tasks if every poll keeps hitting the limit."""
+        existing = self._rate_limit_retry_task
+        if existing is not None and not existing.done():
+            return
+        delay = random.uniform(
+            RATE_LIMIT_FAST_RETRY_MIN_SECONDS,
+            RATE_LIMIT_FAST_RETRY_MAX_SECONDS,
+        )
+        logger.info(
+            "credential refresh rate-limited — scheduling fast retry "
+            "in %.1fs (vs. %ds natural poll)",
+            delay, REFRESH_POLL_SECONDS,
+        )
+
+        async def _retry() -> None:
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+            self._refresh_request.set()
+
+        coro = _retry()
+        try:
+            self._rate_limit_retry_task = asyncio.create_task(coro)
+        except RuntimeError:
+            # No running loop yet — happens in some unit-test paths.
+            # Close the coroutine cleanly (no "never awaited" warning)
+            # and rely on the natural poll to pick the retry up.
+            coro.close()
+            self._rate_limit_retry_task = None
 
     def _flip_refresh_broken(self, outcome: RefreshOutcome) -> None:
         from .state import RuntimeState

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -71,33 +71,18 @@ REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 
 # 2 ticks ≈ 4 min @ 120s poll: surfaces fast, doesn't false-positive on
-# a single transient subprocess hiccup. RATE_LIMITED also contributes.
+# a single transient subprocess hiccup.
 REFRESH_BROKEN_THRESHOLD = 2
 
-# PUF-265 v2: refresh probe model. The refresh subprocess just needs
-# to make ANY successful API call so Anthropic's auth layer rotates
-# the OAuth token; the model doesn't matter for the rotation itself.
-# Defaulting to the cheapest current model (Haiku 4.5) instead of the
-# operator's interactive default (typically Opus) makes the probe
-# (a) cheaper per call, and (b) less likely to hit per-model rate
-# limits during high-usage windows.
+# Haiku to dodge per-model rate-limit windows on operator's Opus/Sonnet.
 REFRESH_PROBE_MODEL = "claude-haiku-4-5"
 
-# PUF-265 v2: when the refresh probe fails specifically because
-# Anthropic rate-limited us, the normal 120s poll wait is wasteful —
-# rate limits typically clear in seconds, not minutes. Wake the
-# refresher loop after a short randomised delay so we re-try sooner
-# without hammering. Window is small (5-15s) so we don't synchronise
-# multiple post-rate-limit retries across the fleet.
+# 5-15s randomised so fleet retries don't synchronise post rate-limit.
 RATE_LIMIT_FAST_RETRY_MIN_SECONDS = 5.0
 RATE_LIMIT_FAST_RETRY_MAX_SECONDS = 15.0
 
-# Patterns matched against the refresh subprocess's stderr+stdout
-# tails. Verbatim canonical Anthropic rate-limit signals + the
-# Claude Code wrapper's most-common surfaces. Anchored / unambiguous
-# tokens only — avoid generic "429" / "limit" which would false-
-# positive on legitimate model output (Haiku probe replies are short
-# but not infallibly clean).
+# Anchored tokens only — avoid generic "429" / "limit" which would false-
+# positive on legitimate Haiku output.
 _RATE_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bAPI Error: Request rejected \(429\)", re.IGNORECASE),
     re.compile(r"\bServer is temporarily limiting requests\b", re.IGNORECASE),
@@ -109,15 +94,25 @@ _RATE_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 
 def _looks_like_rate_limit(out_tail: str, err_tail: str) -> bool:
-    """True iff the refresh subprocess output matches one of the
-    canonical Anthropic rate-limit signatures. Drives the fast-retry
-    path so a transient rate-limit doesn't park the refresher on a
-    full 120s wait."""
     combined = f"{out_tail}\n{err_tail}"
-    for pattern in _RATE_LIMIT_PATTERNS:
-        if pattern.search(combined):
-            return True
-    return False
+    return any(p.search(combined) for p in _RATE_LIMIT_PATTERNS)
+
+
+def _classify_failed_refresh(
+    out_tail: str, err_tail: str, *, rc: int, elapsed: float, log_prefix: str,
+) -> RefreshOutcome:
+    # Shared rc!=0 classification used by FileBackend + KeychainBackend.
+    if _looks_like_rate_limit(out_tail, err_tail):
+        logger.warning(
+            "%s rate-limited rc=%d in %.1fs | stdout: %s | stderr: %s",
+            log_prefix, rc, elapsed, out_tail, err_tail,
+        )
+        return RefreshOutcome.RATE_LIMITED
+    logger.warning(
+        "%s rc=%d in %.1fs | stdout: %s | stderr: %s",
+        log_prefix, rc, elapsed, out_tail, err_tail,
+    )
+    return RefreshOutcome.FAILED
 
 # Codex's OAuth access_token is a JWT — the only authoritative expiry
 # is the ``exp`` claim inside the token. Codex's own ``last_refresh``
@@ -153,15 +148,8 @@ class RefreshOutcome(enum.Enum):
     REFRESHED = "refreshed"
     UNCHANGED = "unchanged"
     FAILED = "failed"
-    # PUF-265 v2: ``FAILED`` whose stderr/stdout matches a canonical
-    # Anthropic rate-limit signature. Counts toward the
-    # ``refresh_broken`` streak the same as ``FAILED`` (the refresh
-    # really didn't happen) but additionally schedules a fast retry
-    # via ``RATE_LIMIT_FAST_RETRY_{MIN,MAX}_SECONDS`` rather than
-    # parking on the full ``REFRESH_POLL_SECONDS`` wait — rate limits
-    # typically clear in seconds, and the refresher waking back up
-    # within 5-15s rather than 2 min materially shrinks the
-    # operator-observable outage when a momentary throttle clears.
+    # Counts toward refresh_broken streak like FAILED but additionally
+    # schedules a fast retry (RATE_LIMIT_FAST_RETRY_{MIN,MAX}_SECONDS).
     RATE_LIMITED = "rate_limited"
 
 
@@ -228,12 +216,6 @@ class FileBackend:
     async def refresh(self) -> RefreshOutcome:
         before = self.expires_in_seconds()
         env = {**os.environ, "HOME": str(self.host_home)}
-        # PUF-265 v2: ``--model`` pins the probe to the cheapest current
-        # Claude (Haiku 4.5) so it doesn't fight per-model rate limits on
-        # the operator's interactive default (Opus / Sonnet) during
-        # high-usage windows. Any successful response refreshes the
-        # OAuth token regardless of model — model choice is a probe-cost
-        # decision, not a correctness one.
         cmd = [
             "claude", "--dangerously-skip-permissions",
             "--model", REFRESH_PROBE_MODEL,
@@ -275,18 +257,10 @@ class FileBackend:
         if proc.returncode != 0:
             err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
             out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
-            if _looks_like_rate_limit(out_tail, err_tail):
-                logger.warning(
-                    "credential refresh rate-limited rc=%d in %.1fs | "
-                    "stdout: %s | stderr: %s",
-                    proc.returncode, elapsed, out_tail, err_tail,
-                )
-                return RefreshOutcome.RATE_LIMITED
-            logger.warning(
-                "credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
-                proc.returncode, elapsed, out_tail, err_tail,
+            return _classify_failed_refresh(
+                out_tail, err_tail, rc=proc.returncode, elapsed=elapsed,
+                log_prefix="credential refresh",
             )
-            return RefreshOutcome.FAILED
         if before is not None and after is not None and after <= before:
             err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
             out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
@@ -529,8 +503,6 @@ class KeychainBackend:
         # UX) instead of wherever the daemon was launched from.
         host_home = Path.home()
         env = {**os.environ, "HOME": str(host_home)}
-        # PUF-265 v2: same model-pin rationale as ``FileBackend.refresh``
-        # — Haiku to dodge per-model rate-limit windows on Opus/Sonnet.
         cmd = [
             "claude", "--dangerously-skip-permissions",
             "--model", REFRESH_PROBE_MODEL,
@@ -567,18 +539,10 @@ class KeychainBackend:
         if proc.returncode != 0:
             err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
             out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
-            if _looks_like_rate_limit(out_tail, err_tail):
-                logger.warning(
-                    "claude credential refresh rate-limited rc=%d in %.1fs "
-                    "| stdout: %s | stderr: %s",
-                    proc.returncode, elapsed, out_tail, err_tail,
-                )
-                return RefreshOutcome.RATE_LIMITED
-            logger.warning(
-                "claude credential refresh rc=%d in %.1fs | stdout: %s | stderr: %s",
-                proc.returncode, elapsed, out_tail, err_tail,
+            return _classify_failed_refresh(
+                out_tail, err_tail, rc=proc.returncode, elapsed=elapsed,
+                log_prefix="claude credential refresh",
             )
-            return RefreshOutcome.FAILED
 
         # Pull the post-refresh blob straight from Keychain — that's
         # where claude wrote it. Then sync our cache so agent fan-out
@@ -718,8 +682,6 @@ class CredentialRefresher:
         self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
-        # In-flight fast-retry task spawned on a RATE_LIMITED outcome.
-        # Tracked so back-to-back hits coalesce (no pile-up).
         self._rate_limit_retry_task: asyncio.Task | None = None
 
     def register_agent(self, agent_home: Path) -> None:
@@ -898,9 +860,6 @@ class CredentialRefresher:
             self._fire_refresh_success()
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
-        # RATE_LIMITED counts toward the refresh_broken streak (same
-        # as FAILED) AND schedules a fast retry so the loop doesn't
-        # park on the full 120s wait when the throttle clears.
         if outcome is RefreshOutcome.REFRESHED:
             if self._consecutive_non_success > 0:
                 logger.info(
@@ -923,11 +882,7 @@ class CredentialRefresher:
             self._schedule_rate_limit_retry()
 
     def _schedule_rate_limit_retry(self) -> None:
-        """Spawn a background task that pings ``_refresh_request`` after
-        a randomised ``[5, 15]`` s delay so the next refresh attempt
-        fires before the natural 120s poll deadline. Multiple
-        concurrent rate-limit hits coalesce into one pending retry —
-        we don't pile up tasks if every poll keeps hitting the limit."""
+        # Coalesce: back-to-back rate-limit hits share one pending retry.
         existing = self._rate_limit_retry_task
         if existing is not None and not existing.done():
             return
@@ -952,9 +907,7 @@ class CredentialRefresher:
         try:
             self._rate_limit_retry_task = asyncio.create_task(coro)
         except RuntimeError:
-            # No running loop yet — happens in some unit-test paths.
-            # Close the coroutine cleanly (no "never awaited" warning)
-            # and rely on the natural poll to pick the retry up.
+            # No running loop (sync test path) — fall back to natural poll.
             coro.close()
             self._rate_limit_retry_task = None
 

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -75,7 +75,15 @@ REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 REFRESH_BROKEN_THRESHOLD = 2
 
 # Haiku to dodge per-model rate-limit windows on operator's Opus/Sonnet.
-REFRESH_PROBE_MODEL = "claude-haiku-4-5"
+# Override via env or auto-disable on model_not_found (see _probe_model_disabled).
+REFRESH_PROBE_MODEL = os.environ.get(
+    "PUFFO_AGENT_REFRESH_MODEL", "claude-haiku-4-5",
+)
+
+# Module-level latch: set True on the first ``model_not_found`` response,
+# then probes drop ``--model`` and use claude's default. Daemon restart
+# resets — fine, the worst case is one extra failed tick before re-latching.
+_probe_model_disabled = False
 
 # 5-15s randomised so fleet retries don't synchronise post rate-limit.
 RATE_LIMIT_FAST_RETRY_MIN_SECONDS = 5.0
@@ -92,16 +100,65 @@ _RATE_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bRepeated 529 Overloaded errors\b", re.IGNORECASE),
 )
 
+# Anthropic surfaces for "model not found / not available". Anchored on
+# the word ``model`` so we don't latch on generic "not_found" (e.g. a
+# 404 from a different endpoint should not disable the probe model).
+_MODEL_NOT_FOUND_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r'"type"\s*:\s*"not_found_error".*?\bmodel\b', re.IGNORECASE),
+    re.compile(r"\bmodel[_ -]+not[_ -]found\b", re.IGNORECASE),
+    re.compile(r"\binvalid[_ -]model\b", re.IGNORECASE),
+    re.compile(r"\bmodel\b.*?\b(?:does not exist|is not available|unknown)\b", re.IGNORECASE),
+)
+
 
 def _looks_like_rate_limit(out_tail: str, err_tail: str) -> bool:
     combined = f"{out_tail}\n{err_tail}"
     return any(p.search(combined) for p in _RATE_LIMIT_PATTERNS)
 
 
+def _looks_like_model_not_found(out_tail: str, err_tail: str) -> bool:
+    combined = f"{out_tail}\n{err_tail}"
+    return any(p.search(combined) for p in _MODEL_NOT_FOUND_PATTERNS)
+
+
+def _build_probe_cmd() -> list[str]:
+    # Drops --model after the latch trips (model_not_found in stderr).
+    # Shared by FileBackend + KeychainBackend.
+    cmd = ["claude", "--dangerously-skip-permissions"]
+    if not _probe_model_disabled:
+        cmd.extend(["--model", REFRESH_PROBE_MODEL])
+    cmd.extend([
+        "--print", "--max-turns", "1",
+        "--output-format", "stream-json", "--verbose",
+        "ok",
+    ])
+    return cmd
+
+
+def _maybe_disable_probe_model(out_tail: str, err_tail: str) -> None:
+    global _probe_model_disabled
+    if _probe_model_disabled:
+        return
+    if not _looks_like_model_not_found(out_tail, err_tail):
+        return
+    _probe_model_disabled = True
+    logger.warning(
+        "credential refresh probe: model %r not available — falling back "
+        "to claude's default for subsequent probes. Update "
+        "REFRESH_PROBE_MODEL (or set PUFFO_AGENT_REFRESH_MODEL env) to a "
+        "current cheap model when convenient.",
+        REFRESH_PROBE_MODEL,
+    )
+
+
 def _classify_failed_refresh(
     out_tail: str, err_tail: str, *, rc: int, elapsed: float, log_prefix: str,
 ) -> RefreshOutcome:
     # Shared rc!=0 classification used by FileBackend + KeychainBackend.
+    # Model-not-found check first: it's a permanent (per-daemon-life)
+    # state change, so it should latch even when the response also
+    # happens to look rate-limit-shaped.
+    _maybe_disable_probe_model(out_tail, err_tail)
     if _looks_like_rate_limit(out_tail, err_tail):
         logger.warning(
             "%s rate-limited rc=%d in %.1fs | stdout: %s | stderr: %s",
@@ -216,13 +273,7 @@ class FileBackend:
     async def refresh(self) -> RefreshOutcome:
         before = self.expires_in_seconds()
         env = {**os.environ, "HOME": str(self.host_home)}
-        cmd = [
-            "claude", "--dangerously-skip-permissions",
-            "--model", REFRESH_PROBE_MODEL,
-            "--print", "--max-turns", "1",
-            "--output-format", "stream-json", "--verbose",
-            "ok",
-        ]
+        cmd = _build_probe_cmd()
         started = time.time()
         try:
             # cwd=host_home so claude's project-resolution doesn't
@@ -503,13 +554,7 @@ class KeychainBackend:
         # UX) instead of wherever the daemon was launched from.
         host_home = Path.home()
         env = {**os.environ, "HOME": str(host_home)}
-        cmd = [
-            "claude", "--dangerously-skip-permissions",
-            "--model", REFRESH_PROBE_MODEL,
-            "--print", "--max-turns", "1",
-            "--output-format", "stream-json", "--verbose",
-            "ok",
-        ]
+        cmd = _build_probe_cmd()
         started = time.time()
         try:
             proc = await asyncio.create_subprocess_exec(

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -840,7 +840,15 @@ class CredentialRefresher:
                     "registered agents",
                     self._consecutive_non_success,
                 )
-                self._clear_refresh_broken()
+            # PR #52 review: always clear on success — not just when the
+            # in-memory streak was non-zero. A daemon restart after the
+            # flip resets the counter to 0 while leaving the disk-state
+            # ``refresh_broken``; without the unconditional clear, the
+            # next successful refresh would never unstick those agents.
+            # ``_clear_refresh_broken`` is idempotent (per-agent guard on
+            # ``rs.health != "refresh_broken"``) so the always-call is
+            # cheap when there's nothing to clear.
+            self._clear_refresh_broken()
             self._consecutive_non_success = 0
             return
         self._consecutive_non_success += 1

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -68,11 +68,8 @@ REFRESH_POLL_SECONDS = 120
 REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
 
-# PUF-265: how many consecutive non-success refresh outcomes
-# (UNCHANGED | FAILED) before flipping registered agents'
-# ``runtime.health`` to ``"refresh_broken"``. 2 = ~4 min of dead refresh
-# at the 120s poll cadence; small enough to surface fast, large enough
-# that a single transient subprocess hiccup doesn't false-positive.
+# 2 ticks ≈ 4 min @ 120s poll: surfaces fast, doesn't false-positive on
+# a single transient subprocess hiccup.
 REFRESH_BROKEN_THRESHOLD = 2
 
 # Codex's OAuth access_token is a JWT — the only authoritative expiry
@@ -220,10 +217,6 @@ class FileBackend:
             )
             return RefreshOutcome.FAILED
         if before is not None and after is not None and after <= before:
-            # PUF-265: dump stdout/stderr on UNCHANGED so the real-fix
-            # PR can discriminate sub-hypothesis 2a (claude CLI stopped
-            # rotating under --print) from 2b (Linux-specific writeback
-            # path failure) from a single in-the-wild event.
             err_tail = stderr.decode("utf-8", errors="replace").strip()[-400:]
             out_tail = stdout.decode("utf-8", errors="replace").strip()[-400:]
             logger.error(
@@ -643,10 +636,6 @@ class CredentialRefresher:
         self._agent_homes: set[Path] = set()
         self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
-        # PUF-265: consecutive UNCHANGED|FAILED outcome streak. Resets
-        # on the next REFRESHED outcome. Used to gate the
-        # ``runtime.health="refresh_broken"`` flip so a single
-        # transient hiccup doesn't false-positive registered agents.
         self._consecutive_non_success = 0
 
     def register_agent(self, agent_home: Path) -> None:
@@ -825,13 +814,6 @@ class CredentialRefresher:
             self._fire_refresh_success()
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
-        """PUF-265: track consecutive non-success outcomes and surface
-        ``runtime.health="refresh_broken"`` on every registered agent
-        once the streak hits ``REFRESH_BROKEN_THRESHOLD``. Cleared by
-        the next REFRESHED outcome. Does not overwrite ``auth_failed``
-        / ``api_error_abandoned`` — those are stronger downstream
-        signals and the operator's recovery action (``claude /login``
-        then ``agent resume``) is identical."""
         if outcome is RefreshOutcome.REFRESHED:
             if self._consecutive_non_success > 0:
                 logger.info(
@@ -840,14 +822,10 @@ class CredentialRefresher:
                     "registered agents",
                     self._consecutive_non_success,
                 )
-            # PR #52 review: always clear on success — not just when the
-            # in-memory streak was non-zero. A daemon restart after the
-            # flip resets the counter to 0 while leaving the disk-state
-            # ``refresh_broken``; without the unconditional clear, the
-            # next successful refresh would never unstick those agents.
-            # ``_clear_refresh_broken`` is idempotent (per-agent guard on
-            # ``rs.health != "refresh_broken"``) so the always-call is
-            # cheap when there's nothing to clear.
+            # Always clear: a daemon restart resets the in-memory counter
+            # to 0 while leaving on-disk ``refresh_broken`` from the
+            # previous instance — without the unconditional call those
+            # agents stay stuck. _clear_refresh_broken is idempotent.
             self._clear_refresh_broken()
             self._consecutive_non_success = 0
             return
@@ -875,9 +853,9 @@ class CredentialRefresher:
                 continue
             if rs is None:
                 continue
-            if rs.health in ("auth_failed", "api_error_abandoned"):
-                continue
-            if rs.health == "refresh_broken":
+            if rs.health in (
+                "auth_failed", "api_error_abandoned", "refresh_broken",
+            ):
                 continue
             rs.health = "refresh_broken"
             rs.error = msg

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1085,8 +1085,17 @@ class RuntimeState:
     #   "api_error_abandoned" — kick-retry exhausted, batch silently
     #                           abandoned; cleared on next successful turn
     #                           (PUF-255's on_turn_success lane)
+    #   "refresh_broken"      — PUF-265: daemon's CredentialRefresher
+    #                           saw N consecutive UNCHANGED/FAILED
+    #                           outcomes; soft upstream signal that the
+    #                           on-disk token isn't advancing, ahead of
+    #                           the eventual 401 → ``auth_failed`` flip.
+    #                           Cleared by the next REFRESHED tick. Does
+    #                           NOT overwrite ``auth_failed`` /
+    #                           ``api_error_abandoned`` (those are
+    #                           stronger downstream signals).
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | auth_failed | api_error_abandoned | unknown
+    health: str = "unknown"  # ok | auth_failed | api_error_abandoned | refresh_broken | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> "RuntimeState | None":

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1085,15 +1085,10 @@ class RuntimeState:
     #   "api_error_abandoned" — kick-retry exhausted, batch silently
     #                           abandoned; cleared on next successful turn
     #                           (PUF-255's on_turn_success lane)
-    #   "refresh_broken"      — PUF-265: daemon's CredentialRefresher
-    #                           saw N consecutive UNCHANGED/FAILED
-    #                           outcomes; soft upstream signal that the
-    #                           on-disk token isn't advancing, ahead of
-    #                           the eventual 401 → ``auth_failed`` flip.
-    #                           Cleared by the next REFRESHED tick. Does
-    #                           NOT overwrite ``auth_failed`` /
-    #                           ``api_error_abandoned`` (those are
-    #                           stronger downstream signals).
+    #   "refresh_broken"      — daemon saw N consecutive non-success
+    #                           refresh outcomes; cleared by next
+    #                           REFRESHED. Does not overwrite the two
+    #                           stronger downstream signals above.
     #   "unknown"             — no probe yet
     health: str = "unknown"  # ok | auth_failed | api_error_abandoned | refresh_broken | unknown
 

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -22,6 +22,8 @@ from puffo_agent.portal.credential_refresh import (
     CredentialRefresher,
     FileBackend,
     RefreshOutcome,
+    _build_probe_cmd,
+    _looks_like_model_not_found,
     _looks_like_rate_limit,
 )
 
@@ -771,3 +773,140 @@ def test_propagate_outcome_rate_limited_does_not_crash_without_event_loop(
     assert r._rate_limit_retry_task is None
     # Streak counter still advanced.
     assert r._consecutive_non_success == 1
+
+
+# ── model_not_found fallback latch ──────────────────────────────────────
+
+
+def test_looks_like_model_not_found_matches_canonical_signatures():
+    canonicals = [
+        '{"type":"not_found_error","message":"model: claude-haiku-4-5"}',
+        "API Error: model not found",
+        "API Error: model_not_found",
+        "Invalid model 'claude-haiku-4-5'",
+        "Model 'claude-haiku-4-5' does not exist",
+        "Model claude-haiku-4-5 is not available",
+    ]
+    for s in canonicals:
+        assert _looks_like_model_not_found("", s), f"missed canonical: {s!r}"
+    # Generic "not found" elsewhere (e.g. message 404) must NOT match.
+    benign = [
+        "404 not found",
+        "Message not found",
+        "API Error: Request rejected (429)",  # rate-limit, not model
+        "rate_limit_error",
+        "",
+    ]
+    for s in benign:
+        assert not _looks_like_model_not_found("", s), f"false positive: {s!r}"
+
+
+def test_build_probe_cmd_includes_model_by_default(monkeypatch):
+    monkeypatch.setattr(credential_refresh, "_probe_model_disabled", False)
+    cmd = _build_probe_cmd()
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == REFRESH_PROBE_MODEL
+
+
+def test_build_probe_cmd_drops_model_when_latched(monkeypatch):
+    monkeypatch.setattr(credential_refresh, "_probe_model_disabled", True)
+    cmd = _build_probe_cmd()
+    assert "--model" not in cmd
+    # Other args unaffected.
+    assert "--dangerously-skip-permissions" in cmd
+    assert "--print" in cmd
+
+
+def test_filebackend_model_not_found_stderr_latches_probe(tmp_path, monkeypatch):
+    # The first model_not_found in stderr must (a) set the module latch
+    # so subsequent probes drop --model, AND (b) still classify the
+    # outcome as FAILED (counts toward streak; next tick uses default
+    # and should succeed, resetting the streak).
+    monkeypatch.setattr(credential_refresh, "_probe_model_disabled", False)
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    backend = FileBackend(host_home=tmp_path)
+
+    class _Proc:
+        returncode = 1
+        async def communicate(self):
+            return (
+                b"",
+                b'API Error: {"type":"not_found_error","message":"model: claude-haiku-4-5 not found"}\n',
+            )
+
+    async def fake_exec(*argv, **kwargs):
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome is RefreshOutcome.FAILED
+    assert credential_refresh._probe_model_disabled is True
+
+
+def test_rate_limit_stderr_does_not_latch_probe(tmp_path, monkeypatch):
+    # A rate-limit response must NOT latch model-disabled — the model
+    # is fine, just throttled.
+    monkeypatch.setattr(credential_refresh, "_probe_model_disabled", False)
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    backend = FileBackend(host_home=tmp_path)
+
+    class _Proc:
+        returncode = 1
+        async def communicate(self):
+            return b"", b"API Error: Request rejected (429)\n"
+
+    async def fake_exec(*argv, **kwargs):
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    asyncio.run(backend.refresh())
+    assert credential_refresh._probe_model_disabled is False
+
+
+def test_probe_uses_default_model_after_latch_persists_across_calls(
+    tmp_path, monkeypatch,
+):
+    # End-to-end through _tick: after the latch trips on call 1, call 2's
+    # subprocess argv must not include --model.
+    monkeypatch.setattr(credential_refresh, "_probe_model_disabled", False)
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    call_count = {"n": 0}
+    spawned_argvs: list = []
+
+    class _ProcLatch:
+        returncode = 1
+        async def communicate(self):
+            return b"", b"API Error: invalid model\n"
+
+    class _ProcOk:
+        returncode = 0
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*argv, **kwargs):
+        spawned_argvs.append(list(argv))
+        call_count["n"] += 1
+        return _ProcLatch() if call_count["n"] == 1 else _ProcOk()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    asyncio.run(r._tick())
+    asyncio.run(r._tick())
+    assert len(spawned_argvs) == 2
+    assert "--model" in spawned_argvs[0]
+    assert "--model" not in spawned_argvs[1]
+
+
+def test_refresh_probe_model_honors_env_var_override(monkeypatch):
+    # Reload the module with the env var set so the module-level
+    # constant picks it up. Verifies the operator escape hatch works.
+    import importlib
+    monkeypatch.setenv("PUFFO_AGENT_REFRESH_MODEL", "claude-sonnet-4-6-fake")
+    reloaded = importlib.reload(credential_refresh)
+    try:
+        assert reloaded.REFRESH_PROBE_MODEL == "claude-sonnet-4-6-fake"
+    finally:
+        # Restore the original module state for downstream tests.
+        monkeypatch.delenv("PUFFO_AGENT_REFRESH_MODEL", raising=False)
+        importlib.reload(credential_refresh)

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -14,10 +14,15 @@ import pytest
 
 from puffo_agent.portal import credential_refresh
 from puffo_agent.portal.credential_refresh import (
+    RATE_LIMIT_FAST_RETRY_MAX_SECONDS,
+    RATE_LIMIT_FAST_RETRY_MIN_SECONDS,
     REFRESH_BROKEN_THRESHOLD,
+    REFRESH_PROBE_MODEL,
     REFRESH_SAFETY_MARGIN_SECONDS,
     CredentialRefresher,
+    FileBackend,
     RefreshOutcome,
+    _looks_like_rate_limit,
 )
 
 
@@ -572,3 +577,164 @@ def test_refresh_broken_streak_mixes_unchanged_and_failed(tmp_path, monkeypatch)
     # The flip message reports the LATEST outcome class — UNCHANGED
     # then FAILED → "failed", not "unchanged".
     assert "failed" in rs.error
+
+
+# ── PUF-265 v2: Haiku probe model + rate-limit fast retry ────────────
+
+
+def test_refresh_probe_passes_model_flag(tmp_path, monkeypatch):
+    """The refresh subprocess must be invoked with
+    ``--model claude-haiku-4-5`` so it doesn't fight per-model rate
+    limits on the operator's interactive default (Opus / Sonnet)."""
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    spawned: list = []
+
+    async def fake_exec(*argv, **kwargs):
+        spawned.append(argv)
+        class _Proc:
+            returncode = 0
+            async def communicate(self):
+                return b"", b""
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    asyncio.run(r._tick())
+    assert len(spawned) == 1
+    argv = list(spawned[0])
+    assert REFRESH_PROBE_MODEL == "claude-haiku-4-5"
+    assert "--model" in argv
+    assert argv[argv.index("--model") + 1] == REFRESH_PROBE_MODEL
+
+
+def test_looks_like_rate_limit_matches_canonical_signatures():
+    """Each canonical Anthropic rate-limit string must match the
+    detector; benign strings must NOT."""
+    canonicals = [
+        "API Error: Request rejected (429)",
+        "Server is temporarily limiting requests, please wait a moment...",
+        'message: {"type":"rate_limit_error","message":"slow down"}',
+        "rate_limit_error",
+        "You've hit your 5-hour usage limit. Please try again later.",
+        "Repeated 529 Overloaded errors",
+    ]
+    for s in canonicals:
+        assert _looks_like_rate_limit("", s), f"missed canonical: {s!r}"
+        assert _looks_like_rate_limit(s, ""), f"missed in stdout: {s!r}"
+    benign = [
+        "ok\n",
+        "Hello world",
+        "Some refresh log line",
+        "",
+    ]
+    for s in benign:
+        assert not _looks_like_rate_limit(s, "")
+        assert not _looks_like_rate_limit("", s)
+
+
+def test_filebackend_returns_rate_limited_on_canonical_stderr(tmp_path, monkeypatch):
+    """When the claude subprocess fails AND its stderr matches a
+    canonical rate-limit pattern, ``FileBackend.refresh`` must return
+    ``RefreshOutcome.RATE_LIMITED`` (not generic ``FAILED``) so the
+    refresher can schedule a fast retry instead of parking on the
+    120s poll wait."""
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    backend = FileBackend(host_home=tmp_path)
+
+    class _Proc:
+        returncode = 1
+        async def communicate(self):
+            return b"", b"API Error: Request rejected (429)\n"
+
+    async def fake_exec(*argv, **kwargs):
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome is RefreshOutcome.RATE_LIMITED
+
+
+def test_filebackend_returns_failed_on_non_rate_limit_stderr(tmp_path, monkeypatch):
+    """A non-zero exit whose stderr does NOT match the rate-limit
+    patterns must remain ``FAILED`` — distinguishes transient throttle
+    from real refresh breakage."""
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    backend = FileBackend(host_home=tmp_path)
+
+    class _Proc:
+        returncode = 1
+        async def communicate(self):
+            return b"", b"some other error\n"
+
+    async def fake_exec(*argv, **kwargs):
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome is RefreshOutcome.FAILED
+
+
+def test_propagate_outcome_rate_limited_counts_toward_streak(tmp_path, monkeypatch):
+    """``RATE_LIMITED`` counts toward the ``refresh_broken`` streak
+    the same as ``FAILED`` — the refresh really didn't happen."""
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+    assert r._consecutive_non_success == 1
+    r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+    assert r._consecutive_non_success >= REFRESH_BROKEN_THRESHOLD
+
+
+def test_propagate_outcome_rate_limited_schedules_fast_retry(tmp_path, monkeypatch):
+    """``RATE_LIMITED`` must spawn a background task that pings
+    ``_refresh_request`` within the ``[5, 15]`` s window so the next
+    refresh attempt fires sooner than the natural 120s poll."""
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # Patch the delay to zero so the test doesn't sleep.
+    monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MIN_SECONDS", 0.0)
+    monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MAX_SECONDS", 0.0)
+
+    async def go():
+        assert not r._refresh_request.is_set()
+        r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+        assert r._rate_limit_retry_task is not None
+        # Give the spawned task a chance to wake the request event.
+        await asyncio.sleep(0.05)
+        assert r._refresh_request.is_set()
+
+    asyncio.run(go())
+
+
+def test_rate_limit_retry_tasks_coalesce(tmp_path, monkeypatch):
+    """Back-to-back ``RATE_LIMITED`` outcomes must NOT pile up multiple
+    pending retry tasks — the second hit while the first task is in
+    flight is a no-op."""
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # Big delay so the first task stays in flight while we fire the
+    # second outcome.
+    monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MIN_SECONDS", 5.0)
+    monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MAX_SECONDS", 5.0)
+
+    async def go():
+        r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+        task1 = r._rate_limit_retry_task
+        assert task1 is not None
+        # Second outcome while first task still pending.
+        r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+        task2 = r._rate_limit_retry_task
+        assert task2 is task1, "expected coalesce; got a new task"
+        task1.cancel()
+        try:
+            await task1
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    asyncio.run(go())
+
+
+def test_refreshed_outcome_does_not_schedule_fast_retry(tmp_path, monkeypatch):
+    """A REFRESHED outcome (success) must NOT spawn a fast-retry task
+    — fast retry is rate-limit-specific."""
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.REFRESHED)
+    assert r._rate_limit_retry_task is None

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -14,8 +14,10 @@ import pytest
 
 from puffo_agent.portal import credential_refresh
 from puffo_agent.portal.credential_refresh import (
+    REFRESH_BROKEN_THRESHOLD,
     REFRESH_SAFETY_MARGIN_SECONDS,
     CredentialRefresher,
+    RefreshOutcome,
 )
 
 
@@ -293,3 +295,237 @@ def test_refresh_token_request_flag_round_trip(tmp_path, monkeypatch):
     # flag on next tick after it was already cleared).
     clear_refresh_token_request()
     assert not refresh_token_request_path().exists()
+
+
+# ── PUF-265: outcome dispatch + refresh_broken propagation ─────
+
+
+def _make_agent_runtime(home_root: Path, agent_id: str) -> Path:
+    """Seed an ``agents/<id>/runtime.json`` under ``home_root`` so
+    ``RuntimeState.load(agent_id)`` resolves via ``PUFFO_AGENT_HOME``."""
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState(status="running", started_at=int(time.time()))
+    # Need PUFFO_AGENT_HOME to be set before save() — the caller's
+    # monkeypatch handles that.
+    rs.save(agent_id)
+    return home_root / "agents" / agent_id / "runtime.json"
+
+
+def _make_refresher_with_agent(
+    tmp_path: Path, monkeypatch, *, agent_id: str = "agent-puf265",
+) -> tuple[CredentialRefresher, str]:
+    """Build a refresher whose registered agent maps to a real
+    runtime.json under ``PUFFO_AGENT_HOME=tmp_path``."""
+    from puffo_agent.portal.state import agent_home_dir
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    # Seed runtime + creds.
+    _write_creds(tmp_path / "host", expires_in_seconds=3600)
+    _make_agent_runtime(tmp_path, agent_id)
+
+    r = CredentialRefresher(host_home=tmp_path / "host")
+    r.register_agent(agent_home_dir(agent_id))
+    return r, agent_id
+
+
+def test_propagate_outcome_refreshed_resets_counter(tmp_path, monkeypatch):
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._consecutive_non_success = 1
+    r._propagate_outcome(RefreshOutcome.REFRESHED)
+    assert r._consecutive_non_success == 0
+
+
+def test_propagate_outcome_unchanged_increments_counter(tmp_path, monkeypatch):
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    assert r._consecutive_non_success == 1
+
+
+def test_propagate_outcome_failed_increments_counter(tmp_path, monkeypatch):
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.FAILED)
+    assert r._consecutive_non_success == 1
+
+
+def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch):
+    """N consecutive UNCHANGED|FAILED outcomes must flip every
+    registered agent's ``runtime.health`` to ``"refresh_broken"`` with a
+    human-readable ``runtime.error``. Below threshold, health stays
+    untouched."""
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # 1 non-success: below threshold, no flip.
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    rs = RuntimeState.load(aid)
+    assert rs is not None
+    assert rs.health != "refresh_broken"
+    # 2nd consecutive non-success hits the threshold → flip.
+    assert REFRESH_BROKEN_THRESHOLD == 2
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    rs = RuntimeState.load(aid)
+    assert rs is not None
+    assert rs.health == "refresh_broken"
+    assert "claude /login" in rs.error
+    assert "unchanged" in rs.error
+
+
+def test_refresh_broken_clears_on_next_refreshed(tmp_path, monkeypatch):
+    """A REFRESHED outcome after the flip must clear ``refresh_broken``
+    back to ``"ok"`` AND reset the counter, so the next streak starts
+    fresh."""
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # Drive the flip.
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    assert RuntimeState.load(aid).health == "refresh_broken"
+    # Recover.
+    r._propagate_outcome(RefreshOutcome.REFRESHED)
+    rs = RuntimeState.load(aid)
+    assert rs is not None
+    assert rs.health == "ok"
+    assert rs.error == ""
+    assert r._consecutive_non_success == 0
+
+
+def test_refresh_broken_does_not_overwrite_auth_failed(tmp_path, monkeypatch):
+    """``auth_failed`` is a stronger downstream signal — refresh_broken
+    is the upstream warning that the daemon's refresh mechanism is
+    dead. Once any agent has actually been blocked by a 401 and worker
+    flipped it to ``auth_failed``, refresh_broken must NOT downgrade
+    that signal."""
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # Seed auth_failed on the agent first.
+    rs = RuntimeState.load(aid)
+    rs.health = "auth_failed"
+    rs.error = "401 from a real turn"
+    rs.save(aid)
+    # Drive the would-be flip.
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    rs = RuntimeState.load(aid)
+    assert rs is not None
+    assert rs.health == "auth_failed", (
+        "refresh_broken should not overwrite auth_failed"
+    )
+    assert rs.error == "401 from a real turn"
+
+
+def test_refresh_broken_does_not_overwrite_api_error_abandoned(
+    tmp_path, monkeypatch,
+):
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    rs = RuntimeState.load(aid)
+    rs.health = "api_error_abandoned"
+    rs.save(aid)
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.FAILED)
+    rs = RuntimeState.load(aid)
+    assert rs.health == "api_error_abandoned"
+
+
+def test_refresh_now_captures_outcome_instead_of_dropping(tmp_path, monkeypatch):
+    """Regression for the PUF-265 root cause: the caller at line 779
+    used to do ``await self.backend.refresh()`` without capturing the
+    outcome, so UNCHANGED silently looked like REFRESHED to
+    ``_refresh_now``. This test pins the new contract — outcome MUST
+    feed ``_propagate_outcome`` for the counter + flip to work."""
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+
+    captured: list[RefreshOutcome] = []
+
+    class _FakeBackend:
+        def expires_in_seconds(self):
+            return 60
+        async def refresh(self):
+            return RefreshOutcome.UNCHANGED
+        def sync_to_agent(self, agent_home):
+            pass
+
+    r.backend = _FakeBackend()
+    orig_propagate = r._propagate_outcome
+
+    def spy_propagate(outcome):
+        captured.append(outcome)
+        orig_propagate(outcome)
+
+    r._propagate_outcome = spy_propagate  # type: ignore[method-assign]
+    asyncio.run(r._refresh_now(expires_in=60, by_agent=True))
+    assert captured == [RefreshOutcome.UNCHANGED]
+
+
+def test_refresh_now_treats_backend_exception_as_failed(tmp_path, monkeypatch):
+    """A backend that raises during ``refresh()`` must be counted as a
+    non-success outcome (FAILED) so a daemon-side bug or transient
+    subprocess error contributes to the refresh_broken streak instead
+    of being silently swallowed."""
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+
+    captured: list[RefreshOutcome] = []
+
+    class _ExplodingBackend:
+        def expires_in_seconds(self):
+            return 60
+        async def refresh(self):
+            raise RuntimeError("backend exploded")
+        def sync_to_agent(self, agent_home):
+            pass
+
+    r.backend = _ExplodingBackend()
+    orig_propagate = r._propagate_outcome
+
+    def spy_propagate(outcome):
+        captured.append(outcome)
+        orig_propagate(outcome)
+
+    r._propagate_outcome = spy_propagate  # type: ignore[method-assign]
+    asyncio.run(r._refresh_now(expires_in=60, by_agent=True))
+    assert captured == [RefreshOutcome.FAILED]
+
+
+def test_filebackend_unchanged_logs_stdout_and_stderr(tmp_path, monkeypatch, caplog):
+    """The UNCHANGED branch must dump ``stdout`` + ``stderr`` tails
+    (real-fix discrimination prereq: differentiates 2a CLI-stopped-
+    refreshing from 2b Linux-writeback-failure on the next in-the-wild
+    event without needing another roundtrip)."""
+    from puffo_agent.portal.credential_refresh import FileBackend
+    _write_creds(tmp_path, expires_in_seconds=3600)  # advance==no-advance both fine; we force the branch
+    backend = FileBackend(host_home=tmp_path)
+
+    class _Proc:
+        returncode = 0
+        async def communicate(self):
+            return b"hello-out", b"hello-err"
+
+    async def fake_exec(*argv, **kwargs):
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    caplog.set_level("ERROR", logger="puffo_agent.portal.credential_refresh")
+    outcome = asyncio.run(backend.refresh())
+    assert outcome is RefreshOutcome.UNCHANGED
+    joined = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "hello-out" in joined
+    assert "hello-err" in joined
+
+
+def test_refresh_broken_flips_all_registered_agents(tmp_path, monkeypatch):
+    """When N consecutive non-success outcomes hit, every registered
+    agent gets the flip — not just the first one in the set."""
+    from puffo_agent.portal.state import RuntimeState, agent_home_dir
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    _write_creds(tmp_path / "host", expires_in_seconds=3600)
+    _make_agent_runtime(tmp_path, "agent-alpha")
+    _make_agent_runtime(tmp_path, "agent-beta")
+
+    r = CredentialRefresher(host_home=tmp_path / "host")
+    r.register_agent(agent_home_dir("agent-alpha"))
+    r.register_agent(agent_home_dir("agent-beta"))
+
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert RuntimeState.load("agent-alpha").health == "refresh_broken"
+    assert RuntimeState.load("agent-beta").health == "refresh_broken"

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -301,12 +301,8 @@ def test_refresh_token_request_flag_round_trip(tmp_path, monkeypatch):
 
 
 def _make_agent_runtime(home_root: Path, agent_id: str) -> Path:
-    """Seed an ``agents/<id>/runtime.json`` under ``home_root`` so
-    ``RuntimeState.load(agent_id)`` resolves via ``PUFFO_AGENT_HOME``."""
     from puffo_agent.portal.state import RuntimeState
     rs = RuntimeState(status="running", started_at=int(time.time()))
-    # Need PUFFO_AGENT_HOME to be set before save() — the caller's
-    # monkeypatch handles that.
     rs.save(agent_id)
     return home_root / "agents" / agent_id / "runtime.json"
 
@@ -314,12 +310,9 @@ def _make_agent_runtime(home_root: Path, agent_id: str) -> Path:
 def _make_refresher_with_agent(
     tmp_path: Path, monkeypatch, *, agent_id: str = "agent-puf265",
 ) -> tuple[CredentialRefresher, str]:
-    """Build a refresher whose registered agent maps to a real
-    runtime.json under ``PUFFO_AGENT_HOME=tmp_path``."""
     from puffo_agent.portal.state import agent_home_dir
 
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    # Seed runtime + creds.
     _write_creds(tmp_path / "host", expires_in_seconds=3600)
     _make_agent_runtime(tmp_path, agent_id)
 
@@ -348,18 +341,12 @@ def test_propagate_outcome_failed_increments_counter(tmp_path, monkeypatch):
 
 
 def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch):
-    """N consecutive UNCHANGED|FAILED outcomes must flip every
-    registered agent's ``runtime.health`` to ``"refresh_broken"`` with a
-    human-readable ``runtime.error``. Below threshold, health stays
-    untouched."""
     from puffo_agent.portal.state import RuntimeState
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    # 1 non-success: below threshold, no flip.
     r._propagate_outcome(RefreshOutcome.UNCHANGED)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health != "refresh_broken"
-    # 2nd consecutive non-success hits the threshold → flip.
     assert REFRESH_BROKEN_THRESHOLD == 2
     r._propagate_outcome(RefreshOutcome.UNCHANGED)
     rs = RuntimeState.load(aid)
@@ -370,16 +357,11 @@ def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch)
 
 
 def test_refresh_broken_clears_on_next_refreshed(tmp_path, monkeypatch):
-    """A REFRESHED outcome after the flip must clear ``refresh_broken``
-    back to ``"ok"`` AND reset the counter, so the next streak starts
-    fresh."""
     from puffo_agent.portal.state import RuntimeState
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    # Drive the flip.
     for _ in range(REFRESH_BROKEN_THRESHOLD):
         r._propagate_outcome(RefreshOutcome.UNCHANGED)
     assert RuntimeState.load(aid).health == "refresh_broken"
-    # Recover.
     r._propagate_outcome(RefreshOutcome.REFRESHED)
     rs = RuntimeState.load(aid)
     assert rs is not None
@@ -389,24 +371,13 @@ def test_refresh_broken_clears_on_next_refreshed(tmp_path, monkeypatch):
 
 
 def test_refresh_broken_cleared_after_daemon_restart(tmp_path, monkeypatch):
-    """PR #52 review: after a daemon restart the in-memory streak
-    counter starts at 0 while the registered agents' on-disk
-    ``runtime.health`` may still be ``refresh_broken`` from the
-    previous daemon's flip. The next REFRESHED tick MUST clear the
-    disk-state even though ``_consecutive_non_success == 0`` —
-    otherwise agents stay stuck at ``[refresh_broken]`` indefinitely
-    even though refresh has recovered."""
     from puffo_agent.portal.state import RuntimeState
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    # Simulate post-restart state: disk says refresh_broken (left
-    # over from previous daemon's flip); in-memory streak is zero
-    # (fresh refresher instance).
     rs = RuntimeState.load(aid)
     rs.health = "refresh_broken"
     rs.error = "left over from previous daemon"
     rs.save(aid)
     assert r._consecutive_non_success == 0
-    # First successful refresh after restart.
     r._propagate_outcome(RefreshOutcome.REFRESHED)
     rs = RuntimeState.load(aid)
     assert rs.health == "ok"
@@ -414,26 +385,17 @@ def test_refresh_broken_cleared_after_daemon_restart(tmp_path, monkeypatch):
 
 
 def test_refresh_broken_does_not_overwrite_auth_failed(tmp_path, monkeypatch):
-    """``auth_failed`` is a stronger downstream signal — refresh_broken
-    is the upstream warning that the daemon's refresh mechanism is
-    dead. Once any agent has actually been blocked by a 401 and worker
-    flipped it to ``auth_failed``, refresh_broken must NOT downgrade
-    that signal."""
     from puffo_agent.portal.state import RuntimeState
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    # Seed auth_failed on the agent first.
     rs = RuntimeState.load(aid)
     rs.health = "auth_failed"
     rs.error = "401 from a real turn"
     rs.save(aid)
-    # Drive the would-be flip.
     for _ in range(REFRESH_BROKEN_THRESHOLD):
         r._propagate_outcome(RefreshOutcome.UNCHANGED)
     rs = RuntimeState.load(aid)
     assert rs is not None
-    assert rs.health == "auth_failed", (
-        "refresh_broken should not overwrite auth_failed"
-    )
+    assert rs.health == "auth_failed"
     assert rs.error == "401 from a real turn"
 
 
@@ -452,11 +414,6 @@ def test_refresh_broken_does_not_overwrite_api_error_abandoned(
 
 
 def test_refresh_now_captures_outcome_instead_of_dropping(tmp_path, monkeypatch):
-    """Regression for the PUF-265 root cause: the caller at line 779
-    used to do ``await self.backend.refresh()`` without capturing the
-    outcome, so UNCHANGED silently looked like REFRESHED to
-    ``_refresh_now``. This test pins the new contract — outcome MUST
-    feed ``_propagate_outcome`` for the counter + flip to work."""
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
 
     captured: list[RefreshOutcome] = []
@@ -482,10 +439,6 @@ def test_refresh_now_captures_outcome_instead_of_dropping(tmp_path, monkeypatch)
 
 
 def test_refresh_now_treats_backend_exception_as_failed(tmp_path, monkeypatch):
-    """A backend that raises during ``refresh()`` must be counted as a
-    non-success outcome (FAILED) so a daemon-side bug or transient
-    subprocess error contributes to the refresh_broken streak instead
-    of being silently swallowed."""
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
 
     captured: list[RefreshOutcome] = []
@@ -511,12 +464,8 @@ def test_refresh_now_treats_backend_exception_as_failed(tmp_path, monkeypatch):
 
 
 def test_filebackend_unchanged_logs_stdout_and_stderr(tmp_path, monkeypatch, caplog):
-    """The UNCHANGED branch must dump ``stdout`` + ``stderr`` tails
-    (real-fix discrimination prereq: differentiates 2a CLI-stopped-
-    refreshing from 2b Linux-writeback-failure on the next in-the-wild
-    event without needing another roundtrip)."""
     from puffo_agent.portal.credential_refresh import FileBackend
-    _write_creds(tmp_path, expires_in_seconds=3600)  # advance==no-advance both fine; we force the branch
+    _write_creds(tmp_path, expires_in_seconds=3600)
     backend = FileBackend(host_home=tmp_path)
 
     class _Proc:
@@ -537,8 +486,6 @@ def test_filebackend_unchanged_logs_stdout_and_stderr(tmp_path, monkeypatch, cap
 
 
 def test_refresh_broken_flips_all_registered_agents(tmp_path, monkeypatch):
-    """When N consecutive non-success outcomes hit, every registered
-    agent gets the flip — not just the first one in the set."""
     from puffo_agent.portal.state import RuntimeState, agent_home_dir
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
     _write_creds(tmp_path / "host", expires_in_seconds=3600)
@@ -554,3 +501,74 @@ def test_refresh_broken_flips_all_registered_agents(tmp_path, monkeypatch):
 
     assert RuntimeState.load("agent-alpha").health == "refresh_broken"
     assert RuntimeState.load("agent-beta").health == "refresh_broken"
+
+
+def test_refresh_broken_flip_is_idempotent_past_threshold(tmp_path, monkeypatch):
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    rs_after_flip = RuntimeState.load(aid)
+    assert rs_after_flip.health == "refresh_broken"
+    initial_error = rs_after_flip.error
+    # Drive 3 more non-success ticks. In-memory counter climbs but the
+    # already-refresh_broken agent's disk state must not be re-written
+    # (avoids log spam + redundant disk writes once flipped).
+    r._propagate_outcome(RefreshOutcome.FAILED)
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.FAILED)
+    rs_later = RuntimeState.load(aid)
+    assert rs_later.health == "refresh_broken"
+    # Error message still reports "saw 2 consecutive ..." not 5 — the
+    # inner-loop guard `health == "refresh_broken": continue` blocked
+    # the re-write.
+    assert rs_later.error == initial_error
+    assert r._consecutive_non_success == 5
+
+
+def test_refresh_broken_does_not_touch_unregistered_agents(tmp_path, monkeypatch):
+    from puffo_agent.portal.state import RuntimeState, agent_home_dir
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    _write_creds(tmp_path / "host", expires_in_seconds=3600)
+    _make_agent_runtime(tmp_path, "agent-stays")
+    _make_agent_runtime(tmp_path, "agent-leaves")
+
+    r = CredentialRefresher(host_home=tmp_path / "host")
+    r.register_agent(agent_home_dir("agent-stays"))
+    r.register_agent(agent_home_dir("agent-leaves"))
+    r.unregister_agent(agent_home_dir("agent-leaves"))
+
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert RuntimeState.load("agent-stays").health == "refresh_broken"
+    assert RuntimeState.load("agent-leaves").health != "refresh_broken"
+
+
+def test_refreshed_outcome_does_not_lift_unrelated_health_to_ok(
+    tmp_path, monkeypatch,
+):
+    # _clear_refresh_broken runs on every REFRESHED. An agent currently
+    # at "unknown" (no probe yet) must NOT be silently lifted to "ok" —
+    # the inner-loop guard `health != "refresh_broken": continue` is
+    # what prevents that.
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    rs_before = RuntimeState.load(aid)
+    assert rs_before.health == "unknown"
+    r._propagate_outcome(RefreshOutcome.REFRESHED)
+    rs_after = RuntimeState.load(aid)
+    assert rs_after.health == "unknown"
+    assert rs_after.error == ""
+
+
+def test_refresh_broken_streak_mixes_unchanged_and_failed(tmp_path, monkeypatch):
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.FAILED)
+    rs = RuntimeState.load(aid)
+    assert rs.health == "refresh_broken"
+    # The flip message reports the LATEST outcome class — UNCHANGED
+    # then FAILED → "failed", not "unchanged".
+    assert "failed" in rs.error

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -388,6 +388,31 @@ def test_refresh_broken_clears_on_next_refreshed(tmp_path, monkeypatch):
     assert r._consecutive_non_success == 0
 
 
+def test_refresh_broken_cleared_after_daemon_restart(tmp_path, monkeypatch):
+    """PR #52 review: after a daemon restart the in-memory streak
+    counter starts at 0 while the registered agents' on-disk
+    ``runtime.health`` may still be ``refresh_broken`` from the
+    previous daemon's flip. The next REFRESHED tick MUST clear the
+    disk-state even though ``_consecutive_non_success == 0`` —
+    otherwise agents stay stuck at ``[refresh_broken]`` indefinitely
+    even though refresh has recovered."""
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # Simulate post-restart state: disk says refresh_broken (left
+    # over from previous daemon's flip); in-memory streak is zero
+    # (fresh refresher instance).
+    rs = RuntimeState.load(aid)
+    rs.health = "refresh_broken"
+    rs.error = "left over from previous daemon"
+    rs.save(aid)
+    assert r._consecutive_non_success == 0
+    # First successful refresh after restart.
+    r._propagate_outcome(RefreshOutcome.REFRESHED)
+    rs = RuntimeState.load(aid)
+    assert rs.health == "ok"
+    assert rs.error == ""
+
+
 def test_refresh_broken_does_not_overwrite_auth_failed(tmp_path, monkeypatch):
     """``auth_failed`` is a stronger downstream signal — refresh_broken
     is the upstream warning that the daemon's refresh mechanism is

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -583,9 +583,6 @@ def test_refresh_broken_streak_mixes_unchanged_and_failed(tmp_path, monkeypatch)
 
 
 def test_refresh_probe_passes_model_flag(tmp_path, monkeypatch):
-    """The refresh subprocess must be invoked with
-    ``--model claude-haiku-4-5`` so it doesn't fight per-model rate
-    limits on the operator's interactive default (Opus / Sonnet)."""
     _write_creds(tmp_path, expires_in_seconds=5 * 60)
     r = CredentialRefresher(host_home=tmp_path)
 
@@ -609,8 +606,6 @@ def test_refresh_probe_passes_model_flag(tmp_path, monkeypatch):
 
 
 def test_looks_like_rate_limit_matches_canonical_signatures():
-    """Each canonical Anthropic rate-limit string must match the
-    detector; benign strings must NOT."""
     canonicals = [
         "API Error: Request rejected (429)",
         "Server is temporarily limiting requests, please wait a moment...",
@@ -633,12 +628,15 @@ def test_looks_like_rate_limit_matches_canonical_signatures():
         assert not _looks_like_rate_limit("", s)
 
 
+def test_looks_like_rate_limit_is_case_insensitive():
+    # All patterns use re.IGNORECASE — pin so a future "drop the flag"
+    # refactor breaks the test (Anthropic surfaces casing varies).
+    assert _looks_like_rate_limit("", "API ERROR: REQUEST REJECTED (429)")
+    assert _looks_like_rate_limit("", "Rate_Limit_Error")
+    assert _looks_like_rate_limit("", "server is TEMPORARILY limiting requests")
+
+
 def test_filebackend_returns_rate_limited_on_canonical_stderr(tmp_path, monkeypatch):
-    """When the claude subprocess fails AND its stderr matches a
-    canonical rate-limit pattern, ``FileBackend.refresh`` must return
-    ``RefreshOutcome.RATE_LIMITED`` (not generic ``FAILED``) so the
-    refresher can schedule a fast retry instead of parking on the
-    120s poll wait."""
     _write_creds(tmp_path, expires_in_seconds=5 * 60)
     backend = FileBackend(host_home=tmp_path)
 
@@ -656,9 +654,6 @@ def test_filebackend_returns_rate_limited_on_canonical_stderr(tmp_path, monkeypa
 
 
 def test_filebackend_returns_failed_on_non_rate_limit_stderr(tmp_path, monkeypatch):
-    """A non-zero exit whose stderr does NOT match the rate-limit
-    patterns must remain ``FAILED`` — distinguishes transient throttle
-    from real refresh breakage."""
     _write_creds(tmp_path, expires_in_seconds=5 * 60)
     backend = FileBackend(host_home=tmp_path)
 
@@ -675,9 +670,27 @@ def test_filebackend_returns_failed_on_non_rate_limit_stderr(tmp_path, monkeypat
     assert outcome is RefreshOutcome.FAILED
 
 
+def test_filebackend_rate_limit_pattern_matches_in_stdout_too(tmp_path, monkeypatch):
+    # _classify_failed_refresh joins stdout+stderr — make sure the
+    # detector doesn't only check stderr (claude can emit the rate-limit
+    # error as an assistant text block on stdout, not stderr).
+    _write_creds(tmp_path, expires_in_seconds=5 * 60)
+    backend = FileBackend(host_home=tmp_path)
+
+    class _Proc:
+        returncode = 1
+        async def communicate(self):
+            return b'{"type":"rate_limit_error"}\n', b""
+
+    async def fake_exec(*argv, **kwargs):
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome is RefreshOutcome.RATE_LIMITED
+
+
 def test_propagate_outcome_rate_limited_counts_toward_streak(tmp_path, monkeypatch):
-    """``RATE_LIMITED`` counts toward the ``refresh_broken`` streak
-    the same as ``FAILED`` — the refresh really didn't happen."""
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
     r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
     assert r._consecutive_non_success == 1
@@ -686,11 +699,7 @@ def test_propagate_outcome_rate_limited_counts_toward_streak(tmp_path, monkeypat
 
 
 def test_propagate_outcome_rate_limited_schedules_fast_retry(tmp_path, monkeypatch):
-    """``RATE_LIMITED`` must spawn a background task that pings
-    ``_refresh_request`` within the ``[5, 15]`` s window so the next
-    refresh attempt fires sooner than the natural 120s poll."""
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    # Patch the delay to zero so the test doesn't sleep.
     monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MIN_SECONDS", 0.0)
     monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MAX_SECONDS", 0.0)
 
@@ -698,7 +707,6 @@ def test_propagate_outcome_rate_limited_schedules_fast_retry(tmp_path, monkeypat
         assert not r._refresh_request.is_set()
         r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
         assert r._rate_limit_retry_task is not None
-        # Give the spawned task a chance to wake the request event.
         await asyncio.sleep(0.05)
         assert r._refresh_request.is_set()
 
@@ -706,12 +714,7 @@ def test_propagate_outcome_rate_limited_schedules_fast_retry(tmp_path, monkeypat
 
 
 def test_rate_limit_retry_tasks_coalesce(tmp_path, monkeypatch):
-    """Back-to-back ``RATE_LIMITED`` outcomes must NOT pile up multiple
-    pending retry tasks — the second hit while the first task is in
-    flight is a no-op."""
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    # Big delay so the first task stays in flight while we fire the
-    # second outcome.
     monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MIN_SECONDS", 5.0)
     monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MAX_SECONDS", 5.0)
 
@@ -719,7 +722,6 @@ def test_rate_limit_retry_tasks_coalesce(tmp_path, monkeypatch):
         r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
         task1 = r._rate_limit_retry_task
         assert task1 is not None
-        # Second outcome while first task still pending.
         r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
         task2 = r._rate_limit_retry_task
         assert task2 is task1, "expected coalesce; got a new task"
@@ -732,9 +734,40 @@ def test_rate_limit_retry_tasks_coalesce(tmp_path, monkeypatch):
     asyncio.run(go())
 
 
+def test_rate_limit_retry_reschedules_after_first_task_done(tmp_path, monkeypatch):
+    # Once the first retry task completes, a subsequent RATE_LIMITED
+    # outcome must spawn a NEW task (not be permanently blocked).
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MIN_SECONDS", 0.0)
+    monkeypatch.setattr(credential_refresh, "RATE_LIMIT_FAST_RETRY_MAX_SECONDS", 0.0)
+
+    async def go():
+        r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+        task1 = r._rate_limit_retry_task
+        await asyncio.sleep(0.05)
+        assert task1.done()
+        r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+        task2 = r._rate_limit_retry_task
+        assert task2 is not task1, "expected new task after first completed"
+
+    asyncio.run(go())
+
+
 def test_refreshed_outcome_does_not_schedule_fast_retry(tmp_path, monkeypatch):
-    """A REFRESHED outcome (success) must NOT spawn a fast-retry task
-    — fast retry is rate-limit-specific."""
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
     r._propagate_outcome(RefreshOutcome.REFRESHED)
     assert r._rate_limit_retry_task is None
+
+
+def test_propagate_outcome_rate_limited_does_not_crash_without_event_loop(
+    tmp_path, monkeypatch,
+):
+    # The _schedule_rate_limit_retry's RuntimeError fallback path: in
+    # a sync test (no running loop) the create_task call would raise.
+    # The function must catch it and leave _rate_limit_retry_task=None
+    # rather than propagate.
+    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
+    assert r._rate_limit_retry_task is None
+    # Streak counter still advanced.
+    assert r._consecutive_non_success == 1


### PR DESCRIPTION
## Summary (P0 defensive fix)

`CredentialRefresher._refresh_now` used to call `backend.refresh()` **without capturing the returned `RefreshOutcome`**, so `UNCHANGED` outcomes (the exact "claude exited 0 but expiresAt didn't advance" case detected at `credential_refresh.py:215-223`) fell through silently. The daemon went back to its 2-min poll loop, `runtime.health` stayed `"unknown"` fleet-wide, and operators only noticed once individual agents 401'd hours later — by which point the fleet had been quietly running on a dead refresh mechanism.

**This is the defensive PR** (Equation msg_57311718 + Calculation msg_5641e7d0 finding). Stops the silent-loop blind spot so operators see "stuck" instead of "stuck-without-knowing." Does NOT fix the underlying refresh — that's the next PR (gated on the captured stderr/stdout from the next UNCHANGED event in the wild to discriminate sub-hypothesis 2a/2b).

## Changes

- `credential_refresh.py`:
  - `_refresh_now` now captures `outcome = await self.backend.refresh()` (was dropping it); backend-raises wrapped as `RefreshOutcome.FAILED`
  - New `_propagate_outcome(outcome)`: REFRESHED resets streak + calls `_clear_refresh_broken`; UNCHANGED/FAILED increments + flips at `REFRESH_BROKEN_THRESHOLD=2` (~4 min at 120s poll)
  - `_flip_refresh_broken` walks every registered agent_home, loads runtime, flips `health="refresh_broken"` with operator-actionable error message (`"Run `claude /login` then `puffo-agent agent resume <id>`"`)
  - **Precedence guard**: skips agents already in `auth_failed` / `api_error_abandoned` (those are stronger downstream signals; same operator recovery path)
  - FileBackend UNCHANGED branch now dumps stdout/stderr tails (400 chars each) for next-incident sub-hypothesis 2a/2b discrimination
- `state.py`: `RuntimeState.health` enum + docstring extended for `"refresh_broken"`
- `cli.py:531`: `agent list` surfaces `[refresh_broken]` alongside `[auth_failed]` / `[api_error_abandoned]`

## Tests

10 new in `tests/test_credential_refresher.py` (+23 total in file, all pass):
- Outcome counter mechanics: REFRESHED resets / UNCHANGED + FAILED increment
- Flip fires at exactly `REFRESH_BROKEN_THRESHOLD=2`, not 1
- Subsequent REFRESHED clears `refresh_broken` → `ok` + resets counter
- **Precedence**: `refresh_broken` does NOT overwrite `auth_failed` OR `api_error_abandoned`
- **Smoking-gun regression guard**: `_refresh_now` captures outcome instead of dropping it (this is the bug class that caused the P0)
- `_refresh_now` exception path: backend that raises is `FAILED` (not silently swallowed)
- FileBackend UNCHANGED branch logs both stdout + stderr tails
- `_flip_refresh_broken` fans out across all registered agents

**Test results:** 23/23 focused + 879 passed, 1 skipped (pre-existing permission-mode test) full suite.

## Known limits

- Does NOT fix the underlying refresh — that's the next PR (real-fix), gated on the captured stderr/stdout from the next UNCHANGED event in the wild
- Web/UI consumers (FB-197/198) already read `runtime.health`; surfacing `refresh_broken` in the bubble / agent-detail UI is its own ticket
- The 2-tick threshold (~4 min) is the smallest fast-feedback window that won't false-positive on a single transient subprocess hiccup. If operators want even faster signaling, drop to 1.

## Ship cadence

Operator-directed live-test branch (msg_5bcd284d): operator will start puffo-agent from this branch to verify the visibility flip fires correctly in the real environment before merge. PR opened for diff review in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)