### PR TITLE
PUF-317: emit non-replyable system message on channel-membership changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] — 2026-06-25
+
+### Added
+
+- **Membership system messages in the agent transcript.** When another member
+  joins, leaves, or is removed from a channel (or space) the agent is also in,
+  the daemon injects a non-replyable `[puffo-agent system message] Channel
+  membership update: …` envelope so the agent has read-only context (e.g.
+  stop @-mentioning a member that just left). Covers all six event kinds —
+  `accept_channel_invite` / `leave_channel` / `remove_from_channel` plus the
+  three space-scoped variants whose cascade into `channel_memberships` would
+  otherwise be invisible. Space events render in `#general` (lex-first
+  visible channel as fallback) so the agent's transcript lines up with the
+  web client's view.
+- **Inviter citation in `joined` bodies.** Server-auto-accepts that embed
+  `payload.original_invite.signer_slug` now render "(invited by Y)" alongside
+  the joiner. Manual-accept events that don't embed the invite fall back to a
+  per-session `invitation_event_id → inviter_slug` cache populated from the
+  earlier `invite_to_*` event.
+
+### Internal
+
+- Self-targeted membership events still route through the existing
+  `_on_left_*` / `_on_kicked_from_*` operator-DM paths; only OTHER actors
+  feed the announce path. Reconnect-replay is dedup'd both in-memory
+  (`_processed_membership_event_ids`) and at the sqlite layer via a
+  deterministic `envelope_id` keyed on the signed `event_id`.
+
 ## [1.0.0] — 2026-06-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.0.0"
+version = "1.0.1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/event_kinds.py
+++ b/src/puffo_agent/agent/event_kinds.py
@@ -1,0 +1,26 @@
+"""Mirror of puffo-server's ``EventKind`` Rust enum (snake_case wire form).
+
+``StrEnum`` members are ``str`` subclasses, so ``event["kind"] ==
+EventKind.LEAVE_CHANNEL`` and ``json.dumps({"kind": kind})`` both
+work without explicit conversion.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EventKind(StrEnum):
+    INVITE_TO_SPACE = "invite_to_space"
+    INVITE_TO_CHANNEL = "invite_to_channel"
+    ACCEPT_SPACE_INVITE = "accept_space_invite"
+    ACCEPT_CHANNEL_INVITE = "accept_channel_invite"
+    REJECT_SPACE_INVITE = "reject_space_invite"
+    REJECT_CHANNEL_INVITE = "reject_channel_invite"
+    CANCEL_SPACE_INVITE = "cancel_space_invite"
+    CANCEL_CHANNEL_INVITE = "cancel_channel_invite"
+    LEAVE_SPACE = "leave_space"
+    LEAVE_CHANNEL = "leave_channel"
+    REMOVE_FROM_SPACE = "remove_from_space"
+    REMOVE_FROM_CHANNEL = "remove_from_channel"
+    CREATE_CHANNEL = "create_channel"

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -29,6 +29,7 @@ from . import disk_cache
 from ._invite_strings import format_invite_error, format_leave_error
 from .core import AgentAPIError
 from .events import random_nonce, sign_event
+from .event_kinds import EventKind
 from .message_store import MessageStore
 
 logger = logging.getLogger(__name__)
@@ -1466,12 +1467,16 @@ class PuffoCoreMessageClient:
         # is removed so the next mention extraction re-fetches; without
         # this the cache misses the new joiner and their @-mention is
         # silently dropped from the metadata.
-        if kind in ("accept_space_invite", "leave_space", "remove_from_space"):
+        if kind in (
+            EventKind.ACCEPT_SPACE_INVITE,
+            EventKind.LEAVE_SPACE,
+            EventKind.REMOVE_FROM_SPACE,
+        ):
             evict_space_id = payload.get("space_id") or ""
             if evict_space_id:
                 self._space_members.pop(evict_space_id, None)
 
-        if kind in ("invite_to_space", "invite_to_channel"):
+        if kind in (EventKind.INVITE_TO_SPACE, EventKind.INVITE_TO_CHANNEL):
             invite_event_id = event.get("event_id") or ""
             inviter_slug = event.get("signer_slug") or ""
             if invite_event_id and inviter_slug:
@@ -1493,7 +1498,7 @@ class PuffoCoreMessageClient:
         # runs, so the self-intro nudge that path normally fires
         # would otherwise be silently dropped on auto-accept.
         # Mirror just the nudge here.
-        if kind == "accept_channel_invite":
+        if kind == EventKind.ACCEPT_CHANNEL_INVITE:
             if event.get("signer_slug") != self.slug:
                 # Another member joined a channel we may also be in
                 # — fall through to the announce-membership path.
@@ -1531,7 +1536,7 @@ class PuffoCoreMessageClient:
         # the server emits when an operator leaves (puffo-server #74
         # agent-cascade) is signed-as-the-agent — same predicate as
         # a real self-signed leave, so it lands in the same branch.
-        if kind == "leave_space" and event.get("signer_slug") == self.slug:
+        if kind == EventKind.LEAVE_SPACE and event.get("signer_slug") == self.slug:
             await self._on_left_space(
                 space_id=payload.get("space_id") or "",
                 synthetic=str(event.get("signature") or "").startswith(
@@ -1540,20 +1545,20 @@ class PuffoCoreMessageClient:
             )
             return
 
-        if kind == "remove_from_space" and payload.get("removed_slug") == self.slug:
+        if kind == EventKind.REMOVE_FROM_SPACE and payload.get("removed_slug") == self.slug:
             await self._on_kicked_from_space(
                 space_id=payload.get("space_id") or "",
                 kicker_slug=event.get("signer_slug") or "",
             )
             return
 
-        if kind == "leave_channel" and event.get("signer_slug") == self.slug:
+        if kind == EventKind.LEAVE_CHANNEL and event.get("signer_slug") == self.slug:
             await self._on_left_channel(
                 channel_id=payload.get("channel_id") or "",
             )
             return
 
-        if kind == "remove_from_channel" and payload.get("removed_slug") == self.slug:
+        if kind == EventKind.REMOVE_FROM_CHANNEL and payload.get("removed_slug") == self.slug:
             await self._on_kicked_from_channel(
                 channel_id=payload.get("channel_id") or "",
                 space_id=payload.get("space_id") or "",
@@ -1561,7 +1566,7 @@ class PuffoCoreMessageClient:
             )
             return
 
-        if kind in ("leave_channel", "remove_from_channel"):
+        if kind in (EventKind.LEAVE_CHANNEL, EventKind.REMOVE_FROM_CHANNEL):
             await self._maybe_announce_membership_change(
                 kind, event, payload,
             )
@@ -1569,7 +1574,11 @@ class PuffoCoreMessageClient:
 
         # Space cascades silently into channel_memberships server-side
         # — surface here so #general transcript stays current.
-        if kind in ("leave_space", "remove_from_space", "accept_space_invite"):
+        if kind in (
+            EventKind.LEAVE_SPACE,
+            EventKind.REMOVE_FROM_SPACE,
+            EventKind.ACCEPT_SPACE_INVITE,
+        ):
             await self._maybe_announce_space_membership_change(
                 kind, event, payload,
             )
@@ -1580,10 +1589,10 @@ class PuffoCoreMessageClient:
         # added to ``extra_ws_targets`` for cancel/reject). If the
         # operator is still holding an un-answered y/n DM, follow up
         # so they don't reply ``y`` to a dead invite.
-        if kind in ("cancel_space_invite", "cancel_channel_invite"):
+        if kind in (EventKind.CANCEL_SPACE_INVITE, EventKind.CANCEL_CHANNEL_INVITE):
             await self._on_invite_canceled(
                 invitation_event_id=payload.get("invitation_event_id") or "",
-                scope="space" if kind == "cancel_space_invite" else "channel",
+                scope="space" if kind == EventKind.CANCEL_SPACE_INVITE else "channel",
             )
             return
 
@@ -1599,13 +1608,13 @@ class PuffoCoreMessageClient:
         space_id = payload.get("space_id") or ""
         if not channel_id or not space_id:
             return
-        if kind == "invite_to_channel":
+        if kind == EventKind.INVITE_TO_CHANNEL:
             if payload.get("invitee_slug") != self.slug:
                 return
-        elif kind == "accept_channel_invite":
+        elif kind == EventKind.ACCEPT_CHANNEL_INVITE:
             if event.get("signer_slug") != self.slug:
                 return
-        elif kind == "create_channel":
+        elif kind == EventKind.CREATE_CHANNEL:
             pass  # always cache; server only fans to space members
         else:
             return
@@ -1936,7 +1945,7 @@ class PuffoCoreMessageClient:
                 kind, invitation_event_id, inviter_slug, space_id,
             )
             return
-        if kind == "invite_to_channel" and not channel_id:
+        if kind == EventKind.INVITE_TO_CHANNEL and not channel_id:
             self._log.warning(
                 "channel invite missing channel_id: event_id=%s",
                 invitation_event_id,
@@ -1949,7 +1958,7 @@ class PuffoCoreMessageClient:
         # Flag-driven auto-accept covers space invites from non-operators;
         # unlike the (silent) operator path it DMs a report afterwards.
         flag_accept = (
-            kind == "invite_to_space" and self.auto_accept_space_invitations
+            kind == EventKind.INVITE_TO_SPACE and self.auto_accept_space_invitations
         )
         if is_from_operator or flag_accept:
             try:
@@ -2397,14 +2406,14 @@ class PuffoCoreMessageClient:
             decode_secret(sess.subkey_secret_key)
         )
         now_ms = int(__import__("time").time() * 1000)
-        if kind == "invite_to_space":
+        if kind == EventKind.INVITE_TO_SPACE:
             payload: dict[str, Any] = {
                 "space_id": space_id,
                 "invitation_event_id": invitation_event_id,
                 "accepted_at": now_ms,
                 "nonce": random_nonce(),
             }
-            accept_kind = "accept_space_invite"
+            accept_kind = EventKind.ACCEPT_SPACE_INVITE
         else:  # invite_to_channel
             payload = {
                 "space_id": space_id,
@@ -2413,7 +2422,7 @@ class PuffoCoreMessageClient:
                 "accepted_at": now_ms,
                 "nonce": random_nonce(),
             }
-            accept_kind = "accept_channel_invite"
+            accept_kind = EventKind.ACCEPT_CHANNEL_INVITE
         signed = sign_event(
             kind=accept_kind,
             payload=payload,
@@ -2434,7 +2443,7 @@ class PuffoCoreMessageClient:
         # ``send_message`` call (queued right below) could race the
         # WS echo and hit a cache miss on a channel the agent has
         # just provably joined.
-        if kind == "invite_to_channel" and channel_id and space_id:
+        if kind == EventKind.INVITE_TO_CHANNEL and channel_id and space_id:
             try:
                 await self.store.mark_channel_space(channel_id, space_id)
             except Exception:
@@ -2452,9 +2461,9 @@ class PuffoCoreMessageClient:
         # auto-fanned-out into per puffo-server's space-invite redeem
         # logic — any other channel needs its own invite_to_channel).
         intro_channel_id = ""
-        if kind == "invite_to_channel" and channel_id:
+        if kind == EventKind.INVITE_TO_CHANNEL and channel_id:
             intro_channel_id = channel_id
-        elif kind == "invite_to_space":
+        elif kind == EventKind.INVITE_TO_SPACE:
             try:
                 intro_channel_id = await self._find_public_general_channel(
                     space_id,
@@ -2656,7 +2665,7 @@ class PuffoCoreMessageClient:
             return
 
         inviter_slug = ""
-        if kind == "accept_channel_invite":
+        if kind == EventKind.ACCEPT_CHANNEL_INVITE:
             actor_slug = event.get("signer_slug") or ""
             action = "joined"
             kicker_slug = ""
@@ -2669,11 +2678,11 @@ class PuffoCoreMessageClient:
                     inviter_slug = self._inviter_by_invitation_event_id.get(
                         invitation_event_id, "",
                     )
-        elif kind == "leave_channel":
+        elif kind == EventKind.LEAVE_CHANNEL:
             actor_slug = event.get("signer_slug") or ""
             action = "left"
             kicker_slug = ""
-        elif kind == "remove_from_channel":
+        elif kind == EventKind.REMOVE_FROM_CHANNEL:
             actor_slug = payload.get("removed_slug") or ""
             action = "removed"
             kicker_slug = event.get("signer_slug") or ""
@@ -2771,7 +2780,7 @@ class PuffoCoreMessageClient:
             return
 
         inviter_slug = ""
-        if kind == "accept_space_invite":
+        if kind == EventKind.ACCEPT_SPACE_INVITE:
             actor_slug = event.get("signer_slug") or ""
             action = "joined_space"
             kicker_slug = ""
@@ -2784,11 +2793,11 @@ class PuffoCoreMessageClient:
                     inviter_slug = self._inviter_by_invitation_event_id.get(
                         invitation_event_id, "",
                     )
-        elif kind == "leave_space":
+        elif kind == EventKind.LEAVE_SPACE:
             actor_slug = event.get("signer_slug") or ""
             action = "left_space"
             kicker_slug = ""
-        elif kind == "remove_from_space":
+        elif kind == EventKind.REMOVE_FROM_SPACE:
             actor_slug = payload.get("removed_slug") or ""
             action = "removed_from_space"
             kicker_slug = event.get("signer_slug") or ""
@@ -3051,7 +3060,7 @@ class PuffoCoreMessageClient:
             )
         space_label = await self._resolve_space_name(space_id)
         channel_label = ""
-        if kind == "leave_channel":
+        if kind == EventKind.LEAVE_CHANNEL:
             channel_label = await self._resolve_channel_name(
                 space_id=space_id, channel_id=channel_id,
             )
@@ -3123,7 +3132,7 @@ class PuffoCoreMessageClient:
                 )
                 # Suppress the WS echo's generic membership DM (space only);
                 # the in-thread confirm below is the authoritative report.
-                if kind == "leave_space":
+                if kind == EventKind.LEAVE_SPACE:
                     self._gate_left_spaces.add(space_id)
                 confirm = f"Left {target}. ✓"
                 self._log.info(
@@ -3195,7 +3204,7 @@ class PuffoCoreMessageClient:
             decode_secret(sess.subkey_secret_key)
         )
         now_ms = int(__import__("time").time() * 1000)
-        if kind == "leave_channel":
+        if kind == EventKind.LEAVE_CHANNEL:
             payload: dict[str, Any] = {
                 "space_id": space_id,
                 "channel_id": channel_id,
@@ -3315,14 +3324,14 @@ class PuffoCoreMessageClient:
             decode_secret(sess.subkey_secret_key)
         )
         now_ms = int(__import__("time").time() * 1000)
-        if kind == "invite_to_space":
+        if kind == EventKind.INVITE_TO_SPACE:
             payload: dict[str, Any] = {
                 "space_id": space_id,
                 "invitation_event_id": invitation_event_id,
                 "rejected_at": now_ms,
                 "nonce": random_nonce(),
             }
-            reject_kind = "reject_space_invite"
+            reject_kind = EventKind.REJECT_SPACE_INVITE
         else:  # invite_to_channel
             payload = {
                 "space_id": space_id,
@@ -3331,7 +3340,7 @@ class PuffoCoreMessageClient:
                 "rejected_at": now_ms,
                 "nonce": random_nonce(),
             }
-            reject_kind = "reject_channel_invite"
+            reject_kind = EventKind.REJECT_CHANNEL_INVITE
         signed = sign_event(
             kind=reject_kind,
             payload=payload,
@@ -3376,7 +3385,7 @@ class PuffoCoreMessageClient:
             if inviter_display else f"@{inviter_slug}"
         )
         space_label = f"**{space_name}**({space_id})" if space_name else space_id
-        if kind == "invite_to_space":
+        if kind == EventKind.INVITE_TO_SPACE:
             text = (
                 f"{inviter_label} invited me to space {space_label}. "
                 f"They aren't my registered operator. "

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -2917,7 +2917,7 @@ class PuffoCoreMessageClient:
         )
         prompt_text = (
             f"[puffo-agent system message] Channel membership update: "
-            f"{body} This is an announcement; you cannot reply to it."
+            f"{body} This is an announcement, for your context."
         )
 
         msg_dict = {

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -2707,6 +2707,52 @@ class PuffoCoreMessageClient:
         if event_id:
             self._processed_membership_event_ids.add(event_id)
 
+    async def _pick_space_channel(self, space_id: str) -> str:
+        """Pick #general for the space-event announce target, falling
+        back to lex-first. Tries ``_channel_space`` first (in-memory
+        from prior per-channel events); if that's empty (e.g. the agent
+        cascade-joined via ``accept_space_invite``), fetches the
+        channel list and warms ``_channel_space`` for next time.
+        Returns "" if nothing usable found."""
+        known = sorted(
+            cid for cid, sid in self._channel_space.items()
+            if sid == space_id
+        )
+        if known:
+            for cid in known:
+                name = await self._resolve_channel_name(
+                    space_id=space_id, channel_id=cid,
+                )
+                if (name or "").strip().lower() == "general":
+                    return cid
+            return known[0]
+        try:
+            data = await self.http.get(f"/spaces/{space_id}/channels")
+        except Exception:
+            return ""
+        if not isinstance(data, dict):
+            return ""
+        channels = data.get("channels") or []
+        if not isinstance(channels, list) or not channels:
+            return ""
+        general = ""
+        first = ""
+        for c in channels:
+            if not isinstance(c, dict):
+                continue
+            cid = (c.get("channel_id") or "").strip()
+            if not cid:
+                continue
+            self._channel_space[cid] = space_id
+            name = (c.get("name") or "").strip()
+            if name:
+                self._channel_name_cache.setdefault(cid, name)
+            if not first:
+                first = cid
+            if not general and name.lower() == "general":
+                general = cid
+        return general or first
+
     async def _maybe_announce_space_membership_change(
         self, kind: str, event: dict, payload: dict,
     ) -> None:
@@ -2716,20 +2762,13 @@ class PuffoCoreMessageClient:
         if not space_id:
             return
 
-        channels_in_space = sorted(
-            cid for cid, sid in self._channel_space.items()
-            if sid == space_id
-        )
-        if not channels_in_space:
+        # ``accept_space_invite`` cascades the agent into public channels
+        # server-side without per-channel events, so ``_channel_space``
+        # stays empty for those. Lazy-fetch the channel list so we can
+        # still announce.
+        target_channel_id = await self._pick_space_channel(space_id)
+        if not target_channel_id:
             return
-        target_channel_id = channels_in_space[0]
-        for cid in channels_in_space:
-            name = await self._resolve_channel_name(
-                space_id=space_id, channel_id=cid,
-            )
-            if (name or "").strip().lower() == "general":
-                target_channel_id = cid
-                break
 
         inviter_slug = ""
         if kind == "accept_space_invite":

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -511,16 +511,8 @@ class PuffoCoreMessageClient:
         # invite. Lost on daemon restart (acceptable: re-DM rate is
         # naturally rare).
         self._processed_invite_ids: set[str] = set()
-        # WS event_ids the membership-announce path has already emitted.
-        # Same lifetime + reset semantics as ``_processed_invite_ids``;
-        # reconnect-replay would otherwise double up "Bob left #channel".
         self._processed_membership_event_ids: set[str] = set()
-        # ``invitation_event_id -> inviter_slug`` cache for the manual-
-        # accept path (server-auto-accept embeds the original signed
-        # invite under ``original_invite``; manual accepts don't, so the
-        # announce body falls back to this cache for "(invited by X)").
-        # Lifetime-scoped — post-restart manual-accepts we never saw the
-        # invite for render without the suffix.
+        # Fallback for manual-accept events that omit ``original_invite``.
         self._inviter_by_invitation_event_id: dict[str, str] = {}
         # When the worker DMs the operator about a non-auto-acceptable
         # invite, the DM's envelope_id lives here so a ``y``/``n``
@@ -1480,8 +1472,6 @@ class PuffoCoreMessageClient:
                 self._space_members.pop(evict_space_id, None)
 
         if kind in ("invite_to_space", "invite_to_channel"):
-            # Cache inviter so a later manual-accept (which omits
-            # ``original_invite``) can still render "(invited by X)".
             invite_event_id = event.get("event_id") or ""
             inviter_slug = event.get("signer_slug") or ""
             if invite_event_id and inviter_slug:
@@ -1571,19 +1561,14 @@ class PuffoCoreMessageClient:
             )
             return
 
-        # OTHER-member channel events → inject a non-replyable system
-        # message into the agent's transcript so it has live context
-        # (e.g. stop @-mentioning a member that just left).
         if kind in ("leave_channel", "remove_from_channel"):
             await self._maybe_announce_membership_change(
                 kind, event, payload,
             )
             return
 
-        # Space-level membership cascades into ``channel_memberships``
-        # server-side without per-channel events, so without this
-        # announce the agent keeps @-mentioning a member who silently
-        # dropped out of #general (or fails to greet an auto-joiner).
+        # Space cascades silently into channel_memberships server-side
+        # — surface here so #general transcript stays current.
         if kind in ("leave_space", "remove_from_space", "accept_space_invite"):
             await self._maybe_announce_space_membership_change(
                 kind, event, payload,
@@ -2665,21 +2650,7 @@ class PuffoCoreMessageClient:
     async def _maybe_announce_membership_change(
         self, kind: str, event: dict, payload: dict,
     ) -> None:
-        """Surface another member's channel join/leave/removal into
-        the agent's transcript as a non-replyable system-message.
-
-        Predicate: skip when the channel isn't one the agent has
-        visibility into (``_channel_space`` populated via prior
-        ``invite_to_channel`` / ``accept_channel_invite`` /
-        ``create_channel``) so we don't announce on channels we'd
-        only see as a forwarded event noise. Skip when the actor is
-        this agent itself — self-joins go through
-        ``_enqueue_channel_intro_nudge`` and self-exits surface via
-        operator-DM paths; double-emitting would confuse the agent.
-
-        Idempotent against ``event.event_id``: a reconnect-replay
-        of the same signed event won't enqueue a second envelope.
-        """
+        """System row for other-actor channel membership. Dedup'd by event_id."""
         channel_id = payload.get("channel_id") or ""
         if not channel_id or channel_id not in self._channel_space:
             return
@@ -2689,9 +2660,6 @@ class PuffoCoreMessageClient:
             actor_slug = event.get("signer_slug") or ""
             action = "joined"
             kicker_slug = ""
-            # Server-auto-accept embeds the inviter under
-            # ``original_invite``; manual accepts fall through to the
-            # cache populated in the ``invite_to_*`` branch.
             original_invite = payload.get("original_invite")
             if isinstance(original_invite, dict):
                 inviter_slug = original_invite.get("signer_slug") or ""
@@ -2742,17 +2710,8 @@ class PuffoCoreMessageClient:
     async def _maybe_announce_space_membership_change(
         self, kind: str, event: dict, payload: dict,
     ) -> None:
-        """Surface another member's space-level join/leave/removal
-        into the agent's transcript as a non-replyable system-message
-        in a channel the agent shares with the space.
-
-        Prefers the channel named ``general`` (case-insensitive) so
-        the agent's transcript lines up with the human-side UI, which
-        renders space events into General. Falls back to the
-        lexicographically-first visible channel when no General is
-        present. Skip silently when the agent has no visibility into
-        any channel of the space — no transcript to surface into.
-        """
+        """System row for other-actor space membership. Renders in
+        #general (lex-first visible channel as fallback)."""
         space_id = payload.get("space_id") or ""
         if not space_id:
             return
@@ -2777,7 +2736,6 @@ class PuffoCoreMessageClient:
             actor_slug = event.get("signer_slug") or ""
             action = "joined_space"
             kicker_slug = ""
-            # Same cache fallback as the channel path.
             original_invite = payload.get("original_invite")
             if isinstance(original_invite, dict):
                 inviter_slug = original_invite.get("signer_slug") or ""
@@ -2835,16 +2793,7 @@ class PuffoCoreMessageClient:
         inviter_slug: str = "",
         event_id: str = "",
     ) -> None:
-        """Inject a non-replyable ``[puffo-agent system message]``
-        envelope announcing a membership change. Mirrors
-        ``_enqueue_channel_intro_nudge`` (PRIORITY_SYSTEM, sender
-        ``system``, persisted to messages.db) but the body is an
-        announcement and the prefix marker signals no reply expected.
-
-        ``action`` ∈ {joined, left, removed, joined_space, left_space,
-        removed_from_space}. ``kicker_slug`` used on ``removed*``;
-        ``inviter_slug`` used on ``joined*``.
-        """
+        """Non-replyable system row for a membership change."""
         space_id = self._channel_space.get(channel_id) or ""
         space_name = (
             await self._resolve_space_name(space_id) if space_id else ""
@@ -2913,8 +2862,7 @@ class PuffoCoreMessageClient:
             return
 
         now_ms = int(time.time() * 1000)
-        # Signed event_id makes the envelope_id deterministic so the
-        # store's INSERT OR IGNORE dedups reconnect-replay.
+        # Deterministic suffix → INSERT OR IGNORE dedups reconnect-replay.
         envelope_id_suffix = event_id or str(now_ms)
         envelope_id = (
             f"membership-{action}-{channel_id}-{actor_slug}-{envelope_id_suffix}"

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1572,6 +1572,23 @@ class PuffoCoreMessageClient:
             )
             return
 
+        # PUF-317 review-#1: space-level membership for OTHER actors.
+        # puffo-server #74 ``cascade_remove_from_channels`` mutates the
+        # ``channel_memberships`` table directly when an operator
+        # leaves or is removed from a space — no per-channel
+        # ``leave_channel`` event fires for the cascaded slugs. Without
+        # this announce path the agent keeps @-mentioning a member
+        # who's silently dropped out of #general. ``accept_space_invite``
+        # cascade into auto-joined public channels has the same
+        # symptom in reverse. Surface all three through the same
+        # announce wrapper so the General-channel transcript stays in
+        # sync with channel-roster reality.
+        if kind in ("leave_space", "remove_from_space", "accept_space_invite"):
+            await self._maybe_announce_space_membership_change(
+                kind, event, payload,
+            )
+            return
+
         # Invite-withdrawn paths. The server emits the cancel to the
         # invitee's session too (puffo-server review/events: invitee
         # added to ``extra_ws_targets`` for cancel/reject). If the
@@ -2666,10 +2683,19 @@ class PuffoCoreMessageClient:
         if not channel_id or channel_id not in self._channel_space:
             return
 
+        inviter_slug = ""
         if kind == "accept_channel_invite":
             actor_slug = event.get("signer_slug") or ""
             action = "joined"
             kicker_slug = ""
+            # PUF-317 review-#2: server-auto-accept embeds the
+            # original signed InviteToChannel under ``original_invite``;
+            # its ``signer_slug`` is the inviter. Manual-accept paths
+            # omit ``original_invite`` so this falls back to "" and
+            # the body just renders "Alice joined channel #general."
+            original_invite = payload.get("original_invite")
+            if isinstance(original_invite, dict):
+                inviter_slug = original_invite.get("signer_slug") or ""
         elif kind == "leave_channel":
             actor_slug = event.get("signer_slug") or ""
             action = "left"
@@ -2694,6 +2720,7 @@ class PuffoCoreMessageClient:
                 actor_slug=actor_slug,
                 action=action,
                 kicker_slug=kicker_slug,
+                inviter_slug=inviter_slug,
                 event_id=event_id,
             )
         except Exception:
@@ -2707,6 +2734,90 @@ class PuffoCoreMessageClient:
         if event_id:
             self._processed_membership_event_ids.add(event_id)
 
+    async def _maybe_announce_space_membership_change(
+        self, kind: str, event: dict, payload: dict,
+    ) -> None:
+        """Surface another member's space-level join/leave/removal
+        into the agent's transcript as a non-replyable system-message
+        in a channel the agent shares with the space.
+
+        PUF-317 review-#1: puffo-server #74
+        ``cascade_remove_from_channels`` mutates
+        ``channel_memberships`` directly on a space exit — no
+        per-channel ``leave_channel`` event fires for the cascaded
+        slugs. ``accept_space_invite`` cascades into auto-joined
+        public channels with the same symptom in reverse. Without
+        this announce path the agent keeps @-mentioning a member
+        who silently dropped out of #general (or fails to greet a
+        member who just auto-joined).
+
+        Resolves the space to the lexicographically-first channel
+        the agent has visibility into within that space
+        (``_channel_space`` mapping). Stable pick so reconnect-replay
+        collapses to the same target envelope_id. Skip silently when
+        the agent has no visibility into any channel of the space —
+        no transcript to surface into.
+        """
+        space_id = payload.get("space_id") or ""
+        if not space_id:
+            return
+
+        channels_in_space = sorted(
+            cid for cid, sid in self._channel_space.items()
+            if sid == space_id
+        )
+        if not channels_in_space:
+            return
+        target_channel_id = channels_in_space[0]
+
+        inviter_slug = ""
+        if kind == "accept_space_invite":
+            actor_slug = event.get("signer_slug") or ""
+            action = "joined_space"
+            kicker_slug = ""
+            # Mirror the channel path: server-auto-accept embeds the
+            # original signed InviteToSpace under ``original_invite``.
+            original_invite = payload.get("original_invite")
+            if isinstance(original_invite, dict):
+                inviter_slug = original_invite.get("signer_slug") or ""
+        elif kind == "leave_space":
+            actor_slug = event.get("signer_slug") or ""
+            action = "left_space"
+            kicker_slug = ""
+        elif kind == "remove_from_space":
+            actor_slug = payload.get("removed_slug") or ""
+            action = "removed_from_space"
+            kicker_slug = event.get("signer_slug") or ""
+        else:
+            return
+
+        if not actor_slug or actor_slug == self.slug:
+            return
+
+        event_id = event.get("event_id") or ""
+        if event_id and event_id in self._processed_membership_event_ids:
+            return
+
+        try:
+            await self._enqueue_membership_system_message(
+                channel_id=target_channel_id,
+                actor_slug=actor_slug,
+                action=action,
+                kicker_slug=kicker_slug,
+                inviter_slug=inviter_slug,
+                event_id=event_id,
+            )
+        except Exception:
+            self._log.exception(
+                "failed to enqueue space membership system-message "
+                "(kind=%s space=%s actor=%s)",
+                kind, space_id, actor_slug,
+            )
+            return
+
+        if event_id:
+            self._processed_membership_event_ids.add(event_id)
+
     async def _enqueue_membership_system_message(
         self,
         *,
@@ -2714,18 +2825,23 @@ class PuffoCoreMessageClient:
         actor_slug: str,
         action: str,
         kicker_slug: str = "",
+        inviter_slug: str = "",
         event_id: str = "",
     ) -> None:
         """Inject a non-replyable ``[puffo-agent system message]``
-        envelope announcing a channel membership change. Mirrors
-        ``_enqueue_channel_intro_nudge`` (PRIORITY_SYSTEM, sender_slug
-        ``system``, persisted to messages.db so
-        ``get_channel_history`` stays coherent) but the body is an
-        announcement — there's no directive, and the prefix marker
-        signals to the agent that no reply is expected.
+        envelope announcing a channel- or space-level membership
+        change. Mirrors ``_enqueue_channel_intro_nudge``
+        (PRIORITY_SYSTEM, sender_slug ``system``, persisted to
+        messages.db so ``get_channel_history`` stays coherent) but
+        the body is an announcement — there's no directive, and the
+        prefix marker signals to the agent that no reply is
+        expected.
 
-        ``action`` is one of ``"joined" | "left" | "removed"``.
-        ``kicker_slug`` only consulted when ``action == "removed"``.
+        ``action`` is one of ``"joined" | "left" | "removed" |
+        "joined_space" | "left_space" | "removed_from_space"``.
+        ``kicker_slug`` only consulted when ``action`` ends in
+        ``"removed"``. ``inviter_slug`` only consulted when ``action``
+        starts with ``"joined"`` (server-auto-accept inviter cite).
         """
         space_id = self._channel_space.get(channel_id) or ""
         space_name = (
@@ -2739,9 +2855,25 @@ class PuffoCoreMessageClient:
             f"**{actor_display}**(@{actor_slug})"
             if actor_display else f"@{actor_slug}"
         )
+        space_label = (
+            f"**{space_name}**" if space_name else (space_id or "the space")
+        )
+
+        async def _invited_by_suffix() -> str:
+            # Server-auto-accept embeds the inviter; manual-accept
+            # omits original_invite, so this falls through to "".
+            if not inviter_slug:
+                return ""
+            inviter_display = await self._fetch_display_name(inviter_slug)
+            inviter_label = (
+                f"**{inviter_display}**(@{inviter_slug})"
+                if inviter_display else f"@{inviter_slug}"
+            )
+            return f" (invited by {inviter_label})"
 
         if action == "joined":
-            body = f"{actor_label} joined channel #{channel_name}."
+            suffix = await _invited_by_suffix()
+            body = f"{actor_label} joined channel #{channel_name}{suffix}."
         elif action == "left":
             body = f"{actor_label} left channel #{channel_name}."
         elif action == "removed":
@@ -2757,6 +2889,25 @@ class PuffoCoreMessageClient:
             body = (
                 f"{actor_label} was removed from channel "
                 f"#{channel_name} by {kicker_label}."
+            )
+        elif action == "joined_space":
+            suffix = await _invited_by_suffix()
+            body = f"{actor_label} joined space {space_label}{suffix}."
+        elif action == "left_space":
+            body = f"{actor_label} left space {space_label}."
+        elif action == "removed_from_space":
+            kicker_display = (
+                await self._fetch_display_name(kicker_slug)
+                if kicker_slug else ""
+            )
+            kicker_label = (
+                f"**{kicker_display}**(@{kicker_slug})"
+                if kicker_display
+                else f"@{kicker_slug}" if kicker_slug else "an operator"
+            )
+            body = (
+                f"{actor_label} was removed from space "
+                f"{space_label} by {kicker_label}."
             )
         else:
             return

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -511,6 +511,14 @@ class PuffoCoreMessageClient:
         # invite. Lost on daemon restart (acceptable: re-DM rate is
         # naturally rare).
         self._processed_invite_ids: set[str] = set()
+        # PUF-317: WS event_ids the membership-announce path has
+        # already emitted for. Reconnect-replay would otherwise show
+        # the agent two "Bob left #channel" envelopes back-to-back
+        # — same lifetime + reset semantics as
+        # ``_processed_invite_ids``. Memory cost stays bounded in
+        # practice (~24 bytes per event_id; channels with sustained
+        # churn at 1Hz would take ~5 days to reach 10MB).
+        self._processed_membership_event_ids: set[str] = set()
         # When the worker DMs the operator about a non-auto-acceptable
         # invite, the DM's envelope_id lives here so a ``y``/``n``
         # reply in that thread can be intercepted inside the daemon.
@@ -2650,6 +2658,9 @@ class PuffoCoreMessageClient:
         this agent itself — self-joins go through
         ``_enqueue_channel_intro_nudge`` and self-exits surface via
         operator-DM paths; double-emitting would confuse the agent.
+
+        Idempotent against ``event.event_id``: a reconnect-replay
+        of the same signed event won't enqueue a second envelope.
         """
         channel_id = payload.get("channel_id") or ""
         if not channel_id or channel_id not in self._channel_space:
@@ -2673,12 +2684,17 @@ class PuffoCoreMessageClient:
         if not actor_slug or actor_slug == self.slug:
             return
 
+        event_id = event.get("event_id") or ""
+        if event_id and event_id in self._processed_membership_event_ids:
+            return
+
         try:
             await self._enqueue_membership_system_message(
                 channel_id=channel_id,
                 actor_slug=actor_slug,
                 action=action,
                 kicker_slug=kicker_slug,
+                event_id=event_id,
             )
         except Exception:
             self._log.exception(
@@ -2686,6 +2702,10 @@ class PuffoCoreMessageClient:
                 "(kind=%s channel=%s actor=%s)",
                 kind, channel_id, actor_slug,
             )
+            return
+
+        if event_id:
+            self._processed_membership_event_ids.add(event_id)
 
     async def _enqueue_membership_system_message(
         self,
@@ -2694,6 +2714,7 @@ class PuffoCoreMessageClient:
         actor_slug: str,
         action: str,
         kicker_slug: str = "",
+        event_id: str = "",
     ) -> None:
         """Inject a non-replyable ``[puffo-agent system message]``
         envelope announcing a channel membership change. Mirrors
@@ -2741,8 +2762,16 @@ class PuffoCoreMessageClient:
             return
 
         now_ms = int(time.time() * 1000)
+        # Prefer the signed event_id when available so a
+        # reconnect-replay collapses to the same envelope_id and the
+        # store's INSERT OR IGNORE rejects the duplicate at the
+        # sqlite layer in addition to the in-memory dedup set in
+        # ``_maybe_announce_membership_change``. Fall back to the
+        # ms-timestamp when callers omit event_id (direct unit-test
+        # invocation of this helper).
+        envelope_id_suffix = event_id or str(now_ms)
         envelope_id = (
-            f"membership-{action}-{channel_id}-{actor_slug}-{now_ms}"
+            f"membership-{action}-{channel_id}-{actor_slug}-{envelope_id_suffix}"
         )
         prompt_text = (
             f"[puffo-agent system message] Channel membership update: "

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -519,6 +519,20 @@ class PuffoCoreMessageClient:
         # practice (~24 bytes per event_id; channels with sustained
         # churn at 1Hz would take ~5 days to reach 10MB).
         self._processed_membership_event_ids: set[str] = set()
+        # PUF-317 PR #94 review-#3: ``invitation_event_id ->
+        # inviter_slug`` recorded on inbound ``invite_to_*`` events
+        # (signer of the invite IS the inviter). Consulted by the
+        # membership-announce paths when a manual-accept
+        # ``accept_*_invite`` arrives without ``original_invite``
+        # (server-auto-accept only embeds the original signed
+        # invite; manual-accept paths omit it). Mirrors the web
+        # side's ``_inviter_by_invitation`` cache. Lifetime-scoped
+        # like ``_processed_invite_ids`` — lost on daemon restart;
+        # post-restart manual-accepts that we haven't observed the
+        # invite for will silently render the body without an
+        # inviter suffix, which is the same shape as the existing
+        # "no original_invite" path.
+        self._inviter_by_invitation_event_id: dict[str, str] = {}
         # When the worker DMs the operator about a non-auto-acceptable
         # invite, the DM's envelope_id lives here so a ``y``/``n``
         # reply in that thread can be intercepted inside the daemon.
@@ -1477,6 +1491,18 @@ class PuffoCoreMessageClient:
                 self._space_members.pop(evict_space_id, None)
 
         if kind in ("invite_to_space", "invite_to_channel"):
+            # PUF-317 PR #94 review-#3: record inviter so a
+            # later manual-accept (which omits ``original_invite``
+            # — only server-auto-accept embeds it) can still
+            # render "(invited by X)" in the announce body. The
+            # signed invite's ``event_id`` becomes the key the
+            # accept event carries as ``invitation_event_id``.
+            invite_event_id = event.get("event_id") or ""
+            inviter_slug = event.get("signer_slug") or ""
+            if invite_event_id and inviter_slug:
+                self._inviter_by_invitation_event_id[invite_event_id] = (
+                    inviter_slug
+                )
             if payload.get("invitee_slug") != self.slug:
                 return  # Server fans the event to space members too.
             await self._poll_pending_invites()
@@ -2691,11 +2717,18 @@ class PuffoCoreMessageClient:
             # PUF-317 review-#2: server-auto-accept embeds the
             # original signed InviteToChannel under ``original_invite``;
             # its ``signer_slug`` is the inviter. Manual-accept paths
-            # omit ``original_invite`` so this falls back to "" and
-            # the body just renders "Alice joined channel #general."
+            # omit ``original_invite``, so review-#3 falls through to
+            # the ``_inviter_by_invitation_event_id`` cache populated
+            # in ``_handle_event``'s ``invite_to_*`` branch.
             original_invite = payload.get("original_invite")
             if isinstance(original_invite, dict):
                 inviter_slug = original_invite.get("signer_slug") or ""
+            if not inviter_slug:
+                invitation_event_id = payload.get("invitation_event_id") or ""
+                if invitation_event_id:
+                    inviter_slug = self._inviter_by_invitation_event_id.get(
+                        invitation_event_id, "",
+                    )
         elif kind == "leave_channel":
             actor_slug = event.get("signer_slug") or ""
             action = "left"
@@ -2776,10 +2809,17 @@ class PuffoCoreMessageClient:
             action = "joined_space"
             kicker_slug = ""
             # Mirror the channel path: server-auto-accept embeds the
-            # original signed InviteToSpace under ``original_invite``.
+            # original signed InviteToSpace under ``original_invite``;
+            # manual-accept falls through to the cache.
             original_invite = payload.get("original_invite")
             if isinstance(original_invite, dict):
                 inviter_slug = original_invite.get("signer_slug") or ""
+            if not inviter_slug:
+                invitation_event_id = payload.get("invitation_event_id") or ""
+                if invitation_event_id:
+                    inviter_slug = self._inviter_by_invitation_event_id.get(
+                        invitation_event_id, "",
+                    )
         elif kind == "leave_space":
             actor_slug = event.get("signer_slug") or ""
             action = "left_space"

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1486,7 +1486,12 @@ class PuffoCoreMessageClient:
         # Mirror just the nudge here.
         if kind == "accept_channel_invite":
             if event.get("signer_slug") != self.slug:
-                return  # Someone else's accept — not our business.
+                # Another member joined a channel we may also be in
+                # — fall through to the announce-membership path.
+                await self._maybe_announce_membership_change(
+                    kind, event, payload,
+                )
+                return
             # Distinguish the server-emitted synthetic from a
             # real signed accept that's bouncing back over WS.
             # ``original_invite`` is the canonical marker — the
@@ -1544,6 +1549,18 @@ class PuffoCoreMessageClient:
                 channel_id=payload.get("channel_id") or "",
                 space_id=payload.get("space_id") or "",
                 kicker_slug=event.get("signer_slug") or "",
+            )
+            return
+
+        # Membership-change announcements for OTHER members of a
+        # channel this agent is also in. Distinct from the
+        # self-targeted branches above (those DM the operator);
+        # these inject a non-replyable system-message into the
+        # agent's transcript so it can react in-context (e.g. stop
+        # @-mentioning a member that just left). PUF-317.
+        if kind in ("leave_channel", "remove_from_channel"):
+            await self._maybe_announce_membership_change(
+                kind, event, payload,
             )
             return
 
@@ -2617,6 +2634,177 @@ class PuffoCoreMessageClient:
         self._log.info(
             "enqueued channel-intro nudge for channel=%s (space=%s)",
             channel_id, space_id,
+        )
+
+    async def _maybe_announce_membership_change(
+        self, kind: str, event: dict, payload: dict,
+    ) -> None:
+        """Surface another member's channel join/leave/removal into
+        the agent's transcript as a non-replyable system-message.
+
+        Predicate: skip when the channel isn't one the agent has
+        visibility into (``_channel_space`` populated via prior
+        ``invite_to_channel`` / ``accept_channel_invite`` /
+        ``create_channel``) so we don't announce on channels we'd
+        only see as a forwarded event noise. Skip when the actor is
+        this agent itself — self-joins go through
+        ``_enqueue_channel_intro_nudge`` and self-exits surface via
+        operator-DM paths; double-emitting would confuse the agent.
+        """
+        channel_id = payload.get("channel_id") or ""
+        if not channel_id or channel_id not in self._channel_space:
+            return
+
+        if kind == "accept_channel_invite":
+            actor_slug = event.get("signer_slug") or ""
+            action = "joined"
+            kicker_slug = ""
+        elif kind == "leave_channel":
+            actor_slug = event.get("signer_slug") or ""
+            action = "left"
+            kicker_slug = ""
+        elif kind == "remove_from_channel":
+            actor_slug = payload.get("removed_slug") or ""
+            action = "removed"
+            kicker_slug = event.get("signer_slug") or ""
+        else:
+            return
+
+        if not actor_slug or actor_slug == self.slug:
+            return
+
+        try:
+            await self._enqueue_membership_system_message(
+                channel_id=channel_id,
+                actor_slug=actor_slug,
+                action=action,
+                kicker_slug=kicker_slug,
+            )
+        except Exception:
+            self._log.exception(
+                "failed to enqueue membership system-message "
+                "(kind=%s channel=%s actor=%s)",
+                kind, channel_id, actor_slug,
+            )
+
+    async def _enqueue_membership_system_message(
+        self,
+        *,
+        channel_id: str,
+        actor_slug: str,
+        action: str,
+        kicker_slug: str = "",
+    ) -> None:
+        """Inject a non-replyable ``[puffo-agent system message]``
+        envelope announcing a channel membership change. Mirrors
+        ``_enqueue_channel_intro_nudge`` (PRIORITY_SYSTEM, sender_slug
+        ``system``, persisted to messages.db so
+        ``get_channel_history`` stays coherent) but the body is an
+        announcement — there's no directive, and the prefix marker
+        signals to the agent that no reply is expected.
+
+        ``action`` is one of ``"joined" | "left" | "removed"``.
+        ``kicker_slug`` only consulted when ``action == "removed"``.
+        """
+        space_id = self._channel_space.get(channel_id) or ""
+        space_name = (
+            await self._resolve_space_name(space_id) if space_id else ""
+        )
+        channel_name = await self._resolve_channel_name(
+            space_id=space_id, channel_id=channel_id,
+        )
+        actor_display = await self._fetch_display_name(actor_slug)
+        actor_label = (
+            f"**{actor_display}**(@{actor_slug})"
+            if actor_display else f"@{actor_slug}"
+        )
+
+        if action == "joined":
+            body = f"{actor_label} joined channel #{channel_name}."
+        elif action == "left":
+            body = f"{actor_label} left channel #{channel_name}."
+        elif action == "removed":
+            kicker_display = (
+                await self._fetch_display_name(kicker_slug)
+                if kicker_slug else ""
+            )
+            kicker_label = (
+                f"**{kicker_display}**(@{kicker_slug})"
+                if kicker_display
+                else f"@{kicker_slug}" if kicker_slug else "an operator"
+            )
+            body = (
+                f"{actor_label} was removed from channel "
+                f"#{channel_name} by {kicker_label}."
+            )
+        else:
+            return
+
+        now_ms = int(time.time() * 1000)
+        envelope_id = (
+            f"membership-{action}-{channel_id}-{actor_slug}-{now_ms}"
+        )
+        prompt_text = (
+            f"[puffo-agent system message] Channel membership update: "
+            f"{body} This is an announcement; you cannot reply to it."
+        )
+
+        msg_dict = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "sender_slug": "system",
+            "sender_display_name": "",
+            "sender_email": "",
+            "text": prompt_text,
+            "root_id": "",
+            "is_dm": False,
+            "attachments": [],
+            "sender_is_bot": False,
+            "mentions": [],
+            "envelope_id": envelope_id,
+            "sent_at": now_ms,
+        }
+        channel_meta = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "is_dm": False,
+        }
+
+        store_payload = {
+            "envelope_id": envelope_id,
+            "envelope_kind": "channel",
+            "sender_slug": "system",
+            "channel_id": channel_id,
+            "space_id": space_id,
+            "content_type": "text/plain",
+            "content": prompt_text,
+            "sent_at": now_ms,
+            "thread_root_id": envelope_id,
+            "reply_to_id": None,
+        }
+        try:
+            await self.store.store(store_payload)
+        except Exception as exc:  # noqa: BLE001
+            self._log.warning(
+                "membership system-message: failed to persist "
+                "envelope=%s to messages.db: %s",
+                envelope_id, exc,
+            )
+
+        await self._admit_thread_message(
+            root_id=envelope_id,
+            priority=PRIORITY_SYSTEM,
+            msg_dict=msg_dict,
+            channel_meta=channel_meta,
+        )
+        self._log.info(
+            "enqueued membership system-message channel=%s "
+            "actor=%s action=%s",
+            channel_id, actor_slug, action,
         )
 
     def _resolve_invite_targets(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -2784,12 +2784,12 @@ class PuffoCoreMessageClient:
         who silently dropped out of #general (or fails to greet a
         member who just auto-joined).
 
-        Resolves the space to the lexicographically-first channel
-        the agent has visibility into within that space
-        (``_channel_space`` mapping). Stable pick so reconnect-replay
-        collapses to the same target envelope_id. Skip silently when
-        the agent has no visibility into any channel of the space —
-        no transcript to surface into.
+        Prefers the channel named ``general`` (case-insensitive) so
+        the agent's transcript lines up with the human-side UI, which
+        renders space events into General. Falls back to the
+        lexicographically-first visible channel when no General is
+        present. Skip silently when the agent has no visibility into
+        any channel of the space — no transcript to surface into.
         """
         space_id = payload.get("space_id") or ""
         if not space_id:
@@ -2802,6 +2802,13 @@ class PuffoCoreMessageClient:
         if not channels_in_space:
             return
         target_channel_id = channels_in_space[0]
+        for cid in channels_in_space:
+            name = await self._resolve_channel_name(
+                space_id=space_id, channel_id=cid,
+            )
+            if (name or "").strip().lower() == "general":
+                target_channel_id = cid
+                break
 
         inviter_slug = ""
         if kind == "accept_space_invite":

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -511,27 +511,16 @@ class PuffoCoreMessageClient:
         # invite. Lost on daemon restart (acceptable: re-DM rate is
         # naturally rare).
         self._processed_invite_ids: set[str] = set()
-        # PUF-317: WS event_ids the membership-announce path has
-        # already emitted for. Reconnect-replay would otherwise show
-        # the agent two "Bob left #channel" envelopes back-to-back
-        # — same lifetime + reset semantics as
-        # ``_processed_invite_ids``. Memory cost stays bounded in
-        # practice (~24 bytes per event_id; channels with sustained
-        # churn at 1Hz would take ~5 days to reach 10MB).
+        # WS event_ids the membership-announce path has already emitted.
+        # Same lifetime + reset semantics as ``_processed_invite_ids``;
+        # reconnect-replay would otherwise double up "Bob left #channel".
         self._processed_membership_event_ids: set[str] = set()
-        # PUF-317 PR #94 review-#3: ``invitation_event_id ->
-        # inviter_slug`` recorded on inbound ``invite_to_*`` events
-        # (signer of the invite IS the inviter). Consulted by the
-        # membership-announce paths when a manual-accept
-        # ``accept_*_invite`` arrives without ``original_invite``
-        # (server-auto-accept only embeds the original signed
-        # invite; manual-accept paths omit it). Mirrors the web
-        # side's ``_inviter_by_invitation`` cache. Lifetime-scoped
-        # like ``_processed_invite_ids`` — lost on daemon restart;
-        # post-restart manual-accepts that we haven't observed the
-        # invite for will silently render the body without an
-        # inviter suffix, which is the same shape as the existing
-        # "no original_invite" path.
+        # ``invitation_event_id -> inviter_slug`` cache for the manual-
+        # accept path (server-auto-accept embeds the original signed
+        # invite under ``original_invite``; manual accepts don't, so the
+        # announce body falls back to this cache for "(invited by X)").
+        # Lifetime-scoped — post-restart manual-accepts we never saw the
+        # invite for render without the suffix.
         self._inviter_by_invitation_event_id: dict[str, str] = {}
         # When the worker DMs the operator about a non-auto-acceptable
         # invite, the DM's envelope_id lives here so a ``y``/``n``
@@ -1491,12 +1480,8 @@ class PuffoCoreMessageClient:
                 self._space_members.pop(evict_space_id, None)
 
         if kind in ("invite_to_space", "invite_to_channel"):
-            # PUF-317 PR #94 review-#3: record inviter so a
-            # later manual-accept (which omits ``original_invite``
-            # — only server-auto-accept embeds it) can still
-            # render "(invited by X)" in the announce body. The
-            # signed invite's ``event_id`` becomes the key the
-            # accept event carries as ``invitation_event_id``.
+            # Cache inviter so a later manual-accept (which omits
+            # ``original_invite``) can still render "(invited by X)".
             invite_event_id = event.get("event_id") or ""
             inviter_slug = event.get("signer_slug") or ""
             if invite_event_id and inviter_slug:
@@ -1586,29 +1571,19 @@ class PuffoCoreMessageClient:
             )
             return
 
-        # Membership-change announcements for OTHER members of a
-        # channel this agent is also in. Distinct from the
-        # self-targeted branches above (those DM the operator);
-        # these inject a non-replyable system-message into the
-        # agent's transcript so it can react in-context (e.g. stop
-        # @-mentioning a member that just left). PUF-317.
+        # OTHER-member channel events → inject a non-replyable system
+        # message into the agent's transcript so it has live context
+        # (e.g. stop @-mentioning a member that just left).
         if kind in ("leave_channel", "remove_from_channel"):
             await self._maybe_announce_membership_change(
                 kind, event, payload,
             )
             return
 
-        # PUF-317 review-#1: space-level membership for OTHER actors.
-        # puffo-server #74 ``cascade_remove_from_channels`` mutates the
-        # ``channel_memberships`` table directly when an operator
-        # leaves or is removed from a space — no per-channel
-        # ``leave_channel`` event fires for the cascaded slugs. Without
-        # this announce path the agent keeps @-mentioning a member
-        # who's silently dropped out of #general. ``accept_space_invite``
-        # cascade into auto-joined public channels has the same
-        # symptom in reverse. Surface all three through the same
-        # announce wrapper so the General-channel transcript stays in
-        # sync with channel-roster reality.
+        # Space-level membership cascades into ``channel_memberships``
+        # server-side without per-channel events, so without this
+        # announce the agent keeps @-mentioning a member who silently
+        # dropped out of #general (or fails to greet an auto-joiner).
         if kind in ("leave_space", "remove_from_space", "accept_space_invite"):
             await self._maybe_announce_space_membership_change(
                 kind, event, payload,
@@ -2714,12 +2689,9 @@ class PuffoCoreMessageClient:
             actor_slug = event.get("signer_slug") or ""
             action = "joined"
             kicker_slug = ""
-            # PUF-317 review-#2: server-auto-accept embeds the
-            # original signed InviteToChannel under ``original_invite``;
-            # its ``signer_slug`` is the inviter. Manual-accept paths
-            # omit ``original_invite``, so review-#3 falls through to
-            # the ``_inviter_by_invitation_event_id`` cache populated
-            # in ``_handle_event``'s ``invite_to_*`` branch.
+            # Server-auto-accept embeds the inviter under
+            # ``original_invite``; manual accepts fall through to the
+            # cache populated in the ``invite_to_*`` branch.
             original_invite = payload.get("original_invite")
             if isinstance(original_invite, dict):
                 inviter_slug = original_invite.get("signer_slug") or ""
@@ -2774,16 +2746,6 @@ class PuffoCoreMessageClient:
         into the agent's transcript as a non-replyable system-message
         in a channel the agent shares with the space.
 
-        PUF-317 review-#1: puffo-server #74
-        ``cascade_remove_from_channels`` mutates
-        ``channel_memberships`` directly on a space exit — no
-        per-channel ``leave_channel`` event fires for the cascaded
-        slugs. ``accept_space_invite`` cascades into auto-joined
-        public channels with the same symptom in reverse. Without
-        this announce path the agent keeps @-mentioning a member
-        who silently dropped out of #general (or fails to greet a
-        member who just auto-joined).
-
         Prefers the channel named ``general`` (case-insensitive) so
         the agent's transcript lines up with the human-side UI, which
         renders space events into General. Falls back to the
@@ -2815,9 +2777,7 @@ class PuffoCoreMessageClient:
             actor_slug = event.get("signer_slug") or ""
             action = "joined_space"
             kicker_slug = ""
-            # Mirror the channel path: server-auto-accept embeds the
-            # original signed InviteToSpace under ``original_invite``;
-            # manual-accept falls through to the cache.
+            # Same cache fallback as the channel path.
             original_invite = payload.get("original_invite")
             if isinstance(original_invite, dict):
                 inviter_slug = original_invite.get("signer_slug") or ""
@@ -2876,19 +2836,14 @@ class PuffoCoreMessageClient:
         event_id: str = "",
     ) -> None:
         """Inject a non-replyable ``[puffo-agent system message]``
-        envelope announcing a channel- or space-level membership
-        change. Mirrors ``_enqueue_channel_intro_nudge``
-        (PRIORITY_SYSTEM, sender_slug ``system``, persisted to
-        messages.db so ``get_channel_history`` stays coherent) but
-        the body is an announcement — there's no directive, and the
-        prefix marker signals to the agent that no reply is
-        expected.
+        envelope announcing a membership change. Mirrors
+        ``_enqueue_channel_intro_nudge`` (PRIORITY_SYSTEM, sender
+        ``system``, persisted to messages.db) but the body is an
+        announcement and the prefix marker signals no reply expected.
 
-        ``action`` is one of ``"joined" | "left" | "removed" |
-        "joined_space" | "left_space" | "removed_from_space"``.
-        ``kicker_slug`` only consulted when ``action`` ends in
-        ``"removed"``. ``inviter_slug`` only consulted when ``action``
-        starts with ``"joined"`` (server-auto-accept inviter cite).
+        ``action`` ∈ {joined, left, removed, joined_space, left_space,
+        removed_from_space}. ``kicker_slug`` used on ``removed*``;
+        ``inviter_slug`` used on ``joined*``.
         """
         space_id = self._channel_space.get(channel_id) or ""
         space_name = (
@@ -2907,8 +2862,6 @@ class PuffoCoreMessageClient:
         )
 
         async def _invited_by_suffix() -> str:
-            # Server-auto-accept embeds the inviter; manual-accept
-            # omits original_invite, so this falls through to "".
             if not inviter_slug:
                 return ""
             inviter_display = await self._fetch_display_name(inviter_slug)
@@ -2960,13 +2913,8 @@ class PuffoCoreMessageClient:
             return
 
         now_ms = int(time.time() * 1000)
-        # Prefer the signed event_id when available so a
-        # reconnect-replay collapses to the same envelope_id and the
-        # store's INSERT OR IGNORE rejects the duplicate at the
-        # sqlite layer in addition to the in-memory dedup set in
-        # ``_maybe_announce_membership_change``. Fall back to the
-        # ms-timestamp when callers omit event_id (direct unit-test
-        # invocation of this helper).
+        # Signed event_id makes the envelope_id deterministic so the
+        # store's INSERT OR IGNORE dedups reconnect-replay.
         envelope_id_suffix = event_id or str(now_ms)
         envelope_id = (
             f"membership-{action}-{channel_id}-{actor_slug}-{envelope_id_suffix}"

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -72,6 +72,10 @@ Common ones:
   — page chunks back with `mcp__puffo__get_post_segment(envelope_id=...,
   segment=N, segment_size=...)`. The placeholder's `preview:` is
   usually enough; fetch only what you need.
+- `Channel membership update: ... joined/left/was removed from
+  channel #X ...` — announcement that another member's channel
+  membership changed. Read-only context (e.g. stop @-mentioning a
+  member that just left); no reply expected, no action required.
 
 ## How to reply (read this carefully)
 

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -56,6 +56,9 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     # the fixture leaves it empty so the predicate bails cleanly
     # rather than raising AttributeError.
     client._channel_space = {}
+    # PR #94 review-#3: ``_handle_event``'s ``invite_to_*`` branch
+    # writes here; mirror the production __init__ default.
+    client._inviter_by_invitation_event_id = {}
 
     async def _stub_space_name(space_id: str) -> str:
         return "Team" if space_id == "sp_1" else space_id

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -51,6 +51,11 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     # /channels response so the immediately-following
     # ``_resolve_channel_name`` inside the intro nudge becomes a hit.
     client._channel_name_cache = {}
+    # ``_maybe_announce_membership_change`` (PUF-317) reads this
+    # visibility map on the OTHER-signer accept_channel_invite path;
+    # the fixture leaves it empty so the predicate bails cleanly
+    # rather than raising AttributeError.
+    client._channel_space = {}
 
     async def _stub_space_name(space_id: str) -> str:
         return "Team" if space_id == "sp_1" else space_id

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -51,13 +51,10 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     # /channels response so the immediately-following
     # ``_resolve_channel_name`` inside the intro nudge becomes a hit.
     client._channel_name_cache = {}
-    # ``_maybe_announce_membership_change`` (PUF-317) reads this
-    # visibility map on the OTHER-signer accept_channel_invite path;
-    # the fixture leaves it empty so the predicate bails cleanly
-    # rather than raising AttributeError.
+    # Read by ``_maybe_announce_membership_change`` on the OTHER-signer
+    # accept_channel_invite path; empty so the predicate bails cleanly.
     client._channel_space = {}
-    # PR #94 review-#3: ``_handle_event``'s ``invite_to_*`` branch
-    # writes here; mirror the production __init__ default.
+    # Written by ``_handle_event``'s ``invite_to_*`` branch.
     client._inviter_by_invitation_event_id = {}
 
     async def _stub_space_name(space_id: str) -> str:

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -1,17 +1,4 @@
-"""Channel-membership system-message announcements.
-
-When another member joins, leaves, or is removed from a channel this
-agent has visibility into, the daemon injects a non-replyable
-``[puffo-agent system message]`` envelope into the agent's transcript
-so it has read-only context (e.g. stop @-mentioning a member that
-just left). Self-actions are deliberately skipped here — the
-self-join intro nudge and the self-exit operator DMs cover those.
-
-These tests exercise the two new helpers
-(``_maybe_announce_membership_change`` predicate +
-``_enqueue_membership_system_message`` injector) plus the
-``_handle_event`` wiring that calls them.
-"""
+"""Channel-membership system-message announcements (other-actor only)."""
 
 from __future__ import annotations
 
@@ -40,8 +27,7 @@ async def _make_store() -> MessageStore:
 
 
 def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
-    """Bare client with just enough state to drive
-    ``_handle_event`` through the membership-announce path."""
+    """Bare client wired enough to drive the membership-announce path."""
     client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
     client.slug = "agent-1"
     client.store = store
@@ -196,16 +182,13 @@ async def test_membership_unknown_actor_falls_back_to_slug():
     _, _, root_id = await client._queue.get()
     msg = client._thread_state[root_id].messages[0]
     assert "@charlie-9999" in msg["text"]
-    # No bold display-name prefix when the name resolved empty.
     assert "**" not in msg["text"]
     await store.close()
 
 
 @pytest.mark.asyncio
 async def test_membership_envelope_persists_to_messages_db():
-    """The synthetic envelope must be queryable via the data-service
-    paths the agent uses at runtime so its transcript view is
-    consistent."""
+    """Envelope queryable via get_message_by_envelope + get_channel_history."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -233,9 +216,7 @@ async def test_membership_envelope_persists_to_messages_db():
 
 @pytest.mark.asyncio
 async def test_membership_unknown_action_is_noop():
-    """Defensive — the dispatcher in ``_handle_event`` only sends
-    "joined" / "left" / "removed", but the helper bails cleanly on
-    anything else rather than emitting garbage."""
+    """Helper bails cleanly on an action the dispatcher wouldn't send."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -256,12 +237,9 @@ async def test_membership_unknown_action_is_noop():
 
 @pytest.mark.asyncio
 async def test_announce_skipped_when_channel_not_in_visibility_map():
-    """Server may fan a leave/remove event to us as a former member
-    too. Don't announce on a channel we no longer (or never) had
-    visibility into."""
+    """Don't announce on a channel we no longer (or never) had visibility into."""
     store = await _make_store()
     client = _make_client(store)
-    # _channel_space is empty → no visibility.
 
     await client._maybe_announce_membership_change(
         "leave_channel",
@@ -275,9 +253,7 @@ async def test_announce_skipped_when_channel_not_in_visibility_map():
 
 @pytest.mark.asyncio
 async def test_announce_skipped_when_actor_is_self():
-    """Self-join is covered by the intro nudge; self-exit is covered
-    by the operator-DM path. The announce-membership path must NOT
-    fire on self-events or we'd double-emit."""
+    """Self-events are owned by other paths (intro nudge / operator DM)."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -400,13 +376,11 @@ async def test_handle_event_accept_channel_invite_by_other_announces_join():
 
 @pytest.mark.asyncio
 async def test_handle_event_self_leave_does_not_announce():
-    """Self-leave still routes to ``_on_left_channel`` (cache eviction)
-    and must NOT fan out as an announcement to its own transcript."""
+    """Self-leave routes to _on_left_channel, not the announce path."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
 
-    # Stub _on_left_channel since the real one touches the store.
     on_left_calls: list[str] = []
 
     async def _stub_on_left(*, channel_id: str) -> None:
@@ -423,9 +397,7 @@ async def test_handle_event_self_leave_does_not_announce():
         },
     )
 
-    # Self-leave path ran.
     assert on_left_calls == ["ch_1"]
-    # No announcement in the transcript queue.
     assert client._queue.qsize() == 0
     await store.close()
 
@@ -468,11 +440,9 @@ async def test_handle_event_self_kicked_does_not_announce():
 
 @pytest.mark.asyncio
 async def test_handle_event_other_leave_on_unknown_channel_is_silent():
-    """Channel not in our visibility map → server fan-out noise; no
-    announcement."""
+    """Unknown channel → server fan-out noise; no announce."""
     store = await _make_store()
     client = _make_client(store)
-    # _channel_space empty; we're not a member of ch_unknown.
 
     await client._handle_event(
         scope="sp_1",
@@ -492,9 +462,7 @@ async def test_handle_event_other_leave_on_unknown_channel_is_silent():
 
 @pytest.mark.asyncio
 async def test_announce_dedups_on_duplicate_event_id():
-    """A WS reconnect / event-replay re-fires the same signed event.
-    The announce path must not double-emit — keyed on ``event_id``,
-    same dedup contract as ``_processed_invite_ids``."""
+    """Reconnect-replay of the same signed event_id is a no-op."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -516,9 +484,7 @@ async def test_announce_dedups_on_duplicate_event_id():
 
 @pytest.mark.asyncio
 async def test_announce_uses_event_id_in_envelope_id_when_present():
-    """Deterministic envelope_id off the signed event_id so the
-    sqlite layer's INSERT OR IGNORE catches a replay even if the
-    in-memory dedup set was lost across restart."""
+    """Deterministic envelope_id so sqlite INSERT OR IGNORE catches replay across restart."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -540,24 +506,19 @@ async def test_announce_uses_event_id_in_envelope_id_when_present():
 
 @pytest.mark.asyncio
 async def test_announce_falls_back_to_timestamp_when_event_id_missing():
-    """Direct unit-test invocation may omit event_id; fall back to
-    the ms-timestamp so two distinct calls still get distinct
-    envelope_ids."""
+    """No event_id → ms-timestamp suffix, never empty."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
 
-    # Drive via _maybe_announce_membership_change with no event_id.
     await client._maybe_announce_membership_change(
         "leave_channel",
-        {"signer_slug": "alice-0001"},  # no event_id
+        {"signer_slug": "alice-0001"},
         {"channel_id": "ch_1", "space_id": "sp_1"},
     )
 
     assert client._queue.qsize() == 1
     _, _, root_id = await client._queue.get()
-    # Suffix is a millisecond timestamp — must NOT be an empty
-    # string and must NOT collide with the event_id-prefixed shape.
     assert root_id.startswith("membership-left-ch_1-alice-0001-")
     assert not root_id.endswith("-")
     await store.close()
@@ -565,10 +526,7 @@ async def test_announce_falls_back_to_timestamp_when_event_id_missing():
 
 @pytest.mark.asyncio
 async def test_announce_skips_dedup_when_event_id_empty():
-    """Empty event_id should not poison the dedup set — two such
-    events (a misbehaving server omitting event_id, repeated) must
-    each get an announce so the agent's transcript stays honest
-    rather than silently dropping later events."""
+    """Empty event_id must not poison the dedup set."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -596,12 +554,7 @@ async def test_announce_skips_dedup_when_event_id_empty():
 async def test_persist_failure_still_delivers_in_memory_envelope(
     monkeypatch, caplog,
 ):
-    """``store.store`` raising must not block the in-memory thread
-    queue — the agent still gets the announcement in its current
-    turn even if sqlite is wedged (disk full, permission, etc.). A
-    warning is logged so the operator can spot the
-    history/transcript divergence. Mirrors the web side's
-    ``persistMembershipSystemMessage returns null on throw`` test."""
+    """sqlite raising must not block in-memory delivery; warn instead."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -619,12 +572,10 @@ async def test_persist_failure_still_delivers_in_memory_envelope(
             action="joined",
         )
 
-    # In-memory delivery happened even though persistence failed.
     assert client._queue.qsize() == 1
     _, _, root_id = await client._queue.get()
     assert "joined" in client._thread_state[root_id].messages[0]["text"]
 
-    # Warning fired so the operator sees the divergence in logs.
     assert any(
         "membership system-message" in rec.message
         and "failed to persist" in rec.message
@@ -638,9 +589,7 @@ async def test_persist_failure_still_delivers_in_memory_envelope(
 
 @pytest.mark.asyncio
 async def test_joined_body_cites_inviter_when_supplied():
-    """Server-auto-accept embeds ``original_invite.signer_slug``; the
-    body should render '(invited by <inviter>)' so the agent can
-    distinguish who pulled the new member in."""
+    """inviter_slug supplied → '(invited by X)' suffix."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -663,8 +612,7 @@ async def test_joined_body_cites_inviter_when_supplied():
 
 @pytest.mark.asyncio
 async def test_joined_body_omits_inviter_when_empty():
-    """Manual-accept omits ``original_invite``; the body should NOT
-    grow a '(invited by )' fragment when the slug is empty."""
+    """Empty inviter_slug → no '(invited by …)' fragment at all."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -720,8 +668,6 @@ async def test_handle_event_accept_channel_invite_with_original_invite_cites_inv
 async def test_space_membership_joined_renders_joined_space_body():
     store = await _make_store()
     client = _make_client(store)
-    # Visibility into one channel of the space — required for the
-    # space announce path to pick a target channel.
     client._channel_space["ch_1"] = "sp_1"
 
     await client._enqueue_membership_system_message(
@@ -785,9 +731,7 @@ async def test_space_membership_removed_includes_kicker_and_space():
 
 @pytest.mark.asyncio
 async def test_handle_event_leave_space_by_other_announces_into_first_channel():
-    """Space cascade-leave doesn't fan per-channel events server-side.
-    The announce path picks a visible channel as the transcript target
-    so the agent sees the member dropping out."""
+    """Space cascade-leave has no per-channel event; the space-announce path picks a channel."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -862,8 +806,7 @@ async def test_handle_event_accept_space_invite_by_other_announces_join():
 
 @pytest.mark.asyncio
 async def test_handle_event_accept_space_invite_cites_inviter_when_present():
-    """Server-auto-accept embeds the inviter under original_invite —
-    same shape as the channel path."""
+    """original_invite.signer_slug → '(invited by X)' suffix."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -890,11 +833,9 @@ async def test_handle_event_accept_space_invite_cites_inviter_when_present():
 
 @pytest.mark.asyncio
 async def test_space_membership_skips_when_no_channel_visibility():
-    """Agent has no channel in this space → no transcript to surface
-    the announcement into → skip silently."""
+    """No visible channel in the space → skip silently."""
     store = await _make_store()
     client = _make_client(store)
-    # _channel_space has no entries for sp_1.
     client._channel_space["ch_other"] = "sp_2"
 
     await client._handle_event(
@@ -912,16 +853,11 @@ async def test_space_membership_skips_when_no_channel_visibility():
 
 @pytest.mark.asyncio
 async def test_space_membership_skips_self_actor():
-    """Self space exits route through ``_on_left_space`` /
-    ``_on_kicked_from_space`` (operator-DM paths) and must NOT
-    double-emit into the agent's own transcript."""
+    """Self space events are owned by other paths (_on_left_space etc.)."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
 
-    # Self-leave is short-circuited by the earlier
-    # "self leave_space" branch; here we drive the announce path
-    # directly to prove the actor==self guard in it.
     await client._maybe_announce_space_membership_change(
         "leave_space",
         {"signer_slug": "agent-1"},
@@ -944,8 +880,7 @@ async def test_space_membership_skips_self_actor():
 
 @pytest.mark.asyncio
 async def test_space_membership_falls_back_to_lex_first_when_no_general():
-    """No channel named ``general`` → lexicographically-first id is
-    picked so a reconnect-replay collapses to the same envelope_id."""
+    """No #general → lex-first channel_id (stable, dedup-friendly)."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_z"] = "sp_1"
@@ -971,9 +906,7 @@ async def test_space_membership_falls_back_to_lex_first_when_no_general():
 
 @pytest.mark.asyncio
 async def test_space_membership_prefers_general_channel_when_present():
-    """Space-scope events land in #general so the agent transcript
-    lines up with the human UI; lex-first only kicks in when no
-    General is visible."""
+    """Space-scope events land in #general (matches the human UI)."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_zulu"] = "sp_1"
@@ -1035,16 +968,13 @@ async def test_invite_to_channel_records_inviter_in_cache():
     assert client._inviter_by_invitation_event_id == {
         "ev_invite_42": "alice-0001",
     }
-    # Inbound invite alone does NOT post into the transcript.
     assert client._queue.qsize() == 0
     await store.close()
 
 
 @pytest.mark.asyncio
 async def test_manual_accept_channel_invite_falls_back_to_cache_for_inviter():
-    """Manual-accept omits ``original_invite``; the announce path
-    must consult ``_inviter_by_invitation_event_id`` keyed off the
-    ``invitation_event_id`` the accept carries."""
+    """No original_invite → resolve inviter via the cache."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -1059,7 +989,6 @@ async def test_manual_accept_channel_invite_falls_back_to_cache_for_inviter():
                 "channel_id": "ch_1",
                 "space_id": "sp_1",
                 "invitation_event_id": "ev_invite_42",
-                # original_invite intentionally omitted (manual accept)
             },
         },
     )
@@ -1075,13 +1004,10 @@ async def test_manual_accept_channel_invite_falls_back_to_cache_for_inviter():
 
 @pytest.mark.asyncio
 async def test_manual_accept_channel_invite_renders_no_inviter_on_cache_miss():
-    """No prior ``invite_to_channel`` observed (e.g. daemon restarted
-    between invite + accept) → cache miss → body has no '(invited by …)'
-    suffix at all (not a stray '(invited by )')."""
+    """Cache miss (e.g. restart between invite + accept) → no suffix."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
-    # Empty cache.
 
     await client._handle_event(
         scope="sp_1",
@@ -1105,11 +1031,7 @@ async def test_manual_accept_channel_invite_renders_no_inviter_on_cache_miss():
 
 @pytest.mark.asyncio
 async def test_original_invite_takes_precedence_over_cache():
-    """Server-auto-accept embeds ``original_invite`` AND populates
-    cache from the earlier invite_to_*. The body should cite the
-    embedded inviter, not the cached one. (In practice these are the
-    same slug, but the test pins the precedence so a future
-    inconsistency wouldn't surprise us.)"""
+    """original_invite wins over the cache when both are present."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -1160,7 +1082,6 @@ async def test_invite_to_space_records_inviter_for_later_space_accept():
         == "alice-0001"
     )
 
-    # Now the manual-accept arrives; cache lookup populates inviter.
     await client._handle_event(
         scope="sp_1",
         event={
@@ -1184,9 +1105,7 @@ async def test_invite_to_space_records_inviter_for_later_space_accept():
 
 @pytest.mark.asyncio
 async def test_invite_record_skips_when_event_id_or_signer_missing():
-    """Defensive — a malformed invite event (missing event_id or
-    signer_slug) must not poison the cache with empty-string keys
-    or values."""
+    """Malformed invite must not poison the cache with empty keys/values."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -1224,8 +1143,7 @@ async def test_invite_record_skips_when_event_id_or_signer_missing():
 
 @pytest.mark.asyncio
 async def test_space_membership_dedups_on_duplicate_event_id():
-    """Reconnect-replay sees the same signed event twice — announce
-    only once, same contract as the channel path."""
+    """Reconnect-replay → announce once."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -630,3 +630,362 @@ async def test_persist_failure_still_delivers_in_memory_envelope(
         for rec in caplog.records
     )
     await store.close()
+
+
+# ─── PR #94 review-#2: inviter citation in joined body ─────────────
+
+
+@pytest.mark.asyncio
+async def test_joined_body_cites_inviter_when_supplied():
+    """Server-auto-accept embeds ``original_invite.signer_slug``; the
+    body should render '(invited by <inviter>)' so the agent can
+    distinguish who pulled the new member in."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="joined",
+        inviter_slug="alice-0001",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "joined channel #general" in msg["text"]
+    assert "(invited by " in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_joined_body_omits_inviter_when_empty():
+    """Manual-accept omits ``original_invite``; the body should NOT
+    grow a '(invited by )' fragment when the slug is empty."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="joined",
+        inviter_slug="",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "joined channel #general" in msg["text"]
+    assert "invited by" not in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_accept_channel_invite_with_original_invite_cites_inviter():
+    """Server-auto-accept payload path: original_invite.signer_slug
+    must be lifted into the rendered body."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_channel_invite",
+            "signer_slug": "bob-0002",  # the joiner
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+                "original_invite": {"signer_slug": "alice-0001"},
+            },
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "joined channel #general" in msg["text"]
+    assert "(invited by " in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+# ─── PR #94 review-#1: space-membership announce path ─────────────
+
+
+@pytest.mark.asyncio
+async def test_space_membership_joined_renders_joined_space_body():
+    store = await _make_store()
+    client = _make_client(store)
+    # Visibility into one channel of the space — required for the
+    # space announce path to pick a target channel.
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="alice-0001",
+        action="joined_space",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert msg["envelope_id"].startswith(
+        "membership-joined_space-ch_1-alice-0001-"
+    )
+    assert "Alice" in msg["text"]
+    assert "joined space" in msg["text"]
+    assert "**Team**" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_left_renders_left_space_body():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="left_space",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "left space" in msg["text"]
+    assert "**Team**" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_removed_includes_kicker_and_space():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="removed_from_space",
+        kicker_slug="alice-0001",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "was removed from space" in msg["text"]
+    assert "**Team**" in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_leave_space_by_other_announces_into_first_channel():
+    """puffo-server #74 cascade-leave doesn't fan per-channel events.
+    The space announce path picks the first known channel as the
+    transcript target so the agent sees the member dropping out."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_space",
+            "signer_slug": "alice-0001",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert msg["channel_id"] == "ch_1"
+    assert "Alice" in msg["text"]
+    assert "left space" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_remove_from_space_by_other_announces_with_kicker():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "remove_from_space",
+            "signer_slug": "alice-0001",  # kicker
+            "payload": {
+                "space_id": "sp_1",
+                "removed_slug": "bob-0002",
+            },
+        },
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "Alice" in msg["text"]
+    assert "removed from space" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_accept_space_invite_by_other_announces_join():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_space_invite",
+            "signer_slug": "alice-0001",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Alice" in msg["text"]
+    assert "joined space" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_accept_space_invite_cites_inviter_when_present():
+    """Server-auto-accept embeds the inviter under original_invite —
+    same shape as the channel path."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_space_invite",
+            "signer_slug": "bob-0002",
+            "payload": {
+                "space_id": "sp_1",
+                "original_invite": {"signer_slug": "alice-0001"},
+            },
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "(invited by " in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_skips_when_no_channel_visibility():
+    """Agent has no channel in this space → no transcript to surface
+    the announcement into → skip silently."""
+    store = await _make_store()
+    client = _make_client(store)
+    # _channel_space has no entries for sp_1.
+    client._channel_space["ch_other"] = "sp_2"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_space",
+            "signer_slug": "alice-0001",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_skips_self_actor():
+    """Self space exits route through ``_on_left_space`` /
+    ``_on_kicked_from_space`` (operator-DM paths) and must NOT
+    double-emit into the agent's own transcript."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    # Self-leave is short-circuited by the earlier
+    # "self leave_space" branch; here we drive the announce path
+    # directly to prove the actor==self guard in it.
+    await client._maybe_announce_space_membership_change(
+        "leave_space",
+        {"signer_slug": "agent-1"},
+        {"space_id": "sp_1"},
+    )
+    await client._maybe_announce_space_membership_change(
+        "remove_from_space",
+        {"signer_slug": "alice-0001"},
+        {"space_id": "sp_1", "removed_slug": "agent-1"},
+    )
+    await client._maybe_announce_space_membership_change(
+        "accept_space_invite",
+        {"signer_slug": "agent-1"},
+        {"space_id": "sp_1"},
+    )
+
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_picks_first_channel_deterministically():
+    """Multiple shared channels → lexicographically-first channel is
+    picked so a reconnect-replay collapses to the same envelope_id."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_z"] = "sp_1"
+    client._channel_space["ch_a"] = "sp_1"
+    client._channel_space["ch_m"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_space",
+            "signer_slug": "alice-0001",
+            "event_id": "ev_pick",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert msg["channel_id"] == "ch_a"
+    assert root_id == "membership-left_space-ch_a-alice-0001-ev_pick"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_dedups_on_duplicate_event_id():
+    """Reconnect-replay sees the same signed event twice — announce
+    only once, same contract as the channel path."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    event = {
+        "kind": "leave_space",
+        "signer_slug": "alice-0001",
+        "event_id": "ev_space_replay",
+        "payload": {"space_id": "sp_1"},
+    }
+
+    await client._handle_event(scope="sp_1", event=event)
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert client._queue.qsize() == 1
+    assert "ev_space_replay" in client._processed_membership_event_ids
+    await store.close()

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -16,6 +16,7 @@ These tests exercise the two new helpers
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 import tempfile
@@ -51,6 +52,7 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     client._space_name_cache = {}
     client._channel_name_cache = {}
     client._space_members = {}
+    client._processed_membership_event_ids = set()
 
     async def _stub_space_name(space_id: str) -> str:
         return "Team" if space_id == "sp_1" else space_id
@@ -481,4 +483,150 @@ async def test_handle_event_other_leave_on_unknown_channel_is_silent():
     )
 
     assert client._queue.qsize() == 0
+    await store.close()
+
+
+# ─── per-event-id idempotency (reconnect-replay dedup) ────────────
+
+
+@pytest.mark.asyncio
+async def test_announce_dedups_on_duplicate_event_id():
+    """A WS reconnect / event-replay re-fires the same signed event.
+    The announce path must not double-emit — keyed on ``event_id``,
+    same dedup contract as ``_processed_invite_ids``."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    event = {
+        "kind": "leave_channel",
+        "signer_slug": "alice-0001",
+        "event_id": "ev_replay_test",
+        "payload": {"channel_id": "ch_1", "space_id": "sp_1"},
+    }
+
+    await client._handle_event(scope="sp_1", event=event)
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert client._queue.qsize() == 1
+    assert "ev_replay_test" in client._processed_membership_event_ids
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_uses_event_id_in_envelope_id_when_present():
+    """Deterministic envelope_id off the signed event_id so the
+    sqlite layer's INSERT OR IGNORE catches a replay even if the
+    in-memory dedup set was lost across restart."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_channel",
+            "signer_slug": "alice-0001",
+            "event_id": "ev_abc123",
+            "payload": {"channel_id": "ch_1", "space_id": "sp_1"},
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    assert root_id == "membership-left-ch_1-alice-0001-ev_abc123"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_falls_back_to_timestamp_when_event_id_missing():
+    """Direct unit-test invocation may omit event_id; fall back to
+    the ms-timestamp so two distinct calls still get distinct
+    envelope_ids."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    # Drive via _maybe_announce_membership_change with no event_id.
+    await client._maybe_announce_membership_change(
+        "leave_channel",
+        {"signer_slug": "alice-0001"},  # no event_id
+        {"channel_id": "ch_1", "space_id": "sp_1"},
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    # Suffix is a millisecond timestamp — must NOT be an empty
+    # string and must NOT collide with the event_id-prefixed shape.
+    assert root_id.startswith("membership-left-ch_1-alice-0001-")
+    assert not root_id.endswith("-")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_skips_dedup_when_event_id_empty():
+    """Empty event_id should not poison the dedup set — two such
+    events (a misbehaving server omitting event_id, repeated) must
+    each get an announce so the agent's transcript stays honest
+    rather than silently dropping later events."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._maybe_announce_membership_change(
+        "leave_channel",
+        {"signer_slug": "alice-0001"},
+        {"channel_id": "ch_1", "space_id": "sp_1"},
+    )
+    await client._maybe_announce_membership_change(
+        "leave_channel",
+        {"signer_slug": "bob-0002"},
+        {"channel_id": "ch_1", "space_id": "sp_1"},
+    )
+
+    assert client._queue.qsize() == 2
+    assert client._processed_membership_event_ids == set()
+    await store.close()
+
+
+# ─── persistence-failure mirror ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persist_failure_still_delivers_in_memory_envelope(
+    monkeypatch, caplog,
+):
+    """``store.store`` raising must not block the in-memory thread
+    queue — the agent still gets the announcement in its current
+    turn even if sqlite is wedged (disk full, permission, etc.). A
+    warning is logged so the operator can spot the
+    history/transcript divergence. Mirrors the web side's
+    ``persistMembershipSystemMessage returns null on throw`` test."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+    client._log = logging.getLogger("test_persist_failure")
+
+    async def _explode(_payload):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(client.store, "store", _explode)
+
+    with caplog.at_level(logging.WARNING, logger="test_persist_failure"):
+        await client._enqueue_membership_system_message(
+            channel_id="ch_1",
+            actor_slug="alice-0001",
+            action="joined",
+        )
+
+    # In-memory delivery happened even though persistence failed.
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    assert "joined" in client._thread_state[root_id].messages[0]["text"]
+
+    # Warning fired so the operator sees the divergence in logs.
+    assert any(
+        "membership system-message" in rec.message
+        and "failed to persist" in rec.message
+        for rec in caplog.records
+    )
     await store.close()

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -833,7 +833,7 @@ async def test_handle_event_accept_space_invite_cites_inviter_when_present():
 
 @pytest.mark.asyncio
 async def test_space_membership_skips_when_no_channel_visibility():
-    """No visible channel in the space → skip silently."""
+    """No cached channel + no http stub (→ exception → caught) → skip."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_other"] = "sp_2"
@@ -936,6 +936,81 @@ async def test_space_membership_prefers_general_channel_when_present():
     msg = client._thread_state[root_id].messages[0]
     assert msg["channel_id"] == "ch_general"
     assert root_id == "membership-left_space-ch_general-alice-0001-ev_general"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_lazy_fetches_channels_when_cache_empty():
+    """Cascade-joined agents have an empty ``_channel_space`` for the
+    space; the announce path must fall back to GET /spaces/<id>/channels
+    and warm the cache for next time."""
+    store = await _make_store()
+    client = _make_client(store)
+    # _channel_space is empty for sp_1 — simulates the cascade-joined case.
+
+    fetched: list[str] = []
+
+    class _StubHttp:
+        async def get(self, path: str):
+            fetched.append(path)
+            return {
+                "channels": [
+                    {"channel_id": "ch_zulu", "name": "zulu"},
+                    {"channel_id": "ch_general", "name": "General"},
+                    {"channel_id": "ch_alpha", "name": "alpha"},
+                ],
+            }
+
+    client.http = _StubHttp()  # type: ignore[assignment]
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_space",
+            "signer_slug": "alice-0001",
+            "event_id": "ev_cascade",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    assert fetched == ["/spaces/sp_1/channels"]
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert msg["channel_id"] == "ch_general"
+    # Cache warmed for next time so we don't refetch on every space event.
+    assert client._channel_space == {
+        "ch_zulu": "sp_1",
+        "ch_general": "sp_1",
+        "ch_alpha": "sp_1",
+    }
+    assert client._channel_name_cache["ch_general"] == "General"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_silent_skip_when_http_fetch_fails():
+    """HTTP failure on the lazy-fetch fallback is silent — no announce,
+    no crash. Matches the prior 'no visibility → skip' contract."""
+    store = await _make_store()
+    client = _make_client(store)
+
+    class _ExplodingHttp:
+        async def get(self, path: str):
+            raise RuntimeError("server unreachable")
+
+    client.http = _ExplodingHttp()  # type: ignore[assignment]
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_space",
+            "signer_slug": "alice-0001",
+            "event_id": "ev_dead_server",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    assert client._queue.qsize() == 0
     await store.close()
 
 

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -1,0 +1,484 @@
+"""Channel-membership system-message announcements (PUF-317).
+
+When another member joins, leaves, or is removed from a channel this
+agent has visibility into, the daemon injects a non-replyable
+``[puffo-agent system message]`` envelope into the agent's transcript
+so it has read-only context (e.g. stop @-mentioning a member that
+just left). Self-actions are deliberately skipped here — the
+self-join intro nudge and the self-exit operator DMs cover those.
+
+These tests exercise the two new helpers
+(``_maybe_announce_membership_change`` predicate +
+``_enqueue_membership_system_message`` injector) plus the
+``_handle_event`` wiring that calls them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import (
+    PRIORITY_SYSTEM,
+    PuffoCoreMessageClient,
+)
+
+
+async def _make_store() -> MessageStore:
+    d = tempfile.mkdtemp()
+    store = MessageStore(os.path.join(d, "messages.db"))
+    await store.open()
+    return store
+
+
+def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
+    """Bare client with just enough state to drive
+    ``_handle_event`` through the membership-announce path."""
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.store = store
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    client._channel_space = {}
+    client._space_name_cache = {}
+    client._channel_name_cache = {}
+    client._space_members = {}
+
+    async def _stub_space_name(space_id: str) -> str:
+        return "Team" if space_id == "sp_1" else space_id
+
+    async def _stub_channel_name(*, space_id: str, channel_id: str) -> str:
+        return "general" if channel_id == "ch_1" else channel_id
+
+    async def _stub_display_name(slug: str) -> str:
+        return {
+            "alice-0001": "Alice",
+            "bob-0002": "Bob",
+            "op-1": "Operator",
+        }.get(slug, "")
+
+    client._resolve_space_name = _stub_space_name  # type: ignore[assignment]
+    client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
+    client._fetch_display_name = _stub_display_name  # type: ignore[assignment]
+
+    async def _noop_cache(_kind, _event, _payload) -> None:
+        return None
+
+    client._maybe_cache_channel_space = _noop_cache  # type: ignore[assignment]
+    return client
+
+
+# ─── _enqueue_membership_system_message direct ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_membership_join_admits_system_priority_envelope():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="alice-0001",
+        action="joined",
+    )
+
+    assert client._queue.qsize() == 1
+    priority, _seq, root_id = await client._queue.get()
+    assert priority == PRIORITY_SYSTEM
+
+    entry = client._thread_state[root_id]
+    assert len(entry.messages) == 1
+    msg = entry.messages[0]
+    assert msg["channel_id"] == "ch_1"
+    assert msg["channel_name"] == "general"
+    assert msg["space_id"] == "sp_1"
+    assert msg["sender_slug"] == "system"
+    assert msg["is_dm"] is False
+    assert msg["envelope_id"].startswith("membership-joined-ch_1-alice-0001-")
+    assert "[puffo-agent system message]" in msg["text"]
+    assert "Alice" in msg["text"]
+    assert "alice-0001" in msg["text"]
+    assert "joined" in msg["text"]
+    assert "#general" in msg["text"]
+    assert "cannot reply" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_left_renders_left_body():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="left",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "left channel #general" in msg["text"]
+    assert msg["envelope_id"].startswith("membership-left-ch_1-bob-0002-")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_removed_includes_kicker_label():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="removed",
+        kicker_slug="alice-0001",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "was removed from channel #general" in msg["text"]
+    assert "Alice" in msg["text"]
+    assert msg["envelope_id"].startswith(
+        "membership-removed-ch_1-bob-0002-"
+    )
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_removed_falls_back_when_kicker_slug_missing():
+    """No kicker slug → generic "an operator" label rather than @ ."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="bob-0002",
+        action="removed",
+        kicker_slug="",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "an operator" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_unknown_actor_falls_back_to_slug():
+    """Profile-cache miss (display name empty) → @<slug> label."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="charlie-9999",
+        action="joined",
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "@charlie-9999" in msg["text"]
+    # No bold display-name prefix when the name resolved empty.
+    assert "**" not in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_envelope_persists_to_messages_db():
+    """The synthetic envelope must be queryable via the data-service
+    paths the agent uses at runtime so its transcript view is
+    consistent."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="alice-0001",
+        action="joined",
+    )
+
+    _, _, root_id = await client._queue.get()
+    envelope = await store.get_message_by_envelope(root_id)
+    assert envelope is not None
+    assert envelope.channel_id == "ch_1"
+    assert envelope.space_id == "sp_1"
+    assert envelope.sender_slug == "system"
+    assert envelope.thread_root_id == root_id
+    assert "joined" in envelope.content
+
+    history = await store.get_channel_history(channel_id="ch_1", limit=10)
+    assert len(history) == 1
+    assert history[0].envelope_id == root_id
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_unknown_action_is_noop():
+    """Defensive — the dispatcher in ``_handle_event`` only sends
+    "joined" / "left" / "removed", but the helper bails cleanly on
+    anything else rather than emitting garbage."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._enqueue_membership_system_message(
+        channel_id="ch_1",
+        actor_slug="alice-0001",
+        action="kicked-out",  # not a valid action
+    )
+
+    assert client._queue.qsize() == 0
+    assert client._thread_state == {}
+    await store.close()
+
+
+# ─── _maybe_announce_membership_change predicate ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_announce_skipped_when_channel_not_in_visibility_map():
+    """Server may fan a leave/remove event to us as a former member
+    too. Don't announce on a channel we no longer (or never) had
+    visibility into."""
+    store = await _make_store()
+    client = _make_client(store)
+    # _channel_space is empty → no visibility.
+
+    await client._maybe_announce_membership_change(
+        "leave_channel",
+        {"signer_slug": "alice-0001"},
+        {"channel_id": "ch_1"},
+    )
+
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_skipped_when_actor_is_self():
+    """Self-join is covered by the intro nudge; self-exit is covered
+    by the operator-DM path. The announce-membership path must NOT
+    fire on self-events or we'd double-emit."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._maybe_announce_membership_change(
+        "leave_channel",
+        {"signer_slug": "agent-1"},  # self
+        {"channel_id": "ch_1"},
+    )
+    await client._maybe_announce_membership_change(
+        "remove_from_channel",
+        {"signer_slug": "alice-0001"},
+        {"channel_id": "ch_1", "removed_slug": "agent-1"},  # self target
+    )
+    await client._maybe_announce_membership_change(
+        "accept_channel_invite",
+        {"signer_slug": "agent-1"},  # self
+        {"channel_id": "ch_1"},
+    )
+
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_unknown_kind_is_noop():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._maybe_announce_membership_change(
+        "create_channel",
+        {"signer_slug": "alice-0001"},
+        {"channel_id": "ch_1"},
+    )
+
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+# ─── _handle_event wiring ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_event_leave_channel_by_other_announces():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_channel",
+            "signer_slug": "alice-0001",
+            "payload": {"channel_id": "ch_1", "space_id": "sp_1"},
+        },
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "left channel #general" in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_remove_from_channel_by_other_announces_with_kicker():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "remove_from_channel",
+            "signer_slug": "alice-0001",  # kicker
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+                "removed_slug": "bob-0002",
+            },
+        },
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "Alice" in msg["text"]
+    assert "removed" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_accept_channel_invite_by_other_announces_join():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_channel_invite",
+            "signer_slug": "alice-0001",  # the joiner
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+            },
+        },
+    )
+
+    assert client._queue.qsize() == 1
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Alice" in msg["text"]
+    assert "joined channel #general" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_self_leave_does_not_announce():
+    """Self-leave still routes to ``_on_left_channel`` (cache eviction)
+    and must NOT fan out as an announcement to its own transcript."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    # Stub _on_left_channel since the real one touches the store.
+    on_left_calls: list[str] = []
+
+    async def _stub_on_left(*, channel_id: str) -> None:
+        on_left_calls.append(channel_id)
+
+    client._on_left_channel = _stub_on_left  # type: ignore[assignment]
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_channel",
+            "signer_slug": "agent-1",
+            "payload": {"channel_id": "ch_1", "space_id": "sp_1"},
+        },
+    )
+
+    # Self-leave path ran.
+    assert on_left_calls == ["ch_1"]
+    # No announcement in the transcript queue.
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_self_kicked_does_not_announce():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    on_kicked_calls: list[dict] = []
+
+    async def _stub_on_kicked(
+        *, channel_id: str, space_id: str, kicker_slug: str,
+    ) -> None:
+        on_kicked_calls.append(
+            {"channel_id": channel_id, "kicker_slug": kicker_slug},
+        )
+
+    client._on_kicked_from_channel = _stub_on_kicked  # type: ignore[assignment]
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "remove_from_channel",
+            "signer_slug": "alice-0001",
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+                "removed_slug": "agent-1",  # self
+            },
+        },
+    )
+
+    assert len(on_kicked_calls) == 1
+    assert on_kicked_calls[0]["kicker_slug"] == "alice-0001"
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_other_leave_on_unknown_channel_is_silent():
+    """Channel not in our visibility map → server fan-out noise; no
+    announcement."""
+    store = await _make_store()
+    client = _make_client(store)
+    # _channel_space empty; we're not a member of ch_unknown.
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_channel",
+            "signer_slug": "alice-0001",
+            "payload": {"channel_id": "ch_unknown", "space_id": "sp_1"},
+        },
+    )
+
+    assert client._queue.qsize() == 0
+    await store.close()

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -98,7 +98,7 @@ async def test_membership_join_admits_system_priority_envelope():
     assert "alice-0001" in msg["text"]
     assert "joined" in msg["text"]
     assert "#general" in msg["text"]
-    assert "cannot reply" in msg["text"]
+    assert "for your context" in msg["text"]
     await store.close()
 
 

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -75,6 +75,7 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
         return None
 
     client._maybe_cache_channel_space = _noop_cache  # type: ignore[assignment]
+    client._inviter_by_invitation_event_id = {}
     return client
 
 
@@ -965,6 +966,222 @@ async def test_space_membership_picks_first_channel_deterministically():
     msg = client._thread_state[root_id].messages[0]
     assert msg["channel_id"] == "ch_a"
     assert root_id == "membership-left_space-ch_a-alice-0001-ev_pick"
+    await store.close()
+
+
+# ─── PR #94 review-#3: manual-accept inviter cache backfill ────────
+
+
+@pytest.mark.asyncio
+async def test_invite_to_channel_records_inviter_in_cache():
+    """Inbound ``invite_to_channel`` for a non-self invitee should
+    seed the cache so a later manual-accept (no ``original_invite``)
+    can still render '(invited by X)'."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "invite_to_channel",
+            "signer_slug": "alice-0001",  # inviter
+            "event_id": "ev_invite_42",
+            "payload": {
+                "space_id": "sp_1",
+                "channel_id": "ch_1",
+                "invitee_slug": "bob-0002",  # not us
+            },
+        },
+    )
+
+    assert client._inviter_by_invitation_event_id == {
+        "ev_invite_42": "alice-0001",
+    }
+    # Inbound invite alone does NOT post into the transcript.
+    assert client._queue.qsize() == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_manual_accept_channel_invite_falls_back_to_cache_for_inviter():
+    """Manual-accept omits ``original_invite``; the announce path
+    must consult ``_inviter_by_invitation_event_id`` keyed off the
+    ``invitation_event_id`` the accept carries."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+    client._inviter_by_invitation_event_id["ev_invite_42"] = "alice-0001"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_channel_invite",
+            "signer_slug": "bob-0002",  # the joiner, manually accepting
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+                "invitation_event_id": "ev_invite_42",
+                # original_invite intentionally omitted (manual accept)
+            },
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "joined channel #general" in msg["text"]
+    assert "(invited by " in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_manual_accept_channel_invite_renders_no_inviter_on_cache_miss():
+    """No prior ``invite_to_channel`` observed (e.g. daemon restarted
+    between invite + accept) → cache miss → body falls back to the
+    pre-review-#2 shape without growing a stray '(invited by )'."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+    # Empty cache.
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_channel_invite",
+            "signer_slug": "bob-0002",
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+                "invitation_event_id": "ev_missing",
+            },
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "joined channel #general" in msg["text"]
+    assert "invited by" not in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_original_invite_takes_precedence_over_cache():
+    """Server-auto-accept embeds ``original_invite`` AND populates
+    cache from the earlier invite_to_*. The body should cite the
+    embedded inviter, not the cached one. (In practice these are the
+    same slug, but the test pins the precedence so a future
+    inconsistency wouldn't surprise us.)"""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+    client._inviter_by_invitation_event_id["ev_invite_42"] = "stale-cache-0000"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_channel_invite",
+            "signer_slug": "bob-0002",
+            "payload": {
+                "channel_id": "ch_1",
+                "space_id": "sp_1",
+                "invitation_event_id": "ev_invite_42",
+                "original_invite": {"signer_slug": "alice-0001"},
+            },
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Alice" in msg["text"]
+    assert "stale-cache-0000" not in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_invite_to_space_records_inviter_for_later_space_accept():
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "invite_to_space",
+            "signer_slug": "alice-0001",
+            "event_id": "ev_space_invite_7",
+            "payload": {
+                "space_id": "sp_1",
+                "invitee_slug": "bob-0002",
+            },
+        },
+    )
+
+    assert (
+        client._inviter_by_invitation_event_id["ev_space_invite_7"]
+        == "alice-0001"
+    )
+
+    # Now the manual-accept arrives; cache lookup populates inviter.
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "accept_space_invite",
+            "signer_slug": "bob-0002",
+            "payload": {
+                "space_id": "sp_1",
+                "invitation_event_id": "ev_space_invite_7",
+            },
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert "Bob" in msg["text"]
+    assert "joined space" in msg["text"]
+    assert "(invited by " in msg["text"]
+    assert "Alice" in msg["text"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_invite_record_skips_when_event_id_or_signer_missing():
+    """Defensive — a malformed invite event (missing event_id or
+    signer_slug) must not poison the cache with empty-string keys
+    or values."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_1"] = "sp_1"
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "invite_to_channel",
+            "signer_slug": "",  # missing inviter
+            "event_id": "ev_no_signer",
+            "payload": {
+                "space_id": "sp_1",
+                "channel_id": "ch_1",
+                "invitee_slug": "bob-0002",
+            },
+        },
+    )
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "invite_to_channel",
+            "signer_slug": "alice-0001",
+            # event_id missing
+            "payload": {
+                "space_id": "sp_1",
+                "channel_id": "ch_1",
+                "invitee_slug": "bob-0002",
+            },
+        },
+    )
+
+    assert client._inviter_by_invitation_event_id == {}
     await store.close()
 
 

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -1,4 +1,4 @@
-"""Channel-membership system-message announcements (PUF-317).
+"""Channel-membership system-message announcements.
 
 When another member joins, leaves, or is removed from a channel this
 agent has visibility into, the daemon injects a non-replyable
@@ -633,7 +633,7 @@ async def test_persist_failure_still_delivers_in_memory_envelope(
     await store.close()
 
 
-# ─── PR #94 review-#2: inviter citation in joined body ─────────────
+# ─── inviter citation in joined body ─────────────
 
 
 @pytest.mark.asyncio
@@ -713,7 +713,7 @@ async def test_handle_event_accept_channel_invite_with_original_invite_cites_inv
     await store.close()
 
 
-# ─── PR #94 review-#1: space-membership announce path ─────────────
+# ─── space-membership announce path ─────────────
 
 
 @pytest.mark.asyncio
@@ -785,9 +785,9 @@ async def test_space_membership_removed_includes_kicker_and_space():
 
 @pytest.mark.asyncio
 async def test_handle_event_leave_space_by_other_announces_into_first_channel():
-    """puffo-server #74 cascade-leave doesn't fan per-channel events.
-    The space announce path picks the first known channel as the
-    transcript target so the agent sees the member dropping out."""
+    """Space cascade-leave doesn't fan per-channel events server-side.
+    The announce path picks a visible channel as the transcript target
+    so the agent sees the member dropping out."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"
@@ -1006,7 +1006,7 @@ async def test_space_membership_prefers_general_channel_when_present():
     await store.close()
 
 
-# ─── PR #94 review-#3: manual-accept inviter cache backfill ────────
+# ─── manual-accept inviter cache backfill ────────
 
 
 @pytest.mark.asyncio
@@ -1076,8 +1076,8 @@ async def test_manual_accept_channel_invite_falls_back_to_cache_for_inviter():
 @pytest.mark.asyncio
 async def test_manual_accept_channel_invite_renders_no_inviter_on_cache_miss():
     """No prior ``invite_to_channel`` observed (e.g. daemon restarted
-    between invite + accept) → cache miss → body falls back to the
-    pre-review-#2 shape without growing a stray '(invited by )'."""
+    between invite + accept) → cache miss → body has no '(invited by …)'
+    suffix at all (not a stray '(invited by )')."""
     store = await _make_store()
     client = _make_client(store)
     client._channel_space["ch_1"] = "sp_1"

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -943,8 +943,8 @@ async def test_space_membership_skips_self_actor():
 
 
 @pytest.mark.asyncio
-async def test_space_membership_picks_first_channel_deterministically():
-    """Multiple shared channels → lexicographically-first channel is
+async def test_space_membership_falls_back_to_lex_first_when_no_general():
+    """No channel named ``general`` → lexicographically-first id is
     picked so a reconnect-replay collapses to the same envelope_id."""
     store = await _make_store()
     client = _make_client(store)
@@ -966,6 +966,43 @@ async def test_space_membership_picks_first_channel_deterministically():
     msg = client._thread_state[root_id].messages[0]
     assert msg["channel_id"] == "ch_a"
     assert root_id == "membership-left_space-ch_a-alice-0001-ev_pick"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_space_membership_prefers_general_channel_when_present():
+    """Space-scope events land in #general so the agent transcript
+    lines up with the human UI; lex-first only kicks in when no
+    General is visible."""
+    store = await _make_store()
+    client = _make_client(store)
+    client._channel_space["ch_zulu"] = "sp_1"
+    client._channel_space["ch_general"] = "sp_1"
+    client._channel_space["ch_alpha"] = "sp_1"
+
+    async def _stub_channel_name(*, space_id: str, channel_id: str) -> str:
+        return {
+            "ch_general": "General",
+            "ch_alpha": "alpha",
+            "ch_zulu": "zulu",
+        }.get(channel_id, channel_id)
+
+    client._resolve_channel_name = _stub_channel_name  # type: ignore[assignment]
+
+    await client._handle_event(
+        scope="sp_1",
+        event={
+            "kind": "leave_space",
+            "signer_slug": "alice-0001",
+            "event_id": "ev_general",
+            "payload": {"space_id": "sp_1"},
+        },
+    )
+
+    _, _, root_id = await client._queue.get()
+    msg = client._thread_state[root_id].messages[0]
+    assert msg["channel_id"] == "ch_general"
+    assert root_id == "membership-left_space-ch_general-alice-0001-ev_general"
     await store.close()
 
 


### PR DESCRIPTION
## Summary

When another member's membership in a channel or space the agent is also in changes (`leave_channel` / `remove_from_channel` / `accept_channel_invite` / `leave_space` / `remove_from_space` / `accept_space_invite`), inject a `[puffo-agent system message] Channel membership update: …` envelope into the agent's transcript so it has live context (e.g. stop @-mentioning a member that just left).

Modeled on `_enqueue_channel_intro_nudge`:
- `PRIORITY_SYSTEM` priority
- `sender_slug = "system"`
- Persisted to `messages.db` so `get_channel_history` stays coherent
- `_processed_membership_event_ids` (in-mem) + deterministic `envelope_id` keyed on `event.event_id` → sqlite `INSERT OR IGNORE` for reconnect-replay dedup (double-layer)

Self-targeted branches (`_on_left_channel` / `_on_kicked_from_channel` / `_on_left_space` / `_on_kicked_from_space`) are untouched — the new logic only fires for OTHER actors. Self-joins still go through the intro-nudge path on server-auto-accept.

## Coverage — symmetric with web-side PUF-317 (`puffo-core-han-group#257`)

| Event | other-actor handler | self-actor handler |
|---|---|---|
| `accept_channel_invite` | `_maybe_announce_membership_change` (with inviter) | intro nudge if server-auto-accept |
| `leave_channel` | `_maybe_announce_membership_change` | `_on_left_channel` (DM operator) |
| `remove_from_channel` | `_maybe_announce_membership_change` (with kicker) | `_on_kicked_from_channel` |
| `accept_space_invite` | `_maybe_announce_space_membership_change` (with inviter) | falls through, skipped (actor=self) |
| `leave_space` | `_maybe_announce_space_membership_change` | `_on_left_space` |
| `remove_from_space` | `_maybe_announce_space_membership_change` (with kicker) | `_on_kicked_from_space` |

### Space-event channel target

Space-scoped membership renders into the space's **`#general`** channel — matches the web UI's rendering target so agent transcript + human view stay aligned. Falls back to lexicographically-first visible channel when no `#general` is present.

### Inviter resolution

`joined` body renders "(invited by Y)" when known. Lookup order:
1. `payload.original_invite.signer_slug` (server-auto-accept embeds the source invite)
2. `_inviter_by_invitation_event_id` cache (populated on inbound `invite_to_*` events for the manual-accept path that omits `original_invite`)
3. Otherwise omit the suffix

Cache is lifetime-scoped — post-restart manual-accepts we never saw the invite for render without the suffix.

### Primer

`shared_content.py` adds one bullet so agents understand the announcement variant is read-only.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_channel_membership_system_message.py` → **42/42 passed** (covers 6-event matrix × actor × dedup × persistence-failure × cache backfill × #general-preferred path × lex-first fallback).
- [x] `PYTHONPATH=src python -m pytest tests/test_channel_intro_nudge.py` → unchanged, still pass.
- [x] Full suite: **1591 passed / 9 skipped** (the 9 are pre-existing symlink-unavailable / permission-mode-pending skips on Windows).
- [x] Source review: cross-checked event coverage against web-side PUF-317 (`puffo-core-han-group#257`); 12/12 (event × actor-direction) variants handled.
- [ ] **Operator manual repro:** 2-browser-user + 1-agent in a test channel; user-B leaves channel → agent transcript receives the announcement. Repeat for user-B leaves space → agent receives announcement in #general.