### PR TITLE
PUF-324: capture codex assistant.text + tool events in the per-agent audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.2-unreleased]
 
+### Added
+
+- **Codex agents now write to the per-agent audit log.** The
+  `ClaudeSession.audit` contract already captured `assistant.text`
+  / `tool` rows from claude-code; the codex adapter was
+  un-instrumented, so operators tailing
+  `<workspace>/.puffo-agent/audit.log` saw nothing for codex-driven
+  agents' replies + tool calls. `CodexSession` now emits one
+  `assistant.text` row per assistant message at completion (not per
+  streaming delta — earlier drafts split a single `[SILENT]` reply
+  into four rows) and one `tool` row per `tool_use` / `mcpToolCall`
+  completion. The `mcpToolCall` `name` uses the
+  `mcp__server__tool` shape that claude-code already emits, so a
+  cross-adapter `grep` on the audit log matches both surfaces.
+- **Per-agent Logs tab in the desktop UI surfaces audit.log.** The
+  `Logs` tab inside an agent's pane previously only showed the
+  daemon-wide Python logger ring filtered by agent id (mostly spawn
+  / WS / supervisor noise). It now tails the agent's audit.log so
+  operators see `assistant.text` / `tool` / `turn.input` /
+  `turn.end` / `session.start` / `auth_error.*` rows without
+  leaving the app. The daemon-wide Python log stays reachable
+  through the left rail's `Logs` section.
+- **`sandbox` is editable through the bridge API and the CLI.**
+  `PATCH /v1/agents/{id}/runtime` accepts a `sandbox` field
+  (`read-only` / `workspace-write` / `danger-full-access`);
+  `puffo-agent agent runtime <id> --sandbox <value>` exposes the
+  same on the terminal. Both routes existed for `permission_mode`
+  / `model` / etc. but skipped `sandbox` — operators had to
+  hand-edit `agent.yml`. Help text flags that `workspace-write`
+  is silently downgraded to read-only on Windows.
+
 ### Fixed
 
 - **`Unclosed client session` warning on every CLI-agent MCP subprocess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Codex agents now write to the per-agent audit log.** The
-  `ClaudeSession.audit` contract already captured `assistant.text`
-  / `tool` rows from claude-code; the codex adapter was
+  `ClaudeSession.audit` contract already captured the per-turn
+  envelope (`session.start` / `turn.input` / `assistant.text` /
+  `tool` / `turn.end`) from claude-code; the codex adapter was
   un-instrumented, so operators tailing
   `<workspace>/.puffo-agent/audit.log` saw nothing for codex-driven
-  agents' replies + tool calls. `CodexSession` now emits one
+  agents. `CodexSession` now emits the matching shape: one
+  `session.start` row at thread start / resume; one `turn.input`
+  row carrying the user message before each turn dispatches; one
   `assistant.text` row per assistant message at completion (not per
   streaming delta — earlier drafts split a single `[SILENT]` reply
-  into four rows) and one `tool` row per `tool_use` / `mcpToolCall`
-  completion. The `mcpToolCall` `name` uses the
-  `mcp__server__tool` shape that claude-code already emits, so a
-  cross-adapter `grep` on the audit log matches both surfaces.
+  into four rows); one `tool` row per `tool_use` / `mcpToolCall`
+  completion; one `turn.end` row with reply_len / tool_calls /
+  tokens / duration after the turn finishes. The `mcpToolCall`
+  `name` uses the `mcp__server__tool` shape that claude-code
+  already emits, so a cross-adapter `grep` on the audit log
+  matches both surfaces.
 - **Per-agent Logs tab in the desktop UI surfaces audit.log.** The
   `Logs` tab inside an agent's pane previously only showed the
   daemon-wide Python logger ring filtered by agent id (mostly spawn

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -299,6 +299,8 @@ class CodexSession:
             )
             self._active_turn = turn
 
+        if self.audit is not None:
+            self.audit.write("turn.input", content=user_message)
         logger.debug(
             "agent %s: codex turn/start sending (msg_len=%d, thread=%s)",
             self.agent_id, len(user_message), self._conversation_id,
@@ -392,6 +394,15 @@ class CodexSession:
             len(turn.send_message_targets),
             turn.input_tokens, turn.output_tokens,
         )
+        if self.audit is not None:
+            self.audit.write(
+                "turn.end",
+                reply_len=len(reply),
+                tool_calls=turn.tool_calls,
+                input_tokens=turn.input_tokens,
+                output_tokens=turn.output_tokens,
+                duration_ms=int((time.time() - turn.started_at) * 1000),
+            )
         self._propagate_turn_outcome(outcome="success")
         # core.py's reply-routing check: a non-empty
         # ``send_message_targets`` list means "agent already posted via

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -1097,8 +1097,6 @@ class CodexSession:
             delta_text = params.get("delta")
             if isinstance(delta_text, str) and delta_text:
                 turn.reply_chunks.append(delta_text)
-                if self.audit is not None:
-                    self.audit.write("assistant.text", text=delta_text)
             return
         # 2. Final item — nested under params.item.
         item = params.get("item") or {}
@@ -1115,12 +1113,14 @@ class CodexSession:
                     joined = "".join(turn.reply_chunks)
                     if joined.strip() != text.strip():
                         turn.reply_chunks = [text]
-                        # Buffer replaced ⇒ prior delta rows are stale;
-                        # emit the authoritative text so audit.log matches.
-                        if self.audit is not None:
-                            self.audit.write(
-                                "assistant.text", text=text,
-                            )
+                # Single audit row per assistant message — matches the
+                # claude-code adapter's shape (one ``assistant.text`` per
+                # text block, not one per streaming token).
+                final_text = "".join(turn.reply_chunks) or (
+                    text if isinstance(text, str) else ""
+                )
+                if self.audit is not None and final_text:
+                    self.audit.write("assistant.text", text=final_text)
             elif kind in ("tool_use", "tooluse", "tool_call", "toolcall"):
                 turn.tool_calls += 1
                 if self.audit is not None:

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from .base import TurnResult
+from .cli_session import AuditLog
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +225,7 @@ class CodexSession:
         permission_mode: str = "bypassPermissions",
         sandbox: str = "danger-full-access",
         model: str = "",
+        audit: Optional[AuditLog] = None,
     ):
         self.agent_id = agent_id
         self.session_file = session_file
@@ -238,6 +240,12 @@ class CodexSession:
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
+        # PUF-324: per-agent NDJSON audit log. Matches the
+        # ``ClaudeSession.audit`` contract — each ``assistant.text``
+        # streaming delta + ``tool``-use completion gets a row so
+        # operators can tail the same ``<workspace>/.puffo-agent/audit.log``
+        # regardless of which adapter is driving the agent.
+        self.audit = audit
 
         self._proc: asyncio.subprocess.Process | None = None
         self._reader_task: asyncio.Task | None = None
@@ -1093,6 +1101,12 @@ class CodexSession:
             delta_text = params.get("delta")
             if isinstance(delta_text, str) and delta_text:
                 turn.reply_chunks.append(delta_text)
+                # PUF-324: tee streaming narrative into the audit log
+                # so the operator can see intermediate ``searching
+                # web`` / ``updating code`` text live, matching the
+                # claude-code adapter's ``assistant.text`` shape.
+                if self.audit is not None:
+                    self.audit.write("assistant.text", text=delta_text)
             return
         # 2. Final item — nested under params.item.
         item = params.get("item") or {}
@@ -1109,8 +1123,31 @@ class CodexSession:
                     joined = "".join(turn.reply_chunks)
                     if joined.strip() != text.strip():
                         turn.reply_chunks = [text]
+                        # PUF-324: when we replace the delta-built
+                        # buffer because of the missed-delta path, the
+                        # streaming-delta audit rows above don't reflect
+                        # the authoritative text. Emit a synthetic
+                        # ``assistant.text`` so audit.log still carries
+                        # the operator-observable final narrative.
+                        if self.audit is not None:
+                            self.audit.write(
+                                "assistant.text", text=text,
+                            )
             elif kind in ("tool_use", "tooluse", "tool_call", "toolcall"):
                 turn.tool_calls += 1
+                # PUF-324: cross-adapter parity with
+                # ``ClaudeSession``'s tool capture. Some codex shapes
+                # nest the tool name as ``item.name`` / args as
+                # ``item.input``; fall through to empty strings rather
+                # than skipping the row entirely so the operator at
+                # least sees the count + presence in audit.log.
+                if self.audit is not None:
+                    self.audit.write(
+                        "tool",
+                        name=str(item.get("name") or kind),
+                        input=item.get("input") or item.get("arguments") or {},
+                        id=str(item.get("id") or ""),
+                    )
             elif kind == "mcptoolcall":
                 # Real codex shape per debug logs: ``item/completed``
                 # with ``item.type == "mcpToolCall"``, ``item.server``
@@ -1134,6 +1171,17 @@ class CodexSession:
                         "channel": str(args.get("channel", "")),
                         "root_id": str(args.get("root_id", "")),
                     })
+                # PUF-324: cross-adapter audit-log shape — the tool
+                # name codex puts on the ``mcpToolCall`` item is
+                # ``server__tool`` (e.g. ``puffo__send_message``),
+                # mirroring how the claude-code adapter sees these.
+                if self.audit is not None:
+                    self.audit.write(
+                        "tool",
+                        name=f"{server}__{tool}" if server and tool else (tool or "mcp"),
+                        input=args,
+                        id=str(item.get("id") or ""),
+                    )
             return
 
     def _absorb_turn_usage(self, turn: _PendingTurn, params: dict) -> None:

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -702,6 +702,12 @@ class CodexSession:
                     "agent %s: resumed codex thread %s",
                     self.agent_id, self._conversation_id,
                 )
+                if self.audit is not None:
+                    self.audit.write(
+                        "session.start",
+                        resume=True,
+                        session_id=self._conversation_id,
+                    )
                 return
             except Exception as exc:
                 logger.warning(
@@ -755,6 +761,12 @@ class CodexSession:
             "agent %s: started codex thread %s",
             self.agent_id, self._conversation_id,
         )
+        if self.audit is not None:
+            self.audit.write(
+                "session.start",
+                resume=False,
+                session_id=self._conversation_id,
+            )
 
 
     async def _teardown_locked(self) -> None:

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -240,11 +240,7 @@ class CodexSession:
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
-        # PUF-324: per-agent NDJSON audit log. Matches the
-        # ``ClaudeSession.audit`` contract — each ``assistant.text``
-        # streaming delta + ``tool``-use completion gets a row so
-        # operators can tail the same ``<workspace>/.puffo-agent/audit.log``
-        # regardless of which adapter is driving the agent.
+        # Cross-adapter audit log; mirrors ClaudeSession.audit.
         self.audit = audit
 
         self._proc: asyncio.subprocess.Process | None = None
@@ -1101,10 +1097,6 @@ class CodexSession:
             delta_text = params.get("delta")
             if isinstance(delta_text, str) and delta_text:
                 turn.reply_chunks.append(delta_text)
-                # PUF-324: tee streaming narrative into the audit log
-                # so the operator can see intermediate ``searching
-                # web`` / ``updating code`` text live, matching the
-                # claude-code adapter's ``assistant.text`` shape.
                 if self.audit is not None:
                     self.audit.write("assistant.text", text=delta_text)
             return
@@ -1123,24 +1115,14 @@ class CodexSession:
                     joined = "".join(turn.reply_chunks)
                     if joined.strip() != text.strip():
                         turn.reply_chunks = [text]
-                        # PUF-324: when we replace the delta-built
-                        # buffer because of the missed-delta path, the
-                        # streaming-delta audit rows above don't reflect
-                        # the authoritative text. Emit a synthetic
-                        # ``assistant.text`` so audit.log still carries
-                        # the operator-observable final narrative.
+                        # Buffer replaced ⇒ prior delta rows are stale;
+                        # emit the authoritative text so audit.log matches.
                         if self.audit is not None:
                             self.audit.write(
                                 "assistant.text", text=text,
                             )
             elif kind in ("tool_use", "tooluse", "tool_call", "toolcall"):
                 turn.tool_calls += 1
-                # PUF-324: cross-adapter parity with
-                # ``ClaudeSession``'s tool capture. Some codex shapes
-                # nest the tool name as ``item.name`` / args as
-                # ``item.input``; fall through to empty strings rather
-                # than skipping the row entirely so the operator at
-                # least sees the count + presence in audit.log.
                 if self.audit is not None:
                     self.audit.write(
                         "tool",
@@ -1171,14 +1153,13 @@ class CodexSession:
                         "channel": str(args.get("channel", "")),
                         "root_id": str(args.get("root_id", "")),
                     })
-                # PUF-324: cross-adapter audit-log shape — the tool
-                # name codex puts on the ``mcpToolCall`` item is
-                # ``server__tool`` (e.g. ``puffo__send_message``),
-                # mirroring how the claude-code adapter sees these.
+                # ``mcp__server__tool`` matches the shape the
+                # claude-code adapter records (e.g. mcp__puffo__send_message)
+                # so an operator's audit-log grep crosses adapters.
                 if self.audit is not None:
                     self.audit.write(
                         "tool",
-                        name=f"{server}__{tool}" if server and tool else (tool or "mcp"),
+                        name=f"mcp__{server}__{tool}" if server and tool else (tool or "mcp"),
                         input=args,
                         id=str(item.get("id") or ""),
                     )

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -240,7 +240,6 @@ class CodexSession:
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
-        # Cross-adapter audit log; mirrors ClaudeSession.audit.
         self.audit = audit
 
         self._proc: asyncio.subprocess.Process | None = None
@@ -1113,9 +1112,7 @@ class CodexSession:
                     joined = "".join(turn.reply_chunks)
                     if joined.strip() != text.strip():
                         turn.reply_chunks = [text]
-                # Single audit row per assistant message — matches the
-                # claude-code adapter's shape (one ``assistant.text`` per
-                # text block, not one per streaming token).
+                # One row per assistant message (not per streaming token).
                 final_text = "".join(turn.reply_chunks) or (
                     text if isinstance(text, str) else ""
                 )
@@ -1153,9 +1150,8 @@ class CodexSession:
                         "channel": str(args.get("channel", "")),
                         "root_id": str(args.get("root_id", "")),
                     })
-                # ``mcp__server__tool`` matches the shape the
-                # claude-code adapter records (e.g. mcp__puffo__send_message)
-                # so an operator's audit-log grep crosses adapters.
+                # ``mcp__server__tool`` prefix matches claude-code's shape
+                # so a cross-adapter audit-log grep lights up on both.
                 if self.audit is not None:
                     self.audit.write(
                         "tool",

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -408,11 +408,6 @@ class LocalCLIAdapter(Adapter):
             )
         argv = [codex_bin, "app-server"]
 
-        # PUF-324: per-agent audit log — mirrors the hermes wiring
-        # below and the ClaudeSession path's audit hookup. Without
-        # this, codex agents' intermediate ``assistant.text`` deltas
-        # never reach ``<workspace>/.puffo-agent/audit.log`` and the
-        # operator can't reconstruct mid-session activity from disk.
         codex_audit = AuditLog(
             Path(self.workspace_dir) / ".puffo-agent" / "audit.log",
             self.agent_id,

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -408,6 +408,15 @@ class LocalCLIAdapter(Adapter):
             )
         argv = [codex_bin, "app-server"]
 
+        # PUF-324: per-agent audit log — mirrors the hermes wiring
+        # below and the ClaudeSession path's audit hookup. Without
+        # this, codex agents' intermediate ``assistant.text`` deltas
+        # never reach ``<workspace>/.puffo-agent/audit.log`` and the
+        # operator can't reconstruct mid-session activity from disk.
+        codex_audit = AuditLog(
+            Path(self.workspace_dir) / ".puffo-agent" / "audit.log",
+            self.agent_id,
+        )
         self._codex_session = CodexSession(
             agent_id=self.agent_id,
             session_file=codex_home / "codex_session.json",
@@ -417,6 +426,7 @@ class LocalCLIAdapter(Adapter):
             permission_mode=self.permission_mode,
             sandbox=self.sandbox,
             model=self.model,
+            audit=codex_audit,
         )
         return self._codex_session
 

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -495,13 +495,13 @@ async def update_runtime(request: web.Request) -> web.Response:
     """Patch the agent's runtime block. Owner-only.
 
     Accepts any subset of: ``kind``, ``provider``, ``model``,
-    ``harness``, ``api_key``, ``permission_mode``, ``allowed_tools``,
-    ``docker_image``, ``max_turns``. Missing fields are untouched.
-    ``harness`` editing requires the corresponding CLI to already be
-    installed + authenticated on the host (`claude login` /
-    `codex login` / ...) — the worker will hit auth_failed on first
-    turn otherwise. validate_triple below catches kind/provider/
-    harness combo violations before save.
+    ``harness``, ``api_key``, ``permission_mode``, ``sandbox``,
+    ``allowed_tools``, ``docker_image``, ``max_turns``. Missing fields
+    are untouched. ``harness`` editing requires the corresponding CLI
+    to already be installed + authenticated on the host
+    (`claude login` / `codex login` / ...) — the worker will hit
+    auth_failed on first turn otherwise. validate_triple below
+    catches kind/provider/harness combo violations before save.
 
     The reconcile loop notices ``runtime`` changed and respawns the
     worker on its next tick.
@@ -539,6 +539,14 @@ async def update_runtime(request: web.Request) -> web.Response:
         rt.api_key = str(payload["api_key"])
     if "permission_mode" in payload:
         rt.permission_mode = str(payload["permission_mode"])
+    if "sandbox" in payload:
+        sandbox = str(payload["sandbox"])
+        if sandbox not in ("read-only", "workspace-write", "danger-full-access"):
+            return _bad(
+                "sandbox must be one of: read-only, workspace-write, "
+                "danger-full-access"
+            )
+        rt.sandbox = sandbox
     if "allowed_tools" in payload:
         tools = payload["allowed_tools"]
         if not isinstance(tools, list):
@@ -572,6 +580,7 @@ async def update_runtime(request: web.Request) -> web.Response:
             "model": rt.model,
             "api_key_set": bool(rt.api_key),
             "permission_mode": rt.permission_mode,
+            "sandbox": rt.sandbox,
             "harness": rt.harness,
             "allowed_tools": list(rt.allowed_tools),
             "docker_image": rt.docker_image,

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -936,6 +936,9 @@ def cmd_agent_runtime(args: argparse.Namespace) -> int:
     if args.permission_mode is not None:
         cfg.runtime.permission_mode = args.permission_mode
         touched = True
+    if args.sandbox is not None:
+        cfg.runtime.sandbox = args.sandbox
+        touched = True
     if args.harness is not None:
         cfg.runtime.harness = args.harness
         touched = True
@@ -958,6 +961,7 @@ def cmd_agent_runtime(args: argparse.Namespace) -> int:
         print(f"  allowed_tools:    {cfg.runtime.allowed_tools or '[]'}")
         print(f"  docker_image:     {cfg.runtime.docker_image or '(bundled default)'}")
         print(f"  permission_mode:  {cfg.runtime.permission_mode}  (cli-local only)")
+        print(f"  sandbox:          {cfg.runtime.sandbox}  (codex only)")
         print(f"  max_turns:        {cfg.runtime.max_turns}  (sdk-local only)")
         return 0
 
@@ -1521,6 +1525,15 @@ def build_parser() -> argparse.ArgumentParser:
             "'bypassPermissions' is supported today — the proxy "
             "modes (default / acceptEdits / auto / dontAsk) need "
             "more work on the permission DM flow."
+        ),
+    )
+    runtime.add_argument(
+        "--sandbox",
+        choices=["read-only", "workspace-write", "danger-full-access"],
+        help=(
+            "codex (cli-local): file-system policy. Note "
+            "``workspace-write`` is silently downgraded to read-only "
+            "on Windows; use ``danger-full-access`` there."
         ),
     )
     runtime.add_argument(

--- a/src/puffo_agent/portal/ui/widgets/agent_workspace.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_workspace.py
@@ -112,7 +112,6 @@ class AgentWorkspace(QWidget):
             self._cfg = AgentConfig.load(agent_id)
         except Exception:
             self._cfg = None
-        slug = self._cfg.puffo_core.slug if self._cfg else ""
 
         if self._cfg:
             from ...state import agent_dir
@@ -123,13 +122,7 @@ class AgentWorkspace(QWidget):
         else:
             audit_path = Path("/nonexistent")
 
-        source = PerAgentLogSource(
-            agent_id=agent_id,
-            slug=slug,
-            audit_path=audit_path,
-            py_snapshot=self._snapshot_fn,
-            py_counter=self._counter_fn,
-        )
+        source = PerAgentLogSource(audit_path=audit_path)
         self._agent_log.set_sources(source.snapshot, source.counter)
 
         self._reload_channels()

--- a/src/puffo_agent/portal/ui/widgets/agent_workspace.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_workspace.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 from ...state import AgentConfig
 from ..names import channel_id_to_name, slug_to_display_name, space_id_to_name
 from .log_view import LogView
+from .per_agent_log_source import PerAgentLogSource
 
 
 class AgentWorkspace(QWidget):
@@ -59,9 +60,10 @@ class AgentWorkspace(QWidget):
         outer.addWidget(self._tabs)
 
     def _build_logs_tab(self) -> QWidget:
-        self._agent_log = LogView(
-            self._snapshot_fn, self._counter_fn, filter_fn=lambda _line: False,
-        )
+        # Start empty; bind() swaps in a PerAgentLogSource once an
+        # agent id is known so the tab can merge daemon-side Python
+        # log lines with the agent's audit.log NDJSON entries.
+        self._agent_log = LogView(lambda: [], lambda: 0)
         return self._agent_log
 
     def _build_files_tab(self) -> QWidget:
@@ -101,7 +103,7 @@ class AgentWorkspace(QWidget):
         self._agent_id = agent_id
         if agent_id is None:
             self._cfg = None
-            self._agent_log.set_filter(lambda _line: False)
+            self._agent_log.set_sources(lambda: [], lambda: 0)
             self._files_tree.setRootIndex(self._files_model.index(""))
             self._channel_list.clear()
             self._channel_messages.clear()
@@ -111,18 +113,24 @@ class AgentWorkspace(QWidget):
         except Exception:
             self._cfg = None
         slug = self._cfg.puffo_core.slug if self._cfg else ""
-        haystack = {agent_id, slug}
-        haystack.discard("")
-        # Worker emits "agent <id>:" and data-service emits "[<id>] ...".
-        self._agent_log.set_filter(lambda line, h=haystack: any(token in line for token in h))
 
-        # Root at the agent dir so .claude/CLAUDE.md, .codex/AGENTS.md,
-        # agent.yml, profile.md are all reachable. keys/ shows up too.
         if self._cfg:
             from ...state import agent_dir
             root = str(agent_dir(self._agent_id))
             self._files_model.setRootPath(root)
             self._files_tree.setRootIndex(self._files_model.index(root))
+            audit_path = self._cfg.resolve_workspace_dir() / ".puffo-agent" / "audit.log"
+        else:
+            audit_path = Path("/nonexistent")
+
+        source = PerAgentLogSource(
+            agent_id=agent_id,
+            slug=slug,
+            audit_path=audit_path,
+            py_snapshot=self._snapshot_fn,
+            py_counter=self._counter_fn,
+        )
+        self._agent_log.set_sources(source.snapshot, source.counter)
 
         self._reload_channels()
 

--- a/src/puffo_agent/portal/ui/widgets/agent_workspace.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_workspace.py
@@ -60,9 +60,7 @@ class AgentWorkspace(QWidget):
         outer.addWidget(self._tabs)
 
     def _build_logs_tab(self) -> QWidget:
-        # Start empty; bind() swaps in a PerAgentLogSource once an
-        # agent id is known so the tab can merge daemon-side Python
-        # log lines with the agent's audit.log NDJSON entries.
+        # bind() swaps in a PerAgentLogSource once an agent id is known.
         self._agent_log = LogView(lambda: [], lambda: 0)
         return self._agent_log
 

--- a/src/puffo_agent/portal/ui/widgets/log_view.py
+++ b/src/puffo_agent/portal/ui/widgets/log_view.py
@@ -55,6 +55,17 @@ class LogView(QPlainTextEdit):
         self._filter_fn = filter_fn
         self.reset()
 
+    def set_sources(
+        self,
+        snapshot_fn: Callable[[], list[str]],
+        counter_fn: Callable[[], int],
+    ) -> None:
+        """Swap the underlying source pair (e.g. when binding to a
+        different agent). Resets so the next poll renders from scratch."""
+        self._snapshot_fn = snapshot_fn
+        self._counter_fn = counter_fn
+        self.reset()
+
     def poll(self) -> None:
         total = self._counter_fn()
         if total < self._seen:

--- a/src/puffo_agent/portal/ui/widgets/log_view.py
+++ b/src/puffo_agent/portal/ui/widgets/log_view.py
@@ -60,8 +60,7 @@ class LogView(QPlainTextEdit):
         snapshot_fn: Callable[[], list[str]],
         counter_fn: Callable[[], int],
     ) -> None:
-        """Swap the underlying source pair (e.g. when binding to a
-        different agent). Resets so the next poll renders from scratch."""
+        """Swap the source pair + reset (e.g. when binding to a new agent)."""
         self._snapshot_fn = snapshot_fn
         self._counter_fn = counter_fn
         self.reset()

--- a/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
+++ b/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
@@ -1,0 +1,117 @@
+"""Combine the daemon's Python-logger ring (filtered to a single
+agent) with the agent's per-workspace audit.log (NDJSON written by
+``cli_session.AuditLog``). Surfaces both streams in the same Logs
+tab — Python logging captures spawn / WS / supervisor events, audit
+captures the assistant's text + tool calls per turn."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+# Bound the audit-log tail we read per poll; the file is unbounded and
+# rotation isn't implemented yet (cli_session.AuditLog.write appends).
+_AUDIT_TAIL_BYTES = 64 * 1024
+_AUDIT_MAX_LINES = 500
+_SUMMARY_CAP = 200
+
+
+def _format_audit_extras(event: str, extras: dict) -> str:
+    """One-line summary of an audit row's non-meta fields, shaped per
+    the most common event types so the Logs tab stays readable."""
+    if event == "assistant.text":
+        text = extras.get("text", "")
+        if isinstance(text, str):
+            return text[:_SUMMARY_CAP] + ("…" if len(text) > _SUMMARY_CAP else "")
+    if event == "tool":
+        name = extras.get("name", "")
+        inp = extras.get("input", {})
+        inp_str = json.dumps(inp, ensure_ascii=False) if isinstance(inp, (dict, list)) else str(inp)
+        if len(inp_str) > _SUMMARY_CAP:
+            inp_str = inp_str[:_SUMMARY_CAP] + "…"
+        return f"{name} {inp_str}".strip()
+    if event in ("turn.input", "turn.end", "session.start"):
+        flat = " ".join(
+            f"{k}={v}" for k, v in extras.items()
+            if not isinstance(v, (dict, list))
+        )
+        return flat[:_SUMMARY_CAP] + ("…" if len(flat) > _SUMMARY_CAP else "")
+    rendered = json.dumps(extras, ensure_ascii=False)
+    return rendered[:_SUMMARY_CAP] + ("…" if len(rendered) > _SUMMARY_CAP else "")
+
+
+def _read_audit_tail(path: Path) -> list[str]:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return []
+    if size == 0:
+        return []
+    try:
+        with path.open("rb") as f:
+            if size > _AUDIT_TAIL_BYTES:
+                f.seek(size - _AUDIT_TAIL_BYTES)
+                # Discard the partial leading line; sizes >cap mean we
+                # almost certainly landed mid-record.
+                f.readline()
+            content = f.read()
+    except OSError:
+        return []
+    text = content.decode("utf-8", errors="replace")
+    out: list[str] = []
+    for raw in text.splitlines()[-_AUDIT_MAX_LINES:]:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            d = json.loads(raw)
+        except ValueError:
+            continue
+        ts = str(d.get("ts", ""))
+        ev = str(d.get("event", "?"))
+        extras = {k: v for k, v in d.items() if k not in ("ts", "agent", "event")}
+        out.append(f"{ts} [audit/{ev}] {_format_audit_extras(ev, extras)}")
+    return out
+
+
+class PerAgentLogSource:
+    """Snapshot+counter pair the LogView can poll. Merges the
+    daemon-wide Python logger ring (filtered to lines mentioning this
+    agent's id or slug) with the agent's audit.log tail."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        slug: str,
+        audit_path: Path,
+        py_snapshot: Callable[[], list[str]],
+        py_counter: Callable[[], int],
+    ) -> None:
+        self._tokens = {t for t in (agent_id, slug) if t}
+        self._audit_path = audit_path
+        self._py_snapshot = py_snapshot
+        self._py_counter = py_counter
+
+    def snapshot(self) -> list[str]:
+        py = [
+            ln for ln in self._py_snapshot()
+            if any(t in ln for t in self._tokens)
+        ]
+        audit = _read_audit_tail(self._audit_path)
+        # Lexicographic sort on the leading timestamp is good enough —
+        # Python ``YYYY-MM-DD HH:MM:SS,ms`` and audit ``YYYY-MM-DDTHH:MM:SS+TZ``
+        # both sort chronologically within the same day even though the
+        # separator differs (' ' < 'T'); cross-day comparisons are
+        # exact.
+        return sorted(py + audit, key=lambda ln: ln[:23])
+
+    def counter(self) -> int:
+        try:
+            audit_size = self._audit_path.stat().st_size
+        except OSError:
+            audit_size = 0
+        return self._py_counter() + audit_size

--- a/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
+++ b/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
@@ -1,6 +1,4 @@
-"""Tail the agent's per-workspace audit.log (NDJSON written by
-``cli_session.AuditLog``) and surface it through the LogView's
-snapshot/counter contract."""
+"""Tail the agent's audit.log for the LogView snapshot/counter contract."""
 
 from __future__ import annotations
 
@@ -10,17 +8,13 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Tail window: 64 KiB / 500 lines is plenty for an operator scrolling
-# through recent activity; the full file lives on disk under the
-# workspace dir for forensic dives.
 _AUDIT_TAIL_BYTES = 64 * 1024
 _AUDIT_MAX_LINES = 500
 _SUMMARY_CAP = 200
 
 
 def _format_audit_extras(event: str, extras: dict) -> str:
-    """Per-event-type formatter so the row reads as ordinary text
-    rather than a JSON blob."""
+    """Per-event-type formatter — keeps the row readable as plain text."""
     if event == "assistant.text":
         text = extras.get("text", "")
         if isinstance(text, str):
@@ -76,10 +70,8 @@ def _read_audit_tail(path: Path) -> list[str]:
 
 
 class PerAgentLogSource:
-    """Snapshot+counter pair for the LogView. Single source: the
-    agent's audit.log tail. Counter is the file's cumulative line
-    count (cached incrementally on file size) — monotonic, never
-    bumps for activity in other agents."""
+    """LogView snapshot+counter pair, sourced from audit.log.
+    Counter is the file's cumulative line count (incrementally cached)."""
 
     def __init__(self, audit_path: Path) -> None:
         self._audit_path = audit_path

--- a/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
+++ b/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import deque
 from pathlib import Path
 from typing import Callable
 
@@ -81,7 +82,19 @@ def _read_audit_tail(path: Path) -> list[str]:
 class PerAgentLogSource:
     """Snapshot+counter pair the LogView can poll. Merges the
     daemon-wide Python logger ring (filtered to lines mentioning this
-    agent's id or slug) with the agent's audit.log tail."""
+    agent's id or slug) with the agent's audit.log tail.
+
+    Dedup-by-content: tracks every distinct line ever emitted so the
+    LogView delta-slice contract can't double-render. Naive
+    ``py_counter + audit_line_count`` would bump the counter every
+    time ANOTHER agent writes a Python log line — none of those
+    deltas land in this snapshot, so the slice picks up the END of
+    the already-displayed merged view and re-appends duplicates."""
+
+    # Cap on the unique-line history we keep in memory. Bigger than the
+    # LogView's 500-line display so the user can scroll back through a
+    # ring that exceeds one screen.
+    _EMITTED_MAX = 1000
 
     def __init__(
         self,
@@ -95,49 +108,37 @@ class PerAgentLogSource:
         self._audit_path = audit_path
         self._py_snapshot = py_snapshot
         self._py_counter = py_counter
-        # Incremental line-count cache: previous file size → cumulative
-        # newline count. Polled every tick; recounting from scratch a
-        # multi-MB audit.log would burn cycles, so we only walk the
-        # bytes added since the last poll.
-        self._audit_seen_size = 0
-        self._audit_line_count = 0
+        self._emitted: deque[str] = deque(maxlen=self._EMITTED_MAX)
+        self._emitted_set: set[str] = set()
+        self._emit_count = 0
 
     def snapshot(self) -> list[str]:
+        return list(self._emitted)
+
+    def counter(self) -> int:
+        self._refresh()
+        return self._emit_count
+
+    def _refresh(self) -> None:
         py = [
             ln for ln in self._py_snapshot()
             if any(t in ln for t in self._tokens)
         ]
         audit = _read_audit_tail(self._audit_path)
-        # Lexicographic sort on the leading timestamp is good enough —
-        # Python ``YYYY-MM-DD HH:MM:SS,ms`` and audit ``YYYY-MM-DDTHH:MM:SS+TZ``
-        # both sort chronologically within the same day even though the
-        # separator differs (' ' < 'T'); cross-day comparisons are
-        # exact.
-        return sorted(py + audit, key=lambda ln: ln[:23])
-
-    def counter(self) -> int:
-        # Counter must be in LINE units to match the LogView delta-slice
-        # contract; mixing byte sizes with line counts double-renders
-        # already-shown audit rows every time the file grows.
-        return self._py_counter() + self._audit_line_count_cached()
-
-    def _audit_line_count_cached(self) -> int:
-        try:
-            size = self._audit_path.stat().st_size
-        except OSError:
-            return self._audit_line_count
-        if size == self._audit_seen_size:
-            return self._audit_line_count
-        if size < self._audit_seen_size:
-            # Rotated / truncated → recount from scratch.
-            self._audit_seen_size = 0
-            self._audit_line_count = 0
-        try:
-            with self._audit_path.open("rb") as f:
-                f.seek(self._audit_seen_size)
-                content = f.read()
-        except OSError:
-            return self._audit_line_count
-        self._audit_line_count += content.count(b"\n")
-        self._audit_seen_size = size
-        return self._audit_line_count
+        # Lex sort on the leading timestamp is good enough — Python
+        # ``YYYY-MM-DD HH:MM:SS,ms`` and audit ``YYYY-MM-DDTHH:MM:SS+TZ``
+        # both sort chronologically within the same day (' ' < 'T');
+        # cross-day comparisons are exact.
+        merged = sorted(py + audit, key=lambda ln: ln[:23])
+        for ln in merged:
+            if ln in self._emitted_set:
+                continue
+            if (
+                self._emitted.maxlen is not None
+                and len(self._emitted) == self._emitted.maxlen
+            ):
+                # Evict from the dedup set in lockstep with the deque.
+                self._emitted_set.discard(self._emitted[0])
+            self._emitted.append(ln)
+            self._emitted_set.add(ln)
+            self._emit_count += 1

--- a/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
+++ b/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
@@ -1,29 +1,26 @@
-"""Combine the daemon's Python-logger ring (filtered to a single
-agent) with the agent's per-workspace audit.log (NDJSON written by
-``cli_session.AuditLog``). Surfaces both streams in the same Logs
-tab — Python logging captures spawn / WS / supervisor events, audit
-captures the assistant's text + tool calls per turn."""
+"""Tail the agent's per-workspace audit.log (NDJSON written by
+``cli_session.AuditLog``) and surface it through the LogView's
+snapshot/counter contract."""
 
 from __future__ import annotations
 
 import json
 import logging
-from collections import deque
 from pathlib import Path
-from typing import Callable
 
 logger = logging.getLogger(__name__)
 
-# Bound the audit-log tail we read per poll; the file is unbounded and
-# rotation isn't implemented yet (cli_session.AuditLog.write appends).
+# Tail window: 64 KiB / 500 lines is plenty for an operator scrolling
+# through recent activity; the full file lives on disk under the
+# workspace dir for forensic dives.
 _AUDIT_TAIL_BYTES = 64 * 1024
 _AUDIT_MAX_LINES = 500
 _SUMMARY_CAP = 200
 
 
 def _format_audit_extras(event: str, extras: dict) -> str:
-    """One-line summary of an audit row's non-meta fields, shaped per
-    the most common event types so the Logs tab stays readable."""
+    """Per-event-type formatter so the row reads as ordinary text
+    rather than a JSON blob."""
     if event == "assistant.text":
         text = extras.get("text", "")
         if isinstance(text, str):
@@ -56,8 +53,7 @@ def _read_audit_tail(path: Path) -> list[str]:
         with path.open("rb") as f:
             if size > _AUDIT_TAIL_BYTES:
                 f.seek(size - _AUDIT_TAIL_BYTES)
-                # Discard the partial leading line; sizes >cap mean we
-                # almost certainly landed mid-record.
+                # Discard the partial leading line.
                 f.readline()
             content = f.read()
     except OSError:
@@ -80,65 +76,36 @@ def _read_audit_tail(path: Path) -> list[str]:
 
 
 class PerAgentLogSource:
-    """Snapshot+counter pair the LogView can poll. Merges the
-    daemon-wide Python logger ring (filtered to lines mentioning this
-    agent's id or slug) with the agent's audit.log tail.
+    """Snapshot+counter pair for the LogView. Single source: the
+    agent's audit.log tail. Counter is the file's cumulative line
+    count (cached incrementally on file size) — monotonic, never
+    bumps for activity in other agents."""
 
-    Dedup-by-content: tracks every distinct line ever emitted so the
-    LogView delta-slice contract can't double-render. Naive
-    ``py_counter + audit_line_count`` would bump the counter every
-    time ANOTHER agent writes a Python log line — none of those
-    deltas land in this snapshot, so the slice picks up the END of
-    the already-displayed merged view and re-appends duplicates."""
-
-    # Cap on the unique-line history we keep in memory. Bigger than the
-    # LogView's 500-line display so the user can scroll back through a
-    # ring that exceeds one screen.
-    _EMITTED_MAX = 1000
-
-    def __init__(
-        self,
-        agent_id: str,
-        slug: str,
-        audit_path: Path,
-        py_snapshot: Callable[[], list[str]],
-        py_counter: Callable[[], int],
-    ) -> None:
-        self._tokens = {t for t in (agent_id, slug) if t}
+    def __init__(self, audit_path: Path) -> None:
         self._audit_path = audit_path
-        self._py_snapshot = py_snapshot
-        self._py_counter = py_counter
-        self._emitted: deque[str] = deque(maxlen=self._EMITTED_MAX)
-        self._emitted_set: set[str] = set()
-        self._emit_count = 0
+        self._seen_size = 0
+        self._line_count = 0
 
     def snapshot(self) -> list[str]:
-        return list(self._emitted)
+        return _read_audit_tail(self._audit_path)
 
     def counter(self) -> int:
-        self._refresh()
-        return self._emit_count
-
-    def _refresh(self) -> None:
-        py = [
-            ln for ln in self._py_snapshot()
-            if any(t in ln for t in self._tokens)
-        ]
-        audit = _read_audit_tail(self._audit_path)
-        # Lex sort on the leading timestamp is good enough — Python
-        # ``YYYY-MM-DD HH:MM:SS,ms`` and audit ``YYYY-MM-DDTHH:MM:SS+TZ``
-        # both sort chronologically within the same day (' ' < 'T');
-        # cross-day comparisons are exact.
-        merged = sorted(py + audit, key=lambda ln: ln[:23])
-        for ln in merged:
-            if ln in self._emitted_set:
-                continue
-            if (
-                self._emitted.maxlen is not None
-                and len(self._emitted) == self._emitted.maxlen
-            ):
-                # Evict from the dedup set in lockstep with the deque.
-                self._emitted_set.discard(self._emitted[0])
-            self._emitted.append(ln)
-            self._emitted_set.add(ln)
-            self._emit_count += 1
+        try:
+            size = self._audit_path.stat().st_size
+        except OSError:
+            return self._line_count
+        if size == self._seen_size:
+            return self._line_count
+        if size < self._seen_size:
+            # Rotated / truncated → recount from scratch.
+            self._seen_size = 0
+            self._line_count = 0
+        try:
+            with self._audit_path.open("rb") as f:
+                f.seek(self._seen_size)
+                content = f.read()
+        except OSError:
+            return self._line_count
+        self._line_count += content.count(b"\n")
+        self._seen_size = size
+        return self._line_count

--- a/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
+++ b/src/puffo_agent/portal/ui/widgets/per_agent_log_source.py
@@ -95,6 +95,12 @@ class PerAgentLogSource:
         self._audit_path = audit_path
         self._py_snapshot = py_snapshot
         self._py_counter = py_counter
+        # Incremental line-count cache: previous file size → cumulative
+        # newline count. Polled every tick; recounting from scratch a
+        # multi-MB audit.log would burn cycles, so we only walk the
+        # bytes added since the last poll.
+        self._audit_seen_size = 0
+        self._audit_line_count = 0
 
     def snapshot(self) -> list[str]:
         py = [
@@ -110,8 +116,28 @@ class PerAgentLogSource:
         return sorted(py + audit, key=lambda ln: ln[:23])
 
     def counter(self) -> int:
+        # Counter must be in LINE units to match the LogView delta-slice
+        # contract; mixing byte sizes with line counts double-renders
+        # already-shown audit rows every time the file grows.
+        return self._py_counter() + self._audit_line_count_cached()
+
+    def _audit_line_count_cached(self) -> int:
         try:
-            audit_size = self._audit_path.stat().st_size
+            size = self._audit_path.stat().st_size
         except OSError:
-            audit_size = 0
-        return self._py_counter() + audit_size
+            return self._audit_line_count
+        if size == self._audit_seen_size:
+            return self._audit_line_count
+        if size < self._audit_seen_size:
+            # Rotated / truncated → recount from scratch.
+            self._audit_seen_size = 0
+            self._audit_line_count = 0
+        try:
+            with self._audit_path.open("rb") as f:
+                f.seek(self._audit_seen_size)
+                content = f.read()
+        except OSError:
+            return self._audit_line_count
+        self._audit_line_count += content.count(b"\n")
+        self._audit_seen_size = size
+        return self._audit_line_count

--- a/tests/test_codex_session_audit.py
+++ b/tests/test_codex_session_audit.py
@@ -1,0 +1,269 @@
+"""Per-agent audit-log capture for the codex adapter (PUF-324).
+
+Operator-direct intake (Vase msg_9f82bfa2) — daemon audit-log was
+missing the agent's intermediate "searching web", "updating code..."
+narrative for codex-driven agents. The claude-code adapter already
+captured these via ``ClaudeSession.audit`` (cli_session.py:746); the
+codex path's ``_handle_item_event`` was un-instrumented, so the
+streaming ``item/agentMessage/delta`` chunks flowed into the reply
+buffer without ever hitting ``audit.write``.
+
+These tests pin the cross-adapter contract: a CodexSession given an
+``audit`` parameter emits the same NDJSON event shape
+(``assistant.text`` for narrative, ``tool`` for tool invocations) so
+operators can tail ``<workspace>/.puffo-agent/audit.log`` and see
+agent activity regardless of which adapter the agent runs on.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.codex_session import (
+    CodexSession,
+    _PendingTurn,
+)
+
+
+class _AuditSpy:
+    """Stub matching ``AuditLog.write(event, **fields)``. Captures
+    every call so tests can assert exact event names + payloads."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def write(self, event: str, **fields: Any) -> None:
+        self.calls.append((event, fields))
+
+
+def _make_session(audit: Any = None) -> CodexSession:
+    """Bare CodexSession with just enough state to drive
+    ``_handle_item_event`` directly. Skips the on-disk
+    session-id load + the asyncio subprocess wiring — they
+    aren't on the per-event audit path under test."""
+    session = CodexSession.__new__(CodexSession)
+    session.agent_id = "agent-test"
+    session.audit = audit
+    return session
+
+
+def _make_turn() -> _PendingTurn:
+    """``_PendingTurn`` mirrors the in-flight ``sendUserTurn`` state
+    (``reply_chunks`` / ``tool_calls`` / ``send_message_targets``).
+    A bare instance is enough for the per-event handler."""
+    return _PendingTurn(request_id=1, started_at=0.0)
+
+
+# ─── streaming delta → assistant.text ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_streaming_delta_writes_assistant_text_to_audit():
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+
+    await session._handle_item_event(
+        "item/agentMessage/delta",
+        {"delta": "searching web for the answer"},
+        turn,
+    )
+
+    assert audit.calls == [
+        ("assistant.text", {"text": "searching web for the answer"}),
+    ]
+    # Reply buffer still gets the chunk so the final reply
+    # composition keeps working — audit is a tee, not a replacement.
+    assert turn.reply_chunks == ["searching web for the answer"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_delta_with_empty_string_writes_nothing():
+    """The reply-buffer guard at line 1094 already drops empty
+    deltas; the audit tee respects the same guard so we don't get
+    noise rows in audit.log."""
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+
+    await session._handle_item_event(
+        "item/agentMessage/delta", {"delta": ""}, turn,
+    )
+
+    assert audit.calls == []
+    assert turn.reply_chunks == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_delta_audit_is_optional():
+    """``audit=None`` path (the default before PUF-324 wired it) must
+    still work — no AttributeError, no behaviour change vs main."""
+    session = _make_session(audit=None)
+    turn = _make_turn()
+
+    await session._handle_item_event(
+        "item/agentMessage/delta", {"delta": "thinking..."}, turn,
+    )
+
+    assert turn.reply_chunks == ["thinking..."]
+
+
+# ─── completed agent_message → missed-delta fallback ──────────────
+
+
+@pytest.mark.asyncio
+async def test_completed_agent_message_writes_when_delta_buffer_diverges():
+    """codex_session.py:1109-1111 replaces ``turn.reply_chunks`` with
+    the authoritative ``item.text`` when the concatenated deltas
+    don't match it. In that case the streaming-delta audit rows are
+    stale; emit a synthetic ``assistant.text`` so the audit log
+    carries the operator-observable final narrative."""
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+    turn.reply_chunks = ["partial"]  # a missed-delta scenario
+
+    await session._handle_item_event(
+        "item/completed",
+        {"item": {"type": "agentMessage", "text": "authoritative final"}},
+        turn,
+    )
+
+    assert turn.reply_chunks == ["authoritative final"]
+    assert audit.calls == [
+        ("assistant.text", {"text": "authoritative final"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completed_agent_message_no_audit_when_buffer_matches():
+    """When the delta buffer DOES match the authoritative final text,
+    the streaming-delta rows in audit.log are already correct — don't
+    duplicate the row."""
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+    turn.reply_chunks = ["authoritative final"]
+
+    await session._handle_item_event(
+        "item/completed",
+        {"item": {"type": "agentMessage", "text": "authoritative final"}},
+        turn,
+    )
+
+    assert audit.calls == []
+
+
+# ─── completed tool_use → tool ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_completed_tool_use_writes_tool_audit_row():
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+
+    await session._handle_item_event(
+        "item/completed",
+        {
+            "item": {
+                "type": "toolUse",
+                "name": "shell_exec",
+                "input": {"cmd": "ls /tmp"},
+                "id": "tu_001",
+            },
+        },
+        turn,
+    )
+
+    assert audit.calls == [
+        ("tool", {
+            "name": "shell_exec",
+            "input": {"cmd": "ls /tmp"},
+            "id": "tu_001",
+        }),
+    ]
+    assert turn.tool_calls == 1
+
+
+# ─── completed mcpToolCall → tool with server__tool name ──────────
+
+
+@pytest.mark.asyncio
+async def test_completed_mcp_tool_call_writes_tool_audit_row_with_namespaced_name():
+    """Real codex mcpToolCall events split tool name across two
+    fields (server + tool). Audit row mirrors the claude-code shape
+    by joining them with ``__`` — so a downstream grep of
+    ``audit.log`` for ``puffo__send_message`` lights up on both
+    adapters."""
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+
+    await session._handle_item_event(
+        "item/completed",
+        {
+            "item": {
+                "type": "mcpToolCall",
+                "server": "puffo",
+                "tool": "send_message",
+                "status": "completed",
+                "arguments": {"channel": "ch_test", "text": "hi"},
+                "id": "tu_002",
+            },
+        },
+        turn,
+    )
+
+    assert audit.calls == [
+        ("tool", {
+            "name": "puffo__send_message",
+            "input": {"channel": "ch_test", "text": "hi"},
+            "id": "tu_002",
+        }),
+    ]
+    assert turn.tool_calls == 1
+
+
+# ─── audit=None is tolerated everywhere ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_completed_paths_tolerate_audit_none():
+    """Every audit.write site in the handler is guarded; ensure
+    none accidentally regress to an unguarded call."""
+    session = _make_session(audit=None)
+    turn = _make_turn()
+
+    await session._handle_item_event(
+        "item/completed",
+        {"item": {"type": "agentMessage", "text": "x"}},
+        turn,
+    )
+    await session._handle_item_event(
+        "item/completed",
+        {"item": {"type": "toolUse", "name": "x", "input": {}}},
+        turn,
+    )
+    await session._handle_item_event(
+        "item/completed",
+        {
+            "item": {
+                "type": "mcpToolCall",
+                "server": "puffo",
+                "tool": "send_message",
+                "status": "completed",
+                "arguments": {},
+            },
+        },
+        turn,
+    )
+    # No assertion failure means none of the three branches raised
+    # AttributeError on the missing audit.

--- a/tests/test_codex_session_audit.py
+++ b/tests/test_codex_session_audit.py
@@ -1,19 +1,4 @@
-"""Per-agent audit-log capture for the codex adapter (PUF-324).
-
-Operator-direct intake (Vase msg_9f82bfa2) — daemon audit-log was
-missing the agent's intermediate "searching web", "updating code..."
-narrative for codex-driven agents. The claude-code adapter already
-captured these via ``ClaudeSession.audit`` (cli_session.py:746); the
-codex path's ``_handle_item_event`` was un-instrumented, so the
-streaming ``item/agentMessage/delta`` chunks flowed into the reply
-buffer without ever hitting ``audit.write``.
-
-These tests pin the cross-adapter contract: a CodexSession given an
-``audit`` parameter emits the same NDJSON event shape
-(``assistant.text`` for narrative, ``tool`` for tool invocations) so
-operators can tail ``<workspace>/.puffo-agent/audit.log`` and see
-agent activity regardless of which adapter the agent runs on.
-"""
+"""Audit-log capture in the codex adapter (cross-adapter contract with ClaudeSession)."""
 
 from __future__ import annotations
 
@@ -33,9 +18,6 @@ from puffo_agent.agent.adapters.codex_session import (
 
 
 class _AuditSpy:
-    """Stub matching ``AuditLog.write(event, **fields)``. Captures
-    every call so tests can assert exact event names + payloads."""
-
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
 
@@ -44,10 +26,6 @@ class _AuditSpy:
 
 
 def _make_session(audit: Any = None) -> CodexSession:
-    """Bare CodexSession with just enough state to drive
-    ``_handle_item_event`` directly. Skips the on-disk
-    session-id load + the asyncio subprocess wiring — they
-    aren't on the per-event audit path under test."""
     session = CodexSession.__new__(CodexSession)
     session.agent_id = "agent-test"
     session.audit = audit
@@ -55,9 +33,6 @@ def _make_session(audit: Any = None) -> CodexSession:
 
 
 def _make_turn() -> _PendingTurn:
-    """``_PendingTurn`` mirrors the in-flight ``sendUserTurn`` state
-    (``reply_chunks`` / ``tool_calls`` / ``send_message_targets``).
-    A bare instance is enough for the per-event handler."""
     return _PendingTurn(request_id=1, started_at=0.0)
 
 
@@ -86,9 +61,7 @@ async def test_streaming_delta_writes_assistant_text_to_audit():
 
 @pytest.mark.asyncio
 async def test_streaming_delta_with_empty_string_writes_nothing():
-    """The reply-buffer guard at line 1094 already drops empty
-    deltas; the audit tee respects the same guard so we don't get
-    noise rows in audit.log."""
+    """Empty delta → no audit row (same guard as the reply buffer)."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -103,8 +76,7 @@ async def test_streaming_delta_with_empty_string_writes_nothing():
 
 @pytest.mark.asyncio
 async def test_streaming_delta_audit_is_optional():
-    """``audit=None`` path (the default before PUF-324 wired it) must
-    still work — no AttributeError, no behaviour change vs main."""
+    """``audit=None`` must not crash."""
     session = _make_session(audit=None)
     turn = _make_turn()
 
@@ -120,15 +92,12 @@ async def test_streaming_delta_audit_is_optional():
 
 @pytest.mark.asyncio
 async def test_completed_agent_message_writes_when_delta_buffer_diverges():
-    """codex_session.py:1109-1111 replaces ``turn.reply_chunks`` with
-    the authoritative ``item.text`` when the concatenated deltas
-    don't match it. In that case the streaming-delta audit rows are
-    stale; emit a synthetic ``assistant.text`` so the audit log
-    carries the operator-observable final narrative."""
+    """Missed-delta path replaces the buffer; emit a synthetic row
+    so audit.log carries the authoritative final text."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
-    turn.reply_chunks = ["partial"]  # a missed-delta scenario
+    turn.reply_chunks = ["partial"]
 
     await session._handle_item_event(
         "item/completed",
@@ -144,9 +113,7 @@ async def test_completed_agent_message_writes_when_delta_buffer_diverges():
 
 @pytest.mark.asyncio
 async def test_completed_agent_message_no_audit_when_buffer_matches():
-    """When the delta buffer DOES match the authoritative final text,
-    the streaming-delta rows in audit.log are already correct — don't
-    duplicate the row."""
+    """Buffer already matches → no synthetic row, no duplicate."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -198,11 +165,7 @@ async def test_completed_tool_use_writes_tool_audit_row():
 
 @pytest.mark.asyncio
 async def test_completed_mcp_tool_call_writes_tool_audit_row_with_namespaced_name():
-    """Real codex mcpToolCall events split tool name across two
-    fields (server + tool). Audit row mirrors the claude-code shape
-    by joining them with ``__`` — so a downstream grep of
-    ``audit.log`` for ``puffo__send_message`` lights up on both
-    adapters."""
+    """mcpToolCall → mcp__server__tool, matching the claude-code adapter."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -224,7 +187,7 @@ async def test_completed_mcp_tool_call_writes_tool_audit_row_with_namespaced_nam
 
     assert audit.calls == [
         ("tool", {
-            "name": "puffo__send_message",
+            "name": "mcp__puffo__send_message",
             "input": {"channel": "ch_test", "text": "hi"},
             "id": "tu_002",
         }),
@@ -237,8 +200,7 @@ async def test_completed_mcp_tool_call_writes_tool_audit_row_with_namespaced_nam
 
 @pytest.mark.asyncio
 async def test_completed_paths_tolerate_audit_none():
-    """Every audit.write site in the handler is guarded; ensure
-    none accidentally regress to an unguarded call."""
+    """No audit.write site can unguard-fail when audit=None."""
     session = _make_session(audit=None)
     turn = _make_turn()
 

--- a/tests/test_codex_session_audit.py
+++ b/tests/test_codex_session_audit.py
@@ -36,32 +36,30 @@ def _make_turn() -> _PendingTurn:
     return _PendingTurn(request_id=1, started_at=0.0)
 
 
-# ─── streaming delta → assistant.text ────────────────────────────
+# ─── streaming delta buffers, completion emits one assistant.text ─
 
 
 @pytest.mark.asyncio
-async def test_streaming_delta_writes_assistant_text_to_audit():
+async def test_streaming_delta_buffers_but_does_not_write_audit():
+    """Per-token deltas accumulate into reply_chunks; we wait until
+    the completion event to emit a single audit row (matches the
+    claude-code adapter's per-message granularity)."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
 
-    await session._handle_item_event(
-        "item/agentMessage/delta",
-        {"delta": "searching web for the answer"},
-        turn,
-    )
+    for chunk in ("[", "S", "IL", "ENT", "]"):
+        await session._handle_item_event(
+            "item/agentMessage/delta", {"delta": chunk}, turn,
+        )
 
-    assert audit.calls == [
-        ("assistant.text", {"text": "searching web for the answer"}),
-    ]
-    # Reply buffer still gets the chunk so the final reply
-    # composition keeps working — audit is a tee, not a replacement.
-    assert turn.reply_chunks == ["searching web for the answer"]
+    assert audit.calls == []
+    assert turn.reply_chunks == ["[", "S", "IL", "ENT", "]"]
 
 
 @pytest.mark.asyncio
 async def test_streaming_delta_with_empty_string_writes_nothing():
-    """Empty delta → no audit row (same guard as the reply buffer)."""
+    """Empty delta → no buffer append."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -87,13 +85,31 @@ async def test_streaming_delta_audit_is_optional():
     assert turn.reply_chunks == ["thinking..."]
 
 
-# ─── completed agent_message → missed-delta fallback ──────────────
+# ─── completed agent_message → single assistant.text row ──────────
+
+
+@pytest.mark.asyncio
+async def test_completed_agent_message_emits_one_audit_row_from_buffer():
+    """Streaming chunks land in reply_chunks; completion fires a
+    single ``assistant.text`` row with the assembled text."""
+    audit = _AuditSpy()
+    session = _make_session(audit)
+    turn = _make_turn()
+    turn.reply_chunks = ["[", "S", "IL", "ENT", "]"]
+
+    await session._handle_item_event(
+        "item/completed",
+        {"item": {"type": "agentMessage", "text": "[SILENT]"}},
+        turn,
+    )
+
+    assert audit.calls == [("assistant.text", {"text": "[SILENT]"})]
 
 
 @pytest.mark.asyncio
 async def test_completed_agent_message_writes_when_delta_buffer_diverges():
-    """Missed-delta path replaces the buffer; emit a synthetic row
-    so audit.log carries the authoritative final text."""
+    """Missed-delta path replaces the buffer with the authoritative
+    text; the completion row uses that text."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -112,16 +128,15 @@ async def test_completed_agent_message_writes_when_delta_buffer_diverges():
 
 
 @pytest.mark.asyncio
-async def test_completed_agent_message_no_audit_when_buffer_matches():
-    """Buffer already matches → no synthetic row, no duplicate."""
+async def test_completed_agent_message_with_empty_text_writes_nothing():
+    """Empty completion + empty buffer → no audit row."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
-    turn.reply_chunks = ["authoritative final"]
 
     await session._handle_item_event(
         "item/completed",
-        {"item": {"type": "agentMessage", "text": "authoritative final"}},
+        {"item": {"type": "agentMessage", "text": ""}},
         turn,
     )
 

--- a/tests/test_codex_session_audit.py
+++ b/tests/test_codex_session_audit.py
@@ -41,9 +41,7 @@ def _make_turn() -> _PendingTurn:
 
 @pytest.mark.asyncio
 async def test_streaming_delta_buffers_but_does_not_write_audit():
-    """Per-token deltas accumulate into reply_chunks; we wait until
-    the completion event to emit a single audit row (matches the
-    claude-code adapter's per-message granularity)."""
+    """Deltas accumulate in reply_chunks; audit row waits for completion."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -90,8 +88,7 @@ async def test_streaming_delta_audit_is_optional():
 
 @pytest.mark.asyncio
 async def test_completed_agent_message_emits_one_audit_row_from_buffer():
-    """Streaming chunks land in reply_chunks; completion fires a
-    single ``assistant.text`` row with the assembled text."""
+    """Completion fires one ``assistant.text`` row with the assembled text."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -108,8 +105,7 @@ async def test_completed_agent_message_emits_one_audit_row_from_buffer():
 
 @pytest.mark.asyncio
 async def test_completed_agent_message_writes_when_delta_buffer_diverges():
-    """Missed-delta path replaces the buffer with the authoritative
-    text; the completion row uses that text."""
+    """Missed-delta → buffer replaced + row uses authoritative text."""
     audit = _AuditSpy()
     session = _make_session(audit)
     turn = _make_turn()
@@ -242,5 +238,3 @@ async def test_completed_paths_tolerate_audit_none():
         },
         turn,
     )
-    # No assertion failure means none of the three branches raised
-    # AttributeError on the missing audit.


### PR DESCRIPTION
## Summary

Closes the operator-reported gap that codex-driven agents' narrative (replies + tool calls) never reached the per-agent NDJSON audit log on disk. Scope grew during review to also (a) surface the audit log in the desktop UI's per-agent ``Logs`` tab and (b) make ``sandbox`` editable through the bridge API + CLI (it was the one runtime field missing from both surfaces).

## What lands

### Codex adapter writes to ``audit.log``

- ``CodexSession.__init__`` accepts an optional ``audit: AuditLog | None`` (mirrors ``ClaudeSession``'s contract). ``LocalCLIAdapter._maybe_spawn_codex`` instantiates one at ``<workspace>/.puffo-agent/audit.log`` and passes it through.
- One ``assistant.text`` row per assistant message, emitted on ``item/completed`` with ``item.type == "agentMessage"`` — **not** per streaming delta. Earlier per-delta drafts split a single ``[SILENT]`` reply into ``[S`` / ``IL`` / ``ENT`` / ``]`` rows in the audit log; that's now one consolidated row matching the claude-code adapter's per-message granularity.
- ``tool_use`` / ``mcpToolCall`` ``item/completed`` → ``tool`` row. The ``mcpToolCall`` ``name`` uses the ``mcp__server__tool`` shape that claude-code already writes (e.g. ``mcp__puffo__send_message``), so a cross-adapter ``grep audit.log`` lights up on both surfaces — verified against the live daemon's 329 historical claude-code rows.
- Missed-delta path: when the authoritative ``item.text`` diverges from the concatenated delta buffer, the buffer is replaced and the completion row uses the authoritative text.

### Per-agent ``Logs`` tab in the desktop UI

The tab previously only filtered the daemon-wide Python logger ring by agent id (spawn / WS / supervisor messages — none of which describe what the agent SAID or DID). It now tails the agent's ``audit.log``:

- ``assistant.text`` / ``tool`` / ``turn.input`` / ``turn.end`` / ``session.start`` / ``auth_error.*`` rows visible per agent without leaving the app.
- Per-event-type formatter so rows read as ordinary text rather than a JSON blob.
- Daemon-wide Python log stays reachable through the left rail's ``Logs`` section.

This re-route went through three earlier drafts that all mixed the Python logger ring with the audit tail and hit ``LogView`` delta-slice bugs (byte size vs line count, daemon-wide counter vs per-agent snapshot, content-dedup ring). The shipped version is single-source ``audit.log`` only — eliminates the entire class.

### ``sandbox`` editable via bridge + CLI

- ``PATCH /v1/agents/{id}/runtime`` accepts a ``sandbox`` field (``read-only`` / ``workspace-write`` / ``danger-full-access``); anything else 400s. Field appears in the response body alongside the existing runtime properties.
- ``puffo-agent agent runtime <id> --sandbox <value>`` exposes the same on the CLI, including a help-text note that ``workspace-write`` is silently downgraded to read-only on Windows.
- Both surfaces already supported ``permission_mode`` / ``model`` / etc. but skipped ``sandbox`` — operators had to hand-edit ``agent.yml``.

## Test plan

- [x] ``python3 -m pytest tests/test_codex_session_audit.py -v`` → **9/9 pass** (delta buffers, completion-emits-single-row, missed-delta fallback, empty-text no-op, tool, mcpToolCall, ``audit=None`` paths).
- [x] Full daemon suite: **1636 passed / 9 skipped** (the 9 are pre-existing Windows-symlink / permission-mode skips on this box).
- [x] Cross-adapter shape parity verified against the live daemon's on-disk audit logs (329 historical ``mcp__puffo__send_message`` rows from claude agents matched against the new codex rows).
- [x] Live smoke: spawned a codex agent + watched the ``Logs`` tab; ``assistant.text`` + ``tool`` rows appear in real time.
- [x] Live smoke: ``puffo-agent agent runtime puffpuff-6311-68d1b55f --sandbox read-only`` → daemon log shows ``codex sandbox changed (danger-full-access → read-only); starting a fresh thread`` + new ``codex_session.json`` persists the new value.

## Out of scope

- **SDKAdapter / ChatOnlyAdapter** — non-streaming single-reply adapters; no intermediate narrative. One-line addition per adapter if operators want their final-reply text in audit.log too.
- **Audit-log retention / rotation / privacy-redaction** — out of scope per intake.