### PR TITLE
fix(keychain): single-parse credential validation + harden non-object blob (0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.2] — 2026-06-06
+
+### Fixed
+
+- **Harden Keychain credential parsing.** A valid-JSON-but-non-object
+  blob (e.g. a bare ``5``) could raise an uncaught ``AttributeError``
+  mid-read; it is now rejected cleanly as ``invalid_oauth_blob``. The
+  per-service validity / expiry / ranking checks were also folded into
+  a single ``_parse_credential`` pass instead of re-parsing the blob
+  up to three times — behavior-preserving otherwise.
+
 ## [0.12.1] — 2026-06-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.12.1"
+version = "0.12.2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/macos/keychain.py
+++ b/src/puffo_agent/macos/keychain.py
@@ -94,22 +94,29 @@ class _KeychainCandidate:
     expires_at_ms: Optional[int]
 
 
-def _credential_expires_at_ms(blob: str) -> Optional[int]:
+def _parse_credential(blob: str) -> tuple[Optional[int], Optional[str]]:
+    """Validate a Claude OAuth blob in a single parse. Returns
+    ``(expires_at_ms, None)`` for a well-formed blob, else
+    ``(None, reason)`` — ``invalid_json`` for bad JSON, otherwise
+    ``invalid_oauth_blob``.
+    """
     try:
         data = json.loads(blob)
-        oauth = data.get("claudeAiOauth")
-        if not isinstance(oauth, dict):
-            return None
-        access_token = oauth.get("accessToken")
-        refresh_token = oauth.get("refreshToken")
-        if not isinstance(access_token, str) or not access_token:
-            return None
-        if not isinstance(refresh_token, str) or not refresh_token:
-            return None
-        value = oauth.get("expiresAt")
-        return int(value)
-    except (json.JSONDecodeError, TypeError, ValueError):
-        return None
+    except json.JSONDecodeError as exc:
+        return None, f"invalid_json: {exc}"
+    oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
+    if not isinstance(oauth, dict):
+        return None, "invalid_oauth_blob"
+    access_token = oauth.get("accessToken")
+    refresh_token = oauth.get("refreshToken")
+    if not isinstance(access_token, str) or not access_token:
+        return None, "invalid_oauth_blob"
+    if not isinstance(refresh_token, str) or not refresh_token:
+        return None, "invalid_oauth_blob"
+    try:
+        return int(oauth.get("expiresAt")), None
+    except (TypeError, ValueError):
+        return None, "invalid_oauth_blob"
 
 
 def _service_rank(service: str) -> int:
@@ -143,7 +150,10 @@ def _select_keychain_candidate(
 def _read_keychain_service(
     service: str,
     timeout: float,
-) -> KeychainReadResult:
+) -> tuple[KeychainReadResult, Optional[int]]:
+    """Read one service. Returns the result plus the parsed
+    ``expiresAt`` (only set when ``result.ok``) so the caller doesn't
+    re-parse the blob to rank candidates."""
     try:
         result = subprocess.run(
             ["security", "find-generic-password", "-s", service, "-w"],
@@ -152,11 +162,11 @@ def _read_keychain_service(
     except FileNotFoundError:
         return KeychainReadResult(
             False, None, "security_binary_missing", None, service,
-        )
+        ), None
     except subprocess.TimeoutExpired:
         return KeychainReadResult(
             False, None, "timeout (ACL prompt may be open)", None, service,
-        )
+        ), None
     if result.returncode != 0:
         return KeychainReadResult(
             False,
@@ -164,21 +174,14 @@ def _read_keychain_service(
             f"exit_code={result.returncode}",
             result.stderr or None,
             service,
-        )
+        ), None
     blob = result.stdout.strip()
     if not blob:
-        return KeychainReadResult(False, None, "empty_stdout", None, service)
-    try:
-        json.loads(blob)
-    except json.JSONDecodeError as exc:
-        return KeychainReadResult(
-            False, None, f"invalid_json: {exc}", None, service,
-        )
-    if _credential_expires_at_ms(blob) is None:
-        return KeychainReadResult(
-            False, None, "invalid_oauth_blob", None, service,
-        )
-    return KeychainReadResult(True, blob, None, None, service)
+        return KeychainReadResult(False, None, "empty_stdout", None, service), None
+    expires_at_ms, reason = _parse_credential(blob)
+    if reason is not None:
+        return KeychainReadResult(False, None, reason, None, service), None
+    return KeychainReadResult(True, blob, None, None, service), expires_at_ms
 
 
 def read_keychain_blob(timeout: float = SECURITY_TIMEOUT_SECONDS) -> KeychainReadResult:
@@ -194,7 +197,7 @@ def read_keychain_blob(timeout: float = SECURITY_TIMEOUT_SECONDS) -> KeychainRea
     errors: list[str] = []
     stderrs: list[str] = []
     for service in KEYCHAIN_SERVICES:
-        result = _read_keychain_service(service, timeout)
+        result, expires_at_ms = _read_keychain_service(service, timeout)
         if not result.ok:
             if result.error == "security_binary_missing":
                 return result
@@ -202,12 +205,11 @@ def read_keychain_blob(timeout: float = SECURITY_TIMEOUT_SECONDS) -> KeychainRea
             if result.stderr:
                 stderrs.append(f"{service}: {result.stderr.strip()}")
             continue
-        blob = result.blob or ""
         candidates.append(
             _KeychainCandidate(
                 service=service,
-                blob=blob,
-                expires_at_ms=_credential_expires_at_ms(blob),
+                blob=result.blob or "",
+                expires_at_ms=expires_at_ms,
             )
         )
     if not candidates:

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -190,6 +190,23 @@ def test_read_keychain_blob_skips_non_oauth_json_for_valid_candidate(monkeypatch
     assert result.service == "Claude Code"
 
 
+def test_read_keychain_blob_rejects_non_object_json_without_crashing(monkeypatch):
+    # A valid-JSON-but-non-object blob (e.g. a bare number) must be
+    # rejected cleanly, not raise AttributeError mid-read.
+    _force_macos(monkeypatch)
+
+    def _fake_run(cmd, **kwargs):
+        service = cmd[cmd.index("-s") + 1]
+        if service == "Claude Code-credentials":
+            return _FakeCompletedProcess(0, stdout="5")
+        return _FakeCompletedProcess(44, stderr="entry not found")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = cm.read_keychain_blob()
+    assert result.ok is False
+    assert "invalid_oauth_blob" in result.error
+
+
 def test_read_keychain_blob_invalid_json(monkeypatch):
     _force_macos(monkeypatch)
     monkeypatch.setattr(


### PR DESCRIPTION
## Why

Follow-up to the review of #67 (Claude Keychain service fallback, shipped as 0.12.1 before the cleanup landed). Two review nits, now addressed:

1. **Redundant parsing** — the Keychain blob was `json.loads`-ed up to **three times per service** (validity check in `_read_keychain_service`, expiry in `_credential_expires_at_ms`, then again for candidate ranking in `read_keychain_blob`).
2. **Latent crash** — `_credential_expires_at_ms` did `data.get("claudeAiOauth")` without checking `data` is a dict. A valid-JSON-but-non-object blob (e.g. a bare `5` or `[]`) raised an **uncaught `AttributeError`** mid-read, propagating out of `read_keychain_blob`.

## What

- New `_parse_credential(blob) -> (expires_at_ms, reason)` — the single parse + validation point. `_read_keychain_service` now returns `(result, expires_at_ms)` so `read_keychain_blob` ranks candidates without re-parsing.
- The non-object blob is now rejected cleanly as `invalid_oauth_blob` instead of crashing (`isinstance(data, dict)` guard).
- Error strings (`invalid_json: …`, `invalid_oauth_blob`, `exit_code=…`, etc.) and the freshest-wins / tie-break selection are **unchanged** — purely behavior-preserving aside from the crash hardening.

## Tests

- Existing keychain / diagnostic / cli tests pass unchanged (internals aren't referenced by tests).
- +1 regression test: `test_read_keychain_blob_rejects_non_object_json_without_crashing`.
- `74 passed` across `test_macos_credential_manager.py` `test_macos_diagnostic.py` `test_cli_bin.py`.

Bumps `0.12.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)