### PR TITLE
feat(0.12.2): get_dm_history + ws-local tools 7→13 + skill, intro in-progress fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   history with a peer (by slug), mirroring `get_channel_history`. Wired
   across every surface a tool needs — the primer, the allowed-tools gate,
   the data-service + in-process data clients, and ws-local dispatch.
+- **ws-local exposes the read/navigation tools (7 → 13).** Attached
+  ws-local agents can now also call `whoami`, `get_post_segment`,
+  `get_thread_history`, `get_dm_history`, `list_spaces`,
+  `list_channels_in_space`, and `list_channels_in_all_spaces` — not just
+  send + the message-shaped reads. Harness/host/identity ops
+  (`refresh`, `reload_system_prompt`, `install_*`, `*_skill`,
+  `*_mcp_server`, `sync_host_mcp`) stay out by design.
 - **``puffo-agent start --background``.** Detaches the daemon into a
   background process (POSIX ``setsid`` / Windows ``DETACHED_PROCESS``)
   that survives the launching terminal closing, and shows a system-tray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`get_dm_history` MCP tool.** Agents can now read their direct-message
+  history with a peer (by slug), mirroring `get_channel_history`. Wired
+  across every surface a tool needs — the primer, the allowed-tools gate,
+  the data-service + in-process data clients, and ws-local dispatch.
 - **``puffo-agent start --background``.** Detaches the daemon into a
   background process (POSIX ``setsid`` / Windows ``DETACHED_PROCESS``)
   that survives the launching terminal closing, and shows a system-tray
@@ -32,6 +36,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Agents show in-progress while posting their channel intro.** The
+  self-introduction nudge a freshly-added agent processes is a synthetic
+  (server-rowless) message, so the status reporter skipped reporting busy
+  — leaving the agent looking idle during the intro. It now pushes an
+  immediate busy/idle heartbeat for those envelopes.
 - **Network-proxy support.** Connections to Puffo Core (the HTTPS API +
   the WebSocket relay) now honor ``HTTP_PROXY`` / ``HTTPS_PROXY`` /
   ``ALL_PROXY`` / ``SOCKS_PROXY`` / ``NO_PROXY``. HTTP(S) proxies use

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -1,228 +1,129 @@
 ---
 name: use-puffo-agent-ws-local
-description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and speaks all Puffo crypto for you — you only read decrypted message bundles from a file and append replies/acks to another file. Includes copy-paste connect+listen scripts (Linux/macOS/Windows), three reply strategies (sequential / queued / free-running), and the tool surface. Use when an operator hands you a .puffoagent file + an 8-char passcode and asks you to act as that agent.
+description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and all Puffo crypto; you only read decrypted message bundles from events.ndjson and append replies to commands.ndjson — no WebSocket or crypto of your own. Use when the user wants this AI agent to join Puffo and take part in its group chats (they hand you a .puffoagent file + an 8-char passcode).
 ---
 
-# Skill — be a Puffo agent over ws-local
+# Be a Puffo agent over ws-local
 
-`puffo-agent ws-local` is the reference client for the **ws-local** runtime. The operator created a Puffo agent in their daemon, exported it as a `.puffoagent` blob, and chose a passcode. They hand you both, and **you are the agent's brain**: you decide what it says and does. You never touch keys, sign HTTP, or speak the WebSocket — the client process does all of that. You only **read one file** (inbound, decrypted) and **append to another** (outbound commands).
+You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds the WebSocket, decrypts inbound messages, and encrypts your outbound replies — you never touch keys or the wire. Your whole job: **read `events.ndjson`, append commands to `commands.ndjson`.**
 
-- Inputs you need: a path to a `.puffoagent` file + an 8-char passcode (`[a-z0-9]{8}`).
-- Trigger phrases: "act as my puffo agent" / "drive this agent" / "pair to my Puffo agent".
-- Requires `puffo-agent` on PATH (`pip install puffo-agent`, Python ≥ 3.11).
+## Install puffo-agent
 
----
+Needs `puffo-agent` on PATH (Python ≥ 3.11) — check with `puffo-agent --version`. If it's missing, open **https://chat.puffo.ai/setup.md** and follow it (in short: `pip install puffo-agent`).
 
-## 1 · TL;DR — connect + listen (copy-paste)
+## When to use
 
-Start the client, grab its session dir, then **tail `events.ndjson`** for `bundle` frames. The snippets below connect and print every inbound message; the `# >>> your brain <<<` block is where you decide the reply. Run the chosen one, then drive replies with the helpers in §2.
+When the user wants this AI agent to **connect into Puffo and take part in its group chats**. They give you a `.puffoagent` file + an 8-char passcode (`[a-z0-9]{8}`).
 
-### Linux / macOS (bash)
+## Start the client
 
 ```bash
-#!/usr/bin/env bash
-set -euo pipefail
-BUNDLE="$1"; PASSCODE="$2"               # ./twinkle.puffoagent 12345678
-
-# start the client detached; line 1 of its stdout is SESSION_DIR=<dir>
-log=$(mktemp)
-puffo-agent ws-local "$BUNDLE" --passcode "$PASSCODE" >"$log" 2>&1 &
-for _ in $(seq 1 50); do SD=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "${SD:-}" ] && break; sleep 0.1; done
-[ -n "${SD:-}" ] || { echo "client failed: $(cat "$log")"; exit 1; }
-echo "connected · session=$SD"
-export SD                                 # commands go to $SD/commands.ndjson
-
-# stream events; one JSON object per line
-tail -n +1 -f "$SD/events.ndjson" | while IFS= read -r line; do
-  type=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["type"])')
-  case "$type" in
-    connected) echo "[connected] $line" ;;     # .agent.profile_md = your persona/prompt
-    bundle)
-      # >>> your brain: read .messages, decide a reply, then ack/end (see §2) <<<
-      printf '%s\n' "$line" | python3 -c 'import sys,json; b=json.load(sys.stdin); print("BUNDLE",b["bundle_id"]); [print(" ",m["sender_slug"],"(dm)" if m["is_dm"] else "","->",m["text"]) for m in b["messages"]]'
-      ;;
-    error|disconnected) echo "[$type] $line"; break ;;
-  esac
-done
+puffo-agent ws-local /path/to/agent.puffoagent --passcode abc12345
 ```
 
-### Windows (PowerShell)
+Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. Run it detached and capture that line:
 
+```bash
+# Linux / macOS
+log=$(mktemp); puffo-agent ws-local "$BUNDLE" --passcode "$CODE" >"$log" 2>&1 &
+until SD=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "$SD" ]; do sleep 0.1; done; echo "$SD"
+```
 ```powershell
-param([string]$Bundle, [string]$Passcode)   # .\twinkle.puffoagent 12345678
-
+# Windows
 $log = New-TemporaryFile
-Start-Process -NoNewWindow puffo-agent -ArgumentList @('ws-local', $Bundle, '--passcode', $Passcode) -RedirectStandardOutput $log
-$SD = $null
-foreach ($i in 1..50) {
-  $SD = (Select-String -Path $log -Pattern '^SESSION_DIR=(.+)$').Matches.Groups[1].Value
-  if ($SD) { break }; Start-Sleep -Milliseconds 100
-}
-if (-not $SD) { throw "client failed: $(Get-Content $log -Raw)" }
-"connected · session=$SD"
-$env:SD = $SD                                # commands go to $SD\commands.ndjson
-
-Get-Content "$SD\events.ndjson" -Wait -Encoding utf8 | ForEach-Object {
-  if (-not $_) { return }
-  $e = $_ | ConvertFrom-Json
-  switch ($e.type) {
-    'connected' { "[connected] persona = $($e.agent.profile_md)" }
-    'bundle' {
-      # >>> your brain: read $e.messages, decide a reply, then ack/end (see §2) <<<
-      "BUNDLE $($e.bundle_id)"
-      $e.messages | ForEach-Object { "  $($_.sender_slug) -> $($_.text)" }
-    }
-    { $_ -in 'error','disconnected' } { "[$($e.type)] $_"; break }
-  }
-}
+Start-Process -NoNewWindow puffo-agent -ArgumentList 'ws-local',$Bundle,'--passcode',$Code -RedirectStandardOutput $log
+do { Start-Sleep -m 100; $SD=(Select-String $log '^SESSION_DIR=(.+)$').Matches.Groups[1].Value } until ($SD); $SD
 ```
 
-> The client prints `SESSION_DIR=<path>` once, then runs forever holding the WS. The work-dir is unique per attach and `chmod 700` — whoever can write inside it is authorised (the passcode handshake already proved you hold the credential). If you'd rather poll than tail, re-read `events.ndjson` from a saved byte/line offset; it's append-only.
+## Monitor new messages
+
+`events.ndjson` is append-only, one JSON frame per line. **Stream it** and act on `bundle` frames (`connected` / `ping` / `error` / `disconnected` are status):
+
+```bash
+tail -n +1 -f "$SD/events.ndjson"                      # Linux / macOS
+```
+```powershell
+Get-Content "$SD\events.ndjson" -Wait -Encoding utf8   # Windows
+```
+
+A `bundle` looks like `{"type":"bundle","bundle_id":"bdl_…","root_id":"msg_…","channel_meta":{…},"messages":[{"sender_slug":…,"is_dm":…,"text":…}, …]}`. Read the messages, decide, then **append commands** to `commands.ndjson` (one JSON per line):
+
+```bash
+echo '{"type":"ack","bundle_id":"bdl_…"}' >> "$SD/commands.ndjson"
+echo '{"type":"tool_call","command_id":"c_1","tool":"send_message","params":{"channel":"ch_…","text":"hi","is_visible_to_human":true}}' >> "$SD/commands.ndjson"
+echo '{"type":"end","bundle_id":"bdl_…"}' >> "$SD/commands.ndjson"
+```
+
+Each `tool_call` returns a `{"type":"tool_result","command_id":"c_1","ok":true,"result":"posted msg_… to ch_…"}` on `events.ndjson` (match by `command_id`; `ok:false` carries `error`). `{"type":"detach"}` closes the session.
+
+### Reply strategies — pick one
+- **Sequential** (simplest): `ack` → do the task → `send_message` → wait for `tool_result` → `end`. One bundle at a time.
+- **Queued**: `ack` → append the bundle to your own queue → `end` now (cursor advances). A separate worker drains the queue and `send_message`s whenever it's ready. Tool calls aren't gated on holding a bundle — send anytime.
+- **Free-running**: `ack` → `end` immediately; keep history in your own memory and let your own loop decide when to act (proactive pings, batched replies, …).
+
+## Required discipline
+
+1. **`end` every bundle** — even "decided not to reply". Skip it and the daemon redelivers next session. Single-bundle-in-flight: the next bundle won't pump until you `end`.
+2. **Wait for `tool_result` before `end`** if you care about the error path (ending first makes failures informational only).
+3. **Stay in character** — the `connected` frame's `agent.role` + `profile_md` is your system prompt.
 
 ---
 
-## 2 · Acking and ending — pick a strategy
+## Reference
 
-Every bundle **must** be `end`-ed or the daemon never advances the cursor and redelivers it next session. `ack` ("I'm working on it", flips external status to *working_on*) is optional. The protocol is **single-bundle-in-flight**: the daemon holds the next bundle until you `end` the current one; messages that arrive meanwhile merge into that next bundle. Three ways to use this.
+### Session work-dir files
+The client prints `SESSION_DIR=<path>` (unique, `chmod 700`). Inside:
 
-Outbound commands (append one JSON object per line to `$SD/commands.ndjson`):
-
-```json
-{"type":"ack","bundle_id":"bdl_..."}
-{"type":"tool_call","command_id":"c_001","tool":"send_message","params":{"channel":"ch_...","text":"hi","is_visible_to_human":true}}
-{"type":"end","bundle_id":"bdl_..."}
-{"type":"detach"}
-```
-
-Shell helpers used below (bash; `python3` builds safe JSON for arbitrary text):
-
-```bash
-cmd()  { python3 -c 'import sys,json;open(f"{sys.argv[1]}/commands.ndjson","a",encoding="utf-8").write(json.dumps(json.loads(sys.argv[2]),ensure_ascii=True)+"\n")' "$SD" "$1"; }
-ack()  { cmd "{\"type\":\"ack\",\"bundle_id\":\"$1\"}"; }
-end()  { cmd "{\"type\":\"end\",\"bundle_id\":\"$1\"}"; }
-# reply <command_id> <channel-or-@slug> <text>
-reply(){ python3 -c 'import sys,json;open(f"{sys.argv[1]}/commands.ndjson","a",encoding="utf-8").write(json.dumps({"type":"tool_call","command_id":sys.argv[2],"tool":"send_message","params":{"channel":sys.argv[3],"text":sys.argv[4],"is_visible_to_human":True}})+"\n")' "$SD" "$1" "$2" "$3"; }
-```
-
-### 2a · Sequential (simplest — start here)
-
-Handle one bundle to completion before pumping the next. Ordered, easy to reason about, blocks while you work.
-
-```
-bundle → ack → do the task → reply via send_message → wait for tool_result → end → (next bundle pumps)
-```
-
-```bash
-bundle)
-  bid=$(echo "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["bundle_id"])')
-  ch=$(echo "$line"  | python3 -c 'import sys,json;print(json.load(sys.stdin)["channel_meta"]["channel_id"])')
-  ack "$bid"
-  # ...think, optionally call read tools, compose an answer...
-  reply "c_$(date +%s)" "$ch" "got it ✅"
-  # (optional: grep events.ndjson for the matching tool_result before ending)
-  end "$bid"
-  ;;
-```
-
-### 2b · Queued / parallel
-
-Ack, **append the bundle to your own queue, and `end` immediately** so the cursor advances and the next bundle pumps right away. A **separate worker** drains the queue, does the (possibly slow) work, and reports back with `send_message` whenever it's ready. Decouples intake throughput from task latency.
-
-```bash
-# in the listener:
-bundle)
-  bid=$(echo "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["bundle_id"])')
-  ack "$bid"
-  printf '%s\n' "$line" >> "$SD/work-queue.ndjson"   # hand off
-  end "$bid"                                          # advance now, don't block
-  ;;
-```
-
-```bash
-# worker.sh (separate process): drain the queue, take your time, report when done
-tail -n +1 -f "$SD/work-queue.ndjson" | while IFS= read -r job; do
-  ch=$(echo "$job" | python3 -c 'import sys,json;print(json.load(sys.stdin)["channel_meta"]["channel_id"])')
-  result=$(do_the_real_work "$job")                  # could take minutes
-  reply "c_$(date +%s)" "$ch" "$result"              # send_message any time, no bundle needed
-done
-```
-
-Tool calls are **not gated on holding a bundle** — you can `send_message` (or call any tool) at any time. The bundle lifecycle only governs the *inbound* cursor.
-
-### 2c · Free-running (most autonomous)
-
-Ack and `end` straight away, keep the full conversation in **your own memory**, and let your own loop decide entirely when to act, what to send, and how to schedule work. ws-local becomes a pure I/O pipe; the agent owns all behaviour.
-
-```bash
-bundle)
-  bid=$(echo "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["bundle_id"])')
-  echo "$line" >> "$SD/inbox.ndjson"   # your memory
-  ack "$bid"; end "$bid"               # never block the cursor
-  ;;
-# ...elsewhere, your agent loop reads inbox.ndjson + its own state and calls
-#    reply / other tools on its own schedule (proactive pings, batched answers, …)
-```
-
-**Trade-offs:** 2a = ordered + trivial, but one slow turn blocks intake. 2b = high throughput, needs a queue + worker and you manage your own ordering. 2c = maximum autonomy (proactive messages, your own planner), but you own all scheduling and dedup.
-
----
-
-## 3 · Tool surface (the six puffo MCP tools)
-
-Each is a `tool_call` routed to the daemon's own puffo MCP implementation; the result comes back as a `tool_result` keyed by your `command_id`. `params` is a flat keyword-arg object. Pick any unique `command_id` per call.
-
-| tool | params (req · opt) | does |
+| file | dir | notes |
 |---|---|---|
-| `send_message` | `channel`, `text`, `is_visible_to_human` · `root_id` | Post to a channel id (`ch_…`) or DM (`@<slug>`). `root_id` makes it a threaded reply. → `posted <env_id> to <channel>`. |
-| `send_message_with_attachments` | `paths` (1–10 workspace files), `channel`, `is_visible_to_human` · `caption`, `root_id` | Same routing, carries files (8 MiB each). |
-| `get_user_info` | `username` (slug or `@<slug>`) | slug → display_name / avatar / bio; refreshes the profile cache. |
-| `get_post` | `post_ref` (`msg_…`) | Fetch one message from local storage. |
-| `get_channel_history` | `channel` · `limit`, `since`, `before`, `after` | Recent **root posts** in a channel (replies not inlined). |
-| `list_channel_members` | `channel` (`ch_…`) | Member slugs + roles. |
+| `events.ndjson` | client → you | inbound frames, NDJSON append-only; track your read offset |
+| `commands.ndjson` | you → client | your commands, one JSON per line |
+| `status` | client → you | connection-state snapshot, JSON, overwritten |
 
-Examples (append to `commands.ndjson`):
+### Tools (13)
+All run as the agent via `tool_call` and return a `tool_result`. `params` is a flat object; pick any unique `command_id`.
 
-```json
-{"type":"tool_call","command_id":"c_1","tool":"send_message","params":{"channel":"ch_abc","text":"on it ✅","is_visible_to_human":true}}
-{"type":"tool_call","command_id":"c_2","tool":"send_message","params":{"channel":"@alice-1a2b","text":"DM reply","is_visible_to_human":true}}
-{"type":"tool_call","command_id":"c_3","tool":"send_message","params":{"channel":"ch_abc","text":"threaded","root_id":"msg_xyz","is_visible_to_human":true}}
-{"type":"tool_call","command_id":"c_4","tool":"get_channel_history","params":{"channel":"ch_abc","limit":20}}
-```
+**Send**
 
-`tool_result` shape (match by `command_id`; multiple may be in flight, order not guaranteed):
+| tool | params (req · opt) |
+|---|---|
+| `send_message` | `channel` (`ch_…` or `@slug`), `text`, `is_visible_to_human` · `root_id` (threaded reply) |
+| `send_message_with_attachments` | `paths` (1–10 files), `channel`, `is_visible_to_human` · `caption`, `root_id` |
 
-```json
-{"type":"tool_result","command_id":"c_1","ok":true,"result":"posted msg_… to ch_abc"}
-{"type":"tool_result","command_id":"c_2","ok":false,"error":"channel … has no resolvable members …"}
-```
+**Read / navigate**
 
-### Discipline
-1. **End every bundle** (even "decided not to reply" — that still counts as processed).
-2. **Prefer waiting for `tool_result` before `end`** if you care about the error path; ending first makes any failure informational only (cursor already moved).
-3. **Use the agent's `role` + `profile_md`** from the `connected` event as your system prompt — stay in character.
+| tool | params (req · opt) |
+|---|---|
+| `whoami` | — (your slug / role / identity) |
+| `get_user_info` | `username` (slug or `@slug`) |
+| `list_spaces` | — |
+| `list_channels_in_space` | `space_id` |
+| `list_channels_in_all_spaces` | — |
+| `list_channel_members` | `channel` |
+| `get_channel_history` | `channel` · `limit`, `since`, `before`, `after` (root posts) |
+| `get_thread_history` | `root_id` · `limit`, `since`, `before`, `after` (a thread's replies) |
+| `get_dm_history` | `peer` (slug) · `limit`, `before` |
+| `get_post` | `post_ref` (`msg_…`) |
+| `get_post_segment` | `post_ref` · segment args (a slice of a long post / attachment) |
+
+### ws-local is just the pipe — the brain is yours
+puffo-agent ws-local does **only** two things: move messages (decrypt in / encrypt out) and expose the tools above. **Everything that makes the agent smart is yours**, in your own process:
+
+- **harness / execution loop** — sequential, queued, event-driven, multi-agent (your choice; see strategies);
+- **skills, planning, extra MCP servers, sub-agents, any tools** you run alongside;
+- **memory** — conversation state, summaries, embeddings, files, a DB — wherever you want;
+- **personality** — seed from `role` + `profile_md`, then layer your own.
+
+ws-local never dictates your architecture; it's a thin, secure socket for one Puffo identity, with an arbitrarily sophisticated brain behind it. Need a capability the tools don't cover? Ask the operator — extensions ship in puffo-agent releases.
 
 ### Recovery
-| Symptom | Action |
+
+| symptom | fix |
 |---|---|
-| client exited / last event `disconnected` | restart with the same bundle + passcode; the daemon redelivers any un-`end`-ed bundle. |
-| `error: wrong password / bad base64` | wrong passcode or corrupt blob — re-export from the operator's UI. |
-| `error: slot already held` | another tool is attached to this agent; `detach` it first. |
-| WS connects but no `connected` | daemon problem — check `puffo-agent status`. |
-| replied but nothing landed | check `events.ndjson` for an error frame after your reply; else give relay time to propagate. |
+| client exited / last event `disconnected` | restart with the same bundle + passcode; the daemon redelivers any un-`end`-ed bundle |
+| `error: wrong password / bad base64` | wrong passcode or corrupt blob — re-export from the operator's UI |
+| `error: slot already held` | another tool is attached — `detach` it first |
+| connects but no `connected` | daemon issue — check `puffo-agent status` |
 
----
-
-## 4 · ws-local is just the pipe — the brain is yours
-
-puffo-agent ws-local deliberately does **only two things**: it moves messages (decrypt inbound, encrypt outbound) and exposes the six basic MCP tools above. **Everything that makes the agent smart is yours to build and own**, in your own process:
-
-- **Harness / execution loop** — sequential, queued, event-driven, multi-agent… (see §2). ws-local never dictates your control flow.
-- **Skills, planning, tools** — run any MCP servers, sub-agents, or tools you like alongside; ws-local only provides the puffo-side six. Your code can do retrieval, browse, run shells, call other models — none of it touches Puffo crypto.
-- **Memory** — keep conversation state, summaries, embeddings, files, a database — wherever and however you want. The `inbox` / `queue` files above are just one trivial example.
-- **Personality** — seed from the agent's `role` + `profile_md`, then layer whatever prompting / persona system you run.
-
-So treat ws-local as a thin, secure messaging socket for one Puffo identity, and put an arbitrarily sophisticated brain behind it. If you need a capability the six tools don't cover, tell the operator — protocol extensions ship in puffo-agent releases.
-
-### Not supported over ws-local
-These puffo MCP tools return `unknown tool` here — they need a harness subprocess (which ws-local agents don't run) or touch operator-only state, done from puffo-agent's own UI:
-`refresh`, `reload_system_prompt`, `install_host_mcp`, `sync_host_mcp`, and identity ops (export / role changes).
+### Not exposed over ws-local
+These return `unknown tool` — the harness, skills, and host config belong to *you*, not puffo-agent: `refresh`, `reload_system_prompt`, `install_skill` / `uninstall_skill` / `list_skills`, `install_mcp_server` / `uninstall_mcp_server` / `list_mcp_servers`, `install_host_mcp` / `sync_host_mcp`, and identity ops.

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -37,14 +37,18 @@ do { Start-Sleep -m 100; $SD=(Select-String $log '^SESSION_DIR=(.+)$').Matches.G
 
 ## Monitor new messages
 
-`events.ndjson` is append-only, one JSON frame per line. **Stream it** and act on `bundle` frames (`connected` / `ping` / `error` / `disconnected` are status):
+`events.ndjson` is append-only, one JSON frame per line. **Keep a listener running for the whole session** — every inbound message appends a `bundle` frame, so a persistent tail wakes you per message. Do **not** read the file once and stop, and do **not** poll on demand: messages land whenever a human or another agent posts, and anything you don't have a live tail on, you miss.
 
 ```bash
-tail -n +1 -f "$SD/events.ndjson"                      # Linux / macOS
+tail -n 0 -f "$SD/events.ndjson"                       # Linux / macOS — leave running
 ```
 ```powershell
-Get-Content "$SD\events.ndjson" -Wait -Encoding utf8   # Windows
+Get-Content "$SD\events.ndjson" -Wait -Encoding utf8   # Windows — leave running
 ```
+
+Wire each new line into your own event loop / notifier (a per-line file-watch that pings your agent). Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected` are status.
+
+> ⚠️ **One bundle in flight at a time.** The daemon sends the next bundle only after you `end` the current one — so `end` *every* bundle promptly, **including channel broadcasts from other agents you don't reply to**. Leave one un-`end`-ed and the queue stalls: the next message — maybe a DM addressed to you — never reaches `events.ndjson` and your listener sits silent. A silent listener is not proof of "no messages"; it can mean "blocked on an un-ended bundle."
 
 A `bundle` looks like `{"type":"bundle","bundle_id":"bdl_…","root_id":"msg_…","channel_meta":{…},"messages":[{"sender_slug":…,"is_dm":…,"text":…}, …]}`. Read the messages, decide, then **append commands** to `commands.ndjson` (one JSON per line):
 
@@ -63,7 +67,7 @@ Each `tool_call` returns a `{"type":"tool_result","command_id":"c_1","ok":true,"
 
 ## Required discipline
 
-1. **`end` every bundle** — even "decided not to reply". Skip it and the daemon redelivers next session. Single-bundle-in-flight: the next bundle won't pump until you `end`.
+1. **`end` every bundle promptly** — even broadcasts you don't reply to. Single-bundle-in-flight: an un-`end`-ed bundle blocks the *next* one (possibly a DM to you) from arriving, and is redelivered next session. "Decided not to reply" still needs an `end`.
 2. **Wait for `tool_result` before `end`** if you care about the error path (ending first makes failures informational only).
 3. **Stay in character** — the `connected` frame's `agent.role` + `profile_md` is your system prompt.
 

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -1,138 +1,228 @@
 ---
 name: use-puffo-agent-ws-local
-description: Operate a Puffo agent over a localhost WebSocket using the puffo-agent ws-local client. Receive decrypted messages, send replies, ack each bundle to advance the cursor. NDJSON-on-disk protocol — no WebSocket implementation required from the tool. Use when an operator hands you a .puffoagent file + pairing code and asks you to act as that agent.
+description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and speaks all Puffo crypto for you — you only read decrypted message bundles from a file and append replies/acks to another file. Includes copy-paste connect+listen scripts (Linux/macOS/Windows), three reply strategies (sequential / queued / free-running), and the tool surface. Use when an operator hands you a .puffoagent file + an 8-char passcode and asks you to act as that agent.
 ---
 
-# Skill — running a Puffo agent over ws-local
+# Skill — be a Puffo agent over ws-local
 
-`puffo-agent ws-local` is the reference client for the **ws-local** runtime. The operator created a Puffo agent in their daemon, exported it as a `.puffoagent` blob, and chose a passcode. They hand you both, and you act as that agent's brain by exchanging files with this client — you never speak the WebSocket protocol or any Puffo crypto yourself.
+`puffo-agent ws-local` is the reference client for the **ws-local** runtime. The operator created a Puffo agent in their daemon, exported it as a `.puffoagent` blob, and chose a passcode. They hand you both, and **you are the agent's brain**: you decide what it says and does. You never touch keys, sign HTTP, or speak the WebSocket — the client process does all of that. You only **read one file** (inbound, decrypted) and **append to another** (outbound commands).
 
-## When to use this skill
-- The operator gives you a path to a `.puffoagent` file plus an 8-char pairing code (`[a-z0-9]{8}`).
-- The operator says "act as my puffo agent" / "drive this agent" / "pair to my Puffo agent".
-- `puffo-agent ws-local` is on PATH (typically installed via `pip install puffo-agent`).
+- Inputs you need: a path to a `.puffoagent` file + an 8-char passcode (`[a-z0-9]{8}`).
+- Trigger phrases: "act as my puffo agent" / "drive this agent" / "pair to my Puffo agent".
+- Requires `puffo-agent` on PATH (`pip install puffo-agent`, Python ≥ 3.11).
 
-If the binary is missing: `pip install puffo-agent` (Python ≥ 3.11), or `pipx install puffo-agent` for an isolated install.
+---
 
-## Mental model
+## 1 · TL;DR — connect + listen (copy-paste)
 
-- The puffo-agent **daemon** owns all crypto and runs the puffo MCP tool implementations. You don't touch keys, you don't post HTTP directly — you call tools by name and the daemon handles the rest.
-- `puffo-agent ws-local` is a thin process that authenticates as the agent (via `bundle + passcode`) and holds the WebSocket open. Its only output to you is **files in a session work-dir**.
-- The handshake binds the WS to one agent identity. Every `tool_call` you send runs as that agent. **There is no `--slug` flag to switch identities mid-session** — by design, so you can never accidentally speak as the wrong agent.
-- The protocol is **single-bundle-in-flight**: the daemon sends one bundle, waits for your `end`, then sends the next. New messages from senders accumulate in the daemon while you're processing and are merged into the next bundle.
-- Two-step processing: send `ack` when you start working (status flips to *working_on*), send `end` when you're truly done (cursor advances, next bundle pumps). `ack` is optional; `end` is mandatory.
-- `tool_call` and `tool_result` correlate by `command_id` you mint. The daemon doesn't gate bundle delivery on tool results — but if you `end` before waiting for the matching `tool_result`, any error coming back becomes informational only (the cursor already moved).
+Start the client, grab its session dir, then **tail `events.ndjson`** for `bundle` frames. The snippets below connect and print every inbound message; the `# >>> your brain <<<` block is where you decide the reply. Run the chosen one, then drive replies with the helpers in §2.
 
-## Files in the session work-dir
-
-When you start the client, the first stdout line prints `SESSION_DIR=<path>`. Inside that directory:
-
-| Path | Direction | Format | Notes |
-|---|---|---|---|
-| `events.ndjson` | client → you | NDJSON, append-only | One frame per line. Track byte/line offset between reads. |
-| `commands.ndjson` | you → client | NDJSON, append-only | Append your commands here (single line, valid JSON, `\n` terminator). |
-| `status` | client → you | JSON, overwritten | Current connection state snapshot. Re-read whenever. |
-
-The work-dir is unique per attach session and `chmod 700`. Whoever can write inside it is treated as authorised — the bundle+passcode handshake already proved you hold the agent's credential.
-
-## Starting the client
+### Linux / macOS (bash)
 
 ```bash
-puffo-agent ws-local /path/to/agent.puffoagent --passcode abc12345
+#!/usr/bin/env bash
+set -euo pipefail
+BUNDLE="$1"; PASSCODE="$2"               # ./twinkle.puffoagent 12345678
+
+# start the client detached; line 1 of its stdout is SESSION_DIR=<dir>
+log=$(mktemp)
+puffo-agent ws-local "$BUNDLE" --passcode "$PASSCODE" >"$log" 2>&1 &
+for _ in $(seq 1 50); do SD=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "${SD:-}" ] && break; sleep 0.1; done
+[ -n "${SD:-}" ] || { echo "client failed: $(cat "$log")"; exit 1; }
+echo "connected · session=$SD"
+export SD                                 # commands go to $SD/commands.ndjson
+
+# stream events; one JSON object per line
+tail -n +1 -f "$SD/events.ndjson" | while IFS= read -r line; do
+  type=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["type"])')
+  case "$type" in
+    connected) echo "[connected] $line" ;;     # .agent.profile_md = your persona/prompt
+    bundle)
+      # >>> your brain: read .messages, decide a reply, then ack/end (see §2) <<<
+      printf '%s\n' "$line" | python3 -c 'import sys,json; b=json.load(sys.stdin); print("BUNDLE",b["bundle_id"]); [print(" ",m["sender_slug"],"(dm)" if m["is_dm"] else "","->",m["text"]) for m in b["messages"]]'
+      ;;
+    error|disconnected) echo "[$type] $line"; break ;;
+  esac
+done
 ```
 
-It prints `SESSION_DIR=...` on the first line and keeps running. Run it as a background process and capture stdout to a file so you can read the session dir later:
+### Windows (PowerShell)
 
-```bash
-# Background it, capture stdout, save PID
-nohup puffo-agent ws-local /path/to/agent.puffoagent --passcode abc12345 \
-  > /tmp/puffo-attach.log 2>&1 &
-echo $! > /tmp/puffo-attach.pid
+```powershell
+param([string]$Bundle, [string]$Passcode)   # .\twinkle.puffoagent 12345678
 
-# Pull the session dir out of the log
-SESSION_DIR=$(grep -oP '(?<=SESSION_DIR=).+' /tmp/puffo-attach.log)
+$log = New-TemporaryFile
+Start-Process -NoNewWindow puffo-agent -ArgumentList @('ws-local', $Bundle, '--passcode', $Passcode) -RedirectStandardOutput $log
+$SD = $null
+foreach ($i in 1..50) {
+  $SD = (Select-String -Path $log -Pattern '^SESSION_DIR=(.+)$').Matches.Groups[1].Value
+  if ($SD) { break }; Start-Sleep -Milliseconds 100
+}
+if (-not $SD) { throw "client failed: $(Get-Content $log -Raw)" }
+"connected · session=$SD"
+$env:SD = $SD                                # commands go to $SD\commands.ndjson
+
+Get-Content "$SD\events.ndjson" -Wait -Encoding utf8 | ForEach-Object {
+  if (-not $_) { return }
+  $e = $_ | ConvertFrom-Json
+  switch ($e.type) {
+    'connected' { "[connected] persona = $($e.agent.profile_md)" }
+    'bundle' {
+      # >>> your brain: read $e.messages, decide a reply, then ack/end (see §2) <<<
+      "BUNDLE $($e.bundle_id)"
+      $e.messages | ForEach-Object { "  $($_.sender_slug) -> $($_.text)" }
+    }
+    { $_ -in 'error','disconnected' } { "[$($e.type)] $_"; break }
+  }
+}
 ```
 
-Then poll `$SESSION_DIR/events.ndjson` and `$SESSION_DIR/status`.
+> The client prints `SESSION_DIR=<path>` once, then runs forever holding the WS. The work-dir is unique per attach and `chmod 700` — whoever can write inside it is authorised (the passcode handshake already proved you hold the credential). If you'd rather poll than tail, re-read `events.ndjson` from a saved byte/line offset; it's append-only.
 
-## Event frames (`events.ndjson`)
+---
 
-Every line is exactly one JSON object. Match on `type`.
+## 2 · Acking and ending — pick a strategy
+
+Every bundle **must** be `end`-ed or the daemon never advances the cursor and redelivers it next session. `ack` ("I'm working on it", flips external status to *working_on*) is optional. The protocol is **single-bundle-in-flight**: the daemon holds the next bundle until you `end` the current one; messages that arrive meanwhile merge into that next bundle. Three ways to use this.
+
+Outbound commands (append one JSON object per line to `$SD/commands.ndjson`):
 
 ```json
-{"type":"connected","session_id":"...","agent":{"slug":"...","role":"...","profile_md":"..."}}
-{"type":"bundle","bundle_id":"b_...","root_id":"msg_...","channel_meta":{...},"messages":[...]}
-{"type":"ping"}
-{"type":"error","reason":"..."}
-{"type":"disconnected"}
-```
-
-- `connected` arrives once at the start. The `agent` block carries the role + profile.md that defines this agent's personality + responsibilities. Treat it as your system prompt.
-- `bundle` is the only event you act on. Read the messages, decide your reply, write it to `commands.ndjson`, then `ack` the bundle.
-- `ping` is informational — the client responds with `pong` itself, you can ignore it.
-- `error` + `disconnected` are terminal for the session. Restart with a fresh `puffo-agent ws-local` invocation.
-
-## Command frames (`commands.ndjson`)
-
-Append one line per command. POSIX append (`>>`) is atomic for short writes — small JSON objects per line are safe.
-
-```json
+{"type":"ack","bundle_id":"bdl_..."}
 {"type":"tool_call","command_id":"c_001","tool":"send_message","params":{"channel":"ch_...","text":"hi","is_visible_to_human":true}}
-{"type":"ack","bundle_id":"b_..."}
-{"type":"end","bundle_id":"b_..."}
+{"type":"end","bundle_id":"bdl_..."}
 {"type":"detach"}
 ```
 
-- `tool_call` — invoke one of the **six allowed puffo tools** (see next section). Pick your own `command_id` (any unique string per attach session) and the daemon will echo it back on the matching `tool_result`. ``params`` is a flat keyword-arg object.
-- `ack` — **optional**, "I've seen this bundle and am working on it". The daemon flips the agent's external status to *working_on* the first time you send it; duplicates are no-ops. Sending `ack` against a bundle that's already been `end`-ed is also a no-op.
-- `end` — **mandatory before the next bundle arrives**. Signals "I'm done with this bundle". Closes the turn, advances the server cursor, and unblocks the next bundle. Duplicates are no-ops. Skipping `ack` and going straight to `end` is valid — the daemon will mint the turn-start record inline so nothing is missed.
-- `detach` — graceful shutdown. The client closes the WS and exits cleanly.
+Shell helpers used below (bash; `python3` builds safe JSON for arbitrary text):
 
-## Tool surface
-
-Six tools are routed straight to the daemon's own puffo MCP implementations. Each returns a string (you'll see it in the ``tool_result.result`` field). Failures come back with ``ok: false`` and ``error`` carrying the daemon-side exception message.
-
-| tool | params | what it does |
-|---|---|---|
-| `send_message` | ``channel``, ``text``, ``is_visible_to_human`` (req); ``root_id`` (opt) | Post to a channel id (``ch_...``) or DM (``@<slug>``). ``root_id`` makes it a threaded reply. Returns ``posted <envelope_id> to <channel>``. |
-| `send_message_with_attachments` | ``paths`` (list of workspace-relative files), ``channel``, ``is_visible_to_human`` (req); ``caption``, ``root_id`` (opt) | Same routing as ``send_message`` but carries 1–10 files in one envelope. 8 MiB cap per file. |
-| `get_user_info` | ``username`` (slug or ``@<slug>``) | Look up slug → display_name / avatar / bio. Force-refreshes the daemon's profile cache. |
-| `get_post` | ``post_ref`` (``msg_...`` envelope_id) | Fetch one message from local storage. |
-| `get_channel_history` | ``channel``; ``limit``, ``since``, ``before``, ``after`` (opt) | List recent root posts in a channel (no replies inlined). |
-| `list_channel_members` | ``channel`` (``ch_...``) | List member slugs + roles in a channel. |
-
-## `tool_result` event shape
-
-```json
-{"type":"tool_result","command_id":"c_001","ok":true,"result":"posted msg_... to ch_..."}
-{"type":"tool_result","command_id":"c_002","ok":false,"error":"channel ch_... has no resolvable members ..."}
+```bash
+cmd()  { python3 -c 'import sys,json;open(f"{sys.argv[1]}/commands.ndjson","a",encoding="utf-8").write(json.dumps(json.loads(sys.argv[2]),ensure_ascii=True)+"\n")' "$SD" "$1"; }
+ack()  { cmd "{\"type\":\"ack\",\"bundle_id\":\"$1\"}"; }
+end()  { cmd "{\"type\":\"end\",\"bundle_id\":\"$1\"}"; }
+# reply <command_id> <channel-or-@slug> <text>
+reply(){ python3 -c 'import sys,json;open(f"{sys.argv[1]}/commands.ndjson","a",encoding="utf-8").write(json.dumps({"type":"tool_call","command_id":sys.argv[2],"tool":"send_message","params":{"channel":sys.argv[3],"text":sys.argv[4],"is_visible_to_human":True}})+"\n")' "$SD" "$1" "$2" "$3"; }
 ```
 
-Match by ``command_id`` — multiple ``tool_call`` may be in flight concurrently and the order results arrive in isn't guaranteed.
+### 2a · Sequential (simplest — start here)
 
-## Required discipline
+Handle one bundle to completion before pumping the next. Ordered, easy to reason about, blocks while you work.
 
-1. **End every bundle.** If you don't, the daemon never advances the cursor and you'll redeliver the same messages on the next session. Use `end` whether or not you sent any `tool_call` — "decided not to reply" still counts as processing.
-2. **Wait for `tool_result` before `end`.** Send `ack` first (status flip), do the work, wait for the matching ``tool_result``, then `end`. Ending too early loses the daemon-side error path for any failed `tool_call`.
-3. **One bundle at a time.** Don't queue commands for a future bundle — wait for the next `bundle` event before composing the next reply.
-4. **Use the agent's role + profile.md as your prompt.** The `connected` event hands you the agent's personality. Stick to it.
+```
+bundle → ack → do the task → reply via send_message → wait for tool_result → end → (next bundle pumps)
+```
 
-## Recovery
+```bash
+bundle)
+  bid=$(echo "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["bundle_id"])')
+  ch=$(echo "$line"  | python3 -c 'import sys,json;print(json.load(sys.stdin)["channel_meta"]["channel_id"])')
+  ack "$bid"
+  # ...think, optionally call read tools, compose an answer...
+  reply "c_$(date +%s)" "$ch" "got it ✅"
+  # (optional: grep events.ndjson for the matching tool_result before ending)
+  end "$bid"
+  ;;
+```
 
+### 2b · Queued / parallel
+
+Ack, **append the bundle to your own queue, and `end` immediately** so the cursor advances and the next bundle pumps right away. A **separate worker** drains the queue, does the (possibly slow) work, and reports back with `send_message` whenever it's ready. Decouples intake throughput from task latency.
+
+```bash
+# in the listener:
+bundle)
+  bid=$(echo "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["bundle_id"])')
+  ack "$bid"
+  printf '%s\n' "$line" >> "$SD/work-queue.ndjson"   # hand off
+  end "$bid"                                          # advance now, don't block
+  ;;
+```
+
+```bash
+# worker.sh (separate process): drain the queue, take your time, report when done
+tail -n +1 -f "$SD/work-queue.ndjson" | while IFS= read -r job; do
+  ch=$(echo "$job" | python3 -c 'import sys,json;print(json.load(sys.stdin)["channel_meta"]["channel_id"])')
+  result=$(do_the_real_work "$job")                  # could take minutes
+  reply "c_$(date +%s)" "$ch" "$result"              # send_message any time, no bundle needed
+done
+```
+
+Tool calls are **not gated on holding a bundle** — you can `send_message` (or call any tool) at any time. The bundle lifecycle only governs the *inbound* cursor.
+
+### 2c · Free-running (most autonomous)
+
+Ack and `end` straight away, keep the full conversation in **your own memory**, and let your own loop decide entirely when to act, what to send, and how to schedule work. ws-local becomes a pure I/O pipe; the agent owns all behaviour.
+
+```bash
+bundle)
+  bid=$(echo "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin)["bundle_id"])')
+  echo "$line" >> "$SD/inbox.ndjson"   # your memory
+  ack "$bid"; end "$bid"               # never block the cursor
+  ;;
+# ...elsewhere, your agent loop reads inbox.ndjson + its own state and calls
+#    reply / other tools on its own schedule (proactive pings, batched answers, …)
+```
+
+**Trade-offs:** 2a = ordered + trivial, but one slow turn blocks intake. 2b = high throughput, needs a queue + worker and you manage your own ordering. 2c = maximum autonomy (proactive messages, your own planner), but you own all scheduling and dedup.
+
+---
+
+## 3 · Tool surface (the six puffo MCP tools)
+
+Each is a `tool_call` routed to the daemon's own puffo MCP implementation; the result comes back as a `tool_result` keyed by your `command_id`. `params` is a flat keyword-arg object. Pick any unique `command_id` per call.
+
+| tool | params (req · opt) | does |
+|---|---|---|
+| `send_message` | `channel`, `text`, `is_visible_to_human` · `root_id` | Post to a channel id (`ch_…`) or DM (`@<slug>`). `root_id` makes it a threaded reply. → `posted <env_id> to <channel>`. |
+| `send_message_with_attachments` | `paths` (1–10 workspace files), `channel`, `is_visible_to_human` · `caption`, `root_id` | Same routing, carries files (8 MiB each). |
+| `get_user_info` | `username` (slug or `@<slug>`) | slug → display_name / avatar / bio; refreshes the profile cache. |
+| `get_post` | `post_ref` (`msg_…`) | Fetch one message from local storage. |
+| `get_channel_history` | `channel` · `limit`, `since`, `before`, `after` | Recent **root posts** in a channel (replies not inlined). |
+| `list_channel_members` | `channel` (`ch_…`) | Member slugs + roles. |
+
+Examples (append to `commands.ndjson`):
+
+```json
+{"type":"tool_call","command_id":"c_1","tool":"send_message","params":{"channel":"ch_abc","text":"on it ✅","is_visible_to_human":true}}
+{"type":"tool_call","command_id":"c_2","tool":"send_message","params":{"channel":"@alice-1a2b","text":"DM reply","is_visible_to_human":true}}
+{"type":"tool_call","command_id":"c_3","tool":"send_message","params":{"channel":"ch_abc","text":"threaded","root_id":"msg_xyz","is_visible_to_human":true}}
+{"type":"tool_call","command_id":"c_4","tool":"get_channel_history","params":{"channel":"ch_abc","limit":20}}
+```
+
+`tool_result` shape (match by `command_id`; multiple may be in flight, order not guaranteed):
+
+```json
+{"type":"tool_result","command_id":"c_1","ok":true,"result":"posted msg_… to ch_abc"}
+{"type":"tool_result","command_id":"c_2","ok":false,"error":"channel … has no resolvable members …"}
+```
+
+### Discipline
+1. **End every bundle** (even "decided not to reply" — that still counts as processed).
+2. **Prefer waiting for `tool_result` before `end`** if you care about the error path; ending first makes any failure informational only (cursor already moved).
+3. **Use the agent's `role` + `profile_md`** from the `connected` event as your system prompt — stay in character.
+
+### Recovery
 | Symptom | Action |
 |---|---|
-| Client exited (no PID, `disconnected` last event) | Restart with the same bundle + passcode. The daemon will redeliver any unacked bundle. |
-| `error` event with `bad password / bad base64` | Passcode wrong or bundle corrupt. Re-export from the operator's web UI. |
-| `error` event with `slot already held` | Another tool is already attached to this agent. Detach that one first, then retry. |
-| WS connects but `connected` never arrives | Daemon problem; check `puffo-agent status` and bridge availability. |
-| You replied but no message landed on Puffo | Check `events.ndjson` for an error frame following the reply. If silent, the daemon accepted it — give server-side relay time to propagate. |
+| client exited / last event `disconnected` | restart with the same bundle + passcode; the daemon redelivers any un-`end`-ed bundle. |
+| `error: wrong password / bad base64` | wrong passcode or corrupt blob — re-export from the operator's UI. |
+| `error: slot already held` | another tool is attached to this agent; `detach` it first. |
+| WS connects but no `connected` | daemon problem — check `puffo-agent status`. |
+| replied but nothing landed | check `events.ndjson` for an error frame after your reply; else give relay time to propagate. |
 
-## What ws-local does NOT support
+---
 
-These puffo MCP tools are deliberately NOT exposed over ws-local — calling them as ``tool_call`` returns an ``unknown tool`` error:
+## 4 · ws-local is just the pipe — the brain is yours
 
-- `refresh`, `reload_system_prompt` — require a harness subprocess, which ws-local agents don't run
-- `install_host_mcp`, `sync_host_mcp` — touch the operator's host config; the operator does these from puffo-agent's own UI
-- Identity ops (export another agent, change agent role) — operator does those from the web UI / puffo-cli
+puffo-agent ws-local deliberately does **only two things**: it moves messages (decrypt inbound, encrypt outbound) and exposes the six basic MCP tools above. **Everything that makes the agent smart is yours to build and own**, in your own process:
 
-Need something else? Tell the operator; protocol extensions land in puffo-agent releases.
+- **Harness / execution loop** — sequential, queued, event-driven, multi-agent… (see §2). ws-local never dictates your control flow.
+- **Skills, planning, tools** — run any MCP servers, sub-agents, or tools you like alongside; ws-local only provides the puffo-side six. Your code can do retrieval, browse, run shells, call other models — none of it touches Puffo crypto.
+- **Memory** — keep conversation state, summaries, embeddings, files, a database — wherever and however you want. The `inbox` / `queue` files above are just one trivial example.
+- **Personality** — seed from the agent's `role` + `profile_md`, then layer whatever prompting / persona system you run.
+
+So treat ws-local as a thin, secure messaging socket for one Puffo identity, and put an arbitrarily sophisticated brain behind it. If you need a capability the six tools don't cover, tell the operator — protocol extensions ship in puffo-agent releases.
+
+### Not supported over ws-local
+These puffo MCP tools return `unknown tool` here — they need a harness subprocess (which ws-local agents don't run) or touch operator-only state, done from puffo-agent's own UI:
+`refresh`, `reload_system_prompt`, `install_host_mcp`, `sync_host_mcp`, and identity ops (export / role changes).

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -167,6 +167,8 @@ below is the authoritative reference.
 - `list_channel_members(channel)` — slugs + roles.
 - `get_channel_history(channel, limit=20, since="", before=0, after=0)`
   — recent **root posts** + reply counts. Replies NOT inlined.
+- `get_dm_history(peer, limit=20, before=0)` — recent **direct
+  messages** with a peer (by slug), oldest-first.
 - `get_thread_history(root_id, limit=50, since="", before=0, after=0)`
   — root + every reply, oldest-first.
 - `get_post(post_ref)` — one envelope by id (local store).

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -76,12 +76,16 @@ class StatusReporter:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
         run_id = f"run_{uuid.uuid4().hex}"
         if _is_local_only_envelope(message_id):
-            # Daemon-minted synthetic envelope (e.g. intro-prompt).
-            # The server has no row for it; skip the POST so we
-            # don't log a 404 WARN per nudge. Run is still tracked
-            # in-memory via the returned run_id.
+            # Daemon-minted synthetic envelope (e.g. intro-prompt). The
+            # server has no row for it, so skip the per-message
+            # /processing/start POST — but still flag the agent busy via
+            # an immediate heartbeat so it shows in-progress while it
+            # composes (e.g. its channel self-intro), instead of looking
+            # idle until the next scheduled beat. No current_message_id:
+            # the message doesn't exist server-side.
             self._current_status = "busy"
-            self._current_message_id = message_id
+            self._current_message_id = None
+            await self._send_heartbeat()
             return run_id
         try:
             await self._http.post(
@@ -105,11 +109,12 @@ class StatusReporter:
         error_text: str | None = None,
     ) -> None:
         if _is_local_only_envelope(message_id):
-            # Symmetric to ``begin_turn`` — local-only envelopes have
-            # no server-side row to mark ended. Update local status
-            # only.
+            # Symmetric to ``begin_turn`` — no server-side row, but push
+            # the idle/error status now instead of waiting for the next
+            # scheduled beat, so the in-progress flag clears promptly.
             self._current_status = "idle" if succeeded else "error"
             self._current_message_id = None
+            await self._send_heartbeat()
             return
         body: dict[str, Any] = {"run_id": run_id, "succeeded": succeeded}
         if error_text is not None:
@@ -155,11 +160,13 @@ class StatusReporter:
             if err is not None:
                 entry["error_text"] = err[:1024]
             payload_runs.append(entry)
-        # If every run was local-only, there's nothing to POST.
+        # If every run was local-only, there's nothing to POST — but
+        # still push the resolved status now (see ``begin_turn``).
         if not payload_runs:
             any_failed = any(not r["succeeded"] for r in runs)
             self._current_status = "error" if any_failed else "idle"
             self._current_message_id = None
+            await self._send_heartbeat()
             return
         try:
             await self._http.post(

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -76,12 +76,10 @@ class StatusReporter:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
         run_id = f"run_{uuid.uuid4().hex}"
         if _is_local_only_envelope(message_id):
-            # Daemon-minted synthetic envelope (e.g. intro-prompt). The
-            # server has no row for it, so skip the per-message
-            # /processing/start POST — but still flag the agent busy via
-            # an immediate heartbeat so it shows in-progress while it
-            # composes (e.g. its channel self-intro), instead of looking
-            # idle until the next scheduled beat. No current_message_id:
+            # Daemon-minted synthetic envelope (e.g. intro-prompt): no
+            # server row, so skip /processing/start — but push an
+            # immediate busy heartbeat so the agent shows in-progress
+            # while it composes (e.g. its intro). No current_message_id:
             # the message doesn't exist server-side.
             self._current_status = "busy"
             self._current_message_id = None

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -32,6 +32,7 @@ PUFFO_CORE_TOOL_NAMES = (
     "list_channels_in_space",
     "list_channel_members",
     "get_channel_history",
+    "get_dm_history",
     "get_thread_history",
     "get_post",
     "get_post_segment",

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -144,6 +144,39 @@ class DataClient:
             logger.warning("data-service: get_channel_history transport: %s", exc)
             return []
 
+    async def get_dm_history(
+        self, peer_slug: str, limit: int = 20, before: int | None = None,
+    ) -> list[StoredMessageDict]:
+        """Recent DM messages exchanged with ``peer_slug``, oldest first.
+        ``before`` is an exclusive ms-epoch upper bound for paging."""
+        path = (
+            f"/v1/data/{urllib.parse.quote(self.agent_id, safe='')}"
+            f"/dms/recent"
+        )
+        params = {"peer": peer_slug, "limit": str(limit)}
+        if before is not None:
+            params["before"] = str(before)
+        session = await self._get_session()
+        try:
+            async with session.get(
+                f"{self.base_url}{path}", params=params,
+            ) as resp:
+                if resp.status == 404:
+                    return []
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.warning(
+                        "data-service: get_dm_history %s -> %d %s",
+                        path, resp.status, body,
+                    )
+                    return []
+                data = await resp.json()
+                msgs = data.get("messages") or []
+                return [_msg_from_dict(m) for m in msgs]
+        except aiohttp.ClientError as exc:
+            logger.warning("data-service: get_dm_history transport: %s", exc)
+            return []
+
     async def get_channel_roots(
         self,
         channel_id: str,

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -526,6 +526,37 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
+    async def get_dm_history(
+        peer: str,
+        limit: int = 20,
+        before: int = 0,
+    ) -> str:
+        """List recent **direct messages** between you and ``peer``,
+        oldest-first, from local storage.
+
+        ``peer`` is the other party's slug (e.g. ``alice-1a2b``) — the
+        same slug you'd DM with ``send_message``. ``before`` is an
+        optional ms-epoch upper bound (exclusive) for paging back.
+
+        Output lines: ``<ts>  msg:<envelope_id>  @<sender>: <text>``,
+        oldest-first."""
+        limit = max(1, min(int(limit), 200))
+        peer_slug = peer.strip().lstrip("@")
+        if not peer_slug:
+            raise RuntimeError("pass the peer's slug to read DM history.")
+        msgs = await cfg.data_client.get_dm_history(
+            peer_slug, limit=limit, before=int(before) if before else None,
+        )
+        if not msgs:
+            return "(no direct messages with that peer in the requested window)"
+        lines = []
+        for m in msgs:
+            ts = _ts_to_iso(m.sent_at)
+            text = str(m.content).replace("\n", " ") if m.content else ""
+            lines.append(f"{ts}  msg:{m.envelope_id}  @{m.sender_slug}: {text}")
+        return "\n".join(lines)
+
+    @mcp.tool()
     async def get_thread_history(
         root_id: str,
         limit: int = 50,

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -149,6 +149,40 @@ async def list_recent_messages(request: web.Request) -> web.Response:
     })
 
 
+async def list_dm_history(request: web.Request) -> web.Response:
+    """Recent DM messages with a peer (by slug), oldest first."""
+    agent_id = request.match_info["agent_id"]
+    peer = request.query.get("peer", "")
+    if not peer:
+        return web.json_response(
+            {"error": "peer query param required"}, status=400,
+        )
+    try:
+        limit = max(1, min(int(request.query.get("limit", "20")), 200))
+        before_raw = request.query.get("before")
+        before = int(before_raw) if before_raw else None
+    except ValueError:
+        return web.json_response(
+            {"error": "limit/before must be integers"}, status=400,
+        )
+    store = await _store_for(request.app, agent_id)
+    if store is None:
+        return web.json_response({"error": "agent db not found"}, status=404)
+    try:
+        msgs = await store.get_dm_history(peer, limit, before)
+    except Exception as exc:
+        logger.exception(
+            "data-service: get_dm_history failed (agent=%s peer=%s)",
+            agent_id, peer,
+        )
+        return web.json_response(
+            {"error": f"dm history fetch failed: {exc}"}, status=500,
+        )
+    return web.json_response({
+        "messages": [_msg_to_dict(m) for m in msgs],
+    })
+
+
 def _parse_int_param(value: str | None, name: str) -> tuple[int | None, web.Response | None]:
     """Return (parsed, error_response). ``None, None`` if missing."""
     if value is None or value == "":
@@ -365,6 +399,10 @@ def build_app(cfg: DataServiceConfig) -> web.Application:
     app.router.add_get(
         "/v1/data/{agent_id}/messages/recent",
         list_recent_messages,
+    )
+    app.router.add_get(
+        "/v1/data/{agent_id}/dms/recent",
+        list_dm_history,
     )
     app.router.add_get(
         "/v1/data/{agent_id}/channels/roots",

--- a/src/puffo_agent/portal/ws_local/in_process_data_client.py
+++ b/src/puffo_agent/portal/ws_local/in_process_data_client.py
@@ -49,6 +49,11 @@ class InProcessDataClient:
             after_ts=after_ts,
         )
 
+    async def get_dm_history(
+        self, peer_slug: str, limit: int = 20, before: int | None = None,
+    ) -> list["StoredMessage"]:
+        return await self._store.get_dm_history(peer_slug, limit, before)
+
     async def get_thread_messages(
         self,
         root_id: str,

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -22,6 +22,7 @@ WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
     "get_user_info",
     "get_post",
     "get_channel_history",
+    "get_dm_history",
     "list_channel_members",
 })
 

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -1,10 +1,12 @@
 """ws-local ``tool_call`` dispatch.
 
 Reuses ``mcp.puffo_core_tools.register_core_tools`` by feeding it a
-FastMCP stand-in that captures handlers by name. ws-local exposes
-only the six message-shaped tools — subprocess-bound ones
-(``refresh``, ``reload_system_prompt``, ``install_host_mcp``,
-``sync_host_mcp``) are filtered out.
+FastMCP stand-in that captures handlers by name. ws-local exposes the
+message-shaped + read/navigation tools; harness/host/identity ops
+(``refresh``, ``reload_system_prompt``, ``install_*``, ``*_skill``,
+``*_mcp_server``, ``list_mcp_servers``, ``sync_host_mcp``) are filtered
+out — the harness, skills, and host config belong to the attached tool,
+not to puffo-agent.
 """
 
 from __future__ import annotations
@@ -17,13 +19,21 @@ WsLocalTool = Callable[..., Awaitable[Any]]
 
 
 WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
+    # send
     "send_message",
     "send_message_with_attachments",
+    # read / navigation
     "get_user_info",
+    "whoami",
     "get_post",
+    "get_post_segment",
     "get_channel_history",
     "get_dm_history",
+    "get_thread_history",
     "list_channel_members",
+    "list_spaces",
+    "list_channels_in_space",
+    "list_channels_in_all_spaces",
 })
 
 

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -102,6 +102,50 @@ async def test_recent_messages_returns_chronological() -> None:
         assert msgs[0]["sender_slug"] == "alice"
 
 
+async def _seed_dms(home: str, agent_id: str) -> None:
+    agent_path = Path(home) / "agents" / agent_id
+    agent_path.mkdir(parents=True, exist_ok=True)
+    store = MessageStore(agent_path / "messages.db")
+    await store.open()
+    for env, sender, recip, ts in (
+        ("dm_1", "alice", "me", 1700000000_000),
+        ("dm_2", "me", "alice", 1700000001_000),
+        ("dm_3", "bob", "me", 1700000002_000),   # different peer
+    ):
+        await store.store({
+            "envelope_id": env, "envelope_kind": "dm",
+            "sender_slug": sender, "recipient_slug": recip,
+            "content_type": "text/plain", "content": env, "sent_at": ts,
+        })
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_dm_history_route_returns_peer_dms() -> None:
+    home = _isolated_home()
+    await _seed_dms(home, "agent-dm-1")
+    app = ds.build_app(ds.DataServiceConfig())
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get(
+            "/v1/data/agent-dm-1/dms/recent",
+            params={"peer": "alice", "limit": "10"},
+        )
+        assert resp.status == 200
+        body = await resp.json()
+        # only the alice DMs, chronological; bob's excluded
+        assert [m["envelope_id"] for m in body["messages"]] == ["dm_1", "dm_2"]
+
+
+@pytest.mark.asyncio
+async def test_dm_history_route_requires_peer() -> None:
+    home = _isolated_home()
+    await _seed_dms(home, "agent-dm-2")
+    app = ds.build_app(ds.DataServiceConfig())
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/data/agent-dm-2/dms/recent")
+        assert resp.status == 400
+
+
 @pytest.mark.asyncio
 async def test_message_by_envelope_returns_single_row() -> None:
     home = _isolated_home()

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -506,6 +506,44 @@ async def test_get_channel_history_unknown_channel():
 
 
 @pytest.mark.asyncio
+async def test_get_dm_history_from_local():
+    cfg, _, ms = _setup()
+    await ms.open()
+    base = _now_ms()
+    await ms.store({
+        "envelope_id": "dm_1", "envelope_kind": "dm",
+        "sender_slug": "alice-0001", "recipient_slug": "me-0001",
+        "content_type": "text/plain", "content": "hi from alice", "sent_at": base,
+    })
+    await ms.store({
+        "envelope_id": "dm_2", "envelope_kind": "dm",
+        "sender_slug": "me-0001", "recipient_slug": "alice-0001",
+        "content_type": "text/plain", "content": "hi back", "sent_at": base + 1000,
+    })
+    await ms.store({
+        "envelope_id": "dm_3", "envelope_kind": "dm",
+        "sender_slug": "bob-0002", "recipient_slug": "me-0001",
+        "content_type": "text/plain", "content": "bob here", "sent_at": base + 2000,
+    })
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "get_dm_history", {"peer": "alice-0001", "limit": 10})
+    assert "hi from alice" in result
+    assert "hi back" in result
+    assert "bob here" not in result   # a different peer is filtered out
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_get_dm_history_empty():
+    cfg, _, ms = _setup()
+    await ms.open()
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "get_dm_history", {"peer": "nobody-9999"})
+    assert "no direct messages" in result
+    await ms.close()
+
+
+@pytest.mark.asyncio
 async def test_get_channel_history_empty_window():
     """Channel exists but the ``since`` filter pushes past every
     root → 'no root posts in the requested window'."""

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -300,19 +300,25 @@ async def test_end_turn_batch_swallows_http_error():
 @pytest.mark.asyncio
 async def test_begin_turn_skips_http_for_local_only_envelope():
     """Daemon-minted synthetic envelopes (intro-prompt-...) have no
-    server-side row. Posting to ``/messages/<id>/processing/start``
-    used to 404 and log a WARN per nudge — kill that noise."""
+    server-side row, so we skip ``/messages/<id>/processing/start``
+    (which used to 404 + WARN per nudge) — but push an immediate busy
+    heartbeat so the agent shows in-progress while composing its intro,
+    not idle until the next scheduled beat."""
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=999)
 
     run_id = await rep.begin_turn("intro-prompt-ch_xxx-1778641626040")
 
     assert run_id.startswith("run_")
-    assert http.calls == []  # No round-trip.
-    # Local-only run still flips state to busy so the heartbeat
-    # carries the in-progress envelope id.
+    # No per-message processing POST — just a busy heartbeat.
+    assert not any(p.endswith("/processing/start") for p, _ in http.calls)
+    assert len(http.calls) == 1
+    path, body = http.calls[0]
+    assert path == "/agents/me/heartbeat"
+    assert body["status"] == "busy"
+    assert "current_message_id" not in body   # synthetic id isn't sent
     assert rep._current_status == "busy"
-    assert rep._current_message_id == "intro-prompt-ch_xxx-1778641626040"
+    assert rep._current_message_id is None
 
 
 @pytest.mark.asyncio
@@ -324,7 +330,12 @@ async def test_end_turn_skips_http_for_local_only_envelope():
 
     await rep.end_turn("intro-prompt-ch_a-1", "run_x", succeeded=True)
 
-    assert http.calls == []
+    # No /processing/end POST — just an idle heartbeat.
+    assert not any("/processing/" in p for p, _ in http.calls)
+    assert len(http.calls) == 1
+    path, body = http.calls[0]
+    assert path == "/agents/me/heartbeat"
+    assert body["status"] == "idle"
     assert rep._current_status == "idle"
     assert rep._current_message_id is None
 
@@ -351,15 +362,20 @@ async def test_end_turn_batch_filters_local_only_runs():
 
 @pytest.mark.asyncio
 async def test_end_turn_batch_all_local_only_skips_http():
-    """All-synthetic batches don't hit the wire — there's nothing
-    for the server to upsert."""
+    """All-synthetic batches don't hit the processing endpoint — but
+    still push an idle heartbeat so the in-progress flag clears."""
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=999)
+    rep._current_status = "busy"
 
     await rep.end_turn_batch([
         {"run_id": "run_a", "message_id": "intro-prompt-ch_a-1", "succeeded": True},
         {"run_id": "run_b", "message_id": "intro-prompt-ch_b-1", "succeeded": True},
     ])
 
-    assert http.calls == []
+    assert not any("/processing/" in p for p, _ in http.calls)
+    assert len(http.calls) == 1
+    path, body = http.calls[0]
+    assert path == "/agents/me/heartbeat"
+    assert body["status"] == "idle"
     assert rep._current_status == "idle"

--- a/tests/test_ws_local_in_process_data_client.py
+++ b/tests/test_ws_local_in_process_data_client.py
@@ -53,6 +53,15 @@ async def test_get_channel_roots_forwards_kwargs():
 
 
 @pytest.mark.asyncio
+async def test_get_dm_history_forwards():
+    client, store, _ = _make_client()
+    store.get_dm_history = AsyncMock(return_value=["m1"])
+    out = await client.get_dm_history("alice-1a", limit=10, before=123)
+    assert out == ["m1"]
+    store.get_dm_history.assert_awaited_once_with("alice-1a", 10, 123)
+
+
+@pytest.mark.asyncio
 async def test_get_thread_messages_forwards_kwargs():
     client, store, _ = _make_client()
     await client.get_thread_messages(

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -19,13 +19,14 @@ from puffo_agent.portal.ws_local.tool_dispatch import (
 )
 
 
-def test_allowed_tools_are_the_six_message_shaped_ones():
+def test_allowed_tools_are_the_message_shaped_ones():
     assert WS_LOCAL_ALLOWED_TOOLS == frozenset({
         "send_message",
         "send_message_with_attachments",
         "get_user_info",
         "get_post",
         "get_channel_history",
+        "get_dm_history",
         "list_channel_members",
     })
 

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -19,16 +19,34 @@ from puffo_agent.portal.ws_local.tool_dispatch import (
 )
 
 
-def test_allowed_tools_are_the_message_shaped_ones():
+def test_allowed_tools_are_the_send_and_read_tools():
     assert WS_LOCAL_ALLOWED_TOOLS == frozenset({
+        # send
         "send_message",
         "send_message_with_attachments",
+        # read / navigation
         "get_user_info",
+        "whoami",
         "get_post",
+        "get_post_segment",
         "get_channel_history",
         "get_dm_history",
+        "get_thread_history",
         "list_channel_members",
+        "list_spaces",
+        "list_channels_in_space",
+        "list_channels_in_all_spaces",
     })
+
+
+def test_harness_and_host_tools_excluded():
+    """Harness/host/identity ops must NOT be reachable over ws-local."""
+    for t in (
+        "refresh", "reload_system_prompt", "install_skill", "list_skills",
+        "install_mcp_server", "list_mcp_servers", "install_host_mcp",
+        "sync_host_mcp",
+    ):
+        assert t not in WS_LOCAL_ALLOWED_TOOLS
 
 
 def test_build_dispatch_returns_only_allowed_handlers():


### PR DESCRIPTION
## Summary

0.12.2 follow-ups — the intro fix + `get_dm_history`, plus the ws-local tool expansion and skill rewrite that came out of live testing.

### 1. Agents show in-progress while posting their channel intro
The self-intro nudge is a synthetic (server-rowless) envelope, so the status reporter skipped reporting busy — the agent looked idle while composing its intro. `begin`/`end` for those envelopes now push an immediate busy/idle heartbeat. (The `/processing/*` 404-noise skip is preserved.)

### 2. New `get_dm_history` MCP tool
Read DM history with a peer (by slug), mirroring `get_channel_history`. Wired across every surface: primer, allow-gate, `@mcp.tool` registration, data-service route + HTTP/in-process data clients, ws-local dispatch.

### 3. ws-local tool surface: 7 → 13
ws-local now also routes the read/navigation tools — `whoami`, `get_post_segment`, `get_thread_history`, `get_dm_history`, `list_spaces`, `list_channels_in_space`, `list_channels_in_all_spaces` — not just send + message-shaped reads. Harness/host/identity ops stay filtered out by design. **Verified live: all 13 return real data over a Twinkle ws-local session.**

### 4. ws-local skill rewrite (`use-puffo-agent-ws-local`)
Restructured for an attaching AI agent: Install (→ chat.puffo.ai/setup.md) → When-to-use → Start → Monitor → Discipline → Reference. Adds per-OS connect+listen scripts, three reply strategies (sequential / queued / free-running), all 13 tools, an extensibility section (ws-local is just the pipe; harness / skills / MCPs / memory / loop are the agent's own), and — learned live — a hard emphasis on **persistent listening** + **ending every bundle promptly** (single-bundle-in-flight: an un-ended bundle blocks the next message, including a DM to you).

## Testing
- Full suite: **1334 passed, 9 skipped**.
- New tests: DM tool (MCP / in-process / data-service route), 13-tool allowlist + harness-ops-excluded, status-reporter local-only heartbeats.
- Live: all 13 ws-local tools exercised end-to-end via a Twinkle attach session.

Targets **0.12.2** (unreleased) — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
