### PR TITLE
PUF-311: Codex post-recovery health-probe gate (companion to PUF-310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.12.6] — unreleased
+## [0.12.6] — 2026-06-18
 
 ### Added
 
@@ -31,6 +31,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   401) previously went silent indefinitely. It now reuses the same
   operator-DM substrate as Claude, sending a bilingual DM with the
   `codex login` recovery command. Claude agents are unchanged.
+- **Codex auth-failure detection + recovery hardened.** The auth classifier
+  recognises more real-world Codex 401 forms (the human-readable
+  `invalidated oauth token`, and 401s on `/backend-api/codex`, not only
+  `/responses`). And after a credential refresh optimistically clears
+  `auth_failed`, the agent verifies the Codex handshake + thread round-trip
+  on respawn before marking itself healthy — a still-broken token
+  re-asserts `auth_failed` instead of going silently "ok".
 
 ## [0.12.5] — 2026-06-17
 

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -103,6 +103,17 @@ class Adapter(ABC):
         """
         return None
 
+    async def health_probe(self) -> bool:
+        """Verify the runtime can reach its provider after a recovery
+        respawn. Worker calls this once post-``warm()`` so the
+        ``on_refresh_success`` eager-clear of ``runtime.health =
+        auth_failed`` can be reasserted if the round-trip still
+        fails. Default-True for adapters without a meaningful
+        round-trip probe — only the Codex (subprocess + thread/start)
+        override needs a real probe; see PUF-311.
+        """
+        return True
+
 
 def format_history_as_prompt(messages: list[dict]) -> str:
     """Render shell conversation history as a single prompt string.

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -105,13 +105,9 @@ class Adapter(ABC):
 
     async def health_probe(self) -> bool:
         """Verify the runtime can reach its provider after a recovery
-        respawn. Worker calls this once post-``warm()`` so the
-        ``on_refresh_success`` eager-clear of ``runtime.health =
-        auth_failed`` can be reasserted if the round-trip still
-        fails. Default-True for adapters without a meaningful
-        round-trip probe — only the Codex (subprocess + thread/start)
-        override needs a real probe; see PUF-311.
-        """
+        respawn — the worker calls it once post-``warm()`` to reassert
+        ``auth_failed`` if the round-trip still fails. Default-True;
+        only the Codex override does a real subprocess/thread probe."""
         return True
 
 

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -412,6 +412,28 @@ class CodexSession:
     def has_persisted_session(self) -> bool:
         return bool(self._conversation_id)
 
+    async def health_probe(self) -> bool:
+        """PUF-311 post-respawn round-trip check. Verify the codex
+        app-server is reachable (or relaunchable) AND a thread is
+        established. ``_ensure_running`` does the load-bearing work:
+        spawns the subprocess if needed and runs ``_bootstrap_session``
+        which initialises + starts (or resumes) a thread. A non-empty
+        ``_conversation_id`` after that means the JSON-RPC handshake
+        + ``thread/start`` round-trip succeeded — which would have
+        re-raised an auth error inline if the host token were still
+        broken. Returns False on any exception so the worker
+        re-asserts ``runtime.health = auth_failed`` rather than
+        marking the agent healthy speculatively."""
+        try:
+            await self._ensure_running(self.current_instructions or "")
+        except Exception as exc:
+            logger.warning(
+                "agent %s: codex health probe failed: %s",
+                self.agent_id, exc,
+            )
+            return False
+        return bool(self._conversation_id)
+
     # ── thread-wedge propagation ──────────────────────────────────────────────
 
     def _propagate_turn_outcome(

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -103,30 +103,38 @@ def _looks_like_codex_thread_limit(err_text: str) -> bool:
 # Verbatim Codex auth-failure signals — anchored so we don't auto-flip on
 # legitimate model/quota errors. ``invalid thread id ... found 0`` is a
 # downstream symptom of an empty conversation_id, not auth — kept out.
+# ``invalidated oauth token`` is codex's human-readable form (distinct from
+# the ``token_invalidated`` JSON field), observed live on a relogin.
 _CODEX_AUTH_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"refresh token (?:was )?revoked", re.IGNORECASE),
     re.compile(r"\btoken_invalidated\b", re.IGNORECASE),
+    re.compile(r"invalidated\s+oauth\s+token", re.IGNORECASE),
 )
 
-# ``401`` next to ``/responses`` in the same clause (bounded distance, no
-# sentence break between), either ordering. Clause-bound so it doesn't FP
-# on unrelated lines that happen to mention both fragments.
-_CODEX_RESPONSES_401_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"/responses[^.;\n]{0,40}\b401\b", re.IGNORECASE),
-    re.compile(r"\b401\b[^.;\n]{0,40}/responses", re.IGNORECASE),
+# A 401 in an OAuth/auth context. Codex surfaces a broken token as a 401 on
+# its API endpoints (``/responses``, ``/backend-api/codex/...``), so require
+# an auth-context marker within the same clause as the ``401`` rather than
+# pinning a single path — bounded distance + no sentence break keeps an
+# unrelated 401 in a log line from tripping it.
+_AUTH_401_CONTEXT = (
+    r"(?:oauth|invalidated|auth[\s_]error|identity_edge|/responses|/backend-api/codex)"
+)
+_CODEX_AUTH_401_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(rf"\b401\b[^.;\n]{{0,40}}{_AUTH_401_CONTEXT}", re.IGNORECASE),
+    re.compile(rf"{_AUTH_401_CONTEXT}[^.;\n]{{0,40}}\b401\b", re.IGNORECASE),
 )
 
 
 def _looks_like_codex_auth_error(err_text: str) -> bool:
-    """True iff ``err_text`` carries a verbatim Codex auth signal
-    (``refresh token (was) revoked`` / ``token_invalidated`` / a
-    ``/responses 401`` clause-bound co-occurrence). Drives converting a
-    ``turn_failed`` into an ``AgentAPIError(is_auth=True)`` so the worker's
-    auth_failed substrate fires."""
+    """True iff ``err_text`` carries a Codex auth signal (``refresh token
+    (was) revoked`` / ``token_invalidated`` / ``invalidated oauth token`` /
+    a clause-bound 401-in-auth-context). Drives converting a ``turn_failed``
+    into an ``AgentAPIError(is_auth=True)`` so the worker's auth_failed
+    substrate fires."""
     text = err_text or ""
     if any(p.search(text) for p in _CODEX_AUTH_ERROR_PATTERNS):
         return True
-    return any(p.search(text) for p in _CODEX_RESPONSES_401_PATTERNS)
+    return any(p.search(text) for p in _CODEX_AUTH_401_PATTERNS)
 
 # Tool names of the puffo MCP server's "this counts as posting a
 # reply" family. When the agent invokes one of these and it completes

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -413,17 +413,11 @@ class CodexSession:
         return bool(self._conversation_id)
 
     async def health_probe(self) -> bool:
-        """PUF-311 post-respawn round-trip check. Verify the codex
-        app-server is reachable (or relaunchable) AND a thread is
-        established. ``_ensure_running`` does the load-bearing work:
-        spawns the subprocess if needed and runs ``_bootstrap_session``
-        which initialises + starts (or resumes) a thread. A non-empty
-        ``_conversation_id`` after that means the JSON-RPC handshake
-        + ``thread/start`` round-trip succeeded — which would have
-        re-raised an auth error inline if the host token were still
-        broken. Returns False on any exception so the worker
-        re-asserts ``runtime.health = auth_failed`` rather than
-        marking the agent healthy speculatively."""
+        """Post-respawn round-trip check: ``_ensure_running`` spawns the
+        app-server + bootstraps a thread (re-raising an auth error inline
+        if the token is still broken), so a non-empty ``_conversation_id``
+        afterwards means the handshake + ``thread/start`` succeeded. Any
+        exception → False so the worker reasserts ``auth_failed``."""
         try:
             await self._ensure_running(self.current_instructions or "")
         except Exception as exc:

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -311,6 +311,18 @@ class LocalCLIAdapter(Adapter):
             await self._codex_session.aclose()
             self._codex_session = None
 
+    async def health_probe(self) -> bool:
+        """PUF-311 post-respawn round-trip check. Delegates to the
+        Codex session probe for Codex harnesses; non-Codex harnesses
+        (claude-code, hermes, gemini-cli) inherit the base True
+        default since their re-spawn doesn't pay a per-provider
+        round-trip cost worth verifying — the next inbound message
+        will surface a real auth failure via the worker leak-filter
+        path the same way it always has."""
+        if self._codex_session is not None:
+            return await self._codex_session.health_probe()
+        return True
+
     def _ensure_codex_session(self) -> CodexSession:
         if self._codex_session is not None:
             return self._codex_session

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -312,13 +312,10 @@ class LocalCLIAdapter(Adapter):
             self._codex_session = None
 
     async def health_probe(self) -> bool:
-        """PUF-311 post-respawn round-trip check. Delegates to the
-        Codex session probe for Codex harnesses; non-Codex harnesses
-        (claude-code, hermes, gemini-cli) inherit the base True
-        default since their re-spawn doesn't pay a per-provider
-        round-trip cost worth verifying — the next inbound message
-        will surface a real auth failure via the worker leak-filter
-        path the same way it always has."""
+        """Delegate to the Codex session probe when one exists; other
+        harnesses (claude-code, hermes, gemini-cli) inherit the True
+        default — their next inbound message surfaces a real auth
+        failure via the worker leak-filter as before."""
         if self._codex_session is not None:
             return await self._codex_session.health_probe()
         return True

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -624,6 +624,35 @@ class Worker:
                 "agent %s: notify_refresh_needed raised: %s", agent_id, exc,
             )
 
+    @staticmethod
+    def _reassert_auth_failed_after_failed_probe(
+        runtime: "RuntimeState",
+        agent_id: str,
+        log: logging.Logger,
+    ) -> None:
+        """PUF-311: ``on_refresh_success`` eagerly clears
+        ``auth_failed`` before the worker even respawns, so by the
+        time the new adapter has warmed up the runtime is showing
+        healthy regardless of whether the round-trip actually works.
+        When the post-warm ``health_probe`` returns False, this re-
+        asserts the failed state so the next refresh cycle retries
+        instead of marking the agent healthy speculatively. No-ops
+        when the runtime is already in a sticky-red state or never
+        cleared (only the eager-clear case matters)."""
+        if runtime.health != "ok":
+            return
+        runtime.health = "auth_failed"
+        runtime.error = (
+            "post-recovery health probe failed — provider still "
+            "unreachable; waiting for next credential refresh"
+        )
+        runtime.save(agent_id)
+        log.warning(
+            "agent %s: post-warm health probe failed; reasserted "
+            "runtime.health = auth_failed",
+            agent_id,
+        )
+
     def _enter_auth_failed(self, agent_id: str) -> None:
         """Flip ``auth_failed`` + fire recovery (refresher kick + operator
         DM). Used on a confirmed adapter auth error so we skip the
@@ -1033,15 +1062,37 @@ class Worker:
 
         # Warm the adapter so persisted-session agents re-spawn their
         # subprocess now rather than on the first DM. Non-fatal.
+        warm_ok = False
         try:
             await self._adapter.warm(claude_md)
+            warm_ok = True
         except Exception as exc:
             logger.warning(
                 "agent %s: warm() failed (will retry on first turn): %s",
                 agent_id, exc,
             )
-        finally:
-            self._warm_done.set()
+        if warm_ok:
+            # PUF-311: post-warm health probe gate. Codex agents need
+            # to verify the JSON-RPC handshake + thread/start round-
+            # trip before we mark the runtime healthy — the
+            # on_refresh_success eager-clear of auth_failed is
+            # optimistic; the probe gives us the second opinion that
+            # prevents marking-healthy-speculatively. Non-Codex
+            # adapters inherit the default-True probe so there's no
+            # behavioral change for Claude.
+            try:
+                probe_ok = await self._adapter.health_probe()
+            except Exception as exc:
+                logger.warning(
+                    "agent %s: health_probe raised; treating as "
+                    "probe-fail: %s", agent_id, exc,
+                )
+                probe_ok = False
+            if not probe_ok:
+                Worker._reassert_auth_failed_after_failed_probe(
+                    self.runtime, agent_id, logger,
+                )
+        self._warm_done.set()
 
         reload_flag_path = Path(workspace_path) / ".puffo-agent" / "reload.flag"
         refresh_flag_path = Path(workspace_path) / ".puffo-agent" / "refresh.flag"

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -625,12 +625,10 @@ class Worker:
             )
 
     async def _run_post_warm_gate(self, agent_id: str) -> None:
-        """PUF-311: probe the adapter's round-trip-readiness AFTER
-        warm() succeeds, reassert ``runtime.health = auth_failed`` if
-        the probe says the provider's still unreachable, THEN release
-        ``_warm_done``. Order matters — flipping ``_warm_done`` first
-        would let a queued message dispatch against an
-        unprobed/possibly-broken runtime."""
+        """Probe the adapter's round-trip readiness after warm() succeeds,
+        reassert ``auth_failed`` if the provider's still unreachable, THEN
+        release ``_warm_done``. Order matters — releasing first would let a
+        queued message dispatch against an unprobed runtime."""
         try:
             probe_ok = await self._adapter.health_probe()
         except Exception as exc:
@@ -651,15 +649,11 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """PUF-311: ``on_refresh_success`` eagerly clears
-        ``auth_failed`` before the worker even respawns, so by the
-        time the new adapter has warmed up the runtime is showing
-        healthy regardless of whether the round-trip actually works.
-        When the post-warm ``health_probe`` returns False, this re-
-        asserts the failed state so the next refresh cycle retries
-        instead of marking the agent healthy speculatively. No-ops
-        when the runtime is already in a sticky-red state or never
-        cleared (only the eager-clear case matters)."""
+        """``on_refresh_success`` eagerly clears ``auth_failed`` before
+        the respawn, so a still-broken provider warms up looking healthy.
+        When the post-warm probe fails, re-assert the failed state so the
+        next refresh cycle retries. No-op unless the runtime is in the
+        eager-cleared ``ok`` state."""
         if runtime.health != "ok":
             return
         runtime.health = "auth_failed"

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -624,6 +624,27 @@ class Worker:
                 "agent %s: notify_refresh_needed raised: %s", agent_id, exc,
             )
 
+    async def _run_post_warm_gate(self, agent_id: str) -> None:
+        """PUF-311: probe the adapter's round-trip-readiness AFTER
+        warm() succeeds, reassert ``runtime.health = auth_failed`` if
+        the probe says the provider's still unreachable, THEN release
+        ``_warm_done``. Order matters — flipping ``_warm_done`` first
+        would let a queued message dispatch against an
+        unprobed/possibly-broken runtime."""
+        try:
+            probe_ok = await self._adapter.health_probe()
+        except Exception as exc:
+            logger.warning(
+                "agent %s: health_probe raised; treating as "
+                "probe-fail: %s", agent_id, exc,
+            )
+            probe_ok = False
+        if not probe_ok:
+            Worker._reassert_auth_failed_after_failed_probe(
+                self.runtime, agent_id, logger,
+            )
+        self._warm_done.set()
+
     @staticmethod
     def _reassert_auth_failed_after_failed_probe(
         runtime: "RuntimeState",
@@ -1072,27 +1093,12 @@ class Worker:
                 agent_id, exc,
             )
         if warm_ok:
-            # PUF-311: post-warm health probe gate. Codex agents need
-            # to verify the JSON-RPC handshake + thread/start round-
-            # trip before we mark the runtime healthy — the
-            # on_refresh_success eager-clear of auth_failed is
-            # optimistic; the probe gives us the second opinion that
-            # prevents marking-healthy-speculatively. Non-Codex
-            # adapters inherit the default-True probe so there's no
-            # behavioral change for Claude.
-            try:
-                probe_ok = await self._adapter.health_probe()
-            except Exception as exc:
-                logger.warning(
-                    "agent %s: health_probe raised; treating as "
-                    "probe-fail: %s", agent_id, exc,
-                )
-                probe_ok = False
-            if not probe_ok:
-                Worker._reassert_auth_failed_after_failed_probe(
-                    self.runtime, agent_id, logger,
-                )
-        self._warm_done.set()
+            await self._run_post_warm_gate(agent_id)
+        else:
+            # Warm failed; release the startup gate so the daemon's
+            # wait_warm doesn't block forever. Probe would have nothing
+            # to verify anyway since the adapter never came up.
+            self._warm_done.set()
 
         reload_flag_path = Path(workspace_path) / ".puffo-agent" / "reload.flag"
         refresh_flag_path = Path(workspace_path) / ".puffo-agent" / "refresh.flag"

--- a/tests/test_codex_auth_failed_classification.py
+++ b/tests/test_codex_auth_failed_classification.py
@@ -108,3 +108,22 @@ def test_responses_and_401_genuine_still_classifies(err_text):
     """Regression-pin: the precision tightening must NOT regress the
     genuine d2d2-class shapes the classifier was built to catch."""
     assert _looks_like_codex_auth_error(err_text)
+
+
+@pytest.mark.parametrize("err_text", [
+    # Observed live on a codex relogin: the human-readable form (a space,
+    # not the ``token_invalidated`` JSON field) + a 401 on
+    # ``/backend-api/codex`` rather than ``/responses``.
+    "failed to refresh available models: unexpected status 401 Unauthorized: "
+    "Encountered invalidated oauth token for user, failing request, "
+    "url: https://chatgpt.com/backend-api/codex/models, "
+    "auth error: identity_edge_internal_error",
+    "401 Unauthorized: Encountered invalidated oauth token",
+    "invalidated oauth token for user",
+    "request to /backend-api/codex/models returned 401",
+])
+def test_real_world_invalidated_oauth_token_classifies(err_text):
+    """Live-observed variant the original d2d2 anchors missed: codex emits
+    ``invalidated oauth token`` (space form) and 401s on /backend-api/codex,
+    not just /responses. Both must classify as auth."""
+    assert _looks_like_codex_auth_error(err_text)

--- a/tests/test_codex_health_probe.py
+++ b/tests/test_codex_health_probe.py
@@ -1,0 +1,176 @@
+"""PUF-311 Codex health-probe round-trip check.
+
+``CodexSession.health_probe`` is the load-bearing primitive — when
+``on_refresh_success`` has just eagerly cleared ``runtime.health =
+auth_failed``, the worker uses this probe to verify the codex
+App Server can actually reach OpenAI before marking the agent
+healthy. The probe must return True iff the JSON-RPC handshake +
+``thread/start`` round-trip succeeded (proxy for "auth + transport
+both work") and False on any failure — including the load-bearing
+case where the host token is still broken after the refresher's
+optimistic clear.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.codex_session import CodexSession
+
+
+FAKE_HEADER = textwrap.dedent('''\
+    import json, sys
+
+    def w(obj):
+        sys.stdout.write(json.dumps(obj) + "\\n")
+        sys.stdout.flush()
+
+    def r():
+        line = sys.stdin.readline()
+        return json.loads(line) if line else None
+
+    def absorb_initialize():
+        msg = r()
+        assert msg["method"] == "initialize"
+        w({"jsonrpc": "2.0", "id": msg["id"], "result": {}})
+''')
+
+
+def _write_fake(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_codex.py"
+    path.write_text(FAKE_HEADER + "\n" + body, encoding="utf-8")
+    return path
+
+
+def _argv_for(fake: Path) -> list[str]:
+    return [sys.executable, str(fake)]
+
+
+def _make_session(tmp_path: Path, body: str) -> CodexSession:
+    fake = _write_fake(tmp_path, body)
+    return CodexSession(
+        agent_id="codex-probe-001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+
+# ── Happy path ────────────────────────────────────────────────────────────
+
+
+def test_probe_passes_when_thread_start_succeeds(tmp_path):
+    """The probe's load-bearing definition: a fresh JSON-RPC handshake
+    + ``thread/start`` returning a valid conversation id is sufficient
+    to confirm the round-trip works."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_healthy"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            return await cs.health_probe()
+        finally:
+            await cs.aclose()
+
+    assert asyncio.run(_run()) is True
+
+
+# ── Auth still broken: thread/start fails ─────────────────────────────────
+
+
+def test_probe_fails_when_thread_start_errors(tmp_path):
+    """The d2d2-class case: host token still broken post-eager-clear.
+    ``thread/start`` returns an auth-class error; ``_bootstrap_session``
+    raises; the probe captures the exception and returns False so the
+    worker can reassert runtime.health = auth_failed."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "error": {"code": -32603, "message": "refresh token was revoked"}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            return await cs.health_probe()
+        finally:
+            await cs.aclose()
+
+    assert asyncio.run(_run()) is False
+
+
+def test_probe_fails_when_subprocess_cannot_spawn(tmp_path):
+    """Defense-in-depth: a missing codex binary (PATH gap, post-
+    upgrade staging issue) raises ``RuntimeError`` from ``_spawn``.
+    The probe swallows it and returns False — the worker decides
+    whether that warrants reasserting auth_failed."""
+    cs = CodexSession(
+        agent_id="codex-probe-noexec",
+        session_file=tmp_path / "codex_session.json",
+        argv=["/nonexistent/codex/binary"],
+        cwd=str(tmp_path),
+    )
+
+    async def _run():
+        try:
+            return await cs.health_probe()
+        finally:
+            await cs.aclose()
+
+    assert asyncio.run(_run()) is False
+
+
+# ── Existing session: probe is idempotent ─────────────────────────────────
+
+
+def test_probe_idempotent_when_subprocess_already_running(tmp_path):
+    """A session that's already ``_ensure_running``-warm shouldn't
+    pay a second spawn cost. ``_ensure_running`` returns early when
+    the proc is alive AND a conversation id is set — the probe's
+    second call is a single check + immediate True."""
+    cs = _make_session(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"],
+   "result": {"thread": {"id": "conv_idemp"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+
+    async def _run():
+        try:
+            first = await cs.health_probe()
+            second = await cs.health_probe()
+            return first, second, cs._conversation_id
+        finally:
+            await cs.aclose()
+
+    first, second, cid = asyncio.run(_run())
+    assert first is True
+    assert second is True
+    assert cid == "conv_idemp"

--- a/tests/test_codex_health_probe.py
+++ b/tests/test_codex_health_probe.py
@@ -1,15 +1,7 @@
-"""PUF-311 Codex health-probe round-trip check.
-
-``CodexSession.health_probe`` is the load-bearing primitive — when
-``on_refresh_success`` has just eagerly cleared ``runtime.health =
-auth_failed``, the worker uses this probe to verify the codex
-App Server can actually reach OpenAI before marking the agent
-healthy. The probe must return True iff the JSON-RPC handshake +
-``thread/start`` round-trip succeeded (proxy for "auth + transport
-both work") and False on any failure — including the load-bearing
-case where the host token is still broken after the refresher's
-optimistic clear.
-"""
+"""Codex ``health_probe`` round-trip check: True iff the JSON-RPC
+handshake + ``thread/start`` succeed (auth + transport both work), False
+on any failure — including a still-broken token after the refresher's
+eager auth_failed clear."""
 
 from __future__ import annotations
 
@@ -68,9 +60,7 @@ def _make_session(tmp_path: Path, body: str) -> CodexSession:
 
 
 def test_probe_passes_when_thread_start_succeeds(tmp_path):
-    """The probe's load-bearing definition: a fresh JSON-RPC handshake
-    + ``thread/start`` returning a valid conversation id is sufficient
-    to confirm the round-trip works."""
+    """Handshake + ``thread/start`` returning a valid conversation id → True."""
     cs = _make_session(tmp_path, '''\
 absorb_initialize()
 msg = r()
@@ -96,10 +86,8 @@ while True:
 
 
 def test_probe_fails_when_thread_start_errors(tmp_path):
-    """The d2d2-class case: host token still broken post-eager-clear.
-    ``thread/start`` returns an auth-class error; ``_bootstrap_session``
-    raises; the probe captures the exception and returns False so the
-    worker can reassert runtime.health = auth_failed."""
+    """``thread/start`` returns an auth-class error → ``_bootstrap_session``
+    raises → probe returns False so the worker can reassert auth_failed."""
     cs = _make_session(tmp_path, '''\
 absorb_initialize()
 msg = r()
@@ -122,10 +110,8 @@ while True:
 
 
 def test_probe_fails_when_subprocess_cannot_spawn(tmp_path):
-    """Defense-in-depth: a missing codex binary (PATH gap, post-
-    upgrade staging issue) raises ``RuntimeError`` from ``_spawn``.
-    The probe swallows it and returns False — the worker decides
-    whether that warrants reasserting auth_failed."""
+    """A missing codex binary raises from ``_spawn``; the probe swallows
+    it and returns False."""
     cs = CodexSession(
         agent_id="codex-probe-noexec",
         session_file=tmp_path / "codex_session.json",
@@ -146,10 +132,8 @@ def test_probe_fails_when_subprocess_cannot_spawn(tmp_path):
 
 
 def test_probe_idempotent_when_subprocess_already_running(tmp_path):
-    """A session that's already ``_ensure_running``-warm shouldn't
-    pay a second spawn cost. ``_ensure_running`` returns early when
-    the proc is alive AND a conversation id is set — the probe's
-    second call is a single check + immediate True."""
+    """An already-warm session returns early (proc alive + conversation
+    id set) — the probe is a single check, no second spawn."""
     cs = _make_session(tmp_path, '''\
 absorb_initialize()
 msg = r()

--- a/tests/test_worker_health_probe_gate.py
+++ b/tests/test_worker_health_probe_gate.py
@@ -1,0 +1,163 @@
+"""PUF-311 worker-side reassertion + adapter dispatch.
+
+Two seams that the round-trip-Codex test doesn't cover:
+
+1. ``LocalCli.health_probe`` must delegate to the live
+   ``CodexSession`` when one exists and short-circuit to True
+   otherwise (Claude / hermes / gemini-cli inherit the no-probe
+   default).
+
+2. ``Worker._reassert_auth_failed_after_failed_probe`` is the
+   state-mutation helper the worker calls when ``health_probe``
+   returns False. It must only re-flip when the runtime is
+   currently ``ok`` (the eager-clear case) and otherwise no-op so
+   sticky-red states aren't clobbered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+
+# ── (1) LocalCli.health_probe dispatch ─────────────────────────────────────
+
+
+def test_local_cli_probe_delegates_to_codex_session(monkeypatch):
+    """Codex harness path: when the adapter has built a CodexSession,
+    its probe is the source of truth. LocalCli is a thin shim."""
+    from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+
+    class _StubCodex:
+        async def health_probe(self):
+            return False
+
+    stub = SimpleNamespace.__new__(SimpleNamespace)
+    # Build a minimal LocalCLIAdapter without going through __init__
+    # — the only attribute the method reads is _codex_session.
+    adapter = LocalCLIAdapter.__new__(LocalCLIAdapter)
+    adapter._session = None
+    adapter._codex_session = _StubCodex()
+
+    assert asyncio.run(adapter.health_probe()) is False
+
+
+def test_local_cli_probe_returns_true_without_codex_session():
+    """Non-Codex agents (no _codex_session built) inherit the safe
+    True default — their next-message path surfaces a real failure
+    via the existing leak filter; the probe doesn't need to
+    pre-empt them."""
+    from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+
+    adapter = LocalCLIAdapter.__new__(LocalCLIAdapter)
+    adapter._session = None
+    adapter._codex_session = None
+
+    assert asyncio.run(adapter.health_probe()) is True
+
+
+# ── (2) Worker._reassert_auth_failed_after_failed_probe ────────────────────
+
+
+class _Runtime:
+    """Stand-in for portal.state.RuntimeState — just the fields the
+    reassert helper touches. The real class hits disk via save();
+    here we record the calls instead."""
+    def __init__(self, health="ok", error=""):
+        self.health = health
+        self.error = error
+        self.saved = []
+
+    def save(self, agent_id):
+        self.saved.append((agent_id, self.health, self.error))
+
+
+def test_reassert_flips_ok_back_to_auth_failed():
+    """The load-bearing case: eager-clear set health=ok before the
+    worker even respawned; post-warm probe returned False; the helper
+    re-asserts auth_failed so the next refresh cycle retries."""
+    from puffo_agent.portal.worker import Worker
+
+    rt = _Runtime(health="ok", error="")
+    Worker._reassert_auth_failed_after_failed_probe(
+        rt, "agent-a", logging.getLogger("puf311-test"),
+    )
+
+    assert rt.health == "auth_failed"
+    assert "health probe failed" in rt.error
+    assert rt.saved == [("agent-a", "auth_failed",
+                         "post-recovery health probe failed — provider "
+                         "still unreachable; waiting for next credential "
+                         "refresh")]
+
+
+def test_reassert_noop_when_already_auth_failed():
+    """No second flip / second DM. Worker's existing
+    _auth_failed_notification_sent dedup gates the DM separately;
+    this helper just refuses to clobber the existing sticky-red
+    state. Specifically: no save() call, so the existing error
+    message survives."""
+    from puffo_agent.portal.worker import Worker
+
+    rt = _Runtime(health="auth_failed", error="original reason")
+    Worker._reassert_auth_failed_after_failed_probe(
+        rt, "agent-b", logging.getLogger("puf311-test"),
+    )
+
+    assert rt.health == "auth_failed"
+    assert rt.error == "original reason"
+    assert rt.saved == []
+
+
+def test_reassert_noop_for_other_sticky_health_values():
+    """Don't clobber api_error_abandoned, codex_thread_wedged,
+    refresh_broken, or any other sticky-red state — the probe only
+    speaks to auth/transport reachability, and other red states have
+    their own clear-on-recover paths that shouldn't be hijacked."""
+    from puffo_agent.portal.worker import Worker
+
+    for sticky in (
+        "api_error_abandoned",
+        "codex_thread_wedged",
+        "refresh_broken",
+        "unhandled_error",
+    ):
+        rt = _Runtime(health=sticky, error=f"due to {sticky}")
+        Worker._reassert_auth_failed_after_failed_probe(
+            rt, "agent-c", logging.getLogger("puf311-test"),
+        )
+        assert rt.health == sticky
+        assert rt.saved == []
+
+
+def test_reassert_noop_when_in_progress():
+    """``in_progress`` is the active-batch marker. The probe runs
+    pre-batch, so this should never trigger in practice — but pin
+    it anyway: don't clobber an in-progress turn."""
+    from puffo_agent.portal.worker import Worker
+
+    rt = _Runtime(health="in_progress", error="")
+    Worker._reassert_auth_failed_after_failed_probe(
+        rt, "agent-d", logging.getLogger("puf311-test"),
+    )
+
+    assert rt.health == "in_progress"
+    assert rt.saved == []
+
+
+# ── (3) Base Adapter health_probe default ──────────────────────────────────
+
+
+def test_base_adapter_health_probe_defaults_true():
+    """The default at the Adapter base — non-Codex adapters must NOT
+    need any new code to opt out of the probe. Returning True keeps
+    the eager-clear behaviour intact for Claude / hermes / etc."""
+    from puffo_agent.agent.adapters.base import Adapter
+
+    class _Concrete(Adapter):
+        async def run_turn(self, ctx):  # noqa: ARG002
+            raise NotImplementedError
+
+    adapter = _Concrete()
+    assert asyncio.run(adapter.health_probe()) is True

--- a/tests/test_worker_health_probe_gate.py
+++ b/tests/test_worker_health_probe_gate.py
@@ -161,3 +161,161 @@ def test_base_adapter_health_probe_defaults_true():
 
     adapter = _Concrete()
     assert asyncio.run(adapter.health_probe()) is True
+
+
+# ── Polish round-1 folds ───────────────────────────────────────────────────
+
+
+def _make_gate_worker(runtime, adapter):
+    """Build a minimal worker stub the post-warm gate can run against.
+    The real Worker constructor does a lot of setup we don't need here;
+    we just need the attributes _run_post_warm_gate reads."""
+    from puffo_agent.portal.worker import Worker
+
+    w = Worker.__new__(Worker)
+    w.runtime = runtime
+    w._adapter = adapter
+    w._warm_done = asyncio.Event()
+    return w
+
+
+def test_warm_done_only_flips_after_probe_completes():
+    """PUF-311 ordering invariant: ``_warm_done`` MUST stay clear
+    until the probe (+ reassert if probe-fail) finishes. Reversing
+    the order would let a queued message dispatch against an
+    unprobed runtime. Stub the adapter probe with an Event so we can
+    observe the order from outside."""
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    captured = {}
+
+    class _SlowProbe:
+        async def health_probe(self):
+            started.set()
+            await release.wait()
+            return True
+
+    async def _run():
+        w = _make_gate_worker(_Runtime("ok"), _SlowProbe())
+        gate_task = asyncio.create_task(w._run_post_warm_gate("agent-a"))
+        await started.wait()
+        captured["mid_probe"] = w._warm_done.is_set()
+        release.set()
+        await gate_task
+        captured["post_gate"] = w._warm_done.is_set()
+
+    asyncio.run(_run())
+    assert captured["mid_probe"] is False
+    assert captured["post_gate"] is True
+
+
+def test_warm_done_only_flips_after_reassert_when_probe_fails():
+    """Tighter ordering: the reassert helper must ALSO finish before
+    ``_warm_done`` flips, otherwise a queued message could fire while
+    runtime.health is mid-reassert. Probe returns False → reassert
+    runs → _warm_done set. Asserted via a runtime stub whose save()
+    is observable from the test."""
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    captured = {}
+
+    class _SlowProbe:
+        async def health_probe(self):
+            started.set()
+            await release.wait()
+            return False
+
+    async def _run():
+        rt = _Runtime("ok")
+        w = _make_gate_worker(rt, _SlowProbe())
+        gate_task = asyncio.create_task(w._run_post_warm_gate("agent-b"))
+        await started.wait()
+        # Mid-probe: nothing has flipped yet.
+        captured["mid_probe_health"] = rt.health
+        captured["mid_probe_warm_done"] = w._warm_done.is_set()
+        release.set()
+        await gate_task
+        captured["post_gate_health"] = rt.health
+        captured["post_gate_warm_done"] = w._warm_done.is_set()
+
+    asyncio.run(_run())
+    assert captured["mid_probe_health"] == "ok"
+    assert captured["mid_probe_warm_done"] is False
+    assert captured["post_gate_health"] == "auth_failed"
+    assert captured["post_gate_warm_done"] is True
+
+
+def test_gate_treats_adapter_probe_exception_as_failure():
+    """A future adapter override that forgets the internal try/except
+    must NOT crash the worker; the gate's own try/except catches and
+    treats as probe-fail, reasserting auth_failed. Otherwise the
+    warm path would die and the agent would stay stuck-spawning."""
+
+    class _RaisingProbe:
+        async def health_probe(self):
+            raise RuntimeError("simulated forgot-to-except in adapter")
+
+    async def _run():
+        rt = _Runtime("ok")
+        w = _make_gate_worker(rt, _RaisingProbe())
+        await w._run_post_warm_gate("agent-c")
+        return rt, w
+
+    rt, w = asyncio.run(_run())
+    # Reassert fired (worker treated the raise as probe-fail).
+    assert rt.health == "auth_failed"
+    # Warm gate still released so the daemon's wait_warm completes.
+    assert w._warm_done.is_set()
+
+
+def test_reassert_does_not_fire_a_second_operator_dm():
+    """The reassert helper must NOT call ``_on_auth_failed_enter`` /
+    schedule a new DM. The operator already got the original
+    auth_failed DM before eager-clear; probe-fail is a "still broken"
+    signal, not a new fault. A future change wiring the ENTER hook
+    into the reassert path would surface as silent operator-spam —
+    pin the no-DM contract via a stub that would fail if any DM is
+    sent."""
+
+    sent: list = []
+
+    class _Probe:
+        async def health_probe(self):
+            return False
+
+    class _StubClient:
+        operator_slug = "@han-0001"
+
+        async def _send_dm(self, recipient, text, root_id):
+            sent.append((recipient, text))
+
+    async def _run():
+        from puffo_agent.portal.worker import Worker
+
+        rt = _Runtime("ok")
+        w = Worker.__new__(Worker)
+        w.runtime = rt
+        w._adapter = _Probe()
+        w._warm_done = asyncio.Event()
+        # Wire the DM substrate path so a regression would catch it.
+        w._client = _StubClient()
+        w._auth_failed_notification_sent = False
+        w.agent_cfg = SimpleNamespace(
+            id="t-agent",
+            display_name="Tester",
+            runtime=SimpleNamespace(harness="codex"),
+        )
+
+        await w._run_post_warm_gate("agent-d")
+        # Yield once in case a regression scheduled a task on the loop.
+        await asyncio.sleep(0)
+        return rt
+
+    rt = asyncio.run(_run())
+    assert rt.health == "auth_failed"
+    assert sent == [], (
+        "reassert path must not fire a second operator DM; "
+        f"got {sent!r}"
+    )

--- a/tests/test_worker_health_probe_gate.py
+++ b/tests/test_worker_health_probe_gate.py
@@ -1,18 +1,7 @@
-"""PUF-311 worker-side reassertion + adapter dispatch.
-
-Two seams that the round-trip-Codex test doesn't cover:
-
-1. ``LocalCli.health_probe`` must delegate to the live
-   ``CodexSession`` when one exists and short-circuit to True
-   otherwise (Claude / hermes / gemini-cli inherit the no-probe
-   default).
-
-2. ``Worker._reassert_auth_failed_after_failed_probe`` is the
-   state-mutation helper the worker calls when ``health_probe``
-   returns False. It must only re-flip when the runtime is
-   currently ``ok`` (the eager-clear case) and otherwise no-op so
-   sticky-red states aren't clobbered.
-"""
+"""Worker-side reassertion + adapter dispatch — the seams the round-trip
+probe test doesn't cover: ``LocalCli.health_probe`` delegates to a live
+``CodexSession`` (else True), and ``_reassert_auth_failed_after_failed_probe``
+only re-flips the eager-cleared ``ok`` state (no clobber of sticky-red)."""
 
 from __future__ import annotations
 
@@ -25,8 +14,7 @@ from types import SimpleNamespace
 
 
 def test_local_cli_probe_delegates_to_codex_session(monkeypatch):
-    """Codex harness path: when the adapter has built a CodexSession,
-    its probe is the source of truth. LocalCli is a thin shim."""
+    """With a CodexSession built, LocalCli delegates to its probe."""
     from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
 
     class _StubCodex:
@@ -34,8 +22,7 @@ def test_local_cli_probe_delegates_to_codex_session(monkeypatch):
             return False
 
     stub = SimpleNamespace.__new__(SimpleNamespace)
-    # Build a minimal LocalCLIAdapter without going through __init__
-    # — the only attribute the method reads is _codex_session.
+    # __new__ to skip __init__ — the method only reads _codex_session.
     adapter = LocalCLIAdapter.__new__(LocalCLIAdapter)
     adapter._session = None
     adapter._codex_session = _StubCodex()
@@ -44,10 +31,8 @@ def test_local_cli_probe_delegates_to_codex_session(monkeypatch):
 
 
 def test_local_cli_probe_returns_true_without_codex_session():
-    """Non-Codex agents (no _codex_session built) inherit the safe
-    True default — their next-message path surfaces a real failure
-    via the existing leak filter; the probe doesn't need to
-    pre-empt them."""
+    """No _codex_session → inherit the True default (non-Codex agents
+    surface a real failure via the existing leak filter)."""
     from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
 
     adapter = LocalCLIAdapter.__new__(LocalCLIAdapter)
@@ -61,9 +46,8 @@ def test_local_cli_probe_returns_true_without_codex_session():
 
 
 class _Runtime:
-    """Stand-in for portal.state.RuntimeState — just the fields the
-    reassert helper touches. The real class hits disk via save();
-    here we record the calls instead."""
+    """Stand-in for RuntimeState — records save() calls instead of
+    hitting disk."""
     def __init__(self, health="ok", error=""):
         self.health = health
         self.error = error
@@ -74,9 +58,7 @@ class _Runtime:
 
 
 def test_reassert_flips_ok_back_to_auth_failed():
-    """The load-bearing case: eager-clear set health=ok before the
-    worker even respawned; post-warm probe returned False; the helper
-    re-asserts auth_failed so the next refresh cycle retries."""
+    """eager-clear left health=ok; probe-fail → re-assert auth_failed."""
     from puffo_agent.portal.worker import Worker
 
     rt = _Runtime(health="ok", error="")
@@ -93,10 +75,7 @@ def test_reassert_flips_ok_back_to_auth_failed():
 
 
 def test_reassert_noop_when_already_auth_failed():
-    """No second flip / second DM. Worker's existing
-    _auth_failed_notification_sent dedup gates the DM separately;
-    this helper just refuses to clobber the existing sticky-red
-    state. Specifically: no save() call, so the existing error
+    """Already auth_failed → no re-flip, no save(); the existing error
     message survives."""
     from puffo_agent.portal.worker import Worker
 
@@ -111,10 +90,8 @@ def test_reassert_noop_when_already_auth_failed():
 
 
 def test_reassert_noop_for_other_sticky_health_values():
-    """Don't clobber api_error_abandoned, codex_thread_wedged,
-    refresh_broken, or any other sticky-red state — the probe only
-    speaks to auth/transport reachability, and other red states have
-    their own clear-on-recover paths that shouldn't be hijacked."""
+    """Other sticky-red states (api_error_abandoned, codex_thread_wedged,
+    refresh_broken, …) have their own recovery paths — don't clobber them."""
     from puffo_agent.portal.worker import Worker
 
     for sticky in (
@@ -132,9 +109,7 @@ def test_reassert_noop_for_other_sticky_health_values():
 
 
 def test_reassert_noop_when_in_progress():
-    """``in_progress`` is the active-batch marker. The probe runs
-    pre-batch, so this should never trigger in practice — but pin
-    it anyway: don't clobber an in-progress turn."""
+    """``in_progress`` (active-batch marker) must not be clobbered."""
     from puffo_agent.portal.worker import Worker
 
     rt = _Runtime(health="in_progress", error="")
@@ -150,9 +125,7 @@ def test_reassert_noop_when_in_progress():
 
 
 def test_base_adapter_health_probe_defaults_true():
-    """The default at the Adapter base — non-Codex adapters must NOT
-    need any new code to opt out of the probe. Returning True keeps
-    the eager-clear behaviour intact for Claude / hermes / etc."""
+    """Base default is True — non-Codex adapters need no opt-out code."""
     from puffo_agent.agent.adapters.base import Adapter
 
     class _Concrete(Adapter):
@@ -167,9 +140,8 @@ def test_base_adapter_health_probe_defaults_true():
 
 
 def _make_gate_worker(runtime, adapter):
-    """Build a minimal worker stub the post-warm gate can run against.
-    The real Worker constructor does a lot of setup we don't need here;
-    we just need the attributes _run_post_warm_gate reads."""
+    """Minimal Worker stub with just the attributes _run_post_warm_gate
+    reads."""
     from puffo_agent.portal.worker import Worker
 
     w = Worker.__new__(Worker)
@@ -180,11 +152,9 @@ def _make_gate_worker(runtime, adapter):
 
 
 def test_warm_done_only_flips_after_probe_completes():
-    """PUF-311 ordering invariant: ``_warm_done`` MUST stay clear
-    until the probe (+ reassert if probe-fail) finishes. Reversing
-    the order would let a queued message dispatch against an
-    unprobed runtime. Stub the adapter probe with an Event so we can
-    observe the order from outside."""
+    """Ordering invariant: ``_warm_done`` stays clear until the probe
+    finishes (else a queued message could dispatch against an unprobed
+    runtime). A slow stubbed probe makes the order observable."""
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -211,11 +181,8 @@ def test_warm_done_only_flips_after_probe_completes():
 
 
 def test_warm_done_only_flips_after_reassert_when_probe_fails():
-    """Tighter ordering: the reassert helper must ALSO finish before
-    ``_warm_done`` flips, otherwise a queued message could fire while
-    runtime.health is mid-reassert. Probe returns False → reassert
-    runs → _warm_done set. Asserted via a runtime stub whose save()
-    is observable from the test."""
+    """Probe-fail path: the reassert must ALSO finish before
+    ``_warm_done`` flips, so no message fires mid-reassert."""
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -248,10 +215,8 @@ def test_warm_done_only_flips_after_reassert_when_probe_fails():
 
 
 def test_gate_treats_adapter_probe_exception_as_failure():
-    """A future adapter override that forgets the internal try/except
-    must NOT crash the worker; the gate's own try/except catches and
-    treats as probe-fail, reasserting auth_failed. Otherwise the
-    warm path would die and the agent would stay stuck-spawning."""
+    """A probe that raises is caught by the gate's own try/except and
+    treated as probe-fail (reassert + release warm), not a crash."""
 
     class _RaisingProbe:
         async def health_probe(self):
@@ -271,13 +236,9 @@ def test_gate_treats_adapter_probe_exception_as_failure():
 
 
 def test_reassert_does_not_fire_a_second_operator_dm():
-    """The reassert helper must NOT call ``_on_auth_failed_enter`` /
-    schedule a new DM. The operator already got the original
-    auth_failed DM before eager-clear; probe-fail is a "still broken"
-    signal, not a new fault. A future change wiring the ENTER hook
-    into the reassert path would surface as silent operator-spam —
-    pin the no-DM contract via a stub that would fail if any DM is
-    sent."""
+    """Probe-fail re-asserts state but must NOT fire a second operator
+    DM (the operator already got the original auth_failed DM before
+    eager-clear) — pinned via a stub that records any DM sent."""
 
     sent: list = []
 


### PR DESCRIPTION
## Summary

Post-recovery health-probe gate for the Codex provider, plus a classifier broadening surfaced by live testing. Companion to PUF-310 (Codex auth DM, on main).

### Health-probe gate (PUF-311)

`on_refresh_success` eagerly clears `runtime.health = auth_failed` before the adapter respawns, so the runtime can show healthy before the round-trip is verified. This adds a post-`warm()` probe gate:

- `Adapter.health_probe()` default-True (regression-safe for claude-code / hermes / gemini-cli).
- `CodexSession.health_probe()` runs `_ensure_running` (spawn + thread/start) and checks `_conversation_id`; a still-broken token re-raises inline → probe returns False.
- `LocalCLIAdapter.health_probe()` delegates to the Codex session if one exists, else True.
- `Worker._run_post_warm_gate` runs the probe **before** releasing `_warm_done` (no message dispatches against an unprobed runtime); on probe-fail, `_reassert_auth_failed_after_failed_probe` re-flips `ok` → `auth_failed` (no-ops on sticky-red / non-cleared states).

### Classifier broadening (from live test)

A live codex relogin surfaced a real auth 401 the original d2d2 anchors missed: codex emits `invalidated oauth token` (space form, not the `token_invalidated` JSON field) and 401s on `/backend-api/codex`, not just `/responses`. The classifier now matches the human-readable string and generalises the 401 co-occurrence to any auth-context marker (`oauth` / `invalidated` / `auth error` / `identity_edge` / `/responses` / `/backend-api/codex`), keeping the 40-char clause bound so the existing false-positive probes still reject.

## Changelog

Added under `## [0.12.6] — 2026-06-18` (date-stamped for release).

## Test plan

- [x] `pytest`: **1549 passed / 9 skipped**.
- [x] Codex probe via fake App Server: happy → True; auth-class thread/start error → False; unspawnable → False; idempotent on warm session.
- [x] Worker reassert state machine: ok → auth_failed (+save), already auth_failed → no clobber, sticky-red → no-op, in_progress → no-op.
- [x] Classifier: live-observed `invalidated oauth token` + `/backend-api/codex` 401 classify; d2d2 strings still classify; `invalid thread id` excluded; FP probes (semicolon/period/newline/>40-char) still reject.
- [x] Live smoke (codex logout/login on the dev box): confirmed the credential refresher re-syncs the agent `auth.json`, the probe gate stays healthy on clean recovery, and a non-fatal background 401 correctly does not flip `auth_failed`.

Closes PUF-311.