### PR TITLE
Support env proxies for Python agent networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,6 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.12.3] — 2026-06-07
-
-### Fixed
-
-- **Proxy support for Python agent networking.** ``puffo-agent`` now
-  installs ``python-socks`` so ``websockets`` can connect through
-  SOCKS proxies configured in the environment. Remote Puffo Core
-  HTTP/import requests now honor ``HTTP_PROXY``, ``HTTPS_PROXY``,
-  ``ALL_PROXY``, ``SOCKS_PROXY``, and ``NO_PROXY``; HTTP proxies use
-  aiohttp's native environment handling, while SOCKS proxies use
-  ``aiohttp-socks``.
-
 ## [0.12.2] — 2026-06-06
 
 ### Added
@@ -44,6 +32,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Proxy support for Python agent networking.** ``puffo-agent`` now
+  installs ``python-socks`` so ``websockets`` can connect through
+  SOCKS proxies configured in the environment. Remote Puffo Core
+  HTTP/import requests now honor ``HTTP_PROXY``, ``HTTPS_PROXY``,
+  ``ALL_PROXY``, ``SOCKS_PROXY``, and ``NO_PROXY``; HTTP proxies use
+  aiohttp's native environment handling, while SOCKS proxies use
+  ``aiohttp-socks``.
 - **UI log view always tails the newest lines.** The view diffed on
   buffer length, but the log buffer is a ring that drops its oldest
   line — so once full it froze on the first ~500 lines (the oldest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.3] — 2026-06-07
+
+### Fixed
+
+- **Proxy support for Python agent networking.** ``puffo-agent`` now
+  installs ``python-socks`` so ``websockets`` can connect through
+  SOCKS proxies configured in the environment. Remote Puffo Core
+  HTTP/import requests now honor ``HTTP_PROXY``, ``HTTPS_PROXY``,
+  ``ALL_PROXY``, ``SOCKS_PROXY``, and ``NO_PROXY``; HTTP proxies use
+  aiohttp's native environment handling, while SOCKS proxies use
+  ``aiohttp-socks``.
+
 ## [0.12.2] — 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **Proxy support for Python agent networking.** ``puffo-agent`` now
-  installs ``python-socks`` so ``websockets`` can connect through
-  SOCKS proxies configured in the environment. Remote Puffo Core
-  HTTP/import requests now honor ``HTTP_PROXY``, ``HTTPS_PROXY``,
-  ``ALL_PROXY``, ``SOCKS_PROXY``, and ``NO_PROXY``; HTTP proxies use
-  aiohttp's native environment handling, while SOCKS proxies use
-  ``aiohttp-socks``.
+- **Network-proxy support.** Connections to Puffo Core (the HTTPS API +
+  the WebSocket relay) now honor ``HTTP_PROXY`` / ``HTTPS_PROXY`` /
+  ``ALL_PROXY`` / ``SOCKS_PROXY`` / ``NO_PROXY``. HTTP(S) proxies use
+  aiohttp's native handling; SOCKS proxies route through ``aiohttp-socks``
+  (HTTP) and ``python-socks`` (WebSocket), both now bundled as
+  dependencies. See the "Network proxies" section in the README.
 - **UI log view always tails the newest lines.** The view diffed on
   buffer length, but the log buffer is a ring that drops its oldest
   line — so once full it froze on the first ~500 lines (the oldest).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,43 @@ resumed via `--resume`; only a missing container triggers a fresh
 `docker run`. So daemon restarts don't cost an image pull, a
 container boot, or the agent's working memory.
 
+## Network proxies
+
+`puffo-agent`'s connections to Puffo Core — the HTTPS API and the
+WebSocket relay — honor the standard proxy environment variables, so you
+can run agents from behind a corporate or SOCKS proxy:
+
+- `HTTPS_PROXY` / `HTTP_PROXY` — route HTTPS / HTTP traffic through an
+  HTTP(S) proxy.
+- `ALL_PROXY` / `SOCKS_PROXY` — route through a SOCKS proxy, e.g.
+  `socks5://127.0.0.1:1080`.
+- `NO_PROXY` — comma-separated hosts that bypass the proxy.
+
+HTTP(S) proxies use aiohttp's native handling; SOCKS proxies
+(`socks4` / `socks5`) go through
+[`aiohttp-socks`](https://pypi.org/project/aiohttp-socks/) for HTTP and
+[`python-socks`](https://pypi.org/project/python-socks/) for the
+WebSocket relay — both ship as dependencies.
+
+```bash
+# HTTP proxy
+export HTTPS_PROXY=http://127.0.0.1:8899
+puffo-agent start
+
+# SOCKS5 proxy, but reach the loopback directly
+export ALL_PROXY=socks5://127.0.0.1:1080
+export NO_PROXY=localhost,127.0.0.1
+puffo-agent start
+```
+
+The same variables are inherited by the agents' `claude` / `codex`
+subprocesses, which honor them for their own LLM API calls.
+
+> **Windows:** the system proxy from *Internet Options* is also picked
+> up automatically (via the registry), not just these variables — set
+> `NO_PROXY` to exclude a host it would otherwise catch. In PowerShell,
+> set variables with `$env:HTTPS_PROXY = "http://127.0.0.1:8899"`.
+
 ## Managing agents
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.12.2"
+version = "0.12.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.9",
+    "aiohttp-socks>=0.10",
     "aiosqlite>=0.20",
     "anthropic>=0.25",
     "cryptography>=43.0",
@@ -45,6 +46,7 @@ dependencies = [
     "openai>=1.30",
     "psutil>=5.9",
     "pyside6>=6.7",
+    "python-socks>=2.4",
     "pyyaml>=6.0",
     "websockets>=12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.12.3"
+version = "0.12.2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 aiohttp>=3.9
+aiohttp-socks>=0.10
 anthropic>=0.25
 mcp>=1.0
 openai>=1.30
 psutil>=5.9
+python-socks>=2.4
 pyyaml>=6.0

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -9,6 +9,7 @@ import aiohttp
 from .certs import create_subkey_cert, needs_rotation
 from .encoding import base64url_encode
 from .http_auth import sign_request
+from .http_session import create_remote_http_session
 from .keystore import KeyStore, Session, decode_secret
 from .primitives import Ed25519KeyPair
 
@@ -31,7 +32,7 @@ class PuffoCoreHttpClient:
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = create_remote_http_session(self.server_url)
         return self._session
 
     async def close(self) -> None:

--- a/src/puffo_agent/crypto/http_session.py
+++ b/src/puffo_agent/crypto/http_session.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+from urllib.request import getproxies, proxy_bypass
+
+import aiohttp
+from aiohttp_socks import ProxyConnector
+
+
+_SOCKS_SCHEMES = {"socks4", "socks4a", "socks5", "socks5h"}
+
+
+def _env_proxy_for_url(url: str) -> str | None:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    host = parsed.hostname
+    if host and proxy_bypass(host):
+        return None
+    proxies = {k.lower(): v for k, v in getproxies().items()}
+    return proxies.get(scheme) or proxies.get("all") or proxies.get("socks")
+
+
+def _is_socks_proxy(proxy_url: str) -> bool:
+    return urlsplit(proxy_url).scheme.lower() in _SOCKS_SCHEMES
+
+
+def create_remote_http_session(
+    base_url: str,
+    *,
+    timeout: aiohttp.ClientTimeout | None = None,
+) -> aiohttp.ClientSession:
+    kwargs = {}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+
+    proxy_url = _env_proxy_for_url(base_url)
+    if proxy_url and _is_socks_proxy(proxy_url):
+        connector = ProxyConnector.from_url(proxy_url)
+        return aiohttp.ClientSession(connector=connector, trust_env=False, **kwargs)
+
+    return aiohttp.ClientSession(trust_env=True, **kwargs)

--- a/src/puffo_agent/portal/import_agents.py
+++ b/src/puffo_agent/portal/import_agents.py
@@ -34,6 +34,7 @@ import aiohttp
 from ..crypto.certs import create_subkey_cert
 from ..crypto.encoding import base64url_decode, base64url_encode
 from ..crypto.http_auth import sign_request
+from ..crypto.http_session import create_remote_http_session
 from ..crypto.keystore import KeyStore, StoredIdentity, decode_secret, encode_secret
 from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
 from .export import (
@@ -54,6 +55,10 @@ from .state import agent_dir, agent_yml_path, agents_dir
 logger = logging.getLogger(__name__)
 
 HTTP_TIMEOUT = aiohttp.ClientTimeout(total=20)
+
+
+def _remote_http_session(server_url: str) -> aiohttp.ClientSession:
+    return create_remote_http_session(server_url, timeout=HTTP_TIMEOUT)
 
 
 class ImportError(Exception):
@@ -281,7 +286,7 @@ async def _register_new_device_subkey(
     new_device_id: str,
     new_signing_key: Ed25519KeyPair,
 ) -> tuple[Ed25519KeyPair, dict]:
-    async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
+    async with _remote_http_session(server_url) as session:
         return await _register_subkey_via_device(
             session,
             server_url=server_url,
@@ -411,7 +416,7 @@ async def _enroll_new_device(
     kem_pk_b64 = base64url_encode(new_kem_pk)
     nonce = base64url_encode(secrets.token_bytes(32))
 
-    async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
+    async with _remote_http_session(server_url) as session:
         old_subkey, old_subkey_cert = await _register_subkey_via_device(
             session,
             server_url=server_url,
@@ -470,7 +475,7 @@ async def _revoke_old_device(
     preregistered_subkey: tuple[Ed25519KeyPair, dict] | None = None,
 ) -> None:
     revocation = create_device_revocation(root_signing_key, old_device_id)
-    async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
+    async with _remote_http_session(server_url) as session:
         if preregistered_subkey is not None:
             new_subkey, new_subkey_cert = preregistered_subkey
         else:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -8,6 +8,7 @@ import time
 import aiohttp
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from aiohttp_socks import ProxyConnector
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -15,6 +16,7 @@ from puffo_agent.crypto.certs import SUBKEY_TTL_HOURS
 from puffo_agent.crypto.encoding import base64url_decode, base64url_encode
 from puffo_agent.crypto.http_auth import sign_request
 from puffo_agent.crypto.http_client import HttpError, PuffoCoreHttpClient
+from puffo_agent.crypto.http_session import create_remote_http_session
 from puffo_agent.crypto.keystore import KeyStore, Session, StoredIdentity, encode_secret
 from puffo_agent.crypto.primitives import Ed25519KeyPair, ed25519_verify
 
@@ -50,6 +52,66 @@ def _make_keystore_with_session(ks, subkey):
     )
     ks.save_session(session)
     return session
+
+
+def _clear_proxy_env(monkeypatch):
+    for key in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "SOCKS_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "socks_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_remote_http_session_trusts_env_without_socks_proxy(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+
+    async def run():
+        session = create_remote_http_session("https://api.puffo.ai")
+        try:
+            assert getattr(session, "_trust_env", None) is True
+            assert not isinstance(session.connector, ProxyConnector)
+        finally:
+            await session.close()
+
+    asyncio.run(run())
+
+
+def test_remote_http_session_uses_socks_connector(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "socks5://127.0.0.1:9")
+
+    async def run():
+        session = create_remote_http_session("https://api.puffo.ai")
+        try:
+            assert getattr(session, "_trust_env", None) is False
+            assert isinstance(session.connector, ProxyConnector)
+        finally:
+            await session.close()
+
+    asyncio.run(run())
+
+
+def test_remote_http_session_uses_socks_proxy_env(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("SOCKS_PROXY", "socks5://127.0.0.1:9")
+
+    async def run():
+        session = create_remote_http_session("https://api.puffo.ai")
+        try:
+            assert getattr(session, "_trust_env", None) is False
+            assert isinstance(session.connector, ProxyConnector)
+        finally:
+            await session.close()
+
+    asyncio.run(run())
 
 
 class TestHttpClientSigning(AioHTTPTestCase):

--- a/tests/test_import_module.py
+++ b/tests/test_import_module.py
@@ -187,6 +187,13 @@ def _build_bundle(server_url: str, password: str = "hunter2") -> tuple[bytes, di
 # ────────────────────────────────────────────────────────────────────
 
 
+async def test_remote_http_session_trusts_proxy_env():
+    from puffo_agent.portal import import_agents as imp
+
+    async with imp._remote_http_session("https://api.puffo.ai") as session:
+        assert getattr(session, "_trust_env", None) is True
+
+
 async def test_import_happy_path(mock_server):
     from puffo_agent.portal import import_agents as imp
     from puffo_agent.portal.state import AgentConfig


### PR DESCRIPTION
## Summary
- add remote HTTP session factory for Puffo Core calls
- route SOCKS env proxies through aiohttp-socks while keeping HTTP proxies on aiohttp trust_env
- add python-socks/aiohttp-socks dependencies and bump to 0.12.3

## Validation
- .venv/bin/python -m pytest tests/test_http_client.py tests/test_import_module.py tests/test_ws_client.py
- uv build
- clean venv wheel install smoke: verified aiohttp SOCKS connector and websocket SOCKS path no longer fails with missing python-socks
