### PR TITLE
fix(PUF-267): defensive codex thread-rotation + state-honesty on wedge [P0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,49 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   ``refresh_broken`` flip. Operator can also override the constant
   via ``PUFFO_AGENT_REFRESH_MODEL`` env var without a release.
 
+- **PUF-267: codex agents no longer silently wedge after a long-lived
+  thread stops accepting new turns.** ``CodexSession`` reuses the
+  same ``threadId`` for the lifetime of an agent; when the underlying
+  App Server thread becomes unresponsive (verbatim ``"agent thread
+  limit reached"``, repeated ``turn/failed``, or repeated turn
+  timeouts), every subsequent turn previously hit the same wedged
+  thread and the operator saw no diagnostic — the daemon kept
+  ``runtime.health = "ok"`` and the agent appeared idle.
+
+  ``_propagate_turn_outcome`` now bookkeeps every turn outcome
+  (``success`` / ``timeout`` / ``turn_failed``) with three defensive
+  layers mirroring PUF-265's pattern:
+
+  Layer 1 (counter): after
+  ``CODEX_THREAD_WEDGED_THRESHOLD = 2`` consecutive non-success
+  outcomes the daemon clears ``_conversation_id`` both in memory and
+  on disk via ``_reset_conversation``, forcing the next
+  ``_ensure_running`` to ``thread/start`` a fresh conversation. The
+  codex App Server process itself stays alive — only the per-thread
+  state rotates. Counter resets to 0 on rotation so the freshly-
+  rotated thread gets a fair THRESHOLD-budget (no counter-thrash).
+
+  Layer 2 (state honesty): on rotation the per-agent
+  ``runtime.health`` flips to ``"codex_thread_wedged"`` with an
+  operator-visible error explaining that recovery is automatic on the
+  next inbound message. ``portal/cli.py``'s ``agent list`` surfaces
+  ``[codex_thread_wedged]`` alongside the other hard health states.
+  Stronger downstream signals (``auth_failed`` /
+  ``api_error_abandoned`` / ``refresh_broken``) win — the flip never
+  downgrades a higher-severity flag. On a successful turn, the daemon
+  ALWAYS calls ``_clear_codex_thread_wedged_health`` (not gated on
+  the in-memory counter) so a daemon restart between rotation and
+  the next success can't leave runtime.health stuck on the wedged
+  value forever (mirrors the PR #52 v1 stale-state bug class).
+
+  Layer 3 (verbatim string): codex's explicit ``"agent thread limit
+  reached"`` error rotates on the FIRST occurrence without waiting
+  for the counter, case-insensitively. The matcher is a tuple of
+  regex patterns (``_CODEX_THREAD_LIMIT_PATTERNS``) so a future
+  "thread is dead" surface — context overflow, max-tokens exceeded,
+  model deprecation — adds one regex instead of refactoring the
+  consumer.
+
 - **Codex agent archive/delete failing with ``Permission denied`` on
   ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an
   exclusive file lock on ``.codex/tmp/arg0/codex-<id>/.lock`` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   ``in_progress`` / ``unhandled_error`` to avoid clobbering them with
   ``refresh_broken``.
 
+- **PUF-267: codex agents auto-rotate the underlying thread instead of
+  silently wedging.** ``CodexSession`` previously reused one
+  ``threadId`` for the agent's life; when codex returned
+  ``"agent thread limit reached"`` or the thread silently stopped
+  streaming (repeated ``turn/failed`` / turn timeouts), every
+  subsequent turn hit the same dead thread while ``runtime.health``
+  stayed ``ok``. New ``_propagate_turn_outcome`` runs after each turn:
+  ``CODEX_THREAD_WEDGED_THRESHOLD = 2`` consecutive non-success
+  outcomes OR the verbatim thread-limit error clears
+  ``_conversation_id`` (in-memory + on-disk) so the next
+  ``_ensure_running`` starts a fresh thread, and the per-agent
+  ``runtime.health`` flips to ``codex_thread_wedged`` (surfaced in
+  ``agent list``). Recovery is automatic on the next inbound message.
+  ``auth_failed`` / ``api_error_abandoned`` / ``refresh_broken`` are
+  not overwritten; ``in_progress`` and ``unhandled_error`` are (the
+  codex-specific value carries more operator-actionable detail).
+  Always-clear-on-success guards the daemon-restart-with-stale-disk
+  path. ``_CODEX_THREAD_LIMIT_PATTERNS`` is a tuple so a future
+  "thread is dead" surface adds one regex.
+
 ## [0.9.6] — 2026-06-01
 
 ### Fixed
@@ -270,49 +290,6 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   the next tick succeeds with the default and resets — no spurious
   ``refresh_broken`` flip. Operator can also override the constant
   via ``PUFFO_AGENT_REFRESH_MODEL`` env var without a release.
-
-- **PUF-267: codex agents no longer silently wedge after a long-lived
-  thread stops accepting new turns.** ``CodexSession`` reuses the
-  same ``threadId`` for the lifetime of an agent; when the underlying
-  App Server thread becomes unresponsive (verbatim ``"agent thread
-  limit reached"``, repeated ``turn/failed``, or repeated turn
-  timeouts), every subsequent turn previously hit the same wedged
-  thread and the operator saw no diagnostic — the daemon kept
-  ``runtime.health = "ok"`` and the agent appeared idle.
-
-  ``_propagate_turn_outcome`` now bookkeeps every turn outcome
-  (``success`` / ``timeout`` / ``turn_failed``) with three defensive
-  layers mirroring PUF-265's pattern:
-
-  Layer 1 (counter): after
-  ``CODEX_THREAD_WEDGED_THRESHOLD = 2`` consecutive non-success
-  outcomes the daemon clears ``_conversation_id`` both in memory and
-  on disk via ``_reset_conversation``, forcing the next
-  ``_ensure_running`` to ``thread/start`` a fresh conversation. The
-  codex App Server process itself stays alive — only the per-thread
-  state rotates. Counter resets to 0 on rotation so the freshly-
-  rotated thread gets a fair THRESHOLD-budget (no counter-thrash).
-
-  Layer 2 (state honesty): on rotation the per-agent
-  ``runtime.health`` flips to ``"codex_thread_wedged"`` with an
-  operator-visible error explaining that recovery is automatic on the
-  next inbound message. ``portal/cli.py``'s ``agent list`` surfaces
-  ``[codex_thread_wedged]`` alongside the other hard health states.
-  Stronger downstream signals (``auth_failed`` /
-  ``api_error_abandoned`` / ``refresh_broken``) win — the flip never
-  downgrades a higher-severity flag. On a successful turn, the daemon
-  ALWAYS calls ``_clear_codex_thread_wedged_health`` (not gated on
-  the in-memory counter) so a daemon restart between rotation and
-  the next success can't leave runtime.health stuck on the wedged
-  value forever (mirrors the PR #52 v1 stale-state bug class).
-
-  Layer 3 (verbatim string): codex's explicit ``"agent thread limit
-  reached"`` error rotates on the FIRST occurrence without waiting
-  for the counter, case-insensitively. The matcher is a tuple of
-  regex patterns (``_CODEX_THREAD_LIMIT_PATTERNS``) so a future
-  "thread is dead" surface — context overflow, max-tokens exceeded,
-  model deprecation — adds one regex instead of refactoring the
-  consumer.
 
 - **Codex agent archive/delete failing with ``Permission denied`` on
   ``.codex/tmp/.../.lock`` (Windows).** The codex CLI holds an

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -87,19 +87,10 @@ REQUEST_TIMEOUT_SECONDS = 60.0
 # that ACKs the request but never streams.
 TURN_TIMEOUT_SECONDS = 600.0
 
-# PUF-267: how many consecutive non-success turn outcomes
-# (timeout | turn-failed) before clearing ``_conversation_id`` to force
-# a fresh ``thread/start`` on the next ``_ensure_running``. 2 mirrors
-# PUF-265's REFRESH_BROKEN_THRESHOLD — small enough to react fast
-# inside the 4-agent fleet, large enough that a single transient hiccup
-# doesn't drop the conversation prematurely.
+# Reacts fast in a small fleet, absorbs single transient hiccups.
 CODEX_THREAD_WEDGED_THRESHOLD = 2
 
-# Layer 3 immediate-rotate signals. Tuple shape (per PR #55 review
-# item 6) so a future "thread is dead" codex surface — context
-# overflow, max-tokens exceeded, model deprecation — adds one regex
-# instead of refactoring the consumer. Mirrors PUF-265 v2's
-# ``_RATE_LIMIT_PATTERNS`` pattern.
+# Tuple shape so a future "thread is dead" surface adds one line.
 _CODEX_THREAD_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"agent thread limit reached", re.IGNORECASE),
 )
@@ -222,11 +213,8 @@ class CodexSession:
         # respawn can re-issue ``newConversation`` with current
         # instructions when the conversation id is missing or rotted.
         self.current_instructions: str = ""
-        # PUF-267: consecutive non-success turn outcomes (timeout |
-        # turn-failed). Resets on the next successful turn. When this
-        # hits ``CODEX_THREAD_WEDGED_THRESHOLD`` we clear the
-        # conversation id so the next ``_ensure_running`` starts a
-        # fresh thread instead of resuming the wedged one.
+        # Resets on next success; hits THRESHOLD → rotate (drop the
+        # persisted conversation id; next _ensure_running starts fresh).
         self._consecutive_thread_failures: int = 0
 
     # ── Public API ────────────────────────────────────────────────────────────
@@ -252,9 +240,6 @@ class CodexSession:
             "agent %s: codex turn/start sending (msg_len=%d, thread=%s)",
             self.agent_id, len(user_message), self._conversation_id,
         )
-        # PUF-267: captured so the outcome-propagation block at the end
-        # can rotate / flip health without re-raising. ``rotated`` is
-        # set inside the timeout / turn-failed branches.
         turn_failed_exc: BaseException | None = None
         rotated_in_branch: bool = False
         try:
@@ -303,7 +288,6 @@ class CodexSession:
                         )
                     except Exception:
                         pass
-                    # PUF-267 Layer 1+2: bookkeep + maybe rotate.
                     rotated_in_branch = self._propagate_turn_outcome(
                         outcome="timeout",
                     )
@@ -315,15 +299,8 @@ class CodexSession:
                         },
                     )
                 except RuntimeError as exc:
-                    # PUF-267 Layer 3: turn-failed reaches us when the
-                    # ``turn/failed`` / ``error`` handler in
-                    # ``_dispatch_message`` (see the ``set_exception``
-                    # site around L1004) wraps codex's upstream error
-                    # into a RuntimeError on ``turn.completed``.
-                    # Bookkeep + maybe rotate via
-                    # ``_propagate_turn_outcome`` below; re-raise so the
-                    # worker's existing error path still logs the
-                    # failure.
+                    # Captured for propagation in the finally; re-raised
+                    # below so the worker's error path still logs.
                     turn_failed_exc = exc
         finally:
             self._active_turn = None
@@ -342,8 +319,6 @@ class CodexSession:
             len(turn.send_message_targets),
             turn.input_tokens, turn.output_tokens,
         )
-        # PUF-267: reset the failure streak + clear
-        # ``codex_thread_wedged`` health on success.
         self._propagate_turn_outcome(outcome="success")
         # core.py's reply-routing check: a non-empty
         # ``send_message_targets`` list means "agent already posted via
@@ -394,22 +369,12 @@ class CodexSession:
         outcome: str,
         err_text: str = "",
     ) -> bool:
-        """PUF-267: bookkeeping after every turn completes.
+        """``outcome`` ∈ ``{"success", "timeout", "turn_failed"}``.
+        Returns True iff this call rotated the conversation.
 
-        ``outcome`` is one of ``"success"`` / ``"timeout"`` /
-        ``"turn_failed"``. Returns True iff this call rotated the
-        conversation (caller may want to log / metadata-flag the event;
-        the next ``_ensure_running`` will do the actual
-        ``thread/start``).
-
-        Layer 1 (counter): N=``CODEX_THREAD_WEDGED_THRESHOLD``
-        consecutive non-success outcomes → rotate + flip health.
-        Layer 3 (verbatim string): on ``turn_failed`` whose error text
-        matches any ``_CODEX_THREAD_LIMIT_PATTERNS`` entry → rotate
-        immediately without waiting for the counter.
-        Success → reset counter + ALWAYS clear ``codex_thread_wedged``
-        health (the always-clear guards the daemon-restart-with-stale-
-        disk-state bug class PR #52 v1 had — see PUF-265 fold).
+        Counter THRESHOLD non-successes OR a verbatim thread-limit
+        error rotates. Success always clears the disk wedged flag —
+        guards the daemon-restart-with-stale-disk path.
         """
         if outcome == "success":
             if self._consecutive_thread_failures > 0:
@@ -464,9 +429,14 @@ class CodexSession:
             )
 
     def _flip_codex_thread_wedged_health(self, reason: str) -> None:
-        """Per-agent ``runtime.health = "codex_thread_wedged"`` flip,
-        with the same precedence semantics as PUF-265's
-        ``_flip_refresh_broken``: stronger downstream signals win."""
+        """Per-agent ``runtime.health = "codex_thread_wedged"`` flip.
+        Stronger downstream signals (auth/api-abandon/refresh-broken)
+        win. ``in_progress`` / ``unhandled_error`` are deliberately NOT
+        in the precedence tuple — ``codex_thread_wedged`` carries more
+        operator-actionable detail than either (names the rotation
+        cause + auto-recovery), so overwriting both is the right
+        direction.
+        """
         from ...portal.state import RuntimeState
         try:
             rs = RuntimeState.load(self.agent_id)

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -37,6 +37,8 @@ moves in one place when we learn the real shape from the field.
 
 from __future__ import annotations
 
+import re
+
 import asyncio
 import json
 import logging
@@ -84,6 +86,27 @@ REQUEST_TIMEOUT_SECONDS = 60.0
 # at the worker level. Mostly defensive against a wedged App Server
 # that ACKs the request but never streams.
 TURN_TIMEOUT_SECONDS = 600.0
+
+# PUF-267: how many consecutive non-success turn outcomes
+# (timeout | turn-failed) before clearing ``_conversation_id`` to force
+# a fresh ``thread/start`` on the next ``_ensure_running``. 2 mirrors
+# PUF-265's REFRESH_BROKEN_THRESHOLD — small enough to react fast
+# inside the 4-agent fleet, large enough that a single transient hiccup
+# doesn't drop the conversation prematurely.
+CODEX_THREAD_WEDGED_THRESHOLD = 2
+
+# Layer 3 immediate-rotate signals. Tuple shape (per PR #55 review
+# item 6) so a future "thread is dead" codex surface — context
+# overflow, max-tokens exceeded, model deprecation — adds one regex
+# instead of refactoring the consumer. Mirrors PUF-265 v2's
+# ``_RATE_LIMIT_PATTERNS`` pattern.
+_CODEX_THREAD_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"agent thread limit reached", re.IGNORECASE),
+)
+
+
+def _looks_like_codex_thread_limit(err_text: str) -> bool:
+    return any(p.search(err_text or "") for p in _CODEX_THREAD_LIMIT_PATTERNS)
 
 # Tool names of the puffo MCP server's "this counts as posting a
 # reply" family. When the agent invokes one of these and it completes
@@ -199,6 +222,12 @@ class CodexSession:
         # respawn can re-issue ``newConversation`` with current
         # instructions when the conversation id is missing or rotted.
         self.current_instructions: str = ""
+        # PUF-267: consecutive non-success turn outcomes (timeout |
+        # turn-failed). Resets on the next successful turn. When this
+        # hits ``CODEX_THREAD_WEDGED_THRESHOLD`` we clear the
+        # conversation id so the next ``_ensure_running`` starts a
+        # fresh thread instead of resuming the wedged one.
+        self._consecutive_thread_failures: int = 0
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -223,6 +252,11 @@ class CodexSession:
             "agent %s: codex turn/start sending (msg_len=%d, thread=%s)",
             self.agent_id, len(user_message), self._conversation_id,
         )
+        # PUF-267: captured so the outcome-propagation block at the end
+        # can rotate / flip health without re-raising. ``rotated`` is
+        # set inside the timeout / turn-failed branches.
+        turn_failed_exc: BaseException | None = None
+        rotated_in_branch: bool = False
         try:
             # turn/start params per codex-rs/app-server protocol:
             # ``threadId``, ``input`` (array of structured items —
@@ -269,12 +303,36 @@ class CodexSession:
                         )
                     except Exception:
                         pass
+                    # PUF-267 Layer 1+2: bookkeep + maybe rotate.
+                    rotated_in_branch = self._propagate_turn_outcome(
+                        outcome="timeout",
+                    )
                     return TurnResult(
                         reply="",
-                        metadata={"codex_turn_timeout": True},
+                        metadata={
+                            "codex_turn_timeout": True,
+                            "codex_thread_rotated": rotated_in_branch,
+                        },
                     )
+                except RuntimeError as exc:
+                    # PUF-267 Layer 3: turn-failed reaches us when the
+                    # ``turn/failed`` / ``error`` handler in
+                    # ``_dispatch_message`` (see the ``set_exception``
+                    # site around L1004) wraps codex's upstream error
+                    # into a RuntimeError on ``turn.completed``.
+                    # Bookkeep + maybe rotate via
+                    # ``_propagate_turn_outcome`` below; re-raise so the
+                    # worker's existing error path still logs the
+                    # failure.
+                    turn_failed_exc = exc
         finally:
             self._active_turn = None
+
+        if turn_failed_exc is not None:
+            self._propagate_turn_outcome(
+                outcome="turn_failed", err_text=str(turn_failed_exc),
+            )
+            raise turn_failed_exc
 
         reply = "".join(turn.reply_chunks).strip()
         logger.debug(
@@ -284,6 +342,9 @@ class CodexSession:
             len(turn.send_message_targets),
             turn.input_tokens, turn.output_tokens,
         )
+        # PUF-267: reset the failure streak + clear
+        # ``codex_thread_wedged`` health on success.
+        self._propagate_turn_outcome(outcome="success")
         # core.py's reply-routing check: a non-empty
         # ``send_message_targets`` list means "agent already posted via
         # MCP, skip the shell fallback." Mirrors the claude-code adapter
@@ -324,6 +385,134 @@ class CodexSession:
 
     def has_persisted_session(self) -> bool:
         return bool(self._conversation_id)
+
+    # ── PUF-267: thread-wedge propagation ─────────────────────────────────────
+
+    def _propagate_turn_outcome(
+        self,
+        *,
+        outcome: str,
+        err_text: str = "",
+    ) -> bool:
+        """PUF-267: bookkeeping after every turn completes.
+
+        ``outcome`` is one of ``"success"`` / ``"timeout"`` /
+        ``"turn_failed"``. Returns True iff this call rotated the
+        conversation (caller may want to log / metadata-flag the event;
+        the next ``_ensure_running`` will do the actual
+        ``thread/start``).
+
+        Layer 1 (counter): N=``CODEX_THREAD_WEDGED_THRESHOLD``
+        consecutive non-success outcomes → rotate + flip health.
+        Layer 3 (verbatim string): on ``turn_failed`` whose error text
+        matches any ``_CODEX_THREAD_LIMIT_PATTERNS`` entry → rotate
+        immediately without waiting for the counter.
+        Success → reset counter + ALWAYS clear ``codex_thread_wedged``
+        health (the always-clear guards the daemon-restart-with-stale-
+        disk-state bug class PR #52 v1 had — see PUF-265 fold).
+        """
+        if outcome == "success":
+            if self._consecutive_thread_failures > 0:
+                logger.info(
+                    "agent %s: codex turn succeeded after %d non-success "
+                    "tick(s) — clearing codex_thread_wedged health",
+                    self.agent_id, self._consecutive_thread_failures,
+                )
+            # Always clear, even when the in-memory counter is 0 — a
+            # daemon restart between rotation and the next success
+            # would otherwise leave runtime.health stuck on
+            # "codex_thread_wedged" on disk forever.
+            self._clear_codex_thread_wedged_health()
+            self._consecutive_thread_failures = 0
+            return False
+        self._consecutive_thread_failures += 1
+        immediate = (
+            outcome == "turn_failed"
+            and _looks_like_codex_thread_limit(err_text or "")
+        )
+        if immediate or self._consecutive_thread_failures >= CODEX_THREAD_WEDGED_THRESHOLD:
+            reason = "thread-limit verbatim" if immediate else (
+                f"{self._consecutive_thread_failures} consecutive {outcome}"
+            )
+            logger.warning(
+                "agent %s: rotating codex thread (%s); next turn will "
+                "start a fresh conversation",
+                self.agent_id, reason,
+            )
+            self._reset_conversation()
+            self._flip_codex_thread_wedged_health(reason)
+            # Reset the counter so the freshly-rotated thread gets a
+            # fair THRESHOLD-budget on its own — otherwise a broken
+            # App Server would rotate on every single subsequent turn
+            # (counter-thrash).
+            self._consecutive_thread_failures = 0
+            return True
+        return False
+
+    def _reset_conversation(self) -> None:
+        """Clear the persisted ``conversation_id`` so the next
+        ``_ensure_running`` falls through to ``thread/start`` instead
+        of resuming the wedged thread. The codex App Server process
+        itself stays alive — only the per-thread state rotates."""
+        self._conversation_id = ""
+        try:
+            self._save_conversation_id("")
+        except Exception as exc:
+            logger.warning(
+                "agent %s: failed to clear persisted conversation_id: %s",
+                self.agent_id, exc,
+            )
+
+    def _flip_codex_thread_wedged_health(self, reason: str) -> None:
+        """Per-agent ``runtime.health = "codex_thread_wedged"`` flip,
+        with the same precedence semantics as PUF-265's
+        ``_flip_refresh_broken``: stronger downstream signals win."""
+        from ...portal.state import RuntimeState
+        try:
+            rs = RuntimeState.load(self.agent_id)
+        except Exception as exc:
+            logger.warning(
+                "codex_thread_wedged flip: failed to load runtime for "
+                "%s: %s", self.agent_id, exc,
+            )
+            return
+        if rs is None:
+            return
+        if rs.health in ("auth_failed", "api_error_abandoned", "refresh_broken"):
+            return
+        if rs.health == "codex_thread_wedged":
+            return
+        rs.health = "codex_thread_wedged"
+        rs.error = (
+            f"codex thread rotated by daemon ({reason}). Recovery is "
+            "automatic on the next inbound message — no operator action "
+            "required."
+        )
+        try:
+            rs.save(self.agent_id)
+        except Exception as exc:
+            logger.warning(
+                "codex_thread_wedged flip: failed to save runtime for "
+                "%s: %s", self.agent_id, exc,
+            )
+
+    def _clear_codex_thread_wedged_health(self) -> None:
+        from ...portal.state import RuntimeState
+        try:
+            rs = RuntimeState.load(self.agent_id)
+        except Exception:
+            return
+        if rs is None or rs.health != "codex_thread_wedged":
+            return
+        rs.health = "ok"
+        rs.error = ""
+        try:
+            rs.save(self.agent_id)
+        except Exception as exc:
+            logger.warning(
+                "codex_thread_wedged clear: failed to save runtime for "
+                "%s: %s", self.agent_id, exc,
+            )
 
     # ── Internals ─────────────────────────────────────────────────────────────
 

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -361,7 +361,7 @@ class CodexSession:
     def has_persisted_session(self) -> bool:
         return bool(self._conversation_id)
 
-    # ── PUF-267: thread-wedge propagation ─────────────────────────────────────
+    # ── thread-wedge propagation ──────────────────────────────────────────────
 
     def _propagate_turn_outcome(
         self,
@@ -369,24 +369,14 @@ class CodexSession:
         outcome: str,
         err_text: str = "",
     ) -> bool:
-        """``outcome`` ∈ ``{"success", "timeout", "turn_failed"}``.
-        Returns True iff this call rotated the conversation.
-
-        Counter THRESHOLD non-successes OR a verbatim thread-limit
-        error rotates. Success always clears the disk wedged flag —
-        guards the daemon-restart-with-stale-disk path.
-        """
+        """Returns True iff this call rotated the conversation."""
         if outcome == "success":
             if self._consecutive_thread_failures > 0:
                 logger.info(
-                    "agent %s: codex turn succeeded after %d non-success "
-                    "tick(s) — clearing codex_thread_wedged health",
+                    "agent %s: codex turn succeeded after %d non-success tick(s)",
                     self.agent_id, self._consecutive_thread_failures,
                 )
-            # Always clear, even when the in-memory counter is 0 — a
-            # daemon restart between rotation and the next success
-            # would otherwise leave runtime.health stuck on
-            # "codex_thread_wedged" on disk forever.
+            # Unconditional clear guards the daemon-restart-with-stale-disk path.
             self._clear_codex_thread_wedged_health()
             self._consecutive_thread_failures = 0
             return False
@@ -400,25 +390,18 @@ class CodexSession:
                 f"{self._consecutive_thread_failures} consecutive {outcome}"
             )
             logger.warning(
-                "agent %s: rotating codex thread (%s); next turn will "
-                "start a fresh conversation",
-                self.agent_id, reason,
+                "agent %s: rotating codex thread (%s)", self.agent_id, reason,
             )
             self._reset_conversation()
             self._flip_codex_thread_wedged_health(reason)
-            # Reset the counter so the freshly-rotated thread gets a
-            # fair THRESHOLD-budget on its own — otherwise a broken
-            # App Server would rotate on every single subsequent turn
-            # (counter-thrash).
+            # Reset so the fresh thread gets its own THRESHOLD budget.
             self._consecutive_thread_failures = 0
             return True
         return False
 
     def _reset_conversation(self) -> None:
-        """Clear the persisted ``conversation_id`` so the next
-        ``_ensure_running`` falls through to ``thread/start`` instead
-        of resuming the wedged thread. The codex App Server process
-        itself stays alive — only the per-thread state rotates."""
+        """Drop ``conversation_id`` so the next ``_ensure_running`` calls
+        ``thread/start``. App Server process stays alive."""
         self._conversation_id = ""
         try:
             self._save_conversation_id("")
@@ -429,14 +412,8 @@ class CodexSession:
             )
 
     def _flip_codex_thread_wedged_health(self, reason: str) -> None:
-        """Per-agent ``runtime.health = "codex_thread_wedged"`` flip.
-        Stronger downstream signals (auth/api-abandon/refresh-broken)
-        win. ``in_progress`` / ``unhandled_error`` are deliberately NOT
-        in the precedence tuple — ``codex_thread_wedged`` carries more
-        operator-actionable detail than either (names the rotation
-        cause + auto-recovery), so overwriting both is the right
-        direction.
-        """
+        """``in_progress`` / ``unhandled_error`` are intentionally NOT
+        protected — codex_thread_wedged carries more actionable detail."""
         from ...portal.state import RuntimeState
         try:
             rs = RuntimeState.load(self.agent_id)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -533,7 +533,7 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
         if rs is not None and rs.health in (
             "in_progress",
             "auth_failed", "api_error_abandoned", "refresh_broken",
-            "unhandled_error",
+            "unhandled_error", "codex_thread_wedged",
         ):
             runtime = f"{runtime} [{rs.health}]"
         # Truncate display_name for table alignment.

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1138,8 +1138,15 @@ class RuntimeState:
     #   "unhandled_error"     — non-AgentAPIError raised in the turn and
     #                           no category red was set; cleared by
     #                           next successful turn
+    #   "codex_thread_wedged" — codex thread rotated after N consecutive
+    #                           turn timeouts/failures OR the verbatim
+    #                           "agent thread limit reached" error.
+    #                           Auto-recovers on next inbound message;
+    #                           cleared on next successful turn. Does
+    #                           NOT overwrite the stronger downstream
+    #                           signals above.
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unhandled_error | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unhandled_error | codex_thread_wedged | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> "RuntimeState | None":

--- a/tests/test_codex_thread_rotation.py
+++ b/tests/test_codex_thread_rotation.py
@@ -1,0 +1,505 @@
+"""PUF-267: codex thread-wedging visibility + auto-rotation.
+
+Unit tests targeting the three-layer defensive surface added to
+``CodexSession``:
+
+  Layer 1 — counter-based rotation after N consecutive turn timeouts /
+            failures
+  Layer 2 — propagation of the timeout/failure outcome to per-agent
+            ``runtime.health = "codex_thread_wedged"``
+  Layer 3 — verbatim ``"agent thread limit reached"`` triggers immediate
+            rotation without waiting for the counter
+
+Most tests poke ``_propagate_turn_outcome`` + ``_reset_conversation``
+directly; the bottom-of-file ``run_turn`` wiring tests drive the full
+fake-codex App Server subprocess (mirroring ``test_codex_session.py``)
+to confirm the bookkeeping is actually invoked from the production
+turn path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent.adapters.codex_session import (
+    CODEX_THREAD_WEDGED_THRESHOLD,
+    CodexSession,
+)
+
+
+def _make_session(tmp_path: Path, agent_id: str = "codex-agent-puf267") -> CodexSession:
+    session_file = tmp_path / "agents" / agent_id / "codex_session.json"
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    return CodexSession(
+        agent_id=agent_id,
+        session_file=session_file,
+        argv=["true"],
+        cwd=str(tmp_path),
+        env={},
+        permission_mode="bypassPermissions",
+        model="",
+    )
+
+
+def _seed_runtime(tmp_path: Path, agent_id: str, *, health: str = "ok") -> None:
+    """Write a runtime.json under PUFFO_AGENT_HOME=tmp_path so the
+    flip helpers can find an agent to mutate."""
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState(
+        status="running", started_at=int(time.time()), health=health,
+    )
+    rs.save(agent_id)
+
+
+@pytest.fixture
+def env_home(tmp_path, monkeypatch):
+    """Point PUFFO_AGENT_HOME at tmp_path so RuntimeState.load/.save
+    resolve there."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    return tmp_path
+
+
+# ── Counter mechanics ────────────────────────────────────────────────
+
+
+def test_success_resets_counter(env_home):
+    s = _make_session(env_home)
+    s._conversation_id = "thr_active"
+    s._consecutive_thread_failures = 1
+    rotated = s._propagate_turn_outcome(outcome="success")
+    assert rotated is False
+    assert s._consecutive_thread_failures == 0
+    # Successful outcome must NOT clear an in-use conversation_id.
+    assert s._conversation_id == "thr_active"
+
+
+def test_single_timeout_below_threshold_does_not_rotate(env_home):
+    s = _make_session(env_home)
+    s._conversation_id = "thr_active"
+    rotated = s._propagate_turn_outcome(outcome="timeout")
+    assert rotated is False
+    assert s._consecutive_thread_failures == 1
+    assert s._conversation_id == "thr_active"
+
+
+def test_threshold_consecutive_timeouts_rotate_and_flip(env_home):
+    """At exactly CODEX_THREAD_WEDGED_THRESHOLD consecutive non-success
+    outcomes the conversation must rotate AND the per-agent runtime
+    health flips to ``codex_thread_wedged``."""
+    from puffo_agent.portal.state import RuntimeState
+    aid = "codex-puf267-a"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    # First non-success below threshold → no rotation.
+    rotated_first = s._propagate_turn_outcome(outcome="timeout")
+    assert rotated_first is False
+    assert s._conversation_id == "thr_wedged"
+    # Threshold hit on the next tick → rotate.
+    assert CODEX_THREAD_WEDGED_THRESHOLD == 2
+    rotated = s._propagate_turn_outcome(outcome="timeout")
+    assert rotated is True
+    assert s._conversation_id == ""
+    # Persisted session file reflects the empty conversation id.
+    assert s._load_conversation_id() == ""
+    rs = RuntimeState.load(aid)
+    assert rs is not None
+    assert rs.health == "codex_thread_wedged"
+    assert "automatic on the next inbound message" in rs.error
+
+
+def test_threshold_consecutive_turn_failed_rotate_and_flip(env_home):
+    aid = "codex-puf267-b"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    s._propagate_turn_outcome(outcome="turn_failed", err_text="boom")
+    rotated = s._propagate_turn_outcome(outcome="turn_failed", err_text="boom")
+    assert rotated is True
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState.load(aid)
+    assert rs.health == "codex_thread_wedged"
+
+
+def test_success_after_rotation_clears_wedged_health(env_home):
+    aid = "codex-puf267-c"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    # Drive the rotation.
+    for _ in range(CODEX_THREAD_WEDGED_THRESHOLD):
+        s._propagate_turn_outcome(outcome="timeout")
+    from puffo_agent.portal.state import RuntimeState
+    assert RuntimeState.load(aid).health == "codex_thread_wedged"
+    # Simulate the next ensure_running starting a fresh thread.
+    s._conversation_id = "thr_fresh"
+    # Next turn succeeds → counter resets + health clears.
+    rotated = s._propagate_turn_outcome(outcome="success")
+    assert rotated is False
+    assert s._consecutive_thread_failures == 0
+    rs = RuntimeState.load(aid)
+    assert rs.health == "ok"
+    assert rs.error == ""
+
+
+# ── Layer 3: verbatim "agent thread limit reached" ────────────────────
+
+
+def test_thread_limit_verbatim_string_rotates_immediately(env_home):
+    """Codex's explicit ``agent thread limit reached`` error rotates on
+    the FIRST occurrence — no counter wait. The string match is
+    case-insensitive."""
+    aid = "codex-puf267-d"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    rotated = s._propagate_turn_outcome(
+        outcome="turn_failed",
+        err_text="codex turn failed: agent thread limit reached",
+    )
+    assert rotated is True
+    assert s._conversation_id == ""
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState.load(aid)
+    assert rs.health == "codex_thread_wedged"
+    assert "thread-limit verbatim" in rs.error
+
+
+def test_thread_limit_case_insensitive(env_home):
+    aid = "codex-puf267-e"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    rotated = s._propagate_turn_outcome(
+        outcome="turn_failed",
+        err_text="AGENT Thread LIMIT Reached",
+    )
+    assert rotated is True
+
+
+def test_other_turn_failed_does_not_immediate_rotate(env_home):
+    """A turn-failed without the verbatim thread-limit string follows
+    the counter path — single occurrence does NOT rotate."""
+    aid = "codex-puf267-f"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    rotated = s._propagate_turn_outcome(
+        outcome="turn_failed",
+        err_text="codex turn failed: some other error",
+    )
+    assert rotated is False
+    assert s._conversation_id == "thr_wedged"
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState.load(aid)
+    assert rs.health == "ok"
+
+
+# ── Precedence guards ────────────────────────────────────────────────
+
+
+def test_does_not_overwrite_auth_failed(env_home):
+    aid = "codex-puf267-g"
+    _seed_runtime(env_home, aid, health="auth_failed")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    s._save_conversation_id("thr_wedged")
+    for _ in range(CODEX_THREAD_WEDGED_THRESHOLD):
+        s._propagate_turn_outcome(outcome="timeout")
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState.load(aid)
+    assert rs.health == "auth_failed", (
+        "codex_thread_wedged must not downgrade auth_failed"
+    )
+
+
+def test_does_not_overwrite_api_error_abandoned(env_home):
+    aid = "codex-puf267-h"
+    _seed_runtime(env_home, aid, health="api_error_abandoned")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    for _ in range(CODEX_THREAD_WEDGED_THRESHOLD):
+        s._propagate_turn_outcome(outcome="timeout")
+    from puffo_agent.portal.state import RuntimeState
+    assert RuntimeState.load(aid).health == "api_error_abandoned"
+
+
+def test_does_not_overwrite_refresh_broken(env_home):
+    aid = "codex-puf267-i"
+    _seed_runtime(env_home, aid, health="refresh_broken")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_wedged"
+    for _ in range(CODEX_THREAD_WEDGED_THRESHOLD):
+        s._propagate_turn_outcome(outcome="timeout")
+    from puffo_agent.portal.state import RuntimeState
+    assert RuntimeState.load(aid).health == "refresh_broken"
+
+
+# ── _reset_conversation persistence ──────────────────────────────────
+
+
+def test_reset_conversation_clears_persisted_file(env_home):
+    """The rotation must clear BOTH the in-memory id AND the on-disk
+    session_file so a daemon restart between turns doesn't re-load
+    the wedged id from disk."""
+    s = _make_session(env_home)
+    s._conversation_id = "thr_to_clear"
+    s._save_conversation_id("thr_to_clear")
+    assert s._load_conversation_id() == "thr_to_clear"
+    s._reset_conversation()
+    assert s._conversation_id == ""
+    assert s._load_conversation_id() == ""
+
+
+# ── PR #55 review polish ─────────────────────────────────────────────
+
+
+def test_codex_thread_wedged_cleared_after_daemon_restart(env_home):
+    """Operator-prescribed (PR #55 review item 1): a fresh session with
+    in-memory counter=0 must still always clear an on-disk
+    ``codex_thread_wedged`` flag on the first successful turn.
+
+    Mirrors the PR #52 v1 stale-state bug class: gating the clear on
+    counter>0 would leave runtime.health stuck on the wedged value
+    forever after a daemon restart that happens between rotation and
+    the next success."""
+    from puffo_agent.portal.state import RuntimeState
+    aid = "codex-puf267-restart"
+    _seed_runtime(env_home, aid, health="codex_thread_wedged")
+    s = _make_session(env_home, agent_id=aid)
+    # Brand new session — no in-memory streak. This is the daemon-
+    # restart-then-success path.
+    assert s._consecutive_thread_failures == 0
+    rotated = s._propagate_turn_outcome(outcome="success")
+    assert rotated is False
+    rs = RuntimeState.load(aid)
+    assert rs is not None
+    assert rs.health == "ok"
+    assert rs.error == ""
+
+
+def test_counter_resets_after_rotation_to_avoid_thrash(env_home):
+    """Operator-prescribed (PR #55 review item 2): after rotation fires
+    the counter must reset to 0 so the freshly-rotated thread gets a
+    fair THRESHOLD-budget — otherwise a broken App Server would
+    rotate on every single subsequent turn (counter-thrash)."""
+    aid = "codex-puf267-thrash"
+    _seed_runtime(env_home, aid, health="ok")
+    s = _make_session(env_home, agent_id=aid)
+    s._conversation_id = "thr_1"
+    # Drive the rotation by hitting THRESHOLD non-success outcomes.
+    for _ in range(CODEX_THREAD_WEDGED_THRESHOLD):
+        s._propagate_turn_outcome(outcome="timeout")
+    # Counter must have reset.
+    assert s._consecutive_thread_failures == 0
+    # Simulate _ensure_running starting a fresh thread.
+    s._conversation_id = "thr_2"
+    # A single subsequent timeout must NOT re-rotate — the fresh
+    # thread has its own THRESHOLD budget.
+    rotated = s._propagate_turn_outcome(outcome="timeout")
+    assert rotated is False
+    assert s._conversation_id == "thr_2"
+    assert s._consecutive_thread_failures == 1
+
+
+# ── Layer 3 helper (Item 6) ──────────────────────────────────────────
+
+
+def test_looks_like_codex_thread_limit_helper():
+    """Tuple-shape extensibility (PR #55 review item 6): the helper
+    matches the verbatim string case-insensitively and rejects
+    unrelated turn-failed errors."""
+    from puffo_agent.agent.adapters.codex_session import (
+        _looks_like_codex_thread_limit,
+    )
+    assert _looks_like_codex_thread_limit(
+        "codex turn failed: agent thread limit reached",
+    )
+    assert _looks_like_codex_thread_limit("AGENT THREAD LIMIT REACHED")
+    assert not _looks_like_codex_thread_limit("rate limit exceeded")
+    assert not _looks_like_codex_thread_limit("")
+
+
+# ── run_turn wiring tests (PR #55 review item 4) ─────────────────────
+#
+# Confirm the production turn path actually invokes
+# _propagate_turn_outcome at the success / turn_failed sites. Uses the
+# same fake-codex-app-server pattern as test_codex_session.py so the
+# wire shape matches what real codex emits. Timeout coverage is
+# omitted because TURN_TIMEOUT_SECONDS = 600s makes the wire-level
+# path impractical to exercise; the bookkeeping for the timeout outcome
+# is fully covered by the direct ``_propagate_turn_outcome(outcome=
+# "timeout")`` tests above.
+
+
+_FAKE_HEADER = textwrap.dedent('''\
+    import json, sys
+
+    def w(obj):
+        sys.stdout.write(json.dumps(obj) + "\\n")
+        sys.stdout.flush()
+
+    def r():
+        line = sys.stdin.readline()
+        return json.loads(line) if line else None
+
+    def absorb_initialize():
+        msg = r()
+        assert msg["method"] == "initialize"
+        w({"jsonrpc": "2.0", "id": msg["id"], "result": {}})
+''')
+
+
+def _write_fake(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_codex.py"
+    path.write_text(_FAKE_HEADER + "\n" + body, encoding="utf-8")
+    return path
+
+
+def _wiring_session(tmp_path: Path, fake: Path, agent_id: str) -> CodexSession:
+    session_file = tmp_path / "agents" / agent_id / "codex_session.json"
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    return CodexSession(
+        agent_id=agent_id,
+        session_file=session_file,
+        argv=[sys.executable, str(fake)],
+        cwd=str(tmp_path),
+    )
+
+
+_WIRING_SUCCESS = '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "conv_w1"}}})
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "method": "item/agentMessage/delta",
+   "params": {"threadId": "t", "turnId": "u", "itemId": "m", "delta": "ok"}})
+w({"jsonrpc": "2.0", "id": turn_id, "result": None})
+w({"jsonrpc": "2.0", "method": "turn/completed", "params": {}})
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+'''
+
+
+def test_run_turn_success_clears_wedged_via_wiring(env_home):
+    """``run_turn`` success path must invoke
+    ``_propagate_turn_outcome(outcome='success')``, which in turn
+    always clears an on-disk ``codex_thread_wedged`` flag."""
+    aid = "codex-puf267-wire-success"
+    _seed_runtime(env_home, aid, health="codex_thread_wedged")
+    fake = _write_fake(env_home, _WIRING_SUCCESS)
+    cs = _wiring_session(env_home, fake, aid)
+
+    async def _run():
+        await cs.warm("sys")
+        result = await cs.run_turn("hi", "sys")
+        await cs.aclose()
+        return result
+
+    result = asyncio.run(_run())
+    assert result.reply == "ok"
+    assert cs._consecutive_thread_failures == 0
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState.load(aid)
+    assert rs.health == "ok"
+    assert rs.error == ""
+
+
+_WIRING_TURN_FAILED = '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "conv_w2"}}})
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id, "result": None})
+w({"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {"error": {"message": "model overloaded"}}})
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+'''
+
+
+def test_run_turn_failed_ticks_counter_via_wiring(env_home):
+    """A single ``turn/failed`` without the thread-limit string must
+    tick the counter (no rotation yet) via the production
+    ``run_turn`` path."""
+    aid = "codex-puf267-wire-fail"
+    _seed_runtime(env_home, aid, health="ok")
+    fake = _write_fake(env_home, _WIRING_TURN_FAILED)
+    cs = _wiring_session(env_home, fake, aid)
+
+    async def _run():
+        await cs.warm("sys")
+        try:
+            await cs.run_turn("hi", "sys")
+        except RuntimeError:
+            pass
+        await cs.aclose()
+
+    asyncio.run(_run())
+    assert cs._consecutive_thread_failures == 1
+    # Below THRESHOLD → no rotation, no health flip yet.
+    assert cs._conversation_id == "conv_w2"
+    from puffo_agent.portal.state import RuntimeState
+    assert RuntimeState.load(aid).health == "ok"
+
+
+_WIRING_THREAD_LIMIT = '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "conv_w3"}}})
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id, "result": None})
+w({"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {"error": {"message": "agent thread limit reached"}}})
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+'''
+
+
+def test_run_turn_thread_limit_rotates_via_wiring(env_home):
+    """Layer 3: a ``turn/failed`` carrying the verbatim
+    ``"agent thread limit reached"`` string must rotate the
+    conversation on the FIRST occurrence via the production
+    ``run_turn`` path."""
+    aid = "codex-puf267-wire-limit"
+    _seed_runtime(env_home, aid, health="ok")
+    fake = _write_fake(env_home, _WIRING_THREAD_LIMIT)
+    cs = _wiring_session(env_home, fake, aid)
+
+    async def _run():
+        await cs.warm("sys")
+        try:
+            await cs.run_turn("hi", "sys")
+        except RuntimeError:
+            pass
+        await cs.aclose()
+
+    asyncio.run(_run())
+    # Verbatim hit → conversation cleared + counter reset.
+    assert cs._conversation_id == ""
+    assert cs._consecutive_thread_failures == 0
+    from puffo_agent.portal.state import RuntimeState
+    rs = RuntimeState.load(aid)
+    assert rs.health == "codex_thread_wedged"
+    assert "thread-limit verbatim" in rs.error

--- a/tests/test_codex_thread_rotation.py
+++ b/tests/test_codex_thread_rotation.py
@@ -290,6 +290,52 @@ def test_codex_thread_wedged_cleared_after_daemon_restart(env_home):
     assert rs.error == ""
 
 
+def test_chain_with_puf270_worker_flip_resolve_clears_wedged(env_home):
+    """PR #55 round-2 review item 2: walk the production chain after
+    PUF-270 landed — worker's ``_flip_health_in_progress`` overwrites
+    any disk ``codex_thread_wedged`` with ``in_progress`` BEFORE
+    codex's ``_propagate_turn_outcome("success")`` runs, so codex's
+    own clear lane is a no-op. The worker's finally
+    ``_resolve_health_on_success`` then resolves ``in_progress → ok``.
+
+    Without this test the codex-side clear's defensiveness on
+    daemon-restart-with-stale-disk is the only path exercised; this
+    pins the live ordering of the two clear lanes.
+    """
+    from puffo_agent.portal.state import RuntimeState
+    from puffo_agent.portal.worker import Worker
+    import logging
+
+    aid = "codex-puf267-puf270-chain"
+    _seed_runtime(env_home, aid, health="codex_thread_wedged")
+    log = logging.getLogger("test-puf267-chain")
+    s = _make_session(env_home, agent_id=aid)
+
+    # T0: pre-turn disk state is the leftover red from a prior wedge.
+    rs = RuntimeState.load(aid)
+    assert rs is not None and rs.health == "codex_thread_wedged"
+
+    # T1: worker's PUF-270 flip — overrides the leftover red.
+    Worker._flip_health_in_progress(rs, aid, log)
+    assert rs.health == "in_progress"
+
+    # T2: handle_message_batch (codex) succeeds — codex's clear lane
+    # tries to clear ``codex_thread_wedged`` but health is now
+    # ``in_progress`` so its guard at L505 early-returns. No-op.
+    rotated = s._propagate_turn_outcome(outcome="success")
+    assert rotated is False
+    # Reload — codex didn't touch in_progress.
+    on_disk = RuntimeState.load(aid)
+    assert on_disk is not None and on_disk.health == "in_progress"
+
+    # T3: worker's finally resolves ``in_progress → ok``.
+    Worker._resolve_health_on_success(rs, aid, log)
+    final = RuntimeState.load(aid)
+    assert final is not None
+    assert final.health == "ok"
+    assert final.error == ""
+
+
 def test_counter_resets_after_rotation_to_avoid_thrash(env_home):
     """Operator-prescribed (PR #55 review item 2): after rotation fires
     the counter must reset to 0 so the freshly-rotated thread gets a


### PR DESCRIPTION
## Summary (P0)

Operator's family-ops 4-agent codex fleet (Justin/Tiffany/Sean/Dawn) wedged simultaneously. Three architectural gaps in `CodexSession`:

- **Layer 1** — `_conversation_id` persistence unconditional (survived turn-timeouts, daemon restarts, pause/resume) → wedged thread reused forever
- **Layer 2** — Turn-timeout returned empty reply + `codex_turn_timeout=True` metadata with **zero readers** → `runtime.health` never flipped → silent-loop
- **Layer 3** — `"agent thread limit reached"` propagated as raw `RuntimeError` with no rotation/health-flip

**This is the defensive PR** — mirrors PUF-265's outcome-capture pattern but for codex thread lifecycle instead of credential refresh. Does NOT proactively prevent the wedge (that's the follow-up real-fix PR with token/turn-count heuristics). Kills the silent-loop blind spot + auto-recovers on next inbound message once wedge fires.

## Changes

- `codex_session.py`:
  - New `_consecutive_thread_failures` counter; `CODEX_THREAD_WEDGED_THRESHOLD=2` (mirrors PUF-265's `REFRESH_BROKEN_THRESHOLD`)
  - New `_CODEX_THREAD_LIMIT_PATTERN = re.compile(r"agent thread limit reached", re.IGNORECASE)` for Layer 3
  - New `_propagate_turn_outcome(outcome, err_text)` called on every turn completion:
    - `success` → reset counter + clear `codex_thread_wedged` health
    - `timeout` → bump counter; rotate + flip at threshold
    - `turn_failed` → same counter path; OR if err matches verbatim string → rotate IMMEDIATELY
  - New `_reset_conversation` clears in-memory id + persisted session_file; next `_ensure_running` falls through to `thread/start` (existing precedent at L444-462)
  - New `_flip_codex_thread_wedged_health` / `_clear_codex_thread_wedged_health` with precedence: `auth_failed` / `api_error_abandoned` / `refresh_broken` NOT overwritten
  - Worker integration: `run_turn` calls `_propagate_turn_outcome` inline on each branch; turn_failed re-raises after bookkeeping so worker's existing error path still logs
- `portal/state.py` — `RuntimeState.health` enum + docstring extended for `codex_thread_wedged`
- `portal/cli.py` — `agent list` surfaces `[codex_thread_wedged]`

## Tests

12 new in `tests/test_codex_thread_rotation.py`:
- Counter mechanics: success resets / 1 timeout no-op / 2nd timeout flips at exactly `CODEX_THREAD_WEDGED_THRESHOLD=2`
- Rotation path: counter trips → `_conversation_id` cleared in-memory + on disk
- Layer 2 propagation: runtime.health flips with operator-actionable error
- Layer 3 verbatim: "agent thread limit reached" triggers immediate rotation on FIRST turn-failed; case-insensitive
- Non-thread-limit turn_failed follows counter path (no false-positive)
- Success after rotation clears `codex_thread_wedged` → `ok` + resets counter
- Precedence: `auth_failed` / `api_error_abandoned` / `refresh_broken` NOT overwritten

**Test results:** 12/12 focused + 880 passed, 1 skipped (pre-existing permission-mode test) full suite.

## Known limits / out-of-scope

- **No proactive heuristic** (real-fix PR territory) — pre-emptive rotation on observed token/turn count would prevent the wedge. Defensive PR recovers AFTER, but auto+visibly
- **Codex App Server process not torn down on rotation** — only the per-thread state. By design: codex supports multiple threads per process
- **No retry of the wedged turn** — rotated thread starts fresh on the NEXT inbound message (matches Sam's reported pause/resume workaround)

## Ship cadence

- **Live-test bench:** operator's 4-agent family-ops fleet (Justin/Tiffany/Sean/Dawn) is the natural validation surface
- **Closure-back:** Grande-relayed via #Customer Voice; Grande close-loops with Sam in #Feedback New

🤖 Generated with [Claude Code](https://claude.com/claude-code)