### PR TITLE
fix: retry archive/delete shutil.move on Windows codex sqlite handle linger

### DIFF
--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -327,7 +327,7 @@ class Daemon:
         stamp = time.strftime("%Y%m%d-%H%M%S")
         dest = archived_dir() / f"{agent_id}-ws-{stamp}"
         try:
-            shutil.move(str(src), str(dest))
+            await _retry_on_oserror(lambda: shutil.move(str(src), str(dest)))
             logger.info("agent %s: archived to %s", agent_id, dest)
         except OSError as exc:
             logger.error(
@@ -350,7 +350,7 @@ class Daemon:
             return
         await _drain_codex_tmp(src)
         try:
-            shutil.rmtree(src)
+            await _retry_on_oserror(lambda: shutil.rmtree(src))
             logger.info("agent %s: deleted", agent_id)
         except OSError as exc:
             logger.error(
@@ -372,6 +372,21 @@ async def _drain_codex_tmp(src: Path) -> None:
         except OSError:
             await asyncio.sleep(0.5)
     shutil.rmtree(codex_tmp, ignore_errors=True)
+
+
+async def _retry_on_oserror(fn, *, attempts: int = 5, delay: float = 0.5) -> None:
+    """Windows: codex App Server's .codex/logs_*.sqlite (WAL mode) holds
+    handles a few hundred ms past subprocess termination; same for any
+    other transient post-stop locks. Retry the caller's fs op until
+    Windows releases. Raises the last OSError on final attempt."""
+    for i in range(attempts):
+        try:
+            fn()
+            return
+        except OSError:
+            if i + 1 == attempts:
+                raise
+            await asyncio.sleep(delay)
 
 
 async def _log_outdated_version_warning() -> None:

--- a/tests/test_archive_codex_tmp_drain.py
+++ b/tests/test_archive_codex_tmp_drain.py
@@ -1,4 +1,4 @@
-"""Regression seal for _drain_codex_tmp."""
+"""Regression seal for _drain_codex_tmp + _retry_on_oserror."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from puffo_agent.portal.daemon import _drain_codex_tmp
+from puffo_agent.portal.daemon import _drain_codex_tmp, _retry_on_oserror
 
 
 def _seed_codex_tmp(root: Path) -> Path:
@@ -95,3 +95,141 @@ async def test_drain_falls_back_to_ignore_errors_after_exhaustion(
 
     assert calls["n"] == 6
     assert calls["ignore_errors_seen"] is True
+
+
+# ── _retry_on_oserror ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retry_on_oserror_returns_on_first_success():
+    calls = {"n": 0}
+
+    def succeed():
+        calls["n"] += 1
+
+    await _retry_on_oserror(succeed)
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_on_oserror_succeeds_after_transient_lock(monkeypatch):
+    """Models the codex App Server logs_*.sqlite lingering past
+    subprocess termination: first call raises WinError 32 / EBUSY, the
+    second succeeds."""
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "still locked")
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_s):
+        await real_sleep(0)
+
+    monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
+    await _retry_on_oserror(flaky)
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_on_oserror_reraises_after_attempts_exhausted(monkeypatch):
+    """Caller's except block depends on getting the OSError back when
+    the file is held longer than the retry window."""
+    calls = {"n": 0}
+
+    def always_fail():
+        calls["n"] += 1
+        raise PermissionError(13, "stuck")
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_s):
+        await real_sleep(0)
+
+    monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
+    with pytest.raises(PermissionError):
+        await _retry_on_oserror(always_fail)
+    assert calls["n"] == 5
+
+
+@pytest.mark.asyncio
+async def test_retry_on_oserror_honors_custom_attempts(monkeypatch):
+    calls = {"n": 0}
+
+    def always_fail():
+        calls["n"] += 1
+        raise OSError("x")
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_s):
+        await real_sleep(0)
+
+    monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
+    with pytest.raises(OSError):
+        await _retry_on_oserror(always_fail, attempts=2, delay=0.1)
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_on_oserror_does_not_swallow_non_oserror():
+    """ValueError / TypeError etc. must NOT be retried — those signal a
+    bug in the caller, not a Windows handle linger."""
+    calls = {"n": 0}
+
+    def bad():
+        calls["n"] += 1
+        raise ValueError("bug")
+
+    with pytest.raises(ValueError):
+        await _retry_on_oserror(bad)
+    assert calls["n"] == 1
+
+
+# ── _archive_on_flag retry wiring (integration) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_archive_on_flag_retries_locked_move(monkeypatch, tmp_path):
+    """End-to-end: shutil.move fails once with the WinError 32
+    signature, then succeeds. Archive completes; no spurious error log."""
+    from puffo_agent.portal import daemon as daemon_mod
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+
+    src = tmp_path / "agents" / "agent-x"
+    src.mkdir(parents=True)
+    (src / "agent.yml").write_text("id: agent-x\n", encoding="utf-8")
+
+    real_move = shutil.move
+    calls = {"n": 0}
+
+    def flaky_move(s, d):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "still locked by codex App Server")
+        return real_move(s, d)
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_s):
+        await real_sleep(0)
+
+    monkeypatch.setattr("puffo_agent.portal.daemon.shutil.move", flaky_move)
+    monkeypatch.setattr("puffo_agent.portal.daemon.asyncio.sleep", fast_sleep)
+
+    class _StubDaemon:
+        workers: dict = {}
+
+        async def _stop_worker(self, _agent_id):
+            return
+
+    await daemon_mod.Daemon._archive_on_flag(_StubDaemon(), "agent-x")
+
+    assert calls["n"] == 2
+    archived_root = tmp_path / "archived"
+    assert archived_root.exists()
+    assert any(p.name.startswith("agent-x-ws-") for p in archived_root.iterdir())
+    assert not src.exists()


### PR DESCRIPTION
## Summary

Operator hit ``archive failed: [WinError 32] another program is using this file ... '.codex/logs_2.sqlite'`` when archiving a codex agent.

- ``_drain_codex_tmp`` only cleans ``.codex/tmp/`` (the older codex CLI lock).
- The codex App Server's ``logs_2.sqlite`` (WAL-mode session log) sits at ``.codex/logs_*.sqlite`` and its handle lingers a few hundred ms past subprocess termination.
- Existing reconciler-tick retry eventually recovers but spams an error log every tick until Windows releases the handle.

## Fix

Add ``_retry_on_oserror(fn, attempts=5, delay=0.5)`` helper, mirroring ``_drain_codex_tmp``'s existing inline retry. Wrap the outer ``shutil.move`` (archive) and ``shutil.rmtree`` (delete) with it — usually one extra 500ms wait clears the handle and the second attempt succeeds.

Does NOT pre-delete ``logs_*.sqlite``: the whole point of archive is to preserve the dir under ``archived/<id>-ws-<ts>/`` for later inspection, and the session log is part of that history.

## Test plan

- [x] pytest tests/test_archive_codex_tmp_drain.py -v → 11/11 pass
- [x] pytest tests/test_archive_codex_tmp_drain.py tests/test_pause_resume_archive.py tests/test_bridge_handlers.py -q → 40/40 pass
- [ ] Manual Windows: create + archive a codex agent → no error log; archived dir lands in ~/.puffo-agent/archived/ on first attempt within 500ms

## Test additions

5 new _retry_on_oserror unit cases (first-try success, transient lock + retry, exhaustion re-raise, custom attempts kwarg, non-OSError pass-through) + 1 integration case driving Daemon._archive_on_flag through a flaky shutil.move mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)