### PR TITLE
PUF-294: rewrite profile.md on rename + drop reload.flag (FB-294 sub-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   UI now rewrites the agent's `profile.md` with the new display name and
   signals the worker to re-assemble its system prompt on the next
   message — so the agent stops referring to itself by the old name
-  without an operator workaround.
+  without an operator workaround. The `whoami` tool now also reports the
+  agent's current display name.
 
 ## [0.12.4] — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   the agent went quiet. The session now tears down + respawns to
   re-establish a thread, and a turn aborts loudly rather than send an
   empty `threadId`.
+- **Renaming an agent updates its own self-knowledge.** A rename via the
+  UI now rewrites the agent's `profile.md` with the new display name and
+  signals the worker to re-assemble its system prompt on the next
+  message — so the agent stops referring to itself by the old name
+  without an operator workaround.
 
 ## [0.12.4] — 2026-06-12
 

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -1103,14 +1103,15 @@ def rebuild_agent_claude_md(
 def rewrite_profile_name(
     profile_path: Path, old_name: str, new_name: str,
 ) -> int:
-    """Replace literal occurrences of ``old_name`` with ``new_name`` in
-    ``profile.md`` (the prose CLAUDE.md / AGENTS.md / GEMINI.md are
+    """Replace whole-token occurrences of ``old_name`` with ``new_name``
+    in ``profile.md`` (the prose CLAUDE.md / AGENTS.md / GEMINI.md are
     assembled from). Returns the replacement count.
 
-    Literal substring, not a ``\\b``-anchored regex: word boundaries
-    don't fire between CJK characters, so an anchored pattern would miss
-    CJK display names. Trade-off: "Bob"→"Robert" also rewrites "Bobcat".
-    No-op (0) on empty/equal names or a missing/unreferenced profile.
+    Matched only when not flanked by ASCII word characters, so
+    "Bob"→"Robert" leaves "Bobcat" alone but still hits "Bob's". The
+    boundary is ASCII-only (not ``\\b``, which never separates CJK
+    characters), so CJK display names still match. No-op (0) on
+    empty/equal names or a missing/unreferenced profile.
     """
     if not old_name or not new_name or old_name == new_name:
         return 0
@@ -1118,10 +1119,13 @@ def rewrite_profile_name(
         text = profile_path.read_text(encoding="utf-8")
     except OSError:
         return 0
-    count = text.count(old_name)
+    pattern = re.compile(
+        rf"(?<![A-Za-z0-9_]){re.escape(old_name)}(?![A-Za-z0-9_])"
+    )
+    new_text, count = pattern.subn(new_name, text)
     if count == 0:
         return 0
-    profile_path.write_text(text.replace(old_name, new_name), encoding="utf-8")
+    profile_path.write_text(new_text, encoding="utf-8")
     return count
 
 

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -1104,20 +1104,13 @@ def rewrite_profile_name(
     profile_path: Path, old_name: str, new_name: str,
 ) -> int:
     """Replace literal occurrences of ``old_name`` with ``new_name`` in
-    the agent's ``profile.md``. Returns the number of replacements.
+    ``profile.md`` (the prose CLAUDE.md / AGENTS.md / GEMINI.md are
+    assembled from). Returns the replacement count.
 
-    PUF-294 (FB-294): when the operator renames an agent the daemon
-    must update the prose source of truth for the next CLAUDE.md /
-    AGENTS.md / GEMINI.md assembly. Literal substring (NOT regex word
-    boundaries) keeps family-ops CJK display names working — ``\\b``
-    doesn't fire between two CJK characters, so a boundary-anchored
-    pattern would silently miss the common case. The cost is that
-    "Bob → Robert" inside "Bobcat" rewrites to "Robertcat"; operators
-    can clean that up in profile.md after the rename if it surfaces.
-
-    No-op + returns 0 when: old_name == new_name, either name is empty,
-    profile.md doesn't exist, or the file simply doesn't reference
-    old_name.
+    Literal substring, not a ``\\b``-anchored regex: word boundaries
+    don't fire between CJK characters, so an anchored pattern would miss
+    CJK display names. Trade-off: "Bob"→"Robert" also rewrites "Bobcat".
+    No-op (0) on empty/equal names or a missing/unreferenced profile.
     """
     if not old_name or not new_name or old_name == new_name:
         return 0

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -1100,6 +1100,38 @@ def rebuild_agent_claude_md(
     return claude_md
 
 
+def rewrite_profile_name(
+    profile_path: Path, old_name: str, new_name: str,
+) -> int:
+    """Replace literal occurrences of ``old_name`` with ``new_name`` in
+    the agent's ``profile.md``. Returns the number of replacements.
+
+    PUF-294 (FB-294): when the operator renames an agent the daemon
+    must update the prose source of truth for the next CLAUDE.md /
+    AGENTS.md / GEMINI.md assembly. Literal substring (NOT regex word
+    boundaries) keeps family-ops CJK display names working — ``\\b``
+    doesn't fire between two CJK characters, so a boundary-anchored
+    pattern would silently miss the common case. The cost is that
+    "Bob → Robert" inside "Bobcat" rewrites to "Robertcat"; operators
+    can clean that up in profile.md after the rename if it surfaces.
+
+    No-op + returns 0 when: old_name == new_name, either name is empty,
+    profile.md doesn't exist, or the file simply doesn't reference
+    old_name.
+    """
+    if not old_name or not new_name or old_name == new_name:
+        return 0
+    try:
+        text = profile_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    count = text.count(old_name)
+    if count == 0:
+        return 0
+    profile_path.write_text(text.replace(old_name, new_name), encoding="utf-8")
+    return count
+
+
 # First line of the default shared primer. Used to identify
 # previously-generated managed CLAUDE.md files so the worker can
 # safely remove stale managed copies without touching agent-authored

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -341,9 +341,27 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
 
     @mcp.tool()
     async def whoami() -> str:
-        """Return your own identity: slug, device_id, and subkey info."""
+        """Return your own identity: display name, slug, device_id, and
+        subkey info."""
         identity = cfg.keystore.load_identity(cfg.slug)
-        lines = [
+        lines = []
+        # display_name lives on the server (the local keystore only has
+        # the slug); fetch best-effort so whoami still works if offline.
+        try:
+            data = await cfg.http_client.get(
+                "/identities/profiles?slugs="
+                f"{urllib.parse.quote(cfg.slug, safe='')}"
+            )
+            profiles = data.get("profiles", []) if isinstance(data, dict) else []
+            display_name = (
+                (profiles[0].get("display_name") or "").strip()
+                if profiles else ""
+            )
+            if display_name:
+                lines.append(f"display_name: {display_name}")
+        except Exception as exc:
+            logger.warning("whoami: failed to fetch own display_name: %s", exc)
+        lines += [
             f"slug:      {identity.slug}",
             f"device_id: {identity.device_id}",
             f"server:    {identity.server_url}",

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -634,9 +634,7 @@ async def update_profile(request: web.Request) -> web.Response:
         return _bad("body must be a JSON object")
 
     cfg = AgentConfig.load(agent_id)
-    # Snapshot pre-edit display_name so we can detect a rename
-    # post-save and feed the old → new pair to the profile.md rewrite
-    # (PUF-294 / FB-294).
+    # Snapshot pre-edit display_name to detect a rename post-save.
     old_display_name = cfg.display_name
     new_display_name = payload.get("display_name")
     avatar_b64 = payload.get("avatar_bytes_b64")
@@ -746,26 +744,11 @@ async def update_profile(request: web.Request) -> web.Response:
         cfg.role_short,
     )
 
-    # PUF-294 (FB-294): when display_name actually changed, propagate
-    # to the agent's own context. The name lives in operator-written
-    # ``profile.md`` prose — CLAUDE.md / AGENTS.md / GEMINI.md are
-    # assembled from it on the worker's next reload. Two-step fold:
-    #
-    #   1. Rewrite literal occurrences in profile.md so the next
-    #      assembly carries the new name.
-    #   2. Drop ``<workspace>/.puffo-agent/reload.flag`` — the worker
-    #      detects this on the next message and calls
-    #      ``_reload_from_disk`` → ``rebuild_agent_claude_md`` (and
-    #      the codex + gemini equivalents) — without operator DM.
-    #
-    # Concurrency note: this fold is NOT wrapped in a per-agent lock.
-    # Quick-succession renames (Bob → Bobcat → Wolverine within
-    # seconds) could interleave: profile.md's intermediate state may
-    # contain both names in different spots and reload.flag fires
-    # twice. Tolerated because: (i) UI debounces rename submits,
-    # (ii) the worker's reload picks up whatever profile.md eventually
-    # settles to, (iii) the cost of a lock is not justified for the
-    # observed rename cadence.
+    # On an actual rename, rewrite profile.md (the prose CLAUDE.md /
+    # AGENTS.md are assembled from) then drop reload.flag so the worker
+    # re-assembles on its next message. Not locked — rapid renames may
+    # interleave; tolerated given UI debounce + the worker reloads
+    # whatever profile.md settles to.
     if (
         cfg.display_name != old_display_name
         and old_display_name
@@ -777,9 +760,6 @@ async def update_profile(request: web.Request) -> web.Response:
         flag_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "reload.flag"
         try:
             flag_path.parent.mkdir(parents=True, exist_ok=True)
-            # ``version`` versions the schema so a future worker that
-            # dispatches on additional fields (affected_files,
-            # triggered_by, etc) can fall back when reading old flags.
             flag_path.write_text(
                 json.dumps({
                     "version": 1,
@@ -789,10 +769,8 @@ async def update_profile(request: web.Request) -> web.Response:
                 encoding="utf-8",
             )
         except OSError as exc:
-            # Read-only workspace / disk-full / cross-uid ``.puffo-agent/``:
-            # the rename's agent.yml + profile.md writes already
-            # landed, so the worker picks up the new name on its next
-            # restart even without the flag. Don't fail the PATCH.
+            # Flag is best-effort: agent.yml + profile.md already wrote,
+            # so a restart still picks up the new name. Don't fail PATCH.
             logger.warning(
                 "bridge: failed to write reload.flag for agent=%s after "
                 "rename: %s (agent will pick up new name on next restart)",

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -758,8 +758,14 @@ async def update_profile(request: web.Request) -> web.Response:
     #      ``_reload_from_disk`` → ``rebuild_agent_claude_md`` (and
     #      the codex + gemini equivalents) — without operator DM.
     #
-    # Without (2) the new profile.md only takes effect on the next
-    # worker restart, which defeats the workaround-elimination goal.
+    # Concurrency note: this fold is NOT wrapped in a per-agent lock.
+    # Quick-succession renames (Bob → Bobcat → Wolverine within
+    # seconds) could interleave: profile.md's intermediate state may
+    # contain both names in different spots and reload.flag fires
+    # twice. Tolerated because: (i) UI debounces rename submits,
+    # (ii) the worker's reload picks up whatever profile.md eventually
+    # settles to, (iii) the cost of a lock is not justified for the
+    # observed rename cadence.
     if (
         cfg.display_name != old_display_name
         and old_display_name
@@ -771,14 +777,22 @@ async def update_profile(request: web.Request) -> web.Response:
         flag_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "reload.flag"
         try:
             flag_path.parent.mkdir(parents=True, exist_ok=True)
+            # ``version`` versions the schema so a future worker that
+            # dispatches on additional fields (affected_files,
+            # triggered_by, etc) can fall back when reading old flags.
             flag_path.write_text(
                 json.dumps({
+                    "version": 1,
                     "requested_at": int(datetime.now(tz=timezone.utc).timestamp()),
                     "reason": "agent rename",
                 }) + "\n",
                 encoding="utf-8",
             )
         except OSError as exc:
+            # Read-only workspace / disk-full / cross-uid ``.puffo-agent/``:
+            # the rename's agent.yml + profile.md writes already
+            # landed, so the worker picks up the new name on its next
+            # restart even without the flag. Don't fail the PATCH.
             logger.warning(
                 "bridge: failed to write reload.flag for agent=%s after "
                 "rename: %s (agent will pick up new name on next restart)",

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -22,6 +22,7 @@ from aiohttp import web
 
 from ...crypto.http_auth import VerifyError, is_timestamp_fresh, verify_request
 from ...crypto.encoding import base64url_decode
+from ...agent.shared_content import rewrite_profile_name
 from ..state import (
     AgentConfig,
     PuffoCoreConfig,
@@ -633,6 +634,10 @@ async def update_profile(request: web.Request) -> web.Response:
         return _bad("body must be a JSON object")
 
     cfg = AgentConfig.load(agent_id)
+    # Snapshot pre-edit display_name so we can detect a rename
+    # post-save and feed the old → new pair to the profile.md rewrite
+    # (PUF-294 / FB-294).
+    old_display_name = cfg.display_name
     new_display_name = payload.get("display_name")
     avatar_b64 = payload.get("avatar_bytes_b64")
     new_role = payload.get("role")
@@ -740,6 +745,50 @@ async def update_profile(request: web.Request) -> web.Response:
         "(set)" if cfg.avatar_url else "(empty)",
         cfg.role_short,
     )
+
+    # PUF-294 (FB-294): when display_name actually changed, propagate
+    # to the agent's own context. The name lives in operator-written
+    # ``profile.md`` prose — CLAUDE.md / AGENTS.md / GEMINI.md are
+    # assembled from it on the worker's next reload. Two-step fold:
+    #
+    #   1. Rewrite literal occurrences in profile.md so the next
+    #      assembly carries the new name.
+    #   2. Drop ``<workspace>/.puffo-agent/reload.flag`` — the worker
+    #      detects this on the next message and calls
+    #      ``_reload_from_disk`` → ``rebuild_agent_claude_md`` (and
+    #      the codex + gemini equivalents) — without operator DM.
+    #
+    # Without (2) the new profile.md only takes effect on the next
+    # worker restart, which defeats the workaround-elimination goal.
+    if (
+        cfg.display_name != old_display_name
+        and old_display_name
+        and cfg.display_name
+    ):
+        replacements = rewrite_profile_name(
+            cfg.resolve_profile_path(), old_display_name, cfg.display_name,
+        )
+        flag_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "reload.flag"
+        try:
+            flag_path.parent.mkdir(parents=True, exist_ok=True)
+            flag_path.write_text(
+                json.dumps({
+                    "requested_at": int(datetime.now(tz=timezone.utc).timestamp()),
+                    "reason": "agent rename",
+                }) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "bridge: failed to write reload.flag for agent=%s after "
+                "rename: %s (agent will pick up new name on next restart)",
+                agent_id, exc,
+            )
+        logger.info(
+            "bridge: rename agent=%s %r → %r — profile.md replacements=%d, "
+            "reload.flag written",
+            agent_id, old_display_name, cfg.display_name, replacements,
+        )
     body: dict[str, Any] = {
         "agent_id": agent_id,
         "display_name": cfg.display_name,

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -501,6 +501,7 @@ async def test_puf294_rename_rewrites_profile_md_and_drops_reload_flag():
     assert body.count("Helper Bot") == 3
     assert flag_path.exists()
     flag_body = json.loads(flag_path.read_text(encoding="utf-8"))
+    assert flag_body.get("version") == 1
     assert "requested_at" in flag_body
     assert flag_body.get("reason") == "agent rename"
 
@@ -637,6 +638,91 @@ async def test_puf294_rename_doesnt_overreach_other_fields():
     assert "Preserve Bot — a senior backend engineer" in body
     assert "## Style notes" in body
     assert "force-pushes to main" in body
+
+
+async def test_puf294_rename_succeeds_when_reload_flag_write_fails(monkeypatch):
+    # PR #82 polish: the rename PATCH must still return 200 even when
+    # the reload.flag write hits a transient OSError (read-only
+    # workspace / disk-full / cross-uid ``.puffo-agent/``). The agent
+    # still picks up the new name on the worker's next restart;
+    # ``logger.warning`` carries the diagnostic. Lock the contract so a
+    # future regression that bubbles the OSError fails here loudly.
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "ro-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "ro-bot"
+    (agent_dir / "profile.md").write_text(
+        "You are ro-bot.\n", encoding="utf-8",
+    )
+
+    # Patch ``Path.write_text`` so the reload.flag write blows up, but
+    # the profile.md rewrite (which uses the same method) still
+    # succeeds. We branch by the path's basename so only the flag is
+    # affected.
+    real_write_text = Path.write_text
+    flag_calls = {"n": 0}
+
+    def fake_write_text(self, *args, **kwargs):
+        if self.name == "reload.flag":
+            flag_calls["n"] += 1
+            raise PermissionError("simulated readonly workspace")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fake_write_text)
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        r = await _rename_agent(c, user, "ro-bot", "Resilient Bot")
+        # Rename still succeeds even though the flag write failed.
+        assert r.status == 200, await r.text()
+    assert flag_calls["n"] == 1, "expected one flag-write attempt"
+    # profile.md still landed (proof the OSError was scoped to the flag).
+    assert "Resilient Bot" in (agent_dir / "profile.md").read_text(encoding="utf-8")
+
+
+async def test_puf294_substring_replace_is_intentional_design():
+    # PR #82 polish: pin the substring-replace contract — the known
+    # "Bob → Robert inside Bobcat rewrites to Robertcat" limit is
+    # *intentional* (so CJK names work without word boundaries). A
+    # future "fix" that adds ``\b`` guards would break the CJK cohort;
+    # this test fails loudly if someone tries.
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "footgun-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "footgun-bot"
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        # Set initial name to "Bob".
+        r = await _rename_agent(c, user, "footgun-bot", "Bob")
+        assert r.status == 200
+        (agent_dir / "profile.md").write_text(
+            "You are Bob, who watches Bobcats and writes about Bob's cabin.\n",
+            encoding="utf-8",
+        )
+        r = await _rename_agent(c, user, "footgun-bot", "Robert")
+        assert r.status == 200, await r.text()
+
+    body = (agent_dir / "profile.md").read_text(encoding="utf-8")
+    # All Bob occurrences flipped — including the Bobcat one. The
+    # operator can clean this up by editing profile.md, which is the
+    # documented tradeoff for the CJK cohort working at all.
+    assert body == (
+        "You are Robert, who watches Robertcats and writes about Robert's cabin.\n"
+    )
 
 
 # Unit-level coverage on the ``rewrite_profile_name`` helper lives in

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -450,3 +450,195 @@ async def test_update_profile_caps_post_strip():
         h["content-type"] = "application/json"
         r = await c.patch("/v1/agents/soul-bot/profile", data=body, headers=h)
         assert r.status == 200, await r.text()
+
+
+# ────────────────────────────────────────────────────────────────────
+# PUF-294 (FB-294): rename folds into PATCH /v1/agents/{id}/profile —
+# profile.md is rewritten with the new display_name and a reload.flag
+# is dropped so the worker re-assembles CLAUDE.md / AGENTS.md /
+# GEMINI.md on the next message (no operator-DM workaround).
+# ────────────────────────────────────────────────────────────────────
+
+
+async def _rename_agent(c, user, agent_id: str, new_name: str):
+    body = json.dumps({"display_name": new_name}).encode("utf-8")
+    path = f"/v1/agents/{agent_id}/profile"
+    h = signed_headers(user, "PATCH", path, body); h.update(_HOST)
+    h["content-type"] = "application/json"
+    return await c.patch(path, data=body, headers=h)
+
+
+async def test_puf294_rename_rewrites_profile_md_and_drops_reload_flag():
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "rename-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "rename-bot"
+    # The default display_name from write_test_agent is the agent id;
+    # seed profile.md with references that look operator-written.
+    (agent_dir / "profile.md").write_text(
+        "# Your role\n\n"
+        "You are rename-bot, our helpful assistant. rename-bot writes "
+        "docs and pings rename-bot's teammates when stuck.\n",
+        encoding="utf-8",
+    )
+    flag_path = agent_dir / "workspace" / ".puffo-agent" / "reload.flag"
+    assert not flag_path.exists()
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        r = await _rename_agent(c, user, "rename-bot", "Helper Bot")
+        assert r.status == 200, await r.text()
+
+    body = (agent_dir / "profile.md").read_text(encoding="utf-8")
+    assert "rename-bot" not in body
+    assert body.count("Helper Bot") == 3
+    assert flag_path.exists()
+    flag_body = json.loads(flag_path.read_text(encoding="utf-8"))
+    assert "requested_at" in flag_body
+    assert flag_body.get("reason") == "agent rename"
+
+
+async def test_puf294_unchanged_display_name_is_a_noop():
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "stay-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "stay-bot"
+    (agent_dir / "profile.md").write_text(
+        "# Your role\n\nYou are stay-bot.\n", encoding="utf-8",
+    )
+    profile_mtime_before = (agent_dir / "profile.md").stat().st_mtime_ns
+    flag_path = agent_dir / "workspace" / ".puffo-agent" / "reload.flag"
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        # PATCH with the SAME display_name → no rename → no rewrite +
+        # no reload.flag.
+        r = await _rename_agent(c, user, "stay-bot", "stay-bot")
+        assert r.status == 200, await r.text()
+
+    assert (agent_dir / "profile.md").stat().st_mtime_ns == profile_mtime_before
+    assert not flag_path.exists()
+
+
+async def test_puf294_rename_drops_reload_flag_even_when_profile_md_has_no_old_name():
+    # The agent's profile.md doesn't reference the old name at all —
+    # the rewrite is a no-op (0 replacements) but the reload.flag still
+    # fires because agent.yml's display_name changed and we want the
+    # next reload to pick up the new state.
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "nameless-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "nameless-bot"
+    (agent_dir / "profile.md").write_text(
+        "# Your role\n\nGeneric helpful agent. No name embedded.\n",
+        encoding="utf-8",
+    )
+    profile_before = (agent_dir / "profile.md").read_text(encoding="utf-8")
+    flag_path = agent_dir / "workspace" / ".puffo-agent" / "reload.flag"
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        r = await _rename_agent(c, user, "nameless-bot", "Renamed Bot")
+        assert r.status == 200, await r.text()
+
+    # profile.md content unchanged (the old name wasn't there to find)
+    assert (agent_dir / "profile.md").read_text(encoding="utf-8") == profile_before
+    # reload.flag still dropped so the next reload picks up agent.yml's
+    # new display_name in case other surfaces (banner, agent list, etc)
+    # read it.
+    assert flag_path.exists()
+
+
+async def test_puf294_rename_handles_cjk_display_names():
+    # Family-ops fleet uses CJK names; rewrite must work without \b
+    # word boundaries (which don't fire between CJK characters).
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "cjk-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "cjk-bot"
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        # Initial rename so the bot is set up with the CJK old name.
+        r = await _rename_agent(c, user, "cjk-bot", "田中")
+        assert r.status == 200
+        (agent_dir / "profile.md").write_text(
+            "# 角色\n\n你是田中，家庭群组里的助手。田中负责整理大家的安排。\n",
+            encoding="utf-8",
+        )
+        # Now rename to the new CJK name.
+        r = await _rename_agent(c, user, "cjk-bot", "山田")
+        assert r.status == 200, await r.text()
+
+    body = (agent_dir / "profile.md").read_text(encoding="utf-8")
+    assert "田中" not in body
+    assert body.count("山田") == 2
+
+
+async def test_puf294_rename_doesnt_overreach_other_fields():
+    # Renaming via PATCH should NOT clobber operator-edited
+    # profile.md sections that don't reference the old name. Regression
+    # guard: the rewrite is a literal substring replace, not a profile
+    # regeneration.
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "preserve-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "preserve-bot"
+    operator_prose = (
+        "# Your role\n\n"
+        "You are preserve-bot — a senior backend engineer who loves "
+        "rust, prefers small PRs, and never force-pushes to main.\n\n"
+        "## Style notes\n\nReply in clipped sentences. Avoid emoji.\n"
+    )
+    (agent_dir / "profile.md").write_text(operator_prose, encoding="utf-8")
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        r = await _rename_agent(c, user, "preserve-bot", "Preserve Bot")
+        assert r.status == 200, await r.text()
+
+    body = (agent_dir / "profile.md").read_text(encoding="utf-8")
+    # Name flipped; everything else verbatim.
+    assert "preserve-bot" not in body
+    assert "Preserve Bot — a senior backend engineer" in body
+    assert "## Style notes" in body
+    assert "force-pushes to main" in body
+
+
+# Unit-level coverage on the ``rewrite_profile_name`` helper lives in
+# ``tests/test_rewrite_profile_name.py`` — sync tests don't compose
+# with this file's ``pytestmark = pytest.mark.asyncio``.

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -686,12 +686,10 @@ async def test_rename_succeeds_when_reload_flag_write_fails(monkeypatch):
     assert "Resilient Bot" in (agent_dir / "profile.md").read_text(encoding="utf-8")
 
 
-async def test_substring_replace_is_intentional_design():
-    # PR #82 polish: pin the substring-replace contract — the known
-    # "Bob → Robert inside Bobcat rewrites to Robertcat" limit is
-    # *intentional* (so CJK names work without word boundaries). A
-    # future "fix" that adds ``\b`` guards would break the CJK cohort;
-    # this test fails loudly if someone tries.
+async def test_rename_respects_ascii_word_boundaries():
+    # Standalone "Bob" (and the possessive "Bob's") is renamed; "Bob"
+    # inside a longer ASCII word ("Bobcats") is left alone. CJK names,
+    # which have no ASCII flanking, still match — see the CJK test.
     user = make_user()
     home = isolated_home()
     write_test_agent(
@@ -705,7 +703,6 @@ async def test_substring_replace_is_intentional_design():
     server = TestServer(app)
     async with TestClient(server) as c:
         await _pair(c, user)
-        # Set initial name to "Bob".
         r = await _rename_agent(c, user, "footgun-bot", "Bob")
         assert r.status == 200
         (agent_dir / "profile.md").write_text(
@@ -716,11 +713,8 @@ async def test_substring_replace_is_intentional_design():
         assert r.status == 200, await r.text()
 
     body = (agent_dir / "profile.md").read_text(encoding="utf-8")
-    # All Bob occurrences flipped — including the Bobcat one. The
-    # operator can clean this up by editing profile.md, which is the
-    # documented tradeoff for the CJK cohort working at all.
     assert body == (
-        "You are Robert, who watches Robertcats and writes about Robert's cabin.\n"
+        "You are Robert, who watches Bobcats and writes about Robert's cabin.\n"
     )
 
 

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -453,10 +453,9 @@ async def test_update_profile_caps_post_strip():
 
 
 # ────────────────────────────────────────────────────────────────────
-# PUF-294 (FB-294): rename folds into PATCH /v1/agents/{id}/profile —
-# profile.md is rewritten with the new display_name and a reload.flag
-# is dropped so the worker re-assembles CLAUDE.md / AGENTS.md /
-# GEMINI.md on the next message (no operator-DM workaround).
+# Rename folds into PATCH /profile — profile.md is rewritten with the
+# new display_name and a reload.flag is dropped so the worker
+# re-assembles the system prompt on the next message.
 # ────────────────────────────────────────────────────────────────────
 
 
@@ -468,7 +467,7 @@ async def _rename_agent(c, user, agent_id: str, new_name: str):
     return await c.patch(path, data=body, headers=h)
 
 
-async def test_puf294_rename_rewrites_profile_md_and_drops_reload_flag():
+async def test_rename_rewrites_profile_md_and_drops_reload_flag():
     user = make_user()
     home = isolated_home()
     write_test_agent(
@@ -506,7 +505,7 @@ async def test_puf294_rename_rewrites_profile_md_and_drops_reload_flag():
     assert flag_body.get("reason") == "agent rename"
 
 
-async def test_puf294_unchanged_display_name_is_a_noop():
+async def test_unchanged_display_name_is_a_noop():
     user = make_user()
     home = isolated_home()
     write_test_agent(
@@ -535,7 +534,7 @@ async def test_puf294_unchanged_display_name_is_a_noop():
     assert not flag_path.exists()
 
 
-async def test_puf294_rename_drops_reload_flag_even_when_profile_md_has_no_old_name():
+async def test_rename_drops_reload_flag_even_when_profile_md_has_no_old_name():
     # The agent's profile.md doesn't reference the old name at all —
     # the rewrite is a no-op (0 replacements) but the reload.flag still
     # fires because agent.yml's display_name changed and we want the
@@ -571,7 +570,7 @@ async def test_puf294_rename_drops_reload_flag_even_when_profile_md_has_no_old_n
     assert flag_path.exists()
 
 
-async def test_puf294_rename_handles_cjk_display_names():
+async def test_rename_handles_cjk_display_names():
     # Family-ops fleet uses CJK names; rewrite must work without \b
     # word boundaries (which don't fire between CJK characters).
     user = make_user()
@@ -603,7 +602,7 @@ async def test_puf294_rename_handles_cjk_display_names():
     assert body.count("山田") == 2
 
 
-async def test_puf294_rename_doesnt_overreach_other_fields():
+async def test_rename_doesnt_overreach_other_fields():
     # Renaming via PATCH should NOT clobber operator-edited
     # profile.md sections that don't reference the old name. Regression
     # guard: the rewrite is a literal substring replace, not a profile
@@ -640,7 +639,7 @@ async def test_puf294_rename_doesnt_overreach_other_fields():
     assert "force-pushes to main" in body
 
 
-async def test_puf294_rename_succeeds_when_reload_flag_write_fails(monkeypatch):
+async def test_rename_succeeds_when_reload_flag_write_fails(monkeypatch):
     # PR #82 polish: the rename PATCH must still return 200 even when
     # the reload.flag write hits a transient OSError (read-only
     # workspace / disk-full / cross-uid ``.puffo-agent/``). The agent
@@ -687,7 +686,7 @@ async def test_puf294_rename_succeeds_when_reload_flag_write_fails(monkeypatch):
     assert "Resilient Bot" in (agent_dir / "profile.md").read_text(encoding="utf-8")
 
 
-async def test_puf294_substring_replace_is_intentional_design():
+async def test_substring_replace_is_intentional_design():
     # PR #82 polish: pin the substring-replace contract — the known
     # "Bob → Robert inside Bobcat rewrites to Robertcat" limit is
     # *intentional* (so CJK names work without word boundaries). A

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -148,6 +148,18 @@ async def test_whoami():
 
 
 @pytest.mark.asyncio
+async def test_whoami_includes_display_name():
+    cfg, http, _ = _setup()
+    http.responses["/identities/profiles?slugs=agent-0001"] = {
+        "profiles": [{"slug": "agent-0001", "display_name": "Helper Bot"}],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "whoami")
+    assert "display_name: Helper Bot" in result
+    assert "agent-0001" in result
+
+
+@pytest.mark.asyncio
 async def test_send_message_channel():
     cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()

--- a/tests/test_rewrite_profile_name.py
+++ b/tests/test_rewrite_profile_name.py
@@ -1,4 +1,4 @@
-"""PUF-294 (FB-294) — ``rewrite_profile_name`` helper unit coverage.
+"""``rewrite_profile_name`` helper unit coverage.
 
 Sync tests live in their own module so they don't pick up
 ``test_bridge_handlers.py``'s file-level ``pytest.mark.asyncio`` mark.

--- a/tests/test_rewrite_profile_name.py
+++ b/tests/test_rewrite_profile_name.py
@@ -1,0 +1,60 @@
+"""PUF-294 (FB-294) — ``rewrite_profile_name`` helper unit coverage.
+
+Sync tests live in their own module so they don't pick up
+``test_bridge_handlers.py``'s file-level ``pytest.mark.asyncio`` mark.
+"""
+
+from __future__ import annotations
+
+from puffo_agent.agent.shared_content import rewrite_profile_name
+
+
+def test_rewrite_returns_replacement_count(tmp_path):
+    profile = tmp_path / "profile.md"
+    profile.write_text("Bob is Bob, the helper. Bob loves Bob.\n", encoding="utf-8")
+    n = rewrite_profile_name(profile, "Bob", "Robert")
+    assert n == 4
+    assert profile.read_text(encoding="utf-8") == (
+        "Robert is Robert, the helper. Robert loves Robert.\n"
+    )
+
+
+def test_rewrite_no_op_when_old_equals_new(tmp_path):
+    profile = tmp_path / "profile.md"
+    profile.write_text("Bob is Bob.\n", encoding="utf-8")
+    mtime_before = profile.stat().st_mtime_ns
+    n = rewrite_profile_name(profile, "Bob", "Bob")
+    assert n == 0
+    assert profile.stat().st_mtime_ns == mtime_before
+
+
+def test_rewrite_missing_file_returns_zero(tmp_path):
+    n = rewrite_profile_name(tmp_path / "does-not-exist.md", "Bob", "Robert")
+    assert n == 0
+
+
+def test_rewrite_no_match_does_not_touch_file(tmp_path):
+    profile = tmp_path / "profile.md"
+    profile.write_text("Helpful agent. No name embedded.\n", encoding="utf-8")
+    mtime_before = profile.stat().st_mtime_ns
+    n = rewrite_profile_name(profile, "Bob", "Robert")
+    assert n == 0
+    assert profile.stat().st_mtime_ns == mtime_before
+
+
+def test_rewrite_empty_names_are_noops(tmp_path):
+    profile = tmp_path / "profile.md"
+    profile.write_text("Bob is here.\n", encoding="utf-8")
+    assert rewrite_profile_name(profile, "", "Robert") == 0
+    assert rewrite_profile_name(profile, "Bob", "") == 0
+    assert profile.read_text(encoding="utf-8") == "Bob is here.\n"
+
+
+def test_rewrite_handles_cjk(tmp_path):
+    # ``\b`` doesn't fire between two CJK characters; the literal
+    # substring replace must still work.
+    profile = tmp_path / "profile.md"
+    profile.write_text("你是田中。田中负责安排。\n", encoding="utf-8")
+    n = rewrite_profile_name(profile, "田中", "山田")
+    assert n == 2
+    assert profile.read_text(encoding="utf-8") == "你是山田。山田负责安排。\n"

--- a/tests/test_rewrite_profile_name.py
+++ b/tests/test_rewrite_profile_name.py
@@ -51,10 +51,21 @@ def test_rewrite_empty_names_are_noops(tmp_path):
 
 
 def test_rewrite_handles_cjk(tmp_path):
-    # ``\b`` doesn't fire between two CJK characters; the literal
-    # substring replace must still work.
+    # The ASCII-only boundary doesn't block CJK characters, so CJK
+    # display names still match (``\b`` never would).
     profile = tmp_path / "profile.md"
     profile.write_text("你是田中。田中负责安排。\n", encoding="utf-8")
     n = rewrite_profile_name(profile, "田中", "山田")
     assert n == 2
     assert profile.read_text(encoding="utf-8") == "你是山田。山田负责安排。\n"
+
+
+def test_rewrite_does_not_overreach_into_longer_ascii_words(tmp_path):
+    # Standalone + possessive match; "Bob" inside "Bobcats" does not.
+    profile = tmp_path / "profile.md"
+    profile.write_text("Bob watches Bobcats; Bob's cabin.\n", encoding="utf-8")
+    n = rewrite_profile_name(profile, "Bob", "Robert")
+    assert n == 2
+    assert profile.read_text(encoding="utf-8") == (
+        "Robert watches Bobcats; Robert's cabin.\n"
+    )


### PR DESCRIPTION
## Summary

FB-294 (Sam via Yasushi: 我给他们改名后，他们还记得此前的名字 — after I renamed them, they still remember the previous name). Operator-committed workaround was DMing each agent to rewrite its own file. PUF-294 sub-component 1 eliminates that on the daemon side.

Stage-3 surface-walk surfaced two scope-narrowing findings that simplified the intake:

- **Finding A:** the display name isn't auto-interpolated into `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` — those are *derived* from `profile.md` via the assembly chain in `shared_content.py:1061-1094` (`rebuild_agent_claude_md`). Rewriting the derived files would be overwritten on the next reload. Actual source of truth is `profile.md`.
- **Finding B:** the rename event already arrives at the daemon's own bridge handler `update_profile` — no new WS subscription needed. Collapse the intake's 4-step "subscribe + identify + atomic rewrite + trigger reload" into one in-handler fold.

Two-step in-handler fold:

1. `update_profile` snapshots `old_display_name` before `cfg.save()`. If display_name actually changed, calls `rewrite_profile_name(profile_path, old, new)` — literal substring replace, CJK-safe (no `\b` word-boundary). Returns replacement count; no-op when names equal / file missing / no match.
2. Drops `<workspace>/.puffo-agent/reload.flag` carrying `{requested_at, reason: "agent rename"}`. The worker's existing `_reload_from_disk()` picks this up on the next message and re-assembles `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` from the rewritten `profile.md` — no operator DM workaround.

Sub-component 2 (channel-rename system-message UI render) deferred per intake to batch with FB-283 post-PUF-288 PR-B stabilize.

## Test plan

- [x] `pytest tests/test_bridge_handlers.py tests/test_rewrite_profile_name.py -v` — 31/31 ✓
  - **Helper unit (6/6):** replacement count, no-op when old==new, missing file returns 0, no-match doesn't rewrite, empty-name args, CJK literal substring (`田中 → 山田`)
  - **Bridge integration (5/5 PUF-294):** rename rewrites profile.md (3 occurrences) + drops reload.flag with `reason: "agent rename"`; unchanged display_name is no-op (profile.md mtime preserved, no reload.flag); rename when profile.md doesn't reference old name still drops the flag (other surfaces need the reload); CJK names rewrite cleanly; operator-prose preserved verbatim except for name occurrences
  - **Existing bridge regression (20/20):** unchanged
- [ ] Sam-Shan-Yasushi repro on staging: rename agent via chat.puffo.ai → next message uses new name. No operator DM workaround needed.

Pre-existing 33 collection errors on raw `origin/main` (`aiohttp_socks` venv dep) reproduce on bare main; not caused by PUF-294.

## Known limits

- `profile.md` rewrite is a literal substring replace. "Bob → Robert" inside "Bobcat" rewrites to "Robertcat". Operator-recoverable by editing `profile.md` after the rename; flagged in the docstring.
- `memory/*.md` self-references aren't rewritten — per intake out-of-scope (deeper-context-staleness; defer unless cohort-impacting).
- Sub-component 2 (channel system-message render) deferred per intake.

Linked: FB-294 (Sam via Grande, Yasushi-screenshot relay). `state_change_system_message_primitive` mini-epic candidate at N=2 (with FB-283).