### PR TITLE
PUF-310: Codex auth-failure operator DM substrate (extends PUF-283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   conservative default). Previously every image was downscaled to 1568px,
   discarding detail newer models can use.
 
+### Fixed
+
+- **Codex agents alert the operator on an auth failure.** A Codex agent that
+  hit an OAuth failure (revoked/invalidated refresh token, or a `/responses`
+  401) previously went silent indefinitely. It now reuses the same
+  operator-DM substrate as Claude, sending a bilingual DM with the
+  `codex login` recovery command. Claude agents are unchanged.
+
 ## [0.12.5] — 2026-06-17
 
 ### Added

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -118,3 +118,22 @@ def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
         "⚠️ Claude OAuth 已过期。请运行 `claude auth login`，"
         "然后给我发条消息即可恢复。"
     )
+
+
+def format_codex_oauth_expired(
+    agent_id: str, agent_display_name: str = "",
+) -> str:
+    """Sibling of :func:`format_oauth_expired` for the Codex provider.
+    Worker dispatches between the two on ``agent_cfg.runtime.harness``
+    so the operator sees the right recovery command for the agent that
+    actually failed."""
+    label = (
+        f"**{agent_display_name}** (`{agent_id}`)"
+        if agent_display_name else f"`{agent_id}`"
+    )
+    return (
+        f"⚠️ {label} — Codex OAuth expired. Run `codex login`, "
+        "then send me a message and I'll pick up where I left off.\n"
+        "⚠️ Codex OAuth 已过期。请运行 `codex login`，"
+        "然后给我发条消息即可恢复。"
+    )

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -100,25 +100,17 @@ def _looks_like_codex_thread_limit(err_text: str) -> bool:
     return any(p.search(err_text or "") for p in _CODEX_THREAD_LIMIT_PATTERNS)
 
 
-# Codex-provider auth-failure strings. Anchored to verbatim signals
-# captured in the d2d2 stuck-state case (msg_2237ad78) so we don't
-# auto-flip on legitimate model/quota errors. ``invalid thread id ...
-# found 0`` is the downstream-of-empty-conversation_id surface symptom,
-# NOT an auth signal — stays out per the diagnostic chain.
+# Verbatim Codex auth-failure signals — anchored so we don't auto-flip on
+# legitimate model/quota errors. ``invalid thread id ... found 0`` is a
+# downstream symptom of an empty conversation_id, not auth — kept out.
 _CODEX_AUTH_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"refresh token (?:was )?revoked", re.IGNORECASE),
     re.compile(r"\btoken_invalidated\b", re.IGNORECASE),
 )
 
-# Co-occurrence signal: ``401`` next to ``/responses`` in the SAME
-# clause — bounded distance + no sentence-boundary punctuation
-# between them. The bidirectional pair covers either ordering
-# ("/responses returned 401" vs "401 Unauthorized from /responses"
-# vs the JSON-envelope shape "code: 401, path: /responses").
-# A loose substring co-occurrence FPs on log lines that mention
-# both fragments for unrelated reasons (e.g. "cache hit for
-# /responses; 401 retries exhausted") — the clause-bound regex
-# rejects those.
+# ``401`` next to ``/responses`` in the same clause (bounded distance, no
+# sentence break between), either ordering. Clause-bound so it doesn't FP
+# on unrelated lines that happen to mention both fragments.
 _CODEX_RESPONSES_401_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"/responses[^.;\n]{0,40}\b401\b", re.IGNORECASE),
     re.compile(r"\b401\b[^.;\n]{0,40}/responses", re.IGNORECASE),
@@ -126,11 +118,10 @@ _CODEX_RESPONSES_401_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 
 def _looks_like_codex_auth_error(err_text: str) -> bool:
-    """True iff ``err_text`` carries one of the verbatim Codex auth
-    signals (``refresh token (was) revoked`` / ``token_invalidated`` /
-    a ``/responses 401`` clause-bound co-occurrence). Drives the
-    conversion of a ``turn_failed`` ``RuntimeError`` into an
-    ``AgentAPIError(is_auth=True)`` so the worker's PUF-283
+    """True iff ``err_text`` carries a verbatim Codex auth signal
+    (``refresh token (was) revoked`` / ``token_invalidated`` / a
+    ``/responses 401`` clause-bound co-occurrence). Drives converting a
+    ``turn_failed`` into an ``AgentAPIError(is_auth=True)`` so the worker's
     auth_failed substrate fires."""
     text = err_text or ""
     if any(p.search(text) for p in _CODEX_AUTH_ERROR_PATTERNS):
@@ -371,11 +362,10 @@ class CodexSession:
             self._propagate_turn_outcome(
                 outcome="turn_failed", err_text=err_text,
             )
-            # Codex auth-failures are sticky + user-actionable (operator
-            # must re-run ``codex login``). Convert to AgentAPIError so
-            # the worker's PUF-283 auth_failed substrate (state-flip +
-            # operator DM + dedup + refresher kick) reuses the Claude
-            # path — see core.py:317 + worker.py:1141-1152.
+            # Codex auth-failures are sticky + operator-actionable (re-run
+            # ``codex login``). Convert to AgentAPIError so the worker's
+            # auth_failed substrate (state-flip + operator DM + refresher
+            # kick) reuses the Claude path.
             if _looks_like_codex_auth_error(err_text):
                 from ..core import AgentAPIError
                 raise AgentAPIError(

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -99,6 +99,38 @@ _CODEX_THREAD_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
 def _looks_like_codex_thread_limit(err_text: str) -> bool:
     return any(p.search(err_text or "") for p in _CODEX_THREAD_LIMIT_PATTERNS)
 
+
+# Codex-provider auth-failure strings. Anchored to verbatim signals
+# captured in the d2d2 stuck-state case (msg_2237ad78) so we don't
+# auto-flip on legitimate model/quota errors. ``invalid thread id ...
+# found 0`` is the downstream-of-empty-conversation_id surface symptom,
+# NOT an auth signal — stays out per the diagnostic chain.
+_CODEX_AUTH_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"refresh token (?:was )?revoked", re.IGNORECASE),
+    re.compile(r"\btoken_invalidated\b", re.IGNORECASE),
+)
+
+# Co-occurrence signal: a 401 alongside a ``/responses`` reference.
+# Kept separate from the pattern tuple because direction-agnostic
+# substring co-occurrence is simpler + more robust than positional
+# regex (``\b/`` doesn't match a word boundary, so a single
+# left-to-right or right-to-left regex would miss real cases).
+_CODEX_RESPONSES_401_PATTERN = re.compile(r"\b401\b")
+
+
+def _looks_like_codex_auth_error(err_text: str) -> bool:
+    """True iff ``err_text`` carries one of the verbatim Codex auth
+    signals (``refresh token (was) revoked`` / ``token_invalidated`` /
+    a ``/responses 401`` co-occurrence). Drives the conversion of a
+    ``turn_failed`` ``RuntimeError`` into an ``AgentAPIError(is_auth=
+    True)`` so the worker's PUF-283 auth_failed substrate fires."""
+    text = err_text or ""
+    if any(p.search(text) for p in _CODEX_AUTH_ERROR_PATTERNS):
+        return True
+    if "/responses" in text and _CODEX_RESPONSES_401_PATTERN.search(text):
+        return True
+    return False
+
 # Tool names of the puffo MCP server's "this counts as posting a
 # reply" family. When the agent invokes one of these and it completes
 # successfully, the worker treats the turn as "agent already replied"
@@ -329,9 +361,20 @@ class CodexSession:
             self._active_turn = None
 
         if turn_failed_exc is not None:
+            err_text = str(turn_failed_exc)
             self._propagate_turn_outcome(
-                outcome="turn_failed", err_text=str(turn_failed_exc),
+                outcome="turn_failed", err_text=err_text,
             )
+            # Codex auth-failures are sticky + user-actionable (operator
+            # must re-run ``codex login``). Convert to AgentAPIError so
+            # the worker's PUF-283 auth_failed substrate (state-flip +
+            # operator DM + dedup + refresher kick) reuses the Claude
+            # path — see core.py:317 + worker.py:1141-1152.
+            if _looks_like_codex_auth_error(err_text):
+                from ..core import AgentAPIError
+                raise AgentAPIError(
+                    f"codex auth failed: {err_text}", is_auth=True,
+                ) from turn_failed_exc
             raise turn_failed_exc
 
         reply = "".join(turn.reply_chunks).strip()

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -110,26 +110,32 @@ _CODEX_AUTH_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\btoken_invalidated\b", re.IGNORECASE),
 )
 
-# Co-occurrence signal: a 401 alongside a ``/responses`` reference.
-# Kept separate from the pattern tuple because direction-agnostic
-# substring co-occurrence is simpler + more robust than positional
-# regex (``\b/`` doesn't match a word boundary, so a single
-# left-to-right or right-to-left regex would miss real cases).
-_CODEX_RESPONSES_401_PATTERN = re.compile(r"\b401\b")
+# Co-occurrence signal: ``401`` next to ``/responses`` in the SAME
+# clause — bounded distance + no sentence-boundary punctuation
+# between them. The bidirectional pair covers either ordering
+# ("/responses returned 401" vs "401 Unauthorized from /responses"
+# vs the JSON-envelope shape "code: 401, path: /responses").
+# A loose substring co-occurrence FPs on log lines that mention
+# both fragments for unrelated reasons (e.g. "cache hit for
+# /responses; 401 retries exhausted") — the clause-bound regex
+# rejects those.
+_CODEX_RESPONSES_401_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"/responses[^.;\n]{0,40}\b401\b", re.IGNORECASE),
+    re.compile(r"\b401\b[^.;\n]{0,40}/responses", re.IGNORECASE),
+)
 
 
 def _looks_like_codex_auth_error(err_text: str) -> bool:
     """True iff ``err_text`` carries one of the verbatim Codex auth
     signals (``refresh token (was) revoked`` / ``token_invalidated`` /
-    a ``/responses 401`` co-occurrence). Drives the conversion of a
-    ``turn_failed`` ``RuntimeError`` into an ``AgentAPIError(is_auth=
-    True)`` so the worker's PUF-283 auth_failed substrate fires."""
+    a ``/responses 401`` clause-bound co-occurrence). Drives the
+    conversion of a ``turn_failed`` ``RuntimeError`` into an
+    ``AgentAPIError(is_auth=True)`` so the worker's PUF-283
+    auth_failed substrate fires."""
     text = err_text or ""
     if any(p.search(text) for p in _CODEX_AUTH_ERROR_PATTERNS):
         return True
-    if "/responses" in text and _CODEX_RESPONSES_401_PATTERN.search(text):
-        return True
-    return False
+    return any(p.search(text) for p in _CODEX_RESPONSES_401_PATTERNS)
 
 # Tool names of the puffo MCP server's "this counts as posting a
 # reply" family. When the agent invokes one of these and it completes

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -683,11 +683,22 @@ class Worker:
                 self.agent_cfg.id,
             )
             return
-        from ..agent._invite_strings import format_oauth_expired
+        from ..agent._invite_strings import (
+            format_codex_oauth_expired,
+            format_oauth_expired,
+        )
         display_name = (
             getattr(self.agent_cfg, "display_name", "") or self.agent_cfg.id
         )
-        text = format_oauth_expired(self.agent_cfg.id, display_name)
+        # Codex agents need the Codex recovery command, not the Claude
+        # one; otherwise the operator runs the wrong CLI and assumes
+        # the alert is broken. Harness is the cheapest signal we have.
+        runtime = getattr(self.agent_cfg, "runtime", None)
+        harness = getattr(runtime, "harness", "") if runtime is not None else ""
+        if harness == "codex":
+            text = format_codex_oauth_expired(self.agent_cfg.id, display_name)
+        else:
+            text = format_oauth_expired(self.agent_cfg.id, display_name)
         try:
             await client._send_dm(operator_slug, text, root_id="")
         except Exception as exc:

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -517,3 +517,125 @@ def test_notify_stays_gated_when_no_operator_slug():
     w = _StubWorker()
     _run_notify(w)
     assert w._auth_failed_notification_sent is True
+
+
+# ── PUF-310: harness-aware DM copy ─────────────────────────────────
+
+
+def _make_dispatch_stub(harness_name: str | None):
+    """Build a stub worker whose ``agent_cfg.runtime.harness`` reads as
+    ``harness_name``. Pass ``None`` to omit the runtime block entirely
+    (covers the pre-PUF-310 agent_cfg shape — must still fall through
+    to the Claude copy without raising)."""
+    captured: dict = {}
+
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            captured["text"] = text
+            return {"envelope_id": "env-fake"}
+
+    if harness_name is None:
+        agent_cfg = type(
+            "A", (), {"id": "t-agent", "display_name": "Planner"},
+        )()
+    else:
+        runtime = type("R", (), {"harness": harness_name})()
+        agent_cfg = type(
+            "A", (),
+            {"id": "t-agent", "display_name": "Planner", "runtime": runtime},
+        )()
+
+    class _StubWorker:
+        pass
+
+    w = _StubWorker()
+    w.agent_cfg = agent_cfg
+    w._client = _StubClient()
+    return w, captured
+
+
+def test_codex_harness_dispatches_codex_copy():
+    """PUF-310: Codex agents must get the Codex recovery command in
+    the bilingual DM, not the Claude one — otherwise the operator
+    runs the wrong CLI and assumes the alert is broken."""
+    from puffo_agent.portal import worker as worker_module
+
+    w, captured = _make_dispatch_stub("codex")
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    assert "Codex OAuth expired" in captured["text"]
+    assert "codex login" in captured["text"]
+    assert "Codex OAuth 已过期" in captured["text"]
+    assert "Claude OAuth" not in captured["text"]
+    assert "claude auth login" not in captured["text"]
+
+
+def test_claude_harness_keeps_claude_copy():
+    """Regression-pin for PUF-283: explicit ``harness="claude-code"``
+    keeps the existing Claude bilingual copy unchanged."""
+    from puffo_agent.portal import worker as worker_module
+
+    w, captured = _make_dispatch_stub("claude-code")
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    assert "Claude OAuth expired" in captured["text"]
+    assert "claude auth login" in captured["text"]
+    assert "Codex" not in captured["text"]
+
+
+def test_missing_runtime_falls_back_to_claude_copy():
+    """Defensive: an agent_cfg without a ``runtime`` block (legacy /
+    test stubs) must NOT raise; falls through to the Claude copy so
+    existing PUF-283 tests + any pre-runtime-config agents still get
+    a DM."""
+    from puffo_agent.portal import worker as worker_module
+
+    w, captured = _make_dispatch_stub(None)
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    assert "Claude OAuth expired" in captured["text"]
+
+
+def test_unknown_harness_falls_back_to_claude_copy():
+    """Forward-compat: a harness name we don't recognise yet (hermes,
+    gemini-cli, future provider) defaults to the Claude copy. Better
+    than silent no-DM until we add the specific copy."""
+    from puffo_agent.portal import worker as worker_module
+
+    w, captured = _make_dispatch_stub("hermes")
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    assert "Claude OAuth expired" in captured["text"]
+
+
+# ── PUF-310: format_codex_oauth_expired bilingual copy ─────────────
+
+
+def test_format_codex_oauth_expired_bilingual_copy():
+    """Mirror of test_format_oauth_expired_contains_both_languages for
+    the Codex sibling: zh + en + the codex login command verbatim."""
+    from puffo_agent.agent._invite_strings import format_codex_oauth_expired
+
+    text = format_codex_oauth_expired("planner-1234", "Planner")
+    assert "Codex OAuth expired" in text
+    assert "Codex OAuth 已过期" in text
+    assert "codex login" in text
+    assert "Planner" in text
+    assert "planner-1234" in text
+
+
+def test_format_codex_oauth_expired_falls_back_to_id_when_no_name():
+    """No display name → label is just the bare id; copy still
+    bilingual."""
+    from puffo_agent.agent._invite_strings import format_codex_oauth_expired
+
+    text = format_codex_oauth_expired("agent-5678", "")
+    assert "agent-5678" in text
+    assert "Codex OAuth expired" in text
+    assert "Codex OAuth 已过期" in text

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -639,3 +639,65 @@ def test_format_codex_oauth_expired_falls_back_to_id_when_no_name():
     assert "agent-5678" in text
     assert "Codex OAuth expired" in text
     assert "Codex OAuth 已过期" in text
+
+
+def test_harness_read_snapshots_before_dm_dispatch():
+    """Mid-flight race: an operator may rename the agent's harness
+    between the worker reading ``agent_cfg.runtime.harness`` and the
+    DM landing on the wire. The pick must snapshot the harness value
+    once and use that local for the dispatch, so a concurrent attr
+    mutation can't half-flip the choice (e.g. read `codex`, dispatch
+    to Claude copy). Python attribute access is atomic, so the local
+    `harness` variable in _notify_operator_of_auth_failed_oauth is
+    stable for the rest of the function regardless of later
+    `agent_cfg.runtime.harness = ...` writes; this test pins that
+    guarantee against a future refactor that re-reads the attribute
+    mid-function."""
+    from puffo_agent.portal import worker as worker_module
+
+    captured: dict = {}
+    sequence: list[str] = []
+
+    class _MutatingRuntime:
+        def __init__(self):
+            self._harness = "codex"
+
+        @property
+        def harness(self):
+            sequence.append(self._harness)
+            return self._harness
+
+    runtime = _MutatingRuntime()
+
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            # Operator mutates the runtime mid-DM. The DM body was
+            # built BEFORE this point; the mutation must not change
+            # which copy got sent.
+            runtime._harness = "claude-code"
+            captured["text"] = text
+            return {"envelope_id": "env-fake"}
+
+    agent_cfg = type(
+        "A", (),
+        {"id": "t-agent", "display_name": "Planner", "runtime": runtime},
+    )()
+
+    class _StubWorker:
+        pass
+
+    w = _StubWorker()
+    w.agent_cfg = agent_cfg
+    w._client = _StubClient()
+
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    # The DM body is the Codex copy snapshotted before the mutation.
+    assert "Codex OAuth expired" in captured["text"]
+    assert "codex login" in captured["text"]
+    # Harness was read exactly once during the call (the property
+    # getter recorded the read on the sequence list).
+    assert sequence == ["codex"]

--- a/tests/test_codex_auth_failed_classification.py
+++ b/tests/test_codex_auth_failed_classification.py
@@ -65,3 +65,46 @@ def test_invalid_thread_id_not_auth_class():
         "codex turn failed: invalid thread id: invalid length: "
         "expected length 32 for simple format, found 0"
     )
+
+
+# ── Classifier precision: /responses + 401 false-positive probes ──────────
+# The clause-bound pattern rejects cases where /responses and 401 appear
+# in the same string but for unrelated reasons (cache references, prose
+# mentioning the endpoint, retries-exhausted log lines).
+
+
+@pytest.mark.parametrize("err_text", [
+    # Solution's polish-round flag: cache hit references both substrings.
+    "upstream cache hit for /responses; 401 retries exhausted in batch 401",
+    # Solution's polish-round flag: agent prose + a separate quota error.
+    "prompt referenced /responses endpoint; 401 model not supported",
+    # Cross-sentence: a period breaks the clause.
+    "Hit /responses. Later batch returned 401 from another endpoint.",
+    # Multi-line log: \n breaks the clause.
+    "fetched /responses ok\n401 errors logged on a different stream",
+    # /responses and 401 too far apart in the same clause (>40 chars).
+    "/responses is the streaming endpoint per the codex docs page 42 and 401 "
+    "is mentioned only as part of a quota retry path with backoff",
+])
+def test_responses_and_401_unrelated_does_not_classify(err_text):
+    """False-positive probes for the /responses + 401 co-occurrence
+    rule. Each string contains BOTH substrings but the surrounding
+    structure makes it clear they're not signalling a real /responses
+    401 auth failure — the clause-bound regex must reject them."""
+    assert not _looks_like_codex_auth_error(err_text)
+
+
+@pytest.mark.parametrize("err_text", [
+    # JSON envelope shape (TRUE — code + path in same object).
+    "{\"error\": {\"code\": 401, \"path\": \"/responses\"}}",
+    # Stderr-style line.
+    "websocket /responses returned 401 Unauthorized",
+    # Reversed ordering with short prefix.
+    "401 Unauthorized from /responses",
+    # The verbatim d2d2 paraphrase Equation captured.
+    "websocket /responses 401",
+])
+def test_responses_and_401_genuine_still_classifies(err_text):
+    """Regression-pin: the precision tightening must NOT regress the
+    genuine d2d2-class shapes the classifier was built to catch."""
+    assert _looks_like_codex_auth_error(err_text)

--- a/tests/test_codex_auth_failed_classification.py
+++ b/tests/test_codex_auth_failed_classification.py
@@ -1,0 +1,67 @@
+"""Codex auth-failure classification — `_looks_like_codex_auth_error`
+matches the verbatim strings captured in the d2d2 stuck-state case
+(refresh token revoked / token_invalidated / /responses 401) while
+NOT matching downstream symptoms (invalid thread id) or unrelated
+adapter failures (model not supported / timeout). Pinning this keeps
+the PUF-310 substrate from auto-flipping legitimate non-auth errors
+to ``auth_failed``."""
+
+from __future__ import annotations
+
+import pytest
+
+from puffo_agent.agent.adapters.codex_session import (
+    _looks_like_codex_auth_error,
+)
+
+
+@pytest.mark.parametrize("err_text", [
+    "codex turn failed: refresh token was revoked",
+    "codex turn failed: refresh token revoked",  # missing 'was'
+    "codex turn failed: REFRESH TOKEN WAS REVOKED",  # case-insensitive
+    "codex turn failed: {'error': 'token_invalidated'}",
+    "codex turn failed: token_invalidated by server",
+    "codex turn failed: websocket /responses returned 401 Unauthorized",
+    "codex turn failed: 401 Unauthorized from /responses",  # reversed order
+    "codex turn failed: {error: {code: 401, path: /responses}}",
+])
+def test_verbatim_d2d2_auth_strings_classify_as_auth(err_text):
+    """The four pattern families anchored to msg_2237ad78's d2d2-case
+    verbatim strings + the most likely whitespace/case variants."""
+    assert _looks_like_codex_auth_error(err_text)
+
+
+@pytest.mark.parametrize("err_text", [
+    "codex turn failed: invalid thread id: invalid length: expected 32, found 0",
+    "codex turn failed: model not supported",
+    "codex turn failed: thread limit reached",
+    "codex turn failed: connection reset by peer",
+    "codex turn failed: TimeoutError",
+    "agent thread limit reached",
+    "",
+])
+def test_non_auth_errors_do_not_classify_as_auth(err_text):
+    """``invalid thread id ... found 0`` is downstream symptom of an
+    empty conversation_id (per d2d2 diagnostic chain), NOT an auth
+    signal. Model / timeout / quota errors stay out too — they reach
+    the worker via the generic Exception path and don't fire DM."""
+    assert not _looks_like_codex_auth_error(err_text)
+
+
+def test_none_input_does_not_raise():
+    """Defensive: classifier is called on ``str(turn_failed_exc)``,
+    which is always a string in practice, but ``err_text or ""``
+    coalesces a stray ``None`` to "" rather than raising."""
+    assert _looks_like_codex_auth_error(None) is False  # type: ignore[arg-type]
+
+
+def test_invalid_thread_id_not_auth_class():
+    """Explicit regression-pin for the d2d2 diagnostic chain: ``invalid
+    thread id ... found 0`` was 矩阵's initial (incorrect) auth-guess,
+    later narrowed to in-memory empty-cid (PUF-311 substance). Keep
+    this pattern OUT of PUF-310's auth set so the runtime.health flip
+    doesn't fire on a thread-state issue."""
+    assert not _looks_like_codex_auth_error(
+        "codex turn failed: invalid thread id: invalid length: "
+        "expected length 32 for simple format, found 0"
+    )

--- a/tests/test_codex_auth_failed_run_turn.py
+++ b/tests/test_codex_auth_failed_run_turn.py
@@ -151,6 +151,88 @@ while True:
     assert "model not supported" in str(excinfo.value)
 
 
+# ── Top-level ``error`` notification path ──────────────────────────────────
+# codex_session.py:990-1006's dispatcher treats both ``turn/failed`` and
+# the top-level ``error`` notification as turn-fatal. The classifier
+# must convert AgentAPIError regardless of which envelope shape carried
+# the err_text.
+
+
+def test_auth_class_top_level_error_notification_raises_agent_api_error_auth(
+    tmp_path,
+):
+    """Codex emits a top-level ``error`` JSON-RPC notification when
+    the failure happens client-side (rather than as a ``turn/failed``
+    upstream from the model). The dispatch path is the same, and
+    PUF-310's conversion must fire either way — pinning here so a
+    future codex protocol shift doesn't silently regress."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_top_error"}}})
+
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id,
+   "result": {"turn": {"id": "t1", "status": "running"}}})
+# Top-level error (m == "error"), NOT turn/failed.
+w({"jsonrpc": "2.0", "method": "error",
+   "params": {"error": {"message": "refresh token was revoked"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            await cs.warm("sp")
+            await cs.run_turn("hi", "sp")
+        finally:
+            await cs.aclose()
+
+    with pytest.raises(AgentAPIError) as excinfo:
+        asyncio.run(_run())
+    assert excinfo.value.is_auth is True
+    assert "refresh token was revoked" in str(excinfo.value).lower()
+
+
+def test_non_auth_top_level_error_notification_raises_runtime_error(tmp_path):
+    """Symmetric regression-pin: a top-level ``error`` carrying a
+    non-auth message must NOT be coerced to AgentAPIError."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_top_nonauth"}}})
+
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id,
+   "result": {"turn": {"id": "t1", "status": "running"}}})
+w({"jsonrpc": "2.0", "method": "error",
+   "params": {"error": {"message": "model not supported"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            await cs.warm("sp")
+            await cs.run_turn("hi", "sp")
+        finally:
+            await cs.aclose()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(_run())
+    assert not isinstance(excinfo.value, AgentAPIError)
+
+
 def test_invalid_thread_id_not_classified_as_auth(tmp_path):
     """Regression-pin: ``invalid thread id ... found 0`` was 矩阵's
     initial (later-corrected) auth-guess in the d2d2 case. PUF-310's

--- a/tests/test_codex_auth_failed_run_turn.py
+++ b/tests/test_codex_auth_failed_run_turn.py
@@ -1,0 +1,188 @@
+"""Codex auth-failure run_turn behavior — when the App Server emits
+a ``turn/failed`` (or top-level ``error``) notification carrying an
+auth-class err_text, ``CodexSession.run_turn`` must raise
+``AgentAPIError(is_auth=True)`` instead of a bare ``RuntimeError``.
+This is the load-bearing handoff into the worker's PUF-283
+``auth_failed`` substrate at worker.py:1141-1152."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.codex_session import CodexSession
+from puffo_agent.agent.core import AgentAPIError
+
+
+FAKE_HEADER = textwrap.dedent('''\
+    import json, sys
+
+    def w(obj):
+        sys.stdout.write(json.dumps(obj) + "\\n")
+        sys.stdout.flush()
+
+    def r():
+        line = sys.stdin.readline()
+        return json.loads(line) if line else None
+
+    def absorb_initialize():
+        msg = r()
+        assert msg["method"] == "initialize"
+        w({"jsonrpc": "2.0", "id": msg["id"], "result": {}})
+''')
+
+
+def _write_fake(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_codex.py"
+    path.write_text(FAKE_HEADER + "\n" + body, encoding="utf-8")
+    return path
+
+
+def _argv_for(fake: Path) -> list[str]:
+    return [sys.executable, str(fake)]
+
+
+def _make_session(tmp_path: Path, body: str) -> CodexSession:
+    fake = _write_fake(tmp_path, body)
+    return CodexSession(
+        agent_id="codex-test-001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+
+# ── Auth-class turn/failed: raises AgentAPIError(is_auth=True) ─────────────
+
+
+@pytest.mark.parametrize("err_message", [
+    "refresh token was revoked",
+    "token_invalidated",
+    "websocket /responses returned 401 Unauthorized",
+])
+def test_auth_class_turn_failed_raises_agent_api_error_auth(
+    tmp_path, err_message,
+):
+    """When ``turn/failed`` carries an auth-class err_text, run_turn
+    converts the inner ``RuntimeError`` into ``AgentAPIError(is_auth=
+    True)`` so the worker's PUF-283 substrate fires the operator DM
+    instead of treating the failure as a generic adapter exception."""
+    cs = _make_session(tmp_path, f'''\
+absorb_initialize()
+# Resolve thread/start so _bootstrap_session completes.
+msg = r()
+w({{"jsonrpc": "2.0", "id": msg["id"],
+   "result": {{"thread": {{"id": "conv_auth"}}}}}})
+
+# turn/start: ACK with running so _send_raw_request resolves; the
+# turn completion comes via the subsequent turn/failed notification.
+msg = r()
+turn_id = msg["id"]
+w({{"jsonrpc": "2.0", "id": turn_id,
+   "result": {{"turn": {{"id": "t1", "status": "running"}}}}}})
+w({{"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {{"error": {{"message": {err_message!r}}}}}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            await cs.warm("sp")
+            await cs.run_turn("hi", "sp")
+        finally:
+            await cs.aclose()
+
+    with pytest.raises(AgentAPIError) as excinfo:
+        asyncio.run(_run())
+    assert excinfo.value.is_auth is True
+    assert "codex auth failed" in str(excinfo.value)
+    assert err_message.lower() in str(excinfo.value).lower()
+
+
+# ── Non-auth turn/failed: still raises RuntimeError ────────────────────────
+
+
+def test_non_auth_turn_failed_raises_runtime_error(tmp_path):
+    """Generic turn/failed (e.g. model not supported) must NOT be
+    coerced to AgentAPIError — the worker's auth_failed substrate
+    would mis-fire an OAuth-expired DM for a quota / model issue."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_nonauth"}}})
+
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id,
+   "result": {"turn": {"id": "t1", "status": "running"}}})
+w({"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {"error": {"message": "model not supported"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            await cs.warm("sp")
+            await cs.run_turn("hi", "sp")
+        finally:
+            await cs.aclose()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(_run())
+    # Must NOT be an AgentAPIError subclass — that would be a false
+    # auth_failed flip.
+    assert not isinstance(excinfo.value, AgentAPIError)
+    assert "model not supported" in str(excinfo.value)
+
+
+def test_invalid_thread_id_not_classified_as_auth(tmp_path):
+    """Regression-pin: ``invalid thread id ... found 0`` was 矩阵's
+    initial (later-corrected) auth-guess in the d2d2 case. PUF-310's
+    pattern set excludes it; this test pins that exclusion at the
+    run_turn integration layer."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_thread_err"}}})
+
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id,
+   "result": {"turn": {"id": "t1", "status": "running"}}})
+w({"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {"error": {"message":
+       "invalid thread id: invalid length: expected length 32, found 0"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            await cs.warm("sp")
+            await cs.run_turn("hi", "sp")
+        finally:
+            await cs.aclose()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(_run())
+    assert not isinstance(excinfo.value, AgentAPIError)


### PR DESCRIPTION
## Summary

D2d2 stuck-state (2026-06-17): Codex agent hit auth failure silently for hours because the PUF-283 substrate only detects Claude `auth_failed`. Extend to Codex:

- New `_looks_like_codex_auth_error` classifier in `codex_session.py` (verbatim d2d2 strings: `refresh token (was) revoked`, `token_invalidated`, `/responses` + `401` co-occurrence). `invalid thread id ... found 0` stays OUT — it's a downstream symptom per the diagnostic chain.
- `CodexSession.run_turn` converts auth-class `turn_failed` into `AgentAPIError(is_auth=True)` so the existing worker substrate (state-flip → DM → dedup → refresher kick) reuses the Claude path.
- New `format_codex_oauth_expired` bilingual copy + harness-aware dispatcher in `Worker._notify_operator_of_auth_failed_oauth`: Codex agents get `codex login`, Claude agents keep `claude auth login`, unknown/missing harness falls back to Claude.

## Test plan

- [x] `python3 -m pytest tests/test_codex_auth_failed_classification.py tests/test_codex_auth_failed_run_turn.py tests/test_auth_failed_dm_notification.py -v` → 47/47 (16 classifier + 5 run_turn integration via fake App Server + 26 worker DM dispatch).
- [x] Classifier verbatim strings + case-insensitive + reverse-order /responses+401 + JSON-shape variants; explicit regression-pin for `invalid thread id` exclusion.
- [x] Worker dispatcher: codex → Codex copy, claude-code → Claude copy (PUF-283 regression-pin), missing runtime → Claude fallback, unknown harness → Claude fallback.
- [x] Bilingual copy assertions (zh + en + `codex login` verbatim + display-name label + bare-id fallback).
- [ ] Live-soak post-merge: d2d2-class Codex auth failure → bilingual DM with `codex login` recovery command lands; PUF-283 regression for Claude side unchanged.

Closes PUF-310. PUF-311 (recovery + health-probe) is the companion ticket and depends on this landing first.