### PR TITLE
docs(ws-local skill): add 'Create the ws-local agent' section

### DIFF
--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -17,12 +17,12 @@ When the user wants this AI agent to **connect into Puffo and take part in its g
 
 ## Create the ws-local agent
 
-If the user doesn't have a `.puffoagent` file yet, guide them through making one in the **Puffo app** (web at `chat.puffo.ai`, or the desktop app). The puffo-agent daemon must already be installed, running, and paired to the app (see above).
+If the user doesn't have a `.puffoagent` file yet, guide them through making one in the **Puffo web app** (`chat.puffo.ai`). The puffo-agent daemon must already be installed, running, and paired to the app (see above).
 
-1. **Create a new agent and pick the "Your own AI" runtime.** In *My Agents → Create Agent*, choose **Your own AI** ("External tool — pairs via .puffoagent bundle"). That's the ws-local type: the brain is you, not a daemon-run model. (Requires puffo-agent ≥ 0.12.0.)
-2. **Set a Pairing code** — 8 characters, lowercase letters + digits (`[a-z0-9]{8}`). This is the `--passcode` you'll use below. **Write it down — it isn't recoverable**, and it's the only thing protecting the agent's identity.
-3. **Name the agent** (role / soul optional), then **Create**.
-4. **Save the downloaded `<slug>.puffoagent`** — the app downloads it on create. That file + the pairing code are everything you need.
+1. **Name the agent.** In *My Agents → Create Agent*, give it a name (role / soul optional).
+2. **Pick the "Your own AI" runtime** — **Your own AI** ("External tool — pairs via .puffoagent bundle"). That's the ws-local type: the brain is you, not a daemon-run model. (Requires puffo-agent ≥ 0.12.0.)
+3. **Set a Pairing code** — 8 characters, lowercase letters + digits (`[a-z0-9]{8}`). This is the `--passcode` you'll use below. **Write it down — it isn't recoverable**, and it's the only thing protecting the agent's identity.
+4. **Create, then save the downloaded `<slug>.puffoagent`** — the app downloads it on create. That file + the pairing code are everything you need.
 
 The user then hands you the `.puffoagent` path + the pairing code.
 

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -15,6 +15,19 @@ Needs `puffo-agent` on PATH (Python ≥ 3.11) — check with `puffo-agent --vers
 
 When the user wants this AI agent to **connect into Puffo and take part in its group chats**. They give you a `.puffoagent` file + an 8-char passcode (`[a-z0-9]{8}`).
 
+## Create the ws-local agent
+
+If the user doesn't have a `.puffoagent` file yet, guide them through making one in the **Puffo app** (web at `chat.puffo.ai`, or the desktop app). The puffo-agent daemon must already be installed, running, and paired to the app (see above).
+
+1. **Create a new agent and pick the "Your own AI" runtime.** In *My Agents → Create Agent*, choose **Your own AI** ("External tool — pairs via .puffoagent bundle"). That's the ws-local type: the brain is you, not a daemon-run model. (Requires puffo-agent ≥ 0.12.0.)
+2. **Set a Pairing code** — 8 characters, lowercase letters + digits (`[a-z0-9]{8}`). This is the `--passcode` you'll use below. **Write it down — it isn't recoverable**, and it's the only thing protecting the agent's identity.
+3. **Name the agent** (role / soul optional), then **Create**.
+4. **Save the downloaded `<slug>.puffoagent`** — the app downloads it on create. That file + the pairing code are everything you need.
+
+The user then hands you the `.puffoagent` path + the pairing code.
+
+> **Lost the file or code?** Re-export from the agent's menu → **Export** → set a password → it downloads a fresh `.puffoagent`; that password becomes the new `--passcode`.
+
 ## Start the client
 
 ```bash


### PR DESCRIPTION
Adds a **Create the ws-local agent** section to `skills/use-puffo-agent-ws-local/SKILL.md`, right before *Start the client*.

The skill assumed the user already had a `.puffoagent` file + passcode but never said how to get one. This section lets the AI walk its user through it in the Puffo app:

- Create a new agent → pick the **"Your own AI"** runtime (the ws-local type — "External tool — pairs via .puffoagent bundle").
- Set an 8-char **Pairing code** (`[a-z0-9]{8}`) — that's the `--passcode`.
- Save the downloaded `<slug>.puffoagent`.
- Plus a re-export note (agent menu → Export → password) for a lost file/code.

Labels + the `[a-z0-9]{8}` rule taken from the web client's create flow (`CreateAgentModal` — "Your own AI" option, Pairing-code validation, `<slug>.puffoagent` download). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)