### PR TITLE
Add Discord message transport skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
 [project.optional-dependencies]
 # pip install puffo-agent[sdk]  — needed for agents with runtime.kind=sdk
 sdk = ["claude-agent-sdk>=0.1.61"]
+discord = ["discord.py>=2.4"]
 # cli-local / cli-docker adapters don't need extra Python deps; they
 # shell out to the `claude` binary (cli-local) or Docker (cli-docker).
 # pip install --editable ".[dev]"  — needed to run the test suite.

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -753,6 +753,7 @@ class ClaudeSession:
                             send_message_targets.append({
                                 "channel": str(tool_input.get("channel", "")),
                                 "root_id": str(tool_input.get("root_id", "")),
+                                "text": str(tool_input.get("text", "")),
                             })
                         if self.audit is not None:
                             self.audit.write(

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -1133,6 +1133,7 @@ class CodexSession:
                     turn.send_message_targets.append({
                         "channel": str(args.get("channel", "")),
                         "root_id": str(args.get("root_id", "")),
+                        "text": str(args.get("text", "")),
                     })
             return
 

--- a/src/puffo_agent/agent/adapters/sdk.py
+++ b/src/puffo_agent/agent/adapters/sdk.py
@@ -121,6 +121,7 @@ class SDKAdapter(Adapter):
                             send_message_targets.append({
                                 "channel": str(tool_input.get("channel", "")),
                                 "root_id": str(tool_input.get("root_id", "")),
+                                "text": str(tool_input.get("text", "")),
                             })
                         if ctx.on_progress is not None:
                             try:

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -53,6 +53,20 @@ def _origin_for_compressed(path: str) -> str | None:
     return base[: -len(marker)] + ".origin" + ext
 
 
+def _format_send_message_fallback(targets: list[dict]) -> str:
+    """Recover text from send_message tool calls when that tool did
+    not post to the active chat transport.
+    """
+    texts = [
+        str(t.get("text") or "").strip()
+        for t in targets
+        if str(t.get("text") or "").strip()
+    ]
+    if len(texts) == 1:
+        return texts[0]
+    return "\n".join(f"- {t}" for t in texts)
+
+
 class PuffoAgent:
     def __init__(
         self,
@@ -62,6 +76,7 @@ class PuffoAgent:
         workspace_dir: str = "",
         claude_dir: str = "",
         agent_id: str = "",
+        send_message_tools_post_externally: bool = True,
     ):
         """Per-agent shell. Owns cross-cutting state (conversation
         log, memory manager) and delegates each turn to an ``Adapter``
@@ -77,6 +92,7 @@ class PuffoAgent:
         self.workspace_dir = workspace_dir
         self.claude_dir = claude_dir
         self.agent_id = agent_id
+        self.send_message_tools_post_externally = send_message_tools_post_externally
         self.logger = agent_logger(__name__, agent_id)
 
         self.memory = MemoryManager(memory_dir)
@@ -243,12 +259,21 @@ class PuffoAgent:
         # failures.
         send_message_called = bool(result.metadata.get("send_message_targets"))
         text_parts: list[str] = result.metadata.get("assistant_text_parts") or []
-        if send_message_called:
+        if send_message_called and self.send_message_tools_post_externally:
             if result.reply:
                 self._append_assistant(
                     channel_meta.get("channel_name", ""), result.reply,
                 )
             return None
+        if send_message_called and not self.send_message_tools_post_externally:
+            tool_reply = _format_send_message_fallback(
+                result.metadata.get("send_message_targets") or [],
+            )
+            if tool_reply:
+                self._append_assistant(
+                    channel_meta.get("channel_name", ""), tool_reply,
+                )
+                return tool_reply
         joined = "\n".join(text_parts) if text_parts else (result.reply or "")
         if "[SILENT]" in joined:
             return None
@@ -297,7 +322,7 @@ class PuffoAgent:
         send_message_called = bool(result.metadata.get("send_message_targets"))
         text_parts: list[str] = result.metadata.get("assistant_text_parts") or []
 
-        if send_message_called:
+        if send_message_called and self.send_message_tools_post_externally:
             self.logger.debug(
                 f"[mcp-only] [{channel_name}] @{sender}: send_message "
                 "called; skipping shell auto-post"
@@ -305,6 +330,13 @@ class PuffoAgent:
             if result.reply:
                 self._append_assistant(channel_name, result.reply)
             return None
+        if send_message_called and not self.send_message_tools_post_externally:
+            tool_reply = _format_send_message_fallback(
+                result.metadata.get("send_message_targets") or [],
+            )
+            if tool_reply:
+                self._append_assistant(channel_name, tool_reply)
+                return tool_reply
 
         # Substring match: marker position in the assistant text
         # doesn't matter. Real replies go via send_message, so a

--- a/src/puffo_agent/agent/discord_client.py
+++ b/src/puffo_agent/agent/discord_client.py
@@ -408,7 +408,7 @@ class DiscordMessageClient:
         if self._send_func is not None:
             await self._send_func(channel_id, outbound, root_id)
             return
-        if self.webhook_url:
+        if self.webhook_url and _raw_discord_id(channel_id) in self._thread_channel_ids:
             await self._send_via_webhook(outbound, channel_id)
             return
         if self._discord_client is None:
@@ -418,6 +418,16 @@ class DiscordMessageClient:
         channel = self._discord_client.get_channel(raw_channel_id)
         if channel is None:
             channel = await self._discord_client.fetch_channel(raw_channel_id)
+        raw_root_id = _raw_discord_id(root_id) if root_id else ""
+        if raw_root_id and raw_root_id != str(raw_channel_id):
+            try:
+                root_message = await channel.fetch_message(int(raw_root_id))
+                await root_message.reply(outbound, mention_author=False)
+                return
+            except Exception:
+                logger.exception(
+                    "discord fallback reply-to-root failed; posting in channel"
+                )
         await channel.send(outbound)
 
     async def _send_via_webhook(self, text: str, channel_id: str) -> None:

--- a/src/puffo_agent/agent/discord_client.py
+++ b/src/puffo_agent/agent/discord_client.py
@@ -1,0 +1,471 @@
+"""Discord message transport for Puffo agents.
+
+The live gateway path is intentionally thin; most behavior is exposed
+through ``handle_discord_message`` so routing, storage, and retry
+semantics can be tested without a Discord connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+from .message_store import MessageStore
+from .puffo_core_client import _compute_priority
+
+logger = logging.getLogger(__name__)
+
+_MENTION_RE = re.compile(r"<@!?(\d+)>")
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _discord_id(kind: str, value: str | int | None) -> str:
+    raw = "" if value is None else str(value)
+    if raw.startswith("discord:"):
+        return raw
+    return f"discord:{kind}:{raw}"
+
+
+def _raw_discord_id(value: str) -> str:
+    return str(value).rsplit(":", 1)[-1]
+
+
+@dataclass
+class _ThreadEntry:
+    current_priority: int
+    current_seq: int
+    messages: list[dict] = field(default_factory=list)
+    in_queue: bool = True
+    channel_meta: dict = field(default_factory=dict)
+    dispatching_ids: set[str] = field(default_factory=set)
+
+
+class DiscordMessageClient:
+    """Discord-backed message client.
+
+    ``send_func`` is a test seam. In production, ``listen`` starts a
+    discord.py client and ``send_fallback_message`` posts through that
+    client. If ``webhook_url`` is configured, a later implementation can
+    route outbound messages through a per-agent webhook identity without
+    changing the worker contract.
+    """
+
+    MAX_API_ERROR_RETRIES = 3
+
+    def __init__(
+        self,
+        *,
+        agent_slug: str,
+        bot_token: str,
+        guild_id: str,
+        agent_user_id: str,
+        message_store: MessageStore,
+        bot_user_id: str = "",
+        channel_ids: list[str] | None = None,
+        webhook_url: str = "",
+        display_prefix: str = "",
+        send_func: Optional[Callable[[str, str, str], Awaitable[None]]] = None,
+    ):
+        self.agent_slug = agent_slug
+        self.bot_token = bot_token
+        self.guild_id = str(guild_id)
+        self.agent_user_id = str(agent_user_id)
+        self.bot_user_id = str(bot_user_id)
+        self.channel_ids = {str(c) for c in (channel_ids or []) if str(c)}
+        self.webhook_url = webhook_url
+        self.display_prefix = display_prefix
+        self.store = message_store
+        self._send_func = send_func
+        self._queue: asyncio.PriorityQueue = asyncio.PriorityQueue()
+        self._queue_seq = 0
+        self._thread_state: dict[str, _ThreadEntry] = {}
+        self._thread_channel_ids: set[str] = set()
+        self._discord_client: Any = None
+        self._consumer_task: asyncio.Task | None = None
+        self._stopped = asyncio.Event()
+
+    async def listen(
+        self,
+        on_message,
+        on_api_error_retry=None,
+        on_api_error_abandon=None,
+        on_turn_success=None,
+    ) -> None:
+        await self.store.open()
+        self._consumer_task = asyncio.create_task(
+            self._consume_queue(
+                on_message,
+                on_api_error_retry,
+                on_api_error_abandon,
+                on_turn_success,
+            ),
+        )
+        try:
+            discord = _import_discord()
+            intents = discord.Intents.default()
+            intents.message_content = True
+            intents.guilds = True
+            intents.members = True
+            client = discord.Client(intents=intents)
+            self._discord_client = client
+
+            @client.event
+            async def on_ready():
+                if not self.bot_user_id and client.user is not None:
+                    self.bot_user_id = str(client.user.id)
+                logger.info("discord transport ready for agent %s", self.agent_slug)
+
+            @client.event
+            async def on_message(message):
+                await self.handle_discord_message(message)
+
+            await client.start(self.bot_token)
+        finally:
+            if self._consumer_task is not None:
+                self._consumer_task.cancel()
+                try:
+                    await self._consumer_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    async def handle_discord_message(self, message: Any) -> None:
+        """Normalize one Discord message into the worker batch queue."""
+        channel = getattr(message, "channel", None)
+        channel_raw = str(getattr(channel, "id", ""))
+        parent_channel_raw = str(getattr(channel, "parent_id", "") or "")
+        if (
+            self.channel_ids
+            and channel_raw not in self.channel_ids
+            and parent_channel_raw not in self.channel_ids
+        ):
+            return
+
+        author = getattr(message, "author", None)
+        author_id = str(getattr(author, "id", ""))
+        if self.bot_user_id and author_id == self.bot_user_id:
+            return
+
+        content = str(getattr(message, "content", "") or "")
+        mention_ids = {m.group(1) for m in _MENTION_RE.finditer(content)}
+        for mentioned in getattr(message, "mentions", []) or []:
+            mid = str(getattr(mentioned, "id", ""))
+            if mid:
+                mention_ids.add(mid)
+        is_self_mention = self.agent_user_id in mention_ids
+        author_is_bot = bool(getattr(author, "bot", False))
+        if author_is_bot and not is_self_mention:
+            return
+
+        message_id = _discord_id("message", getattr(message, "id", ""))
+        channel_id = _discord_id("channel", channel_raw)
+        if _looks_like_thread(channel):
+            self._thread_channel_ids.add(channel_raw)
+        guild_obj = getattr(message, "guild", None)
+        guild_id = _discord_id("guild", getattr(guild_obj, "id", self.guild_id))
+
+        root_id = self._root_id_for(message)
+        thread_root_id = None if root_id == message_id else root_id
+        sender_slug = self._sender_slug(author)
+        sent_at = self._sent_at_ms(message)
+        clean_text = self._rewrite_self_mentions(content) if is_self_mention else content
+
+        await self.store.store({
+            "envelope_id": message_id,
+            "envelope_kind": "channel",
+            "sender_slug": sender_slug,
+            "channel_id": channel_id,
+            "space_id": guild_id,
+            "recipient_slug": None,
+            "content_type": "text/plain",
+            "content": clean_text,
+            "sent_at": sent_at,
+            "thread_root_id": thread_root_id,
+            "reply_to_id": self._reply_to_id_for(message),
+        })
+        await self.store.mark_channel_space(channel_id, guild_id)
+
+        last_processed = await self.store.get_last_processed_sent_at(root_id)
+        if sent_at <= last_processed:
+            return
+
+        mentions = [
+            {
+                "username": self.agent_slug,
+                "is_bot": True,
+                "is_self": True,
+            }
+        ] if is_self_mention else []
+        priority = _compute_priority(is_self_mention, author_is_bot)
+        channel_name = str(getattr(channel, "name", channel_raw))
+        guild_name = str(getattr(guild_obj, "name", self.guild_id))
+        msg_dict = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": guild_id,
+            "space_name": guild_name,
+            "sender_slug": sender_slug,
+            "sender_display_name": str(
+                getattr(author, "display_name", "")
+                or getattr(author, "name", "")
+                or author_id
+            ),
+            "sender_email": "",
+            "text": clean_text,
+            "root_id": thread_root_id or "",
+            "is_dm": False,
+            "attachments": [],
+            "sender_is_bot": author_is_bot,
+            "mentions": mentions,
+            "envelope_id": message_id,
+            "sent_at": sent_at,
+            "is_visible_to_human": True,
+        }
+        channel_meta = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": guild_id,
+            "space_name": guild_name,
+            "is_dm": False,
+        }
+        await self._admit_thread_message(
+            root_id=root_id,
+            priority=priority,
+            msg_dict=msg_dict,
+            channel_meta=channel_meta,
+        )
+
+    def _root_id_for(self, message: Any) -> str:
+        channel = getattr(message, "channel", None)
+        if _looks_like_thread(channel):
+            return _discord_id("message", getattr(channel, "id", ""))
+        reply_id = self._reply_to_id_for(message)
+        return reply_id or _discord_id("message", getattr(message, "id", ""))
+
+    def _reply_to_id_for(self, message: Any) -> str | None:
+        ref = getattr(message, "reference", None)
+        if ref is None:
+            return None
+        ref_id = getattr(ref, "message_id", None)
+        if not ref_id:
+            resolved = getattr(ref, "resolved", None)
+            ref_id = getattr(resolved, "id", None)
+        return _discord_id("message", ref_id) if ref_id else None
+
+    def _sender_slug(self, author: Any) -> str:
+        name = (
+            getattr(author, "global_name", "")
+            or getattr(author, "name", "")
+            or "discord-user"
+        )
+        safe = re.sub(r"[^a-zA-Z0-9_-]+", "-", str(name)).strip("-").lower()
+        return f"discord-{safe or 'user'}-{getattr(author, 'id', '')}"
+
+    def _sent_at_ms(self, message: Any) -> int:
+        created_at = getattr(message, "created_at", None)
+        if created_at is not None and hasattr(created_at, "timestamp"):
+            return int(created_at.timestamp() * 1000)
+        return _now_ms()
+
+    def _rewrite_self_mentions(self, content: str) -> str:
+        return re.sub(
+            rf"<@!?{re.escape(self.agent_user_id)}>",
+            f"@you({self.agent_slug})",
+            content,
+        )
+
+    async def _admit_thread_message(
+        self,
+        *,
+        root_id: str,
+        priority: int,
+        msg_dict: dict,
+        channel_meta: dict,
+    ) -> None:
+        entry = self._thread_state.get(root_id)
+        incoming_id = msg_dict.get("envelope_id", "")
+        if entry is not None and incoming_id and incoming_id in entry.dispatching_ids:
+            return
+        if entry is None or not entry.in_queue:
+            self._queue_seq += 1
+            if entry is None:
+                entry = _ThreadEntry(
+                    current_priority=priority,
+                    current_seq=self._queue_seq,
+                    messages=[msg_dict],
+                    in_queue=True,
+                    channel_meta=channel_meta,
+                )
+                self._thread_state[root_id] = entry
+            else:
+                entry.current_priority = priority
+                entry.current_seq = self._queue_seq
+                entry.messages = [msg_dict]
+                entry.in_queue = True
+                entry.channel_meta = channel_meta
+            await self._queue.put((priority, entry.current_seq, root_id))
+            return
+        if incoming_id and any(m.get("envelope_id") == incoming_id for m in entry.messages):
+            return
+        entry.messages.append(msg_dict)
+        if priority < entry.current_priority:
+            self._queue_seq += 1
+            entry.current_priority = priority
+            entry.current_seq = self._queue_seq
+            await self._queue.put((priority, entry.current_seq, root_id))
+
+    async def _consume_queue(
+        self,
+        on_message_batch,
+        on_api_error_retry=None,
+        on_api_error_abandon=None,
+        on_turn_success=None,
+    ) -> None:
+        from .core import AgentAPIError
+
+        while True:
+            try:
+                _priority, popped_seq, root_id = await self._queue.get()
+            except asyncio.CancelledError:
+                return
+            entry = self._thread_state.get(root_id)
+            if entry is None or not entry.in_queue or entry.current_seq != popped_seq:
+                continue
+            batch = entry.messages
+            channel_meta = entry.channel_meta
+            entry.messages = []
+            entry.in_queue = False
+            entry.dispatching_ids = {
+                m.get("envelope_id") for m in batch if m.get("envelope_id")
+            }
+            try:
+                await on_message_batch(root_id, batch, channel_meta)
+            except AgentAPIError:
+                await self._do_api_error_retries(
+                    root_id=root_id,
+                    entry=entry,
+                    batch=batch,
+                    channel_meta=channel_meta,
+                    on_api_error_retry=on_api_error_retry,
+                    on_api_error_abandon=on_api_error_abandon,
+                    on_turn_success=on_turn_success,
+                )
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("discord batch handler failed for root %s", root_id)
+                continue
+            if batch:
+                await self.store.mark_thread_processed(root_id, batch[-1].get("sent_at", 0))
+            entry.dispatching_ids = set()
+            if on_turn_success is not None:
+                await on_turn_success(root_id, batch, channel_meta)
+
+    async def _do_api_error_retries(
+        self,
+        *,
+        root_id: str,
+        entry: _ThreadEntry,
+        batch: list[dict],
+        channel_meta: dict,
+        on_api_error_retry,
+        on_api_error_abandon,
+        on_turn_success,
+    ) -> None:
+        from .core import AgentAPIError
+
+        entry.dispatching_ids = set()
+        if on_api_error_retry is None:
+            if on_api_error_abandon is not None:
+                await on_api_error_abandon(root_id, batch, channel_meta, 0)
+            return
+        attempts = 0
+        for attempt in range(1, self.MAX_API_ERROR_RETRIES + 1):
+            attempts = attempt
+            try:
+                await on_api_error_retry(root_id, batch, channel_meta)
+                if batch:
+                    await self.store.mark_thread_processed(root_id, batch[-1].get("sent_at", 0))
+                if on_turn_success is not None:
+                    await on_turn_success(root_id, batch, channel_meta)
+                return
+            except AgentAPIError:
+                continue
+        if on_api_error_abandon is not None:
+            await on_api_error_abandon(root_id, batch, channel_meta, attempts)
+
+    async def send_fallback_message(
+        self, channel_id: str, text: str, root_id: str = "",
+    ) -> None:
+        outbound = f"{self.display_prefix}: {text}" if self.display_prefix else text
+        if self._send_func is not None:
+            await self._send_func(channel_id, outbound, root_id)
+            return
+        if self.webhook_url:
+            await self._send_via_webhook(outbound, channel_id)
+            return
+        if self._discord_client is None:
+            logger.warning("discord fallback send dropped: client is not connected")
+            return
+        raw_channel_id = int(_raw_discord_id(channel_id))
+        channel = self._discord_client.get_channel(raw_channel_id)
+        if channel is None:
+            channel = await self._discord_client.fetch_channel(raw_channel_id)
+        await channel.send(outbound)
+
+    async def _send_via_webhook(self, text: str, channel_id: str) -> None:
+        import aiohttp
+
+        url = self.webhook_url
+        raw_channel_id = _raw_discord_id(channel_id)
+        if raw_channel_id in self._thread_channel_ids:
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}thread_id={raw_channel_id}"
+        payload = {"content": text}
+        if self.display_prefix:
+            payload["username"] = self.display_prefix
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise RuntimeError(
+                        f"Discord webhook send failed: HTTP {resp.status}: {body[:200]}"
+                    )
+
+    async def stop(self) -> None:
+        self._stopped.set()
+        if self._consumer_task is not None:
+            self._consumer_task.cancel()
+            try:
+                await self._consumer_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._discord_client is not None:
+            await self._discord_client.close()
+        await self.store.close()
+
+
+def _looks_like_thread(channel: Any) -> bool:
+    if channel is None:
+        return False
+    if bool(getattr(channel, "is_thread", False)):
+        return True
+    return channel.__class__.__name__.lower() == "thread"
+
+
+def _import_discord():
+    try:
+        import discord  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "Discord transport requires `pip install puffo-agent[discord]` "
+            "and Discord Message Content Intent enabled for the bot."
+        ) from exc
+    return discord

--- a/src/puffo_agent/agent/message_client.py
+++ b/src/puffo_agent/agent/message_client.py
@@ -1,0 +1,33 @@
+"""Message transport interface for agent workers.
+
+The worker owns the LLM runtime loop; message clients own chat
+transport details and feed thread batches into that loop.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Coroutine, Protocol
+
+
+BatchCallback = Callable[[str, list[dict], dict], Coroutine[Any, Any, Any]]
+RetryCallback = Callable[[str, list[dict], dict], Coroutine[Any, Any, Any]]
+AbandonCallback = Callable[[str, list[dict], dict, int], Coroutine[Any, Any, Any]]
+
+
+class MessageClient(Protocol):
+    async def listen(
+        self,
+        on_message: BatchCallback,
+        on_api_error_retry: RetryCallback | None = None,
+        on_api_error_abandon: AbandonCallback | None = None,
+        on_turn_success: BatchCallback | None = None,
+    ) -> None:
+        """Run the transport listener until stopped."""
+
+    async def send_fallback_message(
+        self, channel_id: str, text: str, root_id: str = "",
+    ) -> None:
+        """Post a fallback reply when the agent did not use a send tool."""
+
+    async def stop(self) -> None:
+        """Release transport resources."""

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -957,6 +957,28 @@ class PuffoCoreConfig:
 
 
 @dataclass
+class DiscordConfig:
+    """Discord transport config.
+
+    One Discord bot token can listen for many agents, but a single
+    process still needs to know which Discord mention maps to this
+    agent. Outbound identity is best-effort: webhook_url gives the
+    transport a per-agent display surface when available; otherwise
+    fallback replies are prefixed with ``display_prefix``.
+    """
+    bot_token: str = ""
+    guild_id: str = ""
+    agent_user_id: str = ""
+    bot_user_id: str = ""
+    channel_ids: list[str] = field(default_factory=list)
+    webhook_url: str = ""
+    display_prefix: str = ""
+
+    def is_configured(self) -> bool:
+        return bool(self.bot_token and self.guild_id and self.agent_user_id)
+
+
+@dataclass
 class RuntimeConfig:
     """Contents of the ``runtime:`` block in agent.yml.
 
@@ -1022,7 +1044,9 @@ class AgentConfig:
     # omits it.
     role: str = ""
     role_short: str = ""
+    chat_backend: str = "puffo-core"  # puffo-core | discord
     puffo_core: PuffoCoreConfig = field(default_factory=PuffoCoreConfig)
+    discord: DiscordConfig = field(default_factory=DiscordConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     profile: str = "profile.md"       # path relative to agent dir, or absolute
     memory_dir: str = "memory"        # path relative to agent dir, or absolute
@@ -1045,6 +1069,7 @@ class AgentConfig:
         with path.open("r", encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
         pc = raw.get("puffo_core") or {}
+        dc = raw.get("discord") or {}
         rt = raw.get("runtime") or {}
         triggers = raw.get("triggers") or {}
 
@@ -1071,6 +1096,7 @@ class AgentConfig:
             avatar_url=raw.get("avatar_url", ""),
             role=raw.get("role", ""),
             role_short=raw.get("role_short", ""),
+            chat_backend=raw.get("chat_backend", "puffo-core"),
             puffo_core=PuffoCoreConfig(
                 server_url=pc.get("server_url") or DEFAULT_PUFFO_SERVER_URL,
                 slug=pc.get("slug", ""),
@@ -1080,6 +1106,15 @@ class AgentConfig:
                 auto_accept_space_invitations=bool(
                     pc.get("auto_accept_space_invitations", False)
                 ),
+            ),
+            discord=DiscordConfig(
+                bot_token=dc.get("bot_token", ""),
+                guild_id=str(dc.get("guild_id", "")),
+                agent_user_id=str(dc.get("agent_user_id", "")),
+                bot_user_id=str(dc.get("bot_user_id", "")),
+                channel_ids=[str(v) for v in (dc.get("channel_ids") or [])],
+                webhook_url=dc.get("webhook_url", ""),
+                display_prefix=dc.get("display_prefix", ""),
             ),
             runtime=RuntimeConfig(
                 kind=kind,
@@ -1117,8 +1152,10 @@ class AgentConfig:
             "avatar_url": self.avatar_url,
             "role": self.role,
             "role_short": self.role_short,
+            "chat_backend": self.chat_backend,
             "created_at": self.created_at,
             "puffo_core": asdict(self.puffo_core),
+            "discord": asdict(self.discord),
             "runtime": asdict(self.runtime),
             "profile": self.profile,
             "memory_dir": self.memory_dir,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -82,6 +82,11 @@ logger = logging.getLogger(__name__)
 RECONNECT_BACKOFF_SECONDS = 5.0
 
 
+def _uses_puffo_core_backend(agent_cfg: AgentConfig) -> bool:
+    backend = (getattr(agent_cfg, "chat_backend", "") or "puffo-core").strip().lower()
+    return backend in ("", "puffo-core", "puffo_core")
+
+
 def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
     """Construct the adapter for ``runtime.kind``. Raises on unknown
     or misconfigured kinds."""
@@ -109,7 +114,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             workspace_dir=str(agent_cfg.resolve_workspace_dir()),
             max_turns=agent_cfg.runtime.max_turns,
         )
-        if agent_cfg.puffo_core.is_configured():
+        if _uses_puffo_core_backend(agent_cfg) and agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_stdio_sdk_config, default_python_executable
             pc = agent_cfg.puffo_core
             adapter.mcp_servers_override = puffo_core_stdio_sdk_config(
@@ -184,7 +189,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
         # ``python -m puffo_agent.mcp.puffo_core_server``. The adapter
         # rewrites path-typed env values to container bind-mount paths
         # at config-write time.
-        if agent_cfg.puffo_core.is_configured():
+        if _uses_puffo_core_backend(agent_cfg) and agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_mcp_env
             pc = agent_cfg.puffo_core
             adapter.puffo_core_mcp_env = puffo_core_mcp_env(
@@ -236,7 +241,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             puffo_core_slug=agent_cfg.puffo_core.slug,
             puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
         )
-        if agent_cfg.puffo_core.is_configured():
+        if _uses_puffo_core_backend(agent_cfg) and agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_mcp_env
             pc = agent_cfg.puffo_core
             adapter.puffo_core_mcp_env = puffo_core_mcp_env(
@@ -1084,10 +1089,12 @@ class Worker:
                 workspace_dir=workspace_path,
                 claude_dir=claude_path,
                 agent_id=agent_id,
+                send_message_tools_post_externally=_uses_puffo_core_backend(
+                    self.agent_cfg,
+                ),
             )
 
-            chat_backend = (self.agent_cfg.chat_backend or "puffo-core").strip().lower()
-            if chat_backend in ("", "puffo-core", "puffo_core") and (
+            if _uses_puffo_core_backend(self.agent_cfg) and (
                 not self.agent_cfg.puffo_core.is_configured()
             ):
                 raise RuntimeError(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -392,6 +392,42 @@ def _build_puffo_core_client(
     )
 
 
+def _build_message_client(
+    agent_cfg: AgentConfig,
+    agent_id: str,
+    daemon_cfg: "DaemonConfig | None" = None,
+):
+    backend = (agent_cfg.chat_backend or "puffo-core").strip().lower()
+    if backend in ("", "puffo-core", "puffo_core"):
+        return _build_puffo_core_client(agent_cfg, agent_id, daemon_cfg)
+    if backend == "discord":
+        from ..agent.discord_client import DiscordMessageClient
+        from ..agent.message_store import MessageStore
+
+        dc = agent_cfg.discord
+        if not dc.is_configured():
+            raise RuntimeError(
+                f"agent {agent_id!r}: discord backend requires "
+                "discord.bot_token, discord.guild_id, and "
+                "discord.agent_user_id in agent.yml"
+            )
+        return DiscordMessageClient(
+            agent_slug=agent_cfg.id,
+            bot_token=dc.bot_token,
+            guild_id=dc.guild_id,
+            agent_user_id=dc.agent_user_id,
+            bot_user_id=dc.bot_user_id,
+            channel_ids=dc.channel_ids,
+            webhook_url=dc.webhook_url,
+            display_prefix=dc.display_prefix or agent_cfg.display_name or agent_cfg.id,
+            message_store=MessageStore(str(agent_dir(agent_id) / "messages.db")),
+        )
+    raise RuntimeError(
+        f"agent {agent_id!r}: unknown chat_backend {agent_cfg.chat_backend!r} "
+        "(valid: puffo-core, discord)"
+    )
+
+
 # PUF-214: auth-class patterns — definitive evidence of OAuth /
 # API-key failure. Shared by the leak filter (suppress the leak)
 # and by health-flip detection (`runtime.health=auth_failed`).
@@ -1050,13 +1086,16 @@ class Worker:
                 agent_id=agent_id,
             )
 
-            if not self.agent_cfg.puffo_core.is_configured():
+            chat_backend = (self.agent_cfg.chat_backend or "puffo-core").strip().lower()
+            if chat_backend in ("", "puffo-core", "puffo_core") and (
+                not self.agent_cfg.puffo_core.is_configured()
+            ):
                 raise RuntimeError(
                     f"agent {agent_id!r}: puffo_core block in agent.yml "
                     "is incomplete. Required fields: server_url, slug, "
                     "device_id, space_id."
                 )
-            client = _build_puffo_core_client(
+            client = _build_message_client(
                 self.agent_cfg, agent_id, daemon_cfg=self.daemon_cfg,
             )
             self._client = client

--- a/tests/test_discord_transport.py
+++ b/tests/test_discord_transport.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.core import AgentAPIError
+from puffo_agent.agent.discord_client import DiscordMessageClient
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.portal.state import AgentConfig, DiscordConfig
+from puffo_agent.portal.worker import _build_message_client
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def _make_store() -> MessageStore:
+    d = tempfile.mkdtemp()
+    store = MessageStore(os.path.join(d, "messages.db"))
+    await store.open()
+    return store
+
+
+@dataclass
+class FakeAuthor:
+    id: str
+    name: str = "Alice"
+    display_name: str = "Alice"
+    bot: bool = False
+
+
+@dataclass
+class FakeGuild:
+    id: str = "123"
+    name: str = "Elon Team"
+
+
+@dataclass
+class FakeChannel:
+    id: str = "456"
+    name: str = "general"
+
+
+@dataclass
+class FakeReference:
+    message_id: str
+
+
+@dataclass
+class FakeMessage:
+    id: str
+    content: str
+    author: FakeAuthor
+    channel: FakeChannel = field(default_factory=FakeChannel)
+    guild: FakeGuild = field(default_factory=FakeGuild)
+    mentions: list = field(default_factory=list)
+    reference: FakeReference | None = None
+    created_at: object | None = None
+
+
+def _client(store: MessageStore, **kwargs) -> DiscordMessageClient:
+    return DiscordMessageClient(
+        agent_slug="engineer-357c8a5e",
+        bot_token="token",
+        guild_id="123",
+        agent_user_id="999",
+        bot_user_id="777",
+        message_store=store,
+        **kwargs,
+    )
+
+
+def test_discord_config_is_configured():
+    assert not DiscordConfig().is_configured()
+    assert DiscordConfig(
+        bot_token="token",
+        guild_id="123",
+        agent_user_id="999",
+    ).is_configured()
+
+
+def test_build_message_client_selects_discord_backend():
+    cfg = AgentConfig(
+        id="engineer-357c8a5e",
+        chat_backend="discord",
+        discord=DiscordConfig(
+            bot_token="token",
+            guild_id="123",
+            agent_user_id="999",
+            channel_ids=["456"],
+        ),
+    )
+
+    client = _build_message_client(cfg, cfg.id)
+
+    assert isinstance(client, DiscordMessageClient)
+    assert client.channel_ids == {"456"}
+
+
+@pytest.mark.asyncio
+async def test_discord_mention_routes_to_thread_queue_and_rewrites_self_mention():
+    store = await _make_store()
+    client = _client(store)
+    msg = FakeMessage(
+        id="1000",
+        content="<@999> please implement this",
+        author=FakeAuthor(id="42"),
+    )
+
+    await client.handle_discord_message(msg)
+
+    entry = client._thread_state["discord:message:1000"]
+    assert entry.messages[0]["mentions"] == [{
+        "username": "engineer-357c8a5e",
+        "is_bot": True,
+        "is_self": True,
+    }]
+    assert "@you(engineer-357c8a5e)" in entry.messages[0]["text"]
+    assert entry.channel_meta["channel_id"] == "discord:channel:456"
+    assert await store.lookup_channel_space("discord:channel:456") == "discord:guild:123"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_loop_suppresses_unmentioned_bot_messages():
+    store = await _make_store()
+    client = _client(store)
+    msg = FakeMessage(
+        id="1001",
+        content="background bot chatter",
+        author=FakeAuthor(id="43", name="helper", bot=True),
+    )
+
+    await client.handle_discord_message(msg)
+
+    assert client._thread_state == {}
+    assert not await store.has_message("discord:message:1001")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_discord_reply_preserves_root_history_with_prefixed_ids():
+    store = await _make_store()
+    client = _client(store)
+
+    await client.handle_discord_message(FakeMessage(
+        id="2000",
+        content="<@999> root task",
+        author=FakeAuthor(id="42"),
+    ))
+    await client.handle_discord_message(FakeMessage(
+        id="2001",
+        content="follow-up",
+        author=FakeAuthor(id="42"),
+        reference=FakeReference(message_id="2000"),
+    ))
+
+    roots = await store.get_channel_roots("discord:channel:456")
+    assert [r.message.envelope_id for r in roots] == ["discord:message:2000"]
+    assert roots[0].reply_count == 1
+    thread = await store.get_thread_messages("discord:message:2000")
+    assert [m.envelope_id for m in thread] == [
+        "discord:message:2000",
+        "discord:message:2001",
+    ]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_discord_consumer_retries_interrupted_turn_and_marks_processed():
+    store = await _make_store()
+    client = _client(store)
+    await client.handle_discord_message(FakeMessage(
+        id="3000",
+        content="<@999> retry this",
+        author=FakeAuthor(id="42"),
+    ))
+    done = asyncio.Event()
+    calls = {"fresh": 0, "retry": 0, "success": 0}
+
+    async def on_message(root_id, batch, channel_meta):
+        calls["fresh"] += 1
+        raise AgentAPIError("rate limited")
+
+    async def on_retry(root_id, batch, channel_meta):
+        calls["retry"] += 1
+
+    async def on_success(root_id, batch, channel_meta):
+        calls["success"] += 1
+        done.set()
+
+    task = asyncio.create_task(
+        client._consume_queue(
+            on_message,
+            on_api_error_retry=on_retry,
+            on_turn_success=on_success,
+        )
+    )
+    await asyncio.wait_for(done.wait(), timeout=2)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert calls == {"fresh": 1, "retry": 1, "success": 1}
+    assert await store.get_last_processed_sent_at("discord:message:3000") > 0
+    await store.close()

--- a/tests/test_discord_transport.py
+++ b/tests/test_discord_transport.py
@@ -13,9 +13,17 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from puffo_agent.agent.core import AgentAPIError
 from puffo_agent.agent.discord_client import DiscordMessageClient
+from puffo_agent.agent.adapters.base import Adapter, TurnContext, TurnResult
+from puffo_agent.agent.core import PuffoAgent
 from puffo_agent.agent.message_store import MessageStore
-from puffo_agent.portal.state import AgentConfig, DiscordConfig
-from puffo_agent.portal.worker import _build_message_client
+from puffo_agent.portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    DiscordConfig,
+    PuffoCoreConfig,
+    RuntimeConfig,
+)
+from puffo_agent.portal.worker import _build_message_client, build_adapter
 
 
 def _now_ms() -> int:
@@ -103,6 +111,29 @@ def test_build_message_client_selects_discord_backend():
 
     assert isinstance(client, DiscordMessageClient)
     assert client.channel_ids == {"456"}
+
+
+def test_discord_backend_does_not_register_puffo_core_mcp_tools():
+    cfg = AgentConfig(
+        id="engineer-357c8a5e",
+        chat_backend="discord",
+        puffo_core=PuffoCoreConfig(
+            server_url="http://localhost:3000",
+            slug="engineer-357c8a5e",
+            device_id="dev_1",
+            space_id="sp_1",
+        ),
+        discord=DiscordConfig(
+            bot_token="token",
+            guild_id="123",
+            agent_user_id="999",
+        ),
+        runtime=RuntimeConfig(kind="cli-local", harness="claude-code"),
+    )
+
+    adapter = build_adapter(DaemonConfig(), cfg)
+
+    assert not getattr(adapter, "puffo_core_mcp_env", None)
 
 
 @pytest.mark.asyncio
@@ -214,3 +245,88 @@ async def test_discord_consumer_retries_interrupted_turn_and_marks_processed():
     assert calls == {"fresh": 1, "retry": 1, "success": 1}
     assert await store.get_last_processed_sent_at("discord:message:3000") > 0
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_discord_fallback_replies_to_root_message():
+    store = await _make_store()
+    client = _client(store)
+    fake_channel = FakeOutboundChannel()
+    client._discord_client = FakeDiscordClient(fake_channel)
+
+    await client.send_fallback_message(
+        "discord:channel:456",
+        "done",
+        root_id="discord:message:4000",
+    )
+
+    assert fake_channel.sent == []
+    assert fake_channel.root.replies == [("done", False)]
+    await store.close()
+
+
+class FakeToolAdapter(Adapter):
+    async def run_turn(self, ctx: TurnContext) -> TurnResult:
+        return TurnResult(
+            reply="",
+            metadata={
+                "send_message_targets": [{
+                    "channel": "discord:channel:456",
+                    "root_id": "discord:message:5000",
+                    "text": "tool body",
+                }],
+                "assistant_text_parts": [],
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_discord_agent_recovers_send_message_tool_body_as_fallback(tmp_path):
+    agent = PuffoAgent(
+        adapter=FakeToolAdapter(),
+        system_prompt="",
+        memory_dir=str(tmp_path / "memory"),
+        send_message_tools_post_externally=False,
+    )
+
+    reply = await agent.handle_message(
+        channel_id="discord:channel:456",
+        channel_name="general",
+        sender="alice",
+        sender_email="",
+        text="<@999> ship it",
+        post_id="discord:message:5000",
+        root_id="discord:message:5000",
+    )
+
+    assert reply == "tool body"
+
+
+class FakeOutboundRoot:
+    def __init__(self):
+        self.replies = []
+
+    async def reply(self, text, mention_author=False):
+        self.replies.append((text, mention_author))
+
+
+class FakeOutboundChannel:
+    def __init__(self):
+        self.root = FakeOutboundRoot()
+        self.sent = []
+
+    async def fetch_message(self, message_id):
+        assert message_id == 4000
+        return self.root
+
+    async def send(self, text):
+        self.sent.append(text)
+
+
+class FakeDiscordClient:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def get_channel(self, channel_id):
+        assert channel_id == 456
+        return self.channel


### PR DESCRIPTION
## Summary
- add a Discord chat backend config and message-client skeleton that feeds the existing worker/PuffoAgent loop
- preserve Discord mention routing, prefixed root/thread metadata, retry continuation, and outbound root/thread replies
- keep Puffo Core as the default backend and avoid registering Puffo MCP tools for Discord-backed agents

## Verification
- .venv/bin/python -m pip install -e '.[dev]'
- .venv/bin/pytest tests/test_discord_transport.py tests/test_worker_integration.py tests/test_message_store.py tests/test_thread_queue.py tests/test_desired_install_gc_and_harness_gates.py::test_build_adapter_cli_docker_installs_desired_skills tests/test_desired_install_gc_and_harness_gates.py::test_build_adapter_cli_docker_empty_desired_does_not_reject -q

## Broad smoke note
- .venv/bin/pytest -q --ignore=tests/test_host_credentials.py currently fails 15 Codex host-MCP/config tests on this host because they read the machine's real ~/.codex/config.toml entries instead of the temp-home fixtures. The Discord-focused suite and the branch-caused desired-install regressions pass.