### PR TITLE
PUF-303: refresh_broken DM + reactive-clear (extends PUF-283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   reports a daemon swap explicitly when a new daemon takes over
   mid-shutdown, and `puffo-agent start` against an already-running
   daemon now exits 0 (the user's intent is met) instead of erroring.
+- **The operator is DM'd when an agent's credential refresh breaks.**
+  When the daemon can't roll a Claude/Codex token (refresh keeps
+  failing), the agent now DMs its operator bilingual recovery
+  instructions (run `claude auth login`) — once per episode — mirroring
+  the existing auth-failed notification. A manual re-login clears the
+  state on the agent's next turn instead of waiting for the next poll.
 
 ## [0.12.4] — 2026-06-12
 

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -118,3 +118,23 @@ def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
         "⚠️ Claude OAuth 已过期。请运行 `claude auth login`，"
         "然后给我发条消息即可恢复。"
     )
+
+
+def format_refresh_broken(agent_id: str, agent_display_name: str = "") -> str:
+    """PUF-303: bilingual (zh+en) operator DM for an agent whose
+    credential-refresh has been failing repeatedly. Mirrors the
+    ``format_oauth_expired`` shape; framing distinguishes the
+    daemon-side refresh failure (``claude auth status`` may still
+    report logged-in but live probe / refresh is broken) from the
+    in-flight 401 path."""
+    label = (
+        f"**{agent_display_name}** (`{agent_id}`)"
+        if agent_display_name else f"`{agent_id}`"
+    )
+    return (
+        f"⚠️ {label} — Claude credential refresh is broken (the daemon "
+        "can't roll the token). Run `claude auth login`, then send me a "
+        "message and I'll pick up where I left off.\n"
+        "⚠️ Claude 凭证刷新失败（守护进程无法续期 token）。"
+        "请运行 `claude auth login`，然后给我发条消息即可恢复。"
+    )

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -121,12 +121,10 @@ def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
 
 
 def format_refresh_broken(agent_id: str, agent_display_name: str = "") -> str:
-    """PUF-303: bilingual (zh+en) operator DM for an agent whose
-    credential-refresh has been failing repeatedly. Mirrors the
-    ``format_oauth_expired`` shape; framing distinguishes the
-    daemon-side refresh failure (``claude auth status`` may still
-    report logged-in but live probe / refresh is broken) from the
-    in-flight 401 path."""
+    """Bilingual (zh+en) operator DM for an agent whose credential
+    refresh keeps failing — distinct from the in-flight 401 path
+    (``claude auth status`` may still say logged-in). Mirrors
+    ``format_oauth_expired``."""
     label = (
         f"**{agent_display_name}** (`{agent_id}`)"
         if agent_display_name else f"`{agent_id}`"

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -748,11 +748,8 @@ class CredentialRefresher:
         self._refresh_request = asyncio.Event()
         self._agent_homes: set[Path] = set()
         self._on_refresh_success: list[Callable[[], None]] = []
-        # PUF-303: callbacks fired when an agent's runtime newly flips
-        # to refresh_broken. Parallel to ``_on_refresh_success`` so the
-        # worker side can DM the operator analogous to PUF-283's
-        # ``auth_failed`` notification. Receives the agent_id of the
-        # newly-broken agent so the worker can scope the dedup flag.
+        # Fired when an agent newly flips to refresh_broken (was_ok →
+        # broken), with the agent_id, so the worker can DM the operator.
         self._on_refresh_broken_enter: list[Callable[[str], None]] = []
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
@@ -791,9 +788,8 @@ class CredentialRefresher:
     def register_on_refresh_broken_enter(
         self, callback: Callable[[str], None],
     ) -> None:
-        """PUF-303: register a callback fired when an agent's runtime
-        newly flips to refresh_broken. The callback receives the
-        agent_id of the newly-broken agent."""
+        """Register a callback fired when an agent newly flips to
+        refresh_broken; it receives the agent_id."""
         self._on_refresh_broken_enter.append(callback)
 
     def unregister_on_refresh_broken_enter(
@@ -1058,11 +1054,8 @@ class CredentialRefresher:
             f"advancing. Run `claude auth login`, then send the agent "
             f"a message to recover."
         )
-        # PUF-303: collect agents that newly flipped so we fire the
-        # refresh-broken-enter callback exactly once per transition.
-        # The skip-if-already-broken branch above means callers can
-        # rely on "fired ⇒ new transition," same was_ok semantics as
-        # worker._enter_auth_failed.
+        # Collect agents that newly flipped (was_ok → broken) so the
+        # callback fires exactly once per transition.
         newly_broken: list[str] = []
         for agent_home in self._agent_homes:
             agent_id = Path(agent_home).name

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -748,6 +748,12 @@ class CredentialRefresher:
         self._refresh_request = asyncio.Event()
         self._agent_homes: set[Path] = set()
         self._on_refresh_success: list[Callable[[], None]] = []
+        # PUF-303: callbacks fired when an agent's runtime newly flips
+        # to refresh_broken. Parallel to ``_on_refresh_success`` so the
+        # worker side can DM the operator analogous to PUF-283's
+        # ``auth_failed`` notification. Receives the agent_id of the
+        # newly-broken agent so the worker can scope the dedup flag.
+        self._on_refresh_broken_enter: list[Callable[[str], None]] = []
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
         self._rate_limit_retry_task: asyncio.Task | None = None
@@ -780,6 +786,33 @@ class CredentialRefresher:
             except Exception as exc:
                 logger.warning(
                     "credential refresh-success callback raised: %s", exc,
+                )
+
+    def register_on_refresh_broken_enter(
+        self, callback: Callable[[str], None],
+    ) -> None:
+        """PUF-303: register a callback fired when an agent's runtime
+        newly flips to refresh_broken. The callback receives the
+        agent_id of the newly-broken agent."""
+        self._on_refresh_broken_enter.append(callback)
+
+    def unregister_on_refresh_broken_enter(
+        self, callback: Callable[[str], None],
+    ) -> None:
+        try:
+            self._on_refresh_broken_enter.remove(callback)
+        except ValueError:
+            pass
+
+    def _fire_refresh_broken_enter(self, agent_id: str) -> None:
+        # list(...) defensive copy: callback may (un)register during dispatch.
+        for cb in list(self._on_refresh_broken_enter):
+            try:
+                cb(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "refresh-broken-enter callback raised for %s: %s",
+                    agent_id, exc,
                 )
 
     def notify_refresh_needed(self) -> None:
@@ -1025,6 +1058,12 @@ class CredentialRefresher:
             f"advancing. Run `claude auth login`, then send the agent "
             f"a message to recover."
         )
+        # PUF-303: collect agents that newly flipped so we fire the
+        # refresh-broken-enter callback exactly once per transition.
+        # The skip-if-already-broken branch above means callers can
+        # rely on "fired ⇒ new transition," same was_ok semantics as
+        # worker._enter_auth_failed.
+        newly_broken: list[str] = []
         for agent_home in self._agent_homes:
             agent_id = Path(agent_home).name
             try:
@@ -1051,6 +1090,10 @@ class CredentialRefresher:
                     "refresh_broken flip: failed to save runtime for %s: %s",
                     agent_id, exc,
                 )
+                continue
+            newly_broken.append(agent_id)
+        for agent_id in newly_broken:
+            self._fire_refresh_broken_enter(agent_id)
 
     def _clear_refresh_broken(self) -> None:
         from .state import RuntimeState

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -280,9 +280,17 @@ class Daemon:
             Worker._clear_auth_failed_if_recoverable(
                 worker.runtime, agent_id, logger,
             )
-            # Re-arm the auth_failed DM dedup so a re-expiry this
-            # session re-notifies the operator.
+            # PUF-303: also clear refresh_broken if the worker was
+            # stuck there. Recovery doesn't need to wait for the next
+            # daemon poll-tick — the on-disk credential is fresh, so
+            # we can flip back to ok immediately.
+            Worker._clear_refresh_broken_if_recoverable(
+                worker.runtime, agent_id, logger,
+            )
+            # Re-arm both DM dedup flags so a re-expiry / re-break
+            # this session re-notifies the operator.
             worker._auth_failed_notification_sent = False
+            worker._refresh_broken_notification_sent = False
             if was_auth_failed:
                 # The running adapter session still holds the stale
                 # credential; a restart re-links the fresh cred and
@@ -304,6 +312,17 @@ class Daemon:
         refresher.register_on_refresh_success(on_refresh_success)
         # Stash callback identity for _stop_worker's unregister.
         worker._refresh_success_callback = on_refresh_success
+
+        # PUF-303: refresh_broken-enter handler. The daemon fires this
+        # with the agent_id when CredentialRefresher flips an agent
+        # newly to refresh_broken; we only act for OUR agent.
+        def on_refresh_broken_enter(flipped_agent_id: str) -> None:
+            if flipped_agent_id != agent_id:
+                return
+            worker._on_refresh_broken_enter()
+
+        refresher.register_on_refresh_broken_enter(on_refresh_broken_enter)
+        worker._refresh_broken_callback = on_refresh_broken_enter
 
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
         return self._refresher_for(agent_cfg).notify_refresh_needed
@@ -341,6 +360,12 @@ class Daemon:
             if cb is not None:
                 self.refresher.unregister_on_refresh_success(cb)
                 self.codex_refresher.unregister_on_refresh_success(cb)
+            # PUF-303: also unregister the refresh-broken-enter
+            # callback so the stopped worker stops receiving events.
+            rb_cb = getattr(worker, "_refresh_broken_callback", None)
+            if rb_cb is not None:
+                self.refresher.unregister_on_refresh_broken_enter(rb_cb)
+                self.codex_refresher.unregister_on_refresh_broken_enter(rb_cb)
             await worker.stop()
 
     async def _stop_all_workers(self) -> None:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -280,10 +280,8 @@ class Daemon:
             Worker._clear_auth_failed_if_recoverable(
                 worker.runtime, agent_id, logger,
             )
-            # PUF-303: also clear refresh_broken if the worker was
-            # stuck there. Recovery doesn't need to wait for the next
-            # daemon poll-tick — the on-disk credential is fresh, so
-            # we can flip back to ok immediately.
+            # Also clear refresh_broken — the on-disk credential is fresh
+            # now, so recover immediately instead of waiting for a poll tick.
             Worker._clear_refresh_broken_if_recoverable(
                 worker.runtime, agent_id, logger,
             )
@@ -313,9 +311,8 @@ class Daemon:
         # Stash callback identity for _stop_worker's unregister.
         worker._refresh_success_callback = on_refresh_success
 
-        # PUF-303: refresh_broken-enter handler. The daemon fires this
-        # with the agent_id when CredentialRefresher flips an agent
-        # newly to refresh_broken; we only act for OUR agent.
+        # Refresh-broken handler — fired with the flipped agent_id; act
+        # only for ours.
         def on_refresh_broken_enter(flipped_agent_id: str) -> None:
             if flipped_agent_id != agent_id:
                 return
@@ -360,8 +357,7 @@ class Daemon:
             if cb is not None:
                 self.refresher.unregister_on_refresh_success(cb)
                 self.codex_refresher.unregister_on_refresh_success(cb)
-            # PUF-303: also unregister the refresh-broken-enter
-            # callback so the stopped worker stops receiving events.
+            # Unregister the refresh-broken callback too.
             rb_cb = getattr(worker, "_refresh_broken_callback", None)
             if rb_cb is not None:
                 self.refresher.unregister_on_refresh_broken_enter(rb_cb)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -696,12 +696,9 @@ class Worker:
         )
 
     # ─────────────────────────────────────────────────────────────────
-    # PUF-303: refresh_broken-state notification + reactive clear.
-    # Parallel to PUF-283's auth_failed substrate above. The daemon's
-    # CredentialRefresher fires _on_refresh_broken_enter when it newly
-    # flips an agent to refresh_broken; this worker DMs the operator
-    # bilingual recovery copy with one-per-session dedup. Recovery
-    # clear runs via the existing on_refresh_success callback.
+    # refresh_broken notification + reactive clear (parallel to the
+    # auth_failed substrate above): DM the operator once per episode on
+    # a refresh_broken flip; clear on refresh-success.
     # ─────────────────────────────────────────────────────────────────
 
     @staticmethod
@@ -857,9 +854,7 @@ class Worker:
         # re-armed on credential refresh-success (daemon
         # on_refresh_success) and on a failed send.
         self._auth_failed_notification_sent = False
-        # PUF-303: parallel dedup flag for the refresh_broken ENTER
-        # operator DM. Re-armed on credential refresh-success (same
-        # callback that re-arms auth_failed) and on a failed send.
+        # Re-armed on refresh-success + on a failed send (like auth_failed).
         self._refresh_broken_notification_sent = False
         self.runtime = RuntimeState(
             status="running",

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -695,6 +695,97 @@ class Worker:
             self.agent_cfg.id, operator_slug,
         )
 
+    # ─────────────────────────────────────────────────────────────────
+    # PUF-303: refresh_broken-state notification + reactive clear.
+    # Parallel to PUF-283's auth_failed substrate above. The daemon's
+    # CredentialRefresher fires _on_refresh_broken_enter when it newly
+    # flips an agent to refresh_broken; this worker DMs the operator
+    # bilingual recovery copy with one-per-session dedup. Recovery
+    # clear runs via the existing on_refresh_success callback.
+    # ─────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _clear_refresh_broken_if_recoverable(
+        runtime: "RuntimeState",
+        agent_id: str,
+        log: logging.Logger,
+    ) -> None:
+        """Symmetric to ``_clear_auth_failed_if_recoverable``: fired on
+        refresh-success so a manual ``claude auth login`` recovery
+        clears the state immediately instead of waiting for the next
+        daemon poll-tick. Optimistic: if the next request still 401s,
+        ``_flip_refresh_broken`` will re-set."""
+        if runtime.health != "refresh_broken":
+            return
+        runtime.health = "ok"
+        runtime.error = ""
+        runtime.save(agent_id)
+        log.info(
+            "agent %s: credential-refresh-success; "
+            "runtime.health cleared from refresh_broken back to ok",
+            agent_id,
+        )
+
+    def _on_refresh_broken_enter(self) -> None:
+        """Fire the operator DM once per refresh_broken episode. The
+        flag re-arms on refresh-success (daemon on_refresh_success)
+        and on a failed send, so a later genuine failure re-notifies."""
+        if self._refresh_broken_notification_sent:
+            return
+        self._refresh_broken_notification_sent = True
+        try:
+            asyncio.create_task(self._notify_operator_of_refresh_broken())
+        except Exception as exc:  # noqa: BLE001
+            # Re-arm so a schedule failure retries on the next ENTER.
+            self._refresh_broken_notification_sent = False
+            logger.warning(
+                "agent %s: couldn't schedule refresh-broken DM: %s",
+                self.agent_cfg.id, exc,
+            )
+
+    async def _notify_operator_of_refresh_broken(self) -> None:
+        """DM the operator the bilingual refresh-broken recovery copy.
+        Re-arms the dedup flag on a transient failure (client not warm,
+        or send raised) so the next ENTER retries instead of staying
+        silently gated."""
+        client = self._client
+        if client is None:
+            # Still warming — re-arm so a later ENTER retries.
+            self._refresh_broken_notification_sent = False
+            logger.warning(
+                "agent %s: refresh-broken DM skipped — client not yet warm",
+                self.agent_cfg.id,
+            )
+            return
+        operator_slug = getattr(client, "operator_slug", "") or ""
+        if not operator_slug:
+            # No operator to DM; stay gated — re-arming would respin
+            # on every refresh-broken flip.
+            logger.warning(
+                "agent %s: refresh-broken but no operator_slug — not DMing",
+                self.agent_cfg.id,
+            )
+            return
+        from ..agent._invite_strings import format_refresh_broken
+        display_name = (
+            getattr(self.agent_cfg, "display_name", "") or self.agent_cfg.id
+        )
+        text = format_refresh_broken(self.agent_cfg.id, display_name)
+        try:
+            await client._send_dm(operator_slug, text, root_id="")
+        except Exception as exc:
+            # Transient send failure — re-arm for the next ENTER.
+            self._refresh_broken_notification_sent = False
+            logger.exception(
+                "agent %s: refresh-broken DM to %s raised: %s",
+                self.agent_cfg.id, operator_slug, exc,
+            )
+            return
+        logger.info(
+            "agent %s: notified operator @%s of refresh_broken",
+            self.agent_cfg.id, operator_slug,
+        )
+
     @staticmethod
     def _flip_health_in_progress(
         runtime: "RuntimeState",
@@ -766,6 +857,10 @@ class Worker:
         # re-armed on credential refresh-success (daemon
         # on_refresh_success) and on a failed send.
         self._auth_failed_notification_sent = False
+        # PUF-303: parallel dedup flag for the refresh_broken ENTER
+        # operator DM. Re-armed on credential refresh-success (same
+        # callback that re-arms auth_failed) and on a failed send.
+        self._refresh_broken_notification_sent = False
         self.runtime = RuntimeState(
             status="running",
             started_at=int(time.time()),

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -420,12 +420,18 @@ def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
         registers without actually wiring the refresh loop."""
         def __init__(self):
             self.callback = None
+            self.refresh_broken_callback = None
 
         def register_agent(self, _path):
             pass
 
         def register_on_refresh_success(self, cb):
             self.callback = cb
+
+        # PUF-303: daemon now also registers a refresh-broken-enter
+        # callback. Capture for completeness; not asserted here.
+        def register_on_refresh_broken_enter(self, cb):
+            self.refresh_broken_callback = cb
 
     class _StubAgentCfg:
         id = "t-agent"
@@ -440,7 +446,9 @@ def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
         agent_cfg = _StubAgentCfg()
         runtime = RuntimeState(status="running", started_at=0, msg_count=0)
         _auth_failed_notification_sent = True
+        _refresh_broken_notification_sent = True
         _refresh_success_callback = None
+        _refresh_broken_callback = None
 
     class _StubDaemon:
         refresher = _StubRefresher()

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -428,8 +428,7 @@ def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
         def register_on_refresh_success(self, cb):
             self.callback = cb
 
-        # PUF-303: daemon now also registers a refresh-broken-enter
-        # callback. Capture for completeness; not asserted here.
+        # Daemon also registers a refresh-broken callback; capture it.
         def register_on_refresh_broken_enter(self, cb):
             self.refresh_broken_callback = cb
 

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -121,6 +121,9 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
         def register_on_refresh_success(self, cb):
             self.callback = cb
 
+        def register_on_refresh_broken_enter(self, cb):
+            self.refresh_broken_callback = cb
+
     class _StubAgentCfg:
         id = "t-agent"
 

--- a/tests/test_refresh_broken_clear.py
+++ b/tests/test_refresh_broken_clear.py
@@ -1,7 +1,6 @@
-"""PUF-303: ``Worker._clear_refresh_broken_if_recoverable`` worker-
-side reactive clear, fired from the daemon's on_refresh_success
-callback so manual ``claude auth login`` recovery doesn't have to
-wait for the next CredentialRefresher poll-tick.
+"""``Worker._clear_refresh_broken_if_recoverable`` reactive clear, fired
+from the daemon's on_refresh_success callback so a manual ``claude auth
+login`` recovery doesn't wait for the next refresher poll-tick.
 
 Mirrors ``_clear_auth_failed_if_recoverable``.
 """

--- a/tests/test_refresh_broken_clear.py
+++ b/tests/test_refresh_broken_clear.py
@@ -1,0 +1,79 @@
+"""PUF-303: ``Worker._clear_refresh_broken_if_recoverable`` worker-
+side reactive clear, fired from the daemon's on_refresh_success
+callback so manual ``claude auth login`` recovery doesn't have to
+wait for the next CredentialRefresher poll-tick.
+
+Mirrors ``_clear_auth_failed_if_recoverable``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.portal.state import RuntimeState
+from puffo_agent.portal.worker import Worker
+
+
+def _make_runtime(health: str) -> RuntimeState:
+    rt = RuntimeState(status="running", started_at=0, msg_count=0)
+    rt.health = health
+    rt.error = "stale message"
+    return rt
+
+
+def test_clear_only_when_refresh_broken(tmp_path, monkeypatch):
+    """The clear is gated on ``runtime.health == "refresh_broken"``.
+    No-op for any other state so we don't accidentally clobber a
+    legitimate auth_failed / api_error_abandoned / in_progress flag."""
+    monkeypatch.chdir(tmp_path)
+    for non_broken_health in (
+        "ok", "auth_failed", "api_error_abandoned",
+        "in_progress", "unhandled_error",
+    ):
+        rt = _make_runtime(non_broken_health)
+        Worker._clear_refresh_broken_if_recoverable(
+            rt, "t-agent", logging.getLogger("test"),
+        )
+        assert rt.health == non_broken_health
+        assert rt.error == "stale message"
+
+
+def test_clear_flips_to_ok(tmp_path, monkeypatch):
+    """Happy path: refresh_broken → ok + error cleared."""
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("refresh_broken")
+    Worker._clear_refresh_broken_if_recoverable(
+        rt, "t-agent", logging.getLogger("test"),
+    )
+    assert rt.health == "ok"
+    assert rt.error == ""
+
+
+def test_clear_logs_recovery(tmp_path, monkeypatch, caplog):
+    """The clear emits an info log naming refresh_broken → ok so the
+    operator can grep for recoveries when debugging."""
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("refresh_broken")
+    log = logging.getLogger("puffo_agent.portal.worker.test")
+    with caplog.at_level(logging.INFO):
+        Worker._clear_refresh_broken_if_recoverable(rt, "t-agent", log)
+    assert any(
+        "refresh_broken back to ok" in r.message for r in caplog.records
+    )
+
+
+def test_clear_no_op_when_already_ok(tmp_path, monkeypatch, caplog):
+    """Idempotency: clear from ok stays ok, no log, no save spam."""
+    monkeypatch.chdir(tmp_path)
+    rt = _make_runtime("ok")
+    rt.error = ""  # match real ok state
+    log = logging.getLogger("puffo_agent.portal.worker.test")
+    with caplog.at_level(logging.INFO):
+        Worker._clear_refresh_broken_if_recoverable(rt, "t-agent", log)
+    assert rt.health == "ok"
+    assert not any(
+        "refresh_broken" in r.message for r in caplog.records
+    )

--- a/tests/test_refresh_broken_notification.py
+++ b/tests/test_refresh_broken_notification.py
@@ -1,0 +1,285 @@
+"""PUF-303: proactive refresh_broken DM to operator on the
+``CredentialRefresher._flip_refresh_broken`` newly-broken transition.
+Mirrors PUF-283's auth_failed substrate.
+
+Tests cover:
+  1. ``format_refresh_broken`` bilingual copy invariants.
+  2. ``CredentialRefresher._flip_refresh_broken`` fires the new
+     ``on_refresh_broken_enter`` callback only for agents that newly
+     transition (was-ok → refresh_broken), NOT for agents already
+     refresh_broken.
+  3. ``Worker._on_refresh_broken_enter`` is dedup-gated by
+     ``_refresh_broken_notification_sent``.
+  4. ``_notify_operator_of_refresh_broken`` skips cleanly on
+     no-warm-client and no-operator-slug paths; happy path DMs the
+     operator with the bilingual recovery copy.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent._invite_strings import format_refresh_broken
+
+
+# ── (1) format_refresh_broken bilingual copy ──────────────────────
+
+
+def test_refresh_broken_copy_includes_english_and_chinese():
+    text = format_refresh_broken("planner-1234", "Planner")
+    # English strand: distinguishes daemon-side refresh failure from
+    # in-flight 401, names `claude auth login` + send-message recovery.
+    assert "credential refresh is broken" in text
+    assert "claude auth login" in text
+    assert "send me a message" in text
+    # Chinese strand
+    assert "凭证刷新失败" in text
+    assert "守护进程无法续期" in text
+    # Bold display name format
+    assert "**Planner**" in text
+
+
+def test_refresh_broken_copy_degrades_when_display_name_missing():
+    text = format_refresh_broken("agent-5678", "")
+    assert "credential refresh is broken" in text
+    assert "凭证刷新失败" in text
+    assert "`agent-5678`" in text
+    # No empty-bold artifact.
+    assert "**" not in text or "**`agent-5678`**" in text
+
+
+# ── (2) CredentialRefresher._flip_refresh_broken transition gate ──
+
+
+def test_flip_refresh_broken_fires_callback_for_newly_broken_only(
+    tmp_path, monkeypatch,
+):
+    """The fire-once-per-transition invariant: an agent already
+    refresh_broken on entry to _flip_refresh_broken must NOT receive
+    a second callback. Mirrors the was_ok semantics from
+    worker._enter_auth_failed."""
+    from puffo_agent.portal import credential_refresh as cr_module
+    from puffo_agent.portal.credential_refresh import (
+        CredentialRefresher, RefreshOutcome,
+    )
+
+    # Stub RuntimeState so we don't need real on-disk agents.
+    saved_states: dict[str, str] = {}
+
+    class _StubRuntimeState:
+        def __init__(self, health: str):
+            self.health = health
+            self.error = ""
+
+        @classmethod
+        def load(cls, agent_id: str):
+            return cls(saved_states.get(agent_id, "ok"))
+
+        def save(self, agent_id: str):
+            saved_states[agent_id] = self.health
+
+    monkeypatch.setattr(cr_module, "logger", logging.getLogger("test"))
+    # Patch the local import inside _flip_refresh_broken.
+    import puffo_agent.portal.state as state_module
+    monkeypatch.setattr(state_module, "RuntimeState", _StubRuntimeState)
+
+    refresher = CredentialRefresher.__new__(CredentialRefresher)
+    refresher._agent_homes = {tmp_path / "fresh-1", tmp_path / "stuck-2"}
+    refresher._on_refresh_broken_enter = []
+    refresher._consecutive_non_success = 2
+
+    fired: list[str] = []
+    refresher.register_on_refresh_broken_enter(fired.append)
+
+    # ``stuck-2`` is already refresh_broken; ``fresh-1`` is ok.
+    saved_states["stuck-2"] = "refresh_broken"
+
+    refresher._flip_refresh_broken(RefreshOutcome.FAILED)
+
+    # Only the newly-broken agent triggers the callback.
+    assert fired == ["fresh-1"]
+    assert saved_states["fresh-1"] == "refresh_broken"
+    # Already-broken agent's state is unchanged (no spurious resave).
+    assert saved_states["stuck-2"] == "refresh_broken"
+
+
+def test_register_unregister_on_refresh_broken_enter():
+    """The register/unregister pair is symmetric and unregister is
+    a no-op when the callback wasn't registered (mirror
+    ``unregister_on_refresh_success``)."""
+    from puffo_agent.portal.credential_refresh import CredentialRefresher
+
+    r = CredentialRefresher.__new__(CredentialRefresher)
+    r._on_refresh_broken_enter = []
+
+    def cb(_):
+        pass
+
+    r.register_on_refresh_broken_enter(cb)
+    assert cb in r._on_refresh_broken_enter
+    r.unregister_on_refresh_broken_enter(cb)
+    assert cb not in r._on_refresh_broken_enter
+    # Idempotent unregister.
+    r.unregister_on_refresh_broken_enter(cb)
+
+
+# ── (3) Worker._on_refresh_broken_enter dedup gate ────────────────
+
+
+class _StubLoop:
+    """Minimal asyncio.create_task stand-in to validate dedup
+    semantics without spinning a real event loop."""
+    def __init__(self):
+        self.calls = 0
+        self.tasks = []
+
+    def create_task(self, coro):
+        self.calls += 1
+        self.tasks.append(coro)
+        # Close the coro so it doesn't warn "never awaited."
+        coro.close()
+        return None
+
+
+def test_worker_dedup_gate_fires_once(monkeypatch):
+    from puffo_agent.portal import worker as worker_module
+
+    stub_loop = _StubLoop()
+    monkeypatch.setattr(
+        worker_module.asyncio, "create_task", stub_loop.create_task,
+    )
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent"})()
+        _client = None
+        _refresh_broken_notification_sent = False
+
+        _on_refresh_broken_enter = (
+            worker_module.Worker._on_refresh_broken_enter
+        )
+        _notify_operator_of_refresh_broken = (
+            worker_module.Worker._notify_operator_of_refresh_broken
+        )
+
+    w = _StubWorker()
+    w._on_refresh_broken_enter()
+    w._on_refresh_broken_enter()
+    w._on_refresh_broken_enter()
+
+    assert stub_loop.calls == 1
+    assert w._refresh_broken_notification_sent is True
+
+
+def test_worker_reset_arms_next_notify(monkeypatch):
+    """Dedup resets on refresh-success (daemon.on_refresh_success).
+    Subsequent ENTER re-fires — symmetric to auth_failed."""
+    from puffo_agent.portal import worker as worker_module
+
+    stub_loop = _StubLoop()
+    monkeypatch.setattr(
+        worker_module.asyncio, "create_task", stub_loop.create_task,
+    )
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent"})()
+        _client = None
+        _refresh_broken_notification_sent = False
+
+        _on_refresh_broken_enter = (
+            worker_module.Worker._on_refresh_broken_enter
+        )
+        _notify_operator_of_refresh_broken = (
+            worker_module.Worker._notify_operator_of_refresh_broken
+        )
+
+    w = _StubWorker()
+    w._on_refresh_broken_enter()                 # fires 1
+    assert stub_loop.calls == 1
+
+    # Simulate refresh-success → daemon.on_refresh_success resets.
+    w._refresh_broken_notification_sent = False
+    w._on_refresh_broken_enter()                 # fires 2
+    assert stub_loop.calls == 2
+
+
+# ── (4) _notify_operator_of_refresh_broken client guards ─────────
+
+
+def test_notify_skipped_when_client_not_warm(caplog):
+    """No PuffoCoreMessageClient yet → log + return cleanly."""
+    from puffo_agent.portal import worker as worker_module
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = None
+        _refresh_broken_notification_sent = True  # gated; clear-and-log
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_refresh_broken(w)
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.worker"):
+        asyncio.new_event_loop().run_until_complete(coro)
+    assert any("client not yet warm" in r.message for r in caplog.records)
+    # Dedup re-armed so a later ENTER retries.
+    assert w._refresh_broken_notification_sent is False
+
+
+def test_notify_skipped_when_operator_slug_empty(caplog):
+    """Operator-less agents skip cleanly with a warning — red-dot UI
+    is the only fallback signal. Dedup stays gated to avoid respin."""
+    from puffo_agent.portal import worker as worker_module
+
+    class _StubClient:
+        operator_slug = ""
+
+    class _StubWorker:
+        agent_cfg = type("A", (), {"id": "t-agent", "display_name": ""})()
+        _client = _StubClient()
+        _refresh_broken_notification_sent = True
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_refresh_broken(w)
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.worker"):
+        asyncio.new_event_loop().run_until_complete(coro)
+    assert any("no operator_slug" in r.message for r in caplog.records)
+    # Dedup stays set — no respin.
+    assert w._refresh_broken_notification_sent is True
+
+
+def test_notify_sends_dm_when_operator_slug_set():
+    """Happy path: client.operator_slug populated → _send_dm called
+    with the bilingual refresh_broken copy + operator's slug."""
+    from puffo_agent.portal import worker as worker_module
+
+    captured: dict = {}
+
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            captured["recipient"] = recipient
+            captured["text"] = text
+            captured["root_id"] = root_id
+            return {"envelope_id": "env-fake"}
+
+    class _StubWorker:
+        agent_cfg = type(
+            "A", (), {"id": "t-agent", "display_name": "Planner"},
+        )()
+        _client = _StubClient()
+        _refresh_broken_notification_sent = True
+
+    w = _StubWorker()
+    coro = worker_module.Worker._notify_operator_of_refresh_broken(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    assert captured["recipient"] == "@han-0001"
+    assert "credential refresh is broken" in captured["text"]
+    assert "凭证刷新失败" in captured["text"]
+    assert "**Planner**" in captured["text"]
+    assert captured["root_id"] == ""
+    # Dedup remains set so a re-fire requires explicit reset.
+    assert w._refresh_broken_notification_sent is True

--- a/tests/test_refresh_broken_notification.py
+++ b/tests/test_refresh_broken_notification.py
@@ -283,3 +283,239 @@ def test_notify_sends_dm_when_operator_slug_set():
     assert captured["root_id"] == ""
     # Dedup remains set so a re-fire requires explicit reset.
     assert w._refresh_broken_notification_sent is True
+
+
+# ── (5) Daemon-side wiring: agent_id filter + unregister + codex ──
+
+
+def _make_daemon_stub_pair(monkeypatch):
+    """Build (StubDaemon, claude_refresher, codex_refresher) with the
+    real ``_register_with_refresher`` and ``_stop_worker`` bound so we
+    can pin the load-bearing wiring without spinning a real refresher.
+    """
+    from puffo_agent.portal import daemon as daemon_module
+
+    captured = {"agent_homes": [], "refresh_success_cbs": [], "refresh_broken_cbs": []}
+
+    class _StubRefresher:
+        def __init__(self, name):
+            self.name = name
+            self.success_cbs: list = []
+            self.broken_cbs: list = []
+            self.agents: set = set()
+
+        def register_agent(self, path):
+            self.agents.add(path)
+
+        def unregister_agent(self, path):
+            self.agents.discard(path)
+
+        def register_on_refresh_success(self, cb):
+            self.success_cbs.append(cb)
+
+        def unregister_on_refresh_success(self, cb):
+            try:
+                self.success_cbs.remove(cb)
+            except ValueError:
+                pass
+
+        def register_on_refresh_broken_enter(self, cb):
+            self.broken_cbs.append(cb)
+
+        def unregister_on_refresh_broken_enter(self, cb):
+            try:
+                self.broken_cbs.remove(cb)
+            except ValueError:
+                pass
+
+    claude_r = _StubRefresher("claude")
+    codex_r = _StubRefresher("codex")
+
+    class _StubDaemon:
+        refresher = claude_r
+        codex_refresher = codex_r
+        workers: dict = {}
+
+        def _refresher_for(self, cfg):
+            if (getattr(cfg.runtime, "harness", "") or "claude-code") == "codex":
+                return self.codex_refresher
+            return self.refresher
+
+        _register_with_refresher = daemon_module.Daemon._register_with_refresher
+
+    # ``agent_home_dir`` is called inside _register_with_refresher.
+    monkeypatch.setattr(
+        daemon_module, "agent_home_dir", lambda agent_id: f"/tmp/agents/{agent_id}",
+    )
+    return _StubDaemon(), claude_r, codex_r, captured
+
+
+def _make_agent_cfg(agent_id: str, harness: str = "claude-code"):
+    cfg = type("Cfg", (), {})()
+    cfg.id = agent_id
+    cfg.runtime = type("R", (), {"harness": harness})()
+    return cfg
+
+
+def _make_worker_for_daemon_test():
+    from puffo_agent.portal.state import RuntimeState
+
+    fired: list[int] = []
+
+    class W:
+        runtime = RuntimeState(status="running", started_at=0, msg_count=0)
+        _auth_failed_notification_sent = True
+        _refresh_broken_notification_sent = True
+        _refresh_success_callback = None
+        _refresh_broken_callback = None
+
+        def _on_refresh_broken_enter(self):
+            fired.append(1)
+
+    return W(), fired
+
+
+def test_daemon_filter_only_dms_own_agent(monkeypatch):
+    """The load-bearing fan-out scope: worker-A's refresh-broken-enter
+    handler must NOT fire when CredentialRefresher reports agent-B
+    broke. Without the ``flipped_agent_id == agent_id`` filter at
+    daemon.py, every worker would DM the operator for every other
+    agent's break."""
+    d, claude_r, _, _ = _make_daemon_stub_pair(monkeypatch)
+
+    w_a, fired_a = _make_worker_for_daemon_test()
+    w_b, fired_b = _make_worker_for_daemon_test()
+    cfg_a = _make_agent_cfg("agent-a")
+    cfg_b = _make_agent_cfg("agent-b")
+
+    d._register_with_refresher(cfg_a, w_a)
+    d._register_with_refresher(cfg_b, w_b)
+    assert len(claude_r.broken_cbs) == 2
+
+    # CredentialRefresher fires the agent-A break.
+    for cb in claude_r.broken_cbs:
+        cb("agent-a")
+
+    assert fired_a == [1]
+    assert fired_b == []  # The load-bearing assert.
+
+
+def test_daemon_stop_worker_unregisters_refresh_broken_callback(monkeypatch):
+    """``_stop_worker`` must unregister the refresh-broken-enter
+    callback from BOTH refreshers so a stopped worker stops receiving
+    events. Mirrors the existing ``_refresh_success_callback``
+    unregister pattern."""
+    from puffo_agent.portal import daemon as daemon_module
+
+    d, claude_r, codex_r, _ = _make_daemon_stub_pair(monkeypatch)
+    w, _ = _make_worker_for_daemon_test()
+    cfg = _make_agent_cfg("agent-x")
+    d._register_with_refresher(cfg, w)
+
+    assert len(claude_r.broken_cbs) == 1
+    assert w._refresh_broken_callback is not None
+
+    # Inline the unregister body from _stop_worker (the rest is
+    # async + touches files; we just need the callback teardown).
+    rb_cb = getattr(w, "_refresh_broken_callback", None)
+    assert rb_cb is not None
+    d.refresher.unregister_on_refresh_broken_enter(rb_cb)
+    d.codex_refresher.unregister_on_refresh_broken_enter(rb_cb)
+    assert claude_r.broken_cbs == []
+    assert codex_r.broken_cbs == []
+
+
+def test_daemon_codex_agent_registers_on_codex_refresher(monkeypatch):
+    """A codex-harness agent must register its refresh-broken
+    callback on the codex_refresher, not the Claude refresher.
+    ``_refresher_for`` routes based on ``runtime.harness``."""
+    d, claude_r, codex_r, _ = _make_daemon_stub_pair(monkeypatch)
+
+    w, _ = _make_worker_for_daemon_test()
+    cfg = _make_agent_cfg("agent-codex", harness="codex")
+    d._register_with_refresher(cfg, w)
+
+    assert len(codex_r.broken_cbs) == 1
+    assert len(claude_r.broken_cbs) == 0
+
+
+# ── (6) Cross-state dedup re-arm + post-re-arm-fires ──────────────
+
+
+def test_on_refresh_success_rearms_refresh_broken_flag_even_when_auth_failed(
+    monkeypatch,
+):
+    """``on_refresh_success`` re-arms BOTH flags unconditionally,
+    even when the prior state was ``auth_failed`` (not refresh_broken).
+    The re-arm is benign (the flag is a gate, not a trigger) but worth
+    pinning so a future "only re-arm if was-broken" optimization
+    doesn't silently break the dedup invariants."""
+    from puffo_agent.portal.state import RuntimeState
+
+    d, claude_r, _, _ = _make_daemon_stub_pair(monkeypatch)
+
+    class W:
+        runtime = RuntimeState(status="running", started_at=0, msg_count=0)
+        _auth_failed_notification_sent = True
+        _refresh_broken_notification_sent = True
+        _refresh_success_callback = None
+        _refresh_broken_callback = None
+
+        def _on_refresh_broken_enter(self):
+            pass
+
+    w = W()
+    cfg = _make_agent_cfg("agent-mixed")
+    # Prior state was auth_failed, not refresh_broken.
+    w.runtime.health = "auth_failed"
+    d._register_with_refresher(cfg, w)
+    assert claude_r.success_cbs, "daemon should register on_refresh_success"
+
+    # Fire the success callback as the daemon would.
+    claude_r.success_cbs[0]()
+
+    # BOTH flags re-armed even though only auth_failed was active.
+    assert w._auth_failed_notification_sent is False
+    assert w._refresh_broken_notification_sent is False
+
+
+def test_dedup_rearm_then_subsequent_fire_actually_schedules(monkeypatch):
+    """The transient-recovery contract: after a no-warm-client (or
+    failed-send) re-arms the dedup, the NEXT ENTER must actually
+    schedule the DM. Pin the 2-step fail→succeed sequence so the
+    re-arm path's recovery value isn't silently lost."""
+    from puffo_agent.portal import worker as worker_module
+
+    stub_loop = _StubLoop()
+    monkeypatch.setattr(
+        worker_module.asyncio, "create_task", stub_loop.create_task,
+    )
+
+    class W:
+        agent_cfg = type("A", (), {"id": "t-agent"})()
+        _client = None  # not warm yet
+        _refresh_broken_notification_sent = False
+
+        _on_refresh_broken_enter = (
+            worker_module.Worker._on_refresh_broken_enter
+        )
+        _notify_operator_of_refresh_broken = (
+            worker_module.Worker._notify_operator_of_refresh_broken
+        )
+
+    w = W()
+    # First ENTER schedules; the async body sees _client=None and
+    # re-arms the dedup flag back to False.
+    w._on_refresh_broken_enter()
+    assert stub_loop.calls == 1
+    # Simulate the no-warm-client async re-arm.
+    asyncio.new_event_loop().run_until_complete(
+        worker_module.Worker._notify_operator_of_refresh_broken(w)
+    )
+    assert w._refresh_broken_notification_sent is False
+
+    # Second ENTER (after re-arm) MUST schedule again — load-bearing
+    # for the transient-recovery path.
+    w._on_refresh_broken_enter()
+    assert stub_loop.calls == 2
+    assert w._refresh_broken_notification_sent is True

--- a/tests/test_refresh_broken_notification.py
+++ b/tests/test_refresh_broken_notification.py
@@ -1,6 +1,6 @@
-"""PUF-303: proactive refresh_broken DM to operator on the
-``CredentialRefresher._flip_refresh_broken`` newly-broken transition.
-Mirrors PUF-283's auth_failed substrate.
+"""Proactive refresh_broken DM to the operator on the
+``CredentialRefresher._flip_refresh_broken`` newly-broken transition
+(mirrors the auth_failed substrate).
 
 Tests cover:
   1. ``format_refresh_broken`` bilingual copy invariants.


### PR DESCRIPTION
## Summary

Sam Claude OAuth credential refresh incident — extend PUF-283 `auth_failed` notification-subsystem + worker-side reactive clear to also cover `refresh_broken` state-transitions (Substances B+C+D+E together).

- New `CredentialRefresher._on_refresh_broken_enter` callback list + `register_/unregister_/_fire_` triplet (parallel to `_on_refresh_success`).
- `_flip_refresh_broken` collects newly-broken agents (was_ok semantics) and fires the callback per-agent so workers can DM the operator.
- New `Worker._on_refresh_broken_enter` dedup-gated DM dispatch + `_notify_operator_of_refresh_broken` async send (mirrors `_on_auth_failed_enter`).
- New bilingual copy `format_refresh_broken` distinguishes daemon-side refresh failure from in-flight 401.
- New `Worker._clear_refresh_broken_if_recoverable` symmetric to `_clear_auth_failed_if_recoverable`; fires from existing `on_refresh_success` so manual `claude auth login` recovery doesn't wait for next poll-tick.
- Daemon wires per-worker callback with agent_id filter; `_stop_worker` unregisters from both Claude + Codex refreshers.

Substance (A) `claude auth status` semantic gap → out-of-scope (upstream Claude CLI); flag for PUF-302 docs.

## Test plan

- [x] `python -m pytest tests/test_refresh_broken_notification.py tests/test_refresh_broken_clear.py tests/test_auth_failed_dm_notification.py` → 32/32 (13 new + 19 PUF-283 regression).
- [x] Bilingual copy invariants (zh + en, bold display name, fallback when display_name empty).
- [x] `_flip_refresh_broken` fires callback only for was_ok → broken (skips already-broken).
- [x] Worker dedup gate fires once per refresh_broken episode + re-arms after reset.
- [x] `_notify_operator_of_refresh_broken` skip paths: no-warm-client (re-arm), no-operator-slug (stay gated).
- [x] Happy-path send to operator slug with `root_id=""`.
- [x] `_clear_refresh_broken_if_recoverable` flips refresh_broken → ok with info log; no-op for other health states.
- [ ] Live soak post-deploy: Sam-class repro (rc=1 ×2 → bilingual DM → manual `claude auth login` → next worker turn → runtime.health clears without poll-tick wait).

Closes PUF-303.