### PR TITLE
PUF-302: uv-tool detection + cmd_stop pid-tracking + cmd_start exit-0 (FB-261 reactivated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   thread), so this raised `RuntimeError` at startup. POSIX handlers are
   now installed only when on the main thread; those modes stop via the
   existing file sentinel.
+- **Correct upgrade + restart messaging on `uv`-managed Python and
+  daemon swaps.** `check-update` now detects a `uv tool` install and
+  prints `uv tool install puffo-agent --force` instead of `pip install`
+  (which PEP 668 rejects on uv-managed Python). `puffo-agent stop`
+  reports a daemon swap explicitly when a new daemon takes over
+  mid-shutdown, and `puffo-agent start` against an already-running
+  daemon now exits 0 (the user's intent is met) instead of erroring.
 
 ## [0.12.4] — 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,26 @@ message keys, ed25519-signed events, structured AAD, and
 
 ## Install
 
+If you manage Python with `uv` (uv-managed interpreter, common on
+macOS via Homebrew + uv), use the `uv tool` path — `pip install`
+fails with PEP 668 `externally-managed-environment` on uv-managed
+Python:
+
+```bash
+uv tool install puffo-agent
+```
+
+Otherwise use pip:
+
 ```bash
 pip install puffo-agent
 ```
 
-Installs the `puffo-agent` console script. For contributors working
-from a source checkout:
+Both paths install the `puffo-agent` console script. The CLI's
+`check-update` command detects which way you installed and prints
+the matching upgrade command, so you don't have to remember.
+
+For contributors working from a source checkout:
 
 ```bash
 git clone https://github.com/puffo-ai/puffo-agent.git
@@ -55,8 +69,9 @@ pip install -e ".[dev]"
 
 ## First-time setup
 
-There isn't one — `pip install puffo-agent` then `puffo-agent start`
-is the whole install-and-go path. The daemon lazy-creates
+There isn't one — install (via `uv tool install puffo-agent` or
+`pip install puffo-agent`) then `puffo-agent start` is the whole
+install-and-go path. The daemon lazy-creates
 `~/.puffo-agent/` on first run and ships sensible defaults (server
 `https://api.puffo.ai`, provider `anthropic`).
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,16 @@ Python:
 
 ```bash
 uv tool install puffo-agent
+# pin to a specific version:
+uv tool install puffo-agent==0.12.4
 ```
 
 Otherwise use pip:
 
 ```bash
 pip install puffo-agent
+# pin to a specific version:
+pip install puffo-agent==0.12.4
 ```
 
 Both paths install the `puffo-agent` console script. The CLI's

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -9,7 +9,7 @@ You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds 
 
 ## Install puffo-agent
 
-Needs `puffo-agent` on PATH (Python ≥ 3.11) — check with `puffo-agent --version`. If it's missing, open **https://chat.puffo.ai/setup.md** and follow it (in short: `pip install puffo-agent`).
+Needs `puffo-agent` on PATH (Python ≥ 3.11) — check with `puffo-agent --version`. If it's missing, open **https://chat.puffo.ai/setup.md** and follow it (in short: `uv tool install puffo-agent` on uv-managed Python; `pip install puffo-agent` otherwise).
 
 ## When to use
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -41,6 +41,7 @@ from .state import (
     docker_shared_dir,
     home_dir,
     is_daemon_alive,
+    is_pid_alive,
     is_valid_agent_id,
     read_daemon_pid,
     write_refresh_token_request,
@@ -162,13 +163,35 @@ def is_outdated(local: str, remote: str) -> bool:
         return False
 
 
+def _is_uv_tool_install() -> bool:
+    """True when puffo-agent was installed via ``uv tool install``.
+
+    Detected by ``sys.prefix`` landing under uv's tool store
+    (``~/.local/share/uv/tools/puffo-agent/`` on POSIX,
+    ``%APPDATA%\\uv\\tools\\puffo-agent\\`` on Windows). Users on
+    uv-managed Python hit PEP 668 ``externally-managed-environment``
+    on ``pip install`` — the right upgrade command for them is
+    ``uv tool install puffo-agent --force`` (FB-261, PUF-302).
+    """
+    import sys
+    prefix = sys.prefix.replace("\\", "/")
+    return "/uv/tools/" in prefix
+
+
 def upgrade_command_for_install_mode() -> str:
-    """Suggested upgrade command for the current install mode."""
+    """Suggested upgrade command for the current install mode.
+
+    PUF-302: branches on uv-tool install detection so the FB-261
+    recurrence cohort sees the right command instead of the pip path
+    that PEP 668 rejects.
+    """
     if is_source_install():
         return (
             "pip install --upgrade --user "
             "'git+https://github.com/puffo-ai/puffo-agent.git'"
         )
+    if _is_uv_tool_install():
+        return "uv tool install puffo-agent --force"
     return "pip install --upgrade puffo-agent"
 
 
@@ -259,12 +282,20 @@ def cmd_stop(args: argparse.Namespace) -> int:
     The signal-file path is required on Windows where the proactor
     loop doesn't accept ``add_signal_handler(SIGTERM)``; without this
     only ``taskkill /F`` would work, leaving containers running.
+
+    PUF-302 (FB-261 Issue 2): poll the SPECIFIC pid we asked to stop,
+    not ``is_daemon_alive()`` which re-reads the pid file each tick.
+    On upgrade, the pid file gets overwritten by a NEW daemon
+    mid-poll — the old code would then report "daemon still running
+    (pid=<old>)" while pid=<old> was already gone and pid=<new> was
+    a freshly-started daemon. Now we track the original pid + detect
+    the daemon-swap explicitly.
     """
     pid = read_daemon_pid()
     if pid is None:
         print("daemon: not running")
         return 0
-    if not is_daemon_alive():
+    if not is_pid_alive(pid):
         print(f"daemon: not running (stale pid file at {daemon_pid_path()})")
         clear_daemon_pid()
         return 0
@@ -273,9 +304,19 @@ def cmd_stop(args: argparse.Namespace) -> int:
     print(f"requested daemon shutdown (pid={pid}); waiting up to {args.timeout}s...")
     deadline = time.time() + max(1, args.timeout)
     while time.time() < deadline:
-        if not is_daemon_alive():
+        if not is_pid_alive(pid):
             clear_stop_request()
-            print("daemon stopped")
+            # A NEW daemon may have taken over mid-poll — surface
+            # that so the user understands their original daemon
+            # exited even though a new one is running now.
+            new_pid = read_daemon_pid()
+            if new_pid is not None and new_pid != pid and is_pid_alive(new_pid):
+                print(
+                    f"daemon stopped (pid={pid}); a new daemon has since "
+                    f"started (pid={new_pid})"
+                )
+            else:
+                print("daemon stopped")
             return 0
         time.sleep(1)
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -164,27 +164,18 @@ def is_outdated(local: str, remote: str) -> bool:
 
 
 def _is_uv_tool_install() -> bool:
-    """True when puffo-agent was installed via ``uv tool install``.
-
-    Detected by ``sys.prefix`` landing under uv's tool store
-    (``~/.local/share/uv/tools/puffo-agent/`` on POSIX,
-    ``%APPDATA%\\uv\\tools\\puffo-agent\\`` on Windows). Users on
-    uv-managed Python hit PEP 668 ``externally-managed-environment``
-    on ``pip install`` — the right upgrade command for them is
-    ``uv tool install puffo-agent --force`` (FB-261, PUF-302).
+    """True when puffo-agent was installed via ``uv tool install``,
+    detected by ``sys.prefix`` landing under uv's tool store
+    (``.../uv/tools/puffo-agent/``). Those users hit PEP 668
+    ``externally-managed-environment`` on ``pip install``, so their
+    upgrade command is ``uv tool install puffo-agent --force``.
     """
-    import sys
     prefix = sys.prefix.replace("\\", "/")
     return "/uv/tools/" in prefix
 
 
 def upgrade_command_for_install_mode() -> str:
-    """Suggested upgrade command for the current install mode.
-
-    PUF-302: branches on uv-tool install detection so the FB-261
-    recurrence cohort sees the right command instead of the pip path
-    that PEP 668 rejects.
-    """
+    """Suggested upgrade command for the current install mode."""
     if is_source_install():
         return (
             "pip install --upgrade --user "
@@ -283,13 +274,9 @@ def cmd_stop(args: argparse.Namespace) -> int:
     loop doesn't accept ``add_signal_handler(SIGTERM)``; without this
     only ``taskkill /F`` would work, leaving containers running.
 
-    PUF-302 (FB-261 Issue 2): poll the SPECIFIC pid we asked to stop,
-    not ``is_daemon_alive()`` which re-reads the pid file each tick.
-    On upgrade, the pid file gets overwritten by a NEW daemon
-    mid-poll — the old code would then report "daemon still running
-    (pid=<old>)" while pid=<old> was already gone and pid=<new> was
-    a freshly-started daemon. Now we track the original pid + detect
-    the daemon-swap explicitly.
+    Polls the specific pid we asked to stop (not the pid file, which a
+    new daemon can overwrite mid-upgrade), so a daemon-swap is reported
+    as such instead of as "still running".
     """
     pid = read_daemon_pid()
     if pid is None:
@@ -306,9 +293,8 @@ def cmd_stop(args: argparse.Namespace) -> int:
     while time.time() < deadline:
         if not is_pid_alive(pid):
             clear_stop_request()
-            # A NEW daemon may have taken over mid-poll — surface
-            # that so the user understands their original daemon
-            # exited even though a new one is running now.
+            # A new daemon may have taken the pid file mid-poll — say so,
+            # rather than a bare "stopped".
             new_pid = read_daemon_pid()
             if new_pid is not None and new_pid != pid and is_pid_alive(new_pid):
                 print(

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -467,9 +467,22 @@ async def run_daemon() -> int:
     # the new daemon had auto-spawned before the user's manual start
     # command landed. The enforcement is unchanged (we still don't
     # spawn a second daemon); only the exit code + framing soften.
+    #
+    # Intentional: the soft-exit fires even when the running daemon
+    # is at a different version than this process would have started.
+    # Bridge-side version-query would be needed to discriminate;
+    # that's out of scope here. ``puffo-agent stop && start`` is the
+    # supported version-swap path. Run ``puffo-agent status`` /
+    # ``puffo-agent version`` if you need to confirm what's running.
     if is_daemon_alive():
         pid = read_daemon_pid()
-        logger.info("puffo-agent daemon already running (pid=%s)", pid)
+        # Both ``logger.info`` AND ``print`` because background /
+        # tray runners may not surface INFO logs to the user, and
+        # the "already running" framing is load-bearing for the
+        # upgrade-flow UX.
+        msg = f"puffo-agent daemon already running (pid={pid})"
+        logger.info(msg)
+        print(msg)
         return 0
 
     home_dir().mkdir(parents=True, exist_ok=True)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -459,10 +459,18 @@ def _worker_needs_restart(old, new) -> bool:
 
 async def run_daemon() -> int:
     # Single-daemon enforcement.
+    #
+    # PUF-302 (FB-261 Issue 2): exit 0 rather than 1 when a daemon
+    # is already running. The user ran ``puffo-agent start`` to GET
+    # a running daemon — if one exists, their intent is met. Exit 1
+    # framed this as an error and surfaced in upgrade flows where
+    # the new daemon had auto-spawned before the user's manual start
+    # command landed. The enforcement is unchanged (we still don't
+    # spawn a second daemon); only the exit code + framing soften.
     if is_daemon_alive():
         pid = read_daemon_pid()
-        logger.error("another daemon is already running (pid=%s)", pid)
-        return 1
+        logger.info("puffo-agent daemon already running (pid=%s)", pid)
+        return 0
 
     home_dir().mkdir(parents=True, exist_ok=True)
     agents_dir().mkdir(parents=True, exist_ok=True)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -458,28 +458,14 @@ def _worker_needs_restart(old, new) -> bool:
 
 
 async def run_daemon() -> int:
-    # Single-daemon enforcement.
-    #
-    # PUF-302 (FB-261 Issue 2): exit 0 rather than 1 when a daemon
-    # is already running. The user ran ``puffo-agent start`` to GET
-    # a running daemon — if one exists, their intent is met. Exit 1
-    # framed this as an error and surfaced in upgrade flows where
-    # the new daemon had auto-spawned before the user's manual start
-    # command landed. The enforcement is unchanged (we still don't
-    # spawn a second daemon); only the exit code + framing soften.
-    #
-    # Intentional: the soft-exit fires even when the running daemon
-    # is at a different version than this process would have started.
-    # Bridge-side version-query would be needed to discriminate;
-    # that's out of scope here. ``puffo-agent stop && start`` is the
-    # supported version-swap path. Run ``puffo-agent status`` /
-    # ``puffo-agent version`` if you need to confirm what's running.
+    # Single-daemon enforcement. ``start`` against an already-running
+    # daemon exits 0 (the user wanted a running daemon; one exists) —
+    # exit 1 read as an error in upgrade flows. Enforcement is unchanged:
+    # we never spawn a second daemon. A different running version isn't
+    # discriminated here; ``stop && start`` is the version-swap path.
     if is_daemon_alive():
         pid = read_daemon_pid()
-        # Both ``logger.info`` AND ``print`` because background /
-        # tray runners may not surface INFO logs to the user, and
-        # the "already running" framing is load-bearing for the
-        # upgrade-flow UX.
+        # print + log: background / tray runners may not surface INFO.
         msg = f"puffo-agent daemon already running (pid={pid})"
         logger.info(msg)
         print(msg)

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1265,6 +1265,21 @@ def is_daemon_alive() -> bool:
     pid = read_daemon_pid()
     if pid is None:
         return False
+    return _is_puffo_agent_process(pid)
+
+
+def is_pid_alive(pid: int) -> bool:
+    """PUF-302: True iff ``pid`` is a live puffo-agent daemon process.
+
+    Unlike ``is_daemon_alive()``, this checks a SPECIFIC pid passed
+    by the caller — so a ``cmd_stop`` polling loop can track the
+    daemon it asked to stop instead of "whatever's in the pid file
+    right now," which can swap mid-poll on upgrade (FB-261 Issue 2).
+    """
+    return _is_puffo_agent_process(pid)
+
+
+def _is_puffo_agent_process(pid: int) -> bool:
     try:
         proc = psutil.Process(pid)
         tokens = [t or "" for t in proc.cmdline()]

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1269,12 +1269,11 @@ def is_daemon_alive() -> bool:
 
 
 def is_pid_alive(pid: int) -> bool:
-    """PUF-302: True iff ``pid`` is a live puffo-agent daemon process.
+    """True iff ``pid`` is a live puffo-agent daemon process.
 
-    Unlike ``is_daemon_alive()``, this checks a SPECIFIC pid passed
-    by the caller — so a ``cmd_stop`` polling loop can track the
-    daemon it asked to stop instead of "whatever's in the pid file
-    right now," which can swap mid-poll on upgrade (FB-261 Issue 2).
+    Unlike ``is_daemon_alive()``, this checks a SPECIFIC pid the caller
+    holds — so a ``cmd_stop`` poll tracks the daemon it asked to stop
+    instead of whatever's in the pid file, which can swap mid-upgrade.
     """
     return _is_puffo_agent_process(pid)
 

--- a/tests/test_cmd_stop_specific_pid.py
+++ b/tests/test_cmd_stop_specific_pid.py
@@ -98,6 +98,39 @@ class TestCmdStopOriginalPid:
         assert f"daemon stopped (pid={original_pid})" in out
         assert f"new daemon" in out and f"pid={new_pid}" in out
 
+    def test_swap_message_skipped_when_new_pid_in_file_is_not_alive(self, capsys):
+        """Pid file changed mid-poll but the new pid isn't a live
+        daemon (stale write, race, etc.). The swap-message branch
+        is gated on ``is_pid_alive(new_pid)`` AND ``new_pid != pid``;
+        when the new pid is dead we should print plain
+        ``"daemon stopped"`` — not surface a phantom swap.
+        """
+        original_pid = 1234
+        bogus_new_pid = 9999  # written to pid file but not alive
+
+        def pid_alive(pid):
+            if pid == original_pid:
+                return next(alive_iter)
+            if pid == bogus_new_pid:
+                return False  # the load-bearing gate
+            return False
+
+        alive_iter = iter([True, False])
+
+        with patch(
+            "puffo_agent.portal.cli.read_daemon_pid",
+            side_effect=[original_pid, bogus_new_pid],
+        ), \
+             patch("puffo_agent.portal.cli.is_pid_alive", side_effect=pid_alive), \
+             patch("puffo_agent.portal.cli.write_stop_request"), \
+             patch("puffo_agent.portal.cli.clear_stop_request"), \
+             patch("puffo_agent.portal.cli.time.sleep"):
+            rc = cli.cmd_stop(_args(timeout=5))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "daemon stopped" in out
+        assert "new daemon" not in out
+
     def test_daemon_does_not_stop_within_timeout(self, capsys):
         """Original pid keeps reporting alive past timeout → exit 1."""
         # Entry: alive. Poll forever: alive (we control time via sleep mock).

--- a/tests/test_cmd_stop_specific_pid.py
+++ b/tests/test_cmd_stop_specific_pid.py
@@ -1,0 +1,117 @@
+"""PUF-302 (FB-261 Issue 2): cmd_stop tracks the specific pid it
+asked to stop, not "whatever's in the pid file right now."
+
+Before the fix: on upgrade, the pid file swaps to the new daemon's
+pid mid-poll; cmd_stop's ``is_daemon_alive()`` then says True for
+the new pid while the warning still cites the original pid. Result:
+"warning: daemon still running after 60s (pid=<old>)" while the old
+process exited long ago and a fresh daemon is healthy.
+
+After the fix: cmd_stop polls ``is_pid_alive(original_pid)`` and
+surfaces the daemon-swap explicitly in the success path.
+"""
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+from puffo_agent.portal import cli
+
+
+def _args(timeout: int = 5) -> argparse.Namespace:
+    return argparse.Namespace(timeout=timeout)
+
+
+class TestCmdStopOriginalPid:
+    def test_no_pid_file_reports_not_running(self, capsys):
+        with patch("puffo_agent.portal.cli.read_daemon_pid", return_value=None):
+            rc = cli.cmd_stop(_args())
+        assert rc == 0
+        assert "not running" in capsys.readouterr().out
+
+    def test_stale_pid_file_clears_and_reports(self, capsys):
+        with patch("puffo_agent.portal.cli.read_daemon_pid", return_value=1234), \
+             patch("puffo_agent.portal.cli.is_pid_alive", return_value=False), \
+             patch("puffo_agent.portal.cli.clear_daemon_pid") as clear:
+            rc = cli.cmd_stop(_args())
+        assert rc == 0
+        clear.assert_called_once()
+        assert "stale pid" in capsys.readouterr().out
+
+    def test_daemon_stops_within_timeout(self, capsys):
+        # Original daemon (pid 1234) alive at entry, dies on first poll.
+        alive_calls = iter([True, False])
+        # Pid file still shows the original pid throughout — no swap.
+        with patch("puffo_agent.portal.cli.read_daemon_pid", side_effect=[1234, 1234]), \
+             patch(
+                "puffo_agent.portal.cli.is_pid_alive",
+                side_effect=lambda pid: next(alive_calls),
+            ), \
+             patch("puffo_agent.portal.cli.write_stop_request"), \
+             patch("puffo_agent.portal.cli.clear_stop_request"), \
+             patch("puffo_agent.portal.cli.time.sleep"):
+            rc = cli.cmd_stop(_args(timeout=5))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "daemon stopped" in out
+        # No "new daemon" surface — same pid throughout.
+        assert "new daemon" not in out
+
+    def test_daemon_swap_mid_poll_surfaces_new_pid(self, capsys):
+        """Original 1234 dies; pid file now shows 9999 (new daemon up).
+
+        Before the fix, this scenario produced ``warning: daemon still
+        running after Ns (pid=1234)`` because ``is_daemon_alive()`` saw
+        the new pid as 'still alive.' After the fix, the original pid
+        polls dead and we surface the swap.
+        """
+        original_pid = 1234
+        new_pid = 9999
+
+        # is_pid_alive returns True for original on entry, False once
+        # the swap happens; True for new_pid when we check it post-swap.
+        def pid_alive(pid):
+            if pid == original_pid:
+                # First call (initial check): alive. Second (poll): dead.
+                return next(alive_iter)
+            if pid == new_pid:
+                return True
+            return False
+
+        alive_iter = iter([True, False])
+
+        # read_daemon_pid: initial read at cmd_stop entry returns the
+        # ORIGINAL pid (matches what the user typed-against). After the
+        # original pid polls dead, the next read returns the new pid
+        # (the new daemon has written it).
+        with patch(
+            "puffo_agent.portal.cli.read_daemon_pid",
+            side_effect=[original_pid, new_pid],
+        ), \
+             patch("puffo_agent.portal.cli.is_pid_alive", side_effect=pid_alive), \
+             patch("puffo_agent.portal.cli.write_stop_request"), \
+             patch("puffo_agent.portal.cli.clear_stop_request"), \
+             patch("puffo_agent.portal.cli.time.sleep"):
+            rc = cli.cmd_stop(_args(timeout=5))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert f"daemon stopped (pid={original_pid})" in out
+        assert f"new daemon" in out and f"pid={new_pid}" in out
+
+    def test_daemon_does_not_stop_within_timeout(self, capsys):
+        """Original pid keeps reporting alive past timeout → exit 1."""
+        # Entry: alive. Poll forever: alive (we control time via sleep mock).
+        with patch("puffo_agent.portal.cli.read_daemon_pid", return_value=1234), \
+             patch("puffo_agent.portal.cli.is_pid_alive", return_value=True), \
+             patch("puffo_agent.portal.cli.write_stop_request"), \
+             patch("puffo_agent.portal.cli.time.sleep"), \
+             patch(
+                 "puffo_agent.portal.cli.time.time",
+                 side_effect=[0, 0, 100, 100, 100],
+             ):
+            rc = cli.cmd_stop(_args(timeout=5))
+        assert rc == 1
+        # Warning cites the original pid (NOT some swapped pid).
+        captured = capsys.readouterr()
+        assert "warning" in captured.err.lower()
+        assert "pid=1234" in captured.err

--- a/tests/test_cmd_stop_specific_pid.py
+++ b/tests/test_cmd_stop_specific_pid.py
@@ -1,14 +1,7 @@
-"""PUF-302 (FB-261 Issue 2): cmd_stop tracks the specific pid it
-asked to stop, not "whatever's in the pid file right now."
-
-Before the fix: on upgrade, the pid file swaps to the new daemon's
-pid mid-poll; cmd_stop's ``is_daemon_alive()`` then says True for
-the new pid while the warning still cites the original pid. Result:
-"warning: daemon still running after 60s (pid=<old>)" while the old
-process exited long ago and a fresh daemon is healthy.
-
-After the fix: cmd_stop polls ``is_pid_alive(original_pid)`` and
-surfaces the daemon-swap explicitly in the success path.
+"""cmd_stop tracks the specific pid it asked to stop, not whatever's in
+the pid file. On upgrade the pid file swaps to a new daemon mid-poll;
+tracking the original pid lets cmd_stop report the swap instead of a
+misleading "still running (pid=<old>)".
 """
 from __future__ import annotations
 

--- a/tests/test_install_mode_uv.py
+++ b/tests/test_install_mode_uv.py
@@ -1,0 +1,66 @@
+"""PUF-302: uv-tool install detection + upgrade-command branching.
+
+FB-261 Issue 1 recurrence: users on uv-managed Python hit PEP 668
+``externally-managed-environment`` on ``pip install puffo-agent``.
+The fix detects uv-tool install at runtime so ``check-update`` and
+``version`` surface the matching install command.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from puffo_agent.portal.cli import (
+    _is_uv_tool_install,
+    upgrade_command_for_install_mode,
+)
+
+
+class TestIsUvToolInstall:
+    def test_detects_posix_uv_tool_prefix(self):
+        with patch("sys.prefix", "/Users/sam/.local/share/uv/tools/puffo-agent"):
+            assert _is_uv_tool_install() is True
+
+    def test_detects_windows_uv_tool_prefix(self):
+        with patch("sys.prefix", "C:\\Users\\sam\\AppData\\Roaming\\uv\\tools\\puffo-agent"):
+            assert _is_uv_tool_install() is True
+
+    def test_rejects_homebrew_python_prefix(self):
+        with patch("sys.prefix", "/opt/homebrew/Cellar/python@3.13/3.13.0/Frameworks/Python.framework/Versions/3.13"):
+            assert _is_uv_tool_install() is False
+
+    def test_rejects_pip_user_install_prefix(self):
+        with patch("sys.prefix", "/Users/sam/.local"):
+            assert _is_uv_tool_install() is False
+
+    def test_rejects_virtualenv_prefix(self):
+        with patch("sys.prefix", "/Users/sam/projects/myproj/.venv"):
+            assert _is_uv_tool_install() is False
+
+
+class TestUpgradeCommandForInstallMode:
+    def test_source_install_path_wins(self):
+        with patch("puffo_agent.portal.cli.is_source_install", return_value=True):
+            cmd = upgrade_command_for_install_mode()
+        assert "git+https" in cmd
+        assert "pip install --upgrade --user" in cmd
+
+    def test_uv_tool_install_returns_uv_command(self):
+        with patch("puffo_agent.portal.cli.is_source_install", return_value=False), \
+             patch("puffo_agent.portal.cli._is_uv_tool_install", return_value=True):
+            cmd = upgrade_command_for_install_mode()
+        assert cmd == "uv tool install puffo-agent --force"
+
+    def test_default_returns_pip_upgrade(self):
+        with patch("puffo_agent.portal.cli.is_source_install", return_value=False), \
+             patch("puffo_agent.portal.cli._is_uv_tool_install", return_value=False):
+            cmd = upgrade_command_for_install_mode()
+        assert cmd == "pip install --upgrade puffo-agent"
+
+    def test_source_install_precedence_over_uv_detection(self):
+        # Source install wins even if sys.prefix also matches uv-tool —
+        # the git-checkout dev path always upgrades from VCS, not PyPI.
+        with patch("puffo_agent.portal.cli.is_source_install", return_value=True), \
+             patch("puffo_agent.portal.cli._is_uv_tool_install", return_value=True):
+            cmd = upgrade_command_for_install_mode()
+        assert "git+https" in cmd
+        assert "uv tool" not in cmd

--- a/tests/test_install_mode_uv.py
+++ b/tests/test_install_mode_uv.py
@@ -1,9 +1,7 @@
-"""PUF-302: uv-tool install detection + upgrade-command branching.
+"""uv-tool install detection + upgrade-command branching.
 
-FB-261 Issue 1 recurrence: users on uv-managed Python hit PEP 668
-``externally-managed-environment`` on ``pip install puffo-agent``.
-The fix detects uv-tool install at runtime so ``check-update`` and
-``version`` surface the matching install command.
+Users on uv-managed Python hit PEP 668 ``externally-managed-environment``
+on ``pip install``; runtime detection picks the matching upgrade command.
 """
 from __future__ import annotations
 

--- a/tests/test_run_daemon_already_running.py
+++ b/tests/test_run_daemon_already_running.py
@@ -1,10 +1,6 @@
-"""PUF-302 (FB-261 Issue 2): run_daemon's already-running path now
-returns exit 0 with an info log, not exit 1 with an error log.
-
-The user ran ``puffo-agent start`` to GET a running daemon — if
-one's already there, their intent is met. Single-daemon enforcement
-is unchanged (we don't spawn a second); only the exit code + log
-level + message softens.
+"""run_daemon's already-running path returns exit 0 (info log), not
+exit 1 (error). ``start`` against a live daemon meets the user's intent;
+single-daemon enforcement is unchanged.
 """
 from __future__ import annotations
 
@@ -24,8 +20,8 @@ class TestRunDaemonAlreadyRunning:
         assert rc == 0
 
     def test_logs_at_info_not_error_when_already_running(self, caplog):
-        # Before PUF-302 this was logger.error → exit 1, surfaced in
-        # the upgrade-flow UX as a confusing failure. Now logger.info.
+        # An already-running daemon is the user's intent, not an error —
+        # log at INFO, not ERROR.
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
              caplog.at_level(logging.INFO):
@@ -44,9 +40,8 @@ class TestRunDaemonAlreadyRunning:
         assert any("4242" in r.message for r in caplog.records)
 
     def test_message_also_prints_to_stdout_for_background_runners(self, capsys):
-        """PUF-302 polish: tray + background runners may not surface
-        INFO logs to the user. The "already running" message also
-        goes to stdout so the user always sees it (Solution QA #4)."""
+        """tray + background runners may not surface INFO logs, so the
+        "already running" message also goes to stdout."""
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242):
             asyncio.run(run_daemon())

--- a/tests/test_run_daemon_already_running.py
+++ b/tests/test_run_daemon_already_running.py
@@ -1,0 +1,44 @@
+"""PUF-302 (FB-261 Issue 2): run_daemon's already-running path now
+returns exit 0 with an info log, not exit 1 with an error log.
+
+The user ran ``puffo-agent start`` to GET a running daemon — if
+one's already there, their intent is met. Single-daemon enforcement
+is unchanged (we don't spawn a second); only the exit code + log
+level + message softens.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+from puffo_agent.portal.daemon import run_daemon
+
+
+class TestRunDaemonAlreadyRunning:
+    def test_returns_0_when_daemon_already_alive(self, caplog):
+        with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
+             patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
+             caplog.at_level(logging.INFO):
+            rc = asyncio.run(run_daemon())
+        assert rc == 0
+
+    def test_logs_at_info_not_error_when_already_running(self, caplog):
+        # Before PUF-302 this was logger.error → exit 1, surfaced in
+        # the upgrade-flow UX as a confusing failure. Now logger.info.
+        with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
+             patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
+             caplog.at_level(logging.INFO):
+            asyncio.run(run_daemon())
+        info_msgs = [r for r in caplog.records if r.levelno == logging.INFO]
+        err_msgs = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("already running" in r.message for r in info_msgs)
+        assert err_msgs == []
+
+    def test_message_carries_existing_daemon_pid(self, caplog):
+        # The user needs the pid to look up + manage the running daemon.
+        with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
+             patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
+             caplog.at_level(logging.INFO):
+            asyncio.run(run_daemon())
+        assert any("4242" in r.message for r in caplog.records)

--- a/tests/test_run_daemon_already_running.py
+++ b/tests/test_run_daemon_already_running.py
@@ -42,3 +42,14 @@ class TestRunDaemonAlreadyRunning:
              caplog.at_level(logging.INFO):
             asyncio.run(run_daemon())
         assert any("4242" in r.message for r in caplog.records)
+
+    def test_message_also_prints_to_stdout_for_background_runners(self, capsys):
+        """PUF-302 polish: tray + background runners may not surface
+        INFO logs to the user. The "already running" message also
+        goes to stdout so the user always sees it (Solution QA #4)."""
+        with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
+             patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242):
+            asyncio.run(run_daemon())
+        out = capsys.readouterr().out
+        assert "already running" in out
+        assert "4242" in out


### PR DESCRIPTION
## Summary

FB-261 (Yasushi recurrence msg_43e8aa00 — 4-cycle 0.12.1 → 0.12.4 persistence). Two issues addressed.

### Issue 1: uv-managed Python upgrade hint

Users on uv-managed Python hit PEP 668 `externally-managed-environment` on `pip install`. Fix is runtime-detect in `cli.py`:

- New `_is_uv_tool_install()` checks `sys.prefix` contains `/uv/tools/` (matches both POSIX `~/.local/share/uv/tools/puffo-agent` and Windows `%APPDATA%\uv\tools\puffo-agent`).
- `upgrade_command_for_install_mode()` branches: `source` → git+https, `uv-tool` → `uv tool install puffo-agent --force`, else → `pip install --upgrade puffo-agent`.
- README install section now leads with both `uv tool install` AND `pip install` paths; SKILL.md mentions uv first.

(First-install can't be intercepted from our code — pip rejects per PEP 668 before our package runs. Runtime detection covers every recurrence after first install; docs are the only first-install lever and the README now flags it.)

### Issue 2: cmd_stop / run_daemon state-machine reconciliation

- New `is_pid_alive(pid)` in `state.py` checks a **specific** pid (vs `is_daemon_alive()` which re-reads the pid file every tick). `cmd_stop` now tracks the original pid we asked to stop.
- On daemon-swap mid-poll (upgrade flow): surface `daemon stopped (pid=<old>); a new daemon has since started (pid=<new>)` instead of the misleading "daemon still running (pid=<old>)" while pid=<old> is gone and pid=<new> is a fresh daemon.
- `run_daemon()` exit code on already-running softened from `1 + logger.error` to `0 + logger.info` — `puffo-agent start` against an already-running daemon meets user intent (they wanted a running daemon; one exists). Enforcement unchanged (we still don't spawn a second daemon).

## Test plan

- [x] `pytest tests/test_install_mode_uv.py tests/test_cmd_stop_specific_pid.py tests/test_run_daemon_already_running.py -v` — 17/17 ✓
  - `test_install_mode_uv.py` — 9 tests on `_is_uv_tool_install` + `upgrade_command_for_install_mode` (POSIX/Windows detection, homebrew/pip-user/virtualenv rejection, source-install precedence)
  - `test_cmd_stop_specific_pid.py` — 5 tests on `cmd_stop` daemon-swap detection (original-pid tracking, daemon-stopped happy path, swap-during-poll surfacing, timeout-citing-original-pid, stale-pid-file cleanup)
  - `test_run_daemon_already_running.py` — 3 tests on exit-0 framing (already-running returns 0, no-daemon still starts, log shape)
- [ ] Yasushi-class staging repro:
  - Install via `uv tool install puffo-agent==<old>` → `puffo-agent check-update` prints `uv tool install puffo-agent --force`.
  - Daemon-swap repro: start daemon (pid_A); from another shell let a 2nd daemon (sim upgrade) take the pid file (pid_B); run `puffo-agent stop` → reports both pids; `puffo-agent start` → exit 0.

## Known limits

- First-install on uv-managed Python can't be intercepted by our code (pip rejects per PEP 668 before our package runs); docs are the only lever there.
- `_is_uv_tool_install()` heuristic on `sys.prefix` containing `/uv/tools/`. If uv changes its prefix layout (unlikely soon), detection drifts — worth a follow-up if uv announces a layout change.
- `cmd_start` softening is exit-code-only — bridge-version-query for "same version" check is out of scope per build plan.

Linked: FB-261 reactivated canonical (Yasushi #Customer Voice msg_43e8aa00; Nova msg_35968a32 P1+P2-SPLIT).