### PR TITLE
PUF-285: catch-up telemetry + ordering invariant docstring (FB-238 audit substrate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Catch-up telemetry on every WS reconnect.** The agent logs its
+  pending-message catch-up count on every reconnect — including zero,
+  with the session id — so a silent reconnect is distinguishable from a
+  no-op in the log stream (the old code only logged a non-zero count).
 - **Desired skills install on the `cli-docker` runtime.** Operator-picked
   skills now install for cli-docker agents too — written into the agent's
   `.claude/skills/`, which docker bind-mounts into the container — not

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -95,7 +95,11 @@ class PuffoCoreWsClient:
         listen. The structured log line below is the FB-238 audit
         surface (catch-up count per reconnect; non-zero values on
         re-connect after a roll-call window are the load-bearing
-        signal).
+        signal). ``self.session_id`` in the log line is the WS
+        session-registry key returned by the server's handshake reply
+        (``ws.rs::handle_connect``); cross-correlating against the
+        server's ``ws_pubsub`` ``NOTIFICATIONS_DISPATCHED`` counter
+        keyed on the same id is how FB-238 audits the receive-side gap.
         """
         try:
             data = await self.http_client.get("/messages/pending")
@@ -107,7 +111,7 @@ class PuffoCoreWsClient:
             # reconnect is indistinguishable from a no-op.
             logger.info(
                 "Catch-up: %d pending messages (session=%s)",
-                len(messages), self.session_id,
+                len(messages), self.session_id or "<pre-handshake>",
             )
             if not messages:
                 return

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -86,12 +86,31 @@ class PuffoCoreWsClient:
         return resp["session_id"]
 
     async def _catchup(self) -> None:
+        """Drain `message_deliveries` rows the server has for us but
+        couldn't deliver via the live WS while we were offline. PUF-204
+        + PUF-285 (β): this MUST run after ``_handshake`` completes —
+        the handshake registers the session server-side, but the
+        catch-up GET pulls the actual envelopes. Ordering invariant:
+        register-via-handshake → /messages/pending fetch → live
+        listen. The structured log line below is the FB-238 audit
+        surface (catch-up count per reconnect; non-zero values on
+        re-connect after a roll-call window are the load-bearing
+        signal).
+        """
         try:
             data = await self.http_client.get("/messages/pending")
             messages = data.get("messages", [])
+            # PUF-285 (β): always log the count, including zero, so
+            # the structured-log stream carries one line per reconnect
+            # for cross-correlation with server-side
+            # NOTIFICATIONS_RECEIVED. Without the zero line, a silent
+            # reconnect is indistinguishable from a no-op.
+            logger.info(
+                "Catch-up: %d pending messages (session=%s)",
+                len(messages), self.session_id,
+            )
             if not messages:
                 return
-            logger.info("Catch-up: %d pending messages", len(messages))
             envelope_ids = []
             for item in messages:
                 envelope = item.get("envelope", item)

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -95,11 +95,8 @@ class PuffoCoreWsClient:
         listen. The structured log line below is the FB-238 audit
         surface (catch-up count per reconnect; non-zero values on
         re-connect after a roll-call window are the load-bearing
-        signal). ``self.session_id`` in the log line is the WS
-        session-registry key returned by the server's handshake reply
-        (``ws.rs::handle_connect``); cross-correlating against the
-        server's ``ws_pubsub`` ``NOTIFICATIONS_DISPATCHED`` counter
-        keyed on the same id is how FB-238 audits the receive-side gap.
+        signal). ``session_id`` matches the server WS registry key;
+        cross-correlate against ``ws_pubsub::NOTIFICATIONS_DISPATCHED``.
         """
         try:
             data = await self.http_client.get("/messages/pending")

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -86,26 +86,16 @@ class PuffoCoreWsClient:
         return resp["session_id"]
 
     async def _catchup(self) -> None:
-        """Drain `message_deliveries` rows the server has for us but
-        couldn't deliver via the live WS while we were offline. PUF-204
-        + PUF-285 (β): this MUST run after ``_handshake`` completes —
-        the handshake registers the session server-side, but the
-        catch-up GET pulls the actual envelopes. Ordering invariant:
-        register-via-handshake → /messages/pending fetch → live
-        listen. The structured log line below is the FB-238 audit
-        surface (catch-up count per reconnect; non-zero values on
-        re-connect after a roll-call window are the load-bearing
-        signal). ``session_id`` matches the server WS registry key;
-        cross-correlate against ``ws_pubsub::NOTIFICATIONS_DISPATCHED``.
+        """Drain `/messages/pending` — rows the server held while we
+        were offline. MUST run after ``_handshake`` (it registers the
+        session); ordering is register → pending fetch → live listen.
         """
         try:
             data = await self.http_client.get("/messages/pending")
             messages = data.get("messages", [])
-            # PUF-285 (β): always log the count, including zero, so
-            # the structured-log stream carries one line per reconnect
-            # for cross-correlation with server-side
-            # NOTIFICATIONS_RECEIVED. Without the zero line, a silent
-            # reconnect is indistinguishable from a no-op.
+            # Log on every reconnect, even zero — a silent reconnect
+            # should still leave one line (else it's indistinguishable
+            # from a no-op).
             logger.info(
                 "Catch-up: %d pending messages (session=%s)",
                 len(messages), self.session_id or "<pre-handshake>",

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -408,11 +408,9 @@ async def test_nonce_unique_per_connect():
 
 @pytest.mark.asyncio
 async def test_catchup_logs_zero_pending_count(caplog):
-    """PUF-285 (β): the catch-up INFO log must fire on every
-    reconnect, including ``N=0`` — that's the FB-238 audit signal
-    distinguishing a silent reconnect from a no-op. A future
-    "tidy-up" that re-introduces zero-suppression must trip this
-    test.
+    """The catch-up INFO log must fire on every reconnect, including
+    ``N=0`` — a future tidy-up that re-suppresses the zero line must
+    trip this test.
     """
     import logging as _stdlib_logging
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -407,6 +407,47 @@ async def test_nonce_unique_per_connect():
 
 
 @pytest.mark.asyncio
+async def test_catchup_logs_zero_pending_count(caplog):
+    """PUF-285 (β): the catch-up INFO log must fire on every
+    reconnect, including ``N=0`` — that's the FB-238 audit signal
+    distinguishing a silent reconnect from a no-op. A future
+    "tidy-up" that re-introduces zero-suppression must trip this
+    test.
+    """
+    import logging as _stdlib_logging
+
+    ks, _subkey = _make_keystore()
+    server = FakeWsServer()
+    await server.start()
+
+    http = FakeHttpClient()
+    http.pending_messages = []  # explicit zero
+
+    client = PuffoCoreWsClient(
+        f"http://127.0.0.1:{server.port}",
+        ks, "alice-0001", http,
+    )
+    client.ws_url = f"ws://127.0.0.1:{server.port}"
+
+    with caplog.at_level(_stdlib_logging.INFO, logger="puffo_agent.crypto.ws_client"):
+        task = asyncio.create_task(client.connect_once())
+        await asyncio.sleep(0.5)
+        client.stop()
+        try:
+            await asyncio.wait_for(task, timeout=2)
+        except (websockets.exceptions.ConnectionClosed, asyncio.CancelledError, OSError):
+            pass
+
+    catchup_lines = [r for r in caplog.records if "Catch-up:" in r.getMessage()]
+    assert len(catchup_lines) == 1, (
+        f"expected exactly one Catch-up log line on reconnect with N=0; got {len(catchup_lines)}"
+    )
+    assert "0 pending messages" in catchup_lines[0].getMessage()
+    assert "session=sess_test" in catchup_lines[0].getMessage()
+    await server.stop()
+
+
+@pytest.mark.asyncio
 async def test_callback_exception_does_not_kill_loop():
     ks, subkey = _make_keystore()
     server = FakeWsServer()


### PR DESCRIPTION
**Two-side ticket — sibling PR:** puffo-ai/puffo-server#100 (server listener telemetry).

## Summary

Agent-side half of the FB-238 audit substrate — make the WS catch-up count observable on every reconnect.

- `_catchup` now logs the pending-message count on **every** reconnect, including `N=0`. The old code only logged when `N > 0`, so a silent reconnect was indistinguishable from a no-op in the log stream. Adds `session_id` to the line for cross-correlation with the server side.
- Docstring pins the ordering invariant: `_catchup` must run after `_handshake` (register → pending fetch → live listen).

## Tests

- **`test_catchup_logs_zero_pending_count`** — asserts exactly one catch-up INFO line on a reconnect with zero pending, carrying the session id. Locks the "log even when `N=0`" contract so a future tidy-up can't silently re-suppress it.
- Full suite: **1352 passed, 9 skipped**.

Rebased onto current main; comments trimmed to the load-bearing WHY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
