### PR TITLE
PUF-283: detect agent auth failures → DM the operator → auto-recover on re-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.12.2] — 2026-06-06
 
+### Added
+
+- **Operator DM on agent auth failure.** When an agent's Claude OAuth
+  expires/revokes (a 401), the daemon DMs the operator a bilingual
+  (zh+en) note with the `claude /login` + `agent resume` recovery steps
+  — once per failure episode, re-armed after the credential recovers.
+
 ### Fixed
 
+- **Auth errors are distinguished from rate-limits.** A `401 Invalid
+  authentication credentials` reply was treated as a generic rate-limit
+  `API Error` — kick-retried then abandoned, never flipping
+  `auth_failed` or notifying the operator. The CLI adapter and `core`
+  now share one auth detector, so a confirmed auth error skips the
+  pointless retries and goes straight to `auth_failed` + the operator
+  DM (the batch redelivers once the operator re-logs in).
 - **Harden Keychain credential parsing.** A valid-JSON-but-non-object
   blob (e.g. a bare ``5``) could raise an uncaught ``AttributeError``
   mid-read; it is now rejected cleanly as ``invalid_oauth_blob``. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   now share one auth detector, so a confirmed auth error skips the
   pointless retries and goes straight to `auth_failed` + the operator
   DM (the batch redelivers once the operator re-logs in).
+- **Re-login now recovers running agents on copy-mode hosts (Windows).**
+  The file-credential backend assumed a symlink carried an operator
+  `claude /login` to every agent — but Windows falls back to a copy, so
+  a re-login never reached running agents and they sat in `auth_failed`
+  until a manual new message / `agent resume`. The refresher now
+  fingerprints the host credential (claude + codex) and, on an external
+  change, syncs every agent and fires refresh-success; the daemon then
+  restarts the agents that were `auth_failed` so their session respawns
+  with the fresh credential and the stalled batch redelivers.
 - **Harden Keychain credential parsing.** A valid-JSON-but-non-object
   blob (e.g. a bare ``5``) could raise an uncaught ``AttributeError``
   mid-read; it is now rejected cleanly as ``invalid_oauth_blob``. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **Operator DM on agent auth failure.** When an agent's Claude OAuth
   expires/revokes (a 401), the daemon DMs the operator a bilingual
-  (zh+en) note with the `claude /login` + `agent resume` recovery steps
-  — once per failure episode, re-armed after the credential recovers.
+  (zh+en) note: run `claude auth login` and just send a message (a new
+  message auto-resumes) — once per failure episode, re-armed after the
+  credential recovers.
 
 ### Fixed
 
@@ -24,9 +25,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   DM (the batch redelivers once the operator re-logs in).
 - **Re-login now recovers running agents on copy-mode hosts (Windows).**
   The file-credential backend assumed a symlink carried an operator
-  `claude /login` to every agent — but Windows falls back to a copy, so
-  a re-login never reached running agents and they sat in `auth_failed`
-  until a manual new message / `agent resume`. The refresher now
+  `claude auth login` to every agent — but Windows falls back to a copy,
+  so a re-login never reached running agents and they sat in
+  `auth_failed` until a manual new message. The refresher now
   fingerprints the host credential (claude + codex) and, on an external
   change, syncs every agent and fires refresh-success; the daemon then
   restarts the agents that were `auth_failed` so their session respawns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   fingerprints the host credential (claude + codex) and, on an external
   change, syncs every agent and fires refresh-success; the daemon then
   restarts the agents that were `auth_failed` so their session respawns
-  with the fresh credential and the stalled batch redelivers.
+  with the fresh credential and the stalled batch redelivers. A new
+  message to an `auth_failed` agent also wakes the refresher on the spot,
+  so recovery doesn't wait for the next poll.
 - **Harden Keychain credential parsing.** A valid-JSON-but-non-object
   blob (e.g. a bare ``5``) could raise an uncaught ``AttributeError``
   mid-read; it is now rejected cleanly as ``invalid_oauth_blob``. The

--- a/src/puffo_agent/agent/_auth_markers.py
+++ b/src/puffo_agent/agent/_auth_markers.py
@@ -1,13 +1,8 @@
 """Shared auth-error detection for adapter / provider error output.
 
-Used by the CLI session adapter (retry decision) and ``core`` (tagging
-``AgentAPIError.is_auth``) so the two can't drift — a divergence here is
-exactly what let a ``401 Invalid authentication credentials`` get
-mis-handled as a rate-limit.
-
-Substring match: safe on adapter *error output*, but do NOT apply to
-free-form agent prose. The worker uses anchored patterns for that, so a
-reply merely *mentioning* an auth concept isn't suppressed.
+Used by the CLI session adapter and ``core`` so their auth-vs-rate-limit
+split can't drift. Substring match — safe on adapter error output, but
+NOT on free-form agent prose (the worker uses anchored patterns there).
 """
 
 from __future__ import annotations

--- a/src/puffo_agent/agent/_auth_markers.py
+++ b/src/puffo_agent/agent/_auth_markers.py
@@ -1,0 +1,34 @@
+"""Shared auth-error detection for adapter / provider error output.
+
+Used by the CLI session adapter (retry decision) and ``core`` (tagging
+``AgentAPIError.is_auth``) so the two can't drift — a divergence here is
+exactly what let a ``401 Invalid authentication credentials`` get
+mis-handled as a rate-limit.
+
+Substring match: safe on adapter *error output*, but do NOT apply to
+free-form agent prose. The worker uses anchored patterns for that, so a
+reply merely *mentioning* an auth concept isn't suppressed.
+"""
+
+from __future__ import annotations
+
+AUTH_ERROR_MARKERS: tuple[str, ...] = (
+    "please run /login",
+    "please run `claude /login`",
+    "run `claude login`",
+    "invalid api key",
+    "invalid_grant",
+    "authentication failed",
+    "failed to authenticate",
+    "credentials expired",
+    "api error: 401",
+    "invalid authentication credentials",
+    '"type":"authentication_error"',
+)
+
+
+def looks_like_auth_error(text: str) -> bool:
+    if not text:
+        return False
+    low = text.lower()
+    return any(marker in low for marker in AUTH_ERROR_MARKERS)

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -1,10 +1,5 @@
-"""PUF-247: human-facing copy for invite-accept/reject failures.
-
-PUF-283: also hosts the bilingual ``format_oauth_expired`` copy fired
-from the daemon when ``runtime.health`` enters ``auth_failed`` due to
-an OAuth 401 / token-revoked / login-required signal in the worker's
-suppressed reply.
-"""
+"""Human-facing copy for invite failures and the OAuth-expired
+operator DM (``format_oauth_expired``)."""
 
 from __future__ import annotations
 
@@ -68,15 +63,9 @@ def format_invite_error(exc: Exception, verb: str) -> str:
 
 
 def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
-    """Bilingual zh+en DM copy fired once per agent-per-session per
-    OAuth-expired 401 ENTER on ``runtime.health=auth_failed``. PUF-283.
-
-    Operator's spec called for a friendly note pointing at concrete
-    recovery steps; the harness-side ``claude /login`` + daemon-side
-    ``puffo-agent agent resume`` pair is the documented recovery flow
-    today (matches ``runtime.error`` copy at
-    ``worker.py::_handle_suppressed_reply``).
-    """
+    """Bilingual (zh+en) operator DM for an OAuth-expired agent, with
+    the ``claude /login`` + ``agent resume`` recovery steps. Falls back
+    to a bare ``id`` when ``agent_display_name`` is empty."""
     label = (
         f"**{agent_display_name}** (`{agent_id}`)"
         if agent_display_name else f"`{agent_id}`"

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -63,16 +63,17 @@ def format_invite_error(exc: Exception, verb: str) -> str:
 
 
 def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
-    """Bilingual (zh+en) operator DM for an OAuth-expired agent, with
-    the ``claude /login`` + ``agent resume`` recovery steps. Falls back
-    to a bare ``id`` when ``agent_display_name`` is empty."""
+    """Bilingual (zh+en) operator DM for an OAuth-expired agent: run
+    ``claude auth login`` and just send a message (a new message
+    auto-resumes the agent). Falls back to a bare ``id`` when
+    ``agent_display_name`` is empty."""
     label = (
         f"**{agent_display_name}** (`{agent_id}`)"
         if agent_display_name else f"`{agent_id}`"
     )
     return (
-        f"⚠️ {label} — Claude OAuth expired. Run `claude /login`, then "
-        f"`puffo-agent agent resume {agent_id}`.\n"
-        f"⚠️ Claude OAuth 已过期。请运行 `claude /login`，再 "
-        f"`puffo-agent agent resume {agent_id}`。"
+        f"⚠️ {label} — Claude OAuth expired. Run `claude auth login`, "
+        "then send me a message and I'll pick up where I left off.\n"
+        "⚠️ Claude OAuth 已过期。请运行 `claude auth login`，"
+        "然后给我发条消息即可恢复。"
     )

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -1,4 +1,10 @@
-"""PUF-247: human-facing copy for invite-accept/reject failures."""
+"""PUF-247: human-facing copy for invite-accept/reject failures.
+
+PUF-283: also hosts the bilingual ``format_oauth_expired`` copy fired
+from the daemon when ``runtime.health`` enters ``auth_failed`` due to
+an OAuth 401 / token-revoked / login-required signal in the worker's
+suppressed reply.
+"""
 
 from __future__ import annotations
 
@@ -59,3 +65,29 @@ def format_invite_error(exc: Exception, verb: str) -> str:
             )
 
     return f"{prefix}: unexpected error. Please try again."
+
+
+def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
+    """Bilingual zh+en DM copy fired once per agent-per-session per
+    OAuth-expired 401 ENTER on ``runtime.health=auth_failed``. PUF-283.
+
+    Operator's spec called for a friendly note pointing at concrete
+    recovery steps; the harness-side ``claude /login`` + daemon-side
+    ``puffo-agent agent resume`` pair is the documented recovery flow
+    today (matches ``runtime.error`` copy at
+    ``worker.py::_handle_suppressed_reply``).
+    """
+    label = (
+        f"**{agent_display_name}** (`{agent_id}`)"
+        if agent_display_name else f"`{agent_id}`"
+    )
+    return (
+        f"⚠️ {label} — Claude OAuth has expired and I can't reach "
+        "the model right now.\n"
+        f"To recover: run `claude /login` in your terminal, then "
+        f"`puffo-agent agent resume {agent_id}` to bring me back online.\n"
+        "\n"
+        f"⚠️ {label} — Claude OAuth 已过期，我现在无法访问模型。\n"
+        f"恢复方法：在终端运行 `claude /login`，然后 "
+        f"`puffo-agent agent resume {agent_id}` 让我重新上线。"
+    )

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -71,12 +71,8 @@ def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
         if agent_display_name else f"`{agent_id}`"
     )
     return (
-        f"⚠️ {label} — Claude OAuth has expired and I can't reach "
-        "the model right now.\n"
-        f"To recover: run `claude /login` in your terminal, then "
-        f"`puffo-agent agent resume {agent_id}` to bring me back online.\n"
-        "\n"
-        f"⚠️ {label} — Claude OAuth 已过期，我现在无法访问模型。\n"
-        f"恢复方法：在终端运行 `claude /login`，然后 "
-        f"`puffo-agent agent resume {agent_id}` 让我重新上线。"
+        f"⚠️ {label} — Claude OAuth expired. Run `claude /login`, then "
+        f"`puffo-agent agent resume {agent_id}`.\n"
+        f"⚠️ Claude OAuth 已过期。请运行 `claude /login`，再 "
+        f"`puffo-agent agent resume {agent_id}`。"
     )

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -61,24 +61,6 @@ _REQUEST_TOO_LARGE_PATTERN: re.Pattern[str] = re.compile(
 )
 
 
-# Case-insensitive substrings that mark a claude reply as an auth /
-# token failure rather than a real response. Kept STRONG-ONLY — weak
-# markers like "401" or "unauthorized" would false-positive on users
-# discussing HTTP / auth concepts.
-_AUTH_ERROR_MARKERS = (
-    "please run /login",
-    "please run `claude /login`",
-    "run `claude login`",
-    "invalid api key",
-    "invalid_grant",
-    "authentication failed",
-    "credentials expired",
-    "failed to authenticate",
-    "api error: 401",
-    "invalid authentication credentials",
-    '"type":"authentication_error"',
-)
-
 # Backoffs between auth-error retries (5 attempts total, worst case
 # ~45s). First interval is short: the common cause is a multi-agent
 # rotating-refresh-token race that resolves within a second of the
@@ -103,11 +85,9 @@ _POISONED_SESSION_MARKERS = (
 )
 
 
-def _looks_like_auth_error(text: str) -> bool:
-    if not text:
-        return False
-    low = text.lower()
-    return any(marker in low for marker in _AUTH_ERROR_MARKERS)
+# Shared with ``core`` (which tags ``AgentAPIError.is_auth``) so the
+# two detections can't drift.
+from .._auth_markers import looks_like_auth_error as _looks_like_auth_error  # noqa: E402
 
 
 def _looks_like_poisoned_session(text: str) -> bool:

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -1,5 +1,6 @@
 import os
 
+from ._auth_markers import looks_like_auth_error
 from ._logging import agent_logger
 from ._time import ms_to_iso as _ms_to_iso
 from .adapters import Adapter, TurnContext
@@ -13,8 +14,16 @@ class AgentAPIError(Exception):
     consumer to suppress the reply, mark the turn errored, and
     re-enqueue the triggering message after a 15-45s backoff so
     transient provider failures recover without operator intervention.
+
+    ``is_auth`` is set when the error is an auth failure (expired/revoked
+    OAuth, invalid key). Retrying that is pointless, so the consumer
+    skips the kick-retries and the worker flips ``auth_failed`` + DMs the
+    operator instead.
     """
-    pass
+
+    def __init__(self, message: str, *, is_auth: bool = False) -> None:
+        super().__init__(message)
+        self.is_auth = is_auth
 
 
 def _format_assistant_fallback(text_parts: list[str], joined_reply: str) -> str:
@@ -230,12 +239,15 @@ class PuffoAgent:
         if "[SILENT]" in joined:
             return None
         if "API Error" in joined:
+            is_auth = looks_like_auth_error(joined)
             self.logger.warning(
-                "[api-error-retry] adapter still rate-limited; "
-                "raising for consumer-side backoff"
+                "[api-error-retry] adapter still %s; raising for "
+                "consumer-side handling",
+                "auth-failed" if is_auth else "rate-limited",
             )
             raise AgentAPIError(
-                "agent adapter output contained 'API Error' on retry"
+                "agent adapter output contained 'API Error' on retry",
+                is_auth=is_auth,
             )
         if not text_parts and not result.reply:
             return None
@@ -296,12 +308,15 @@ class PuffoAgent:
         # internals and spam the thread on transient rate-limits.
         # Raise so the consumer can re-enqueue after a backoff.
         if "API Error" in joined:
+            is_auth = looks_like_auth_error(joined)
             self.logger.warning(
                 f"[api-error] [{channel_name}] @{sender}: adapter output "
-                "contained 'API Error'; suppressing post, abandoning batch"
+                "contained 'API Error' (%s); suppressing post",
+                "auth-failed" if is_auth else "rate-limited",
             )
             raise AgentAPIError(
-                "agent adapter output contained 'API Error'"
+                "agent adapter output contained 'API Error'",
+                is_auth=is_auth,
             )
 
         if not text_parts and not result.reply:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1022,19 +1022,15 @@ class PuffoCoreMessageClient:
 
         if is_auth:
             # Auth failure: retrying is pointless until the operator
-            # re-logs in. The worker already flipped auth_failed + DMed;
-            # abandon now (cursor not advanced → redelivers on recovery).
+            # re-logs in. The worker already flipped auth_failed + DMed,
+            # so we just stop here — the cursor stays un-advanced (the
+            # batch redelivers on recovery). Deliberately NOT firing the
+            # api-error-abandon callback: it would overwrite the
+            # auth_failed status with api_error_abandoned.
             self._log.warning(
                 "agent reply was an auth error for thread %s (last envelope "
-                "%s); skipping kick-retries, abandoning batch",
+                "%s); skipping kick-retries until operator re-login",
                 root_id, last_envelope,
-            )
-            await self._fire_api_error_abandon(
-                on_api_error_abandon=on_api_error_abandon,
-                root_id=root_id,
-                batch=batch,
-                channel_meta=channel_meta,
-                attempts=0,
             )
             return
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -992,6 +992,7 @@ class PuffoCoreMessageClient:
         on_api_error_abandon: Optional[Callable[..., Coroutine[Any, Any, Any]]],
         on_turn_success: Optional[Callable[..., Coroutine[Any, Any, Any]]] = None,
         last_envelope: str,
+        is_auth: bool = False,
     ) -> None:
         """Loop the API-Error kick-retry path until the agent
         succeeds, the retry cap is hit, or a non-retry exception
@@ -1018,6 +1019,24 @@ class PuffoCoreMessageClient:
         # those envelopes need to be caught by the cursor (advanced
         # by the kick's successful dispatch) or by in-batch dedup.
         entry.dispatching_ids = set()
+
+        if is_auth:
+            # Auth failure: retrying is pointless until the operator
+            # re-logs in. The worker already flipped auth_failed + DMed;
+            # abandon now (cursor not advanced → redelivers on recovery).
+            self._log.warning(
+                "agent reply was an auth error for thread %s (last envelope "
+                "%s); skipping kick-retries, abandoning batch",
+                root_id, last_envelope,
+            )
+            await self._fire_api_error_abandon(
+                on_api_error_abandon=on_api_error_abandon,
+                root_id=root_id,
+                batch=batch,
+                channel_meta=channel_meta,
+                attempts=0,
+            )
+            return
 
         if on_api_error_retry is None:
             self._log.warning(
@@ -1246,7 +1265,7 @@ class PuffoCoreMessageClient:
 
             try:
                 await on_message_batch(root_id, batch, channel_meta)
-            except AgentAPIError:
+            except AgentAPIError as exc:
                 # Adapter surfaced "API Error" — most commonly
                 # claude-code's transient rate-limit error. The
                 # original user input is already in claude-code's
@@ -1261,7 +1280,8 @@ class PuffoCoreMessageClient:
                 # via ``on_api_error_retry``; if ``--resume`` is no
                 # longer valid the adapter falls back to the original
                 # payload on its own so the agent has something to
-                # work from.
+                # work from. Auth errors skip retries entirely (the
+                # worker already flipped auth_failed + DMed).
                 last_envelope = batch[-1].get("envelope_id", "") if batch else ""
                 await self._do_api_error_retries(
                     root_id=root_id,
@@ -1272,6 +1292,7 @@ class PuffoCoreMessageClient:
                     on_api_error_abandon=on_api_error_abandon,
                     on_turn_success=on_turn_success,
                     last_envelope=last_envelope,
+                    is_auth=getattr(exc, "is_auth", False),
                 )
                 continue
             except asyncio.CancelledError:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1021,12 +1021,10 @@ class PuffoCoreMessageClient:
         entry.dispatching_ids = set()
 
         if is_auth:
-            # Auth failure: retrying is pointless until the operator
-            # re-logs in. The worker already flipped auth_failed + DMed,
-            # so we just stop here — the cursor stays un-advanced (the
-            # batch redelivers on recovery). Deliberately NOT firing the
-            # api-error-abandon callback: it would overwrite the
-            # auth_failed status with api_error_abandoned.
+            # Retrying is pointless until re-login (worker already set
+            # auth_failed + DMed). Don't fire the abandon callback — it
+            # would overwrite auth_failed; cursor stays un-advanced so
+            # the batch redelivers on recovery.
             self._log.warning(
                 "agent reply was an auth error for thread %s (last envelope "
                 "%s); skipping kick-retries until operator re-login",

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -334,8 +334,8 @@ class FileBackend:
 
     def fingerprint(self) -> tuple[int, int] | None:
         """(mtime_ns, size) of the host credential. Lets the refresher
-        spot an external rotation — operator `claude /login` — on
-        copy-mode hosts (Windows) where there's no symlink to carry it."""
+        spot an external rotation (operator re-login) on copy-mode hosts
+        (Windows) where there's no symlink to carry it."""
         try:
             st = self.host_credentials.stat()
         except OSError:
@@ -747,10 +747,10 @@ class CredentialRefresher:
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
         self._rate_limit_retry_task: asyncio.Task | None = None
-        # Last host-credential fingerprint we observed, for spotting an
-        # external rotation (operator `claude /login`) on copy-mode hosts
-        # where there's no symlink to carry it. ``None`` until the first
-        # tick establishes a baseline (so we don't false-fire on start).
+        # Last host-credential fingerprint, for spotting an external
+        # rotation (operator re-login) on copy-mode hosts with no symlink
+        # to carry it. ``None`` until the first tick sets a baseline (so
+        # we don't false-fire on start).
         self._last_cred_fingerprint: tuple[int, int] | None = None
 
     def register_agent(self, agent_home: Path) -> None:
@@ -879,12 +879,11 @@ class CredentialRefresher:
             refresh_task.cancel()
 
     def _detect_external_rotation(self) -> None:
-        """Spot an external host-credential change (operator
-        `claude /login`) against the last fingerprint and, if changed,
-        sync to agents + fire refresh-success. This is the copy-mode
-        (Windows) counterpart to the macOS Keychain rotation poll, whose
-        symlink-propagation assumption doesn't hold here. No-op for
-        backends without ``fingerprint`` (e.g. Keychain)."""
+        """Spot an external host-credential change (operator re-login)
+        against the last fingerprint and, if changed, sync to agents +
+        fire refresh-success — the copy-mode (Windows) counterpart to the
+        macOS Keychain rotation poll. No-op for backends without
+        ``fingerprint`` (e.g. Keychain, which has its own poll)."""
         fingerprint = getattr(self.backend, "fingerprint", None)
         if fingerprint is None:
             return

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1019,8 +1019,8 @@ class CredentialRefresher:
         msg = (
             f"daemon CredentialRefresher saw {self._consecutive_non_success} "
             f"consecutive {outcome.value} outcome(s); on-disk token isn't "
-            f"advancing. Run `claude /login` then "
-            f"`puffo-agent agent resume <id>` to recover."
+            f"advancing. Run `claude auth login`, then send the agent "
+            f"a message to recover."
         )
         for agent_home in self._agent_homes:
             agent_id = Path(agent_home).name

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -332,6 +332,16 @@ class FileBackend:
     def sync_to_agent(self, agent_home: Path) -> None:
         link_host_credentials(self.host_home, agent_home)
 
+    def fingerprint(self) -> tuple[int, int] | None:
+        """(mtime_ns, size) of the host credential. Lets the refresher
+        spot an external rotation — operator `claude /login` — on
+        copy-mode hosts (Windows) where there's no symlink to carry it."""
+        try:
+            st = self.host_credentials.stat()
+        except OSError:
+            return None
+        return (st.st_mtime_ns, st.st_size)
+
     async def bootstrap(self) -> tuple[bool, Optional[str]]:
         return (True, "host_file_authoritative")
 
@@ -454,6 +464,15 @@ class CodexFileBackend:
         if not agent_codex_home.exists():
             return
         link_host_codex_auth(self.host_home, agent_codex_home)
+
+    def fingerprint(self) -> tuple[int, int] | None:
+        """(mtime_ns, size) of the host codex auth — external-rotation
+        signal for copy-mode hosts, mirroring ``FileBackend``."""
+        try:
+            st = self.host_auth.stat()
+        except OSError:
+            return None
+        return (st.st_mtime_ns, st.st_size)
 
     async def bootstrap(self) -> tuple[bool, Optional[str]]:
         if not self.host_auth.exists():
@@ -728,6 +747,11 @@ class CredentialRefresher:
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
         self._rate_limit_retry_task: asyncio.Task | None = None
+        # Last host-credential fingerprint we observed, for spotting an
+        # external rotation (operator `claude /login`) on copy-mode hosts
+        # where there's no symlink to carry it. ``None`` until the first
+        # tick establishes a baseline (so we don't false-fire on start).
+        self._last_cred_fingerprint: tuple[int, int] | None = None
 
     def register_agent(self, agent_home: Path) -> None:
         self._agent_homes.add(Path(agent_home))
@@ -854,12 +878,45 @@ class CredentialRefresher:
             stop_task.cancel()
             refresh_task.cancel()
 
+    def _detect_external_rotation(self) -> None:
+        """Spot an external host-credential change (operator
+        `claude /login`) against the last fingerprint and, if changed,
+        sync to agents + fire refresh-success. This is the copy-mode
+        (Windows) counterpart to the macOS Keychain rotation poll, whose
+        symlink-propagation assumption doesn't hold here. No-op for
+        backends without ``fingerprint`` (e.g. Keychain)."""
+        fingerprint = getattr(self.backend, "fingerprint", None)
+        if fingerprint is None:
+            return
+        current = fingerprint()
+        if current is None or self._last_cred_fingerprint is None:
+            return
+        if current != self._last_cred_fingerprint:
+            logger.info(
+                "external credential rotation detected (host file changed) "
+                "— syncing agents + firing refresh-success",
+            )
+            self._sync_views()
+            self._fire_refresh_success()
+
+    def _record_cred_fingerprint(self) -> None:
+        fingerprint = getattr(self.backend, "fingerprint", None)
+        if fingerprint is None:
+            return
+        current = fingerprint()
+        if current is not None:
+            self._last_cred_fingerprint = current
+
     async def _tick(self, *, triggered_by_agent: bool = False) -> None:
-        """One refresh cycle: check expiry, refresh if needed, sync
-        views regardless so external rotation propagates."""
+        """One refresh cycle: detect external rotation, check expiry,
+        refresh if needed, sync views regardless so rotation propagates.
+        The trailing fingerprint record absorbs our own refresh so it
+        isn't re-seen as 'external' next tick."""
+        self._detect_external_rotation()
         expires_in = self.expires_in_seconds()
         if expires_in is None and not triggered_by_agent:
             self._sync_views()
+            self._record_cred_fingerprint()
             return
         should_refresh = triggered_by_agent or (
             expires_in is not None
@@ -870,6 +927,7 @@ class CredentialRefresher:
                 expires_in=expires_in, by_agent=triggered_by_agent,
             )
         self._sync_views()
+        self._record_cred_fingerprint()
 
     async def _refresh_now(
         self, *, expires_in: int | None, by_agent: bool,

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -279,11 +279,8 @@ class Daemon:
             Worker._clear_auth_failed_if_recoverable(
                 worker.runtime, agent_id, logger,
             )
-            # PUF-283: arm the per-session DM dedup so the NEXT
-            # auth_failed ENTER (if the credential expires again
-            # within the same daemon process lifetime) re-notifies
-            # the operator. Matches the "once per 401 event" semantics
-            # in the operator spec.
+            # Re-arm the auth_failed DM dedup so a re-expiry this
+            # session re-notifies the operator.
             worker._auth_failed_notification_sent = False
 
         refresher.register_on_refresh_success(on_refresh_success)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -279,6 +279,12 @@ class Daemon:
             Worker._clear_auth_failed_if_recoverable(
                 worker.runtime, agent_id, logger,
             )
+            # PUF-283: arm the per-session DM dedup so the NEXT
+            # auth_failed ENTER (if the credential expires again
+            # within the same daemon process lifetime) re-notifies
+            # the operator. Matches the "once per 401 event" semantics
+            # in the operator spec.
+            worker._auth_failed_notification_sent = False
 
         refresher.register_on_refresh_success(on_refresh_success)
         # Stash callback identity for _stop_worker's unregister.

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -276,12 +276,30 @@ class Daemon:
         agent_id = agent_cfg.id
 
         def on_refresh_success() -> None:
+            was_auth_failed = worker.runtime.health == "auth_failed"
             Worker._clear_auth_failed_if_recoverable(
                 worker.runtime, agent_id, logger,
             )
             # Re-arm the auth_failed DM dedup so a re-expiry this
             # session re-notifies the operator.
             worker._auth_failed_notification_sent = False
+            if was_auth_failed:
+                # The running adapter session still holds the stale
+                # credential; a restart re-links the fresh cred and
+                # redelivers the stalled batch (cursor wasn't advanced).
+                try:
+                    flag = restart_flag_path(agent_id)
+                    flag.parent.mkdir(parents=True, exist_ok=True)
+                    flag.write_text("")
+                    logger.info(
+                        "agent %s: credential recovered — requesting restart "
+                        "to pick up the new credential", agent_id,
+                    )
+                except OSError as exc:
+                    logger.warning(
+                        "agent %s: could not write restart flag: %s",
+                        agent_id, exc,
+                    )
 
         refresher.register_on_refresh_success(on_refresh_success)
         # Stash callback identity for _stop_worker's unregister.

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -474,9 +474,9 @@ def _handle_suppressed_reply(
     it. ``on_auth_failure`` fires on the auth-class branch only;
     PUF-221 hooks the daemon's ``CredentialRefresher.notify_refresh_needed``
     here so a 401-leak short-circuits the 2-min poll instead of
-    waiting for the next tick. ``on_auth_failed_enter`` (PUF-283)
-    fires ONLY on the was-ok→auth_failed transition (not re-entries),
-    so the per-session DM dedup gate has a natural firing edge."""
+    waiting for the next tick. ``on_auth_failed_enter`` fires ONLY on
+    the was-ok→auth_failed transition (not re-entries), giving the
+    per-session DM dedup a natural firing edge."""
     safe_reply = _suppress_worker_error_leak(reply)
     if safe_reply is not None:
         return False, 0.0
@@ -588,24 +588,16 @@ class Worker:
         )
 
     def _on_auth_failed_enter(self) -> None:
-        """PUF-283: ENTER-edge callback from ``_handle_suppressed_reply``.
-        Dedup gate + asyncio-task dispatch — the actual DM send is async
-        so it can't block the suppression backoff loop. The dedup flag
-        is in-memory + reset on auth_failed CLEAR (see
-        ``daemon.py:on_refresh_success``).
-        """
+        """Fire the operator DM once per auth_failed episode. The flag
+        re-arms on auth_failed CLEAR (daemon ``on_refresh_success``) and
+        on a failed send, so a later genuine failure re-notifies."""
         if self._auth_failed_notification_sent:
             return
         self._auth_failed_notification_sent = True
         try:
             asyncio.create_task(self._notify_operator_of_auth_failed_oauth())
         except Exception as exc:  # noqa: BLE001
-            # Defensive: no running loop (the documented RuntimeError
-            # shape from asyncio) OR any other scheduling failure.
-            # ``_handle_suppressed_reply`` always runs from inside an
-            # awaited turn so this is extremely rare, but resetting
-            # broadly here means a future schedule-broken corner case
-            # still arms the next ENTER instead of silently swallowing.
+            # Re-arm so a schedule failure retries on the next ENTER.
             self._auth_failed_notification_sent = False
             logger.warning(
                 "agent %s: couldn't schedule auth-failed DM: %s",
@@ -613,14 +605,14 @@ class Worker:
             )
 
     async def _notify_operator_of_auth_failed_oauth(self) -> None:
-        """Send the bilingual OAuth-expired DM to the operator. Mirrors
-        ``puffo_core_client.PuffoCoreMessageClient._notify_operator_of_invite``:
-        early-guard on ``operator_slug``, format via the
-        ``_invite_strings.format_oauth_expired`` helper, send via the
-        client's existing ``_send_dm`` primitive. PUF-283.
-        """
+        """DM the operator the bilingual OAuth-expired recovery copy.
+        Re-arms the dedup flag on a transient failure (client not warm,
+        or send raised) so the next ENTER retries instead of staying
+        silently gated."""
         client = self._client
         if client is None:
+            # Still warming — re-arm so a later ENTER retries.
+            self._auth_failed_notification_sent = False
             logger.warning(
                 "agent %s: auth-failed DM skipped — client not yet warm",
                 self.agent_cfg.id,
@@ -628,18 +620,14 @@ class Worker:
             return
         operator_slug = getattr(client, "operator_slug", "") or ""
         if not operator_slug:
+            # No operator to DM; the red-dot UI is the only signal. Stay
+            # gated — re-arming would respin on every 401.
             logger.warning(
-                "agent %s: auth-failed but no operator_slug configured — "
-                "not DMing (red-dot UI is the only visible signal until "
-                "operator runs `claude /login` + resume)",
+                "agent %s: auth-failed but no operator_slug — not DMing",
                 self.agent_cfg.id,
             )
             return
         from ..agent._invite_strings import format_oauth_expired
-        # Display name is best-effort: agent.yml carries it as
-        # ``display_name`` but the client's ``slug`` is the addressable
-        # identity. Empty display_name degrades gracefully to a
-        # bare ``id`` in the copy.
         display_name = (
             getattr(self.agent_cfg, "display_name", "") or self.agent_cfg.id
         )
@@ -647,13 +635,15 @@ class Worker:
         try:
             await client._send_dm(operator_slug, text, root_id="")
         except Exception as exc:
+            # Transient send failure — re-arm for the next ENTER.
+            self._auth_failed_notification_sent = False
             logger.exception(
                 "agent %s: auth-failed DM to %s raised: %s",
                 self.agent_cfg.id, operator_slug, exc,
             )
             return
         logger.info(
-            "agent %s: notified operator @%s of OAuth-expired (auth_failed ENTER)",
+            "agent %s: notified operator @%s of OAuth-expired",
             self.agent_cfg.id, operator_slug,
         )
 
@@ -724,12 +714,9 @@ class Worker:
         # 401 surfacing in a reply short-circuits the daemon's 2-min
         # poll instead of waiting for the next tick.
         self._notify_refresh_needed = notify_refresh_needed
-        # PUF-283: in-memory dedup gate for the operator-DM that fires
-        # on the auth_failed ENTER edge. Reset on auth_failed CLEAR
-        # via daemon.py's on_refresh_success callback so the next
-        # ENTER-cycle re-notifies. Daemon restart also resets — matches
-        # PUF-258's sticky-state-on-disk + transient-state-in-memory
-        # design.
+        # In-memory dedup for the auth_failed ENTER operator DM;
+        # re-armed on credential refresh-success (daemon
+        # on_refresh_success) and on a failed send.
         self._auth_failed_notification_sent = False
         self.runtime = RuntimeState(
             status="running",

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -599,10 +599,13 @@ class Worker:
         self._auth_failed_notification_sent = True
         try:
             asyncio.create_task(self._notify_operator_of_auth_failed_oauth())
-        except RuntimeError as exc:
-            # No running loop (extremely defensive — _handle_suppressed_reply
-            # always runs from inside an awaited turn). Reset the flag so
-            # the next ENTER tries again instead of silently swallowing.
+        except Exception as exc:  # noqa: BLE001
+            # Defensive: no running loop (the documented RuntimeError
+            # shape from asyncio) OR any other scheduling failure.
+            # ``_handle_suppressed_reply`` always runs from inside an
+            # awaited turn so this is extremely rare, but resetting
+            # broadly here means a future schedule-broken corner case
+            # still arms the next ENTER instead of silently swallowing.
             self._auth_failed_notification_sent = False
             logger.warning(
                 "agent %s: couldn't schedule auth-failed DM: %s",

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -587,6 +587,27 @@ class Worker:
             agent_id,
         )
 
+    def _enter_auth_failed(self, agent_id: str) -> None:
+        """Flip ``auth_failed`` and fire recovery: the refresher kick
+        (so the daemon re-checks credentials now) + the operator DM.
+        Used when an adapter raises a *confirmed* auth error so we skip
+        the pointless rate-limit kick-retries and go straight to the
+        recover-via-relogin flow."""
+        rt = self.runtime
+        was_ok = rt.health != "auth_failed"
+        rt.health = "auth_failed"
+        rt.error = "auth error — run `claude /login`, then resume the agent"
+        rt.save(agent_id)
+        if self._notify_refresh_needed is not None:
+            try:
+                self._notify_refresh_needed()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent %s: notify_refresh_needed raised: %s", agent_id, exc,
+                )
+        if was_ok:
+            self._on_auth_failed_enter()
+
     def _on_auth_failed_enter(self) -> None:
         """Fire the operator DM once per auth_failed episode. The flag
         re-arms on auth_failed CLEAR (daemon ``on_refresh_success``) and
@@ -1090,11 +1111,23 @@ class Worker:
                 # Adapter surfaced an "API Error" string. Mark turn
                 # errored and re-raise; the consumer loop re-enqueues
                 # the batch with cursor preserved and backs off.
-                logger.warning("agent %s: api-error retry: %s", agent_id, exc)
+                if getattr(exc, "is_auth", False):
+                    # Auth error: kick-retries are pointless. Flip
+                    # auth_failed + DM the operator now; the consumer
+                    # skips retries and abandons (batch redelivers once
+                    # the operator re-logs in).
+                    logger.warning(
+                        "agent %s: adapter auth error — flagging auth_failed, "
+                        "no kick-retry", agent_id,
+                    )
+                    self._enter_auth_failed(agent_id)
+                    turn_error = "auth error"
+                else:
+                    logger.warning("agent %s: api-error retry: %s", agent_id, exc)
+                    turn_error = "API Error"
                 reply = None
                 turn_succeeded = False
                 turn_will_retry = True
-                turn_error = "API Error"
                 raise
             except Exception as exc:
                 logger.error(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -457,6 +457,7 @@ def _handle_suppressed_reply(
     *,
     scope: str,
     on_auth_failure: Optional[Callable[[], None]] = None,
+    on_auth_failed_enter: Optional[Callable[[], None]] = None,
 ) -> tuple[bool, float]:
     """Shared landing for a suppressed worker-error leak. Returns
     ``(suppressed, backoff_seconds)``:
@@ -473,7 +474,9 @@ def _handle_suppressed_reply(
     it. ``on_auth_failure`` fires on the auth-class branch only;
     PUF-221 hooks the daemon's ``CredentialRefresher.notify_refresh_needed``
     here so a 401-leak short-circuits the 2-min poll instead of
-    waiting for the next tick."""
+    waiting for the next tick. ``on_auth_failed_enter`` (PUF-283)
+    fires ONLY on the was-ok→auth_failed transition (not re-entries),
+    so the per-session DM dedup gate has a natural firing edge."""
     safe_reply = _suppress_worker_error_leak(reply)
     if safe_reply is not None:
         return False, 0.0
@@ -487,6 +490,7 @@ def _handle_suppressed_reply(
         agent_id, scope, backoff, reply[:200],
     )
     if is_auth:
+        was_ok = runtime.health != "auth_failed"
         runtime.health = "auth_failed"
         if on_auth_failure is not None:
             try:
@@ -494,6 +498,14 @@ def _handle_suppressed_reply(
             except Exception as exc:
                 logger.warning(
                     "agent %s: on_auth_failure callback raised: %s",
+                    agent_id, exc,
+                )
+        if was_ok and on_auth_failed_enter is not None:
+            try:
+                on_auth_failed_enter()
+            except Exception as exc:
+                logger.warning(
+                    "agent %s: on_auth_failed_enter callback raised: %s",
                     agent_id, exc,
                 )
     if scope == "api-error-retry":
@@ -575,6 +587,73 @@ class Worker:
             agent_id,
         )
 
+    def _on_auth_failed_enter(self) -> None:
+        """PUF-283: ENTER-edge callback from ``_handle_suppressed_reply``.
+        Dedup gate + asyncio-task dispatch — the actual DM send is async
+        so it can't block the suppression backoff loop. The dedup flag
+        is in-memory + reset on auth_failed CLEAR (see
+        ``daemon.py:on_refresh_success``).
+        """
+        if self._auth_failed_notification_sent:
+            return
+        self._auth_failed_notification_sent = True
+        try:
+            asyncio.create_task(self._notify_operator_of_auth_failed_oauth())
+        except RuntimeError as exc:
+            # No running loop (extremely defensive — _handle_suppressed_reply
+            # always runs from inside an awaited turn). Reset the flag so
+            # the next ENTER tries again instead of silently swallowing.
+            self._auth_failed_notification_sent = False
+            logger.warning(
+                "agent %s: couldn't schedule auth-failed DM: %s",
+                self.agent_cfg.id, exc,
+            )
+
+    async def _notify_operator_of_auth_failed_oauth(self) -> None:
+        """Send the bilingual OAuth-expired DM to the operator. Mirrors
+        ``puffo_core_client.PuffoCoreMessageClient._notify_operator_of_invite``:
+        early-guard on ``operator_slug``, format via the
+        ``_invite_strings.format_oauth_expired`` helper, send via the
+        client's existing ``_send_dm`` primitive. PUF-283.
+        """
+        client = self._client
+        if client is None:
+            logger.warning(
+                "agent %s: auth-failed DM skipped — client not yet warm",
+                self.agent_cfg.id,
+            )
+            return
+        operator_slug = getattr(client, "operator_slug", "") or ""
+        if not operator_slug:
+            logger.warning(
+                "agent %s: auth-failed but no operator_slug configured — "
+                "not DMing (red-dot UI is the only visible signal until "
+                "operator runs `claude /login` + resume)",
+                self.agent_cfg.id,
+            )
+            return
+        from ..agent._invite_strings import format_oauth_expired
+        # Display name is best-effort: agent.yml carries it as
+        # ``display_name`` but the client's ``slug`` is the addressable
+        # identity. Empty display_name degrades gracefully to a
+        # bare ``id`` in the copy.
+        display_name = (
+            getattr(self.agent_cfg, "display_name", "") or self.agent_cfg.id
+        )
+        text = format_oauth_expired(self.agent_cfg.id, display_name)
+        try:
+            await client._send_dm(operator_slug, text, root_id="")
+        except Exception as exc:
+            logger.exception(
+                "agent %s: auth-failed DM to %s raised: %s",
+                self.agent_cfg.id, operator_slug, exc,
+            )
+            return
+        logger.info(
+            "agent %s: notified operator @%s of OAuth-expired (auth_failed ENTER)",
+            self.agent_cfg.id, operator_slug,
+        )
+
     @staticmethod
     def _flip_health_in_progress(
         runtime: "RuntimeState",
@@ -642,6 +721,13 @@ class Worker:
         # 401 surfacing in a reply short-circuits the daemon's 2-min
         # poll instead of waiting for the next tick.
         self._notify_refresh_needed = notify_refresh_needed
+        # PUF-283: in-memory dedup gate for the operator-DM that fires
+        # on the auth_failed ENTER edge. Reset on auth_failed CLEAR
+        # via daemon.py's on_refresh_success callback so the next
+        # ENTER-cycle re-notifies. Daemon restart also resets — matches
+        # PUF-258's sticky-state-on-disk + transient-state-in-memory
+        # design.
+        self._auth_failed_notification_sent = False
         self.runtime = RuntimeState(
             status="running",
             started_at=int(time.time()),
@@ -1090,6 +1176,7 @@ class Worker:
                     agent_id,
                     scope="fallback",
                     on_auth_failure=self._notify_refresh_needed,
+                    on_auth_failed_enter=self._on_auth_failed_enter,
                 )
                 if suppressed:
                     await asyncio.sleep(backoff)
@@ -1132,6 +1219,7 @@ class Worker:
                     agent_id,
                     scope="api-error-retry",
                     on_auth_failure=self._notify_refresh_needed,
+                    on_auth_failed_enter=self._on_auth_failed_enter,
                 )
                 if suppressed:
                     # Hottest leak site (FB-88 / FB-159 case-studies).

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -587,6 +587,22 @@ class Worker:
             agent_id,
         )
 
+    def _maybe_wake_refresher_if_auth_failed(self, agent_id: str) -> None:
+        """If a new batch arrives while we're auth_failed, wake the
+        refresher so it re-checks for an operator re-login immediately
+        (which, on a detected change, syncs the new credential and
+        restarts us) instead of waiting up to a full poll interval."""
+        if self.runtime.health != "auth_failed":
+            return
+        if self._notify_refresh_needed is None:
+            return
+        try:
+            self._notify_refresh_needed()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "agent %s: notify_refresh_needed raised: %s", agent_id, exc,
+            )
+
     def _enter_auth_failed(self, agent_id: str) -> None:
         """Flip ``auth_failed`` and fire recovery: the refresher kick
         (so the daemon re-checks credentials now) + the operator DM.
@@ -1083,6 +1099,10 @@ class Worker:
                     "agent %s: could not write current_turn.json: %s "
                     "(permission hook will fail-open)", agent_id, exc,
                 )
+            # A new batch arrived while auth_failed: wake the refresher
+            # to check for an operator re-login NOW rather than waiting
+            # for the next poll (the flip below would mask auth_failed).
+            self._maybe_wake_refresher_if_auth_failed(agent_id)
             try:
                 Worker._flip_health_in_progress(self.runtime, agent_id, logger)
             except Exception as exc:  # noqa: BLE001

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -588,10 +588,8 @@ class Worker:
         )
 
     def _maybe_wake_refresher_if_auth_failed(self, agent_id: str) -> None:
-        """If a new batch arrives while we're auth_failed, wake the
-        refresher so it re-checks for an operator re-login immediately
-        (which, on a detected change, syncs the new credential and
-        restarts us) instead of waiting up to a full poll interval."""
+        """A new batch while auth_failed: wake the refresher to re-check
+        for an operator re-login now instead of waiting for the poll."""
         if self.runtime.health != "auth_failed":
             return
         if self._notify_refresh_needed is None:
@@ -604,11 +602,9 @@ class Worker:
             )
 
     def _enter_auth_failed(self, agent_id: str) -> None:
-        """Flip ``auth_failed`` and fire recovery: the refresher kick
-        (so the daemon re-checks credentials now) + the operator DM.
-        Used when an adapter raises a *confirmed* auth error so we skip
-        the pointless rate-limit kick-retries and go straight to the
-        recover-via-relogin flow."""
+        """Flip ``auth_failed`` + fire recovery (refresher kick + operator
+        DM). Used on a confirmed adapter auth error so we skip the
+        pointless kick-retries and go straight to recover-via-relogin."""
         rt = self.runtime
         was_ok = rt.health != "auth_failed"
         rt.health = "auth_failed"
@@ -1099,9 +1095,8 @@ class Worker:
                     "agent %s: could not write current_turn.json: %s "
                     "(permission hook will fail-open)", agent_id, exc,
                 )
-            # A new batch arrived while auth_failed: wake the refresher
-            # to check for an operator re-login NOW rather than waiting
-            # for the next poll (the flip below would mask auth_failed).
+            # New batch while auth_failed: wake the refresher to check
+            # for a re-login now (the flip below would mask auth_failed).
             self._maybe_wake_refresher_if_auth_failed(agent_id)
             try:
                 Worker._flip_health_in_progress(self.runtime, agent_id, logger)
@@ -1132,10 +1127,8 @@ class Worker:
                 # errored and re-raise; the consumer loop re-enqueues
                 # the batch with cursor preserved and backs off.
                 if getattr(exc, "is_auth", False):
-                    # Auth error: kick-retries are pointless. Flip
-                    # auth_failed + DM the operator now; the consumer
-                    # skips retries and abandons (batch redelivers once
-                    # the operator re-logs in).
+                    # Auth: skip the pointless kick-retries — flag
+                    # auth_failed + DM now; consumer abandons (redelivers).
                     logger.warning(
                         "agent %s: adapter auth error — flagging auth_failed, "
                         "no kick-retry", agent_id,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -512,9 +512,9 @@ def _handle_suppressed_reply(
         if is_auth:
             runtime.error = (
                 "Worker emitted an auth-error string after an API "
-                "error; suppressed from channel post. Re-run "
-                "`claude /login`, then "
-                f"`puffo-agent agent resume {agent_id}`."
+                "error; suppressed from channel post. Run "
+                "`claude auth login`, then send the agent a message "
+                "to recover."
             )
         else:
             runtime.error = (
@@ -612,7 +612,7 @@ class Worker:
         rt = self.runtime
         was_ok = rt.health != "auth_failed"
         rt.health = "auth_failed"
-        rt.error = "auth error — run `claude /login`, then resume the agent"
+        rt.error = "auth error — run `claude auth login`, then send a message to recover"
         rt.save(agent_id)
         if self._notify_refresh_needed is not None:
             try:

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -1,0 +1,183 @@
+"""Auth errors must be classified as auth (not rate-limit), so the
+consumer skips the pointless kick-retries and the worker flips
+auth_failed + DMs the operator.
+
+Regression for: a ``401 Invalid authentication credentials`` reply was
+seen as a generic ``API Error`` rate-limit, kick-retried 3×, abandoned,
+and never DMed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+
+from puffo_agent.agent._auth_markers import looks_like_auth_error
+from puffo_agent.agent.core import AgentAPIError
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.portal.worker import Worker
+
+
+# ── shared detector ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("reply", [
+    "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+    "API Error: 401",
+    "Invalid API key · Please run /login",
+    "invalid_grant",
+    "authentication failed",
+    "credentials expired",
+    '{"type":"authentication_error"}',
+])
+def test_detector_flags_auth(reply):
+    assert looks_like_auth_error(reply) is True
+
+
+@pytest.mark.parametrize("reply", [
+    "API Error: Request rejected (429)",
+    "API Error: Server is temporarily limiting requests",
+    "I hit a 401 earlier but it cleared up",   # bare 401 in prose → not auth
+    "Let me explain how unauthorized access works",
+    "",
+])
+def test_detector_does_not_flag_non_auth(reply):
+    assert looks_like_auth_error(reply) is False
+
+
+def test_agent_api_error_carries_is_auth():
+    assert AgentAPIError("x", is_auth=True).is_auth is True
+    assert AgentAPIError("y").is_auth is False
+
+
+# ── consumer: auth skips kick-retries ──────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    real = asyncio.sleep
+
+    async def fast(_s):
+        await real(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fast)
+
+
+def _make_client() -> PuffoCoreMessageClient:
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "tester-1234"
+    client._log = logging.getLogger("test-auth-class")
+    client.MAX_API_ERROR_RETRIES = 3  # type: ignore[attr-defined]
+
+    class _StubStore:
+        async def mark_thread_processed(self, *a, **k):
+            return None
+
+    client.store = _StubStore()  # type: ignore[assignment]
+    return client
+
+
+def _make_entry():
+    class _Entry:
+        def __init__(self):
+            self.dispatching_ids: set[str] = set()
+
+    return _Entry()
+
+
+@pytest.mark.asyncio
+async def test_auth_error_skips_kick_retries_and_abandons():
+    client = _make_client()
+    retry_calls: list[int] = []
+    abandon: list[Any] = []
+
+    async def on_retry(root_id, batch, channel_meta):
+        retry_calls.append(1)
+
+    async def on_abandon(root_id, batch, channel_meta, attempts):
+        abandon.append(attempts)
+
+    await client._do_api_error_retries(  # type: ignore[arg-type]
+        root_id="r",
+        entry=_make_entry(),  # type: ignore[arg-type]
+        batch=[{"envelope_id": "e1"}],
+        channel_meta={},
+        on_api_error_retry=on_retry,
+        on_api_error_abandon=on_abandon,
+        last_envelope="e1",
+        is_auth=True,
+    )
+    assert retry_calls == []   # no pointless kick-retries
+    assert abandon == [0]      # abandoned immediately (0 attempts)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_still_kick_retries(monkeypatch):
+    """Sanity: a non-auth API error keeps the existing retry path."""
+    client = _make_client()
+    retry_calls: list[int] = []
+
+    async def on_retry(root_id, batch, channel_meta):
+        retry_calls.append(1)
+        raise AgentAPIError("still rate-limited")
+
+    async def on_abandon(*a):
+        return None
+
+    await client._do_api_error_retries(  # type: ignore[arg-type]
+        root_id="r",
+        entry=_make_entry(),  # type: ignore[arg-type]
+        batch=[{"envelope_id": "e1"}],
+        channel_meta={},
+        on_api_error_retry=on_retry,
+        on_api_error_abandon=on_abandon,
+        last_envelope="e1",
+        is_auth=False,
+    )
+    assert len(retry_calls) == 3   # MAX_API_ERROR_RETRIES kicks
+
+
+# ── worker: _enter_auth_failed edge ────────────────────────────────
+
+
+class _RT:
+    def __init__(self, health: str):
+        self.health = health
+        self.error = ""
+
+    def save(self, agent_id: str) -> None:
+        pass
+
+
+def _stub_worker(health: str):
+    class _W:
+        pass
+
+    w = _W()
+    w.runtime = _RT(health)
+    w.dm_fired: list[int] = []
+    w.refresh_fired: list[int] = []
+    # Stub the DM-enter + refresher-kick so the edge logic is exercised
+    # without the async DM machinery.
+    w._on_auth_failed_enter = lambda: w.dm_fired.append(1)
+    w._notify_refresh_needed = lambda: w.refresh_fired.append(1)
+    return w
+
+
+def test_enter_auth_failed_fires_dm_on_edge():
+    w = _stub_worker("ok")
+    Worker._enter_auth_failed(w, "t-agent")
+    assert w.runtime.health == "auth_failed"
+    assert w.refresh_fired == [1]   # refresher kicked
+    assert w.dm_fired == [1]        # DM fired on the ok→auth_failed edge
+
+
+def test_enter_auth_failed_no_dm_on_reentry():
+    w = _stub_worker("auth_failed")   # already failed
+    Worker._enter_auth_failed(w, "t-agent")
+    assert w.runtime.health == "auth_failed"
+    assert w.refresh_fired == [1]     # still kicks the refresher
+    assert w.dm_fired == []           # but no duplicate DM (was_ok=False)

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -53,6 +53,66 @@ def test_agent_api_error_carries_is_auth():
     assert AgentAPIError("y").is_auth is False
 
 
+@pytest.mark.asyncio
+async def test_core_tags_is_auth_on_raise(tmp_path):
+    """A turn whose output contains an auth-class `API Error` raises
+    AgentAPIError(is_auth=True); a rate-limit one stays is_auth=False."""
+    from puffo_agent.agent.adapters import Adapter, TurnContext, TurnResult
+    from puffo_agent.agent.core import PuffoAgent
+
+    class _StubAdapter(Adapter):
+        def __init__(self, reply):
+            self._reply = reply
+
+        async def run_turn(self, ctx: TurnContext) -> TurnResult:
+            return TurnResult(reply=self._reply, metadata={})
+
+    async def _raise_for(reply):
+        agent = PuffoAgent(
+            adapter=_StubAdapter(reply),
+            system_prompt="t",
+            memory_dir=str(tmp_path),
+        )
+        try:
+            await agent.handle_message(
+                channel_id="c", channel_name="g", sender="u",
+                sender_email="u@x", text="hi", post_id="p", root_id="",
+            )
+        except AgentAPIError as exc:
+            return exc
+        return None
+
+    auth = await _raise_for(
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+    )
+    assert auth is not None and auth.is_auth is True
+
+    rate = await _raise_for("API Error: Request rejected (429)")
+    assert rate is not None and rate.is_auth is False
+
+    # Same tagging on the retry path (handle_api_error_retry).
+    async def _retry_raise_for(reply):
+        agent = PuffoAgent(
+            adapter=_StubAdapter(reply),
+            system_prompt="t",
+            memory_dir=str(tmp_path),
+        )
+        try:
+            await agent.handle_api_error_retry(
+                root_id="r",
+                channel_meta={"channel_name": "g"},
+                fallback_batch=[{"text": "hi"}],
+            )
+        except AgentAPIError as exc:
+            return exc
+        return None
+
+    auth_retry = await _retry_raise_for(
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+    )
+    assert auth_retry is not None and auth_retry.is_auth is True
+
+
 # ── consumer: auth skips kick-retries ──────────────────────────────
 
 
@@ -183,3 +243,16 @@ def test_enter_auth_failed_no_dm_on_reentry():
     assert w.runtime.health == "auth_failed"
     assert w.refresh_fired == [1]     # still kicks the refresher
     assert w.dm_fired == []           # but no duplicate DM (was_ok=False)
+
+
+def test_enter_auth_failed_survives_refresh_kick_raising():
+    """A throwing notify_refresh_needed must not break the flip/DM."""
+    w = _stub_worker("ok")
+
+    def _boom():
+        raise RuntimeError("no loop")
+
+    w._notify_refresh_needed = _boom
+    Worker._enter_auth_failed(w, "t-agent")   # no crash
+    assert w.runtime.health == "auth_failed"
+    assert w.dm_fired == [1]

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -89,7 +89,7 @@ def _make_entry():
 
 
 @pytest.mark.asyncio
-async def test_auth_error_skips_kick_retries_and_abandons():
+async def test_auth_error_skips_kick_retries_without_overwriting_status():
     client = _make_client()
     retry_calls: list[int] = []
     abandon: list[Any] = []
@@ -111,7 +111,9 @@ async def test_auth_error_skips_kick_retries_and_abandons():
         is_auth=True,
     )
     assert retry_calls == []   # no pointless kick-retries
-    assert abandon == [0]      # abandoned immediately (0 attempts)
+    # The api-error-abandon callback must NOT fire — it would overwrite
+    # the worker's auth_failed status with api_error_abandoned.
+    assert abandon == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -28,13 +28,14 @@ from puffo_agent.portal.worker import _handle_suppressed_reply
 
 def test_oauth_copy_includes_english_and_chinese():
     text = format_oauth_expired("planner-1234", "Planner")
-    # English strand
+    # English strand: `claude auth login` + send-a-message (auto-resume)
     assert "Claude OAuth expired" in text
-    assert "claude /login" in text
-    assert "puffo-agent agent resume planner-1234" in text
+    assert "claude auth login" in text
+    assert "send me a message" in text
+    assert "agent resume" not in text   # no manual resume step anymore
     # Chinese strand
     assert "Claude OAuth 已过期" in text
-    assert "puffo-agent agent resume planner-1234" in text
+    assert "发条消息" in text
     # Bold display name format
     assert "**Planner**" in text
 
@@ -295,7 +296,7 @@ def test_notify_sends_dm_when_operator_slug_set(tmp_path, monkeypatch):
     assert captured["root_id"] == ""
     assert "Claude OAuth expired" in captured["text"]
     assert "Claude OAuth 已过期" in captured["text"]
-    assert "puffo-agent agent resume t-agent" in captured["text"]
+    assert "claude auth login" in captured["text"]
 
 
 def test_notify_swallows_send_dm_exception(monkeypatch, caplog):
@@ -401,8 +402,8 @@ def test_oauth_copy_quotes_agent_id_for_markdown_safety():
     [a-z0-9-] today so injection is near-zero risk, but pinning the
     contract avoids future regression if the slug regex changes."""
     text = format_oauth_expired("a-b-c", "")
-    # Backtick-wrap in both strands of recovery instruction.
-    assert "`puffo-agent agent resume a-b-c`" in text
+    # agent_id is backtick-wrapped in the label so a stray markdown char
+    # can't break the rendered DM.
     assert "`a-b-c`" in text
 
 

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -1,0 +1,322 @@
+"""PUF-283: proactive OAuth-expired DM to operator on
+``runtime.health = auth_failed`` ENTER. Fire-once-per-agent-per-
+session, reset on auth_failed CLEAR.
+
+Tests four invariants:
+  1. The bilingual ``format_oauth_expired`` copy contains both
+     English + Chinese strands + concrete recovery instructions.
+  2. ``_handle_suppressed_reply`` fires ``on_auth_failed_enter``
+     only on was-ok → auth_failed transition (NOT re-entry).
+  3. ``Worker._on_auth_failed_enter`` is dedup-gated by
+     ``_auth_failed_notification_sent``.
+  4. ``daemon.on_refresh_success`` reset arms the next ENTER.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent._invite_strings import format_oauth_expired
+from puffo_agent.portal.state import RuntimeState
+from puffo_agent.portal.worker import _handle_suppressed_reply
+
+
+# ── (1) format_oauth_expired bilingual copy ────────────────────────
+
+
+def test_oauth_copy_includes_english_and_chinese():
+    text = format_oauth_expired("planner-1234", "Planner")
+    # English strand
+    assert "Claude OAuth has expired" in text
+    assert "claude /login" in text
+    assert "puffo-agent agent resume planner-1234" in text
+    # Chinese strand
+    assert "Claude OAuth 已过期" in text
+    assert "终端" in text
+    assert "puffo-agent agent resume planner-1234" in text
+    # Bold display name format
+    assert "**Planner**" in text
+
+
+def test_oauth_copy_degrades_when_display_name_missing():
+    text = format_oauth_expired("agent-5678", "")
+    # Both strands still present
+    assert "Claude OAuth has expired" in text
+    assert "Claude OAuth 已过期" in text
+    # Backtick-id (no bold display name) — degrades cleanly
+    assert "`agent-5678`" in text
+    # No empty-bold artifact
+    assert "**" not in text or "**`agent-5678`**" in text
+
+
+# ── (2) _handle_suppressed_reply on_auth_failed_enter edge ─────────
+
+
+def _make_runtime(health: str = "ok") -> RuntimeState:
+    rt = RuntimeState(status="running", started_at=0, msg_count=0)
+    rt.health = health
+    return rt
+
+
+def test_on_auth_failed_enter_fires_on_fresh_transition(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("ok")
+    fired: list[int] = []
+
+    def cb():
+        fired.append(1)
+
+    suppressed, _ = _handle_suppressed_reply(
+        "Not logged in · Please run /login",
+        rt,
+        "t-agent",
+        scope="fallback",
+        on_auth_failed_enter=cb,
+    )
+    assert suppressed is True
+    assert rt.health == "auth_failed"
+    assert fired == [1]
+
+
+def test_on_auth_failed_enter_does_NOT_fire_on_re_entry(tmp_path, monkeypatch):
+    """Second 401 on an already auth_failed runtime should NOT fire
+    the ENTER callback. This is the operator's load-bearing
+    "no message storm" invariant."""
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("auth_failed")
+    fired: list[int] = []
+
+    def cb():
+        fired.append(1)
+
+    suppressed, _ = _handle_suppressed_reply(
+        "OAuth token revoked",
+        rt,
+        "t-agent",
+        scope="fallback",
+        on_auth_failed_enter=cb,
+    )
+    assert suppressed is True
+    assert rt.health == "auth_failed"
+    assert fired == []  # dedup: no notification on re-entry
+
+
+def test_on_auth_failed_enter_silent_when_clean_reply(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("ok")
+    fired: list[int] = []
+
+    def cb():
+        fired.append(1)
+
+    suppressed, _ = _handle_suppressed_reply(
+        "Hello, world.",
+        rt,
+        "t-agent",
+        scope="fallback",
+        on_auth_failed_enter=cb,
+    )
+    assert suppressed is False
+    assert rt.health == "ok"
+    assert fired == []
+
+
+def test_on_auth_failed_enter_callback_exception_does_not_crash(
+    tmp_path, monkeypatch,
+):
+    """If the DM-task-create callback raises, the suppression flow
+    still completes — operator DM is best-effort, runtime state
+    update is load-bearing."""
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("ok")
+
+    def cb():
+        raise RuntimeError("loop closed")
+
+    suppressed, _ = _handle_suppressed_reply(
+        "Not logged in · Please run /login",
+        rt,
+        "t-agent",
+        scope="fallback",
+        on_auth_failed_enter=cb,
+    )
+    assert suppressed is True
+    assert rt.health == "auth_failed"
+
+
+# ── (3) Worker._on_auth_failed_enter dedup gate ────────────────────
+
+
+class _StubLoop:
+    """Stand-in for asyncio.create_task that records the call but
+    doesn't actually schedule. Used to verify the dedup gate
+    semantics without spinning a real event loop."""
+    def __init__(self):
+        self.calls = 0
+        self.tasks = []
+
+    def create_task(self, coro):
+        self.calls += 1
+        self.tasks.append(coro)
+        # Close the coro so it doesn't warn "never awaited."
+        coro.close()
+        return None
+
+
+def test_worker_dedup_gate_fires_once(monkeypatch):
+    from puffo_agent.portal import worker as worker_module
+
+    stub_loop = _StubLoop()
+    monkeypatch.setattr(
+        worker_module.asyncio, "create_task", stub_loop.create_task,
+    )
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent"})()
+        _client = None
+        _auth_failed_notification_sent = False
+
+        _on_auth_failed_enter = worker_module.Worker._on_auth_failed_enter
+        _notify_operator_of_auth_failed_oauth = (
+            worker_module.Worker._notify_operator_of_auth_failed_oauth
+        )
+
+    w = _StubWorker()
+    w._on_auth_failed_enter()
+    w._on_auth_failed_enter()
+    w._on_auth_failed_enter()
+
+    assert stub_loop.calls == 1
+    assert w._auth_failed_notification_sent is True
+
+
+def test_worker_reset_arms_next_notify(monkeypatch):
+    """The intake's load-bearing semantics: dedup resets on
+    auth_failed CLEAR (daemon.on_refresh_success). Subsequent ENTER
+    re-fires."""
+    from puffo_agent.portal import worker as worker_module
+
+    stub_loop = _StubLoop()
+    monkeypatch.setattr(
+        worker_module.asyncio, "create_task", stub_loop.create_task,
+    )
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent"})()
+        _client = None
+        _auth_failed_notification_sent = False
+
+        _on_auth_failed_enter = worker_module.Worker._on_auth_failed_enter
+        _notify_operator_of_auth_failed_oauth = (
+            worker_module.Worker._notify_operator_of_auth_failed_oauth
+        )
+
+    w = _StubWorker()
+    w._on_auth_failed_enter()                 # fires 1
+    assert stub_loop.calls == 1
+
+    # Simulate refresh-success → daemon.on_refresh_success resets.
+    w._auth_failed_notification_sent = False
+    w._on_auth_failed_enter()                 # fires 2
+    assert stub_loop.calls == 2
+
+
+# ── (4) _notify_operator_of_auth_failed_oauth client guards ────────
+
+
+import asyncio
+
+
+def test_notify_skipped_when_client_not_warm(tmp_path, monkeypatch, caplog):
+    """No PuffoCoreMessageClient yet (warm() hasn't completed) →
+    log + return cleanly."""
+    import logging
+    from puffo_agent.portal import worker as worker_module
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = None
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.worker"):
+        asyncio.new_event_loop().run_until_complete(coro)
+    assert any("client not yet warm" in r.message for r in caplog.records)
+
+
+def test_notify_skipped_when_operator_slug_empty(tmp_path, monkeypatch, caplog):
+    """Operator-less agents (early provisioning) skip cleanly with a
+    warning — red-dot UI is the only fallback signal."""
+    import logging
+    from puffo_agent.portal import worker as worker_module
+
+    class _StubClient:
+        operator_slug = ""
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = _StubClient()
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.worker"):
+        asyncio.new_event_loop().run_until_complete(coro)
+    assert any("no operator_slug configured" in r.message for r in caplog.records)
+
+
+def test_notify_sends_dm_when_operator_slug_set(tmp_path, monkeypatch):
+    """Happy path: client.operator_slug populated → _send_dm called
+    with the bilingual copy + the operator's slug."""
+    from puffo_agent.portal import worker as worker_module
+
+    captured: dict = {}
+
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            captured["recipient"] = recipient
+            captured["text"] = text
+            captured["root_id"] = root_id
+            return {"envelope_id": "env-fake"}
+
+    class _StubWorker:
+        agent_cfg = type(
+            "A", (), {"id": "t-agent", "display_name": "Planner"},
+        )()
+        _client = _StubClient()
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    assert captured["recipient"] == "@han-0001"
+    assert captured["root_id"] == ""
+    assert "Claude OAuth has expired" in captured["text"]
+    assert "Claude OAuth 已过期" in captured["text"]
+    assert "puffo-agent agent resume t-agent" in captured["text"]
+
+
+def test_notify_swallows_send_dm_exception(monkeypatch, caplog):
+    """A crashing _send_dm must not bubble out of the
+    auth-failed-notify path — the daemon stays up."""
+    import logging
+    from puffo_agent.portal import worker as worker_module
+
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            raise RuntimeError("network down")
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = _StubClient()
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.portal.worker"):
+        asyncio.new_event_loop().run_until_complete(coro)
+    assert any("auth-failed DM" in r.message for r in caplog.records)

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -29,12 +29,11 @@ from puffo_agent.portal.worker import _handle_suppressed_reply
 def test_oauth_copy_includes_english_and_chinese():
     text = format_oauth_expired("planner-1234", "Planner")
     # English strand
-    assert "Claude OAuth has expired" in text
+    assert "Claude OAuth expired" in text
     assert "claude /login" in text
     assert "puffo-agent agent resume planner-1234" in text
     # Chinese strand
     assert "Claude OAuth 已过期" in text
-    assert "终端" in text
     assert "puffo-agent agent resume planner-1234" in text
     # Bold display name format
     assert "**Planner**" in text
@@ -43,7 +42,7 @@ def test_oauth_copy_includes_english_and_chinese():
 def test_oauth_copy_degrades_when_display_name_missing():
     text = format_oauth_expired("agent-5678", "")
     # Both strands still present
-    assert "Claude OAuth has expired" in text
+    assert "Claude OAuth expired" in text
     assert "Claude OAuth 已过期" in text
     # Backtick-id (no bold display name) — degrades cleanly
     assert "`agent-5678`" in text
@@ -294,7 +293,7 @@ def test_notify_sends_dm_when_operator_slug_set(tmp_path, monkeypatch):
 
     assert captured["recipient"] == "@han-0001"
     assert captured["root_id"] == ""
-    assert "Claude OAuth has expired" in captured["text"]
+    assert "Claude OAuth expired" in captured["text"]
     assert "Claude OAuth 已过期" in captured["text"]
     assert "puffo-agent agent resume t-agent" in captured["text"]
 

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -263,7 +263,7 @@ def test_notify_skipped_when_operator_slug_empty(tmp_path, monkeypatch, caplog):
     coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
     with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.worker"):
         asyncio.new_event_loop().run_until_complete(coro)
-    assert any("no operator_slug configured" in r.message for r in caplog.records)
+    assert any("no operator_slug" in r.message for r in caplog.records)
 
 
 def test_notify_sends_dm_when_operator_slug_set(tmp_path, monkeypatch):
@@ -462,3 +462,58 @@ def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
     d.refresher.callback()
     assert w.runtime.health == "ok"
     assert w._auth_failed_notification_sent is False
+
+
+# ── re-arm on a transient failed send (PR #70 review) ──────────────
+
+
+def _run_notify(worker_obj):
+    from puffo_agent.portal import worker as worker_module
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(worker_obj)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_notify_rearms_dedup_when_client_not_warm():
+    """Client not yet warm at send time → no DM went out, so re-arm the
+    flag for the next ENTER instead of staying silently gated."""
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = None
+        _auth_failed_notification_sent = True
+
+    w = _StubWorker()
+    _run_notify(w)
+    assert w._auth_failed_notification_sent is False
+
+
+def test_notify_rearms_dedup_when_send_dm_raises():
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            raise RuntimeError("network down")
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = _StubClient()
+        _auth_failed_notification_sent = True
+
+    w = _StubWorker()
+    _run_notify(w)
+    assert w._auth_failed_notification_sent is False
+
+
+def test_notify_stays_gated_when_no_operator_slug():
+    """No operator is a permanent config gap — stay gated so we don't
+    respin a task on every 401."""
+    class _StubClient:
+        operator_slug = ""
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = _StubClient()
+        _auth_failed_notification_sent = True
+
+    w = _StubWorker()
+    _run_notify(w)
+    assert w._auth_failed_notification_sent is True

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -320,3 +320,145 @@ def test_notify_swallows_send_dm_exception(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR, logger="puffo_agent.portal.worker"):
         asyncio.new_event_loop().run_until_complete(coro)
     assert any("auth-failed DM" in r.message for r in caplog.records)
+
+
+# ── PR #70 polish folds ────────────────────────────────────────────
+
+
+def test_create_task_failure_broadly_caught(monkeypatch):
+    """PR #70 nit #3: any failure to schedule the async DM (not just
+    ``RuntimeError``) should reset the dedup flag so the next ENTER
+    re-tries. Otherwise the flag stays stuck-True until a refresh
+    arrives, masking a legitimate retry opportunity."""
+    from puffo_agent.portal import worker as worker_module
+
+    def crash(_coro):
+        # close coro so it doesn't warn "never awaited"
+        try:
+            _coro.close()
+        except Exception:
+            pass
+        raise OSError("unexpected scheduler failure")
+
+    monkeypatch.setattr(worker_module.asyncio, "create_task", crash)
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent"})()
+        _client = None
+        _auth_failed_notification_sent = False
+
+        _on_auth_failed_enter = worker_module.Worker._on_auth_failed_enter
+        _notify_operator_of_auth_failed_oauth = (
+            worker_module.Worker._notify_operator_of_auth_failed_oauth
+        )
+
+    w = _StubWorker()
+    w._on_auth_failed_enter()
+    # Flag reset so a subsequent ENTER tries again instead of
+    # silently swallowing.
+    assert w._auth_failed_notification_sent is False
+
+
+def test_workers_have_independent_dedup_flags(monkeypatch):
+    """PR #70 nit #4: a Worker's ``_auth_failed_notification_sent``
+    is instance state; one agent's ENTER must not silence another's."""
+    from puffo_agent.portal import worker as worker_module
+
+    stub_loop = _StubLoop()
+    monkeypatch.setattr(
+        worker_module.asyncio, "create_task", stub_loop.create_task,
+    )
+
+    class _StubWorker:
+        _client = None
+        _auth_failed_notification_sent = False
+
+        _on_auth_failed_enter = worker_module.Worker._on_auth_failed_enter
+        _notify_operator_of_auth_failed_oauth = (
+            worker_module.Worker._notify_operator_of_auth_failed_oauth
+        )
+
+        def __init__(self, agent_id: str):
+            self.agent_cfg = type("A", (), {"id": agent_id})()
+            self._auth_failed_notification_sent = False
+
+    w_a = _StubWorker("agent-a")
+    w_b = _StubWorker("agent-b")
+
+    w_a._on_auth_failed_enter()
+    w_b._on_auth_failed_enter()
+
+    # Both fired exactly once; the flag is per-instance.
+    assert stub_loop.calls == 2
+    assert w_a._auth_failed_notification_sent is True
+    assert w_b._auth_failed_notification_sent is True
+
+
+def test_oauth_copy_quotes_agent_id_for_markdown_safety():
+    """PR #70 nit #5: ``agent_id`` is interpolated into a Markdown DM;
+    backtick-wrapping it (which is what the helper does today) is the
+    load-bearing defense against a stray ``*``/``_``/``[`` slipping
+    through and breaking the rendered recovery instruction. Slugs are
+    [a-z0-9-] today so injection is near-zero risk, but pinning the
+    contract avoids future regression if the slug regex changes."""
+    text = format_oauth_expired("a-b-c", "")
+    # Backtick-wrap in both strands of recovery instruction.
+    assert "`puffo-agent agent resume a-b-c`" in text
+    assert "`a-b-c`" in text
+
+
+def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
+    """PR #70 nit #1: the daemon's refresh-success closure resets
+    ``worker._auth_failed_notification_sent``. The pieces are
+    unit-tested individually; this pins the wiring between
+    ``daemon._register_with_refresher`` and Worker."""
+    from puffo_agent.portal import daemon as daemon_module
+    from puffo_agent.portal.state import RuntimeState
+
+    class _StubRefresher:
+        """Captures the ``on_refresh_success`` callback the daemon
+        registers without actually wiring the refresh loop."""
+        def __init__(self):
+            self.callback = None
+
+        def register_agent(self, _path):
+            pass
+
+        def register_on_refresh_success(self, cb):
+            self.callback = cb
+
+    class _StubAgentCfg:
+        id = "t-agent"
+
+        class runtime:
+            harness = "claude-code"
+
+        class puffo_core:
+            slug = "alice-0001"
+
+    class _StubWorker:
+        agent_cfg = _StubAgentCfg()
+        runtime = RuntimeState(status="running", started_at=0, msg_count=0)
+        _auth_failed_notification_sent = True
+        _refresh_success_callback = None
+
+    class _StubDaemon:
+        refresher = _StubRefresher()
+        codex_refresher = _StubRefresher()
+
+        def _refresher_for(self, _cfg):
+            return self.refresher
+
+        _register_with_refresher = daemon_module.Daemon._register_with_refresher
+
+    d = _StubDaemon()
+    w = _StubWorker()
+    # Simulate auth_failed → refresh_success → expect both
+    # ``runtime.health`` cleared AND ``_auth_failed_notification_sent``
+    # reset, so the next ENTER re-notifies.
+    w.runtime.health = "auth_failed"
+    d._register_with_refresher(w.agent_cfg, w)
+    assert d.refresher.callback is not None
+    d.refresher.callback()
+    assert w.runtime.health == "ok"
+    assert w._auth_failed_notification_sent is False

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -1,0 +1,165 @@
+"""Bug-2: external credential rotation (operator `claude /login`) must
+propagate to running agents on copy-mode hosts (Windows), where the
+FileBackend's symlink-propagation assumption doesn't hold.
+
+- backends expose a ``fingerprint`` so the refresher can spot the change
+- the refresher fires refresh-success on a detected change (not on the
+  first/baseline tick)
+- the daemon's on_refresh_success restarts agents that were auth_failed
+  so their claude session respawns with the fresh credential
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.portal.credential_refresh import (
+    CodexFileBackend,
+    CredentialRefresher,
+    FileBackend,
+)
+
+
+def _write_creds(host_home: Path, *, expires_in_seconds: int) -> Path:
+    creds_path = host_home / ".claude" / ".credentials.json"
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat01-test",
+            "refreshToken": "sk-ant-ort01-test",
+            "expiresAt": int((time.time() + expires_in_seconds) * 1000),
+            "scopes": ["user:inference"],
+        }
+    }
+    creds_path.write_text(json.dumps(payload))
+    return creds_path
+
+
+# ── backend fingerprints ───────────────────────────────────────────
+
+
+def test_filebackend_fingerprint(tmp_path):
+    fb = FileBackend(host_home=tmp_path)
+    assert fb.fingerprint() is None            # missing host file
+    p = _write_creds(tmp_path, expires_in_seconds=3600)
+    fp = fb.fingerprint()
+    assert fp is not None and fp[1] == p.stat().st_size
+
+
+def test_codexbackend_fingerprint(tmp_path):
+    cb = CodexFileBackend(host_home=tmp_path)
+    assert cb.fingerprint() is None
+    auth = tmp_path / ".codex" / "auth.json"
+    auth.parent.mkdir(parents=True)
+    auth.write_text('{"tokens": {"access_token": "x"}}')
+    fp = cb.fingerprint()
+    assert fp is not None and fp[1] == auth.stat().st_size
+
+
+# ── change detection ───────────────────────────────────────────────
+
+
+def test_detect_fires_on_fingerprint_change(tmp_path, monkeypatch):
+    _write_creds(tmp_path, expires_in_seconds=3600)
+    r = CredentialRefresher(host_home=tmp_path)
+    fired: list[int] = []
+    r.register_on_refresh_success(lambda: fired.append(1))
+
+    seq = {"fp": (1, 10)}
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: seq["fp"])
+
+    # No baseline yet → no fire.
+    r._detect_external_rotation()
+    assert fired == []
+
+    r._record_cred_fingerprint()        # baseline = (1, 10)
+    seq["fp"] = (2, 11)                  # operator re-login
+    r._detect_external_rotation()
+    assert fired == [1]
+
+    # Unchanged on the next tick → no re-fire.
+    r._record_cred_fingerprint()        # baseline = (2, 11)
+    r._detect_external_rotation()
+    assert fired == [1]
+
+
+@pytest.mark.asyncio
+async def test_first_tick_establishes_baseline_without_firing(tmp_path):
+    """A fresh daemon start must NOT fire refresh-success (which would
+    mass-restart agents); the first tick only records the baseline."""
+    _write_creds(tmp_path, expires_in_seconds=3600)   # far future → no refresh
+    r = CredentialRefresher(host_home=tmp_path)
+    fired: list[int] = []
+    r.register_on_refresh_success(lambda: fired.append(1))
+
+    await r._tick()
+    assert fired == []
+    assert r._last_cred_fingerprint is not None
+
+
+# ── daemon: restart auth_failed agents on recovery ─────────────────
+
+
+def _daemon_harness(monkeypatch, tmp_path, health: str):
+    from puffo_agent.portal import daemon as daemon_module
+    from puffo_agent.portal.state import RuntimeState
+
+    flag = tmp_path / "restart.flag"
+    monkeypatch.setattr(daemon_module, "restart_flag_path", lambda aid: flag)
+
+    class _StubRefresher:
+        def __init__(self):
+            self.callback = None
+
+        def register_agent(self, _p):
+            pass
+
+        def register_on_refresh_success(self, cb):
+            self.callback = cb
+
+    class _StubAgentCfg:
+        id = "t-agent"
+
+        class runtime:
+            harness = "claude-code"
+
+        class puffo_core:
+            slug = "alice-0001"
+
+    class _StubWorker:
+        agent_cfg = _StubAgentCfg()
+        runtime = RuntimeState(status="running", started_at=0, msg_count=0)
+        _auth_failed_notification_sent = True
+        _refresh_success_callback = None
+
+    class _StubDaemon:
+        refresher = _StubRefresher()
+        codex_refresher = _StubRefresher()
+
+        def _refresher_for(self, _cfg):
+            return self.refresher
+
+        _register_with_refresher = daemon_module.Daemon._register_with_refresher
+
+    d = _StubDaemon()
+    w = _StubWorker()
+    w.runtime.health = health
+    d._register_with_refresher(w.agent_cfg, w)
+    return d, w, flag
+
+
+def test_on_refresh_success_restarts_auth_failed_agent(tmp_path, monkeypatch):
+    d, w, flag = _daemon_harness(monkeypatch, tmp_path, "auth_failed")
+    d.refresher.callback()
+    assert w.runtime.health == "ok"
+    assert flag.exists()        # restart requested to pick up new cred
+
+
+def test_on_refresh_success_no_restart_when_healthy(tmp_path, monkeypatch):
+    d, w, flag = _daemon_harness(monkeypatch, tmp_path, "ok")
+    d.refresher.callback()
+    assert not flag.exists()    # nothing to recover → no restart

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -163,3 +163,40 @@ def test_on_refresh_success_no_restart_when_healthy(tmp_path, monkeypatch):
     d, w, flag = _daemon_harness(monkeypatch, tmp_path, "ok")
     d.refresher.callback()
     assert not flag.exists()    # nothing to recover → no restart
+
+
+# ── new message while auth_failed wakes the refresher ──────────────
+
+
+def _wake_stub(health: str, *, has_cb: bool = True):
+    from puffo_agent.portal.worker import Worker
+
+    class _RT:
+        def __init__(self, h):
+            self.health = h
+
+    class _W:
+        pass
+
+    w = _W()
+    w.runtime = _RT(health)
+    w.fired: list[int] = []
+    w._notify_refresh_needed = (lambda: w.fired.append(1)) if has_cb else None
+    return Worker, w
+
+
+def test_new_message_while_auth_failed_wakes_refresher():
+    Worker, w = _wake_stub("auth_failed")
+    Worker._maybe_wake_refresher_if_auth_failed(w, "t-agent")
+    assert w.fired == [1]
+
+
+def test_new_message_when_healthy_does_not_wake():
+    Worker, w = _wake_stub("ok")
+    Worker._maybe_wake_refresher_if_auth_failed(w, "t-agent")
+    assert w.fired == []
+
+
+def test_wake_is_noop_without_notify_callback():
+    Worker, w = _wake_stub("auth_failed", has_cb=False)
+    Worker._maybe_wake_refresher_if_auth_failed(w, "t-agent")   # no crash

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -200,3 +200,13 @@ def test_new_message_when_healthy_does_not_wake():
 def test_wake_is_noop_without_notify_callback():
     Worker, w = _wake_stub("auth_failed", has_cb=False)
     Worker._maybe_wake_refresher_if_auth_failed(w, "t-agent")   # no crash
+
+
+def test_wake_survives_notify_raising():
+    Worker, w = _wake_stub("auth_failed")
+
+    def _boom():
+        raise RuntimeError("no loop")
+
+    w._notify_refresh_needed = _boom
+    Worker._maybe_wake_refresher_if_auth_failed(w, "t-agent")   # no crash

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -359,7 +359,7 @@ def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health == "refresh_broken"
-    assert "claude /login" in rs.error
+    assert "claude auth login" in rs.error
     assert "unchanged" in rs.error
 
 

--- a/tests/test_worker_error_suppress.py
+++ b/tests/test_worker_error_suppress.py
@@ -186,9 +186,9 @@ def test_handle_suppressed_reply_returns_true_on_leak_api_retry_scope(tmp_path, 
     )
     assert suppressed is True
     assert _SUPPRESSION_BACKOFF_MIN_SECONDS <= backoff <= _SUPPRESSION_BACKOFF_MAX_SECONDS
-    # API-retry / auth-class branch: re-login + resume recovery copy.
-    assert "claude /login" in runtime.error
-    assert "puffo-agent agent resume agent-suppress-retry" in runtime.error
+    # API-retry / auth-class branch: re-login + send-a-message copy.
+    assert "claude auth login" in runtime.error
+    assert "send the agent a message" in runtime.error
     assert runtime.health == "auth_failed"
 
 
@@ -209,8 +209,8 @@ def test_handle_suppressed_reply_api_retry_rate_limit_branches_message(tmp_path,
     assert runtime.health == "unknown"  # NOT auth_failed
     assert "rate-limit" in runtime.error
     assert "self-recovers" in runtime.error
-    assert "claude /login" not in runtime.error
-    assert "puffo-agent agent resume" not in runtime.error
+    assert "claude auth login" not in runtime.error
+    assert "agent resume" not in runtime.error
 
 
 def test_handle_suppressed_reply_returns_false_on_legit_prose(tmp_path, monkeypatch):
@@ -467,7 +467,7 @@ def test_call_site_skips_send_on_suppressed_leak(tmp_path, monkeypatch):
     assert client.calls == []  # NEVER called when filter suppresses
     # Operator-side surface populated.
     assert runtime.health == "auth_failed"
-    assert "puffo-agent agent resume agent-skip-send" in runtime.error
+    assert "send the agent a message" in runtime.error
     # And the call site DID sleep with a backoff in range.
     assert len(sleeps) == 1
     assert _SUPPRESSION_BACKOFF_MIN_SECONDS <= sleeps[0] <= _SUPPRESSION_BACKOFF_MAX_SECONDS


### PR DESCRIPTION
## Summary

Makes agent OAuth/auth failures **visible and self-healing**.

Before this PR a Claude `401` was misread as a rate-limit — kick-retried, abandoned, and never surfaced; and after the operator re-logged in, running agents (on Windows) stayed stuck until a manual `agent resume`.

Now: auth failures are classified correctly → the operator gets a concise DM → and once they re-authenticate, agents recover on their own.

## What changed

**1. Classify auth vs rate-limit (no more silent abandon)**
- One shared auth detector (`agent/_auth_markers.py`) used by the CLI adapter *and* `core`, so the two can't drift — that drift is exactly what let `401 Invalid authentication credentials` get mis-handled as a rate-limit.
- `AgentAPIError` carries `is_auth`, set by `core` via the shared detector.
- An `is_auth` error skips the pointless kick-retries and goes straight to `auth_failed` (status preserved — the abandon path no longer overwrites it with `api_error_abandoned`). The batch's cursor stays un-advanced so it redelivers on recovery.

**2. Notify the operator**
- On entering `auth_failed`, the daemon DMs the operator a concise bilingual (zh+en) note: run `claude auth login`, then just send a message. Once per failure episode, re-armed after recovery — and on a failed send, so a notification that never went out doesn't permanently gate the next one.

**3. Recover on re-login (incl. Windows copy-mode)**
- The file backend assumed a symlink carried the operator's re-login to every agent — but Windows falls back to a **copy**, so re-login never reached running agents. Backends (claude + codex) now expose `fingerprint()`; the refresher detects an external host-credential change each tick and, on a change, syncs every agent + fires refresh-success — the copy-mode counterpart to the macOS Keychain rotation poll. (First tick only sets a baseline, so startup doesn't mass-restart; our own refresh is absorbed so it isn't re-seen as external.)
- The daemon then **restarts** the agents that were `auth_failed`, so their session respawns with the fresh credential and the stalled batch redelivers — no manual `agent resume`.
- A **new message** to an `auth_failed` agent also wakes the refresher on the spot, so recovery doesn't wait for the ~2-min poll.

## Operator UX

1. An agent's Claude OAuth expires → status goes `auth_failed`, the operator gets a DM.
2. Operator runs `claude auth login`.
3. The agent recovers automatically — within ~2 min (poll) or immediately when the next message arrives. No `agent resume` needed.

## Testing

- Full suite **1304 passed**.
- New modules `_auth_markers.py` / `_invite_strings.py`: **100%**; `credential_refresh.py`: **87%**.
- Covered: the shared detector, `core`'s `is_auth` tagging on both raise paths (main + `handle_api_error_retry`), the consumer skip-retry, `auth_failed` status preservation, the DM copy + dedup re-arm, backend fingerprints, external-rotation detection (+ first-tick baseline), the daemon restart-on-recovery, and the new-message wake (incl. the defensive exception branches).

## Notes

- Versioned under **0.12.2** (unreleased) — no minor bump.
- Recovery is `claude auth login` + send-a-message (auto-resume); no manual `puffo-agent agent resume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
