### PR TITLE
chore(release): date-stamp 0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.12.5] — unreleased
+## [0.12.5] — 2026-06-17
 
 ### Added
 


### PR DESCRIPTION
## What

Date-stamps the `[0.12.5]` changelog header (`unreleased` → `2026-06-17`) ahead of the 0.12.5 release. `pyproject.toml` is already at `0.12.5`.

Merging this, then publishing a `v0.12.5` GitHub Release, triggers the PyPI publish workflow.

## 0.12.5 contents

- **#83** per-agent codex sandbox policy + auto-reset on change + UI access row
- **#81** codex agents recover from an empty `conversation_id` instead of wedging
- **#82** rename → rewrites `profile.md` (word-boundary match) + `whoami` reports display name
- **#86** `--background` / `--ui` no longer crash on Linux/macOS (signal handlers gated to the main thread)
- **#84** correct upgrade/restart messaging on `uv`-managed Python + daemon swaps; `start` exits 0 when already running

(#85 `refresh_broken` DM was closed — redundant with the reactive `auth_failed` path + false-positive prone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
