### PR TITLE
feat(membership): agent-initiated leave_space / leave_channel (operator-gated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.12.4] — unreleased
 
+### Added
+
+- **Agents can request to leave a space or channel.** New `leave_space`
+  / `leave_channel` MCP tools let an agent ask to leave (with an optional
+  reason). The request is operator-gated, mirroring invites: the operator
+  gets a DM and replies `y` (the daemon signs the leave and reports back
+  in that thread) or `n` (the agent stays). Replies are threaded — one
+  request, one thread. Currently available on the harness runtimes
+  (claude-code / codex).
+
 ### Fixed
 
 - **Operator invite `y`/`n` works as a top-level reply.** An invite's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   reason). The request is operator-gated, mirroring invites: the operator
   gets a DM and replies `y` (the daemon signs the leave and reports back
   in that thread) or `n` (the agent stays). Replies are threaded — one
-  request, one thread. Currently available on the harness runtimes
-  (claude-code / codex).
+  request, one thread. A public channel can't be left on its own, so
+  `leave_channel` tells the agent up front to leave the whole space
+  instead, without bothering the operator. Currently available on the
+  harness runtimes (claude-code / codex).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   in that thread) or `n` (the agent stays). Replies are threaded — one
   request, one thread. A public channel can't be left on its own, so
   `leave_channel` tells the agent up front to leave the whole space
-  instead, without bothering the operator. Currently available on the
-  harness runtimes (claude-code / codex).
+  instead, without bothering the operator.
 
 ### Fixed
 

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -62,6 +62,47 @@ def format_invite_error(exc: Exception, verb: str) -> str:
     return f"{prefix}: unexpected error. Please try again."
 
 
+def format_leave_error(exc: Exception) -> str:
+    """Translate a ``leave_space``/``leave_channel`` failure into copy
+    safe to surface in the operator-DM confirm. The two server-enforced
+    rejections worth naming: a space owner can't leave directly, and a
+    public channel can't be left without leaving the whole space."""
+    prefix = "Couldn't leave"
+    if isinstance(exc, HttpError):
+        error_code = ""
+        message_text = ""
+        try:
+            parsed = json.loads(exc.body)
+            if isinstance(parsed, dict):
+                error_code = str(parsed.get("error") or "")
+                message_text = str(parsed.get("message") or "")
+        except (ValueError, TypeError):
+            pass
+        lower_msg = message_text.lower()
+        if "owner" in lower_msg:
+            return (
+                f"{prefix}: I'm the space owner, so I can't leave directly — "
+                "ownership has to be transferred first."
+            )
+        if "public" in lower_msg:
+            return (
+                f"{prefix}: that's a public channel — I can only leave the "
+                "whole space, not just the channel."
+            )
+        if exc.status == 403 or error_code == "FORBIDDEN":
+            return f"{prefix}: the server won't let me leave this one."
+        if exc.status == 409 or error_code == "CONFLICT":
+            return f"{prefix}: looks like I'm already out."
+        if 400 <= exc.status < 500:
+            return f"{prefix}: please try again."
+        if exc.status >= 500:
+            return (
+                f"{prefix}: Puffo server hit an issue. "
+                "Please try again in a moment."
+            )
+    return f"{prefix}: unexpected error. Please try again."
+
+
 def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
     """Bilingual (zh+en) operator DM for an OAuth-expired agent: run
     ``claude auth login`` and just send a message (a new message

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -26,7 +26,7 @@ from ..crypto.message import (
 from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
 from ..crypto.ws_client import PuffoCoreWsClient
 from . import disk_cache
-from ._invite_strings import format_invite_error
+from ._invite_strings import format_invite_error, format_leave_error
 from .core import AgentAPIError
 from .events import random_nonce, sign_event
 from .message_store import MessageStore
@@ -481,6 +481,12 @@ class PuffoCoreMessageClient:
         # reply in that thread can be intercepted inside the daemon.
         # In-memory only — on restart we re-DM from the next poll.
         self._pending_invite_dms: dict[str, dict[str, Any]] = {}
+        # Agent-initiated leave requests awaiting operator y/n, keyed by
+        # the approval-DM envelope_id. ``_gate_left_spaces`` marks spaces
+        # left via that gate so the WS echo's ``_on_left_space`` skips its
+        # generic DM (the gate already reported in the approval thread).
+        self._pending_leave_dms: dict[str, dict[str, Any]] = {}
+        self._gate_left_spaces: set[str] = set()
 
         # channel_id → space_id learned from inbound envelopes. The
         # agent's config carries one "home" space_id, but cross-space
@@ -678,6 +684,14 @@ class PuffoCoreMessageClient:
                         await self._send_invite_bulk_summary(
                             handled_labels, text_raw, payload_thread_root_id or "",
                         )
+                    return
+                # Same gate for agent-initiated leave requests, but
+                # threaded-only — each leave is confirmed in its own
+                # thread (no direct/bulk path).
+                if await self._maybe_handle_leave_reply(
+                    thread_root_id=payload_thread_root_id or "", text=text_raw,
+                ):
+                    self._last_dm_sender = payload.sender_slug
                     return
 
             channel_id = payload.channel_id or ""
@@ -1638,6 +1652,11 @@ class PuffoCoreMessageClient:
             return
         space_label = await self._resolve_space_name(space_id)
         await self._evict_space_caches(space_id)
+        # Leaves the operator already approved via the leave-request gate
+        # are reported in that DM thread; don't also send the generic one.
+        if not synthetic and space_id in self._gate_left_spaces:
+            self._gate_left_spaces.discard(space_id)
+            return
         reason = (
             "your space exit cascaded to me"
             if synthetic else "I signed a LeaveSpace"
@@ -2592,6 +2611,167 @@ class PuffoCoreMessageClient:
             )
             return f"channel {channel_label} in space {space_label}"
         return f"space {space_label}"
+
+    # ── Agent-initiated leave (operator-gated, mirrors invite) ────────
+
+    async def request_leave_approval(
+        self, *, kind: str, space_id: str, channel_id: str, reason: str,
+    ) -> str:
+        """DM the operator to approve an agent-requested leave and
+        register it as pending. ``kind`` is ``leave_space`` /
+        ``leave_channel``. Returns a short status line for the calling
+        MCP tool to relay to the agent. The actual leave is signed only
+        after the operator replies ``y`` in the DM thread (the gate in
+        ``handle_envelope`` → ``_maybe_handle_leave_reply``)."""
+        if not self.operator_slug:
+            return (
+                "No operator is configured, so I can't request approval "
+                "to leave."
+            )
+        space_label = await self._resolve_space_name(space_id)
+        channel_label = ""
+        if kind == "leave_channel":
+            channel_label = await self._resolve_channel_name(
+                space_id=space_id, channel_id=channel_id,
+            )
+            target = (
+                f"channel **{channel_label}**({channel_id}) in space "
+                f"**{space_label}**({space_id})"
+            )
+        else:
+            target = f"space **{space_label}**({space_id})"
+        reason_line = f" Reason: {reason.strip()}" if reason.strip() else ""
+        text = (
+            f"I'd like to leave {target}.{reason_line} "
+            f"Reply `y` in this thread to approve, or `n` to keep me there."
+        )
+        envelope = await self._send_dm(self.operator_slug, text, root_id="")
+        env_id = envelope.get("envelope_id", "") if envelope else ""
+        if not env_id:
+            return (
+                "I couldn't reach your operator to ask — no approval DM "
+                "was sent. Try again later."
+            )
+        self._pending_leave_dms[env_id] = {
+            "kind": kind,
+            "space_id": space_id,
+            "channel_id": channel_id,
+            "space_name": space_label,
+            "channel_name": channel_label or None,
+            "reason": reason,
+        }
+        plain = self._leave_target_label(self._pending_leave_dms[env_id])
+        return (
+            f"Asked your operator to approve leaving {plain}. "
+            f"I'll act once they reply `y` in that thread."
+        )
+
+    async def _maybe_handle_leave_reply(
+        self, *, thread_root_id: str, text: str,
+    ) -> bool:
+        """Operator ``y``/``n`` on a pending leave-request DM. Threaded
+        only — the reply must land in the approval DM's own thread.
+        Returns ``True`` when consumed (caller skips the LLM)."""
+        meta = self._pending_leave_dms.get(thread_root_id)
+        if meta is None:
+            return False
+        normalized = text.strip().lower()
+        if normalized in ("y", "yes"):
+            approved = True
+        elif normalized in ("n", "no"):
+            approved = False
+        else:
+            return False
+
+        kind = meta["kind"]
+        space_id = meta["space_id"]
+        channel_id = meta.get("channel_id") or ""
+        target = self._leave_target_label(meta)
+        if approved:
+            try:
+                await self._sign_and_post_leave(
+                    kind=kind, space_id=space_id, channel_id=channel_id,
+                )
+                # Suppress the WS echo's generic membership DM (space
+                # only — ``_on_left_channel`` doesn't DM); the line below
+                # is the authoritative report, in this thread.
+                if kind == "leave_space":
+                    self._gate_left_spaces.add(space_id)
+                confirm = f"Left {target}. ✓"
+                self._log.info(
+                    "operator-approved leave of %s (space=%s channel=%s)",
+                    kind, space_id, channel_id,
+                )
+            except Exception as exc:
+                self._log.exception(
+                    "operator-approved leave of %s failed (space=%s channel=%s)",
+                    kind, space_id, channel_id,
+                )
+                confirm = f"{format_leave_error(exc)} ({target})"
+        else:
+            confirm = f"Understood — I'll stay in {target}."
+
+        self._pending_leave_dms.pop(thread_root_id, None)
+        try:
+            await self._send_dm(
+                self.operator_slug, confirm, root_id=thread_root_id,
+            )
+        except Exception:
+            self._log.exception(
+                "failed to confirm leave-reply outcome to operator",
+            )
+        return True
+
+    @staticmethod
+    def _leave_target_label(meta: dict) -> str:
+        """Human label for a leave's destination (space or channel)."""
+        space_id = meta.get("space_id") or ""
+        space_label = f"**{meta['space_name']}**" if meta.get("space_name") else space_id
+        if meta.get("kind") == "leave_channel":
+            channel_id = meta.get("channel_id") or ""
+            channel_label = (
+                f"**{meta['channel_name']}**" if meta.get("channel_name") else channel_id
+            )
+            return f"channel {channel_label} in space {space_label}"
+        return f"space {space_label}"
+
+    async def _sign_and_post_leave(
+        self, *, kind: str, space_id: str, channel_id: str,
+    ) -> None:
+        """Sign + POST a ``leave_space`` / ``leave_channel`` event.
+        Mirrors ``_accept_invite``'s signing; the leave payload uses
+        ``effective_from`` (not ``accepted_at``) and the server rejects
+        unknown fields, so the shapes are exact."""
+        sess = self.keystore.load_session(self.slug)
+        signing_key = Ed25519KeyPair.from_secret_bytes(
+            decode_secret(sess.subkey_secret_key)
+        )
+        now_ms = int(__import__("time").time() * 1000)
+        if kind == "leave_channel":
+            payload: dict[str, Any] = {
+                "space_id": space_id,
+                "channel_id": channel_id,
+                "effective_from": now_ms,
+                "nonce": random_nonce(),
+            }
+        else:
+            payload = {
+                "space_id": space_id,
+                "effective_from": now_ms,
+                "nonce": random_nonce(),
+            }
+        signed = sign_event(
+            kind=kind,
+            payload=payload,
+            signer_slug=self.slug,
+            signer_device_id=self.device_id,
+            signer_subkey_id=sess.subkey_id,
+            signing_key=signing_key,
+        )
+        await self.http.post(
+            "/spaces/events",
+            {"space_id": space_id, "events": [signed]},
+        )
 
     async def _maybe_handle_invite_reply(
         self, *, thread_root_id: str, text: str,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -418,6 +418,7 @@ class PuffoCoreMessageClient:
         http_client: PuffoCoreHttpClient,
         message_store: MessageStore,
         operator_slug: str = "",
+        auto_accept_space_invitations: bool = False,
         workspace: str = "",
         max_inline_chars: int = 4000,
         segment_chars: int = 2000,
@@ -431,6 +432,9 @@ class PuffoCoreMessageClient:
         # Operator's slug — used to DM them on non-auto-acceptable
         # invites. Empty string falls back to log-only handling.
         self.operator_slug = operator_slug
+        # Hidden agent.yml flag: auto-accept non-operator space invites,
+        # then DM the operator a report.
+        self.auto_accept_space_invitations = bool(auto_accept_space_invitations)
         # Absolute path to the agent's workspace. Inbound attachments
         # are decrypted into ``<workspace>/.puffo/inbox/<envelope_id>/``.
         self.workspace = workspace
@@ -1883,20 +1887,34 @@ class PuffoCoreMessageClient:
             return
 
         is_from_operator = await self._inviter_is_operator(inviter_slug)
-        if is_from_operator:
+        # Auto-accept when the operator invited us, or — space invites
+        # only — when the hidden auto_accept_space_invitations flag is on.
+        # The operator case is silent (they know); the flag case DMs a
+        # report afterwards (they didn't initiate it).
+        flag_accept = (
+            kind == "invite_to_space" and self.auto_accept_space_invitations
+        )
+        if is_from_operator or flag_accept:
             try:
                 await self._accept_invite(
                     kind, invitation_event_id, space_id, channel_id,
                 )
                 self._log.info(
-                    "auto-accepted %s from operator %s (event_id=%s)",
+                    "auto-accepted %s from %s (event_id=%s)",
                     kind, inviter_slug, invitation_event_id,
                 )
                 self._processed_invite_ids.add(invitation_event_id)
             except Exception:
                 self._log.exception(
-                    "failed to auto-accept %s from operator %s (event_id=%s)",
+                    "failed to auto-accept %s from %s (event_id=%s)",
                     kind, inviter_slug, invitation_event_id,
+                )
+                return
+            if not is_from_operator:
+                await self._report_auto_accepted_space_invite(
+                    inviter_slug=inviter_slug,
+                    space_id=space_id,
+                    space_name=space_name,
                 )
         else:
             try:
@@ -1913,6 +1931,31 @@ class PuffoCoreMessageClient:
                 # Mark processed even on DM failure — the operator
                 # still sees the invite in their chat client.
                 self._processed_invite_ids.add(invitation_event_id)
+
+    async def _report_auto_accepted_space_invite(
+        self, *, inviter_slug: str, space_id: str, space_name: str | None,
+    ) -> None:
+        """Tell the operator we auto-accepted a non-operator space invite
+        on their behalf (the auto_accept_space_invitations flag is on).
+        Best-effort."""
+        if not self.operator_slug:
+            return
+        space_label = f"**{space_name}**({space_id})" if space_name else space_id
+        inviter_display = await self._fetch_display_name(inviter_slug)
+        inviter_label = (
+            f"**{inviter_display}**(@{inviter_slug})"
+            if inviter_display else f"@{inviter_slug}"
+        )
+        text = (
+            f"Auto-accepted an invite to space {space_label} from "
+            f"{inviter_label} (auto-accept-space-invitations is on)."
+        )
+        try:
+            await self._send_dm(self.operator_slug, text, root_id="")
+        except Exception:
+            self._log.exception(
+                "failed to report auto-accepted space invite to operator",
+            )
 
     async def _inviter_is_operator(self, inviter_slug: str) -> bool:
         """True iff ``inviter_slug``'s root pubkey matches our

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -481,10 +481,9 @@ class PuffoCoreMessageClient:
         # reply in that thread can be intercepted inside the daemon.
         # In-memory only — on restart we re-DM from the next poll.
         self._pending_invite_dms: dict[str, dict[str, Any]] = {}
-        # Agent-initiated leave requests awaiting operator y/n, keyed by
-        # the approval-DM envelope_id. ``_gate_left_spaces`` marks spaces
-        # left via that gate so the WS echo's ``_on_left_space`` skips its
-        # generic DM (the gate already reported in the approval thread).
+        # Agent-initiated leaves awaiting operator y/n, keyed by approval-DM
+        # envelope_id. ``_gate_left_spaces`` marks gate-approved space leaves
+        # so the WS echo's ``_on_left_space`` skips its now-duplicate DM.
         self._pending_leave_dms: dict[str, dict[str, Any]] = {}
         self._gate_left_spaces: set[str] = set()
 
@@ -2634,9 +2633,8 @@ class PuffoCoreMessageClient:
             channel_label = await self._resolve_channel_name(
                 space_id=space_id, channel_id=channel_id,
             )
-            # Public channels can't be left on their own (server rejects
-            # it). Tell the agent up front so it leaves the space instead,
-            # rather than asking the operator for an approval that 403s.
+            # Public channels can't be left on their own; tell the agent
+            # up front instead of asking the operator for a doomed approval.
             if await self._channel_is_public(space_id, channel_id):
                 return (
                     f"**{channel_label}** is a public channel, which can't "
@@ -2701,9 +2699,8 @@ class PuffoCoreMessageClient:
                 await self._sign_and_post_leave(
                     kind=kind, space_id=space_id, channel_id=channel_id,
                 )
-                # Suppress the WS echo's generic membership DM (space
-                # only — ``_on_left_channel`` doesn't DM); the line below
-                # is the authoritative report, in this thread.
+                # Suppress the WS echo's generic membership DM (space only);
+                # the in-thread confirm below is the authoritative report.
                 if kind == "leave_space":
                     self._gate_left_spaces.add(space_id)
                 confirm = f"Left {target}. ✓"

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -2634,6 +2634,15 @@ class PuffoCoreMessageClient:
             channel_label = await self._resolve_channel_name(
                 space_id=space_id, channel_id=channel_id,
             )
+            # Public channels can't be left on their own (server rejects
+            # it). Tell the agent up front so it leaves the space instead,
+            # rather than asking the operator for an approval that 403s.
+            if await self._channel_is_public(space_id, channel_id):
+                return (
+                    f"**{channel_label}** is a public channel, which can't "
+                    f"be left on its own. To leave it, request to leave the "
+                    f"whole space instead with `leave_space`."
+                )
             target = (
                 f"channel **{channel_label}**({channel_id}) in space "
                 f"**{space_label}**({space_id})"
@@ -2734,6 +2743,26 @@ class PuffoCoreMessageClient:
             )
             return f"channel {channel_label} in space {space_label}"
         return f"space {space_label}"
+
+    async def _channel_is_public(
+        self, space_id: str, channel_id: str,
+    ) -> bool | None:
+        """Whether ``channel_id`` is public (and so can't be left on its
+        own). ``True``/``False`` from ``GET /spaces/<id>/channels``;
+        ``None`` when undeterminable, so callers fall through to the
+        normal approval path rather than blocking on a flake."""
+        if not space_id or not channel_id:
+            return None
+        try:
+            data = await self.http.get(f"/spaces/{space_id}/channels")
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
+        for entry in data.get("channels") or []:
+            if (entry.get("channel_id") or "") == channel_id:
+                return bool(entry.get("is_public"))
+        return None
 
     async def _sign_and_post_leave(
         self, *, kind: str, space_id: str, channel_id: str,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -432,8 +432,6 @@ class PuffoCoreMessageClient:
         # Operator's slug — used to DM them on non-auto-acceptable
         # invites. Empty string falls back to log-only handling.
         self.operator_slug = operator_slug
-        # Hidden agent.yml flag: auto-accept non-operator space invites,
-        # then DM the operator a report.
         self.auto_accept_space_invitations = bool(auto_accept_space_invitations)
         # Absolute path to the agent's workspace. Inbound attachments
         # are decrypted into ``<workspace>/.puffo/inbox/<envelope_id>/``.
@@ -1887,10 +1885,8 @@ class PuffoCoreMessageClient:
             return
 
         is_from_operator = await self._inviter_is_operator(inviter_slug)
-        # Auto-accept when the operator invited us, or — space invites
-        # only — when the hidden auto_accept_space_invitations flag is on.
-        # The operator case is silent (they know); the flag case DMs a
-        # report afterwards (they didn't initiate it).
+        # Flag-driven auto-accept covers space invites from non-operators;
+        # unlike the (silent) operator path it DMs a report afterwards.
         flag_accept = (
             kind == "invite_to_space" and self.auto_accept_space_invitations
         )

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -190,6 +190,12 @@ below is the authoritative reference.
 - `sync_host_mcp(template_id)` — copy the operator's populated entry
   from host into your own `.claude.json`. Pair with `refresh()`.
 
+**Membership:**
+- `leave_space(space_id, reason="")` / `leave_channel(channel_id,
+  reason="")` — *request* to leave; does NOT leave immediately. Your
+  operator gets a DM and replies `y` (you leave) or `n` (you stay). Use
+  sparingly, and give an honest `reason`.
+
 Use write tools with intent — proactive messages surprise people.
 Read tools are cheap.
 

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -88,3 +88,21 @@ class PuffoRpcClient:
         return await self._post(
             "sync-mcp", {"template_id": template_id},
         )
+
+    async def request_leave(
+        self,
+        *,
+        kind: str,
+        space_id: str,
+        channel_id: str = "",
+        reason: str = "",
+    ) -> str:
+        return await self._post(
+            "leave-request",
+            {
+                "kind": kind,
+                "space_id": space_id,
+                "channel_id": channel_id,
+                "reason": reason,
+            },
+        )

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -47,6 +47,8 @@ PUFFO_CORE_TOOL_NAMES = (
     "list_mcp_servers",
     "install_host_mcp",
     "sync_host_mcp",
+    "leave_space",
+    "leave_channel",
     "refresh",
 )
 PUFFO_CORE_TOOL_FQNS = tuple(

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -85,6 +85,9 @@ class PuffoCoreToolsConfig:
     # None when PUFFO_RPC_URL isn't set; install/sync tools surface
     # a clear error rather than touching operator files in-process.
     rpc_client: Optional[PuffoRpcClient] = None
+    # Set only on the in-process (ws-local) path, where tools run inside
+    # the daemon and drive the message client directly instead of via RPC.
+    message_client: Any = None
 
 
 async def _fetch_device_keys(
@@ -1160,14 +1163,20 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         Note: a space owner can't leave directly, and the request only
         goes through while you're a member.
         """
+        sp = space_id.strip()
+        if not sp:
+            raise RuntimeError("space_id is required")
+        # ws-local runs in-process → drive the client directly; harness
+        # runtimes go through the daemon's rpc_service.
+        if cfg.message_client is not None:
+            return await cfg.message_client.request_leave_approval(
+                kind="leave_space", space_id=sp, channel_id="", reason=reason,
+            )
         if cfg.rpc_client is None:
             raise RuntimeError(
                 "leave_space unavailable — PUFFO_RPC_URL not set on this "
                 "MCP runtime, so the puffo-agent daemon isn't reachable."
             )
-        sp = space_id.strip()
-        if not sp:
-            raise RuntimeError("space_id is required")
         return await cfg.rpc_client.request_leave(
             kind="leave_space", space_id=sp, channel_id="", reason=reason,
         )
@@ -1187,16 +1196,21 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         Note: public channels can't be left on their own — to leave one
         you'd leave the whole space (``leave_space``).
         """
+        ch = channel_id.strip()
+        if not ch:
+            raise RuntimeError("channel_id is required")
+        space_id = await _resolve_channel_space(cfg, ch)
+        if cfg.message_client is not None:
+            return await cfg.message_client.request_leave_approval(
+                kind="leave_channel", space_id=space_id, channel_id=ch,
+                reason=reason,
+            )
         if cfg.rpc_client is None:
             raise RuntimeError(
                 "leave_channel unavailable — PUFFO_RPC_URL not set on "
                 "this MCP runtime, so the puffo-agent daemon isn't "
                 "reachable."
             )
-        ch = channel_id.strip()
-        if not ch:
-            raise RuntimeError("channel_id is required")
-        space_id = await _resolve_channel_space(cfg, ch)
         return await cfg.rpc_client.request_leave(
             kind="leave_channel", space_id=space_id, channel_id=ch,
             reason=reason,

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -1145,3 +1145,60 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             )
         return await cfg.rpc_client.sync_mcp(template_id=template_id)
 
+    @mcp.tool()
+    async def leave_space(space_id: str, reason: str = "") -> str:
+        """Request to leave a space. This does NOT leave immediately —
+        it asks your operator to approve. The operator gets a DM and
+        replies `y` (you leave) or `n` (you stay); you'll see their
+        decision in that thread.
+
+        space_id: the space to leave (e.g. 'sp_<uuid>'). Use
+            ``list_spaces`` to find it.
+        reason: optional — a short why, shown to the operator in the
+            approval DM. Be honest and specific.
+
+        Note: a space owner can't leave directly, and the request only
+        goes through while you're a member.
+        """
+        if cfg.rpc_client is None:
+            raise RuntimeError(
+                "leave_space unavailable — PUFFO_RPC_URL not set on this "
+                "MCP runtime, so the puffo-agent daemon isn't reachable."
+            )
+        sp = space_id.strip()
+        if not sp:
+            raise RuntimeError("space_id is required")
+        return await cfg.rpc_client.request_leave(
+            kind="leave_space", space_id=sp, channel_id="", reason=reason,
+        )
+
+    @mcp.tool()
+    async def leave_channel(channel_id: str, reason: str = "") -> str:
+        """Request to leave a channel. This does NOT leave immediately —
+        it asks your operator to approve. The operator gets a DM and
+        replies `y` (you leave) or `n` (you stay); you'll see their
+        decision in that thread.
+
+        channel_id: the channel to leave (e.g. 'ch_<uuid>'). Use
+            ``list_channels_in_all_spaces`` to find it.
+        reason: optional — a short why, shown to the operator in the
+            approval DM.
+
+        Note: public channels can't be left on their own — to leave one
+        you'd leave the whole space (``leave_space``).
+        """
+        if cfg.rpc_client is None:
+            raise RuntimeError(
+                "leave_channel unavailable — PUFFO_RPC_URL not set on "
+                "this MCP runtime, so the puffo-agent daemon isn't "
+                "reachable."
+            )
+        ch = channel_id.strip()
+        if not ch:
+            raise RuntimeError("channel_id is required")
+        space_id = await _resolve_channel_space(cfg, ch)
+        return await cfg.rpc_client.request_leave(
+            kind="leave_channel", space_id=space_id, channel_id=ch,
+            reason=reason,
+        )
+

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -38,6 +38,9 @@ class HostMcpContext:
     harness: str
     keystore: KeyStore
     http_client: PuffoCoreHttpClient
+    # The worker's live PuffoCoreMessageClient, for tools that drive
+    # daemon-side state (leave requests). None until warm().
+    message_client: Any = None
 
 
 # ── filesystem helpers (host & agent .claude.json) ─────────────────
@@ -453,4 +456,34 @@ async def sync(ctx: HostMcpContext, *, template_id: str) -> str:
         f"Synced host's {template_id!r} entry into your "
         f"~/.claude.json. Call refresh() so claude respawns and "
         f"loads it."
+    )
+
+
+async def request_leave(
+    ctx: HostMcpContext,
+    *,
+    kind: str,
+    space_id: str,
+    channel_id: str,
+    reason: str,
+) -> str:
+    """Agent asked to leave a space/channel — hand off to the daemon's
+    message client, which DMs the operator for y/n and signs the leave
+    only on approval. ``kind`` is ``leave_space`` / ``leave_channel``."""
+    client = ctx.message_client
+    if client is None:
+        raise RuntimeError(
+            "agent isn't fully warm yet — try again in a moment"
+        )
+    if kind not in ("leave_space", "leave_channel"):
+        raise RuntimeError(f"unknown leave kind {kind!r}")
+    if not space_id:
+        raise RuntimeError("space_id is required")
+    if kind == "leave_channel" and not channel_id:
+        raise RuntimeError("channel_id is required for leave_channel")
+    return await client.request_leave_approval(
+        kind=kind,
+        space_id=space_id,
+        channel_id=channel_id,
+        reason=reason or "",
     )

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -93,6 +93,15 @@ async def sync_host_mcp_route(request: web.Request) -> web.Response:
     )
 
 
+async def leave_request_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/leave-request —
+    ``{kind, space_id, channel_id, reason}``."""
+    return await _dispatch(
+        request, host_mcp_handler.request_leave,
+        body_keys=("kind", "space_id", "channel_id", "reason"),
+    )
+
+
 def build_app(cfg: RpcServiceConfig) -> web.Application:
     app = web.Application()
     app.router.add_post(
@@ -102,6 +111,10 @@ def build_app(cfg: RpcServiceConfig) -> web.Application:
     app.router.add_post(
         "/v1/rpc/{agent_id}/sync-mcp",
         sync_host_mcp_route,
+    )
+    app.router.add_post(
+        "/v1/rpc/{agent_id}/leave-request",
+        leave_request_route,
     )
     return app
 

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -948,6 +948,9 @@ class PuffoCoreConfig:
     # human attention is needed. Cryptographic ownership is still
     # carried by ``identity_cert.declared_operator_public_key``.
     operator_slug: str = ""
+    # Hidden knob (no UI, agent.yml only): when true, space invites from
+    # non-operators are auto-accepted, then the operator is DM'd a report.
+    auto_accept_space_invitations: bool = False
 
     def is_configured(self) -> bool:
         return bool(self.server_url and self.slug and self.device_id and self.space_id)
@@ -1071,6 +1074,9 @@ class AgentConfig:
                 device_id=pc.get("device_id", ""),
                 space_id=pc.get("space_id", ""),
                 operator_slug=pc.get("operator_slug", ""),
+                auto_accept_space_invitations=bool(
+                    pc.get("auto_accept_space_invitations", False)
+                ),
             ),
             runtime=RuntimeConfig(
                 kind=kind,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -372,6 +372,7 @@ def _build_puffo_core_client(
         device_id=pc.device_id,
         space_id=pc.space_id,
         operator_slug=pc.operator_slug,
+        auto_accept_space_invitations=pc.auto_accept_space_invitations,
         keystore=ks,
         http_client=http,
         message_store=ms,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -825,6 +825,7 @@ class Worker:
             harness=harness,
             keystore=client.keystore,
             http_client=client.http,
+            message_client=client,
         )
 
     async def stop(self) -> None:

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -43,6 +43,7 @@ def _build_tool_dispatch(point: AttachPoint):
         data_client=InProcessDataClient(client.store, client),
         space_id=getattr(client, "space_id", None),
         workspace=getattr(client, "workspace", None),
+        message_client=client,
     )
     return _build_dispatch(cfg)
 

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -34,6 +34,9 @@ WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
     "list_spaces",
     "list_channels_in_space",
     "list_channels_in_all_spaces",
+    # membership
+    "leave_space",
+    "leave_channel",
 })
 
 

--- a/tests/test_auto_accept_space_invites.py
+++ b/tests/test_auto_accept_space_invites.py
@@ -1,0 +1,114 @@
+"""Hidden ``auto_accept_space_invitations`` flag. When on, a space
+invite from a non-operator is auto-accepted and the operator is DM'd a
+report — instead of the usual y/n approval prompt. Channel invites are
+unaffected, and the operator-inviter path stays silent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+
+def _make_client(*, flag: bool, operator_slug: str = "op-1"):
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.operator_slug = operator_slug
+    client.auto_accept_space_invitations = flag
+    client._processed_invite_ids = set()
+    client._pending_invite_dms = {}
+    client._log = logging.getLogger("auto-accept-space-test")
+
+    accepts: list[tuple] = []
+    notifies: list[dict] = []
+    reports: list[dict] = []
+
+    async def _stub_inviter_is_operator(inviter_slug):
+        return inviter_slug == operator_slug
+
+    async def _stub_accept(kind, eid, space_id, channel_id):
+        accepts.append((kind, eid, space_id, channel_id))
+
+    async def _stub_notify(**kw):
+        notifies.append(kw)
+
+    async def _stub_report(*, inviter_slug, space_id, space_name):
+        reports.append({"inviter": inviter_slug, "space_id": space_id, "space_name": space_name})
+
+    client._inviter_is_operator = _stub_inviter_is_operator  # type: ignore[assignment]
+    client._accept_invite = _stub_accept  # type: ignore[assignment]
+    client._notify_operator_of_invite = _stub_notify  # type: ignore[assignment]
+    client._report_auto_accepted_space_invite = _stub_report  # type: ignore[assignment]
+    client._accepts = accepts  # type: ignore[attr-defined]
+    client._notifies = notifies  # type: ignore[attr-defined]
+    client._reports = reports  # type: ignore[attr-defined]
+    return client
+
+
+def _kw(kind="invite_to_space", inviter="alice-0001", **over):
+    base = {
+        "kind": kind,
+        "invitation_event_id": "ev_1",
+        "inviter_slug": inviter,
+        "space_id": "sp_1",
+        "channel_id": "ch_1" if kind == "invite_to_channel" else "",
+        "space_name": "Team",
+        "channel_name": "general" if kind == "invite_to_channel" else None,
+    }
+    base.update(over)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_flag_on_auto_accepts_nonoperator_space_invite_and_reports():
+    client = _make_client(flag=True)
+    await client._process_invite(**_kw())
+    assert client._accepts == [("invite_to_space", "ev_1", "sp_1", "")]
+    assert client._notifies == []  # no y/n prompt
+    assert len(client._reports) == 1
+    assert client._reports[0]["space_id"] == "sp_1"
+    assert "ev_1" in client._processed_invite_ids
+
+
+@pytest.mark.asyncio
+async def test_flag_off_still_prompts_operator():
+    client = _make_client(flag=False)
+    await client._process_invite(**_kw())
+    assert client._accepts == []
+    assert len(client._notifies) == 1
+    assert client._reports == []
+
+
+@pytest.mark.asyncio
+async def test_flag_does_not_touch_channel_invites():
+    client = _make_client(flag=True)
+    await client._process_invite(**_kw(kind="invite_to_channel"))
+    # Channel invites still go through the y/n prompt even with the flag.
+    assert client._accepts == []
+    assert len(client._notifies) == 1
+    assert client._reports == []
+
+
+@pytest.mark.asyncio
+async def test_operator_inviter_auto_accepts_silently_even_with_flag():
+    client = _make_client(flag=True)
+    await client._process_invite(**_kw(inviter="op-1"))
+    assert client._accepts == [("invite_to_space", "ev_1", "sp_1", "")]
+    assert client._reports == []  # operator initiated → no report
+    assert client._notifies == []
+
+
+@pytest.mark.asyncio
+async def test_failed_auto_accept_is_not_marked_processed_and_no_report():
+    client = _make_client(flag=True)
+
+    async def _boom(kind, eid, space_id, channel_id):
+        raise RuntimeError("server rejected")
+
+    client._accept_invite = _boom  # type: ignore[assignment]
+    await client._process_invite(**_kw())
+    assert "ev_1" not in client._processed_invite_ids  # retries next poll
+    assert client._reports == []

--- a/tests/test_invite_dedup_persistence.py
+++ b/tests/test_invite_dedup_persistence.py
@@ -38,6 +38,7 @@ def _make_client(operator_slug: str = "op-1") -> tuple[PuffoCoreMessageClient, l
     client.operator_slug = operator_slug
     client._processed_invite_ids = set()
     client._pending_invite_dms = {}
+    client.auto_accept_space_invitations = False
     client._operator_root_pubkey = b"op-root-pk"
     client._inviter_root_cache = {}
     client._invites_response: dict = {"invites": []}

--- a/tests/test_leave_request_routing.py
+++ b/tests/test_leave_request_routing.py
@@ -1,0 +1,334 @@
+"""Agent-initiated leave requests. The agent calls leave_space /
+leave_channel; the daemon DMs the operator for approval and signs the
+leave only on a threaded ``y``. Mirrors the invite-reply gate, but
+threaded-only (no direct/bulk path).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent import puffo_core_client as pcc
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.http_client import HttpError
+
+
+def _make_client(operator_slug: str = "op-1") -> PuffoCoreMessageClient:
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.device_id = "dev-1"
+    client.operator_slug = operator_slug
+    client._pending_leave_dms = {}
+    client._gate_left_spaces = set()
+    client._log = logging.getLogger("leave-routing-test")
+
+    leave_calls: list[tuple] = []
+    sent_dms: list[dict] = []
+
+    async def _stub_sign_post(*, kind, space_id, channel_id):
+        leave_calls.append((kind, space_id, channel_id))
+
+    async def _stub_send_dm(recipient_slug, text, root_id=""):
+        sent_dms.append({"to": recipient_slug, "text": text, "root_id": root_id})
+        return {"envelope_id": f"env_dm_{len(sent_dms)}"}
+
+    async def _stub_resolve_space(space_id):
+        return {"sp_1": "Team"}.get(space_id, space_id)
+
+    async def _stub_resolve_channel(*, space_id, channel_id):
+        return {"ch_1": "general"}.get(channel_id, channel_id)
+
+    client._sign_and_post_leave = _stub_sign_post  # type: ignore[assignment]
+    client._send_dm = _stub_send_dm  # type: ignore[assignment]
+    client._resolve_space_name = _stub_resolve_space  # type: ignore[assignment]
+    client._resolve_channel_name = _stub_resolve_channel  # type: ignore[assignment]
+    client._leave_calls = leave_calls  # type: ignore[attr-defined]
+    client._sent_dms = sent_dms  # type: ignore[attr-defined]
+    return client
+
+
+# ─── request_leave_approval (DM + register pending) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_leave_space_registers_pending_and_dms():
+    client = _make_client()
+    msg = await client.request_leave_approval(
+        kind="leave_space", space_id="sp_1", channel_id="", reason="too noisy",
+    )
+    assert len(client._sent_dms) == 1
+    dm = client._sent_dms[0]
+    assert dm["to"] == "op-1"
+    assert dm["root_id"] == ""
+    assert "too noisy" in dm["text"]
+    assert "**Team**" in dm["text"]
+    meta = client._pending_leave_dms["env_dm_1"]
+    assert meta["kind"] == "leave_space"
+    assert meta["space_id"] == "sp_1"
+    assert "Team" in msg
+
+
+@pytest.mark.asyncio
+async def test_request_leave_channel_resolves_name_and_omits_empty_reason():
+    client = _make_client()
+    await client.request_leave_approval(
+        kind="leave_channel", space_id="sp_1", channel_id="ch_1", reason="",
+    )
+    meta = client._pending_leave_dms["env_dm_1"]
+    assert meta["channel_name"] == "general"
+    text = client._sent_dms[0]["text"]
+    assert "**general**" in text
+    assert "Reason:" not in text
+
+
+@pytest.mark.asyncio
+async def test_request_leave_no_operator_no_dm():
+    client = _make_client(operator_slug="")
+    msg = await client.request_leave_approval(
+        kind="leave_space", space_id="sp_1", channel_id="", reason="",
+    )
+    assert "no operator" in msg.lower()
+    assert client._sent_dms == []
+    assert client._pending_leave_dms == {}
+
+
+# ─── _maybe_handle_leave_reply (threaded y/n gate) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_threaded_y_signs_leave_and_confirms_in_thread():
+    client = _make_client()
+    client._pending_leave_dms["env_x"] = {
+        "kind": "leave_space", "space_id": "sp_1", "channel_id": "",
+        "space_name": "Team", "channel_name": None,
+    }
+    handled = await client._maybe_handle_leave_reply(
+        thread_root_id="env_x", text="y",
+    )
+    assert handled is True
+    assert client._leave_calls == [("leave_space", "sp_1", "")]
+    assert "env_x" not in client._pending_leave_dms
+    assert "sp_1" in client._gate_left_spaces  # suppresses the WS-echo DM
+    confirm = client._sent_dms[-1]
+    assert confirm["root_id"] == "env_x"
+    assert confirm["text"].startswith("Left space **Team**")
+    assert confirm["text"].endswith("✓")
+
+
+@pytest.mark.asyncio
+async def test_threaded_n_keeps_and_signs_nothing():
+    client = _make_client()
+    client._pending_leave_dms["env_x"] = {
+        "kind": "leave_space", "space_id": "sp_1", "channel_id": "",
+        "space_name": "Team", "channel_name": None,
+    }
+    handled = await client._maybe_handle_leave_reply(
+        thread_root_id="env_x", text="n",
+    )
+    assert handled is True
+    assert client._leave_calls == []
+    assert "env_x" not in client._pending_leave_dms
+    assert "sp_1" not in client._gate_left_spaces
+    assert "stay" in client._sent_dms[-1]["text"].lower()
+    assert client._sent_dms[-1]["root_id"] == "env_x"
+
+
+@pytest.mark.asyncio
+async def test_non_yn_threaded_reply_falls_through_untouched():
+    client = _make_client()
+    client._pending_leave_dms["env_x"] = {
+        "kind": "leave_space", "space_id": "sp_1", "channel_id": "",
+        "space_name": "Team", "channel_name": None,
+    }
+    handled = await client._maybe_handle_leave_reply(
+        thread_root_id="env_x", text="why do you want to go?",
+    )
+    assert handled is False
+    assert "env_x" in client._pending_leave_dms
+    assert client._leave_calls == []
+    assert client._sent_dms == []
+
+
+@pytest.mark.asyncio
+async def test_reply_in_unknown_thread_is_not_a_leave():
+    client = _make_client()
+    client._pending_leave_dms["env_x"] = {
+        "kind": "leave_space", "space_id": "sp_1", "channel_id": "",
+        "space_name": "Team", "channel_name": None,
+    }
+    handled = await client._maybe_handle_leave_reply(
+        thread_root_id="env_other", text="y",
+    )
+    assert handled is False
+    assert client._leave_calls == []
+
+
+@pytest.mark.asyncio
+async def test_channel_leave_does_not_set_space_suppression_flag():
+    client = _make_client()
+    client._pending_leave_dms["env_c"] = {
+        "kind": "leave_channel", "space_id": "sp_1", "channel_id": "ch_1",
+        "space_name": "Team", "channel_name": "general",
+    }
+    await client._maybe_handle_leave_reply(thread_root_id="env_c", text="y")
+    assert client._leave_calls == [("leave_channel", "sp_1", "ch_1")]
+    assert client._gate_left_spaces == set()
+    assert "channel **general**" in client._sent_dms[-1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_owner_rejection_is_reported_and_pending_cleared():
+    client = _make_client()
+
+    async def _boom(*, kind, space_id, channel_id):
+        raise HttpError(
+            403, '{"error":"FORBIDDEN","message":"space owner cannot leave"}',
+        )
+
+    client._sign_and_post_leave = _boom  # type: ignore[assignment]
+    client._pending_leave_dms["env_x"] = {
+        "kind": "leave_space", "space_id": "sp_1", "channel_id": "",
+        "space_name": "Team", "channel_name": None,
+    }
+    handled = await client._maybe_handle_leave_reply(
+        thread_root_id="env_x", text="y",
+    )
+    assert handled is True
+    assert "owner" in client._sent_dms[-1]["text"].lower()
+    assert "env_x" not in client._pending_leave_dms
+    assert "sp_1" not in client._gate_left_spaces
+
+
+# ─── _sign_and_post_leave (exact event payload) ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sign_and_post_leave_space_payload_shape(monkeypatch):
+    posted: list[dict] = []
+
+    class _FakeSess:
+        subkey_secret_key = "sk"
+        subkey_id = "subkey-1"
+
+    class _FakeHttp:
+        async def post(self, path, body):
+            posted.append({"path": path, "body": body})
+
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.device_id = "dev-1"
+    client.keystore = type("KS", (), {"load_session": lambda self, slug: _FakeSess()})()
+    client.http = _FakeHttp()
+
+    monkeypatch.setattr(pcc, "decode_secret", lambda v: b"x")
+    monkeypatch.setattr(pcc.Ed25519KeyPair, "from_secret_bytes", staticmethod(lambda b: "KEY"))
+    monkeypatch.setattr(pcc, "random_nonce", lambda: "NONCE")
+    monkeypatch.setattr(
+        pcc, "sign_event",
+        lambda **kw: {"kind": kw["kind"], "payload": kw["payload"]},
+    )
+
+    await client._sign_and_post_leave(
+        kind="leave_space", space_id="sp_1", channel_id="",
+    )
+    assert posted[0]["path"] == "/spaces/events"
+    assert posted[0]["body"]["space_id"] == "sp_1"
+    event = posted[0]["body"]["events"][0]
+    assert event["kind"] == "leave_space"
+    payload = event["payload"]
+    assert set(payload) == {"space_id", "effective_from", "nonce"}
+    assert payload["space_id"] == "sp_1"
+    assert "channel_id" not in payload
+    assert "left_at" not in payload  # server uses effective_from
+
+
+@pytest.mark.asyncio
+async def test_sign_and_post_leave_channel_payload_includes_channel(monkeypatch):
+    posted: list[dict] = []
+
+    class _FakeSess:
+        subkey_secret_key = "sk"
+        subkey_id = "subkey-1"
+
+    class _FakeHttp:
+        async def post(self, path, body):
+            posted.append({"path": path, "body": body})
+
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.device_id = "dev-1"
+    client.keystore = type("KS", (), {"load_session": lambda self, slug: _FakeSess()})()
+    client.http = _FakeHttp()
+
+    monkeypatch.setattr(pcc, "decode_secret", lambda v: b"x")
+    monkeypatch.setattr(pcc.Ed25519KeyPair, "from_secret_bytes", staticmethod(lambda b: "KEY"))
+    monkeypatch.setattr(pcc, "random_nonce", lambda: "NONCE")
+    monkeypatch.setattr(
+        pcc, "sign_event",
+        lambda **kw: {"kind": kw["kind"], "payload": kw["payload"]},
+    )
+
+    await client._sign_and_post_leave(
+        kind="leave_channel", space_id="sp_1", channel_id="ch_1",
+    )
+    payload = posted[0]["body"]["events"][0]["payload"]
+    assert set(payload) == {"space_id", "channel_id", "effective_from", "nonce"}
+    assert payload["channel_id"] == "ch_1"
+
+
+# ─── _on_left_space dedup (suppress generic DM after gate leave) ────
+
+
+@pytest.mark.asyncio
+async def test_on_left_space_suppresses_generic_dm_after_gate_leave():
+    client = _make_client()
+    evicted: list[str] = []
+    membership: list[str] = []
+
+    async def _evict(space_id):
+        evicted.append(space_id)
+
+    async def _still(space_id):
+        return False
+
+    async def _membership_dm(text):
+        membership.append(text)
+
+    client._evict_space_caches = _evict  # type: ignore[assignment]
+    client._still_member_of_space = _still  # type: ignore[assignment]
+    client._dm_operator_membership_change = _membership_dm  # type: ignore[assignment]
+    client._gate_left_spaces = {"sp_1"}
+
+    await client._on_left_space(space_id="sp_1", synthetic=False)
+    assert membership == []  # the gate already reported in-thread
+    assert "sp_1" not in client._gate_left_spaces  # flag consumed
+    assert evicted == ["sp_1"]  # cache cleanup still runs
+
+
+@pytest.mark.asyncio
+async def test_on_left_space_dms_when_not_gate_initiated():
+    client = _make_client()
+    membership: list[str] = []
+
+    async def _evict(space_id):
+        return None
+
+    async def _still(space_id):
+        return False
+
+    async def _membership_dm(text):
+        membership.append(text)
+
+    client._evict_space_caches = _evict  # type: ignore[assignment]
+    client._still_member_of_space = _still  # type: ignore[assignment]
+    client._dm_operator_membership_change = _membership_dm  # type: ignore[assignment]
+
+    await client._on_left_space(space_id="sp_1", synthetic=False)
+    assert len(membership) == 1
+    assert "Team" in membership[0]

--- a/tests/test_leave_request_routing.py
+++ b/tests/test_leave_request_routing.py
@@ -44,6 +44,10 @@ def _make_client(operator_slug: str = "op-1") -> PuffoCoreMessageClient:
     async def _stub_resolve_channel(*, space_id, channel_id):
         return {"ch_1": "general"}.get(channel_id, channel_id)
 
+    async def _stub_channel_is_public(space_id, channel_id):
+        return False
+
+    client._channel_is_public = _stub_channel_is_public  # type: ignore[assignment]
     client._sign_and_post_leave = _stub_sign_post  # type: ignore[assignment]
     client._send_dm = _stub_send_dm  # type: ignore[assignment]
     client._resolve_space_name = _stub_resolve_space  # type: ignore[assignment]
@@ -85,6 +89,24 @@ async def test_request_leave_channel_resolves_name_and_omits_empty_reason():
     text = client._sent_dms[0]["text"]
     assert "**general**" in text
     assert "Reason:" not in text
+
+
+@pytest.mark.asyncio
+async def test_request_leave_public_channel_short_circuits_to_space():
+    client = _make_client()
+
+    async def _public(space_id, channel_id):
+        return True
+
+    client._channel_is_public = _public  # type: ignore[assignment]
+    msg = await client.request_leave_approval(
+        kind="leave_channel", space_id="sp_1", channel_id="ch_1", reason="x",
+    )
+    # Agent is told to leave the space; operator is NOT bothered.
+    assert "public channel" in msg.lower()
+    assert "leave_space" in msg
+    assert client._sent_dms == []
+    assert client._pending_leave_dms == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -54,6 +54,8 @@ def _make_client(
     client._space_members = {}
     client._processed_invite_ids = set()
     client._pending_invite_dms = {}
+    client._pending_leave_dms = {}
+    client._gate_left_spaces = set()
 
     # _evict_*_caches now also drops persistent ``channel_space_map``
     # rows so the MCP subprocess's send_message tool doesn't keep

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -19,7 +19,7 @@ from puffo_agent.portal.ws_local.tool_dispatch import (
 )
 
 
-def test_allowed_tools_are_the_send_and_read_tools():
+def test_allowed_tools_are_the_send_read_and_membership_tools():
     assert WS_LOCAL_ALLOWED_TOOLS == frozenset({
         # send
         "send_message",
@@ -36,6 +36,9 @@ def test_allowed_tools_are_the_send_and_read_tools():
         "list_spaces",
         "list_channels_in_space",
         "list_channels_in_all_spaces",
+        # membership
+        "leave_space",
+        "leave_channel",
     })
 
 
@@ -82,3 +85,54 @@ def test_capture_stub_resource_decorator_is_passthrough():
 async def test_build_dispatch_subset_filter_drops_unknown_names():
     dispatch = build_dispatch(MagicMock(), allowed=frozenset({"send_message", "nonsense"}))
     assert set(dispatch.keys()) == {"send_message"}
+
+
+@pytest.mark.asyncio
+async def test_ws_local_leave_space_drives_client_in_process():
+    """ws-local has no rpc_client; leave_space must call the message
+    client's request_leave_approval directly."""
+    from puffo_agent.mcp.puffo_core_tools import PuffoCoreToolsConfig
+
+    calls: list[tuple] = []
+
+    class _Client:
+        async def request_leave_approval(self, *, kind, space_id, channel_id, reason):
+            calls.append((kind, space_id, channel_id, reason))
+            return "asked your operator"
+
+    cfg = PuffoCoreToolsConfig(
+        slug="agent-1", device_id="dev-1", keystore=MagicMock(),
+        http_client=MagicMock(), data_client=MagicMock(),
+        message_client=_Client(),
+    )
+    dispatch = build_dispatch(cfg)
+    assert "leave_space" in dispatch
+    result = await dispatch["leave_space"]("sp_1", "too noisy")
+    assert result == "asked your operator"
+    assert calls == [("leave_space", "sp_1", "", "too noisy")]
+
+
+@pytest.mark.asyncio
+async def test_ws_local_leave_channel_resolves_space_and_drives_client():
+    from puffo_agent.mcp.puffo_core_tools import PuffoCoreToolsConfig
+
+    calls: list[tuple] = []
+
+    class _Client:
+        async def request_leave_approval(self, *, kind, space_id, channel_id, reason):
+            calls.append((kind, space_id, channel_id, reason))
+            return "asked your operator"
+
+    class _Data:
+        async def lookup_channel_space(self, channel_id):
+            return "sp_1"
+
+    cfg = PuffoCoreToolsConfig(
+        slug="agent-1", device_id="dev-1", keystore=MagicMock(),
+        http_client=MagicMock(), data_client=_Data(),
+        message_client=_Client(),
+    )
+    dispatch = build_dispatch(cfg)
+    result = await dispatch["leave_channel"]("ch_1", "leaving")
+    assert result == "asked your operator"
+    assert calls == [("leave_channel", "sp_1", "ch_1", "leaving")]


### PR DESCRIPTION
## What

Two new agent-callable MCP tools — `leave_space` and `leave_channel` — that let an agent **request** to leave a space or channel (with an optional `reason`). Leaving is **operator-gated**, mirroring the invite-accept flow:

1. The agent calls `leave_space(space_id, reason="")` / `leave_channel(channel_id, reason="")`.
2. The daemon DMs the operator: *"I'd like to leave space **X**. Reply `y` to approve, or `n` to keep me there."* (with the reason, if given).
3. The operator replies **in that thread** — `y` or `n`.
4. On `y`, the daemon signs the leave event and posts it; on `n`, the agent stays.
5. The outcome is reported back **in the same thread**.

Replies are **threaded-only** — one request, one thread (no direct/bulk path, unlike invites).

## How it's wired

The tools reach the `PuffoCoreMessageClient`, where the pending-leave state and the `y`/`n` gate live (symmetric with the invite gate):

- **Harness runtimes** (claude-code / codex) run the MCP in a subprocess → the tool calls the daemon's loopback `rpc_service` (new `POST /v1/rpc/{agent_id}/leave-request`), which hands off to the worker's client.
- **ws-local** runs the MCP in-process → the tool drives the client directly via `PuffoCoreToolsConfig.message_client` (no RPC). When attached, ws-local runs `client.listen()`, so the operator y/n gate fires there too.

Other details:

- The signed event uses the server's **exact** leave payload — `{space_id[, channel_id], effective_from, nonce}` (the server uses `effective_from`, not `left_at`, and rejects unknown fields).
- A space leave sets a one-shot suppression flag so the WS echo's generic membership DM doesn't double-report on top of the in-thread confirmation. (Channel leaves don't DM on echo, so no flag needed.)
- **Public channels can't be left on their own.** `leave_channel` checks the channel's `is_public` (via `GET /spaces/<id>/channels`) **before** DMing the operator: if public, it returns a message straight to the agent telling it to leave the whole space (`leave_space`) instead, and never bothers the operator. If membership can't be determined up front, it falls through to the approval path, where the post-`403` copy still explains the rejection in-thread.
- A space **owner** can't leave directly — that rejection is surfaced in-thread.

The tools are wired across every MCP surface: registration, the `PUFFO_CORE_TOOL_NAMES` gate (+ SDK FQNs), the primer, and the ws-local allow-list.

## Also in this PR — hidden `auto_accept_space_invitations` flag

A small, **hidden** agent setting (no UI, no changelog): `puffo_core.auto_accept_space_invitations` in `agent.yml` (default `false`). When `true`, a **space** invite from a non-operator is auto-accepted and the operator is DM'd a report afterwards, instead of the usual `y`/`n` prompt. Channel invites are unaffected; the operator-inviter path stays silent; a failed auto-accept isn't marked processed (retries) and sends no report. Set via `agent.yml` only.

## Tests

`tests/test_leave_request_routing.py` (14) — the leave flow end to end. `tests/test_ws_local_tool_dispatch.py` (+2) — ws-local routes leave_space/leave_channel to the in-process client. `tests/test_auto_accept_space_invites.py` (5) — the hidden flag.

`PYTHONPATH=src python -m pytest`: **1420 passed / 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
