### PR TITLE
PUF-308: preserve original attachment alongside downscaled image (FB-303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.6] — unreleased
+
+### Added
+
+- **Full-resolution copy of downscaled inbound images.** When an inbound
+  image is over the model's vision cap and gets downscaled, the pre-resize
+  bytes are now kept alongside it: the in-bounds version is saved as
+  `<name>.compressed.<ext>` and the original as `<name>.origin.<ext>`. The
+  attachment list points the agent at the original and suggests cropping a
+  region of it for fine detail rather than reading the whole file. Images
+  within the cap are untouched and keep their bare name.
+
+### Changed
+
+- **Inbound-image downscale cap is now model-aware.** The long-edge cap
+  follows the agent's effective model — 2576px for Opus 4.7+ (which resolve
+  high-resolution images natively), 1568px for all other models (the
+  conservative default). Previously every image was downscaled to 1568px,
+  discarding detail newer models can use.
+
 ## [0.12.5] — 2026-06-17
 
 ### Added

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -39,6 +39,20 @@ def _format_assistant_fallback(text_parts: list[str], joined_reply: str) -> str:
     return "\n".join(f"- {p}" for p in cleaned)
 
 
+def _origin_for_compressed(path: str) -> str | None:
+    """If ``path`` is a downscaled ``<stem>.compressed<ext>`` attachment,
+    return its full-resolution ``<stem>.origin<ext>`` sibling, else None.
+    String-only so it's separator-agnostic across hosts."""
+    dot = path.rfind(".")
+    if dot <= 0:
+        return None
+    base, ext = path[:dot], path[dot:]
+    marker = ".compressed"
+    if not base.endswith(marker):
+        return None
+    return base[: -len(marker)] + ".origin" + ext
+
+
 class PuffoAgent:
     def __init__(
         self,
@@ -445,6 +459,14 @@ class PuffoAgent:
             lines.append("- attachments:")
             for path in attachments:
                 lines.append(f"  - {path}")
+                origin = _origin_for_compressed(path)
+                if origin:
+                    lines.append(
+                        f"    (downscaled to fit the model; full-resolution "
+                        f"original at {origin} — to read fine detail, crop a "
+                        f"region of the original rather than opening the whole "
+                        f"image)"
+                    )
         lines.append("- message: " + text)
         if followups:
             # Messages that arrived in the same thread/channel AFTER

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -343,9 +343,17 @@ def _downscale_oversized_image(path, original_path=None) -> None:
             if original_path is not None:
                 import shutil
                 from pathlib import Path
-                op = Path(original_path)
-                op.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(path, op)
+                try:
+                    op = Path(original_path)
+                    op.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(path, op)
+                except Exception as exc:  # noqa: BLE001
+                    # A failed original-copy must not block the size-cap
+                    # downscale — that downscale is the session-poison guard.
+                    logger.warning(
+                        "could not preserve original image %s: %s",
+                        original_path, exc,
+                    )
             scale = _MAX_IMAGE_EDGE_PX / longest
             new_size = (max(1, round(w * scale)), max(1, round(h * scale)))
             fmt = img.format or "PNG"

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -305,10 +305,11 @@ def _maybe_redact_long_text(
     return placeholder
 
 
-# Inbound images are downscaled to the model's native vision resolution so
-# the harness can Read them without the image dominating context — and so a
-# >20-image request (where the Anthropic API rejects anything over 2000px,
-# poisoning the session) stays in bounds. The native long-edge cap is
+# Inbound images are downscaled to the model's native vision resolution at
+# save time. The Claude API resizes a single oversized image on its own, but
+# a request carrying >20 images rejects any whose longest edge tops 2000px
+# ("many-image requests"), and a full-res image costs ~4784 visual tokens on
+# Opus 4.7+ — capping on disk avoids both. The native long-edge cap is
 # model-specific: Opus 4.7+ resolves 2576px, all other models 1568px.
 _DEFAULT_IMAGE_EDGE_PX = 1568
 _HIGH_RES_IMAGE_EDGE_PX = 2576
@@ -340,7 +341,7 @@ def _downscale_oversized_image(
     except ImportError:
         logger.warning(
             "Pillow missing — inbound images aren't dimension-checked; "
-            "an oversized image can dead-lock the claude session "
+            "a many-image request can then reject an oversized one "
             "(pip install pillow)",
         )
         return False
@@ -359,8 +360,8 @@ def _downscale_oversized_image(
                     op.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(path, op)
                 except Exception as exc:  # noqa: BLE001
-                    # A failed original-copy must not block the size-cap
-                    # downscale — that downscale is the session-poison guard.
+                    # A failed original-copy must not block the resize — the
+                    # in-bounds version is what the agent actually Reads.
                     logger.warning(
                         "could not preserve original image %s: %s",
                         original_path, exc,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -305,25 +305,36 @@ def _maybe_redact_long_text(
     return placeholder
 
 
-# Anthropic's API rejects any conversation containing an image whose
-# longest edge tops 2000px. Claude-code Read-ing such an attachment
-# poisons the session transcript — every later turn then fails
-# wholesale (see ClaudeSession._looks_like_poisoned_session). We
-# can't stop claude-code Read-ing a file, but we CAN keep the file
-# on disk in bounds. 1568px is Anthropic's recommended max — well
-# under the 2000px hard cap.
-_MAX_IMAGE_EDGE_PX = 1568
+# Inbound images are downscaled to the model's native vision resolution so
+# the harness can Read them without the image dominating context — and so a
+# >20-image request (where the Anthropic API rejects anything over 2000px,
+# poisoning the session) stays in bounds. The native long-edge cap is
+# model-specific: Opus 4.7+ resolves 2576px, all other models 1568px.
+_DEFAULT_IMAGE_EDGE_PX = 1568
+_HIGH_RES_IMAGE_EDGE_PX = 2576
+# Model-id substrings that resolve high-resolution vision. Unknown models
+# default to 1568 — safe (over-shrinks at worst); add new ones here.
+_HIGH_RES_MODEL_MARKERS = ("opus-4-7", "opus-4-8")
 
 
-def _downscale_oversized_image(path, original_path=None) -> None:
-    """Resize ``path`` in place if it's an image whose longest edge
-    tops ``_MAX_IMAGE_EDGE_PX``. When ``original_path`` is supplied
-    AND the resize is actually about to fire, the pre-resize bytes
-    are copied there first so the agent's file-access tools can
-    reach the full-fidelity version while the LLM-payload version
-    stays under the cap. No-op (and no copy) for non-images, small
-    images, or anything Pillow can't open. Best-effort — never
-    raises."""
+def max_image_edge_px(model: str) -> int:
+    """Native vision long-edge cap for ``model`` — 2576px for models with
+    high-resolution input, else the conservative 1568px default."""
+    m = (model or "").lower()
+    if any(marker in m for marker in _HIGH_RES_MODEL_MARKERS):
+        return _HIGH_RES_IMAGE_EDGE_PX
+    return _DEFAULT_IMAGE_EDGE_PX
+
+
+def _downscale_oversized_image(
+    path, original_path=None, max_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
+) -> bool:
+    """Resize ``path`` in place when it's an image whose longest edge tops
+    ``max_edge_px``; return whether a resize happened. When ``original_path``
+    is supplied and the resize fires, the pre-resize bytes are copied there
+    first so the agent's file-access tools can reach the full-fidelity
+    version. Returns False (no-op) for non-images, small images, or anything
+    Pillow can't open. Best-effort — never raises."""
     try:
         from PIL import Image
     except ImportError:
@@ -332,14 +343,14 @@ def _downscale_oversized_image(path, original_path=None) -> None:
             "an oversized image can dead-lock the claude session "
             "(pip install pillow)",
         )
-        return
+        return False
     try:
         with Image.open(path) as img:
             img.load()
             w, h = img.size
             longest = max(w, h)
-            if longest <= _MAX_IMAGE_EDGE_PX:
-                return
+            if longest <= max_edge_px:
+                return False
             if original_path is not None:
                 import shutil
                 from pathlib import Path
@@ -354,17 +365,19 @@ def _downscale_oversized_image(path, original_path=None) -> None:
                         "could not preserve original image %s: %s",
                         original_path, exc,
                     )
-            scale = _MAX_IMAGE_EDGE_PX / longest
+            scale = max_edge_px / longest
             new_size = (max(1, round(w * scale)), max(1, round(h * scale)))
             fmt = img.format or "PNG"
             img.resize(new_size, Image.LANCZOS).save(path, format=fmt)
         logger.info(
-            "downscaled inbound image %s: %dx%d -> %dx%d "
-            "(claude image dimension cap)",
+            "downscaled inbound image %s: %dx%d -> %dx%d (cap %dpx)",
             getattr(path, "name", path), w, h, new_size[0], new_size[1],
+            max_edge_px,
         )
+        return True
     except Exception as exc:
         logger.warning("could not dimension-check image %s: %s", path, exc)
+        return False
 
 
 class DeviceKeyCache:
@@ -440,6 +453,7 @@ class PuffoCoreMessageClient:
         max_inline_chars: int = 4000,
         segment_chars: int = 2000,
         agent_created_at: int = 0,
+        image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -462,6 +476,7 @@ class PuffoCoreMessageClient:
         # 200k-context model with a verbose system prompt.
         self._max_inline_chars = max(1, int(max_inline_chars))
         self._segment_chars = max(1, int(segment_chars))
+        self._image_edge_px = int(image_edge_px) or _DEFAULT_IMAGE_EDGE_PX
         self.keystore = keystore
         self.http = http_client
         self.store = message_store
@@ -3103,15 +3118,30 @@ class PuffoCoreMessageClient:
                     "attachment save failed (%s): %s", target, exc,
                 )
                 continue
-            # Shrink oversized images before the agent can Read them
-            # into — and poison — its claude session. Off-loop: Pillow
-            # decode/resize is blocking. ``original/<name>`` keeps the
-            # full-fidelity copy for the agent's file-access tools.
-            original = target.parent / "original" / target.name
-            await asyncio.to_thread(
-                _downscale_oversized_image, target, original,
+            # Shrink oversized images so the agent can Read them without
+            # the image dominating context (or being rejected in a
+            # >20-image request). Off-loop: Pillow decode/resize is
+            # blocking. When a resize fires, the in-place file becomes
+            # ``<stem>.compressed<ext>`` and the pre-resize bytes are kept
+            # alongside as ``<stem>.origin<ext>`` for full-fidelity access.
+            origin = target.with_name(f"{target.stem}.origin{target.suffix}")
+            resized = await asyncio.to_thread(
+                _downscale_oversized_image, target, origin, self._image_edge_px,
             )
-            paths.append(str(target))
+            if resized:
+                compressed = target.with_name(
+                    f"{target.stem}.compressed{target.suffix}"
+                )
+                try:
+                    target.rename(compressed)
+                    paths.append(str(compressed))
+                except OSError as exc:
+                    self._log.warning(
+                        "could not rename compressed image %s: %s", target, exc,
+                    )
+                    paths.append(str(target))
+            else:
+                paths.append(str(target))
         return paths
 
     async def _send_dm(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -315,12 +315,15 @@ def _maybe_redact_long_text(
 _MAX_IMAGE_EDGE_PX = 1568
 
 
-def _downscale_oversized_image(path) -> None:
+def _downscale_oversized_image(path, original_path=None) -> None:
     """Resize ``path`` in place if it's an image whose longest edge
-    tops ``_MAX_IMAGE_EDGE_PX``. No-op for non-images, small images,
-    or anything Pillow can't open (claude-code's loader can't open
-    it either, so it can't reach the API as an oversized image).
-    Best-effort — never raises."""
+    tops ``_MAX_IMAGE_EDGE_PX``. When ``original_path`` is supplied
+    AND the resize is actually about to fire, the pre-resize bytes
+    are copied there first so the agent's file-access tools can
+    reach the full-fidelity version while the LLM-payload version
+    stays under the cap. No-op (and no copy) for non-images, small
+    images, or anything Pillow can't open. Best-effort — never
+    raises."""
     try:
         from PIL import Image
     except ImportError:
@@ -337,6 +340,12 @@ def _downscale_oversized_image(path) -> None:
             longest = max(w, h)
             if longest <= _MAX_IMAGE_EDGE_PX:
                 return
+            if original_path is not None:
+                import shutil
+                from pathlib import Path
+                op = Path(original_path)
+                op.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(path, op)
             scale = _MAX_IMAGE_EDGE_PX / longest
             new_size = (max(1, round(w * scale)), max(1, round(h * scale)))
             fmt = img.format or "PNG"
@@ -3088,8 +3097,12 @@ class PuffoCoreMessageClient:
                 continue
             # Shrink oversized images before the agent can Read them
             # into — and poison — its claude session. Off-loop: Pillow
-            # decode/resize is blocking.
-            await asyncio.to_thread(_downscale_oversized_image, target)
+            # decode/resize is blocking. ``original/<name>`` keeps the
+            # full-fidelity copy for the agent's file-access tools.
+            original = target.parent / "original" / target.name
+            await asyncio.to_thread(
+                _downscale_oversized_image, target, original,
+            )
             paths.append(str(target))
         return paths
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -350,7 +350,7 @@ def _build_puffo_core_client(
     the dataclass defaults.
     """
     from ..agent.message_store import MessageStore
-    from ..agent.puffo_core_client import PuffoCoreMessageClient
+    from ..agent.puffo_core_client import PuffoCoreMessageClient, max_image_edge_px
     from ..crypto.http_client import PuffoCoreHttpClient
     from ..crypto.keystore import KeyStore
 
@@ -368,6 +368,13 @@ def _build_puffo_core_client(
         daemon_cfg.segment_chars if daemon_cfg is not None else 2000
     )
 
+    # The inbound-image downscale cap follows the harness's effective model
+    # (Opus 4.7+ resolves 2576px, else 1568px).
+    if (agent_cfg.runtime.harness or "claude-code") == "codex":
+        model = agent_cfg.runtime.model or (daemon_cfg.openai.model if daemon_cfg else "")
+    else:
+        model = agent_cfg.runtime.model or (daemon_cfg.anthropic.model if daemon_cfg else "")
+
     return PuffoCoreMessageClient(
         slug=pc.slug,
         device_id=pc.device_id,
@@ -381,6 +388,7 @@ def _build_puffo_core_client(
         max_inline_chars=max_inline,
         segment_chars=segment_chars,
         agent_created_at=agent_cfg.created_at,
+        image_edge_px=max_image_edge_px(model),
     )
 
 

--- a/tests/test_attachment_annotation.py
+++ b/tests/test_attachment_annotation.py
@@ -1,0 +1,43 @@
+"""Attachment-line rendering: a ``<stem>.compressed<ext>`` attachment is
+annotated with a pointer to its full-res ``<stem>.origin<ext>`` sibling and
+guidance to crop rather than open the whole image; plain attachments aren't.
+"""
+
+from __future__ import annotations
+
+from puffo_agent.agent.core import PuffoAgent, _origin_for_compressed
+
+
+def test_origin_for_compressed():
+    assert _origin_for_compressed("/x/shot.compressed.png") == "/x/shot.origin.png"
+    assert _origin_for_compressed("/x/a.b.compressed.jpg") == "/x/a.b.origin.jpg"
+    assert _origin_for_compressed("/x/shot.png") is None
+    assert _origin_for_compressed("/x/notes.txt") is None
+    assert _origin_for_compressed("noext") is None
+
+
+def _block(attachments):
+    # _format_user_block uses only its args (no ``self``), so an unbound call
+    # with a dummy first arg renders the block in isolation.
+    return PuffoAgent._format_user_block(
+        object(),
+        channel_name="general",
+        sender="alice",
+        sender_email="",
+        text="see attached",
+        attachments=attachments,
+    )
+
+
+def test_compressed_attachment_gets_origin_annotation():
+    block = _block(["/inbox/env/shot.compressed.png"])
+    assert "/inbox/env/shot.compressed.png" in block
+    assert "/inbox/env/shot.origin.png" in block
+    assert "crop a region" in block
+
+
+def test_plain_attachment_has_no_annotation():
+    block = _block(["/inbox/env/thumb.png"])
+    assert "/inbox/env/thumb.png" in block
+    assert "origin" not in block
+    assert "crop a region" not in block

--- a/tests/test_image_dimension_guard.py
+++ b/tests/test_image_dimension_guard.py
@@ -232,3 +232,26 @@ def test_resize_failure_does_not_raise_after_original_copied(
     # Original copy made it to disk before the save blew up — that's
     # fine; the agent's file-access tools can still reach it.
     assert original.exists()
+
+
+def test_copy_failure_does_not_block_downscale(tmp_path, monkeypatch):
+    """A failed original-copy must NOT defeat the size-cap downscale.
+    The downscale is the session-poison guard; preserving the original
+    is a nice-to-have that can't be allowed to leave an oversized image
+    on the LLM-payload path."""
+    path = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+    original = tmp_path / "original" / "big.png"
+
+    import shutil as _shutil
+
+    def boom_copy2(*a, **kw):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(_shutil, "copy2", boom_copy2)
+
+    _downscale_oversized_image(path, original)  # must not raise
+
+    assert not original.exists()
+    with Image.open(path) as img:
+        assert max(img.size) <= _MAX_IMAGE_EDGE_PX

--- a/tests/test_image_dimension_guard.py
+++ b/tests/test_image_dimension_guard.py
@@ -1,8 +1,8 @@
-"""Tests for ``_downscale_oversized_image`` — the prevention half of
-the oversized-image session-poison fix. An inbound image whose longest
-edge tops Anthropic's 2000px many-image cap, once Read into the claude
-session, makes every later turn fail wholesale. We downscale the file
-on disk at save time so claude-code only ever loads in-bounds images.
+"""Tests for ``_downscale_oversized_image`` and the per-model cap. Inbound
+images are downscaled to the model's native vision resolution so they don't
+dominate context and so a >20-image request (which rejects any image whose
+longest edge tops 2000px) stays in bounds. The cap is 2576px on Opus 4.7+,
+1568px otherwise.
 """
 
 from __future__ import annotations

--- a/tests/test_image_dimension_guard.py
+++ b/tests/test_image_dimension_guard.py
@@ -10,9 +10,46 @@ from __future__ import annotations
 from PIL import Image
 
 from puffo_agent.agent.puffo_core_client import (
-    _MAX_IMAGE_EDGE_PX,
+    _DEFAULT_IMAGE_EDGE_PX,
+    _HIGH_RES_IMAGE_EDGE_PX,
     _downscale_oversized_image,
+    max_image_edge_px,
 )
+
+_MAX_IMAGE_EDGE_PX = _DEFAULT_IMAGE_EDGE_PX
+
+
+def test_max_image_edge_px_per_model():
+    assert max_image_edge_px("claude-opus-4-8") == _HIGH_RES_IMAGE_EDGE_PX
+    assert max_image_edge_px("claude-opus-4-7") == _HIGH_RES_IMAGE_EDGE_PX
+    assert max_image_edge_px("claude-sonnet-4-6") == _DEFAULT_IMAGE_EDGE_PX
+    assert max_image_edge_px("") == _DEFAULT_IMAGE_EDGE_PX
+    assert max_image_edge_px(None) == _DEFAULT_IMAGE_EDGE_PX
+
+
+def test_downscale_returns_whether_it_resized(tmp_path):
+    big = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(big)
+    assert _downscale_oversized_image(big) is True
+
+    small = tmp_path / "small.png"
+    Image.new("RGB", (800, 600), color="green").save(small)
+    assert _downscale_oversized_image(small) is False
+
+
+def test_higher_cap_keeps_more_detail(tmp_path):
+    """A 2000px image is over the 1568 default but within the 2576 high-res
+    cap — at the higher cap it's left untouched."""
+    path = tmp_path / "shot.png"
+    Image.new("RGB", (2000, 1200), color="blue").save(path)
+    before = path.read_bytes()
+
+    assert _downscale_oversized_image(path, None, _HIGH_RES_IMAGE_EDGE_PX) is False
+    assert path.read_bytes() == before  # untouched at the high-res cap
+
+    assert _downscale_oversized_image(path, None, _DEFAULT_IMAGE_EDGE_PX) is True
+    with Image.open(path) as img:
+        assert max(img.size) <= _DEFAULT_IMAGE_EDGE_PX
 
 
 def test_oversized_landscape_image_is_downscaled(tmp_path):

--- a/tests/test_image_dimension_guard.py
+++ b/tests/test_image_dimension_guard.py
@@ -92,3 +92,143 @@ def test_corrupt_image_is_left_alone(tmp_path):
     _downscale_oversized_image(path)  # must not raise
 
     assert path.read_bytes() == before
+
+
+# ---- original-preserve side ----------------------------------------------
+# When the caller hands an ``original_path``, the pre-resize bytes are
+# copied there ONLY when the resize is actually about to fire — small
+# images, non-images, and unreadable files don't get a spurious copy.
+
+
+def test_original_path_preserved_on_resize(tmp_path):
+    """Oversized image + original_path → both files exist; original
+    holds the pre-resize bytes; in-place file is downscaled."""
+    path = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+    pre_resize = path.read_bytes()
+    original = tmp_path / "original" / "big.png"
+
+    _downscale_oversized_image(path, original)
+
+    assert original.read_bytes() == pre_resize
+    with Image.open(path) as img:
+        assert max(img.size) <= _MAX_IMAGE_EDGE_PX
+
+
+def test_no_original_copy_when_image_within_cap(tmp_path):
+    """Small image + original_path → no original copy: downscale is a
+    no-op, so the agent shouldn't get a misleading 'original/' dir."""
+    path = tmp_path / "ok.png"
+    Image.new("RGB", (_MAX_IMAGE_EDGE_PX, 900), color="green").save(path)
+    original = tmp_path / "original" / "ok.png"
+
+    _downscale_oversized_image(path, original)
+
+    assert not original.exists()
+    assert not original.parent.exists()
+
+
+def test_no_original_copy_for_non_image(tmp_path):
+    """Non-image attachment + original_path → no spurious copy. The
+    Pillow open fails before we reach the resize gate."""
+    path = tmp_path / "notes.txt"
+    path.write_text("not an image", encoding="utf-8")
+    original = tmp_path / "original" / "notes.txt"
+
+    _downscale_oversized_image(path, original)
+
+    assert not original.exists()
+
+
+def test_no_original_copy_for_corrupt_image(tmp_path):
+    """Garbage-bytes-with-PNG-extension + original_path → no copy:
+    Pillow can't decode, so resize never runs."""
+    path = tmp_path / "broken.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    original = tmp_path / "original" / "broken.png"
+
+    _downscale_oversized_image(path, original)
+
+    assert not original.exists()
+
+
+def test_no_original_copy_when_pillow_missing(tmp_path, monkeypatch):
+    """Pillow ImportError + original_path → early-return before any
+    decision; no copy, no raise."""
+    path = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+    original = tmp_path / "original" / "big.png"
+
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "PIL":
+            raise ImportError("simulated missing Pillow")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    _downscale_oversized_image(path, original)
+
+    assert not original.exists()
+
+
+def test_original_path_omitted_keeps_legacy_behavior(tmp_path):
+    """No ``original_path`` arg → exactly the pre-PUF-308 behavior:
+    in-place resize, no sibling files. Backward-compat for any caller
+    that hasn't been migrated."""
+    path = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+    sibling_dir = tmp_path / "original"
+
+    _downscale_oversized_image(path)
+
+    with Image.open(path) as img:
+        assert max(img.size) <= _MAX_IMAGE_EDGE_PX
+    assert not sibling_dir.exists()
+
+
+def test_original_path_dir_created_on_demand(tmp_path):
+    """Caller passes a nested ``original_path`` whose parent dir
+    doesn't exist yet → function creates it before the copy."""
+    path = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+    pre = path.read_bytes()
+    original = tmp_path / "deep" / "nested" / "original" / "big.png"
+
+    _downscale_oversized_image(path, original)
+
+    assert original.read_bytes() == pre
+
+
+def test_resize_failure_does_not_raise_after_original_copied(
+    tmp_path, monkeypatch,
+):
+    """If the in-place save raises AFTER the original copy lands,
+    the function still swallows the exception (best-effort contract)
+    and the original copy is left on disk — caller-visible behavior
+    matches the pre-PUF-308 best-effort guarantee."""
+    path = tmp_path / "big.png"
+    Image.new("RGB", (4000, 1000), color="red").save(path)
+    original = tmp_path / "original" / "big.png"
+
+    # Force the post-copy resize.save() to blow up.
+    real_resize = Image.Image.resize
+
+    def boom_resize(self, *args, **kwargs):
+        out = real_resize(self, *args, **kwargs)
+
+        def boom_save(*a, **kw):
+            raise OSError("simulated disk full")
+
+        out.save = boom_save
+        return out
+
+    monkeypatch.setattr(Image.Image, "resize", boom_resize)
+
+    _downscale_oversized_image(path, original)  # must not raise
+
+    # Original copy made it to disk before the save blew up — that's
+    # fine; the agent's file-access tools can still reach it.
+    assert original.exists()

--- a/tests/test_save_inbound_attachments_preserve_original.py
+++ b/tests/test_save_inbound_attachments_preserve_original.py
@@ -1,8 +1,8 @@
-"""End-to-end coverage for the dual-storage attachment write path:
-inbound oversized images land downscaled at
-``inbox/<env>/<name>`` (LLM-payload) AND originals land at
-``inbox/<env>/original/<name>`` (agent file-access). Non-oversized
-attachments don't get a spurious ``original/`` sibling.
+"""End-to-end coverage for the dual-storage attachment write path: when an
+inbound image is oversized it's split into ``<stem>.compressed<ext>`` (the
+in-bounds LLM-payload version, returned in the attachment list) and
+``<stem>.origin<ext>`` (the full-fidelity sibling). Non-oversized
+attachments keep their bare name with no spurious siblings.
 """
 
 from __future__ import annotations
@@ -17,7 +17,8 @@ from PIL import Image
 
 from puffo_agent.agent import puffo_core_client as pcc
 from puffo_agent.agent.puffo_core_client import (
-    _MAX_IMAGE_EDGE_PX,
+    _DEFAULT_IMAGE_EDGE_PX,
+    _HIGH_RES_IMAGE_EDGE_PX,
     PuffoCoreMessageClient,
 )
 
@@ -39,11 +40,12 @@ def _png_bytes(w: int, h: int) -> bytes:
     return buf.getvalue()
 
 
-def _stub_self(workspace: Path) -> SimpleNamespace:
+def _stub_self(workspace: Path, edge_px: int = _DEFAULT_IMAGE_EDGE_PX) -> SimpleNamespace:
     return SimpleNamespace(
         workspace=str(workspace),
         http=object(),
         _log=logging.getLogger("puf308-test"),
+        _image_edge_px=edge_px,
     )
 
 
@@ -60,13 +62,10 @@ def _patch_decrypt(monkeypatch, payloads: dict[str, bytes]) -> None:
     )
 
 
-def test_oversized_image_lands_in_both_locations(tmp_path, monkeypatch):
-    """Happy path: an oversized inbound image is downscaled in place
-    at ``inbox/<env>/<name>`` and the original bytes are preserved
-    at ``inbox/<env>/original/<name>``. Returned LLM-payload paths
-    point at the downscaled file only. ``shutil.copy2`` is used so
-    the original's mtime tracks the on-disk source — agent tools
-    that key freshness on stat() see a coherent timestamp."""
+def test_oversized_image_splits_into_compressed_and_origin(tmp_path, monkeypatch):
+    """An oversized inbound image lands as ``shot.compressed.png`` (downscaled,
+    returned in the attachment list) plus ``shot.origin.png`` (full-res). The
+    bare ``shot.png`` is renamed away, not left behind."""
     oversized = _png_bytes(4000, 1000)
     _patch_decrypt(monkeypatch, {"blob-1": oversized})
 
@@ -78,21 +77,20 @@ def test_oversized_image_lands_in_both_locations(tmp_path, monkeypatch):
     )
 
     inbox = tmp_path / ".puffo" / "inbox" / "env_a"
-    downscaled = inbox / "shot.png"
-    original = inbox / "original" / "shot.png"
-    assert downscaled.exists()
-    assert original.exists()
-    assert original.read_bytes() == oversized
-    with Image.open(downscaled) as img:
-        assert max(img.size) <= _MAX_IMAGE_EDGE_PX
-    assert paths == [str(downscaled)]
+    compressed = inbox / "shot.compressed.png"
+    origin = inbox / "shot.origin.png"
+    assert compressed.exists()
+    assert origin.exists()
+    assert not (inbox / "shot.png").exists()
+    assert origin.read_bytes() == oversized
+    with Image.open(compressed) as img:
+        assert max(img.size) <= _DEFAULT_IMAGE_EDGE_PX
+    assert paths == [str(compressed)]
 
 
-def test_original_mtime_tracks_pre_resize_source(tmp_path, monkeypatch):
-    """``shutil.copy2`` preserves the source mtime. The original copy
-    must carry the pre-resize file's mtime — any agent tool that
-    keys cache freshness on stat() sees a coherent timestamp linked
-    to the actual receive moment, not the resize moment."""
+def test_origin_mtime_tracks_pre_resize_source(tmp_path, monkeypatch):
+    """``shutil.copy2`` preserves the source mtime, so ``shot.origin.png``
+    carries the pre-resize file's mtime."""
     import shutil as _shutil
 
     oversized = _png_bytes(4000, 1000)
@@ -114,21 +112,15 @@ def test_original_mtime_tracks_pre_resize_source(tmp_path, monkeypatch):
         )
     )
 
-    original = tmp_path / ".puffo" / "inbox" / "env_mtime" / "original" / "shot.png"
-    # copy2's mtime preservation is the contract we're pinning;
-    # tolerate filesystem-rounding to whole seconds across platforms.
-    assert abs(original.stat().st_mtime - pre_resize_mtime["src_mtime"]) < 1
+    origin = tmp_path / ".puffo" / "inbox" / "env_mtime" / "shot.origin.png"
+    assert abs(origin.stat().st_mtime - pre_resize_mtime["src_mtime"]) < 1
 
 
-def test_repeated_envelope_overwrites_original_with_latest_bytes(
+def test_repeated_envelope_overwrites_origin_with_latest_bytes(
     tmp_path, monkeypatch,
 ):
-    """Envelope-id reuse / partial-retry rewrite case: a second call
-    with the same envelope_id and filename but different bytes lands
-    the latest version in ``original/`` (last-write-wins semantic).
-    Same envelope_id and filename can occur on daemon-restart-during-
-    write or relay-side replay; users should see the most-recently-
-    received bytes, not a stale first copy."""
+    """Envelope-id reuse: a second call with the same envelope_id + filename
+    but different bytes lands the latest version in ``shot.origin.png``."""
     first = _png_bytes(4000, 1000)
     second = _png_bytes(5000, 800)
     assert first != second
@@ -142,7 +134,6 @@ def test_repeated_envelope_overwrites_original_with_latest_bytes(
         )
     )
 
-    # Second pass: replace the patched payload with `second`.
     _patch_decrypt(monkeypatch, {"blob-1": second})
     asyncio.run(
         PuffoCoreMessageClient._save_inbound_attachments(
@@ -151,19 +142,13 @@ def test_repeated_envelope_overwrites_original_with_latest_bytes(
         )
     )
 
-    original = tmp_path / ".puffo" / "inbox" / "env_dup" / "original" / "shot.png"
-    assert original.read_bytes() == second
+    origin = tmp_path / ".puffo" / "inbox" / "env_dup" / "shot.origin.png"
+    assert origin.read_bytes() == second
 
 
-def test_concurrent_oversized_writes_share_original_dir(
-    tmp_path, monkeypatch,
-):
-    """Forward-looking race: if a future refactor parallelises
-    attachment writes via ``asyncio.gather`` over ``metas_raw``,
-    multiple oversized images in one envelope must share the
-    ``original/`` subdir without a ``FileExistsError`` collision.
-    ``Path.mkdir(parents=True, exist_ok=True)`` covers the gate;
-    this test pins that guarantee against future changes."""
+def test_concurrent_oversized_writes_share_inbox(tmp_path, monkeypatch):
+    """Two oversized images in one envelope each split into their own
+    compressed/origin pair in the same inbox dir without collision."""
     overs_a = _png_bytes(4000, 1000)
     overs_b = _png_bytes(3000, 1200)
     _patch_decrypt(monkeypatch, {"blob-a": overs_a, "blob-b": overs_b})
@@ -183,17 +168,16 @@ def test_concurrent_oversized_writes_share_original_dir(
 
     asyncio.run(race())
 
-    original_dir = tmp_path / ".puffo" / "inbox" / "env_race" / "original"
-    assert (original_dir / "a.png").exists()
-    assert (original_dir / "b.png").exists()
-    assert (original_dir / "a.png").read_bytes() == overs_a
-    assert (original_dir / "b.png").read_bytes() == overs_b
+    inbox = tmp_path / ".puffo" / "inbox" / "env_race"
+    assert (inbox / "a.compressed.png").exists()
+    assert (inbox / "b.compressed.png").exists()
+    assert (inbox / "a.origin.png").read_bytes() == overs_a
+    assert (inbox / "b.origin.png").read_bytes() == overs_b
 
 
-def test_small_image_no_original_sibling(tmp_path, monkeypatch):
-    """Unhappy-of-original-preservation: a small image doesn't trip
-    the downscale, so the ``original/`` subdir is never created. The
-    LLM-payload path is the (untouched) original."""
+def test_small_image_keeps_bare_name(tmp_path, monkeypatch):
+    """A small image doesn't trip the downscale, so it keeps its bare name
+    with no compressed/origin split."""
     small = _png_bytes(800, 600)
     _patch_decrypt(monkeypatch, {"blob-1": small})
 
@@ -206,13 +190,32 @@ def test_small_image_no_original_sibling(tmp_path, monkeypatch):
 
     inbox = tmp_path / ".puffo" / "inbox" / "env_b"
     assert (inbox / "thumb.png").exists()
-    assert not (inbox / "original").exists()
+    assert not (inbox / "thumb.compressed.png").exists()
+    assert not (inbox / "thumb.origin.png").exists()
     assert paths == [str(inbox / "thumb.png")]
 
 
-def test_non_image_attachment_no_original_sibling(tmp_path, monkeypatch):
-    """A text attachment never hits the downscale gate; no spurious
-    ``original/`` directory."""
+def test_within_high_res_cap_keeps_bare_name(tmp_path, monkeypatch):
+    """At the 2576px high-res cap (Opus 4.7+), a 2000px image is in-bounds —
+    no split, bare name retained."""
+    img = _png_bytes(2000, 1200)
+    _patch_decrypt(monkeypatch, {"blob-1": img})
+
+    stub = _stub_self(tmp_path, edge_px=_HIGH_RES_IMAGE_EDGE_PX)
+    paths = asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_hr", metas_raw=[_meta("blob-1", "shot.png")],
+        )
+    )
+
+    inbox = tmp_path / ".puffo" / "inbox" / "env_hr"
+    assert (inbox / "shot.png").exists()
+    assert not (inbox / "shot.origin.png").exists()
+    assert paths == [str(inbox / "shot.png")]
+
+
+def test_non_image_attachment_keeps_bare_name(tmp_path, monkeypatch):
+    """A text attachment never hits the downscale gate; bare name, no split."""
     _patch_decrypt(monkeypatch, {"blob-1": b"hello world"})
 
     stub = _stub_self(tmp_path)
@@ -224,15 +227,13 @@ def test_non_image_attachment_no_original_sibling(tmp_path, monkeypatch):
 
     inbox = tmp_path / ".puffo" / "inbox" / "env_c"
     assert (inbox / "notes.txt").exists()
-    assert not (inbox / "original").exists()
+    assert not (inbox / "notes.origin.txt").exists()
     assert paths == [str(inbox / "notes.txt")]
 
 
-def test_mixed_envelope_only_oversized_gets_original(tmp_path, monkeypatch):
-    """Race-shape coverage: a single envelope with text + small image
-    + oversized image. The ``original/`` subdir holds only the
-    oversized image; the LLM-payload list carries one path per
-    attachment."""
+def test_mixed_envelope_only_oversized_splits(tmp_path, monkeypatch):
+    """A single envelope with text + small image + oversized image: only the
+    oversized one gets the compressed/origin split."""
     oversized = _png_bytes(4000, 1000)
     small = _png_bytes(800, 600)
     _patch_decrypt(monkeypatch, {
@@ -254,14 +255,12 @@ def test_mixed_envelope_only_oversized_gets_original(tmp_path, monkeypatch):
     )
 
     inbox = tmp_path / ".puffo" / "inbox" / "env_d"
-    original_dir = inbox / "original"
-    assert original_dir.is_dir()
-    assert (original_dir / "big.png").exists()
-    assert (original_dir / "big.png").read_bytes() == oversized
-    assert not (original_dir / "thumb.png").exists()
-    assert not (original_dir / "notes.txt").exists()
+    assert (inbox / "big.compressed.png").exists()
+    assert (inbox / "big.origin.png").read_bytes() == oversized
+    assert not (inbox / "thumb.origin.png").exists()
+    assert not (inbox / "notes.origin.txt").exists()
     assert set(paths) == {
         str(inbox / "notes.txt"),
         str(inbox / "thumb.png"),
-        str(inbox / "big.png"),
+        str(inbox / "big.compressed.png"),
     }

--- a/tests/test_save_inbound_attachments_preserve_original.py
+++ b/tests/test_save_inbound_attachments_preserve_original.py
@@ -64,7 +64,9 @@ def test_oversized_image_lands_in_both_locations(tmp_path, monkeypatch):
     """Happy path: an oversized inbound image is downscaled in place
     at ``inbox/<env>/<name>`` and the original bytes are preserved
     at ``inbox/<env>/original/<name>``. Returned LLM-payload paths
-    point at the downscaled file only."""
+    point at the downscaled file only. ``shutil.copy2`` is used so
+    the original's mtime tracks the on-disk source — agent tools
+    that key freshness on stat() see a coherent timestamp."""
     oversized = _png_bytes(4000, 1000)
     _patch_decrypt(monkeypatch, {"blob-1": oversized})
 
@@ -84,6 +86,108 @@ def test_oversized_image_lands_in_both_locations(tmp_path, monkeypatch):
     with Image.open(downscaled) as img:
         assert max(img.size) <= _MAX_IMAGE_EDGE_PX
     assert paths == [str(downscaled)]
+
+
+def test_original_mtime_tracks_pre_resize_source(tmp_path, monkeypatch):
+    """``shutil.copy2`` preserves the source mtime. The original copy
+    must carry the pre-resize file's mtime — any agent tool that
+    keys cache freshness on stat() sees a coherent timestamp linked
+    to the actual receive moment, not the resize moment."""
+    import shutil as _shutil
+
+    oversized = _png_bytes(4000, 1000)
+    pre_resize_mtime: dict[str, float] = {}
+    real_copy2 = _shutil.copy2
+
+    def spying_copy2(src, dst, *args, **kwargs):
+        pre_resize_mtime["src_mtime"] = Path(src).stat().st_mtime
+        return real_copy2(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(_shutil, "copy2", spying_copy2)
+
+    _patch_decrypt(monkeypatch, {"blob-1": oversized})
+    stub = _stub_self(tmp_path)
+    asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_mtime",
+            metas_raw=[_meta("blob-1", "shot.png")],
+        )
+    )
+
+    original = tmp_path / ".puffo" / "inbox" / "env_mtime" / "original" / "shot.png"
+    # copy2's mtime preservation is the contract we're pinning;
+    # tolerate filesystem-rounding to whole seconds across platforms.
+    assert abs(original.stat().st_mtime - pre_resize_mtime["src_mtime"]) < 1
+
+
+def test_repeated_envelope_overwrites_original_with_latest_bytes(
+    tmp_path, monkeypatch,
+):
+    """Envelope-id reuse / partial-retry rewrite case: a second call
+    with the same envelope_id and filename but different bytes lands
+    the latest version in ``original/`` (last-write-wins semantic).
+    Same envelope_id and filename can occur on daemon-restart-during-
+    write or relay-side replay; users should see the most-recently-
+    received bytes, not a stale first copy."""
+    first = _png_bytes(4000, 1000)
+    second = _png_bytes(5000, 800)
+    assert first != second
+
+    _patch_decrypt(monkeypatch, {"blob-1": first})
+    stub = _stub_self(tmp_path)
+    asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_dup",
+            metas_raw=[_meta("blob-1", "shot.png")],
+        )
+    )
+
+    # Second pass: replace the patched payload with `second`.
+    _patch_decrypt(monkeypatch, {"blob-1": second})
+    asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_dup",
+            metas_raw=[_meta("blob-1", "shot.png")],
+        )
+    )
+
+    original = tmp_path / ".puffo" / "inbox" / "env_dup" / "original" / "shot.png"
+    assert original.read_bytes() == second
+
+
+def test_concurrent_oversized_writes_share_original_dir(
+    tmp_path, monkeypatch,
+):
+    """Forward-looking race: if a future refactor parallelises
+    attachment writes via ``asyncio.gather`` over ``metas_raw``,
+    multiple oversized images in one envelope must share the
+    ``original/`` subdir without a ``FileExistsError`` collision.
+    ``Path.mkdir(parents=True, exist_ok=True)`` covers the gate;
+    this test pins that guarantee against future changes."""
+    overs_a = _png_bytes(4000, 1000)
+    overs_b = _png_bytes(3000, 1200)
+    _patch_decrypt(monkeypatch, {"blob-a": overs_a, "blob-b": overs_b})
+    stub = _stub_self(tmp_path)
+
+    async def race() -> list[list[str]]:
+        return await asyncio.gather(
+            PuffoCoreMessageClient._save_inbound_attachments(
+                stub, envelope_id="env_race",
+                metas_raw=[_meta("blob-a", "a.png")],
+            ),
+            PuffoCoreMessageClient._save_inbound_attachments(
+                stub, envelope_id="env_race",
+                metas_raw=[_meta("blob-b", "b.png")],
+            ),
+        )
+
+    asyncio.run(race())
+
+    original_dir = tmp_path / ".puffo" / "inbox" / "env_race" / "original"
+    assert (original_dir / "a.png").exists()
+    assert (original_dir / "b.png").exists()
+    assert (original_dir / "a.png").read_bytes() == overs_a
+    assert (original_dir / "b.png").read_bytes() == overs_b
 
 
 def test_small_image_no_original_sibling(tmp_path, monkeypatch):

--- a/tests/test_save_inbound_attachments_preserve_original.py
+++ b/tests/test_save_inbound_attachments_preserve_original.py
@@ -1,0 +1,163 @@
+"""End-to-end coverage for the dual-storage attachment write path:
+inbound oversized images land downscaled at
+``inbox/<env>/<name>`` (LLM-payload) AND originals land at
+``inbox/<env>/original/<name>`` (agent file-access). Non-oversized
+attachments don't get a spurious ``original/`` sibling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+from PIL import Image
+
+from puffo_agent.agent import puffo_core_client as pcc
+from puffo_agent.agent.puffo_core_client import (
+    _MAX_IMAGE_EDGE_PX,
+    PuffoCoreMessageClient,
+)
+
+
+def _meta(blob_id: str, filename: str) -> dict:
+    return {
+        "blob_id": blob_id,
+        "filename": filename,
+        "mime_type": "image/png",
+        "size": 0,
+        "key": "a" * 43,
+        "nonce": "b" * 16,
+    }
+
+
+def _png_bytes(w: int, h: int) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), color="red").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _stub_self(workspace: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        workspace=str(workspace),
+        http=object(),
+        _log=logging.getLogger("puf308-test"),
+    )
+
+
+def _patch_decrypt(monkeypatch, payloads: dict[str, bytes]) -> None:
+    async def fake_fetch(http, blob_id):
+        return payloads[blob_id]
+
+    def fake_decrypt(ciphertext, meta):
+        return ciphertext
+
+    monkeypatch.setattr(pcc, "_fetch_blob_with_retry", fake_fetch)
+    monkeypatch.setattr(
+        "puffo_agent.crypto.attachments.decrypt_attachment", fake_decrypt,
+    )
+
+
+def test_oversized_image_lands_in_both_locations(tmp_path, monkeypatch):
+    """Happy path: an oversized inbound image is downscaled in place
+    at ``inbox/<env>/<name>`` and the original bytes are preserved
+    at ``inbox/<env>/original/<name>``. Returned LLM-payload paths
+    point at the downscaled file only."""
+    oversized = _png_bytes(4000, 1000)
+    _patch_decrypt(monkeypatch, {"blob-1": oversized})
+
+    stub = _stub_self(tmp_path)
+    paths = asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_a", metas_raw=[_meta("blob-1", "shot.png")],
+        )
+    )
+
+    inbox = tmp_path / ".puffo" / "inbox" / "env_a"
+    downscaled = inbox / "shot.png"
+    original = inbox / "original" / "shot.png"
+    assert downscaled.exists()
+    assert original.exists()
+    assert original.read_bytes() == oversized
+    with Image.open(downscaled) as img:
+        assert max(img.size) <= _MAX_IMAGE_EDGE_PX
+    assert paths == [str(downscaled)]
+
+
+def test_small_image_no_original_sibling(tmp_path, monkeypatch):
+    """Unhappy-of-original-preservation: a small image doesn't trip
+    the downscale, so the ``original/`` subdir is never created. The
+    LLM-payload path is the (untouched) original."""
+    small = _png_bytes(800, 600)
+    _patch_decrypt(monkeypatch, {"blob-1": small})
+
+    stub = _stub_self(tmp_path)
+    paths = asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_b", metas_raw=[_meta("blob-1", "thumb.png")],
+        )
+    )
+
+    inbox = tmp_path / ".puffo" / "inbox" / "env_b"
+    assert (inbox / "thumb.png").exists()
+    assert not (inbox / "original").exists()
+    assert paths == [str(inbox / "thumb.png")]
+
+
+def test_non_image_attachment_no_original_sibling(tmp_path, monkeypatch):
+    """A text attachment never hits the downscale gate; no spurious
+    ``original/`` directory."""
+    _patch_decrypt(monkeypatch, {"blob-1": b"hello world"})
+
+    stub = _stub_self(tmp_path)
+    paths = asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_c", metas_raw=[_meta("blob-1", "notes.txt")],
+        )
+    )
+
+    inbox = tmp_path / ".puffo" / "inbox" / "env_c"
+    assert (inbox / "notes.txt").exists()
+    assert not (inbox / "original").exists()
+    assert paths == [str(inbox / "notes.txt")]
+
+
+def test_mixed_envelope_only_oversized_gets_original(tmp_path, monkeypatch):
+    """Race-shape coverage: a single envelope with text + small image
+    + oversized image. The ``original/`` subdir holds only the
+    oversized image; the LLM-payload list carries one path per
+    attachment."""
+    oversized = _png_bytes(4000, 1000)
+    small = _png_bytes(800, 600)
+    _patch_decrypt(monkeypatch, {
+        "blob-1": b"some text",
+        "blob-2": small,
+        "blob-3": oversized,
+    })
+
+    stub = _stub_self(tmp_path)
+    paths = asyncio.run(
+        PuffoCoreMessageClient._save_inbound_attachments(
+            stub, envelope_id="env_d",
+            metas_raw=[
+                _meta("blob-1", "notes.txt"),
+                _meta("blob-2", "thumb.png"),
+                _meta("blob-3", "big.png"),
+            ],
+        )
+    )
+
+    inbox = tmp_path / ".puffo" / "inbox" / "env_d"
+    original_dir = inbox / "original"
+    assert original_dir.is_dir()
+    assert (original_dir / "big.png").exists()
+    assert (original_dir / "big.png").read_bytes() == oversized
+    assert not (original_dir / "thumb.png").exists()
+    assert not (original_dir / "notes.txt").exists()
+    assert set(paths) == {
+        str(inbox / "notes.txt"),
+        str(inbox / "thumb.png"),
+        str(inbox / "big.png"),
+    }


### PR DESCRIPTION
## Summary

Christian image-quality feedback (FB-303): the inbound downscaler at 1568px ceiling drops ~95% bytes for high-DPI screenshots, which loses detail when the agent OCRs / inspects. Preserve original bytes side-by-side so:

- the LLM payload stays under the cap (existing `inbox/<env>/<name>` path is downscaled — token-cost optimization preserved)
- the agent's Read tool can reach full-fidelity bytes at `inbox/<env>/original/<name>`

Single-file change at `puffo_core_client.py` (signature extension + one call-site). Backward-compat: `original_path` defaults to `None`; the `original/` copy fires ONLY when the resize is actually about to fire (skipped for small images, non-images, corrupt images, Pillow-missing).

## Test plan

- [x] `python3 -m pytest tests/test_image_dimension_guard.py tests/test_save_inbound_attachments_preserve_original.py -v` → 18/18 (6 pre-existing + 8 new unit + 4 new e2e).
- [x] Unit covers all branches of the new gate: copy fires only when resize fires; nested parent dir created on demand; resize-failure-after-copy swallowed; backward-compat with omitted `original_path`.
- [x] E2E through `_save_inbound_attachments`: happy oversized → both files; small image → no spurious `original/`; non-image → no spurious `original/`; mixed envelope (text + small + oversized) → only oversized image gets the original copy.
- [ ] Live-soak (post-merge): inbound oversized screenshot to a deployed agent → agent's Read tool can reach `inbox/<env>/original/<name>` AND LLM payload stays under cap.

Closes PUF-308.