### PR TITLE
PUF-291: codex agents recover from empty conversation_id silent-wedge (FB-274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   codex thread on the next turn so the new policy takes effect (codex
   doesn't re-send thread params on resume).
 
+### Fixed
+
+- **Codex agents recover from an empty `conversation_id` instead of
+  silently wedging.** A corrupt `codex_session.json` (or a future
+  reset-without-respawn) could leave a live codex process with no
+  conversation id, after which every turn sent an empty `threadId` and
+  the agent went quiet. The session now tears down + respawns to
+  re-establish a thread, and a turn aborts loudly rather than send an
+  empty `threadId`.
+
 ## [0.12.4] — 2026-06-12
 
 ### Added

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -505,6 +505,15 @@ class CodexSession:
         # ``thread/start`` returning no id; see ``:_bootstrap_session``).
         # Post-call invariant: proc alive AND ``_conversation_id`` non-empty.
         if proc_alive:
+            # Log the load-bearing diagnostic so Shan-Shadow-class
+            # incidents are visible from daemon logs alone, without
+            # needing a live repro.
+            logger.info(
+                "agent %s: codex session has alive proc but empty "
+                "conversation_id; tearing down + respawning to recover "
+                "(PUF-291)",
+                self.agent_id,
+            )
             await self._teardown_locked()
         await self._spawn()
 

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -230,6 +230,16 @@ class CodexSession:
         """Send one turn; wait for ``turn/completed``."""
         async with self._lock:
             await self._ensure_running(system_prompt)
+            # PUF-291 (β / FB-274): ``_ensure_running`` is supposed to
+            # guarantee a non-empty cid on return (see its docstring +
+            # the α invariant), but a future regression that loosens
+            # that contract would silently send ``threadId=""`` and
+            # wedge the agent. Surface the failure loudly instead.
+            if not self._conversation_id:
+                raise RuntimeError(
+                    f"agent {self.agent_id}: codex run_turn aborted — "
+                    f"empty conversation_id after _ensure_running"
+                )
             turn = _PendingTurn(
                 request_id=self._reserve_id(),
                 started_at=time.time(),
@@ -482,8 +492,20 @@ class CodexSession:
         # per turn anyway.
         if system_prompt:
             self.current_instructions = system_prompt
-        if self._proc is not None and self._proc.returncode is None:
+        proc_alive = self._proc is not None and self._proc.returncode is None
+        if proc_alive and self._conversation_id:
             return
+        # PUF-291 (α / FB-274): a stale proc with empty
+        # ``_conversation_id`` (corrupt ``codex_session.json`` load +
+        # warm-spawn race, or a future bug that resets the cid without
+        # respawning) would otherwise make ``run_turn`` send
+        # ``threadId=""`` and silently wedge. Tear the proc down so
+        # ``_spawn`` runs the full bootstrap and ``_bootstrap_session``
+        # either resumes / creates a new thread (it raises on
+        # ``thread/start`` returning no id; see ``:_bootstrap_session``).
+        # Post-call invariant: proc alive AND ``_conversation_id`` non-empty.
+        if proc_alive:
+            await self._teardown_locked()
         await self._spawn()
 
     async def _spawn(self) -> None:

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -602,3 +602,199 @@ while True:
     # 10s graceful + 3s terminate window + slack for slow CI.
     elapsed = asyncio.run(_run())
     assert elapsed < 20.0, f"aclose hung for {elapsed:.1f}s"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PUF-291: silent-wedge recovery when conversation_id loads empty
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_puf291_load_conversation_id_failsoft_on_corrupt_json(tmp_path):
+    """Regression-guard on the failsoft itself — corrupt session JSON
+    must return ``""`` (the load-time signal that PUF-291 (α) keys on
+    inside ``_ensure_running``)."""
+    session_file = tmp_path / "codex_session.json"
+    session_file.write_text("not-valid-json{", encoding="utf-8")
+    cs = CodexSession.__new__(CodexSession)
+    cs.session_file = session_file
+    assert cs._load_conversation_id() == ""
+
+
+def test_puf291_ensure_running_with_empty_cid_and_alive_proc_respawns(tmp_path):
+    """PUF-291 (α): if a previous load left ``_conversation_id`` empty
+    but the proc handle is still alive (corrupt session file +
+    warm-spawn race), ``_ensure_running`` must tear the proc down and
+    respawn so ``_bootstrap_session`` re-establishes a thread.
+    """
+    cs = CodexSession.__new__(CodexSession)
+    cs.agent_id = "puf291-empty-cid"
+    cs._conversation_id = ""
+    cs.current_instructions = None
+    # Fake "alive" proc — returncode None signals running.
+    class _FakeProc:
+        returncode = None
+    cs._proc = _FakeProc()
+
+    calls = {"teardown": 0, "spawn": 0}
+
+    async def _stub_teardown():
+        calls["teardown"] += 1
+        cs._proc = None
+
+    async def _stub_spawn():
+        calls["spawn"] += 1
+        # Simulate _bootstrap_session establishing a fresh thread.
+        cs._conversation_id = "conv_fresh"
+        cs._proc = _FakeProc()
+
+    cs._teardown_locked = _stub_teardown  # type: ignore[assignment]
+    cs._spawn = _stub_spawn  # type: ignore[assignment]
+
+    asyncio.run(cs._ensure_running("sys"))
+
+    assert calls["teardown"] == 1, "expected teardown of stale proc"
+    assert calls["spawn"] == 1, "expected respawn after teardown"
+    assert cs._conversation_id == "conv_fresh"
+
+
+def test_puf291_ensure_running_with_non_empty_cid_and_alive_proc_is_noop(tmp_path):
+    """Regression-guard: the (α) added branch must NOT respawn when
+    the proc is alive AND ``_conversation_id`` is already set."""
+    cs = CodexSession.__new__(CodexSession)
+    cs.agent_id = "puf291-warm-noop"
+    cs._conversation_id = "conv_existing"
+    cs.current_instructions = None
+    class _FakeProc:
+        returncode = None
+    cs._proc = _FakeProc()
+
+    calls = {"teardown": 0, "spawn": 0}
+
+    async def _stub_teardown():
+        calls["teardown"] += 1
+
+    async def _stub_spawn():
+        calls["spawn"] += 1
+
+    cs._teardown_locked = _stub_teardown  # type: ignore[assignment]
+    cs._spawn = _stub_spawn  # type: ignore[assignment]
+
+    asyncio.run(cs._ensure_running("sys"))
+
+    assert calls["teardown"] == 0
+    assert calls["spawn"] == 0
+    assert cs._conversation_id == "conv_existing"
+
+
+def test_puf291_ensure_running_with_dead_proc_spawns_without_teardown(tmp_path):
+    """Regression-guard on the existing dead-proc path: cold-start +
+    after-aclose must still go straight to ``_spawn`` without the
+    extra teardown the (α) branch only fires on a live-proc-empty-cid
+    pairing.
+    """
+    cs = CodexSession.__new__(CodexSession)
+    cs.agent_id = "puf291-cold-start"
+    cs._conversation_id = ""
+    cs.current_instructions = None
+    cs._proc = None  # No live proc.
+
+    calls = {"teardown": 0, "spawn": 0}
+
+    async def _stub_teardown():
+        calls["teardown"] += 1
+
+    async def _stub_spawn():
+        calls["spawn"] += 1
+        cs._conversation_id = "conv_new"
+
+    cs._teardown_locked = _stub_teardown  # type: ignore[assignment]
+    cs._spawn = _stub_spawn  # type: ignore[assignment]
+
+    asyncio.run(cs._ensure_running("sys"))
+
+    assert calls["teardown"] == 0, "no proc to tear down"
+    assert calls["spawn"] == 1
+    assert cs._conversation_id == "conv_new"
+
+
+def test_puf291_run_turn_raises_when_cid_stays_empty(tmp_path):
+    """PUF-291 (β / FB-274): defence-in-depth — even if a future
+    regression lets ``_ensure_running`` return without securing a
+    cid, ``run_turn`` must surface the failure rather than send
+    ``threadId=""`` and silently wedge.
+    """
+    cs = CodexSession.__new__(CodexSession)
+    cs.agent_id = "puf291-beta-fail-loud"
+    cs._conversation_id = ""
+    cs._lock = asyncio.Lock()
+    cs._next_id = 1
+    cs._active_turn = None
+    cs.current_instructions = None
+
+    async def _stub_ensure_running(_system_prompt):
+        # Simulate the regression: ensure_running returns without
+        # populating the cid. The (β) guard should catch this.
+        pass
+
+    cs._ensure_running = _stub_ensure_running  # type: ignore[assignment]
+
+    async def _run():
+        return await cs.run_turn("hi", "sys")
+
+    with pytest.raises(RuntimeError, match="empty conversation_id after _ensure_running"):
+        asyncio.run(_run())
+
+
+def test_puf291_shan_shadow_repro_corrupt_session_recovers(tmp_path):
+    """Shan-Shadow user-observable repro: a corrupt session-file +
+    cold start must recover via the spawn-path's
+    ``METHOD_NEW_CONVERSATION`` branch — no manual delete needed.
+    Existing tests already cover cold-start recovery through
+    ``_load_conversation_id`` returning ``""``; this one explicitly
+    seeds a corrupt JSON file to lock the Shan-Shadow user-observable
+    fingerprint.
+    """
+    fake = _write_fake(tmp_path, '''\
+absorb_initialize()
+
+msg = r()
+assert msg["method"] == "thread/start", f"unexpected first method {msg.get('method')!r}"
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_recovered", "createdAt": "2026-06-13T23:58:00Z"}}})
+
+msg = r()  # turn/start
+assert msg["method"] == "turn/start"
+assert msg["params"]["threadId"] == "conv_recovered"
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "method": "item/agentMessage/delta",
+   "params": {"threadId": "t", "turnId": "u", "itemId": "m", "delta": "back"}})
+w({"jsonrpc": "2.0", "id": turn_id, "result": None})
+w({"jsonrpc": "2.0", "method": "turn/completed", "params": {}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+    session_file = tmp_path / "codex_session.json"
+    # Shan-Shadow's case: file exists but JSON is invalid.
+    session_file.write_text("partial-corrupt{not-json", encoding="utf-8")
+
+    cs = CodexSession(
+        agent_id="shan-shadow-puf291",
+        session_file=session_file,
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+    async def _run():
+        await cs.warm("sys")
+        result = await cs.run_turn("are you there?", "sys")
+        await cs.aclose()
+        return result
+
+    result = asyncio.run(_run())
+    assert "back" in (result.reply or "")
+    # Session file should now hold the fresh cid the spawn-path created.
+    persisted = json.loads(session_file.read_text(encoding="utf-8"))
+    assert persisted.get("conversation_id") == "conv_recovered"

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -798,3 +798,53 @@ while True:
     # Session file should now hold the fresh cid the spawn-path created.
     persisted = json.loads(session_file.read_text(encoding="utf-8"))
     assert persisted.get("conversation_id") == "conv_recovered"
+
+
+def test_puf291_bootstrap_raises_when_thread_start_returns_no_id(tmp_path):
+    """PUF-291 polish (Solution QA gap #2/#4 combined): the post-call
+    invariant of ``_ensure_running`` (proc alive AND cid non-empty) is
+    only sound if ``_bootstrap_session`` reliably surfaces a malformed
+    ``thread/start`` response as an exception. Guard the chain so a
+    future regression that drops the "no thread id" check would fail
+    here loudly instead of letting the session limp along with
+    ``_conversation_id=""`` (the exact Shan-Shadow wedge).
+    """
+    fake = _write_fake(tmp_path, '''\
+absorb_initialize()
+msg = r()
+assert msg["method"] == "thread/start"
+# Reply with a structurally valid result that nonetheless carries no
+# thread id under any of the keys _extract_thread_id walks.
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"createdAt": "2026-06-13T00:00:00Z"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+    session_file = tmp_path / "codex_session.json"
+    cs = CodexSession(
+        agent_id="puf291-bootstrap-no-id",
+        session_file=session_file,
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+    async def _run():
+        try:
+            await cs.warm("sys")
+            return None
+        except RuntimeError as exc:
+            return str(exc)
+        finally:
+            await cs.aclose()
+
+    err = asyncio.run(_run())
+    assert err is not None, "warm should propagate the bootstrap failure"
+    assert "no thread id" in err, err
+    # _spawn's try/except must have torn the proc back down so a
+    # subsequent _ensure_running goes through the cold-start path
+    # instead of seeing a half-initialised live proc.
+    assert cs._proc is None
+    assert cs._conversation_id == ""


### PR DESCRIPTION
## Summary

FB-274 (Shan-Shadow): codex agents silent-wedge when `_load_conversation_id()` returns `""` (corrupt session file) but `_ensure_running` only checks proc liveness — `run_turn` sends `threadId=""` and codex never replies. Fix is (α) + (β) belt-and-suspenders per Equation's lean.

- **(α)** `_ensure_running` validates `_conversation_id` non-empty AFTER proc-alive check. Stale proc with empty cid → `_teardown_locked` + `_spawn` → `_bootstrap_session` re-establishes the thread (or raises loudly on `thread/start` returning no id). Post-call invariant: proc alive AND `_conversation_id` non-empty.
- **(β)** `run_turn` raises `RuntimeError` if cid stays empty after `_ensure_running` — defense-in-depth surface against a future regression that loosens (α). Worker-layer flips to clear-failure instead of silent-wedge.

`_teardown_locked + _spawn` reuse over `_create_new_conversation` extraction: lock already held + teardown IS the wedge-recovery primitive.

## Test plan

- [x] `pytest tests/test_codex_session.py -k puf291 -v` — 6/6 ✓
  - `puf291_load_conversation_id_failsoft_on_corrupt_json` — regression-guard on the load-time failsoft
  - `puf291_ensure_running_with_empty_cid_and_alive_proc_respawns` — (α) tear-down + respawn path
  - `puf291_ensure_running_with_non_empty_cid_and_alive_proc_is_noop` — (α) non-regression on the warm-noop path
  - `puf291_ensure_running_with_dead_proc_spawns_without_teardown` — (α) cold-start path preserved
  - `puf291_run_turn_raises_when_cid_stays_empty` — (β) RuntimeError contract
  - `puf291_shan_shadow_repro_corrupt_session_recovers` — Shan-Shadow end-to-end (corrupt JSON → `warm` → `run_turn` → reply + cid persisted)
- [x] Full `test_codex_session.py` — 15/15 ✓
- [ ] Manual Shan-Shadow on staging: pick a codex agent, corrupt `codex_session.json`, restart daemon → next message recovers (no wedge, no manual delete).

Pre-existing 3 failures on `test_codex_thread_rotation` / `test_codex_credential_refresh` are environmental (`aiohttp` ModuleNotFoundError) and reproduce on raw `origin/main` — not caused by PUF-291.

Linked: FB-274 (Shan-Shadow, Grande-relayed). Sibling axis: FB-282 dead-agent silent-fail UX surface (separate work).