### PR TITLE
fix(daemon): don't install asyncio signal handlers off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   message — so the agent stops referring to itself by the old name
   without an operator workaround. The `whoami` tool now also reports the
   agent's current display name.
+- **`--background` / `--ui` mode no longer crashes on Linux/macOS.** The
+  daemon installs SIGINT/SIGTERM via the asyncio loop, which calls
+  `signal.set_wakeup_fd` — only allowed on the main thread. In `--ui` /
+  `--background` the daemon runs in a child thread (Qt owns the main
+  thread), so this raised `RuntimeError` at startup. POSIX handlers are
+  now installed only when on the main thread; those modes stop via the
+  existing file sentinel.
 
 ## [0.12.4] — 2026-06-12
 

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import signal
+import threading
 import time
 
 from pathlib import Path
@@ -457,6 +458,32 @@ def _worker_needs_restart(old, new) -> bool:
     )
 
 
+def _install_posix_stop_handlers(loop, handle_signal) -> bool:
+    """Wire SIGINT/SIGTERM to ``handle_signal`` via the asyncio loop;
+    return whether it succeeded.
+
+    No-op (``False``) off the main thread: ``add_signal_handler`` →
+    ``signal.set_wakeup_fd`` raises ``RuntimeError`` there, which is the
+    Linux/macOS ``--ui`` / ``--background`` case (the daemon runs in
+    DaemonThread while Qt holds the main thread). Those modes stop via
+    the file sentinel, so skipping the asyncio signal route is fine.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        return False
+    installed = False
+    for sig_name in ("SIGINT", "SIGTERM"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, handle_signal)
+            installed = True
+        except NotImplementedError:
+            # Windows proactor loop doesn't support add_signal_handler.
+            pass
+    return installed
+
+
 async def run_daemon() -> int:
     # Single-daemon enforcement.
     if is_daemon_alive():
@@ -481,18 +508,7 @@ async def run_daemon() -> int:
         logger.info("received stop signal; shutting down")
         daemon.request_stop()
 
-    # SIGINT/SIGTERM on posix.
-    posix_handlers_installed = False
-    for sig_name in ("SIGINT", "SIGTERM"):
-        sig = getattr(signal, sig_name, None)
-        if sig is None:
-            continue
-        try:
-            loop.add_signal_handler(sig, handle_signal)
-            posix_handlers_installed = True
-        except NotImplementedError:
-            # Windows proactor loop doesn't support add_signal_handler.
-            pass
+    posix_handlers_installed = _install_posix_stop_handlers(loop, handle_signal)
 
     # Windows fallback: synchronous C-runtime Ctrl+C handler dispatched
     # back onto the loop via call_soon_threadsafe. Without this the

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -459,14 +459,10 @@ def _worker_needs_restart(old, new) -> bool:
 
 
 def _install_posix_stop_handlers(loop, handle_signal) -> bool:
-    """Wire SIGINT/SIGTERM to ``handle_signal`` via the asyncio loop;
-    return whether it succeeded.
-
-    No-op (``False``) off the main thread: ``add_signal_handler`` →
-    ``signal.set_wakeup_fd`` raises ``RuntimeError`` there, which is the
-    Linux/macOS ``--ui`` / ``--background`` case (the daemon runs in
-    DaemonThread while Qt holds the main thread). Those modes stop via
-    the file sentinel, so skipping the asyncio signal route is fine.
+    """Install SIGINT/SIGTERM via the asyncio loop; return whether it
+    did. No-op off the main thread, where ``add_signal_handler`` →
+    ``set_wakeup_fd`` raises (the ``--ui`` / ``--background`` DaemonThread
+    case — those stop via the file sentinel instead).
     """
     if threading.current_thread() is not threading.main_thread():
         return False

--- a/tests/test_daemon_signal_handlers.py
+++ b/tests/test_daemon_signal_handlers.py
@@ -1,0 +1,36 @@
+"""Off-main-thread stop-signal gating.
+
+Under ``--ui`` / ``--background`` the daemon runs in a child thread
+(DaemonThread) while Qt owns the main thread. ``add_signal_handler`` →
+``signal.set_wakeup_fd`` raises ``RuntimeError`` off the main thread, so
+the POSIX install must be skipped (the file sentinel stops those modes),
+not crash.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from puffo_agent.portal.daemon import _install_posix_stop_handlers
+
+
+def test_posix_stop_handlers_skipped_off_main_thread():
+    out: dict = {}
+
+    def run():
+        loop = asyncio.new_event_loop()
+        try:
+            out["installed"] = _install_posix_stop_handlers(loop, lambda: None)
+        except BaseException as exc:  # noqa: BLE001
+            out["error"] = repr(exc)
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+
+    # No RuntimeError from set_wakeup_fd, and nothing installed off-thread.
+    assert "error" not in out, out.get("error")
+    assert out["installed"] is False


### PR DESCRIPTION
## Problem

`puffo-agent start --background` (and `--ui`) crashes at startup on **Linux and macOS**:

```
RuntimeError: set_wakeup_fd only works in main thread of the main interpreter
```

Plain foreground `start` is unaffected.

## Root cause

In `--ui` / `--background`, Qt owns the main thread, so the daemon's asyncio loop runs in a child thread (`DaemonThread`). `loop.add_signal_handler()` internally calls `signal.set_wakeup_fd()`, which CPython only permits on the main thread — so it raises `RuntimeError` off-thread. The existing guard only caught `NotImplementedError` (the Windows proactor case), so the Linux/macOS child-thread `RuntimeError` propagated and killed startup.

## Fix

Gate the POSIX `add_signal_handler` install on `threading.current_thread() is threading.main_thread()`. `--ui` / `--background` don't need asyncio signal handlers — they already stop via the file sentinel (`DaemonThread.request_stop` → `stop-request`, picked up by the reconcile loop). Foreground keeps the original behaviour (it runs on the main thread).

The install was extracted into `_install_posix_stop_handlers(loop, handle_signal) -> bool` so the off-main-thread skip is unit-tested.

- **Gate, not catch** `RuntimeError`: a precise predicate, won't silently swallow an unrelated future `RuntimeError` from `add_signal_handler`.
- **No Windows change**: on Windows `--background` the daemon is already off-thread; before this it fell through `NotImplementedError` → the Windows `signal.signal` fallback → `ValueError` (off-thread) → no-op. Same end state now, just skipped earlier.
- **No foreground change**: main-thread predicate is true → original path runs → SIGINT/SIGTERM still wired.

Credit: diagnosed by a user on Ubuntu 26.04 / Python 3.14.

## Tests

`tests/test_daemon_signal_handlers.py`: runs `_install_posix_stop_handlers` in a child thread and asserts it returns `False` without raising (the exact crash scenario).

`PYTHONPATH=src python -m pytest`: **1448 passed / 9 skipped**.

Can't live-smoke locally (Windows box; the bug is Linux/macOS) — a reviewer on Linux/macOS can confirm `start --background` now comes up + stops cleanly via the tray/`stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
