### PR TITLE
feat(codex): per-agent sandbox policy + auto-reset + UI access row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `workspace-write`, or `danger-full-access`. Defaults to
   `danger-full-access` (the prior behaviour), so existing agents are
   unchanged; an unrecognised value falls back to `danger-full-access`
-  with a warning.
+  with a warning. Changing the sandbox automatically starts a fresh
+  codex thread on the next turn so the new policy takes effect (codex
+  doesn't re-send thread params on resume).
 
 ## [0.12.4] — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.5] — unreleased
+
+### Added
+
+- **Per-agent codex sandbox policy.** A new `runtime.sandbox` field in
+  `agent.yml` (cli-local / codex) sets codex's sandbox: `read-only`,
+  `workspace-write`, or `danger-full-access`. Defaults to
+  `danger-full-access` (the prior behaviour), so existing agents are
+  unchanged; an unrecognised value falls back to `danger-full-access`
+  with a warning.
+
 ## [0.12.4] — 2026-06-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "0.12.4"
+version = "0.12.5"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -185,6 +185,7 @@ class CodexSession:
         cwd: Optional[str] = None,
         env: Optional[dict[str, str]] = None,
         permission_mode: str = "bypassPermissions",
+        sandbox: str = "danger-full-access",
         model: str = "",
     ):
         self.agent_id = agent_id
@@ -196,6 +197,7 @@ class CodexSession:
         # The plan's v1 stance — other modes are deferred until the
         # permission-proxy DM flow is ready for codex too.
         self.permission_mode = permission_mode
+        self.sandbox = sandbox
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
@@ -600,16 +602,17 @@ class CodexSession:
         # live behaviour. Puffo trust model = operator vouches for the
         # agent + machine, all tools allowed.
         #
-        # ``sandbox: "danger-full-access"`` removes codex's in-process
-        # sandbox. cli-local runs as the operator's UID anyway —
-        # codex's sandbox is mostly cosmetic here. (cli-docker will
-        # keep this when supported; the container is the boundary.)
+        # ``sandbox`` is codex's sandbox policy (read-only |
+        # workspace-write | danger-full-access), per-agent via agent.yml.
+        # Default keeps it fully open — cli-local runs as the operator's
+        # UID, so codex's in-process sandbox is mostly cosmetic; the real
+        # boundary is cli-docker's container.
         new_conv_params: dict[str, Any] = {
             "cwd": self.cwd or os.getcwd(),
             "approvalPolicy": (
                 "never" if self.permission_mode == "bypassPermissions" else "untrusted"
             ),
-            "sandbox": "danger-full-access",
+            "sandbox": self.sandbox,
         }
         if self.model:
             new_conv_params["model"] = self.model

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -210,6 +210,19 @@ class CodexSession:
         self._active_turn: _PendingTurn | None = None
         self._lock = asyncio.Lock()
         self._conversation_id: str = self._load_conversation_id()
+        # ``sandbox`` (+ the other thread/start params) aren't re-sent on
+        # resume, so a sandbox change would silently keep the old policy.
+        # Drop the persisted thread when it was created under a different
+        # sandbox; the next start re-applies the current one.
+        if self._conversation_id:
+            persisted_sandbox = self._load_persisted_sandbox()
+            if persisted_sandbox != self.sandbox:
+                logger.info(
+                    "agent %s: codex sandbox changed (%s → %s); starting a "
+                    "fresh thread so the new policy applies",
+                    self.agent_id, persisted_sandbox, self.sandbox,
+                )
+                self._conversation_id = ""
         # The latest system prompt we've been handed. Stored so
         # ``reload`` can detect a no-op vs a real change, and so a
         # respawn can re-issue ``newConversation`` with current
@@ -466,11 +479,22 @@ class CodexSession:
             return ""
         return str(data.get("conversation_id") or "")
 
+    def _load_persisted_sandbox(self) -> str:
+        """Sandbox the persisted thread was created under. A missing key
+        (pre-sandbox-config session files) defaults to
+        ``danger-full-access`` — the old hardcoded value — so agents that
+        never changed sandbox don't get reset."""
+        try:
+            data = json.loads(self.session_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return "danger-full-access"
+        return str(data.get("sandbox") or "danger-full-access")
+
     def _save_conversation_id(self, cid: str) -> None:
         try:
             self.session_file.parent.mkdir(parents=True, exist_ok=True)
             self.session_file.write_text(
-                json.dumps({"conversation_id": cid}),
+                json.dumps({"conversation_id": cid, "sandbox": self.sandbox}),
                 encoding="utf-8",
             )
         except OSError as exc:

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -129,6 +129,28 @@ def _sanitise_permission_mode(mode: str, agent_id: str) -> str:
     return "bypassPermissions"
 
 
+VALID_SANDBOX_MODES = frozenset({
+    "read-only",
+    "workspace-write",
+    "danger-full-access",
+})
+
+
+def _sanitise_sandbox(mode: str, agent_id: str) -> str:
+    """Validate ``mode`` against codex's sandbox set; unknown values
+    fall back to ``danger-full-access`` (the prior hardcoded default)
+    with a WARNING."""
+    if mode in VALID_SANDBOX_MODES:
+        return mode
+    if mode:
+        logger.warning(
+            "agent %s: sandbox %r is not a valid codex sandbox — "
+            "falling back to 'danger-full-access'. valid: %s",
+            agent_id, mode, sorted(VALID_SANDBOX_MODES),
+        )
+    return "danger-full-access"
+
+
 class LocalCLIAdapter(Adapter):
     def __init__(
         self,
@@ -141,6 +163,7 @@ class LocalCLIAdapter(Adapter):
         agent_home_dir: str,
         owner_username: str = "",
         permission_mode: str = "default",
+        sandbox: str = "danger-full-access",
         harness=None,
         desired_skills: list[str] | None = None,
         desired_mcps: list[str] | None = None,
@@ -160,6 +183,7 @@ class LocalCLIAdapter(Adapter):
         self.agent_home_dir = Path(agent_home_dir)
         self.owner_username = owner_username
         self.permission_mode = _sanitise_permission_mode(permission_mode, agent_id)
+        self.sandbox = _sanitise_sandbox(sandbox, agent_id)
         self.desired_skills = list(desired_skills or [])
         self.desired_mcps = list(desired_mcps or [])
         self.puffo_core_server_url = puffo_core_server_url
@@ -382,6 +406,7 @@ class LocalCLIAdapter(Adapter):
             cwd=self.workspace_dir,
             env=env,
             permission_mode=self.permission_mode,
+            sandbox=self.sandbox,
             model=self.model,
         )
         return self._codex_session

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -982,6 +982,9 @@ class RuntimeConfig:
     # cli-local Claude Code permission mode. Only ``bypassPermissions``
     # is supported today; see LocalCLIAdapter._sanitise_permission_mode.
     permission_mode: str = "bypassPermissions"
+    # codex (cli-local) sandbox policy: read-only | workspace-write |
+    # danger-full-access. Default leaves codex's sandbox fully open.
+    sandbox: str = "danger-full-access"
     # Agent engine (CLI kinds only):
     #   - ``claude-code``: ``claude`` CLI with our stream-json session
     #     protocol, --resume, --model, and the puffo MCP tool suite.
@@ -1088,6 +1091,7 @@ class AgentConfig:
                 docker_memory_limit=rt.get("docker_memory_limit", ""),
                 docker_memory_reservation=rt.get("docker_memory_reservation", ""),
                 permission_mode=rt.get("permission_mode", "bypassPermissions"),
+                sandbox=rt.get("sandbox", "danger-full-access"),
                 harness=harness,
                 max_turns=int(rt.get("max_turns", 10)),
             ),

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -275,6 +275,13 @@ class AgentDetail(QWidget):
         self._model = QComboBox()
         layout.addRow("Model", self._model)
 
+        # Read-only access policy: claude-code shows its permission mode;
+        # codex shows the sandbox + approval policy.
+        self._access = QLabel("")
+        self._access.setStyleSheet("color: #6b7280;")
+        self._access.setWordWrap(True)
+        layout.addRow("Access", self._access)
+
         actions = QHBoxLayout()
         self._save_btn = QPushButton("Save")
         self._save_btn.clicked.connect(self._on_save)
@@ -386,6 +393,7 @@ class AgentDetail(QWidget):
         self._set_combo(self._runtime_kind, cfg.runtime.kind)
         self._set_combo(self._harness, cfg.runtime.harness)
         self._populate_model_combo(cfg.runtime.harness, cfg.runtime.model)
+        self._access.setText(self._access_summary(cfg.runtime.harness, cfg))
         self._populate_skills(cfg)
         self._populate_mcp(cfg)
         # ws-local agents bring their own brain — runtime / harness / model
@@ -659,6 +667,21 @@ class AgentDetail(QWidget):
     def _on_harness_changed(self, harness: str) -> None:
         current = self._model.currentText()
         self._populate_model_combo(harness, current)
+        if self._cfg is not None:
+            self._access.setText(self._access_summary(harness, self._cfg))
+
+    def _access_summary(self, harness: str, cfg) -> str:
+        """Read-only access line: permission mode for claude-code,
+        sandbox + approval policy for codex."""
+        if (cfg.runtime.kind or "") == "ws-local":
+            return "n/a — ws-local brings its own AI"
+        if harness == "codex":
+            policy = (
+                "never" if cfg.runtime.permission_mode == "bypassPermissions"
+                else "untrusted"
+            )
+            return f"sandbox: {cfg.runtime.sandbox} · approve: {policy}"
+        return f"permission: {cfg.runtime.permission_mode}"
 
     def _populate_model_combo(self, harness: str, current: str) -> None:
         self._model.blockSignals(True)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -228,6 +228,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             agent_home_dir=str(agent_home_dir(agent_cfg.id)),
             owner_username=operator,
             permission_mode=agent_cfg.runtime.permission_mode,
+            sandbox=agent_cfg.runtime.sandbox,
             harness=harness,
             desired_skills=agent_cfg.desired_skills,
             desired_mcps=agent_cfg.desired_mcps,

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -654,3 +654,39 @@ def test_sanitise_sandbox_falls_back_on_unknown():
     assert _sanitise_sandbox("danger-full-access", "a") == "danger-full-access"
     assert _sanitise_sandbox("bogus", "a") == "danger-full-access"
     assert _sanitise_sandbox("", "a") == "danger-full-access"
+
+
+def test_codex_sandbox_change_resets_persisted_thread(tmp_path):
+    sf = tmp_path / "codex_session.json"
+    sf.write_text(
+        json.dumps({"conversation_id": "old_thread", "sandbox": "danger-full-access"}),
+        encoding="utf-8",
+    )
+    cs = CodexSession(
+        agent_id="a", session_file=sf, argv=["x"], sandbox="workspace-write",
+    )
+    assert cs._conversation_id == ""  # changed → fresh thread next start
+
+
+def test_codex_same_sandbox_keeps_persisted_thread(tmp_path):
+    sf = tmp_path / "codex_session.json"
+    sf.write_text(
+        json.dumps({"conversation_id": "old_thread", "sandbox": "workspace-write"}),
+        encoding="utf-8",
+    )
+    cs = CodexSession(
+        agent_id="a", session_file=sf, argv=["x"], sandbox="workspace-write",
+    )
+    assert cs._conversation_id == "old_thread"  # unchanged → resume
+
+
+def test_codex_legacy_session_file_treated_as_full_access(tmp_path):
+    # Pre-feature file: only conversation_id, no sandbox → danger-full-access.
+    sf = tmp_path / "codex_session.json"
+    sf.write_text(json.dumps({"conversation_id": "old_thread"}), encoding="utf-8")
+    keep = CodexSession(agent_id="a", session_file=sf, argv=["x"])
+    assert keep._conversation_id == "old_thread"  # still full-access → resume
+    reset = CodexSession(
+        agent_id="a", session_file=sf, argv=["x"], sandbox="workspace-write",
+    )
+    assert reset._conversation_id == ""  # now differs → reset

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -602,3 +602,55 @@ while True:
     # 10s graceful + 3s terminate window + slack for slow CI.
     elapsed = asyncio.run(_run())
     assert elapsed < 20.0, f"aclose hung for {elapsed:.1f}s"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sandbox policy — thread/start carries the configured sandbox; adapter
+# sanitises unknown values
+# ─────────────────────────────────────────────────────────────────────────────
+
+SANDBOX_SCRIPT = '''\
+absorb_initialize()
+
+msg = r()
+assert msg["method"] == "thread/start"
+assert msg["params"]["sandbox"] == "workspace-write", \\
+    f"sandbox was {msg['params'].get('sandbox')!r}"
+assert msg["params"]["approvalPolicy"] == "never"
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_sb", "createdAt": "2026-05-15T00:00:00Z"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+'''
+
+
+def test_thread_start_carries_configured_sandbox(tmp_path):
+    fake = _write_fake(tmp_path, SANDBOX_SCRIPT)
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+        sandbox="workspace-write",
+    )
+
+    async def _run():
+        # The fake asserts sandbox/approvalPolicy on thread/start — a
+        # mismatch crashes it, so warm() fails.
+        await cs.warm("system prompt v1")
+        await cs.aclose()
+
+    asyncio.run(_run())
+
+
+def test_sanitise_sandbox_falls_back_on_unknown():
+    from puffo_agent.agent.adapters.local_cli import _sanitise_sandbox
+
+    assert _sanitise_sandbox("workspace-write", "a") == "workspace-write"
+    assert _sanitise_sandbox("read-only", "a") == "read-only"
+    assert _sanitise_sandbox("danger-full-access", "a") == "danger-full-access"
+    assert _sanitise_sandbox("bogus", "a") == "danger-full-access"
+    assert _sanitise_sandbox("", "a") == "danger-full-access"


### PR DESCRIPTION
## What

Codex's sandbox was hardcoded to `danger-full-access`. This makes it **per-agent configurable** via `agent.yml`, surfaces it in the UI, and makes a change actually take effect.

### 1. `runtime.sandbox` in `agent.yml`
A new field on the cli-local / codex runtime: `read-only` | `workspace-write` | `danger-full-access`. Threads `agent.yml` → `RuntimeConfig` → `LocalCLIAdapter` → `CodexSession` → codex `thread/start`. Defaults to `danger-full-access` (the prior behaviour), so existing agents are unchanged; an unrecognised value falls back to `danger-full-access` with a warning.

### 2. Auto-reset the codex thread when the sandbox changes
`thread/start` params (including `sandbox`) are **not re-sent on `thread/resume`**, so editing the sandbox on an agent with an existing conversation was silently ignored. The sandbox is now persisted alongside `conversation_id` in `codex_session.json`; on session construction, if the persisted sandbox differs from the current config, the thread is dropped so the next start re-applies the new policy. Legacy session files (no `sandbox` key) are treated as `danger-full-access`, so unchanged agents don't reset.

### 3. UI "Access" row
The agent detail panel now shows a read-only access line: claude-code → its permission mode; codex → `sandbox: <value> · approve: <never|untrusted>`; ws-local → n/a.

## Note: codex sandboxing is a no-op on Windows
Codex's sandbox relies on OS primitives (macOS Seatbelt / Linux Landlock) that **Windows doesn't have**, so anything other than `danger-full-access` fail-closes to effectively read-only + blocked commands (`approvalPolicy: never` auto-rejects the escalations). On Windows, `workspace-write` / `read-only` make a codex agent unable to write or run commands — they're only meaningful on macOS/Linux (or use the cli-docker container as the boundary). The config is honoured; the OS just can't enforce the scoped variants on Windows.

## Tests
`tests/test_codex_session.py` (+6): `thread/start` carries the configured sandbox; the sanitiser fallback; the auto-reset on change / no-reset on match / legacy-file default.

`PYTHONPATH=src python -m pytest`: **1425 passed / 9 skipped**. Bumps version to 0.12.5; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
