### PR TITLE
UI: 3-state status on Home AI tool cards (not installed / need log in / ready)

### DIFF
--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -137,3 +138,31 @@ def _hermes_bundle_paths() -> list[Path]:
 
 def _expand(*paths: str) -> list[Path]:
     return [Path(os.path.expandvars(p)).expanduser() for p in paths]
+
+
+# ── Credential presence (UI status discrimination) ───────────────────
+
+
+def claude_has_credentials(home: Path | None = None) -> bool:
+    """True if Claude OAuth credentials exist on this host. On macOS
+    the canonical store is the ``Claude Code-credentials`` Keychain
+    entry; on Linux/Windows it's ``~/.claude/.credentials.json``."""
+    h = home if home is not None else Path.home()
+    if (h / ".claude" / ".credentials.json").exists():
+        return True
+    if sys.platform == "darwin":
+        try:
+            r = subprocess.run(
+                ["security", "find-generic-password", "-s", "Claude Code-credentials"],
+                capture_output=True, timeout=2,
+            )
+            return r.returncode == 0
+        except Exception:
+            return False
+    return False
+
+
+def codex_has_credentials(home: Path | None = None) -> bool:
+    """True if Codex OAuth credentials exist at ``~/.codex/auth.json``."""
+    h = home if home is not None else Path.home()
+    return (h / ".codex" / "auth.json").exists()

--- a/src/puffo_agent/portal/ui/widgets/home_view.py
+++ b/src/puffo_agent/portal/ui/widgets/home_view.py
@@ -60,10 +60,16 @@ def _card() -> tuple[QFrame, QVBoxLayout]:
 class _CliCard(QFrame):
     """One card per CLI tool; the path hides behind a small triangle."""
 
-    def __init__(self, label: str, resolver: Callable[[], Optional[str]]) -> None:
+    def __init__(
+        self,
+        label: str,
+        resolver: Callable[[], Optional[str]],
+        cred_check: Optional[Callable[[], bool]] = None,
+    ) -> None:
         super().__init__()
         self.setObjectName("card")
         self._resolver = resolver
+        self._cred_check = cred_check
         self._coming_soon = False
 
         layout = QVBoxLayout(self)
@@ -130,18 +136,33 @@ class _CliCard(QFrame):
             path = self._resolver()
         except Exception:
             path = None
-        if path:
+        if not path:
+            self._dot.setStyleSheet("font-size: 14pt; color: #ef4444;")
+            self._status_label.setText("not installed")
+            self._status_label.setStyleSheet("color: #9ca3af; font-size: 9pt;")
+            self._path_label.setText("(not on PATH and no env override)")
+            return
+        # Installed — discriminate logged-in vs needs-login when a
+        # cred_check is supplied (cards without one are treated as ready).
+        has_cred = True
+        if self._cred_check is not None:
+            try:
+                has_cred = self._cred_check()
+            except Exception:
+                has_cred = False
+        if has_cred:
             self._dot.setStyleSheet("font-size: 14pt; color: #22c55e;")
-            self._status_label.setText("installed")
+            self._status_label.setText("ready")
             self._status_label.setStyleSheet(
                 "color: #16a34a; font-size: 9pt; font-weight: 500;"
             )
-            self._path_label.setText(path)
         else:
-            self._dot.setStyleSheet("font-size: 14pt; color: #ef4444;")
-            self._status_label.setText("not found")
-            self._status_label.setStyleSheet("color: #9ca3af; font-size: 9pt;")
-            self._path_label.setText("(not on PATH and no env override)")
+            self._dot.setStyleSheet("font-size: 14pt; color: #f59e0b;")
+            self._status_label.setText("need log in")
+            self._status_label.setStyleSheet(
+                "color: #d97706; font-size: 9pt; font-weight: 500;"
+            )
+        self._path_label.setText(path)
 
     def _on_toggled(self, checked: bool) -> None:
         self._toggle.setText("▾" if checked else "▸")
@@ -198,16 +219,21 @@ class HomeView(QWidget):
         outer.addWidget(bridge_card)
 
         # AI tool cards
-        from ....agent.cli_bin import resolve_claude_bin, resolve_codex_bin
-        cli_specs: list[tuple[str, Callable[[], Optional[str]]]] = [
-            ("Claude Code", resolve_claude_bin),
-            ("Codex",       resolve_codex_bin),
+        from ....agent.cli_bin import (
+            claude_has_credentials,
+            codex_has_credentials,
+            resolve_claude_bin,
+            resolve_codex_bin,
+        )
+        cli_specs: list[tuple[str, Callable[[], Optional[str]], Optional[Callable[[], bool]]]] = [
+            ("Claude Code", resolve_claude_bin, claude_has_credentials),
+            ("Codex",       resolve_codex_bin,  codex_has_credentials),
         ]
         cli_grid = QHBoxLayout()
         cli_grid.setSpacing(12)
         self._cli_cards: list[_CliCard] = []
-        for label, resolver in cli_specs:
-            card = _CliCard(label, resolver)
+        for label, resolver, cred_check in cli_specs:
+            card = _CliCard(label, resolver, cred_check)
             self._cli_cards.append(card)
             cli_grid.addWidget(card, stretch=1)
         hermes_card = _CliCard("Hermes", lambda: None)

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -130,3 +130,73 @@ def test_hermes_bundle_paths_per_platform(platform_value, want_substr, monkeypat
     assert paths, f"no candidates for platform {platform_value!r}"
     first = paths[0].as_posix() if platform_value != "win32" else str(paths[0])
     assert want_substr in first
+
+
+# ── credential presence (UI 3-state status) ──────────────────────────
+
+
+def test_codex_has_credentials_true_when_auth_file_exists(tmp_path):
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "auth.json").write_text("{}", encoding="utf-8")
+    assert cli_bin.codex_has_credentials(home=tmp_path) is True
+
+
+def test_codex_has_credentials_false_when_dir_missing(tmp_path):
+    assert cli_bin.codex_has_credentials(home=tmp_path) is False
+
+
+def test_codex_has_credentials_false_when_file_missing_but_dir_exists(tmp_path):
+    (tmp_path / ".codex").mkdir()
+    assert cli_bin.codex_has_credentials(home=tmp_path) is False
+
+
+def test_claude_has_credentials_true_when_file_exists(tmp_path):
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / ".credentials.json").write_text("{}", encoding="utf-8")
+    assert cli_bin.claude_has_credentials(home=tmp_path) is True
+
+
+def test_claude_has_credentials_false_when_file_missing(tmp_path, monkeypatch):
+    # On macOS we'd also probe Keychain; force the platform off so the
+    # test runs identically across CI envs.
+    monkeypatch.setattr("puffo_agent.agent.cli_bin.sys.platform", "linux")
+    assert cli_bin.claude_has_credentials(home=tmp_path) is False
+
+
+def test_claude_has_credentials_macos_falls_back_to_keychain(tmp_path, monkeypatch):
+    """When the file is missing on macOS, the Keychain probe (``security
+    find-generic-password``) decides. rc=0 → True, rc!=0 → False."""
+    import subprocess as _sp
+
+    monkeypatch.setattr("puffo_agent.agent.cli_bin.sys.platform", "darwin")
+
+    class _RC:
+        def __init__(self, code):
+            self.returncode = code
+
+    monkeypatch.setattr(
+        "puffo_agent.agent.cli_bin.subprocess.run",
+        lambda *a, **kw: _RC(0),
+    )
+    assert cli_bin.claude_has_credentials(home=tmp_path) is True
+
+    monkeypatch.setattr(
+        "puffo_agent.agent.cli_bin.subprocess.run",
+        lambda *a, **kw: _RC(44),
+    )
+    assert cli_bin.claude_has_credentials(home=tmp_path) is False
+
+
+def test_claude_has_credentials_keychain_probe_failure_treated_as_false(
+    tmp_path, monkeypatch,
+):
+    """Timeout / subprocess error must NOT raise into the UI poll."""
+    import subprocess as _sp
+
+    monkeypatch.setattr("puffo_agent.agent.cli_bin.sys.platform", "darwin")
+
+    def boom(*_a, **_kw):
+        raise _sp.TimeoutExpired(cmd="security", timeout=2)
+
+    monkeypatch.setattr("puffo_agent.agent.cli_bin.subprocess.run", boom)
+    assert cli_bin.claude_has_credentials(home=tmp_path) is False


### PR DESCRIPTION
## Summary

Operator wanted a single-glance signal that distinguishes:

| Color | Label | Meaning |
|---|---|---|
| 🔴 | not installed | binary not on PATH, no env override, no bundle hit |
| 🟡 | need log in | binary present but no OAuth credentials |
| 🟢 | ready | binary + credentials both present |

Before this PR the card collapsed states 2 and 3 into ``installed``. An operator who just installed Claude / Codex but had not run ``claude login`` / ``codex login`` saw a green dot, then hit credential errors on the first agent spawn.

## Credential check rules

- **Claude**: ``~/.claude/.credentials.json`` first (canonical on Linux/Windows). On macOS, fall back to the ``Claude Code-credentials`` Keychain entry via ``security find-generic-password``. 2s timeout, subprocess errors swallowed so a stuck Keychain can't pin the UI poll.
- **Codex**: ``~/.codex/auth.json`` (codex has no Keychain mode).

## Code shape

- ``cli_bin.claude_has_credentials(home=None)`` + ``codex_has_credentials(home=None)``. The ``home`` kwarg lets tests point at ``tmp_path`` without monkeypatching ``Path.home``.
- ``_CliCard`` gains an optional ``cred_check`` callback. ``refresh()`` short-circuits to ``not installed`` when the resolver returns ``None``; otherwise calls ``cred_check`` (treated as ready when absent — the Hermes coming-soon card stays unchanged).

## Test plan

- [x] ``pytest tests/test_cli_bin.py -q`` → 22/22 pass (15 existing + 7 new)
- [ ] Manual: open the UI, look at Home cards
  - With both ``claude`` and ``codex`` installed and logged in → both green ``ready``
  - Delete ``~/.codex/auth.json`` → codex card flips amber ``need log in``
  - Uninstall ``claude`` from PATH → claude card flips red ``not installed``

## Test additions

7 new in ``test_cli_bin.py``:
- codex auth file present / dir-missing / dir-present-file-missing
- claude file present (forces ``sys.platform=linux`` to bypass Keychain branch)
- claude macOS Keychain ``rc=0`` → True
- claude macOS Keychain ``rc != 0`` → False
- claude Keychain ``TimeoutExpired`` → False (no exception leak into UI poll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)