### PR TITLE
PUF-323: close aiohttp ClientSession on MCP subprocess teardown + log creator call-site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2-unreleased]
+
+### Fixed
+
+- **`Unclosed client session` warning on every CLI-agent MCP subprocess
+  shutdown.** `DataClient`, `PuffoRpcClient`, and `PuffoCoreHttpClient` each
+  lazy-init an `aiohttp.ClientSession` and define `close()`, but `close()`
+  was never called. `FastMCP.run()` is blocking, so the subprocess exited
+  with sessions open and Python's gc emitted the warning during teardown.
+  A new FastMCP `lifespan` hook now closes each adapter's session while
+  the event loop is still alive. Per-adapter `try`/`except` so one
+  `close()` raising can't strand the rest.
+
+### Internal
+
+- `DataClient._get_session()` and `PuffoRpcClient._get_session()` log an
+  INFO line at first lazy-create (class name + `base_url` + `agent_id`),
+  so any future leak warning has a grep-able creation timestamp to match
+  against aiohttp's bare-memory-address gc repr.
+
 ## [1.0.1] — 2026-06-26
 
 ### Added

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -25,10 +25,7 @@ class PuffoRpcClient:
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
-            # PUF-323: pin the call-site so any future ``Unclosed
-            # client session`` warning has a grep-able prior log line
-            # the operator can match against the bare memory-address
-            # repr aiohttp emits at gc time.
+            # Match the bare-address repr aiohttp gc-emits on a leak.
             logger.info(
                 "aiohttp ClientSession created (class=PuffoRpcClient "
                 "base_url=%s agent_id=%s)",

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -25,6 +25,15 @@ class PuffoRpcClient:
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
+            # PUF-323: pin the call-site so any future ``Unclosed
+            # client session`` warning has a grep-able prior log line
+            # the operator can match against the bare memory-address
+            # repr aiohttp emits at gc time.
+            logger.info(
+                "aiohttp ClientSession created (class=PuffoRpcClient "
+                "base_url=%s agent_id=%s)",
+                self.base_url, self.agent_id,
+            )
         return self._session
 
     async def close(self) -> None:

--- a/src/puffo_agent/mcp/_lifespan.py
+++ b/src/puffo_agent/mcp/_lifespan.py
@@ -1,12 +1,8 @@
-"""FastMCP lifespan hook that closes the puffo-core MCP subprocess's
-aiohttp.ClientSession holders on teardown (PUF-323).
+"""FastMCP lifespan hook that closes the MCP subprocess's
+aiohttp.ClientSession holders on teardown.
 
-Lives in its own module so the unit tests can import the cleanup
-function without also pulling in ``mcp.server.fastmcp`` (the ``mcp``
-SDK is optional in dev environments — exercising the lifespan
-contract through a real FastMCP would gate the test on having the
-SDK installed, which the rest of the daemon test suite already
-intentionally avoids).
+In its own module so tests can import ``make_lifespan`` without
+pulling in ``mcp.server.fastmcp`` (the SDK is optional in dev).
 """
 
 from __future__ import annotations
@@ -27,22 +23,15 @@ def make_lifespan(
     rpc_client: _AsyncCloseable | None,
     http: _AsyncCloseable,
 ):
-    """Build the async context manager FastMCP runs around its serve
-    loop. Yields ``None`` (tool handlers already hold references to
-    ``data`` / ``rpc`` / ``http`` via ``PuffoCoreToolsConfig`` — no
-    shared lifespan context object needed); the value is the
-    ``finally`` block that closes every adapter's aiohttp session
-    while the event loop is still alive."""
+    """Async context manager FastMCP wraps around its serve loop;
+    closes every adapter session while the loop is still alive."""
 
     @asynccontextmanager
     async def _lifespan(_app: Any) -> AsyncIterator[None]:
         try:
             yield
         finally:
-            # Each close() is wrapped so a failure to close one
-            # adapter doesn't strand the others. The unclosed-warning
-            # we're fixing fires from any one of them; bailing on
-            # the first exception would leave the rest leaked.
+            # Per-adapter try so one close() raising can't strand the rest.
             for label, closer in (
                 ("DataClient", data.close),
                 ("PuffoRpcClient", rpc_client.close if rpc_client else None),
@@ -54,10 +43,7 @@ def make_lifespan(
                     await closer()
                 except Exception:  # noqa: BLE001
                     logger.exception(
-                        "PUF-323: %s.close() raised during MCP "
-                        "subprocess teardown; other adapters will "
-                        "still be closed.",
-                        label,
+                        "%s.close() raised during MCP teardown", label,
                     )
 
     return _lifespan

--- a/src/puffo_agent/mcp/_lifespan.py
+++ b/src/puffo_agent/mcp/_lifespan.py
@@ -1,0 +1,63 @@
+"""FastMCP lifespan hook that closes the puffo-core MCP subprocess's
+aiohttp.ClientSession holders on teardown (PUF-323).
+
+Lives in its own module so the unit tests can import the cleanup
+function without also pulling in ``mcp.server.fastmcp`` (the ``mcp``
+SDK is optional in dev environments — exercising the lifespan
+contract through a real FastMCP would gate the test on having the
+SDK installed, which the rest of the daemon test suite already
+intentionally avoids).
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class _AsyncCloseable(Protocol):
+    async def close(self) -> None: ...
+
+
+def make_lifespan(
+    data: _AsyncCloseable,
+    rpc_client: _AsyncCloseable | None,
+    http: _AsyncCloseable,
+):
+    """Build the async context manager FastMCP runs around its serve
+    loop. Yields ``None`` (tool handlers already hold references to
+    ``data`` / ``rpc`` / ``http`` via ``PuffoCoreToolsConfig`` — no
+    shared lifespan context object needed); the value is the
+    ``finally`` block that closes every adapter's aiohttp session
+    while the event loop is still alive."""
+
+    @asynccontextmanager
+    async def _lifespan(_app: Any) -> AsyncIterator[None]:
+        try:
+            yield
+        finally:
+            # Each close() is wrapped so a failure to close one
+            # adapter doesn't strand the others. The unclosed-warning
+            # we're fixing fires from any one of them; bailing on
+            # the first exception would leave the rest leaked.
+            for label, closer in (
+                ("DataClient", data.close),
+                ("PuffoRpcClient", rpc_client.close if rpc_client else None),
+                ("PuffoCoreHttpClient", http.close),
+            ):
+                if closer is None:
+                    continue
+                try:
+                    await closer()
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "PUF-323: %s.close() raised during MCP "
+                        "subprocess teardown; other adapters will "
+                        "still be closed.",
+                        label,
+                    )
+
+    return _lifespan

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -15,6 +15,8 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class StoredMessageDict:
@@ -80,6 +82,15 @@ class DataClient:
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
+            # PUF-323: pin the call-site so any future ``Unclosed
+            # client session`` warning has a grep-able prior log line
+            # the operator can match against the bare memory-address
+            # repr aiohttp emits at gc time.
+            logger.info(
+                "aiohttp ClientSession created (class=DataClient "
+                "base_url=%s agent_id=%s)",
+                self.base_url, self.agent_id,
+            )
         return self._session
 
     async def close(self) -> None:

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -15,8 +15,6 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 
 @dataclass
 class StoredMessageDict:

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -80,10 +80,7 @@ class DataClient:
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
-            # PUF-323: pin the call-site so any future ``Unclosed
-            # client session`` warning has a grep-able prior log line
-            # the operator can match against the bare memory-address
-            # repr aiohttp emits at gc time.
+            # Match the bare-address repr aiohttp gc-emits on a leak.
             logger.info(
                 "aiohttp ClientSession created (class=DataClient "
                 "base_url=%s agent_id=%s)",

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -19,6 +19,7 @@ from mcp.server.fastmcp import FastMCP
 
 from ..crypto.http_client import PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore
+from ._lifespan import make_lifespan
 from .data_client import DataClient
 from ._host_mcp import PuffoRpcClient
 from .host_tools import (
@@ -211,7 +212,16 @@ def build_server(
         rpc_client=rpc_client,
     )
 
-    mcp = FastMCP("puffo-core")
+    # PUF-323: wire FastMCP's lifespan hook so the aiohttp.ClientSession
+    # instances inside DataClient + PuffoRpcClient (+ PuffoCoreHttpClient)
+    # close while the event loop is still alive. Without this, the
+    # ``FastMCP.run()`` blocking call exits with sessions open, the
+    # loop tears down, and Python's gc emits the operator-confusing
+    # ``Unclosed client session`` error every subprocess shutdown.
+    mcp = FastMCP(
+        "puffo-core",
+        lifespan=make_lifespan(data, rpc_client, http),
+    )
     register_core_tools(mcp, core_cfg)
     _register_local_tools(mcp, workspace, runtime_kind, harness)
     return mcp

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -212,12 +212,8 @@ def build_server(
         rpc_client=rpc_client,
     )
 
-    # PUF-323: wire FastMCP's lifespan hook so the aiohttp.ClientSession
-    # instances inside DataClient + PuffoRpcClient (+ PuffoCoreHttpClient)
-    # close while the event loop is still alive. Without this, the
-    # ``FastMCP.run()`` blocking call exits with sessions open, the
-    # loop tears down, and Python's gc emits the operator-confusing
-    # ``Unclosed client session`` error every subprocess shutdown.
+    # Lifespan closes adapter sessions while the loop is alive,
+    # silencing the ``Unclosed client session`` gc warning.
     mcp = FastMCP(
         "puffo-core",
         lifespan=make_lifespan(data, rpc_client, http),

--- a/tests/test_puffo_core_server_lifespan.py
+++ b/tests/test_puffo_core_server_lifespan.py
@@ -1,0 +1,147 @@
+"""FastMCP lifespan hook closes the MCP subprocess's aiohttp clients
+on teardown (PUF-323).
+
+Without the lifespan, ``FastMCP.run()`` exits the stdio loop with the
+DataClient + PuffoRpcClient sessions still open; Python's gc emits the
+operator-confusing ``Unclosed client session`` warning during process
+shutdown. These tests pin the contract:
+
+  1. Successful teardown closes every adapter that was wired.
+  2. A ``None`` ``rpc_client`` (PUFFO_RPC_URL unset) is tolerated.
+  3. A close that raises doesn't strand later closes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import warnings
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.mcp._lifespan import make_lifespan
+
+
+class _CloseSpy:
+    """Stub adapter with an awaitable ``close()`` that records its call
+    and (optionally) raises. Mirrors the surface
+    ``make_lifespan`` consumes from DataClient / PuffoRpcClient /
+    PuffoCoreHttpClient — they all expose ``async def close()``."""
+
+    def __init__(self, raise_on_close: bool = False) -> None:
+        self.close_count = 0
+        self.raise_on_close = raise_on_close
+
+    async def close(self) -> None:
+        self.close_count += 1
+        if self.raise_on_close:
+            raise RuntimeError("simulated adapter teardown failure")
+
+
+@pytest.mark.asyncio
+async def test_lifespan_closes_each_wired_adapter():
+    """Happy path: every adapter's ``close()`` is awaited on exit."""
+    data = _CloseSpy()
+    rpc = _CloseSpy()
+    http = _CloseSpy()
+
+    lifespan = make_lifespan(data, rpc, http)
+    async with lifespan(_app=None) as _:
+        # Simulate the MCP server's serve loop body — nothing to do
+        # for the teardown test besides existing inside the context.
+        pass
+
+    assert data.close_count == 1
+    assert rpc.close_count == 1
+    assert http.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_tolerates_none_rpc_client():
+    """PUFFO_RPC_URL unset → ``rpc_client=None`` in build_server. The
+    lifespan must NOT call ``close()`` on it (would AttributeError)."""
+    data = _CloseSpy()
+    http = _CloseSpy()
+
+    lifespan = make_lifespan(data, None, http)
+    async with lifespan(_app=None) as _:
+        pass
+
+    assert data.close_count == 1
+    assert http.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_close_failure_does_not_strand_later_adapters(
+    caplog,
+):
+    """The whole point of the lifespan is to clean up the leak; one
+    adapter blowing up at teardown can't prevent the OTHERS from
+    closing (otherwise we're back to the pre-PUF-323 leak for them)."""
+    data = _CloseSpy(raise_on_close=True)
+    rpc = _CloseSpy()
+    http = _CloseSpy()
+
+    lifespan = make_lifespan(data, rpc, http)
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.mcp._lifespan"):
+        async with lifespan(_app=None) as _:
+            pass
+
+    # First adapter raised but its close() ran (count==1).
+    assert data.close_count == 1
+    # Later adapters still got closed.
+    assert rpc.close_count == 1
+    assert http.close_count == 1
+    # The failure surfaced as an ERROR-level log so the operator can
+    # tell what went wrong — but didn't propagate out of the lifespan.
+    assert any(
+        "DataClient.close()" in rec.message
+        and "raised" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifespan_close_failure_on_middle_adapter_still_closes_last(
+    caplog,
+):
+    """Belt-and-suspenders: the order-iteration logic continues
+    iterating past an exception, not just the first one."""
+    data = _CloseSpy()
+    rpc = _CloseSpy(raise_on_close=True)
+    http = _CloseSpy()
+
+    lifespan = make_lifespan(data, rpc, http)
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.mcp._lifespan"):
+        async with lifespan(_app=None) as _:
+            pass
+
+    assert data.close_count == 1
+    assert rpc.close_count == 1
+    assert http.close_count == 1
+    assert any(
+        "PuffoRpcClient.close()" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifespan_yields_under_async_with():
+    """Defensive — the lifespan needs to be a real async context
+    manager so FastMCP can wrap its serve loop. Failing this would
+    mean build_server's ``lifespan=`` arg is wired wrong."""
+    data = _CloseSpy()
+    http = _CloseSpy()
+
+    lifespan = make_lifespan(data, None, http)
+    # ``async with`` is the only way FastMCP enters/exits the lifespan;
+    # if this raises ``TypeError: object ... not an async context
+    # manager``, the wiring is broken.
+    async with lifespan(_app=None) as ctx:
+        # The lifespan yields ``None`` — handlers don't need a shared
+        # context object since they already hold refs to the adapters
+        # through PuffoCoreToolsConfig.
+        assert ctx is None

--- a/tests/test_puffo_core_server_lifespan.py
+++ b/tests/test_puffo_core_server_lifespan.py
@@ -1,22 +1,10 @@
-"""FastMCP lifespan hook closes the MCP subprocess's aiohttp clients
-on teardown (PUF-323).
-
-Without the lifespan, ``FastMCP.run()`` exits the stdio loop with the
-DataClient + PuffoRpcClient sessions still open; Python's gc emits the
-operator-confusing ``Unclosed client session`` warning during process
-shutdown. These tests pin the contract:
-
-  1. Successful teardown closes every adapter that was wired.
-  2. A ``None`` ``rpc_client`` (PUFFO_RPC_URL unset) is tolerated.
-  3. A close that raises doesn't strand later closes.
-"""
+"""FastMCP lifespan closes the MCP subprocess's aiohttp clients on teardown."""
 
 from __future__ import annotations
 
 import logging
 import os
 import sys
-import warnings
 
 import pytest
 
@@ -26,11 +14,6 @@ from puffo_agent.mcp._lifespan import make_lifespan
 
 
 class _CloseSpy:
-    """Stub adapter with an awaitable ``close()`` that records its call
-    and (optionally) raises. Mirrors the surface
-    ``make_lifespan`` consumes from DataClient / PuffoRpcClient /
-    PuffoCoreHttpClient — they all expose ``async def close()``."""
-
     def __init__(self, raise_on_close: bool = False) -> None:
         self.close_count = 0
         self.raise_on_close = raise_on_close
@@ -43,15 +26,10 @@ class _CloseSpy:
 
 @pytest.mark.asyncio
 async def test_lifespan_closes_each_wired_adapter():
-    """Happy path: every adapter's ``close()`` is awaited on exit."""
-    data = _CloseSpy()
-    rpc = _CloseSpy()
-    http = _CloseSpy()
+    data, rpc, http = _CloseSpy(), _CloseSpy(), _CloseSpy()
 
     lifespan = make_lifespan(data, rpc, http)
-    async with lifespan(_app=None) as _:
-        # Simulate the MCP server's serve loop body — nothing to do
-        # for the teardown test besides existing inside the context.
+    async with lifespan(_app=None):
         pass
 
     assert data.close_count == 1
@@ -61,13 +39,11 @@ async def test_lifespan_closes_each_wired_adapter():
 
 @pytest.mark.asyncio
 async def test_lifespan_tolerates_none_rpc_client():
-    """PUFFO_RPC_URL unset → ``rpc_client=None`` in build_server. The
-    lifespan must NOT call ``close()`` on it (would AttributeError)."""
-    data = _CloseSpy()
-    http = _CloseSpy()
+    """PUFFO_RPC_URL unset → rpc_client=None; must not AttributeError."""
+    data, http = _CloseSpy(), _CloseSpy()
 
     lifespan = make_lifespan(data, None, http)
-    async with lifespan(_app=None) as _:
+    async with lifespan(_app=None):
         pass
 
     assert data.close_count == 1
@@ -75,73 +51,48 @@ async def test_lifespan_tolerates_none_rpc_client():
 
 
 @pytest.mark.asyncio
-async def test_lifespan_close_failure_does_not_strand_later_adapters(
-    caplog,
-):
-    """The whole point of the lifespan is to clean up the leak; one
-    adapter blowing up at teardown can't prevent the OTHERS from
-    closing (otherwise we're back to the pre-PUF-323 leak for them)."""
+async def test_lifespan_close_failure_does_not_strand_later_adapters(caplog):
+    """First-adapter raise must not skip the rest."""
     data = _CloseSpy(raise_on_close=True)
-    rpc = _CloseSpy()
-    http = _CloseSpy()
+    rpc, http = _CloseSpy(), _CloseSpy()
 
     lifespan = make_lifespan(data, rpc, http)
     with caplog.at_level(logging.ERROR, logger="puffo_agent.mcp._lifespan"):
-        async with lifespan(_app=None) as _:
+        async with lifespan(_app=None):
             pass
 
-    # First adapter raised but its close() ran (count==1).
     assert data.close_count == 1
-    # Later adapters still got closed.
     assert rpc.close_count == 1
     assert http.close_count == 1
-    # The failure surfaced as an ERROR-level log so the operator can
-    # tell what went wrong — but didn't propagate out of the lifespan.
     assert any(
-        "DataClient.close()" in rec.message
-        and "raised" in rec.message
+        "DataClient.close()" in rec.message and "raised" in rec.message
         for rec in caplog.records
     )
 
 
 @pytest.mark.asyncio
-async def test_lifespan_close_failure_on_middle_adapter_still_closes_last(
-    caplog,
-):
-    """Belt-and-suspenders: the order-iteration logic continues
-    iterating past an exception, not just the first one."""
+async def test_lifespan_close_failure_on_middle_adapter_still_closes_last(caplog):
+    """Iteration continues past every exception, not just the first."""
     data = _CloseSpy()
     rpc = _CloseSpy(raise_on_close=True)
     http = _CloseSpy()
 
     lifespan = make_lifespan(data, rpc, http)
     with caplog.at_level(logging.ERROR, logger="puffo_agent.mcp._lifespan"):
-        async with lifespan(_app=None) as _:
+        async with lifespan(_app=None):
             pass
 
     assert data.close_count == 1
     assert rpc.close_count == 1
     assert http.close_count == 1
-    assert any(
-        "PuffoRpcClient.close()" in rec.message
-        for rec in caplog.records
-    )
+    assert any("PuffoRpcClient.close()" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_lifespan_yields_under_async_with():
-    """Defensive — the lifespan needs to be a real async context
-    manager so FastMCP can wrap its serve loop. Failing this would
-    mean build_server's ``lifespan=`` arg is wired wrong."""
-    data = _CloseSpy()
-    http = _CloseSpy()
+    """async-context-manager wiring — FastMCP needs `async with` to work."""
+    data, http = _CloseSpy(), _CloseSpy()
 
     lifespan = make_lifespan(data, None, http)
-    # ``async with`` is the only way FastMCP enters/exits the lifespan;
-    # if this raises ``TypeError: object ... not an async context
-    # manager``, the wiring is broken.
     async with lifespan(_app=None) as ctx:
-        # The lifespan yields ``None`` — handlers don't need a shared
-        # context object since they already hold refs to the adapters
-        # through PuffoCoreToolsConfig.
         assert ctx is None


### PR DESCRIPTION
## Summary

Fixes the operator-reported `[ERROR] asyncio: Unclosed client session client_session: <aiohttp.client.ClientSession object at 0x...>` warning that fires on every CLI-based agent's `puffo_core_server` MCP subprocess shutdown.

**Mechanism (β)**: `DataClient` / `PuffoRpcClient` / `PuffoCoreHttpClient` lazy-init `aiohttp.ClientSession` instances inside `_get_session()` and have correct `async def close()` methods, but **`close()` was never called** — `FastMCP.run()` is blocking; the subprocess exits with the event loop tearing down while sessions are still open → Python's gc emits the unclosed-warning.

**Two fixes folded in (iii)**:

1. **Leak fix** — new `mcp/_lifespan.py` builds an async context manager whose `finally` closes each adapter's session while the event loop is still alive. `build_server()` passes it as `lifespan=` to the `FastMCP(...)` ctor (FastMCP supports this hook out of the box). Per-adapter try/except so one close() raising can't strand the others.

2. **Diagnostic improvement** — both `DataClient._get_session()` and `PuffoRpcClient._get_session()` now log an INFO line at first lazy-create: `aiohttp ClientSession created (class=<X> base_url=<...> agent_id=<...>)`. If any future unclosed-warning fires (e.g. a not-yet-wired adapter), the operator has a grep-able prior log line to match against aiohttp's bare-memory-address repr.

**Module-extraction note**: `make_lifespan` lives in its own module so the test file can import the cleanup contract without dragging in the optional `mcp.server.fastmcp` SDK chain (the rest of the daemon test suite already works around this).

## Test plan

- [x] `python3 -m pytest tests/test_puffo_core_server_lifespan.py -v` → **5/5 pass** (happy + None-rpc + per-adapter-failure-doesn't-strand + middle-failure + async-context-manager contract).
- [x] Full daemon suite (excl. pre-existing `mcp` / `PySide6` infra gaps): 1472 passed / 0 new failures vs main.
- [x] Sibling sweep: 4 `aiohttp.ClientSession()` instantiation sites; 3 covered by the new lifespan, the 4th (`crypto/http_session.py`) consumed via `async with`-scoped helper in `portal/import_agents.py` — no leak.
- [x] Polish fold: duplicate `logger = logging.getLogger(__name__)` in `data_client.py` dropped in `f5dbe95`.
- [ ] Operator manual smoke post-merge: spawn a CLI-based agent → signal subprocess → grep audit log for `Unclosed client session` (should be silent post-PUF-323) + grep for `aiohttp ClientSession created` (should land at first tool call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)