### PR TITLE
fix: DEFAULT_PUFFO_SERVER_URL → chat.puffo.ai/relay

### DIFF
--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -483,7 +483,7 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
         "next: register a puffo-core identity for this agent with "
         "`puffo-cli agent register`, then fill the puffo_core: block in "
         f"{agent_yml_path(agent_id)} (slug, device_id, space_id; "
-        "server_url defaults to https://api.puffo.ai)."
+        "server_url defaults to https://chat.puffo.ai/relay)."
     )
     if not is_daemon_alive():
         print("daemon is not running — run `puffo-agent start` to activate.")

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -905,7 +905,9 @@ class TriggerRules:
 
 ## Default puffo-core server. Override per-agent via
 ## ``puffo_core.server_url`` for self-hosted relays or local dev.
-DEFAULT_PUFFO_SERVER_URL = "https://api.puffo.ai"
+## ``api.puffo.ai`` is platform-internal only; client traffic goes
+## through the public ``chat.puffo.ai/relay`` edge.
+DEFAULT_PUFFO_SERVER_URL = "https://chat.puffo.ai/relay"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Flip the daemon's hardcoded backend default from the platform-internal `https://api.puffo.ai` to the public `https://chat.puffo.ai/relay`. Any new agent created without an explicit `puffo_core.server_url` in its `agent.yml` previously fell through to `api.puffo.ai`, which clients can't reach — surfacing as immediate WS / HTTP connection failures.

## Why this slipped through until now

The fallback in `state.py:1036` (`pc.get("server_url") or DEFAULT_PUFFO_SERVER_URL`) only fires when the create-agent path forgets to fill `server_url`. Every prior create path explicitly populated it, so the wrong default was unobserved.

A new agent created today via the web `chat.puffo.ai/chat/agents` flow surfaced an agent.yml with `server_url: https://api.puffo.ai` — the daemon had no chance to connect. The web client's `PROD_BACKEND_URL` constant pointing at the same internal URL is the other half of the bug and is being fixed separately in puffo-core-han-group.

## Bug archaeology

- Introduced: commit `7beb349` on 2026-05-10 (v0.7.2), during the puffo-agent extraction from the monorepo.
- Hidden because earlier creation paths always passed `server_url` explicitly.
- Two on-disk locations carry this value (`agent.yml::puffo_core.server_url` and the keystore JSON's `server_url` field). Only the `agent.yml` value is load-bearing at runtime; the keystore's is cosmetic.

## Changes

- `src/puffo_agent/portal/state.py:908` — `DEFAULT_PUFFO_SERVER_URL = "https://chat.puffo.ai/relay"` with a comment noting `api.puffo.ai` is platform-internal.
- `src/puffo_agent/portal/cli.py:486` — help text for the create-agent flow now mentions `chat.puffo.ai/relay`.

## Test plan

- [x] Full suite: 971 passed, 9 skipped, 0 failed (unchanged from main).
- [ ] Create a new agent without explicit `server_url`; verify `agent.yml` reads `chat.puffo.ai/relay` and the WS handshake completes.
- [ ] Existing agents on disk with the old URL: fix in place (one-off scripted rewrite) or wait for next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)