### PR TITLE
feat(cli_bin): resolve claude/codex via the user's real PATH + persist it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   whose modification time predated 1980 (which ZIP can't represent)
   failed the whole `.puffoagent` export with a `ValueError`; entries are
   now stamped with the current time.
+- **`claude` / `codex` are found even when off the daemon's PATH.** A
+  daemon started by a service / before a shell-profile refresh inherits
+  a narrow, stale PATH and missed npm-global / scoop / nvm / homebrew
+  installs. The resolver now reconstructs the user's real PATH
+  (Machine+User registry env on Windows, a login shell on POSIX) and
+  caches the resolved path to `resolved_clis.json`, so restarts don't
+  re-search.
 
 ## [0.12.3] — 2026-06-11
 

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -1,21 +1,20 @@
 """Resolve ``codex`` and ``claude`` binaries with broader-than-PATH
 search.
 
-LaunchAgent (macOS) and Windows service contexts run with a narrow
-PATH that misses ``/opt/homebrew/bin`` (Apple Silicon Homebrew) and
-ignores ``.app`` bundles entirely. Operators who installed Codex via
-the desktop app (binary tucked inside
-``/Applications/Codex.app/Contents/Resources/codex``) hit
-``[Errno 2] No such file or directory: 'codex'`` even though the
-binary exists.
-
-The resolver layers three lookups so the operator doesn't need to
-fiddle with ``launchd`` plists or symlink the binary into ``/usr/local/bin``:
+A daemon started by a LaunchAgent (macOS) / Windows service / before a
+shell-profile refresh inherits a narrow, stale PATH that misses
+npm-global / scoop / nvm / fnm / volta / homebrew installs. The
+resolver layers, in order:
 
 1. ``$PUFFO_<NAME>_BIN`` env var — explicit operator override.
-2. ``shutil.which(<name>)`` — npm / brew / scoop install.
-3. OS-specific bundle paths — Codex.app on macOS, %LOCALAPPDATA%
-   on Windows, /opt on Linux.
+2. Caches — an in-memory one for this daemon's lifetime and a
+   ``resolved_clis.json`` file so a restart skips the (slow) PATH
+   reconstruction; both validated against the filesystem.
+3. ``shutil.which`` against the process PATH.
+4. ``shutil.which`` against the user's *real* PATH, reconstructed from
+   the persistent Machine+User registry env (Windows) or a login shell
+   (POSIX) — catches installs the narrow process PATH missed.
+5. OS-specific bundle paths (desktop-app installs).
 
 Returns absolute path on hit, ``None`` on full miss. Callers
 distinguish "binary missing" (raise / report to status) from
@@ -24,11 +23,17 @@ distinguish "binary missing" (raise / report to status) from
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+# Resolved-path caches: in-memory for this daemon's lifetime, plus a
+# JSON file so a restart skips the (slow) real-PATH reconstruction.
+_resolve_memcache: dict[str, str] = {}
+_real_path_cache: str | None = None
 
 
 def resolve_codex_bin() -> str | None:
@@ -55,18 +60,138 @@ def resolve_hermes_bin() -> str | None:
 
 
 def _resolve(name: str, env_var: str, bundle_paths: list[Path]) -> str | None:
+    # 1. Explicit operator override — always wins, read live.
     env_override = os.environ.get(env_var)
     if env_override:
         p = Path(env_override).expanduser()
         if p.is_file():
             return str(p)
-    on_path = shutil.which(name)
-    if on_path:
-        return on_path
-    for cand in bundle_paths:
+    # 2. Caches (in-memory, then on-disk) — validated against the FS so
+    #    an uninstalled / moved binary falls through to a fresh lookup.
+    cached = _resolve_memcache.get(name)
+    if cached and Path(cached).is_file():
+        return cached
+    saved = _read_path_cache().get(name)
+    if saved and Path(saved).is_file():
+        _resolve_memcache[name] = saved
+        return saved
+    # 3-5. Live lookup: process PATH → the user's real (reconstructed)
+    #      PATH → OS bundle paths. Persist whatever resolves.
+    resolved = shutil.which(name)
+    if not resolved:
+        resolved = shutil.which(name, path=_real_path())
+    if not resolved:
+        resolved = _first_existing(bundle_paths)
+    if resolved:
+        _resolve_memcache[name] = resolved
+        _write_path_cache(name, resolved)
+    return resolved
+
+
+def _first_existing(paths: list[Path]) -> str | None:
+    for cand in paths:
         if cand.is_file():
             return str(cand)
     return None
+
+
+# ── Real-PATH reconstruction (broader than the daemon's process PATH) ──
+
+
+def _real_path() -> str:
+    """The user's actual PATH, reconstructed + cached once. Falls back
+    to the process PATH if the reconstruction fails."""
+    global _real_path_cache
+    if _real_path_cache is None:
+        base = os.environ.get("PATH", "")
+        extra = (
+            _windows_persistent_path() if sys.platform == "win32"
+            else _login_shell_path()
+        )
+        _real_path_cache = _merge_path(base, extra)
+    return _real_path_cache
+
+
+def _windows_persistent_path() -> str:
+    """Machine + User ``Path`` from the registry, env-expanded — what a
+    fresh shell sees, not the service's stale process PATH."""
+    script = (
+        "[Environment]::ExpandEnvironmentVariables("
+        "([Environment]::GetEnvironmentVariable('Path','Machine') + ';' + "
+        "[Environment]::GetEnvironmentVariable('Path','User')))"
+    )
+    return _run_capture(
+        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script]
+    )
+
+
+def _login_shell_path() -> str:
+    """The PATH a login + interactive shell sets — picks up nvm / fnm /
+    volta / homebrew sourced from the user's profile + rc files."""
+    shell = os.environ.get("SHELL") or "/bin/sh"
+    out = _run_capture([shell, "-ilc", 'printf "P=%s" "$PATH"'])
+    for line in out.splitlines():
+        if line.startswith("P="):
+            return line[2:]
+    return ""
+
+
+def _run_capture(cmd: list[str]) -> str:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=8)
+        return r.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _merge_path(*values: str) -> str:
+    """Concatenate PATH strings, dropping empties + duplicates
+    (case-insensitive on Windows)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        for seg in value.split(os.pathsep):
+            seg = seg.strip()
+            if not seg:
+                continue
+            key = seg.lower() if sys.platform == "win32" else seg
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(seg)
+    return os.pathsep.join(out)
+
+
+# ── Resolved-path cache file ──────────────────────────────────────────
+
+
+def _cache_file() -> Path:
+    from ..portal.state import home_dir  # lazy — avoid an import cycle
+
+    return home_dir() / "resolved_clis.json"
+
+
+def _read_path_cache() -> dict:
+    try:
+        data = json.loads(_cache_file().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_path_cache(name: str, path: str) -> None:
+    cache = _read_path_cache()
+    if cache.get(name) == path:
+        return
+    cache[name] = path
+    target = _cache_file()
+    tmp = target.with_suffix(".json.tmp")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError:
+        pass  # best-effort cache
 
 
 def _codex_bundle_paths() -> list[Path]:

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -1,11 +1,24 @@
 """Unit tests for ``puffo_agent.agent.cli_bin``."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 from puffo_agent.agent import cli_bin
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    # Isolate the on-disk cache + neutralize the (subprocess) real-PATH
+    # reconstruction so unit tests never fork PowerShell / a login shell.
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(cli_bin, "_real_path", lambda: "")
+    cli_bin._resolve_memcache.clear()
+    monkeypatch.setattr(cli_bin, "_real_path_cache", None)
+    yield
+    cli_bin._resolve_memcache.clear()
 
 
 def _make_exe(tmp_path: Path, name: str) -> Path:
@@ -19,7 +32,7 @@ def test_env_override_wins(tmp_path, monkeypatch):
     """``$PUFFO_CODEX_BIN`` beats PATH + bundle paths."""
     fake = _make_exe(tmp_path, "fake_codex")
     monkeypatch.setenv("PUFFO_CODEX_BIN", str(fake))
-    monkeypatch.setattr("shutil.which", lambda _name: "/some/other/codex")
+    monkeypatch.setattr("shutil.which", lambda name, path=None: "/some/other/codex")
     assert cli_bin.resolve_codex_bin() == str(fake)
 
 
@@ -28,13 +41,13 @@ def test_env_override_ignored_when_file_missing(tmp_path, monkeypatch):
     falls through to PATH — protects against stale env vars."""
     bogus = tmp_path / "nope" / "codex"
     monkeypatch.setenv("PUFFO_CODEX_BIN", str(bogus))
-    monkeypatch.setattr("shutil.which", lambda _name: "/from/path/codex")
+    monkeypatch.setattr("shutil.which", lambda name, path=None: "/from/path/codex")
     assert cli_bin.resolve_codex_bin() == "/from/path/codex"
 
 
 def test_path_used_when_env_unset(monkeypatch):
     monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
-    monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/codex")
+    monkeypatch.setattr("shutil.which", lambda name, path=None: "/usr/local/bin/codex")
     assert cli_bin.resolve_codex_bin() == "/usr/local/bin/codex"
 
 
@@ -43,14 +56,14 @@ def test_bundle_path_hit_when_env_and_path_miss(tmp_path, monkeypatch):
     bundle path resolves the binary."""
     bundled = _make_exe(tmp_path, "codex_bundled")
     monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
     monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [bundled])
     assert cli_bin.resolve_codex_bin() == str(bundled)
 
 
 def test_returns_none_on_full_miss(monkeypatch):
     monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
     monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [])
     assert cli_bin.resolve_codex_bin() is None
 
@@ -61,7 +74,7 @@ def test_claude_resolver_uses_its_own_env(tmp_path, monkeypatch):
     fake_claude = _make_exe(tmp_path, "fake_claude")
     monkeypatch.setenv("PUFFO_CLAUDE_BIN", str(fake_claude))
     monkeypatch.setenv("PUFFO_CODEX_BIN", "/should/not/leak")
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
     monkeypatch.setattr(cli_bin, "_claude_bundle_paths", lambda: [])
     assert cli_bin.resolve_claude_bin() == str(fake_claude)
 
@@ -89,19 +102,19 @@ def test_hermes_env_override_wins(tmp_path, monkeypatch):
     """``$PUFFO_HERMES_BIN`` beats PATH + bundle paths."""
     fake = _make_exe(tmp_path, "fake_hermes")
     monkeypatch.setenv("PUFFO_HERMES_BIN", str(fake))
-    monkeypatch.setattr("shutil.which", lambda _name: "/some/other/hermes")
+    monkeypatch.setattr("shutil.which", lambda name, path=None: "/some/other/hermes")
     assert cli_bin.resolve_hermes_bin() == str(fake)
 
 
 def test_hermes_path_used_when_env_unset(monkeypatch):
     monkeypatch.delenv("PUFFO_HERMES_BIN", raising=False)
-    monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/hermes")
+    monkeypatch.setattr("shutil.which", lambda name, path=None: "/usr/local/bin/hermes")
     assert cli_bin.resolve_hermes_bin() == "/usr/local/bin/hermes"
 
 
 def test_hermes_returns_none_on_full_miss(monkeypatch):
     monkeypatch.delenv("PUFFO_HERMES_BIN", raising=False)
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
     monkeypatch.setattr(cli_bin, "_hermes_bundle_paths", lambda: [])
     assert cli_bin.resolve_hermes_bin() is None
 
@@ -114,9 +127,58 @@ def test_hermes_resolver_uses_its_own_env(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_HERMES_BIN", str(fake_hermes))
     monkeypatch.setenv("PUFFO_CODEX_BIN", "/should/not/leak")
     monkeypatch.setenv("PUFFO_CLAUDE_BIN", "/should/not/leak")
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
     monkeypatch.setattr(cli_bin, "_hermes_bundle_paths", lambda: [])
     assert cli_bin.resolve_hermes_bin() == str(fake_hermes)
+
+
+def test_real_path_used_when_process_path_misses(monkeypatch):
+    """When the process PATH misses, resolution retries against the
+    reconstructed real PATH."""
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr(cli_bin, "_real_path", lambda: "/real/bin")
+    monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [])
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name, path=None: "/real/bin/codex" if path == "/real/bin" else None,
+    )
+    assert cli_bin.resolve_codex_bin() == "/real/bin/codex"
+
+
+def test_resolved_path_survives_restart_via_disk_cache(tmp_path, monkeypatch):
+    """First resolve writes resolved_clis.json; a later resolve (fresh
+    process, PATH now missing) reads it back instead of re-searching."""
+    real = _make_exe(tmp_path, "codex_real")
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [])
+    monkeypatch.setattr("shutil.which", lambda name, path=None: str(real))
+    assert cli_bin.resolve_codex_bin() == str(real)
+
+    # Simulate a restart: in-memory cache gone, binary no longer on PATH.
+    cli_bin._resolve_memcache.clear()
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
+    assert cli_bin.resolve_codex_bin() == str(real)  # served from disk cache
+
+
+def test_disk_cache_rejected_when_binary_gone(tmp_path, monkeypatch):
+    """A cached path that no longer exists falls through to a fresh
+    lookup instead of returning a dead path."""
+    real = _make_exe(tmp_path, "codex_real")
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [])
+    monkeypatch.setattr("shutil.which", lambda name, path=None: str(real))
+    assert cli_bin.resolve_codex_bin() == str(real)
+
+    real.unlink()  # uninstalled
+    cli_bin._resolve_memcache.clear()
+    monkeypatch.setattr("shutil.which", lambda name, path=None: None)
+    assert cli_bin.resolve_codex_bin() is None
+
+
+def test_merge_path_dedups_and_drops_empties():
+    sep = os.pathsep
+    merged = cli_bin._merge_path(f"/a{sep}/b", f"/b{sep}{sep}/c")
+    assert merged.split(sep) == ["/a", "/b", "/c"]
 
 
 @pytest.mark.parametrize("platform_value,want_substr", [


### PR DESCRIPTION
## Problem

Users' `claude`/`codex` install paths vary wildly, and a daemon started by a LaunchAgent / Windows service / before a shell-profile refresh inherits a **narrow, stale PATH**. So the binary is (1) not on the daemon's PATH, and (2) not in our hardcoded bundle-path list (custom npm prefix, scoop, winget, nvm/fnm/volta, homebrew…) → `No such file or directory: 'claude'` even though it's installed.

## Approach

Instead of guessing more locations, **reconstruct the user's *real* PATH** and let `shutil.which` (which honours PATHEXT / `.cmd` shims) do the search:

- **Windows**: PowerShell reads the persistent **Machine + User** `Path` from the registry (`[Environment]::GetEnvironmentVariable('Path','Machine'/'User')`, env-expanded), merged + deduped with the process PATH.
- **POSIX**: a login + interactive shell (`$SHELL -ilc`) to pick up nvm / fnm / volta / homebrew sourced from the user's profile/rc.

New resolver order: `$PUFFO_*_BIN` override → caches → `which` (process PATH) → `which` (real PATH) → OS bundle paths.

## Persistence (no re-search on restart)

A resolved path is written to **`~/.puffo-agent/resolved_clis.json`** (+ an in-memory cache for the daemon's lifetime). On the next start it's read back and **validated with `is_file`** — a moved/uninstalled binary falls through to a fresh lookup. Atomic write (temp + `os.replace`) for the concurrent-worker case. No TTL (mid-session installs are rare).

## Verification

- **Live on Windows**: the registry read added **40 PATH segments** the process PATH lacked; resolved `claude.EXE` + `codex.CMD`; `resolved_clis.json` written with both.
- Unit tests: real-PATH fallback, disk-cache persist-across-restart, stale-cache rejection, PATH merge/dedup (+ the existing override/PATH/bundle tests, isolated so they never fork PowerShell). Full suite **1399 passed / 9 skipped**.

Scope: claude + codex (hermes/gemini unchanged but flow through the same `_resolve`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
