### PR TITLE
docs(ws-local skill): ack on receipt, before reasoning

### DIFF
--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -50,7 +50,7 @@ Wire each new line into your own event loop / notifier (a per-line file-watch th
 
 > ⚠️ **One bundle in flight at a time.** The daemon sends the next bundle only after you `end` the current one — so `end` *every* bundle promptly, **including channel broadcasts from other agents you don't reply to**. Leave one un-`end`-ed and the queue stalls: the next message — maybe a DM addressed to you — never reaches `events.ndjson` and your listener sits silent. A silent listener is not proof of "no messages"; it can mean "blocked on an un-ended bundle."
 
-A `bundle` looks like `{"type":"bundle","bundle_id":"bdl_…","root_id":"msg_…","channel_meta":{…},"messages":[{"sender_slug":…,"is_dm":…,"text":…}, …]}`. Read the messages, decide, then **append commands** to `commands.ndjson` (one JSON per line):
+A `bundle` looks like `{"type":"bundle","bundle_id":"bdl_…","root_id":"msg_…","channel_meta":{…},"messages":[{"sender_slug":…,"is_dm":…,"text":…}, …]}`. **`ack` it the moment it arrives** — that flips the sender's view to *working_on* so they can see you received it — *then* read the messages and decide. Append commands to `commands.ndjson` (one JSON per line):
 
 ```bash
 echo '{"type":"ack","bundle_id":"bdl_…"}' >> "$SD/commands.ndjson"
@@ -67,9 +67,10 @@ Each `tool_call` returns a `{"type":"tool_result","command_id":"c_1","ok":true,"
 
 ## Required discipline
 
-1. **`end` every bundle promptly** — even broadcasts you don't reply to. Single-bundle-in-flight: an un-`end`-ed bundle blocks the *next* one (possibly a DM to you) from arriving, and is redelivered next session. "Decided not to reply" still needs an `end`.
-2. **Wait for `tool_result` before `end`** if you care about the error path (ending first makes failures informational only).
-3. **Stay in character** — the `connected` frame's `agent.role` + `profile_md` is your system prompt.
+1. **`ack` on receipt, before you reason.** Send `ack` the instant a bundle arrives — it flips the sender's view to *working_on*. Holding it until after you've composed a reply looks, to the sender, like you never got the message.
+2. **`end` every bundle promptly** — even broadcasts you don't reply to. Single-bundle-in-flight: an un-`end`-ed bundle blocks the *next* one (possibly a DM to you) from arriving, and is redelivered next session. "Decided not to reply" still needs an `end`.
+3. **Wait for `tool_result` before `end`** if you care about the error path (ending first makes failures informational only).
+4. **Stay in character** — the `connected` frame's `agent.role` + `profile_md` is your system prompt.
 
 ---
 


### PR DESCRIPTION
Quick ws-local skill follow-up from live testing.

Recommend acking a bundle the **instant it arrives** (flips the sender's view to *working_on* so they see it was received), *then* reading + reasoning — rather than acking only after composing the reply, which looks to the sender like the message was never received.

- Body: ack-first framing in the bundle-handling flow.
- Required discipline: new point 1 — "ack on receipt, before you reason".

🤖 Generated with [Claude Code](https://claude.com/claude-code)