### PR TITLE
feat(link): open the standalone /link-machine page from CLI + tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.1] — 2026-06-25
+## [1.0.1] — 2026-06-26
 
 ### Added
 
@@ -23,6 +23,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   the joiner. Manual-accept events that don't embed the invite fall back to a
   per-session `invitation_event_id → inviter_slug` cache populated from the
   earlier `invite_to_*` event.
+- **Browser-based machine linking.** `puffo-agent machine link` now opens the
+  link page (`/link-machine?code=…`) in a browser and waits for approval; pass
+  `--not-open` to only print the code. The tray's "Link a new operator" dialog
+  gains an **Open in browser** button.
+- **Friendlier default machine name on Windows.** The name registered at link
+  time defaults to the manufacturer + model (e.g. "Razer Blade 14") instead of
+  the bare hostname, falling back to the hostname when the SMBIOS fields are
+  unavailable.
+
+### Changed
+
+- Machine-link URLs point at the standalone `/link-machine` page instead of
+  `/chat/agents?linkCode=…`.
 
 ### Internal
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1087,7 +1087,7 @@ def cmd_link(args: argparse.Namespace) -> int:
     name = args.name or socket.gethostname() or "machine"
     server_url = args.server_url or DEFAULT_SERVER_URL
     try:
-        return asyncio.run(run_link(server_url, name))
+        return asyncio.run(run_link(server_url, name, open_browser=not args.not_open))
     except KeyboardInterrupt:
         print("\nlink: cancelled.")
         return 1
@@ -1702,6 +1702,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--name",
         default=None,
         help="Name for this machine in the portal (default: hostname).",
+    )
+    machine_link.add_argument(
+        "--not-open",
+        action="store_true",
+        help="Don't auto-open the link page in your browser.",
     )
     machine_link.set_defaults(func=cmd_link)
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1073,9 +1073,7 @@ def cmd_pairing_unpair(args: argparse.Namespace) -> int:
 
 def cmd_link(args: argparse.Namespace) -> int:
     """Link this machine to an operator via the online agent portal."""
-    import socket
-
-    from .control.link import DEFAULT_SERVER_URL, run_link
+    from .control.link import DEFAULT_SERVER_URL, friendly_device_name, run_link
 
     # The daemon holds the control WS that serves the operator's commands
     # once approved — auto-start it (without the local bridge) if it isn't
@@ -1084,7 +1082,7 @@ def cmd_link(args: argparse.Namespace) -> int:
         from .background import spawn_background
         spawn_background()
 
-    name = args.name or socket.gethostname() or "machine"
+    name = args.name or friendly_device_name()
     server_url = args.server_url or DEFAULT_SERVER_URL
     try:
         return asyncio.run(run_link(server_url, name, open_browser=not args.not_open))

--- a/src/puffo_agent/portal/control/link.py
+++ b/src/puffo_agent/portal/control/link.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import webbrowser
 
 import aiohttp
 
@@ -144,9 +145,10 @@ async def migrate_owned_agents(operator_root_pubkey: str) -> int:
     return reported
 
 
-async def run_link(server_url: str, hostname: str) -> int:
+async def run_link(server_url: str, hostname: str, open_browser: bool = True) -> int:
     """Register this machine, mint a link code, and wait for an operator to
-    approve it (CLI entry point)."""
+    approve it (CLI entry point). Auto-opens the link page in a browser unless
+    ``open_browser`` is False."""
     try:
         code, base = await mint_link_code(server_url, hostname)
     except LinkError as exc:
@@ -154,10 +156,16 @@ async def run_link(server_url: str, hostname: str) -> int:
         return 1
 
     web = _web_url_from_server(server_url)
+    link_url = f"{web}/link-machine?code={code}"
     print(f"\n  Link code:  {code}\n")
-    print(f"  Open:  {web}/chat/agents?linkCode={code}")
+    print(f"  Open:  {link_url}")
     print("  (the link opens the puffo web app with the code pre-filled —")
     print(f"   or go to My Agents → Link machine and enter it to approve '{hostname}'.)\n")
+    if open_browser:
+        try:
+            webbrowser.open(link_url)
+        except Exception as exc:  # noqa: BLE001 — best-effort; the URL is printed above
+            logger.debug("link: could not auto-open browser: %s", exc)
     print("  Waiting for approval (Ctrl-C to cancel)...")
 
     try:

--- a/src/puffo_agent/portal/control/link.py
+++ b/src/puffo_agent/portal/control/link.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import socket
+import sys
 import webbrowser
 
 import aiohttp
@@ -28,6 +30,62 @@ logger = logging.getLogger(__name__)
 DEFAULT_SERVER_URL = "https://chat.puffo.ai/relay"
 POLL_INTERVAL_SECONDS = 2.0
 LINK_TIMEOUT_SECONDS = 300
+
+# SMBIOS placeholder strings OEMs leave when the field isn't set — useless as
+# a device name.
+_OEM_PLACEHOLDERS = {
+    "", "system manufacturer", "system product name", "to be filled by o.e.m.",
+    "default string", "none", "not applicable", "o.e.m.", "not specified",
+}
+
+
+def _compose_device_name(maker: str, model: str) -> str | None:
+    """Combine SMBIOS manufacturer + product into a friendly name (e.g.
+    ``Razer Blade 14``), dropping SKU noise and OEM placeholders. None if
+    unusable."""
+    maker = maker.strip()
+    model = model.split(" - ")[0].strip()  # "Blade 14 - RZ09-0370" -> "Blade 14"
+    if model.lower() in _OEM_PLACEHOLDERS:
+        model = ""
+    if maker.lower() in _OEM_PLACEHOLDERS:
+        maker = ""
+    if not model:
+        return None
+    if maker and not model.lower().startswith(maker.lower()):
+        return f"{maker} {model}"
+    return model
+
+
+def _windows_device_name() -> str | None:
+    """Manufacturer + model from the SMBIOS values in the registry (no
+    subprocess). e.g. ``Razer Blade 14``."""
+    try:
+        import winreg
+
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, r"HARDWARE\DESCRIPTION\System\BIOS"
+        ) as key:
+            def _read(name: str) -> str:
+                try:
+                    return str(winreg.QueryValueEx(key, name)[0]).strip()
+                except OSError:
+                    return ""
+
+            return _compose_device_name(
+                _read("SystemManufacturer"), _read("SystemProductName")
+            )
+    except OSError:
+        return None
+
+
+def friendly_device_name() -> str:
+    """A human-friendly default name for this machine, e.g. ``Razer Blade 14``,
+    falling back to the OS hostname. The operator can rename it at approval."""
+    if sys.platform == "win32":
+        name = _windows_device_name()
+        if name:
+            return name
+    return socket.gethostname() or "machine"
 
 
 def _web_url_from_server(server_url: str) -> str:

--- a/src/puffo_agent/portal/ui/widgets/operators_view.py
+++ b/src/puffo_agent/portal/ui/widgets/operators_view.py
@@ -7,7 +7,6 @@ operator-side in the web app; this page shows the code and polls for it.
 from __future__ import annotations
 
 import asyncio
-import socket
 import threading
 import webbrowser
 from typing import Optional
@@ -28,13 +27,14 @@ from PySide6.QtWidgets import (
 from ...control.link import (
     DEFAULT_SERVER_URL,
     await_link_approval,
+    friendly_device_name,
     mint_link_code,
 )
 from ...control.store import load_pairings
 
 
 def _machine_name() -> str:
-    return socket.gethostname() or "machine"
+    return friendly_device_name()
 
 
 class _LinkDialog(QDialog):

--- a/src/puffo_agent/portal/ui/widgets/operators_view.py
+++ b/src/puffo_agent/portal/ui/widgets/operators_view.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import socket
 import threading
+import webbrowser
 from typing import Optional
 
 from PySide6.QtCore import Qt, Signal
@@ -49,6 +50,7 @@ class _LinkDialog(QDialog):
         self.setWindowTitle("Link a new operator")
         self.setMinimumWidth(440)
         self._hostname = _machine_name()
+        self._link_url = ""
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 18, 20, 18)
@@ -79,10 +81,15 @@ class _LinkDialog(QDialog):
         row.addStretch(1)
         self._close = QPushButton("Close")
         self._close.clicked.connect(self.reject)
+        self._open_browser = QPushButton("Open in browser")
+        self._open_browser.setCursor(Qt.PointingHandCursor)
+        self._open_browser.clicked.connect(self._on_open_browser)
+        self._open_browser.hide()
         self._create = QPushButton("Create link")
         self._create.setDefault(True)
         self._create.clicked.connect(self._on_create)
         row.addWidget(self._close)
+        row.addWidget(self._open_browser)
         row.addWidget(self._create)
         layout.addLayout(row)
 
@@ -111,11 +118,13 @@ class _LinkDialog(QDialog):
 
     def _on_minted(self, code: str, base: str) -> None:
         web = base[: -len("/relay")] if base.endswith("/relay") else base
+        self._link_url = f"{web}/link-machine?code={code}"
         self._status.setText(
             f"Link code:  {code}\n\n"
-            f"Approve at  {web}/chat/agents?linkCode={code}\n"
+            f"Approve at  {self._link_url}\n"
             "or in My Agents → Link machine.\n\nWaiting for approval…"
         )
+        self._open_browser.show()
 
         def worker() -> None:
             try:
@@ -127,6 +136,10 @@ class _LinkDialog(QDialog):
                 self._approval_failed.emit(str(exc))
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def _on_open_browser(self) -> None:
+        if self._link_url:
+            webbrowser.open(self._link_url)
 
     def _on_mint_failed(self, error: str) -> None:
         self._status.setText(f"Could not create link: {error}")
@@ -140,11 +153,13 @@ class _LinkDialog(QDialog):
             return
         msg = "Code expired." if status == "expired" else "Timed out waiting for approval."
         self._status.setText(f"{msg} Try again.")
+        self._open_browser.hide()  # the code is stale
         self._create.setEnabled(True)
         self._url.setEnabled(True)
 
     def _on_approval_failed(self, error: str) -> None:
         self._status.setText(f"Approval failed: {error}")
+        self._open_browser.hide()
         self._create.setEnabled(True)
         self._url.setEnabled(True)
 

--- a/tests/test_portal_onboarding.py
+++ b/tests/test_portal_onboarding.py
@@ -123,7 +123,7 @@ async def test_migrate_survives_one_agent_failing(monkeypatch):
 # ── F3: link auto-starts the daemon ─────────────────────────────────
 
 def _link_ns():
-    return argparse.Namespace(name=None, server_url="https://x")
+    return argparse.Namespace(name=None, server_url="https://x", not_open=True)
 
 
 def test_cmd_link_autostarts_when_daemon_down(monkeypatch):
@@ -135,7 +135,7 @@ def test_cmd_link_autostarts_when_daemon_down(monkeypatch):
     monkeypatch.setattr(cli, "is_daemon_alive", lambda: False)
     monkeypatch.setattr(bg, "spawn_background", lambda **kw: spawned.append(kw) or 0)
 
-    async def _fake_run_link(url, name):
+    async def _fake_run_link(url, name, open_browser=True):
         return 0
 
     monkeypatch.setattr(link, "run_link", _fake_run_link)
@@ -152,7 +152,7 @@ def test_cmd_link_skips_autostart_when_daemon_running(monkeypatch):
     monkeypatch.setattr(cli, "is_daemon_alive", lambda: True)
     monkeypatch.setattr(bg, "spawn_background", lambda **kw: spawned.append(kw) or 0)
 
-    async def _fake_run_link(url, name):
+    async def _fake_run_link(url, name, open_browser=True):
         return 0
 
     monkeypatch.setattr(link, "run_link", _fake_run_link)

--- a/tests/test_portal_onboarding.py
+++ b/tests/test_portal_onboarding.py
@@ -243,3 +243,26 @@ async def test_run_unlink_refuses_server_mismatch(monkeypatch):
     )
     rc = await link.run_unlink("op", expected_server_url="https://staging")
     assert rc == 2  # paired on a different server → refused, nothing torn down
+
+
+# ── friendly device name ─────────────────────────────────────────────
+
+def test_compose_device_name_cleans_sku_and_placeholders():
+    from puffo_agent.portal.control.link import _compose_device_name
+
+    assert _compose_device_name("Razer", "Blade 14 - RZ09-0370") == "Razer Blade 14"
+    # Model already carries the maker → don't double it up.
+    assert _compose_device_name("Dell Inc.", "Dell Inc. XPS 13") == "Dell Inc. XPS 13"
+    # OEM placeholder strings are unusable.
+    assert _compose_device_name("System manufacturer", "System Product Name") is None
+    assert _compose_device_name("Razer", "To be filled by O.E.M.") is None
+    # Maker-less but a real model still works.
+    assert _compose_device_name("", "MacBookPro18,3") == "MacBookPro18,3"
+
+
+def test_friendly_device_name_falls_back_to_hostname(monkeypatch):
+    from puffo_agent.portal.control import link
+
+    monkeypatch.setattr(link, "_windows_device_name", lambda: None)
+    monkeypatch.setattr(link.socket, "gethostname", lambda: "fallback-host")
+    assert link.friendly_device_name() == "fallback-host"


### PR DESCRIPTION
Updates `machine link` + the tray Link dialog to use the new standalone `/link-machine?code=` web page and make it one-click to open.

## Changes
- **New URL** — mint links now point at `<web>/link-machine?code=XXXX` (CLI `control/link.py` + tray `ui/widgets/operators_view.py`), replacing `/chat/agents?linkCode=`.
- **CLI auto-open** — `puffo-agent machine link` opens the link page in a browser after minting (best-effort, wrapped). New **`--not-open`** flag suppresses it.
- **Tray "Open in browser" button** — appears in the Link dialog once a code is minted; opens the link page; hides again if the code goes stale (expired/timeout).

## Test
- `PYTHONPATH=src python -m pytest` — full suite green (exit 0).
- Updated the two `test_portal_onboarding` `run_link` fakes for the new `open_browser` param (tests pass `not_open=True` so they don't pop a browser).

## Coordination
The emitted `/link-machine` URL depends on the new web page (puffo-core-han-group PR #266, `update/agent-portal-feedback`). Land/ship this alongside or after that page is deployed, or the printed link 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)