### PR TITLE
PUF-273: spawn-time GC + cli-docker reject + hermes early-return for desired-install

### DIFF
--- a/src/puffo_agent/agent/adapters/desired_install.py
+++ b/src/puffo_agent/agent/adapters/desired_install.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,9 @@ _MCP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 # host-sync pruner doesn't sweep these and operators can tell which
 # layer wrote what.
 DESIRED_INSTALLED_MARKER = "desired-installed.md"
+# Stronger-provenance markers the desired pruner must never sweep.
+AGENT_INSTALLED_MARKER = "agent-installed.md"
+HOST_SYNCED_MARKER = "host-synced.md"
 _DESIRED_INSTALLED_BODY = (
     "Installed at spawn time from a puffo-server template selected "
     "by the operator. See PUF-268.\n"
@@ -137,15 +141,13 @@ def prune_stale_desired_skills(
     agent-installed entries are left alone — those lifecycles are
     owned elsewhere. Returns the count of dirs removed.
 
-    Idempotent; spawn-time `_install_desired` calls this after the
-    install loop so a freshly-installed skill is never pruned in the
-    same pass. PUF-273 item (a).
+    Idempotent; spawn-time install calls this after the install loop
+    so a freshly-installed skill is never pruned in the same pass.
     """
     if not skills_root.is_dir():
         return 0
     current_set = set(current_desired)
     pruned = 0
-    import shutil
     for entry in skills_root.iterdir():
         if not entry.is_dir():
             continue
@@ -156,9 +158,9 @@ def prune_stale_desired_skills(
         # Stronger provenance wins — host-sync or agent-install
         # signals the skill should stay even after operator drops it
         # from the desired list.
-        if (entry / "agent-installed.md").exists():
+        if (entry / AGENT_INSTALLED_MARKER).exists():
             continue
-        if (entry / "host-synced.md").exists():
+        if (entry / HOST_SYNCED_MARKER).exists():
             continue
         try:
             shutil.rmtree(entry)
@@ -280,6 +282,56 @@ def _codex_extras_entry(spec: dict[str, Any]) -> dict[str, Any]:
     return {"url": spec["url"], "env": spec["env"]}
 
 
+async def run_spawn_install(
+    *,
+    agent_id: str,
+    agent_home: Path,
+    workspace_dir: Path,
+    harness_name: str,
+    desired_skills: list[str],
+    desired_mcps: list[str],
+    server_url: str,
+    slug: str,
+    keys_dir: str,
+) -> dict[str, dict[str, Any]]:
+    """Build the puffo-core client from spawn wiring and run
+    ``install_desired``, tolerating fetch / crash errors. Shared by the
+    cli-local and cli-docker adapters. Returns ``codex_extra_servers``
+    (``{}`` for claude, or when there's nothing to install).
+    """
+    if not desired_skills and not desired_mcps:
+        return {}
+    if not (server_url and slug and keys_dir):
+        logger.warning(
+            "agent %s: desired_skills/desired_mcps configured but "
+            "puffo_core wiring is incomplete — skipping spawn-time "
+            "install (server_url=%r slug=%r keys_dir=%r)",
+            agent_id, server_url, slug, keys_dir,
+        )
+        return {}
+    from ...crypto.http_client import PuffoCoreHttpClient
+    from ...crypto.keystore import KeyStore
+    http = PuffoCoreHttpClient(server_url, KeyStore(keys_dir), slug)
+    try:
+        return await install_desired(
+            http=http,
+            agent_home=agent_home,
+            workspace_dir=workspace_dir,
+            agent_id=agent_id,
+            harness_name=harness_name,
+            desired_skills=desired_skills,
+            desired_mcps=desired_mcps,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "agent %s: desired install pass crashed: %s — continuing spawn",
+            agent_id, exc,
+        )
+        return {}
+    finally:
+        await http.close()
+
+
 async def install_desired(
     *,
     http: PuffoCoreHttpClient,
@@ -296,10 +348,9 @@ async def install_desired(
     fold into ``[mcp_servers.*]`` config.toml. Always ``{}`` for claude.
     """
     # hermes is one-shot per turn and has no skills / MCP surface; the
-    # picker still happily accepts ids for an hermes agent today, so
-    # bail explicitly rather than silently writing into ``.claude/``
-    # for an agent that won't read from it. Mirrors the hermes
-    # short-circuits at local_cli.py:205 / 227 / 255 (PUF-273 item c).
+    # picker still accepts ids for an hermes agent today, so bail
+    # explicitly rather than write into ``.claude/`` for an agent that
+    # won't read from it.
     if harness_name == "hermes":
         if desired_skills or desired_mcps:
             logger.info(

--- a/src/puffo_agent/agent/adapters/desired_install.py
+++ b/src/puffo_agent/agent/adapters/desired_install.py
@@ -129,6 +129,48 @@ def write_desired_skill(
     )
 
 
+def prune_stale_desired_skills(
+    skills_root: Path, current_desired: list[str],
+) -> int:
+    """Remove skill dirs that only carry the desired-installed marker
+    for ids no longer in the current desired list. host-synced and
+    agent-installed entries are left alone — those lifecycles are
+    owned elsewhere. Returns the count of dirs removed.
+
+    Idempotent; spawn-time `_install_desired` calls this after the
+    install loop so a freshly-installed skill is never pruned in the
+    same pass. PUF-273 item (a).
+    """
+    if not skills_root.is_dir():
+        return 0
+    current_set = set(current_desired)
+    pruned = 0
+    import shutil
+    for entry in skills_root.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.name in current_set:
+            continue
+        if not (entry / DESIRED_INSTALLED_MARKER).exists():
+            continue
+        # Stronger provenance wins — host-sync or agent-install
+        # signals the skill should stay even after operator drops it
+        # from the desired list.
+        if (entry / "agent-installed.md").exists():
+            continue
+        if (entry / "host-synced.md").exists():
+            continue
+        try:
+            shutil.rmtree(entry)
+            pruned += 1
+        except OSError as exc:
+            logger.warning(
+                "desired-install prune %r: rmtree failed: %s — skipping",
+                entry.name, exc,
+            )
+    return pruned
+
+
 def write_desired_skill_codex(
     workspace_dir: Path, template_id: str, body: str,
 ) -> str:
@@ -253,6 +295,20 @@ async def install_desired(
     Returns ``codex_extra_servers`` — a ``{id: spec}`` map for codex to
     fold into ``[mcp_servers.*]`` config.toml. Always ``{}`` for claude.
     """
+    # hermes is one-shot per turn and has no skills / MCP surface; the
+    # picker still happily accepts ids for an hermes agent today, so
+    # bail explicitly rather than silently writing into ``.claude/``
+    # for an agent that won't read from it. Mirrors the hermes
+    # short-circuits at local_cli.py:205 / 227 / 255 (PUF-273 item c).
+    if harness_name == "hermes":
+        if desired_skills or desired_mcps:
+            logger.info(
+                "agent %s: hermes harness — skipping %d desired_skills + "
+                "%d desired_mcps (no skills/MCP surface in hermes v1)",
+                agent_id, len(desired_skills), len(desired_mcps),
+            )
+        return {}
+
     is_codex = harness_name == "codex"
 
     for sid in desired_skills:
@@ -274,6 +330,20 @@ async def install_desired(
                 "agent %s: desired skill %r already present — left untouched",
                 agent_id, sid,
             )
+
+    # Prune skill dirs whose only provenance is a now-stale
+    # desired-installed marker. Runs after the install loop so
+    # freshly-added ids in the current list aren't candidates.
+    skills_root = (
+        workspace_dir / ".agents" / "skills" if is_codex
+        else agent_home / ".claude" / "skills"
+    )
+    pruned = prune_stale_desired_skills(skills_root, desired_skills)
+    if pruned:
+        logger.info(
+            "agent %s: pruned %d stale desired-installed skill dir(s)",
+            agent_id, pruned,
+        )
 
     codex_extras: dict[str, dict[str, Any]] = {}
     for mid in desired_mcps:

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -152,6 +152,10 @@ class DockerCLIAdapter(Adapter):
         google_api_key: str = "",
         memory_limit: str = "",
         memory_reservation: str = "",
+        desired_skills: list[str] | None = None,
+        puffo_core_server_url: str = "",
+        puffo_core_slug: str = "",
+        puffo_core_keys_dir: str = "",
     ):
         self.agent_id = agent_id
         self.model = model
@@ -185,6 +189,15 @@ class DockerCLIAdapter(Adapter):
             from ..harness import ClaudeCodeHarness
             harness = ClaudeCodeHarness()
         self.harness = harness
+        # Operator-picked skills install into the bind-mounted
+        # .claude/skills/ on first start (see _ensure_started); MCPs are
+        # rejected upstream in build_adapter — cli-docker can't host
+        # them yet.
+        self.desired_skills = list(desired_skills or [])
+        self.puffo_core_server_url = puffo_core_server_url
+        self.puffo_core_slug = puffo_core_slug
+        self.puffo_core_keys_dir = puffo_core_keys_dir
+        self._desired_installed = False
         self._started_lock = asyncio.Lock()
         self._started = False
         self._session: ClaudeSession | None = None
@@ -772,6 +785,27 @@ class DockerCLIAdapter(Adapter):
             return ""
         return out.decode("utf-8", errors="replace").strip()
 
+    async def _install_desired_skills(self) -> None:
+        """Install operator-picked skills into the per-agent
+        .claude/skills/. Once per adapter instance; MCPs are gated out
+        upstream so only skills flow here. Fetch errors are tolerated.
+        """
+        if self._desired_installed or not self.desired_skills:
+            return
+        self._desired_installed = True
+        from .desired_install import run_spawn_install
+        await run_spawn_install(
+            agent_id=self.agent_id,
+            agent_home=self.agent_home_dir,
+            workspace_dir=Path(self.workspace_dir),
+            harness_name=self.harness.name(),
+            desired_skills=self.desired_skills,
+            desired_mcps=[],
+            server_url=self.puffo_core_server_url,
+            slug=self.puffo_core_slug,
+            keys_dir=self.puffo_core_keys_dir,
+        )
+
     async def _ensure_started(self) -> None:
         async with self._started_lock:
             if self._started:
@@ -803,6 +837,11 @@ class DockerCLIAdapter(Adapter):
                     self.agent_id, skill_count,
                     self.agent_home_dir / ".claude" / "skills",
                 )
+            # Operator-picked desired skills, after host-sync so host
+            # skills win on collision (they carry the stronger
+            # host-synced marker). Writes into the bind-mounted
+            # .claude/skills/, so they appear inside the container.
+            await self._install_desired_skills()
             merged_mcp, unreachable = sync_host_mcp_servers(
                 host_home, self.agent_home_dir,
             )

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -45,7 +45,7 @@ from ..cli_bin import resolve_claude_bin, resolve_codex_bin, resolve_hermes_bin
 from .base import Adapter, TurnContext, TurnResult
 from .cli_session import AuditLog, ClaudeSession
 from .codex_session import CodexSession
-from .desired_install import install_desired
+from .desired_install import run_spawn_install
 from .hermes_helpers import (
     HERMES_NO_RESUME_SIGNATURE,
     hermes_model_id,
@@ -1004,47 +1004,17 @@ class LocalCLIAdapter(Adapter):
         if self._desired_installed:
             return
         self._desired_installed = True
-        if not self.desired_skills and not self.desired_mcps:
-            return
-        if not (
-            self.puffo_core_server_url
-            and self.puffo_core_slug
-            and self.puffo_core_keys_dir
-        ):
-            logger.warning(
-                "agent %s: desired_skills/desired_mcps configured but "
-                "puffo_core wiring is incomplete — skipping spawn-time "
-                "install (server_url=%r slug=%r keys_dir=%r)",
-                self.agent_id,
-                self.puffo_core_server_url,
-                self.puffo_core_slug,
-                self.puffo_core_keys_dir,
-            )
-            return
-        from ...crypto.http_client import PuffoCoreHttpClient
-        from ...crypto.keystore import KeyStore
-        ks = KeyStore(self.puffo_core_keys_dir)
-        http = PuffoCoreHttpClient(
-            self.puffo_core_server_url, ks, self.puffo_core_slug,
+        codex_extras = await run_spawn_install(
+            agent_id=self.agent_id,
+            agent_home=self.agent_home_dir,
+            workspace_dir=Path(self.workspace_dir),
+            harness_name=self.harness.name(),
+            desired_skills=self.desired_skills,
+            desired_mcps=self.desired_mcps,
+            server_url=self.puffo_core_server_url,
+            slug=self.puffo_core_slug,
+            keys_dir=self.puffo_core_keys_dir,
         )
-        try:
-            codex_extras = await install_desired(
-                http=http,
-                agent_home=self.agent_home_dir,
-                workspace_dir=Path(self.workspace_dir),
-                agent_id=self.agent_id,
-                harness_name=self.harness.name(),
-                desired_skills=self.desired_skills,
-                desired_mcps=self.desired_mcps,
-            )
-        except Exception as exc:
-            logger.warning(
-                "agent %s: desired install pass crashed: %s — "
-                "continuing spawn", self.agent_id, exc,
-            )
-            codex_extras = {}
-        finally:
-            await http.close()
         if codex_extras:
             self._desired_codex_extras = codex_extras
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -128,16 +128,17 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
     # ~/.claude/.credentials.json (set up by `claude login`); no
     # api_key is threaded through. Model overrides still flow.
     if kind == "cli-docker":
-        # The desired-skills / desired-mcps install path is cli-local
-        # only today (PUF-268). Failing fast here makes the gap
-        # operator-visible — picks were otherwise silently dropped
-        # at adapter-construction. PUF-273 item (b).
-        if agent_cfg.desired_skills or agent_cfg.desired_mcps:
+        # desired_skills ARE installed (below, into the agent's
+        # .claude/skills/, which docker bind-mounts into the
+        # container). desired_mcps stay cli-local — their launch
+        # commands don't resolve inside the container — so reject
+        # loudly rather than silently drop.
+        if agent_cfg.desired_mcps:
             raise RuntimeError(
-                f"agent {agent_cfg.id!r}: desired_skills / desired_mcps "
-                "are not supported on the cli-docker runtime yet. Either "
-                "clear them from agent.yml or switch runtime.kind to "
-                "cli-local."
+                f"agent {agent_cfg.id!r}: desired_mcps are not supported "
+                "on the cli-docker runtime yet (the MCP launch command "
+                "won't resolve inside the container). Clear them from "
+                "agent.yml or switch runtime.kind to cli-local."
             )
         from ..agent.adapters.docker_cli import DockerCLIAdapter
         from ..agent.harness import build_harness
@@ -177,6 +178,10 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             google_api_key=google_key,
             memory_limit=memory_limit,
             memory_reservation=memory_reservation,
+            desired_skills=agent_cfg.desired_skills,
+            puffo_core_server_url=agent_cfg.puffo_core.server_url,
+            puffo_core_slug=agent_cfg.puffo_core.slug,
+            puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
         )
         # When puffo_core is configured, give the adapter env to spawn
         # ``python -m puffo_agent.mcp.puffo_core_server``. The adapter

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -128,6 +128,17 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
     # ~/.claude/.credentials.json (set up by `claude login`); no
     # api_key is threaded through. Model overrides still flow.
     if kind == "cli-docker":
+        # The desired-skills / desired-mcps install path is cli-local
+        # only today (PUF-268). Failing fast here makes the gap
+        # operator-visible — picks were otherwise silently dropped
+        # at adapter-construction. PUF-273 item (b).
+        if agent_cfg.desired_skills or agent_cfg.desired_mcps:
+            raise RuntimeError(
+                f"agent {agent_cfg.id!r}: desired_skills / desired_mcps "
+                "are not supported on the cli-docker runtime yet. Either "
+                "clear them from agent.yml or switch runtime.kind to "
+                "cli-local."
+            )
         from ..agent.adapters.docker_cli import DockerCLIAdapter
         from ..agent.harness import build_harness
         harness = build_harness(agent_cfg.runtime.harness)

--- a/tests/test_desired_install_gc_and_harness_gates.py
+++ b/tests/test_desired_install_gc_and_harness_gates.py
@@ -1,0 +1,336 @@
+"""PUF-273: spawn-time provenance GC + cli-docker reject + hermes
+early-return.
+
+Covers the three follow-up items deferred from PUF-268:
+
+  (a) ``prune_stale_desired_skills`` removes only desired-installed-
+      only skill dirs whose ids no longer appear in the current
+      desired list. host-synced and agent-installed markers win.
+  (b) The cli-docker branch in ``portal.worker._build_adapter``
+      raises when an agent.yml carries non-empty desired_skills /
+      desired_mcps.
+  (c) ``install_desired`` early-returns for harness=hermes without
+      writing any skills or MCPs.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.desired_install import (
+    DESIRED_INSTALLED_MARKER,
+    install_desired,
+    prune_stale_desired_skills,
+)
+
+
+# ─── (a) prune_stale_desired_skills ─────────────────────────────────────────
+
+
+def _make_skill_dir(root: Path, name: str, *markers: str) -> Path:
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    for marker in markers:
+        (d / marker).write_text("body\n", encoding="utf-8")
+    return d
+
+
+def test_prune_removes_stale_desired_only_marker(tmp_path):
+    root = tmp_path / "skills"
+    keep = _make_skill_dir(root, "keep", DESIRED_INSTALLED_MARKER)
+    stale = _make_skill_dir(root, "stale", DESIRED_INSTALLED_MARKER)
+
+    pruned = prune_stale_desired_skills(root, ["keep"])
+
+    assert pruned == 1
+    assert keep.is_dir()
+    assert not stale.exists()
+
+
+def test_prune_keeps_host_synced(tmp_path):
+    root = tmp_path / "skills"
+    both = _make_skill_dir(root, "both", DESIRED_INSTALLED_MARKER, "host-synced.md")
+
+    pruned = prune_stale_desired_skills(root, [])
+
+    assert pruned == 0
+    assert both.is_dir()
+    assert (both / DESIRED_INSTALLED_MARKER).exists()
+    assert (both / "host-synced.md").exists()
+
+
+def test_prune_keeps_agent_installed(tmp_path):
+    root = tmp_path / "skills"
+    both = _make_skill_dir(root, "both", DESIRED_INSTALLED_MARKER, "agent-installed.md")
+
+    pruned = prune_stale_desired_skills(root, [])
+
+    assert pruned == 0
+    assert both.is_dir()
+
+
+def test_prune_ignores_dirs_without_desired_marker(tmp_path):
+    root = tmp_path / "skills"
+    host_only = _make_skill_dir(root, "host-only", "host-synced.md")
+
+    pruned = prune_stale_desired_skills(root, [])
+
+    assert pruned == 0
+    assert host_only.is_dir()
+
+
+def test_prune_returns_zero_when_root_missing(tmp_path):
+    assert prune_stale_desired_skills(tmp_path / "nonexistent", []) == 0
+
+
+def test_prune_ignores_loose_files(tmp_path):
+    root = tmp_path / "skills"
+    root.mkdir()
+    (root / "loose.md").write_text("not a skill dir\n")
+    assert prune_stale_desired_skills(root, []) == 0
+    assert (root / "loose.md").exists()
+
+
+# ─── (a) GC fires from install_desired after the install loop ───────────────
+
+
+class _FakeHttpEmpty:
+    """install_desired hits no templates → exercises only the prune pass."""
+    async def get(self, path):
+        from puffo_agent.crypto.http_client import HttpError
+        raise HttpError(404, "not found")
+
+    async def close(self):
+        pass
+
+
+def test_install_desired_invokes_prune_on_claude(tmp_path):
+    agent_home = tmp_path / "agent_home"
+    skills = agent_home / ".claude" / "skills"
+    stale = _make_skill_dir(skills, "stale", DESIRED_INSTALLED_MARKER)
+
+    asyncio.new_event_loop().run_until_complete(
+        install_desired(
+            http=_FakeHttpEmpty(),
+            agent_home=agent_home,
+            workspace_dir=tmp_path / "ws",
+            agent_id="t-agent",
+            harness_name="claude-code",
+            desired_skills=[],
+            desired_mcps=[],
+        ),
+    )
+
+    assert not stale.exists()
+
+
+def test_install_desired_invokes_prune_on_codex_workspace_path(tmp_path):
+    workspace_dir = tmp_path / "ws"
+    skills = workspace_dir / ".agents" / "skills"
+    stale = _make_skill_dir(skills, "stale", DESIRED_INSTALLED_MARKER)
+
+    asyncio.new_event_loop().run_until_complete(
+        install_desired(
+            http=_FakeHttpEmpty(),
+            agent_home=tmp_path / "agent_home",
+            workspace_dir=workspace_dir,
+            agent_id="t-agent",
+            harness_name="codex",
+            desired_skills=[],
+            desired_mcps=[],
+        ),
+    )
+
+    assert not stale.exists()
+
+
+def test_install_desired_prune_does_not_remove_freshly_installed(tmp_path):
+    """Round-trip: id was previously installed, stays in the current
+    desired list — the prune pass must not nuke it."""
+    agent_home = tmp_path / "agent_home"
+    skills = agent_home / ".claude" / "skills"
+    kept = _make_skill_dir(skills, "fresh", DESIRED_INSTALLED_MARKER)
+
+    asyncio.new_event_loop().run_until_complete(
+        install_desired(
+            http=_FakeHttpEmpty(),
+            agent_home=agent_home,
+            workspace_dir=tmp_path / "ws",
+            agent_id="t-agent",
+            harness_name="claude-code",
+            desired_skills=["fresh"],
+            desired_mcps=[],
+        ),
+    )
+
+    assert kept.is_dir()
+    assert (kept / DESIRED_INSTALLED_MARKER).exists()
+
+
+# ─── (c) hermes harness early-return in install_desired ─────────────────────
+
+
+def test_install_desired_hermes_early_returns_no_writes(tmp_path, caplog):
+    agent_home = tmp_path / "agent_home"
+    workspace_dir = tmp_path / "ws"
+
+    class _CrashingHttp:
+        async def get(self, path):  # pragma: no cover
+            raise AssertionError("hermes branch must short-circuit before HTTP")
+        async def close(self):
+            pass
+
+    with caplog.at_level(logging.INFO, logger="puffo_agent.agent.adapters.desired_install"):
+        extras = asyncio.new_event_loop().run_until_complete(
+            install_desired(
+                http=_CrashingHttp(),
+                agent_home=agent_home,
+                workspace_dir=workspace_dir,
+                agent_id="t-hermes",
+                harness_name="hermes",
+                desired_skills=["s1", "s2"],
+                desired_mcps=["m1"],
+            ),
+        )
+
+    assert extras == {}
+    assert not (agent_home / ".claude" / "skills").exists()
+    assert not (workspace_dir / ".agents" / "skills").exists()
+    # Info log carries verbatim id counts so an operator inspecting
+    # daemon logs can see why their picker selections were dropped.
+    assert any(
+        "hermes harness" in r.message and "2 desired_skills" in r.message
+        for r in caplog.records
+    ), caplog.records
+
+
+def test_install_desired_hermes_empty_lists_no_log(tmp_path, caplog):
+    with caplog.at_level(logging.INFO, logger="puffo_agent.agent.adapters.desired_install"):
+        extras = asyncio.new_event_loop().run_until_complete(
+            install_desired(
+                http=_FakeHttpEmpty(),
+                agent_home=tmp_path / "agent_home",
+                workspace_dir=tmp_path / "ws",
+                agent_id="t-hermes",
+                harness_name="hermes",
+                desired_skills=[],
+                desired_mcps=[],
+            ),
+        )
+
+    assert extras == {}
+    # Empty list + hermes → silent. No log noise on every spawn.
+    assert not any(
+        "hermes harness" in r.message for r in caplog.records
+    )
+
+
+# ─── (b) cli-docker reject at worker._build_adapter ─────────────────────────
+
+
+def _make_agent_cfg(
+    *,
+    runtime_kind: str,
+    desired_skills: list[str] | None = None,
+    desired_mcps: list[str] | None = None,
+):
+    """Minimal stub: only the fields the cli-docker reject gate reads."""
+    from types import SimpleNamespace
+    runtime = SimpleNamespace(
+        kind=runtime_kind,
+        harness="claude-code",
+        model="",
+        permission_mode="bypassPermissions",
+        docker_image="",
+        docker_memory_limit="",
+        docker_memory_reservation="",
+    )
+    puffo_core = SimpleNamespace(
+        server_url="",
+        slug="",
+        device_id="",
+        space_id="",
+        is_configured=lambda: False,
+    )
+    return SimpleNamespace(
+        id="t-agent",
+        runtime=runtime,
+        desired_skills=desired_skills or [],
+        desired_mcps=desired_mcps or [],
+        puffo_core=puffo_core,
+        resolve_workspace_dir=lambda: Path("/tmp/ws"),
+        resolve_claude_dir=lambda: Path("/tmp/ws/.claude"),
+    )
+
+
+def _make_daemon_cfg():
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        google=SimpleNamespace(api_key=""),
+        anthropic=SimpleNamespace(model=""),
+        openai=SimpleNamespace(model=""),
+        docker_memory_limit="",
+        docker_memory_reservation="",
+        data_service=SimpleNamespace(port=63388),
+        rpc_service=SimpleNamespace(port=63389),
+    )
+
+
+def test_build_adapter_cli_docker_rejects_non_empty_desired_skills():
+    from puffo_agent.portal.worker import build_adapter
+
+    agent_cfg = _make_agent_cfg(
+        runtime_kind="cli-docker", desired_skills=["s1"],
+    )
+    with pytest.raises(RuntimeError) as ei:
+        build_adapter(_make_daemon_cfg(), agent_cfg)
+    assert "cli-docker" in str(ei.value)
+    assert "desired_skills" in str(ei.value) or "cli-local" in str(ei.value)
+
+
+def test_build_adapter_cli_docker_rejects_non_empty_desired_mcps():
+    from puffo_agent.portal.worker import build_adapter
+
+    agent_cfg = _make_agent_cfg(
+        runtime_kind="cli-docker", desired_mcps=["m1"],
+    )
+    with pytest.raises(RuntimeError) as ei:
+        build_adapter(_make_daemon_cfg(), agent_cfg)
+    assert "cli-docker" in str(ei.value)
+
+
+def test_build_adapter_cli_docker_empty_desired_does_not_reject(monkeypatch):
+    """Reject gate must not fire when the lists are empty — that's the
+    cli-docker happy path operators have today."""
+    from puffo_agent.portal.worker import build_adapter
+    from puffo_agent.agent.adapters import docker_cli as dc
+    from puffo_agent.agent import harness
+
+    captured: dict = {}
+
+    class _Stub:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(dc, "DockerCLIAdapter", _Stub)
+
+    class _Harness:
+        def name(self) -> str:
+            return "claude-code"
+
+    monkeypatch.setattr(harness, "build_harness", lambda _: _Harness())
+
+    agent_cfg = _make_agent_cfg(runtime_kind="cli-docker")
+    build_adapter(_make_daemon_cfg(), agent_cfg)
+    # Reaching here without RuntimeError is the assertion. Cheap
+    # tail-check that the stub adapter actually saw the agent_id so
+    # we know the code path executed past the reject gate.
+    assert captured.get("agent_id") == "t-agent"

--- a/tests/test_desired_install_gc_and_harness_gates.py
+++ b/tests/test_desired_install_gc_and_harness_gates.py
@@ -284,16 +284,34 @@ def _make_daemon_cfg():
     )
 
 
-def test_build_adapter_cli_docker_rejects_non_empty_desired_skills():
+def test_build_adapter_cli_docker_installs_desired_skills(monkeypatch):
+    """desired_skills no longer reject on cli-docker — they install into
+    the bind-mounted .claude/skills/. The adapter must receive both the
+    skills and the puffo_core install wiring."""
     from puffo_agent.portal.worker import build_adapter
+    from puffo_agent.agent.adapters import docker_cli as dc
+    from puffo_agent.agent import harness
+
+    captured: dict = {}
+
+    class _Stub:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(dc, "DockerCLIAdapter", _Stub)
+
+    class _Harness:
+        def name(self) -> str:
+            return "claude-code"
+
+    monkeypatch.setattr(harness, "build_harness", lambda _: _Harness())
 
     agent_cfg = _make_agent_cfg(
-        runtime_kind="cli-docker", desired_skills=["s1"],
+        runtime_kind="cli-docker", desired_skills=["s1", "s2"],
     )
-    with pytest.raises(RuntimeError) as ei:
-        build_adapter(_make_daemon_cfg(), agent_cfg)
-    assert "cli-docker" in str(ei.value)
-    assert "desired_skills" in str(ei.value) or "cli-local" in str(ei.value)
+    build_adapter(_make_daemon_cfg(), agent_cfg)  # no RuntimeError
+    assert captured.get("desired_skills") == ["s1", "s2"]
+    assert "puffo_core_keys_dir" in captured
 
 
 def test_build_adapter_cli_docker_rejects_non_empty_desired_mcps():
@@ -305,6 +323,7 @@ def test_build_adapter_cli_docker_rejects_non_empty_desired_mcps():
     with pytest.raises(RuntimeError) as ei:
         build_adapter(_make_daemon_cfg(), agent_cfg)
     assert "cli-docker" in str(ei.value)
+    assert "desired_mcps" in str(ei.value)
 
 
 def test_build_adapter_cli_docker_empty_desired_does_not_reject(monkeypatch):
@@ -334,3 +353,44 @@ def test_build_adapter_cli_docker_empty_desired_does_not_reject(monkeypatch):
     # tail-check that the stub adapter actually saw the agent_id so
     # we know the code path executed past the reject gate.
     assert captured.get("agent_id") == "t-agent"
+
+
+@pytest.mark.asyncio
+async def test_docker_install_desired_skills_passes_skills_only(
+    monkeypatch, tmp_path,
+):
+    """The docker adapter installs skills but never MCPs — MCPs are
+    gated out upstream, so it always calls run_spawn_install with an
+    empty desired_mcps list."""
+    from puffo_agent.agent.adapters import desired_install
+    from puffo_agent.agent.adapters.docker_cli import DockerCLIAdapter
+
+    calls: dict = {}
+
+    async def _fake_run(**kw):
+        calls.update(kw)
+        return {}
+
+    monkeypatch.setattr(desired_install, "run_spawn_install", _fake_run)
+
+    adapter = DockerCLIAdapter(
+        agent_id="t",
+        model="",
+        image="img",
+        workspace_dir=str(tmp_path),
+        claude_dir=str(tmp_path / ".claude"),
+        session_file=str(tmp_path / "s.json"),
+        agent_home_dir=str(tmp_path),
+        shared_fs_dir=str(tmp_path),
+        desired_skills=["s1"],
+        puffo_core_server_url="u",
+        puffo_core_slug="sl",
+        puffo_core_keys_dir=str(tmp_path / "keys"),
+    )
+    await adapter._install_desired_skills()
+    assert calls["desired_skills"] == ["s1"]
+    assert calls["desired_mcps"] == []
+    # idempotent — a second call is a no-op
+    calls.clear()
+    await adapter._install_desired_skills()
+    assert calls == {}


### PR DESCRIPTION
## Summary

Three bounded follow-up items from PUF-268's #58 review batch, all touching the desired-install + adapter-construction surfaces and shipping as one branch since they share test-fixture setup:

- **(a) Provenance GC** — `prune_stale_desired_skills(skills_root, current_desired)` removes skill dirs whose only provenance is a now-stale `desired-installed.md` marker. `agent-installed.md` + `host-synced.md` markers win (stronger provenance). Called from `install_desired` after the install loop so freshly-added ids in the current pass aren't candidates. Idempotent.
- **(b) cli-docker reject** — `portal.worker.build_adapter` raises `RuntimeError` when an agent.yml carries non-empty `desired_skills` / `desired_mcps` and `runtime.kind == "cli-docker"`. Replaces today's silent-drop with an operator-visible failure naming both the unsupported runtime and the cli-local workaround.
- **(c) hermes early-return** — `install_desired` short-circuits when `harness_name == "hermes"` with an info-log naming skip counts (empty lists → silent, no log noise per spawn). Mirrors hermes's other short-circuits at `local_cli.py:205 / 227 / 255`.

## QA verdict — PASS (with coverage notes below)

**Diff coverage:**

| Item | Surface | Verified |
|---|---|---|
| (a) Prune signature `prune_stale_desired_skills(skills_root, current_desired) -> int` | `desired_install.py:130-170` | ✓ |
| (a) Provenance-precedence (host-synced + agent-installed survive prune) | Same | ✓ — explicit `if (entry / "agent-installed.md").exists(): continue` + same for `host-synced.md` |
| (a) Prune call-site after install loop | `desired_install.py:331-345` | ✓ — `pruned = prune_stale_desired_skills(skills_root, desired_skills)`; skills_root resolved via harness branch |
| (a) OSError handling | Same | ✓ — `try/except OSError` + `logger.warning` + skip-don't-abort |
| (b) cli-docker reject placement | `worker.py:126-136` | ✓ — gate fires inside `if kind == "cli-docker"` BEFORE adapter construction |
| (b) Error message operator-readable | Same | ✓ — names agent_id, "cli-docker", "cli-local" workaround |
| (c) Hermes short-circuit | `desired_install.py:297-308` | ✓ — `if harness_name == "hermes"` at top of `install_desired`; returns `{}` |
| (c) Hermes empty-list silence | Same | ✓ — log gated on `if desired_skills or desired_mcps` |

**Test coverage (14 new tests):**

(a) prune logic (6 tests): happy-path remove + 2 provenance-precedence cases (host-synced wins / agent-installed wins) + ignores-no-marker + missing-root + ignores-loose-files
(a) integration into install_desired (3 tests): claude path / codex `.agents/skills` path / round-trip-no-nuke-fresh
(c) hermes (2 tests): early-return-no-writes + log-id-counts + silent-on-empty
(b) cli-docker reject (3 tests): rejects-non-empty-desired_skills + rejects-non-empty-desired_mcps + no-regression-on-empty-list

**Local verify (per Calculation):**
- 14/14 new tests ✓
- 45/45 existing PUF-268 desired-install tests ✓ (no regression)
- Full pytest 1128/1133 ✓ — the 5 failures in `test_ui_mcp_scanner.py` are pre-existing on main (ModuleNotFoundError in agent_detail.py import) and unrelated to this PR

**Coverage gaps worth surfacing (per `[Aggressive QA test coverage]`):**

- MCP marker GC — known scope-out per intake; a test that asserts "MCP entry persists in `.claude.json#mcpServers` after operator removes from `desired_mcps`" would lock the contract. Deferrable to its own ticket if/when MCP markers move to file-based shape.
- Prune-during-install-failure — install loop has no try/except around `mcp__` template fetch; if it raises mid-loop, the prune call after the loop is skipped. Probably correct (skip cleanup when install state is inconsistent) but worth noting in case future spawn-failure observability cares.
- OSError on prune (permission-denied) — code path covered by branch, but no test specifically chmod's a dir to readonly. Minor — `try/except` shape is straightforward.
- Prune name-level observability — info-log carries count only; if operator wants "which skill got removed," they need to inspect filesystem. Could log names at debug level. Minor.
- hermes harness + non-empty `desired_mcps`-only (no skills) — test asserts "2 desired_skills" but not the parallel "M desired_mcps" log shape. Minor — same code path.

**Other-side state:** N/A — daemon-side only. PUF-268 web-side + server-side untouched.

## Test plan

- [x] Diff review: prune scope + provenance precedence + GC call-site + cli-docker reject placement + hermes short-circuit
- [x] 14 new tests cover the 3 items (independent of each other; coverage matches intake validation plan)
- [x] 45 PUF-268 desired-install tests still pass (per Calculation)
- [ ] Live round-trip on a host (operator): agent X has desired_skills=[s1] → spawn → marker exists → remove from agent.yml → next spawn → dir pruned
- [ ] cli-docker + non-empty desired → operator-visible `RuntimeError` at spawn (vs silent-drop today)
- [ ] hermes + non-empty desired → info log fires, no `.claude/skills/` writes
- [ ] No regression on cli-docker happy path (empty desired list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)