### PR TITLE
feat(PUF-270): runtime.health=in_progress override-red on begin_turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,24 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   the wire format. UI Import + Export file dialogs use the same
   extension so the round-trip lines up.
 
+- **PUF-270: ``runtime.health = "in_progress"`` overrides sticky reds
+  while a turn is mid-flight.** Operators reported agents with a stale
+  ``auth_failed`` / ``api_error_abandoned`` / ``refresh_broken`` on
+  disk looking dead in ``puffoagent agent list`` even when actively
+  processing a new message. ``on_message_batch`` now flips
+  ``runtime.health`` to ``in_progress`` at the top of every batch and
+  resolves to ``ok`` on success; in-turn category reds (set inside
+  the turn body) still survive the resolve. The
+  ``AgentAPIError → consumer kick-retry → on_turn_success`` chain
+  also resolves cleanly. Non-AgentAPIError exceptions that escape the
+  handler fall back to a new red ``unhandled_error`` (distinct from
+  ``unknown`` = not probed yet) so the CLI surfaces them as
+  actionable. The heartbeat carries both per-turn ``status`` and
+  persistent ``health`` so the server can render the alive-vs-red
+  discrimination. ``CredentialRefresher`` skips agents in
+  ``in_progress`` / ``unhandled_error`` to avoid clobbering them with
+  ``refresh_broken``.
+
 ## [0.9.6] — 2026-06-01
 
 ### Fixed

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import time
 import uuid
-from typing import Any
+from typing import Any, Callable, Optional
 
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 
@@ -46,11 +46,17 @@ class StatusReporter:
         http: PuffoCoreHttpClient,
         *,
         heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+        runtime_health_provider: Optional[Callable[[], str]] = None,
     ) -> None:
         self._http = http
         self._interval = max(10.0, heartbeat_interval_s)
         self._current_status: str = "idle"
         self._current_message_id: str | None = None
+        # PUF-270: lazy provider so the heartbeat reads the freshest
+        # ``runtime.health`` at send-time, not at construction-time.
+        # ``None`` keeps the legacy single-stream wire shape for
+        # callers that don't carry a runtime (tests, no-op fallback).
+        self._runtime_health_provider = runtime_health_provider
         self._stop = asyncio.Event()
 
     async def run_heartbeat_loop(self) -> None:
@@ -195,6 +201,15 @@ class StatusReporter:
         body: dict[str, Any] = {"status": self._current_status}
         if self._current_status == "busy" and self._current_message_id is not None:
             body["current_message_id"] = self._current_message_id
+        # PUF-270: carry persistent ``runtime.health`` alongside the
+        # per-turn ``status`` so the server can render the alive-vs-
+        # red discrimination without relying on either stream alone.
+        # Provider failures are swallowed — heartbeat best-effort.
+        if self._runtime_health_provider is not None:
+            try:
+                body["health"] = self._runtime_health_provider()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("runtime_health_provider raised (%s)", exc)
         try:
             await self._http.post("/agents/me/heartbeat", body)
         except HttpError as exc:

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -52,10 +52,7 @@ class StatusReporter:
         self._interval = max(10.0, heartbeat_interval_s)
         self._current_status: str = "idle"
         self._current_message_id: str | None = None
-        # PUF-270: lazy provider so the heartbeat reads the freshest
-        # ``runtime.health`` at send-time, not at construction-time.
-        # ``None`` keeps the legacy single-stream wire shape for
-        # callers that don't carry a runtime (tests, no-op fallback).
+        # None keeps the legacy single-stream wire shape.
         self._runtime_health_provider = runtime_health_provider
         self._stop = asyncio.Event()
 
@@ -201,10 +198,6 @@ class StatusReporter:
         body: dict[str, Any] = {"status": self._current_status}
         if self._current_status == "busy" and self._current_message_id is not None:
             body["current_message_id"] = self._current_message_id
-        # PUF-270: carry persistent ``runtime.health`` alongside the
-        # per-turn ``status`` so the server can render the alive-vs-
-        # red discrimination without relying on either stream alone.
-        # Provider failures are swallowed — heartbeat best-effort.
         if self._runtime_health_provider is not None:
             try:
                 body["health"] = self._runtime_health_provider()

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -530,8 +530,11 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
                 uptime = "—"
         # Surface non-ok health alongside lifecycle status so the
         # operator can see at a glance which agents need
-        # re-auth or refresh/restart.
+        # re-auth or refresh/restart. ``in_progress`` (PUF-270) also
+        # surfaces so the operator can confirm a sticky-red agent is
+        # actually alive while a turn is mid-flight.
         if rs is not None and rs.health in (
+            "in_progress",
             "auth_failed", "api_error_abandoned", "refresh_broken",
         ):
             runtime = f"{runtime} [{rs.health}]"

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -529,13 +529,11 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
             else:
                 uptime = "—"
         # Surface non-ok health alongside lifecycle status so the
-        # operator can see at a glance which agents need
-        # re-auth or refresh/restart. ``in_progress`` (PUF-270) also
-        # surfaces so the operator can confirm a sticky-red agent is
-        # actually alive while a turn is mid-flight.
+        # operator can see at a glance which agents need attention.
         if rs is not None and rs.health in (
             "in_progress",
             "auth_failed", "api_error_abandoned", "refresh_broken",
+            "unhandled_error",
         ):
             runtime = f"{runtime} [{rs.health}]"
         # Truncate display_name for table alignment.

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -978,7 +978,7 @@ class CredentialRefresher:
                 continue
             if rs.health in (
                 "auth_failed", "api_error_abandoned", "refresh_broken",
-                "in_progress",
+                "in_progress", "unhandled_error",
             ):
                 continue
             rs.health = "refresh_broken"

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -978,6 +978,7 @@ class CredentialRefresher:
                 continue
             if rs.health in (
                 "auth_failed", "api_error_abandoned", "refresh_broken",
+                "in_progress",
             ):
                 continue
             rs.health = "refresh_broken"

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1121,6 +1121,15 @@ class RuntimeState:
     #   "ok"                  — refresh-ping passed, a turn cleared a
     #                           prior abandon, or a credential refresh
     #                           cleared a prior auth_failed
+    #   "in_progress"         — a turn is mid-flight. PUF-270:
+    #                           ``worker.on_message_batch`` flips here
+    #                           UNCONDITIONALLY at batch-top (overrides
+    #                           any sticky red) and resolves to "ok" on
+    #                           success / give-up-red on abandon /
+    #                           leaves as "in_progress" on retry. Lets
+    #                           the UI show the agent is actually alive
+    #                           even while a recent failure left a
+    #                           sticky red value on disk.
     #   "auth_failed"         — adapter saw 401 / authentication_error
     #                           (set in worker._handle_suppressed_reply);
     #                           cleared by the CredentialRefresher's
@@ -1134,7 +1143,7 @@ class RuntimeState:
     #                           REFRESHED. Does not overwrite the two
     #                           stronger downstream signals above.
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | auth_failed | api_error_abandoned | refresh_broken | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> "RuntimeState | None":

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1121,15 +1121,8 @@ class RuntimeState:
     #   "ok"                  — refresh-ping passed, a turn cleared a
     #                           prior abandon, or a credential refresh
     #                           cleared a prior auth_failed
-    #   "in_progress"         — a turn is mid-flight. PUF-270:
-    #                           ``worker.on_message_batch`` flips here
-    #                           UNCONDITIONALLY at batch-top (overrides
-    #                           any sticky red) and resolves to "ok" on
-    #                           success / give-up-red on abandon /
-    #                           leaves as "in_progress" on retry. Lets
-    #                           the UI show the agent is actually alive
-    #                           even while a recent failure left a
-    #                           sticky red value on disk.
+    #   "in_progress"         — turn mid-flight; overrides any sticky
+    #                           red so the UI reads alive (PUF-270)
     #   "auth_failed"         — adapter saw 401 / authentication_error
     #                           (set in worker._handle_suppressed_reply);
     #                           cleared by the CredentialRefresher's

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1135,8 +1135,11 @@ class RuntimeState:
     #                           refresh outcomes; cleared by next
     #                           REFRESHED. Does not overwrite the two
     #                           stronger downstream signals above.
+    #   "unhandled_error"     — non-AgentAPIError raised in the turn and
+    #                           no category red was set (PUF-270 backstop);
+    #                           cleared by next successful turn
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unhandled_error | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> "RuntimeState | None":

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1122,7 +1122,7 @@ class RuntimeState:
     #                           prior abandon, or a credential refresh
     #                           cleared a prior auth_failed
     #   "in_progress"         — turn mid-flight; overrides any sticky
-    #                           red so the UI reads alive (PUF-270)
+    #                           red so the UI reads alive
     #   "auth_failed"         — adapter saw 401 / authentication_error
     #                           (set in worker._handle_suppressed_reply);
     #                           cleared by the CredentialRefresher's
@@ -1136,8 +1136,8 @@ class RuntimeState:
     #                           REFRESHED. Does not overwrite the two
     #                           stronger downstream signals above.
     #   "unhandled_error"     — non-AgentAPIError raised in the turn and
-    #                           no category red was set (PUF-270 backstop);
-    #                           cleared by next successful turn
+    #                           no category red was set; cleared by
+    #                           next successful turn
     #   "unknown"             — no probe yet
     health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unhandled_error | unknown
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -564,6 +564,58 @@ class Worker:
             agent_id,
         )
 
+    @staticmethod
+    def _flip_health_in_progress(
+        runtime: "RuntimeState",
+        agent_id: str,
+        log: logging.Logger,
+    ) -> None:
+        """PUF-270: flip ``runtime.health`` to ``in_progress`` at the
+        top of every ``on_message_batch``. Overrides any sticky red
+        (auth_failed / api_error_abandoned / refresh_broken) so the UI
+        can show the agent is actually alive while a turn is mid-
+        flight. Idempotent — no-op when already ``in_progress``.
+
+        Override-all-reds shape was Stage-3 picked per operator's
+        rule 1 ("before agent starts processing any message"). The
+        false-positive concern (auth_failed → in_progress right
+        before the API call 401s again) is self-correcting because
+        ``_handle_suppressed_reply`` re-flips back to auth_failed
+        within the same turn.
+        """
+        if runtime.health == "in_progress":
+            return
+        runtime.health = "in_progress"
+        runtime.error = ""
+        runtime.save(agent_id)
+        log.info(
+            "agent %s: runtime.health flipped to in_progress at "
+            "begin_turn",
+            agent_id,
+        )
+
+    @staticmethod
+    def _resolve_health_on_success(
+        runtime: "RuntimeState",
+        agent_id: str,
+        log: logging.Logger,
+    ) -> None:
+        """PUF-270: after a successful turn, transition
+        ``in_progress`` → ``ok``. Only fires when the flip lane set
+        the in_progress value — leaves any externally-set state
+        (e.g., a give-up red set inside the turn) untouched.
+        """
+        if runtime.health != "in_progress":
+            return
+        runtime.health = "ok"
+        runtime.error = ""
+        runtime.save(agent_id)
+        log.info(
+            "agent %s: turn succeeded; runtime.health resolved "
+            "from in_progress to ok",
+            agent_id,
+        )
+
     def __init__(
         self,
         daemon_cfg: DaemonConfig,
@@ -850,6 +902,15 @@ class Worker:
                     "agent %s: could not write current_turn.json: %s "
                     "(permission hook will fail-open)", agent_id, exc,
                 )
+            # PUF-270: flip to in_progress before the agent visibly
+            # starts work. Resolved in the finally below.
+            try:
+                Worker._flip_health_in_progress(self.runtime, agent_id, logger)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent %s: _flip_health_in_progress failed: %s",
+                    agent_id, exc,
+                )
             # Server-side processing-run + status transitions.
             # Reporter swallows network errors so a flaky status push
             # never blocks the actual reply.
@@ -906,6 +967,21 @@ class Worker:
                             "error_text": turn_error,
                         })
                     await reporter.end_turn_batch(runs)
+                # PUF-270 resolve: on success, in_progress → ok. On
+                # failure we leave the current state — category-
+                # specific paths may have set a give-up red, or the
+                # consumer-loop will re-enqueue and the next begin
+                # flips back to in_progress.
+                if turn_succeeded:
+                    try:
+                        Worker._resolve_health_on_success(
+                            self.runtime, agent_id, logger,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent %s: _resolve_health_on_success failed: %s",
+                            agent_id, exc,
+                        )
                 # Clear turn context so post-turn background work
                 # doesn't inherit a stale channel/root. Hook
                 # fails-open when the file is absent.
@@ -1042,7 +1118,17 @@ class Worker:
         # Server-side status reporter: own heartbeat task; begin_turn /
         # end_turn fire inline from on_message via this closure. Falls
         # back to a no-op when the client has no http client (tests).
-        reporter = StatusReporter(client.http) if hasattr(client, "http") else None
+        # PUF-270: hand the reporter a lazy provider so each heartbeat
+        # carries the freshest ``runtime.health`` alongside the per-turn
+        # ``status``.
+        reporter = (
+            StatusReporter(
+                client.http,
+                runtime_health_provider=lambda: self.runtime.health,
+            )
+            if hasattr(client, "http")
+            else None
+        )
         if reporter is None:  # pragma: no cover — defensive
             class _NoopReporter:
                 async def begin_turn(self, _mid):

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -570,18 +570,10 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """PUF-270: flip ``runtime.health`` to ``in_progress`` at the
-        top of every ``on_message_batch``. Overrides any sticky red
-        (auth_failed / api_error_abandoned / refresh_broken) so the UI
-        can show the agent is actually alive while a turn is mid-
-        flight. Idempotent — no-op when already ``in_progress``.
-
-        Override-all-reds shape was Stage-3 picked per operator's
-        rule 1 ("before agent starts processing any message"). The
-        false-positive concern (auth_failed → in_progress right
-        before the API call 401s again) is self-correcting because
-        ``_handle_suppressed_reply`` re-flips back to auth_failed
-        within the same turn.
+        """PUF-270: at every batch-top, override any sticky red with
+        ``in_progress``. False-positives (auth_failed → in_progress
+        right before the API 401s again) self-correct in-turn via
+        ``_handle_suppressed_reply``. Idempotent.
         """
         if runtime.health == "in_progress":
             return
@@ -614,6 +606,37 @@ class Worker:
             "agent %s: turn succeeded; runtime.health resolved "
             "from in_progress to ok",
             agent_id,
+        )
+
+    @staticmethod
+    def _fallback_unknown_if_stuck_in_progress(
+        runtime: "RuntimeState",
+        agent_id: str,
+        turn_error: str | None,
+        log: logging.Logger,
+    ) -> None:
+        """PUF-270 backstop: a turn that didn't succeed AND won't be
+        re-enqueued (non-AgentAPIError swallow) would otherwise leave
+        ``runtime.health == "in_progress"`` until daemon restart.
+        Fall back to ``unknown`` + populated ``error`` so the UI shows
+        an honest state instead of "still working" forever.
+
+        No-op when a category-specific give-up red (auth_failed /
+        api_error_abandoned / refresh_broken) was already written
+        in-turn — those carry better detail than ``unknown``.
+        """
+        if runtime.health != "in_progress":
+            return
+        runtime.health = "unknown"
+        runtime.error = turn_error or (
+            "turn did not succeed; no category-specific health "
+            "value was written"
+        )
+        runtime.save(agent_id)
+        log.warning(
+            "agent %s: turn did not succeed and no category-specific "
+            "red was set; runtime.health fell back to unknown (%s)",
+            agent_id, runtime.error,
         )
 
     def __init__(
@@ -902,8 +925,7 @@ class Worker:
                     "agent %s: could not write current_turn.json: %s "
                     "(permission hook will fail-open)", agent_id, exc,
                 )
-            # PUF-270: flip to in_progress before the agent visibly
-            # starts work. Resolved in the finally below.
+            # PUF-270: flip to in_progress; resolved in the finally.
             try:
                 Worker._flip_health_in_progress(self.runtime, agent_id, logger)
             except Exception as exc:  # noqa: BLE001
@@ -920,6 +942,7 @@ class Worker:
                 else None
             )
             turn_succeeded = True
+            turn_will_retry = False
             turn_error: str | None = None
             try:
                 reply = await puffo.handle_message_batch(
@@ -934,6 +957,7 @@ class Worker:
                 logger.warning("agent %s: api-error retry: %s", agent_id, exc)
                 reply = None
                 turn_succeeded = False
+                turn_will_retry = True
                 turn_error = "API Error"
                 raise
             except Exception as exc:
@@ -967,11 +991,12 @@ class Worker:
                             "error_text": turn_error,
                         })
                     await reporter.end_turn_batch(runs)
-                # PUF-270 resolve: on success, in_progress → ok. On
-                # failure we leave the current state — category-
-                # specific paths may have set a give-up red, or the
-                # consumer-loop will re-enqueue and the next begin
-                # flips back to in_progress.
+                # PUF-270: success → resolve in_progress → ok. Failed
+                # but will retry (AgentAPIError) → leave in_progress;
+                # consumer re-enqueues and next begin overrides anyway.
+                # Failed and won't retry (non-AgentAPIError swallow) →
+                # backstop to unknown so the UI doesn't render
+                # "still working" forever.
                 if turn_succeeded:
                     try:
                         Worker._resolve_health_on_success(
@@ -980,6 +1005,16 @@ class Worker:
                     except Exception as exc:  # noqa: BLE001
                         logger.warning(
                             "agent %s: _resolve_health_on_success failed: %s",
+                            agent_id, exc,
+                        )
+                elif not turn_will_retry:
+                    try:
+                        Worker._fallback_unknown_if_stuck_in_progress(
+                            self.runtime, agent_id, turn_error, logger,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent %s: in_progress backstop failed: %s",
                             agent_id, exc,
                         )
                 # Clear turn context so post-turn background work
@@ -1099,6 +1134,13 @@ class Worker:
         ):
             Worker._clear_api_error_abandoned_if_recoverable(
                 self.runtime, agent_id, root_id, logger,
+            )
+            # PUF-270: an AgentAPIError-then-retry-success lands here
+            # without going back through on_message_batch's finally, so
+            # in_progress would otherwise stick. Idempotent on the
+            # clean-first-try path (resolve already ran in the finally).
+            Worker._resolve_health_on_success(
+                self.runtime, agent_id, logger,
             )
 
         async def heartbeat():

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -570,10 +570,7 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """Override any sticky red with ``in_progress`` at batch-top.
-        False-positives (auth_failed → in_progress just before the API
-        401s again) self-correct in-turn via ``_handle_suppressed_reply``.
-        """
+        """Override any sticky red with ``in_progress`` at batch-top."""
         if runtime.health == "in_progress":
             return
         runtime.health = "in_progress"
@@ -587,9 +584,7 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """Transition ``in_progress`` → ``ok`` after a successful turn.
-        Skips any in-turn-written red so give-up signals survive.
-        """
+        """Transition ``in_progress`` → ``ok``; skip any in-turn red."""
         if runtime.health != "in_progress":
             return
         runtime.health = "ok"
@@ -604,10 +599,9 @@ class Worker:
         turn_error: str | None,
         log: logging.Logger,
     ) -> None:
-        """Backstop when a non-AgentAPIError swallow leaves the agent
-        flagged ``in_progress`` with no retry path. Routes to a new red
-        (``unhandled_error``) — distinct from ``unknown`` (= not probed
-        yet) so the CLI / heartbeat can surface it as actionable.
+        """``in_progress`` → ``unhandled_error`` when a non-retry-able
+        exception left the flip stuck. Distinct from ``unknown`` so the
+        CLI / heartbeat can surface it.
         """
         if runtime.health != "in_progress":
             return
@@ -970,9 +964,7 @@ class Worker:
                             "error_text": turn_error,
                         })
                     await reporter.end_turn_batch(runs)
-                # Success → ok. AgentAPIError → leave in_progress for
-                # the next batch's flip to override. Other swallow →
-                # unhandled_error backstop (no retry will re-flip).
+                # AgentAPIError leaves in_progress for next batch's flip.
                 if turn_succeeded:
                     try:
                         Worker._resolve_health_on_success(
@@ -1111,8 +1103,7 @@ class Worker:
             Worker._clear_api_error_abandoned_if_recoverable(
                 self.runtime, agent_id, root_id, logger,
             )
-            # AgentAPIError-then-retry-success skips on_message_batch's
-            # finally; resolve here so in_progress doesn't stick.
+            # retry-success path bypasses on_message_batch's finally.
             Worker._resolve_health_on_success(
                 self.runtime, agent_id, logger,
             )

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -570,21 +570,16 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """PUF-270: at every batch-top, override any sticky red with
-        ``in_progress``. False-positives (auth_failed → in_progress
-        right before the API 401s again) self-correct in-turn via
-        ``_handle_suppressed_reply``. Idempotent.
+        """Override any sticky red with ``in_progress`` at batch-top.
+        False-positives (auth_failed → in_progress just before the API
+        401s again) self-correct in-turn via ``_handle_suppressed_reply``.
         """
         if runtime.health == "in_progress":
             return
         runtime.health = "in_progress"
         runtime.error = ""
         runtime.save(agent_id)
-        log.info(
-            "agent %s: runtime.health flipped to in_progress at "
-            "begin_turn",
-            agent_id,
-        )
+        log.info("agent %s: runtime.health → in_progress", agent_id)
 
     @staticmethod
     def _resolve_health_on_success(
@@ -592,50 +587,35 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """PUF-270: after a successful turn, transition
-        ``in_progress`` → ``ok``. Only fires when the flip lane set
-        the in_progress value — leaves any externally-set state
-        (e.g., a give-up red set inside the turn) untouched.
+        """Transition ``in_progress`` → ``ok`` after a successful turn.
+        Skips any in-turn-written red so give-up signals survive.
         """
         if runtime.health != "in_progress":
             return
         runtime.health = "ok"
         runtime.error = ""
         runtime.save(agent_id)
-        log.info(
-            "agent %s: turn succeeded; runtime.health resolved "
-            "from in_progress to ok",
-            agent_id,
-        )
+        log.info("agent %s: runtime.health in_progress → ok", agent_id)
 
     @staticmethod
-    def _fallback_unknown_if_stuck_in_progress(
+    def _fallback_unhandled_error_if_stuck_in_progress(
         runtime: "RuntimeState",
         agent_id: str,
         turn_error: str | None,
         log: logging.Logger,
     ) -> None:
-        """PUF-270 backstop: a turn that didn't succeed AND won't be
-        re-enqueued (non-AgentAPIError swallow) would otherwise leave
-        ``runtime.health == "in_progress"`` until daemon restart.
-        Fall back to ``unknown`` + populated ``error`` so the UI shows
-        an honest state instead of "still working" forever.
-
-        No-op when a category-specific give-up red (auth_failed /
-        api_error_abandoned / refresh_broken) was already written
-        in-turn — those carry better detail than ``unknown``.
+        """Backstop when a non-AgentAPIError swallow leaves the agent
+        flagged ``in_progress`` with no retry path. Routes to a new red
+        (``unhandled_error``) — distinct from ``unknown`` (= not probed
+        yet) so the CLI / heartbeat can surface it as actionable.
         """
         if runtime.health != "in_progress":
             return
-        runtime.health = "unknown"
-        runtime.error = turn_error or (
-            "turn did not succeed; no category-specific health "
-            "value was written"
-        )
+        runtime.health = "unhandled_error"
+        runtime.error = turn_error or "turn raised; no category red set"
         runtime.save(agent_id)
         log.warning(
-            "agent %s: turn did not succeed and no category-specific "
-            "red was set; runtime.health fell back to unknown (%s)",
+            "agent %s: runtime.health → unhandled_error (%s)",
             agent_id, runtime.error,
         )
 
@@ -925,7 +905,6 @@ class Worker:
                     "agent %s: could not write current_turn.json: %s "
                     "(permission hook will fail-open)", agent_id, exc,
                 )
-            # PUF-270: flip to in_progress; resolved in the finally.
             try:
                 Worker._flip_health_in_progress(self.runtime, agent_id, logger)
             except Exception as exc:  # noqa: BLE001
@@ -991,12 +970,9 @@ class Worker:
                             "error_text": turn_error,
                         })
                     await reporter.end_turn_batch(runs)
-                # PUF-270: success → resolve in_progress → ok. Failed
-                # but will retry (AgentAPIError) → leave in_progress;
-                # consumer re-enqueues and next begin overrides anyway.
-                # Failed and won't retry (non-AgentAPIError swallow) →
-                # backstop to unknown so the UI doesn't render
-                # "still working" forever.
+                # Success → ok. AgentAPIError → leave in_progress for
+                # the next batch's flip to override. Other swallow →
+                # unhandled_error backstop (no retry will re-flip).
                 if turn_succeeded:
                     try:
                         Worker._resolve_health_on_success(
@@ -1009,7 +985,7 @@ class Worker:
                         )
                 elif not turn_will_retry:
                     try:
-                        Worker._fallback_unknown_if_stuck_in_progress(
+                        Worker._fallback_unhandled_error_if_stuck_in_progress(
                             self.runtime, agent_id, turn_error, logger,
                         )
                     except Exception as exc:  # noqa: BLE001
@@ -1135,10 +1111,8 @@ class Worker:
             Worker._clear_api_error_abandoned_if_recoverable(
                 self.runtime, agent_id, root_id, logger,
             )
-            # PUF-270: an AgentAPIError-then-retry-success lands here
-            # without going back through on_message_batch's finally, so
-            # in_progress would otherwise stick. Idempotent on the
-            # clean-first-try path (resolve already ran in the finally).
+            # AgentAPIError-then-retry-success skips on_message_batch's
+            # finally; resolve here so in_progress doesn't stick.
             Worker._resolve_health_on_success(
                 self.runtime, agent_id, logger,
             )
@@ -1160,9 +1134,7 @@ class Worker:
         # Server-side status reporter: own heartbeat task; begin_turn /
         # end_turn fire inline from on_message via this closure. Falls
         # back to a no-op when the client has no http client (tests).
-        # PUF-270: hand the reporter a lazy provider so each heartbeat
-        # carries the freshest ``runtime.health`` alongside the per-turn
-        # ``status``.
+        # Lazy provider so each heartbeat reads live runtime.health.
         reporter = (
             StatusReporter(
                 client.http,

--- a/tests/test_runtime_health_in_progress.py
+++ b/tests/test_runtime_health_in_progress.py
@@ -1,0 +1,216 @@
+"""PUF-270: ``runtime.health = "in_progress"`` lifecycle.
+
+Tests the two new static helpers on Worker:
+- ``_flip_health_in_progress`` (called at the top of every
+  ``on_message_batch``) overrides any sticky red into in_progress.
+- ``_resolve_health_on_success`` (called in the finally on
+  ``turn_succeeded``) transitions in_progress → ok, but leaves any
+  other state alone.
+
+Also covers the StatusReporter heartbeat shape extension (carries
+both per-turn ``status`` AND persistent ``health``) and the
+``cli.cmd_agent_list`` surfaced-health tuple includes
+``in_progress``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from puffo_agent.portal.state import RuntimeState
+from puffo_agent.portal.worker import Worker
+
+
+_LOG = logging.getLogger("test-puf-270")
+
+
+def _seed_runtime(tmp_path: Path, monkeypatch, *, health: str) -> str:
+    """Materialize a per-agent runtime.json on disk so save() round-
+    trips correctly. Returns the agent_id."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    agent_id = "tester-puf270"
+    (tmp_path / "agents" / agent_id).mkdir(parents=True, exist_ok=True)
+    rs = RuntimeState(
+        status="running",
+        started_at=1,
+        msg_count=0,
+        health=health,
+        error="prior",
+    )
+    rs.save(agent_id)
+    return agent_id
+
+
+# ── _flip_health_in_progress ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "starting_health",
+    ["ok", "unknown", "auth_failed", "api_error_abandoned", "refresh_broken"],
+)
+def test_flip_in_progress_overrides_any_starting_state(
+    tmp_path, monkeypatch, starting_health,
+):
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health=starting_health)
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._flip_health_in_progress(rs, agent_id, _LOG)
+    assert rs.health == "in_progress"
+    assert rs.error == ""
+    # Persisted to disk.
+    on_disk = RuntimeState.load(agent_id)
+    assert on_disk is not None
+    assert on_disk.health == "in_progress"
+    assert on_disk.error == ""
+
+
+def test_flip_in_progress_is_idempotent_when_already_in_progress(
+    tmp_path, monkeypatch,
+):
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="in_progress")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    # Carry a stale error string + assert flip leaves it alone (no-op).
+    rs.error = "stale"
+    Worker._flip_health_in_progress(rs, agent_id, _LOG)
+    assert rs.health == "in_progress"
+    assert rs.error == "stale", "no-op path must not clear unrelated error"
+
+
+# ── _resolve_health_on_success ───────────────────────────────────
+
+
+def test_resolve_on_success_transitions_in_progress_to_ok(
+    tmp_path, monkeypatch,
+):
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="in_progress")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._resolve_health_on_success(rs, agent_id, _LOG)
+    assert rs.health == "ok"
+    assert rs.error == ""
+    on_disk = RuntimeState.load(agent_id)
+    assert on_disk is not None
+    assert on_disk.health == "ok"
+
+
+@pytest.mark.parametrize(
+    "give_up_health",
+    ["api_error_abandoned", "auth_failed", "refresh_broken"],
+)
+def test_resolve_on_success_leaves_give_up_red_untouched(
+    tmp_path, monkeypatch, give_up_health,
+):
+    """If a category-specific path mid-turn set a give-up red (e.g.,
+    api_error_abandoned at L1006 in worker.py), the resolve must NOT
+    overwrite it back to ``ok`` — that's the give-up signal operator's
+    rule 3 preserves."""
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health=give_up_health)
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._resolve_health_on_success(rs, agent_id, _LOG)
+    assert rs.health == give_up_health, (
+        f"resolve must not clobber {give_up_health!r}"
+    )
+
+
+def test_resolve_on_success_leaves_ok_alone(tmp_path, monkeypatch):
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="ok")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._resolve_health_on_success(rs, agent_id, _LOG)
+    assert rs.health == "ok"
+
+
+# ── StatusReporter heartbeat shape ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_carries_both_status_and_health():
+    from puffo_agent.agent.status_reporter import StatusReporter
+    mock_http = AsyncMock()
+    health_value = {"v": "in_progress"}
+    reporter = StatusReporter(
+        mock_http,
+        runtime_health_provider=lambda: health_value["v"],
+    )
+    reporter._current_status = "busy"
+    reporter._current_message_id = "env_abc"
+    await reporter._send_heartbeat()
+    mock_http.post.assert_called_once()
+    args, _kwargs = mock_http.post.call_args
+    path, body = args
+    assert path == "/agents/me/heartbeat"
+    assert body == {
+        "status": "busy",
+        "current_message_id": "env_abc",
+        "health": "in_progress",
+    }
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_without_provider_omits_health_field():
+    """Back-compat: when constructed without a provider (no-op /
+    tests), heartbeat carries the legacy single-stream shape."""
+    from puffo_agent.agent.status_reporter import StatusReporter
+    mock_http = AsyncMock()
+    reporter = StatusReporter(mock_http)
+    reporter._current_status = "idle"
+    await reporter._send_heartbeat()
+    args, _kwargs = mock_http.post.call_args
+    _path, body = args
+    assert body == {"status": "idle"}
+    assert "health" not in body
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_provider_exception_does_not_break_heartbeat():
+    from puffo_agent.agent.status_reporter import StatusReporter
+    mock_http = AsyncMock()
+
+    def broken_provider() -> str:
+        raise RuntimeError("runtime not loaded")
+
+    reporter = StatusReporter(
+        mock_http,
+        runtime_health_provider=broken_provider,
+    )
+    reporter._current_status = "idle"
+    # Should not raise.
+    await reporter._send_heartbeat()
+    mock_http.post.assert_called_once()
+    _args, _kwargs = mock_http.post.call_args
+    body = _args[1]
+    # health field is OMITTED on provider failure; status still ships.
+    assert body == {"status": "idle"}
+
+
+# ── CLI surfaced-health includes in_progress ─────────────────────
+
+
+def test_cli_surfaced_health_tuple_includes_in_progress():
+    """Sanity-check that the tuple in cli.py adds in_progress to the
+    list of values that get the ``[<health>]`` suffix in ``agent
+    list``. Source-string check rather than running the CLI subcommand
+    because the CLI does heavy daemon/runtime initialization."""
+    cli_path = (
+        Path(__file__).parent.parent
+        / "src" / "puffo_agent" / "portal" / "cli.py"
+    )
+    text = cli_path.read_text(encoding="utf-8")
+    # The surfaced-health tuple lives in cmd_agent_list. Locate the
+    # tuple by anchor + assert in_progress is a member.
+    assert '"in_progress"' in text, (
+        "in_progress must be in cli.py surfaced-health tuple so the "
+        "operator can see at a glance the agent is alive mid-turn"
+    )
+    # Defensive: the legacy reds must still surface — no regression.
+    for legacy in ("auth_failed", "api_error_abandoned", "refresh_broken"):
+        assert f'"{legacy}"' in text, (
+            f"surfaced-health tuple lost {legacy!r}"
+        )

--- a/tests/test_runtime_health_in_progress.py
+++ b/tests/test_runtime_health_in_progress.py
@@ -127,6 +127,142 @@ def test_resolve_on_success_leaves_ok_alone(tmp_path, monkeypatch):
     assert rs.health == "ok"
 
 
+# PR #59 round-1 review item #5: simulate the in-turn flow
+# (flip → in-turn red set → resolve sees red and skips), not just
+# the bare "seed direct red" path the parametrized test above covers.
+@pytest.mark.parametrize(
+    "in_turn_red",
+    ["auth_failed", "api_error_abandoned", "refresh_broken"],
+)
+def test_resolve_skips_when_in_turn_path_wrote_red(
+    tmp_path, monkeypatch, in_turn_red,
+):
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="ok")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._flip_health_in_progress(rs, agent_id, _LOG)
+    assert rs.health == "in_progress"
+    # In-turn category-specific path writes its give-up red directly,
+    # bypassing the resolve lane (matches the live worker.py paths).
+    rs.health = in_turn_red
+    Worker._resolve_health_on_success(rs, agent_id, _LOG)
+    assert rs.health == in_turn_red
+
+
+# ── _fallback_unknown_if_stuck_in_progress (PR #59 Blocker 2) ────
+
+
+def test_fallback_unknown_fires_when_swallowed_exception_left_in_progress(
+    tmp_path, monkeypatch,
+):
+    """Mirrors the live shape: ``handle_message_batch`` raised a non-
+    AgentAPIError that the worker swallows. Finally branch must
+    backstop in_progress → unknown."""
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="in_progress")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._fallback_unknown_if_stuck_in_progress(
+        rs, agent_id, "KeyError: 'missing-key'", _LOG,
+    )
+    assert rs.health == "unknown"
+    assert "KeyError" in rs.error
+    # Persisted.
+    on_disk = RuntimeState.load(agent_id)
+    assert on_disk is not None and on_disk.health == "unknown"
+
+
+def test_fallback_unknown_leaves_category_red_untouched(tmp_path, monkeypatch):
+    """If an in-turn give-up red was already written, the backstop
+    must NOT overwrite it (category red carries better detail than
+    'unknown')."""
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="api_error_abandoned")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._fallback_unknown_if_stuck_in_progress(
+        rs, agent_id, "anything", _LOG,
+    )
+    assert rs.health == "api_error_abandoned"
+
+
+def test_fallback_unknown_default_error_when_caller_passes_none(
+    tmp_path, monkeypatch,
+):
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="in_progress")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+    Worker._fallback_unknown_if_stuck_in_progress(rs, agent_id, None, _LOG)
+    assert rs.health == "unknown"
+    assert rs.error  # populated even when caller had no error text
+
+
+# ── chain integration tests (PR #59 Blocker 1 + Blocker 2) ───────
+
+
+def test_chain_agent_api_error_then_retry_success_resolves_to_ok(
+    tmp_path, monkeypatch,
+):
+    """Blocker 1 chain: AgentAPIError raise leaves in_progress
+    intact (turn_will_retry → backstop skipped), consumer kick-retry
+    succeeds → on_turn_success fires → resolve clears to ok.
+
+    Walks the helper sequence the live worker now invokes; without
+    the round-1 fix the chain would terminate with in_progress on
+    disk forever.
+    """
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="ok")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+
+    # T0: on_message_batch flips to in_progress.
+    Worker._flip_health_in_progress(rs, agent_id, _LOG)
+    assert rs.health == "in_progress"
+
+    # T1: handle_message_batch raises AgentAPIError → finally's
+    # success branch is skipped. turn_will_retry=True, so the
+    # backstop also skips. in_progress survives.
+    # (Simulated by reading the on-disk value after a no-op.)
+    on_disk = RuntimeState.load(agent_id)
+    assert on_disk is not None and on_disk.health == "in_progress"
+
+    # T2: consumer kicks the retry; it succeeds; on_turn_success
+    # fires the same helper pair the worker installed in this PR.
+    Worker._clear_api_error_abandoned_if_recoverable(
+        rs, agent_id, "root_x", _LOG,
+    )
+    Worker._resolve_health_on_success(rs, agent_id, _LOG)
+
+    assert rs.health == "ok"
+    on_disk = RuntimeState.load(agent_id)
+    assert on_disk is not None and on_disk.health == "ok"
+
+
+def test_chain_non_api_error_swallow_falls_back_to_unknown(
+    tmp_path, monkeypatch,
+):
+    """Blocker 2 chain: non-AgentAPIError swallow (e.g., KeyError)
+    means turn_succeeded=False AND turn_will_retry=False. Without the
+    backstop, in_progress would persist until daemon restart. With
+    the backstop, the finally lands at unknown + populated error.
+    """
+    agent_id = _seed_runtime(tmp_path, monkeypatch, health="ok")
+    rs = RuntimeState.load(agent_id)
+    assert rs is not None
+
+    Worker._flip_health_in_progress(rs, agent_id, _LOG)
+    assert rs.health == "in_progress"
+
+    # Simulate the swallowed-exception finally landing on the
+    # backstop branch.
+    Worker._fallback_unknown_if_stuck_in_progress(
+        rs, agent_id, "KeyError: 'thread_root_id'", _LOG,
+    )
+
+    assert rs.health == "unknown"
+    assert "KeyError" in rs.error
+    on_disk = RuntimeState.load(agent_id)
+    assert on_disk is not None and on_disk.health == "unknown"
+
+
 # ── StatusReporter heartbeat shape ───────────────────────────────
 
 

--- a/tests/test_runtime_health_in_progress.py
+++ b/tests/test_runtime_health_in_progress.py
@@ -149,49 +149,47 @@ def test_resolve_skips_when_in_turn_path_wrote_red(
     assert rs.health == in_turn_red
 
 
-# ── _fallback_unknown_if_stuck_in_progress (PR #59 Blocker 2) ────
+# ── _fallback_unhandled_error_if_stuck_in_progress (PR #59 Blocker 2) ────
 
 
-def test_fallback_unknown_fires_when_swallowed_exception_left_in_progress(
+def test_fallback_unhandled_error_fires_when_swallowed_exception_left_in_progress(
     tmp_path, monkeypatch,
 ):
     """Mirrors the live shape: ``handle_message_batch`` raised a non-
     AgentAPIError that the worker swallows. Finally branch must
-    backstop in_progress → unknown."""
+    backstop in_progress → unhandled_error."""
     agent_id = _seed_runtime(tmp_path, monkeypatch, health="in_progress")
     rs = RuntimeState.load(agent_id)
     assert rs is not None
-    Worker._fallback_unknown_if_stuck_in_progress(
+    Worker._fallback_unhandled_error_if_stuck_in_progress(
         rs, agent_id, "KeyError: 'missing-key'", _LOG,
     )
-    assert rs.health == "unknown"
+    assert rs.health == "unhandled_error"
     assert "KeyError" in rs.error
-    # Persisted.
     on_disk = RuntimeState.load(agent_id)
-    assert on_disk is not None and on_disk.health == "unknown"
+    assert on_disk is not None and on_disk.health == "unhandled_error"
 
 
-def test_fallback_unknown_leaves_category_red_untouched(tmp_path, monkeypatch):
+def test_fallback_unhandled_error_leaves_category_red_untouched(tmp_path, monkeypatch):
     """If an in-turn give-up red was already written, the backstop
-    must NOT overwrite it (category red carries better detail than
-    'unknown')."""
+    must NOT overwrite it (category red carries better detail)."""
     agent_id = _seed_runtime(tmp_path, monkeypatch, health="api_error_abandoned")
     rs = RuntimeState.load(agent_id)
     assert rs is not None
-    Worker._fallback_unknown_if_stuck_in_progress(
+    Worker._fallback_unhandled_error_if_stuck_in_progress(
         rs, agent_id, "anything", _LOG,
     )
     assert rs.health == "api_error_abandoned"
 
 
-def test_fallback_unknown_default_error_when_caller_passes_none(
+def test_fallback_unhandled_error_default_error_when_caller_passes_none(
     tmp_path, monkeypatch,
 ):
     agent_id = _seed_runtime(tmp_path, monkeypatch, health="in_progress")
     rs = RuntimeState.load(agent_id)
     assert rs is not None
-    Worker._fallback_unknown_if_stuck_in_progress(rs, agent_id, None, _LOG)
-    assert rs.health == "unknown"
+    Worker._fallback_unhandled_error_if_stuck_in_progress(rs, agent_id, None, _LOG)
+    assert rs.health == "unhandled_error"
     assert rs.error  # populated even when caller had no error text
 
 
@@ -236,13 +234,13 @@ def test_chain_agent_api_error_then_retry_success_resolves_to_ok(
     assert on_disk is not None and on_disk.health == "ok"
 
 
-def test_chain_non_api_error_swallow_falls_back_to_unknown(
+def test_chain_non_api_error_swallow_falls_back_to_unhandled_error(
     tmp_path, monkeypatch,
 ):
     """Blocker 2 chain: non-AgentAPIError swallow (e.g., KeyError)
     means turn_succeeded=False AND turn_will_retry=False. Without the
     backstop, in_progress would persist until daemon restart. With
-    the backstop, the finally lands at unknown + populated error.
+    the backstop, the finally lands at unhandled_error + populated error.
     """
     agent_id = _seed_runtime(tmp_path, monkeypatch, health="ok")
     rs = RuntimeState.load(agent_id)
@@ -251,16 +249,14 @@ def test_chain_non_api_error_swallow_falls_back_to_unknown(
     Worker._flip_health_in_progress(rs, agent_id, _LOG)
     assert rs.health == "in_progress"
 
-    # Simulate the swallowed-exception finally landing on the
-    # backstop branch.
-    Worker._fallback_unknown_if_stuck_in_progress(
+    Worker._fallback_unhandled_error_if_stuck_in_progress(
         rs, agent_id, "KeyError: 'thread_root_id'", _LOG,
     )
 
-    assert rs.health == "unknown"
+    assert rs.health == "unhandled_error"
     assert "KeyError" in rs.error
     on_disk = RuntimeState.load(agent_id)
-    assert on_disk is not None and on_disk.health == "unknown"
+    assert on_disk is not None and on_disk.health == "unhandled_error"
 
 
 # ── StatusReporter heartbeat shape ───────────────────────────────
@@ -326,27 +322,24 @@ async def test_heartbeat_provider_exception_does_not_break_heartbeat():
     assert body == {"status": "idle"}
 
 
-# ── CLI surfaced-health includes in_progress ─────────────────────
+# ── CLI surfaced-health includes new values ──────────────────────
 
 
-def test_cli_surfaced_health_tuple_includes_in_progress():
-    """Sanity-check that the tuple in cli.py adds in_progress to the
-    list of values that get the ``[<health>]`` suffix in ``agent
-    list``. Source-string check rather than running the CLI subcommand
-    because the CLI does heavy daemon/runtime initialization."""
+def test_cli_surfaced_health_tuple_includes_new_values():
+    """Source-string check on cli.py's cmd_agent_list tuple (running
+    the CLI does heavy daemon init). Pins the new PUF-270 values."""
     cli_path = (
         Path(__file__).parent.parent
         / "src" / "puffo_agent" / "portal" / "cli.py"
     )
     text = cli_path.read_text(encoding="utf-8")
-    # The surfaced-health tuple lives in cmd_agent_list. Locate the
-    # tuple by anchor + assert in_progress is a member.
-    assert '"in_progress"' in text, (
-        "in_progress must be in cli.py surfaced-health tuple so the "
-        "operator can see at a glance the agent is alive mid-turn"
-    )
-    # Defensive: the legacy reds must still surface — no regression.
-    for legacy in ("auth_failed", "api_error_abandoned", "refresh_broken"):
-        assert f'"{legacy}"' in text, (
-            f"surfaced-health tuple lost {legacy!r}"
+    for required in (
+        "in_progress",
+        "unhandled_error",
+        "auth_failed",
+        "api_error_abandoned",
+        "refresh_broken",
+    ):
+        assert f'"{required}"' in text, (
+            f"surfaced-health tuple missing {required!r}"
         )


### PR DESCRIPTION
## Summary

- New `runtime.health` value `"in_progress"` flips at the top of every `Worker.on_message_batch` and resolves to `"ok"` on success, leaving any give-up red (set inside the turn) untouched.
- Operator-visible discrimination: a sticky red on disk no longer masks the fact that the agent is actively processing a new message.
- StatusReporter heartbeat extended to carry both `status` (per-turn busy/idle) and `health` (persistent) so the server can render the alive-vs-red distinction.
- `puffoagent agent list` surfaced-health tuple includes `"in_progress"`.

## Operator's 4-rule coverage

1. **Before processing → in_progress.** `_flip_health_in_progress` runs at `on_message_batch` top; overrides any starting state (including sticky reds).
2. **Mid-process error + retry → re-flip.** On exception, the consumer loop re-enqueues; the next batch's flip lane returns to `in_progress`.
3. **Give-up → category-specific red.** Existing `api_error_abandoned` / `auth_failed` / `refresh_broken` paths still fire inside the turn; `_resolve_health_on_success` only transitions `in_progress → ok`, never overwrites a red set in-turn.
4. **Not error / not processing → ok.** Resolve lane transitions `in_progress → ok` on success.

## Stage-3 pick

Q1 = override-all-reds (operator rule 1 verbatim). The auth_failed false-positive concern is self-correcting: if the in-turn API call 401s, `_handle_suppressed_reply` re-flips back to auth_failed within the same turn. Documented in `_flip_health_in_progress` docstring.

## Tests

- **15 new pytest** in `tests/test_runtime_health_in_progress.py` — starting-state flips, give-up red preservation, idempotence, heartbeat dual-stream shape, provider-failure resilience, CLI surfaced-health.
- **117 broader smoke** across runtime_health + api_error + credential_refresh + bridge_handlers. No regression on PUF-258 / PUF-265 / existing clear paths.

## Test plan

- [ ] `pytest tests/test_runtime_health_in_progress.py -v` → 15 pass
- [ ] `pytest tests/test_runtime_health_in_progress.py tests/test_api_error_abandon_state.py tests/test_api_error_recovery_state.py tests/test_credential_refresh_clears_auth_failed.py tests/test_credential_refresher.py tests/test_bridge_handlers.py` → 117 pass
- [ ] Operator E2E: agent with sticky `refresh_broken` receives a message → CLI shows `[in_progress]`; on success → `[ok]`

## Interactions

- **PUF-267** (codex thread-wedged) still in queue — small docstring merge conflict expected in `state.py:health` enum comment when both land; clean to resolve. The `_flip_health_in_progress` override applies symmetrically to `codex_thread_wedged` once PUF-267 merges (no extra work).
- **PUF-258 / PUF-265** (recovery-clear paths) — unaffected; their category-specific success events still fire independently of the in_progress lane.

## Coverage gaps (follow-up if surfaced)

- **Idle-check / run-now / explicit-probe entry points** don't currently flip in_progress. If those paths surface the same sticky-red-while-alive symptom, sweep to add the flip site. Probably out of scope for v1 — `on_message_batch` is the canonical work-entry for incoming messages, the bug shape operator reported.
- **Concurrent credential-refresh write** during the same instant as begin_turn flip — no observed race today, but worth a stress test if the symptom recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)