### PR TITLE
agent profile sync — soul-on-bridge-edit, disk-first, reload/restart split, startup full-sync, linked-op bridge filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,55 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.3-unreleased]
+## [1.0.3] — 2026-06-27
+
+### Added
+
+- **Startup full-sync of agent profiles.** On daemon boot the
+  daemon now PATCHes every owned agent's `display_name` + `role` +
+  `role_short` + `avatar_url` + `soul` (full `profile.md` body) to
+  `/identities/self`, in parallel, independent of link state. Each
+  worker also fires a fire-and-forget sync after `adapter.warm()`
+  completes. Together these defend against the operator
+  hand-editing `agent.yml` / `profile.md` while the daemon was
+  offline — the server-side view would otherwise stay stale until
+  the next manual edit through the bridge.
+- **Bridge `list_agents` is empty for linked operators.** When the
+  bridge-paired operator is also one of the entries in
+  `control/pairings.json` (the operator has run
+  `puffo-agent machine link`), `GET /v1/agents` returns
+  `{"agents": []}`. The operator already sees the same agents
+  through the server's link channel; the bridge would otherwise
+  double-list them in the web UI.
+
+### Fixed
+
+- **Bridge UI soul edit silently no-op'd the agent.** The
+  `update_profile` handler wrote `profile.md` on disk but never
+  PATCHed `soul` to `/identities/self` — server-side soul stayed
+  stale on any UI soul edit. It also dropped `reload.flag` only on
+  display_name rename, so pure soul edits never refreshed the
+  running worker's system prompt. Both fixed; `reload.flag` now
+  fires on any prompt-affecting change (soul, display_name, role).
+- **CLI `agent rename` drifted from the bridge.** Previously
+  updated `agent.yml` only — didn't rewrite the `profile.md`
+  heading, didn't PATCH the new name to the server, didn't reload
+  the running worker. Now mirrors the bridge edit flow exactly.
+
+### Changed
+
+- **Disk-first ordering across every edit path.** Bridge
+  `update_profile`, control-WS `op=edit`, and CLI `agent profile` /
+  `agent rename` now all write `agent.yml` + `profile.md` BEFORE
+  pushing to the server. A sync failure leaves the local edit
+  intact instead of silently dropping it.
+- **Control-WS `op=edit` no longer always restart.flag-bombs.**
+  Runtime block changes (provider/model/harness/kind) still write
+  `restart.flag` (the CLI spawn args differ; full worker respawn
+  is required). Prompt-only changes (display_name, role, soul,
+  avatar_url, raw profile body) now write `reload.flag` instead —
+  lazy on next batch, preserves the AI session via
+  `claude --resume` / `codex thread/resume`.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   updated `agent.yml` only — didn't rewrite the `profile.md`
   heading, didn't PATCH the new name to the server, didn't reload
   the running worker. Now mirrors the bridge edit flow exactly.
+- **Server sync used to ship the entire `profile.md` as `soul`.**
+  Both startup full-sync (`sync_full_profile`) and link-migrate
+  (`migrate_owned_agents`) read the file with
+  `path.read_text(...)` and passed the whole body as the soul
+  patch. The bridge's `update_profile` correctly handled just the
+  `# Soul` section, so server-side soul kept getting flipped
+  between "section body" (from bridge edits) and "whole file"
+  (from daemon restarts / link-migrates). Extracted the
+  `# Soul` (or description / about / summary) section helper into
+  `profile_sync.extract_soul_body`, single source of truth, and
+  both sync paths now ship only the section body. When the file
+  has no soul-style heading the server's stored soul is preserved
+  rather than clobbered.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.0.2"
+version = "1.0.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -353,110 +353,18 @@ async def list_agents(request: web.Request) -> web.Response:
     return web.json_response({"agents": items})
 
 
-_DESCRIPTION_HEADINGS = {"soul", "description", "about", "summary"}
-
-
-def _atx_heading(raw: str) -> tuple[int, str]:
-    """``(level, lowercased text)`` for an ATX markdown heading, or
-    ``(0, "")`` for any non-heading line. ``#hashtag`` (no space after
-    the ``#``) isn't a heading in CommonMark and reads as level 0."""
-    stripped = raw.lstrip()
-    if not stripped.startswith("#"):
-        return 0, ""
-    i = 0
-    while i < len(stripped) and stripped[i] == "#":
-        i += 1
-    if i < len(stripped) and stripped[i] in " \t":
-        return i, stripped[i:].strip().lower()
-    return 0, ""
-
-
-def _soul_section_span(lines: list[str]) -> tuple[int, int, int] | None:
-    """Locate the description / ``# Soul`` section in a profile.md.
-
-    Returns ``(heading_idx, body_start, body_end)``:
-      - ``heading_idx`` — index of the ``# Soul`` (or ``description`` /
-        ``about`` / ``summary``) heading line,
-      - ``body_start`` — first line after that heading,
-      - ``body_end`` — exclusive index where the section ends: the
-        next heading of the same-or-higher level that appears *after*
-        the soul body has real (non-blank, non-heading) content, or
-        EOF.
-
-    ``None`` when there is no description-like heading.
-
-    The "after real content" gate is the fix for the opening-heading
-    footgun: a soul body legitimately opens with its own heading
-    (``# Soul`` immediately followed by ``# <agent-name>``), and that
-    heading must not be mistaken for the *end* of the section. A
-    same-or-higher heading only closes the section once actual prose
-    has been collected — matching the operator's intent: a trailing
-    ``# Notes`` section is theirs, an opening ``# Name`` line is the
-    soul's. Single source of truth for both the read path
-    (``_profile_summary``) and the write path
-    (``_update_profile_summary``)."""
-    heading_idx = -1
-    section_level = 0
-    for idx, raw in enumerate(lines):
-        level, text = _atx_heading(raw)
-        if level and text in _DESCRIPTION_HEADINGS:
-            heading_idx = idx
-            section_level = level
-            break
-    if heading_idx == -1:
-        return None
-
-    body_start = heading_idx + 1
-    body_end = len(lines)
-    has_text = False
-    for idx in range(body_start, len(lines)):
-        raw = lines[idx]
-        level, _ = _atx_heading(raw)
-        if level:
-            if level <= section_level and has_text:
-                body_end = idx
-                break
-            # Deeper heading, or a heading before any prose — part of
-            # the soul body either way.
-            continue
-        if raw.strip():
-            has_text = True
-    return heading_idx, body_start, body_end
+from ..profile_sync import _soul_section_span  # noqa: E402  re-export shim
 
 
 def _profile_summary(cfg: AgentConfig) -> str:
-    """Return the full body of the agent's ``# Soul`` section from
-    profile.md (or any description-like heading: ``description`` /
-    ``about`` / ``summary``) — see ``_soul_section_span`` for exactly
-    where the section starts and ends. Sub-headings inside the
-    section (``## Tone`` etc.), and an opening heading the soul body
-    leads with, stay part of the body so the operator's structured
-    markdown round-trips faithfully.
-
-    Surrounding blank lines are trimmed; internal blank lines are
-    preserved. Empty string when no such section exists or the
-    profile is unreadable."""
+    """Read profile.md and return its soul-section body. Empty on
+    read failure / no soul heading."""
+    from ..profile_sync import extract_soul_body
     try:
         text = cfg.resolve_profile_path().read_text(encoding="utf-8")
     except Exception:
         return ""
-
-    lines = text.splitlines()
-    span = _soul_section_span(lines)
-    if span is None:
-        return ""
-    _, body_start, body_end = span
-    body_lines = lines[body_start:body_end]
-
-    # Trim leading + trailing blank lines so the returned body
-    # doesn't carry the layout whitespace operators leave around
-    # the markdown.
-    while body_lines and not body_lines[0].strip():
-        body_lines.pop(0)
-    while body_lines and not body_lines[-1].strip():
-        body_lines.pop()
-
-    return "\n".join(body_lines)
+    return extract_soul_body(text)
 
 
 async def get_agent(request: web.Request) -> web.Response:

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -295,8 +295,23 @@ async def pair(request: web.Request) -> web.Response:
 # ────────────────────────────────────────────────────────────────────
 
 
+def _operator_has_active_link(paired_root_pubkey: str) -> bool:
+    """True if this operator already has a machine-link pairing."""
+    if not paired_root_pubkey:
+        return False
+    from ..control.store import load_pairings
+    return any(
+        p.operator_root_pubkey == paired_root_pubkey
+        for p in load_pairings().values()
+    )
+
+
 async def list_agents(request: web.Request) -> web.Response:
     paired_root = request["paired_root_pubkey"]
+    # Linked operators see agents via the server's link channel;
+    # bridge returns empty to avoid double-listing.
+    if _operator_has_active_link(paired_root):
+        return web.json_response({"agents": []})
     items: list[dict] = []
     for aid in discover_agents():
         # Skip agents pending tear-down — the reconcile loop runs
@@ -702,8 +717,56 @@ async def update_profile(request: web.Request) -> web.Response:
     if isinstance(new_role_short, str):
         profile_patch["role_short"] = new_role_short
 
-    # Best-effort server sync; failure logs but doesn't fail the
-    # request since agent.yml is still updated locally.
+    new_profile_summary = payload.get("profile_summary")
+    stripped_summary: str | None = None
+    if isinstance(new_profile_summary, str):
+        stripped_summary = new_profile_summary.strip()
+        summary_bytes = len(stripped_summary.encode("utf-8"))
+        if summary_bytes > MAX_PROFILE_SUMMARY_BYTES:
+            return _bad(
+                f"profile_summary is {summary_bytes} bytes; cap is "
+                f"{MAX_PROFILE_SUMMARY_BYTES}"
+            )
+
+    # Disk-first so a sync failure can't drop the operator's edit.
+    if isinstance(new_display_name, str):
+        cfg.display_name = new_display_name.strip() or cfg.display_name
+    if new_avatar_url is not None:
+        cfg.avatar_url = new_avatar_url
+    if isinstance(new_role, str):
+        cfg.role = new_role
+        if not isinstance(new_role_short, str):
+            cfg.role_short = _derive_role_short(new_role)
+    if isinstance(new_role_short, str):
+        cfg.role_short = new_role_short
+    cfg.save()
+    if stripped_summary is not None:
+        _update_profile_summary(cfg, stripped_summary)
+        profile_patch["soul"] = stripped_summary
+    renamed = (
+        isinstance(new_display_name, str)
+        and cfg.display_name != old_display_name
+        and old_display_name
+        and cfg.display_name
+    )
+    if renamed:
+        rewrite_profile_name(
+            cfg.resolve_profile_path(), old_display_name, cfg.display_name,
+        )
+    logger.info(
+        "bridge: updated profile for agent=%s display_name=%r avatar=%s role_short=%r",
+        agent_id, cfg.display_name,
+        "(set)" if cfg.avatar_url else "(empty)",
+        cfg.role_short,
+    )
+
+    # reload.flag is lazy + session-preserving; right primitive for
+    # any prompt-affecting change.
+    if renamed or stripped_summary is not None or isinstance(new_role, str):
+        from ..profile_sync import write_reload_flag
+        write_reload_flag(cfg, reason="bridge profile edit")
+
+    # Server sync LAST so a failure can't drop the local edit.
     if profile_patch:
         try:
             await _sync_agent_profile(cfg, profile_patch)
@@ -714,86 +777,6 @@ async def update_profile(request: web.Request) -> web.Response:
             logger.warning(
                 "bridge: profile sync failed for agent=%s: %s", agent_id, exc,
             )
-
-    new_profile_summary = payload.get("profile_summary")
-    if isinstance(new_profile_summary, str):
-        # PUF-208 v2: cap before write so a stale UI / future automation
-        # client can't drop a multi-megabyte soul on disk + into the
-        # next CLAUDE.md sync. UTF-8 byte count matches storage. Cap
-        # the STRIPPED payload so the gate sees what storage actually
-        # writes — otherwise 10010 bytes of content surrounded by
-        # whitespace (strips to 9990) would 400 even though the disk
-        # write would have landed under the cap.
-        stripped_summary = new_profile_summary.strip()
-        summary_bytes = len(stripped_summary.encode("utf-8"))
-        if summary_bytes > MAX_PROFILE_SUMMARY_BYTES:
-            return _bad(
-                f"profile_summary is {summary_bytes} bytes; cap is "
-                f"{MAX_PROFILE_SUMMARY_BYTES}"
-            )
-        _update_profile_summary(cfg, stripped_summary)
-
-    # Write agent.yml last so local state reflects what we asked
-    # the server for, even if the sync warned.
-    if isinstance(new_display_name, str):
-        cfg.display_name = new_display_name.strip() or cfg.display_name
-    if new_avatar_url is not None:
-        cfg.avatar_url = new_avatar_url
-    if isinstance(new_role, str):
-        cfg.role = new_role
-        # If the caller didn't override role_short, mirror the
-        # server-side derive locally so agent.yml stays consistent
-        # with what the server stores. The server is still
-        # authoritative — this is a best-effort local cache.
-        if not isinstance(new_role_short, str):
-            cfg.role_short = _derive_role_short(new_role)
-    if isinstance(new_role_short, str):
-        cfg.role_short = new_role_short
-    cfg.save()
-    logger.info(
-        "bridge: updated profile for agent=%s display_name=%r avatar=%s role_short=%r",
-        agent_id, cfg.display_name,
-        "(set)" if cfg.avatar_url else "(empty)",
-        cfg.role_short,
-    )
-
-    # On an actual rename, rewrite profile.md (the prose CLAUDE.md /
-    # AGENTS.md are assembled from) then drop reload.flag so the worker
-    # re-assembles on its next message. Not locked — rapid renames may
-    # interleave; tolerated given UI debounce + the worker reloads
-    # whatever profile.md settles to.
-    if (
-        cfg.display_name != old_display_name
-        and old_display_name
-        and cfg.display_name
-    ):
-        replacements = rewrite_profile_name(
-            cfg.resolve_profile_path(), old_display_name, cfg.display_name,
-        )
-        flag_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "reload.flag"
-        try:
-            flag_path.parent.mkdir(parents=True, exist_ok=True)
-            flag_path.write_text(
-                json.dumps({
-                    "version": 1,
-                    "requested_at": int(datetime.now(tz=timezone.utc).timestamp()),
-                    "reason": "agent rename",
-                }) + "\n",
-                encoding="utf-8",
-            )
-        except OSError as exc:
-            # Flag is best-effort: agent.yml + profile.md already wrote,
-            # so a restart still picks up the new name. Don't fail PATCH.
-            logger.warning(
-                "bridge: failed to write reload.flag for agent=%s after "
-                "rename: %s (agent will pick up new name on next restart)",
-                agent_id, exc,
-            )
-        logger.info(
-            "bridge: rename agent=%s %r → %r — profile.md replacements=%d, "
-            "reload.flag written",
-            agent_id, old_display_name, cfg.display_name, replacements,
-        )
     body: dict[str, Any] = {
         "agent_id": agent_id,
         "display_name": cfg.display_name,

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -725,11 +725,12 @@ def _set_agent_state(agent_id: str, new_state: str) -> int:
 
 
 def cmd_agent_rename(args: argparse.Namespace) -> int:
-    """Change the operator-facing display_name in agent.yml.
+    """Change display_name on disk, in profile.md heading, on the
+    server identity, and drop reload.flag (mirrors bridge edit)."""
+    import asyncio
+    from ..agent.shared_content import rewrite_profile_name
+    from .profile_sync import sync_agent_profile, write_reload_flag
 
-    The chat-visible identity profile lives on puffo-core under the
-    agent's slug; manage that via ``puffo-cli``.
-    """
     agent_id = args.id
     new_name = (args.display_name or "").strip()
     if not new_name:
@@ -739,13 +740,31 @@ def cmd_agent_rename(args: argparse.Namespace) -> int:
         print(f"error: agent {agent_id!r} not found", file=sys.stderr)
         return 2
     cfg = AgentConfig.load(agent_id)
+    old_name = cfg.display_name
+    if new_name == old_name:
+        print(f"agent {agent_id!r} display_name already {new_name!r}")
+        return 0
     cfg.display_name = new_name
     cfg.save()
-    print(f"agent {agent_id!r} display_name set to {new_name!r}")
-    print(
-        "note: this updates the local agent.yml only. "
-        "use puffo-cli to change the puffo-core identity profile."
-    )
+    if old_name:
+        try:
+            rewrite_profile_name(cfg.resolve_profile_path(), old_name, new_name)
+        except Exception as exc:
+            print(
+                f"warning: profile.md heading rewrite failed: {exc}",
+                file=sys.stderr,
+            )
+    write_reload_flag(cfg, reason="cli agent rename")
+    try:
+        asyncio.run(sync_agent_profile(cfg, {"display_name": new_name}))
+    except Exception as exc:
+        print(
+            f"warning: server profile sync failed: {exc} "
+            f"(local agent.yml is updated; retry via the UI / linked "
+            f"operator if you need the puffo-core identity to match)",
+            file=sys.stderr,
+        )
+    print(f"agent {agent_id!r} display_name {old_name!r} → {new_name!r}")
     return 0
 
 

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -130,12 +130,16 @@ async def execute_command(
     if op == "edit":
         cfg = AgentConfig.load(agent_slug)
         patch: dict = {}
+        prompt_changed = False
+        runtime_changed = False
         if isinstance(params.get("display_name"), str):
             cfg.display_name = params["display_name"]
             patch["display_name"] = params["display_name"]
+            prompt_changed = True
         if isinstance(params.get("role"), str):
             cfg.role = params["role"]
             patch["role"] = params["role"]
+            prompt_changed = True
         # avatar_url points to a blob the operator already uploaded; sync it to
         # the server identity (avatars are public, so no gating needed).
         if isinstance(params.get("avatar_url"), str):
@@ -145,6 +149,7 @@ async def execute_command(
         # agent.yml); the profile.md body carries it for the worker.
         if isinstance(params.get("soul"), str):
             patch["soul"] = params["soul"]
+            prompt_changed = True
         # Runtime block (kind/provider/harness/model) — same fields the local
         # bridge's update_runtime accepts; reject invalid triples before saving.
         rt_in = params.get("runtime")
@@ -153,6 +158,7 @@ async def execute_command(
             for key in ("kind", "provider", "harness", "model"):
                 if isinstance(rt_in.get(key), str):
                     setattr(rt, key, rt_in[key])
+                    runtime_changed = True
             from ..runtime_matrix import validate_triple
 
             result = validate_triple(rt.kind, rt.provider, rt.harness)
@@ -163,8 +169,7 @@ async def execute_command(
             (agent_yml_path(agent_slug).parent / cfg.profile).write_text(
                 params["profile"], encoding="utf-8"
             )
-        # Sync display_name/role to the server identity so the operator's portal
-        # reflects the edit — agent.yml alone isn't visible server-side.
+            prompt_changed = True
         if patch:
             try:
                 from ..api.handlers import _sync_agent_profile
@@ -172,10 +177,14 @@ async def execute_command(
                 await _sync_agent_profile(cfg, patch)
             except Exception as exc:  # noqa: BLE001
                 log.warning("control: edit profile sync failed: %s", exc)
-        # Restart a running worker so profile.md / runtime / identity edits take
-        # effect now rather than on the next manual restart.
+        # restart.flag for runtime (spawn-args change); reload.flag
+        # for prompt-only (lazy, preserves the AI session).
         if cfg.state == "running":
-            _touch_flag(restart_flag_path(agent_slug))
+            if runtime_changed:
+                _touch_flag(restart_flag_path(agent_slug))
+            elif prompt_changed:
+                from ..profile_sync import write_reload_flag
+                write_reload_flag(cfg, reason="control-ws edit")
         return {"ok": True}
     if op == "create":
         return await _create_agent_command(params, server_url, paired_root_pubkey)

--- a/src/puffo_agent/portal/control/link.py
+++ b/src/puffo_agent/portal/control/link.py
@@ -219,8 +219,19 @@ async def migrate_owned_agents(operator_root_pubkey: str) -> int:
                 )
                 soul_text = None
             if soul_text is not None:
-                await sync_agent_profile(cfg, {"soul": soul_text})
-                logger.debug("migrate %s: soul synced (%d chars)", cfg.id, len(soul_text))
+                from ..profile_sync import extract_soul_body
+                soul_body = extract_soul_body(soul_text)
+                if soul_body:
+                    await sync_agent_profile(cfg, {"soul": soul_body})
+                    logger.debug(
+                        "migrate %s: soul synced (%d chars)",
+                        cfg.id, len(soul_body),
+                    )
+                else:
+                    logger.debug(
+                        "migrate %s: profile.md has no soul section; skipping",
+                        cfg.id,
+                    )
         except HttpError as exc:
             logger.warning(
                 "migrate %s: soul sync rejected (HTTP %s); machine_id "

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -109,6 +109,9 @@ class Daemon:
         # Re-assert machine_id for already-linked operators' agents so agents
         # created/paused before linking show as remote without a re-link.
         asyncio.ensure_future(_migrate_linked_agents_at_startup())
+        # Re-push every owned agent's profile to the server in case
+        # the operator hand-edited agent.yml / profile.md offline.
+        asyncio.ensure_future(_full_sync_all_owned_agents_at_startup())
 
         # Start auxiliary HTTP services. Both are non-fatal on bind
         # failure — the daemon's primary job is still running agents.
@@ -532,6 +535,42 @@ async def _migrate_linked_agents_at_startup() -> None:
                 "startup machine_id migration failed for %s: %s",
                 pairing.operator_slug, exc,
             )
+
+
+async def _full_sync_all_owned_agents_at_startup() -> None:
+    """Push every owned agent's profile to puffo-server on boot —
+    defends against offline hand-edits. Independent of link state."""
+    from ..crypto.keystore import KeyStore
+    from .profile_sync import sync_full_profile
+
+    async def _sync_one(agent_id: str) -> str | None:
+        try:
+            cfg = AgentConfig.load(agent_id)
+        except Exception as exc:  # noqa: BLE001
+            return f"{agent_id}: load failed: {exc}"
+        if not cfg.puffo_core.is_configured():
+            return None
+        try:
+            KeyStore.for_agent(agent_id).load_session(cfg.puffo_core.slug)
+        except Exception:
+            return None
+        try:
+            await sync_full_profile(cfg)
+        except Exception as exc:  # noqa: BLE001
+            return f"{agent_id}: {exc}"
+        return None
+
+    ids = discover_agents()
+    if not ids:
+        return
+    results = await asyncio.gather(
+        *(_sync_one(aid) for aid in ids), return_exceptions=False,
+    )
+    failures = [r for r in results if r]
+    ok = len(ids) - len(failures)
+    logger.info("startup: full-profile sync — ok=%d failed=%d", ok, len(failures))
+    for line in failures:
+        logger.warning("startup full-sync: %s", line)
 
 
 async def _log_outdated_version_warning() -> None:

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -1,22 +1,23 @@
-"""Shared helper: PATCH ``/identities/self`` signed by an agent's
-own keystore. Used by both the local bridge edit handler and the
-``puffo-agent agent profile`` CLI so they speak the same wire format
-without duplicating crypto plumbing.
-"""
+"""Shared helpers: PATCH ``/identities/self``, write reload.flag,
+push every server-tracked field in one shot (startup full-sync)."""
 
 from __future__ import annotations
 
+import json
+import logging
+import time
 from typing import Any
 
 from .state import AgentConfig
+
+logger = logging.getLogger(__name__)
 
 
 async def sync_agent_profile(cfg: AgentConfig, patch: dict[str, Any]) -> None:
     """Push ``patch`` (any subset of display_name / avatar_url /
     role / role_short / soul) to the agent's server identity. Signed
-    by the AGENT's subkey — callers (bridge / CLI / link-migrate)
-    own their own authorization gating before reaching here. Raises
-    on HTTP / network failure."""
+    by the AGENT's subkey — callers own their own authorization
+    gating before reaching here. Raises on HTTP / network failure."""
     from ..crypto.http_client import PuffoCoreHttpClient
     from ..crypto.keystore import KeyStore
 
@@ -27,3 +28,48 @@ async def sync_agent_profile(cfg: AgentConfig, patch: dict[str, Any]) -> None:
         await http.patch("/identities/self", patch)
     finally:
         await http.close()
+
+
+def write_reload_flag(cfg: AgentConfig, *, reason: str) -> None:
+    """Drop ``reload.flag`` so the worker rebuilds its system prompt
+    on the next batch. Best-effort."""
+    flag_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "reload.flag"
+    try:
+        flag_path.parent.mkdir(parents=True, exist_ok=True)
+        flag_path.write_text(
+            json.dumps({
+                "version": 1,
+                "requested_at": int(time.time()),
+                "reason": reason,
+            }) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning(
+            "reload.flag write failed for agent=%s (%s): %s",
+            cfg.id, reason, exc,
+        )
+
+
+async def sync_full_profile(cfg: AgentConfig) -> None:
+    """One-shot PATCH of every server-tracked profile field plus
+    profile.md→soul. profile.md absence skips just the soul key."""
+    patch: dict[str, Any] = {
+        "display_name": cfg.display_name,
+        "role": cfg.role,
+        "role_short": cfg.role_short,
+        "avatar_url": cfg.avatar_url,
+    }
+    try:
+        soul = cfg.resolve_profile_path().read_text(encoding="utf-8")
+    except FileNotFoundError:
+        soul = None
+    except OSError as exc:
+        logger.warning(
+            "sync_full_profile: profile.md read failed for agent=%s: %s",
+            cfg.id, exc,
+        )
+        soul = None
+    if soul is not None:
+        patch["soul"] = soul
+    await sync_agent_profile(cfg, patch)

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -1,5 +1,6 @@
 """Shared helpers: PATCH ``/identities/self``, write reload.flag,
-push every server-tracked field in one shot (startup full-sync)."""
+push every server-tracked field in one shot (startup full-sync),
+and extract the soul section from a profile.md."""
 
 from __future__ import annotations
 
@@ -11,6 +12,71 @@ from typing import Any
 from .state import AgentConfig
 
 logger = logging.getLogger(__name__)
+
+
+_DESCRIPTION_HEADINGS = {"soul", "description", "about", "summary"}
+
+
+def _atx_heading(raw: str) -> tuple[int, str]:
+    stripped = raw.lstrip()
+    if not stripped.startswith("#"):
+        return 0, ""
+    i = 0
+    while i < len(stripped) and stripped[i] == "#":
+        i += 1
+    if i < len(stripped) and stripped[i] in " \t":
+        return i, stripped[i:].strip().lower()
+    return 0, ""
+
+
+def _soul_section_span(lines: list[str]) -> tuple[int, int, int] | None:
+    """``(heading_idx, body_start, body_end)`` of the soul section, or
+    None. A same-or-higher heading only closes the section once real
+    prose has been collected — covers the legitimate case where the
+    body opens with its own heading (e.g. ``# <agent-name>``)."""
+    heading_idx = -1
+    section_level = 0
+    for idx, raw in enumerate(lines):
+        level, text = _atx_heading(raw)
+        if level and text in _DESCRIPTION_HEADINGS:
+            heading_idx = idx
+            section_level = level
+            break
+    if heading_idx == -1:
+        return None
+    body_start = heading_idx + 1
+    body_end = len(lines)
+    has_text = False
+    for idx in range(body_start, len(lines)):
+        raw = lines[idx]
+        level, _ = _atx_heading(raw)
+        if level:
+            if level <= section_level and has_text:
+                body_end = idx
+                break
+            continue
+        if raw.strip():
+            has_text = True
+    return heading_idx, body_start, body_end
+
+
+def extract_soul_body(profile_md_text: str) -> str:
+    """Return the body of the ``# Soul`` section from a profile.md
+    (or any description-like heading: description / about / summary).
+    Trims surrounding blank lines. Empty when no such section
+    exists. Single source of truth shared by the bridge read path
+    and the server-sync paths."""
+    lines = profile_md_text.splitlines()
+    span = _soul_section_span(lines)
+    if span is None:
+        return ""
+    _, body_start, body_end = span
+    body_lines = lines[body_start:body_end]
+    while body_lines and not body_lines[0].strip():
+        body_lines.pop(0)
+    while body_lines and not body_lines[-1].strip():
+        body_lines.pop()
+    return "\n".join(body_lines)
 
 
 async def sync_agent_profile(cfg: AgentConfig, patch: dict[str, Any]) -> None:
@@ -52,8 +118,10 @@ def write_reload_flag(cfg: AgentConfig, *, reason: str) -> None:
 
 
 async def sync_full_profile(cfg: AgentConfig) -> None:
-    """One-shot PATCH of every server-tracked profile field plus
-    profile.md→soul. profile.md absence skips just the soul key."""
+    """One-shot PATCH of every server-tracked profile field plus the
+    ``# Soul`` section extracted from profile.md. Soul is omitted
+    when profile.md is missing OR has no soul-like heading — the
+    server's stored value is preserved rather than clobbered."""
     patch: dict[str, Any] = {
         "display_name": cfg.display_name,
         "role": cfg.role,
@@ -61,15 +129,17 @@ async def sync_full_profile(cfg: AgentConfig) -> None:
         "avatar_url": cfg.avatar_url,
     }
     try:
-        soul = cfg.resolve_profile_path().read_text(encoding="utf-8")
+        text = cfg.resolve_profile_path().read_text(encoding="utf-8")
     except FileNotFoundError:
-        soul = None
+        text = None
     except OSError as exc:
         logger.warning(
             "sync_full_profile: profile.md read failed for agent=%s: %s",
             cfg.id, exc,
         )
-        soul = None
-    if soul is not None:
-        patch["soul"] = soul
+        text = None
+    if text is not None:
+        soul = extract_soul_body(text)
+        if soul:
+            patch["soul"] = soul
     await sync_agent_profile(cfg, patch)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1107,6 +1107,21 @@ class Worker:
             # to verify anyway since the adapter never came up.
             self._warm_done.set()
 
+        # Per-agent counterpart to daemon-startup full-sync: covers
+        # paused→running flips + restart.flag respawns. Fire-and-
+        # forget; never blocks listen().
+        async def _post_warm_sync() -> None:
+            from .profile_sync import sync_full_profile
+            try:
+                await sync_full_profile(self.agent_cfg)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent %s: post-warm profile sync failed: %s",
+                    agent_id, exc,
+                )
+
+        asyncio.ensure_future(_post_warm_sync())
+
         reload_flag_path = Path(workspace_path) / ".puffo-agent" / "reload.flag"
         refresh_flag_path = Path(workspace_path) / ".puffo-agent" / "refresh.flag"
         # Per-turn context for the cli-local permission hook. The hook

--- a/tests/test_agent_sync.py
+++ b/tests/test_agent_sync.py
@@ -16,10 +16,44 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from _bridge_support import isolated_home, write_test_agent  # noqa: E402
 
 from puffo_agent.portal.profile_sync import (  # noqa: E402
+    extract_soul_body,
     sync_full_profile,
     write_reload_flag,
 )
 from puffo_agent.portal.state import AgentConfig  # noqa: E402
+
+
+class TestExtractSoulBody:
+    def test_returns_section_only_not_whole_file(self):
+        # The regression that motivated the helper extraction —
+        # earlier sync paths sent the WHOLE profile.md as soul.
+        md = (
+            "# Bot Name\n\nHeader content.\n\n"
+            "# Soul\n\nThe agent's soul.\n\n"
+            "# Notes\n\nOperator notes that aren't soul.\n"
+        )
+        assert extract_soul_body(md) == "The agent's soul."
+
+    def test_returns_empty_when_no_soul_heading(self):
+        assert extract_soul_body("# Misc\n\nNo soul here.\n") == ""
+
+    def test_accepts_description_about_summary_aliases(self):
+        for alias in ("description", "about", "summary"):
+            md = f"# {alias.title()}\n\nbody\n"
+            assert extract_soul_body(md) == "body"
+
+    def test_preserves_subheadings_inside_section(self):
+        md = "# Soul\n\nintro line\n\n## Tone\n\nfriendly\n"
+        assert extract_soul_body(md) == (
+            "intro line\n\n## Tone\n\nfriendly"
+        )
+
+    def test_opening_heading_in_soul_body_is_kept(self):
+        # The "after real content" gate in _soul_section_span: the
+        # soul body opening with its own heading must not be mistaken
+        # for the section end.
+        md = "# Soul\n\n# Inner\n\nbody\n"
+        assert extract_soul_body(md) == "# Inner\n\nbody"
 
 
 # ── write_reload_flag ─────────────────────────────────────────────
@@ -52,7 +86,15 @@ async def test_sync_full_profile_sends_every_field_plus_soul(tmp_path, monkeypat
     cfg.avatar_url = "https://example.test/avatar.png"
     cfg.save()
     profile_path = cfg.resolve_profile_path()
-    profile_path.write_text("# Full Bot\n\nfull system prompt\n", encoding="utf-8")
+    profile_path.write_text(
+        "# Full Bot\n\n"
+        "Header section the agent uses internally.\n\n"
+        "# Soul\n\n"
+        "I am Full Bot. I help with testing.\n\n"
+        "# Notes\n\n"
+        "Some unrelated section operators added.\n",
+        encoding="utf-8",
+    )
 
     posted: list[tuple[str, dict]] = []
 
@@ -80,7 +122,47 @@ async def test_sync_full_profile_sends_every_field_plus_soul(tmp_path, monkeypat
     assert body["role"] == "Dev: tester"
     assert body["role_short"] == "Dev"
     assert body["avatar_url"] == "https://example.test/avatar.png"
-    assert body["soul"] == "# Full Bot\n\nfull system prompt\n"
+    # ONLY the # Soul section body — not the "# Full Bot" header, not
+    # the "# Notes" trailing section.
+    assert body["soul"] == "I am Full Bot. I help with testing."
+
+
+@pytest.mark.asyncio
+async def test_sync_full_profile_skips_soul_when_no_soul_section(monkeypatch):
+    # profile.md exists but has no # Soul / description / about /
+    # summary heading. Don't clobber whatever soul the server has.
+    home = isolated_home()
+    write_test_agent(home, "no-soul-bot")
+    cfg = AgentConfig.load("no-soul-bot")
+    cfg.display_name = "No Soul"
+    cfg.save()
+    cfg.resolve_profile_path().write_text(
+        "# Random Heading\n\nThis has no soul section.\n",
+        encoding="utf-8",
+    )
+
+    posted: list[tuple[str, dict]] = []
+
+    class _FakeHttp:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def patch(self, path: str, body: dict) -> dict:
+            posted.append((path, body))
+            return {}
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient", _FakeHttp,
+    )
+    await sync_full_profile(cfg)
+
+    assert len(posted) == 1
+    _, body = posted[0]
+    assert "soul" not in body  # omitted, not empty — preserves server-side soul
+    assert body["display_name"] == "No Soul"
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_sync.py
+++ b/tests/test_agent_sync.py
@@ -1,0 +1,288 @@
+"""Profile sync — reload.flag drop, control-WS flag differentiation,
+sync_full_profile."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from _bridge_support import isolated_home, write_test_agent  # noqa: E402
+
+from puffo_agent.portal.profile_sync import (  # noqa: E402
+    sync_full_profile,
+    write_reload_flag,
+)
+from puffo_agent.portal.state import AgentConfig  # noqa: E402
+
+
+# ── write_reload_flag ─────────────────────────────────────────────
+
+
+def test_write_reload_flag_drops_versioned_json():
+    home = isolated_home()
+    write_test_agent(home, "flag-bot")
+    cfg = AgentConfig.load("flag-bot")
+    write_reload_flag(cfg, reason="unit test")
+    flag_path = cfg.resolve_workspace_dir() / ".puffo-agent" / "reload.flag"
+    assert flag_path.exists()
+    payload = json.loads(flag_path.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert payload["reason"] == "unit test"
+    assert isinstance(payload["requested_at"], int)
+
+
+# ── sync_full_profile ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_full_profile_sends_every_field_plus_soul(tmp_path, monkeypatch):
+    home = isolated_home()
+    write_test_agent(home, "full-bot")
+    cfg = AgentConfig.load("full-bot")
+    cfg.display_name = "Full Bot"
+    cfg.role = "Dev: tester"
+    cfg.role_short = "Dev"
+    cfg.avatar_url = "https://example.test/avatar.png"
+    cfg.save()
+    profile_path = cfg.resolve_profile_path()
+    profile_path.write_text("# Full Bot\n\nfull system prompt\n", encoding="utf-8")
+
+    posted: list[tuple[str, dict]] = []
+
+    class _FakeHttp:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def patch(self, path: str, body: dict) -> dict:
+            posted.append((path, body))
+            return {}
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        _FakeHttp,
+    )
+    await sync_full_profile(cfg)
+
+    assert len(posted) == 1
+    path, body = posted[0]
+    assert path == "/identities/self"
+    assert body["display_name"] == "Full Bot"
+    assert body["role"] == "Dev: tester"
+    assert body["role_short"] == "Dev"
+    assert body["avatar_url"] == "https://example.test/avatar.png"
+    assert body["soul"] == "# Full Bot\n\nfull system prompt\n"
+
+
+@pytest.mark.asyncio
+async def test_sync_full_profile_skips_soul_when_profile_md_absent(monkeypatch):
+    home = isolated_home()
+    write_test_agent(home, "no-md-bot")
+    cfg = AgentConfig.load("no-md-bot")
+    cfg.display_name = "No MD"
+    cfg.save()
+    try:
+        cfg.resolve_profile_path().unlink()
+    except FileNotFoundError:
+        pass
+
+    posted: list[tuple[str, dict]] = []
+
+    class _FakeHttp:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def patch(self, path: str, body: dict) -> dict:
+            posted.append((path, body))
+            return {}
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        _FakeHttp,
+    )
+    await sync_full_profile(cfg)
+
+    assert len(posted) == 1
+    _, body = posted[0]
+    assert "soul" not in body
+    assert body["display_name"] == "No MD"
+
+
+# ── control-WS op=edit flag differentiation ──────────────────────
+
+
+def _patch_sync(monkeypatch):
+    """Stub the server PATCH so op=edit can run end-to-end without HTTP."""
+    sent: list[dict] = []
+
+    async def _fake_sync(cfg, patch):
+        sent.append(dict(patch))
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.api.handlers._sync_agent_profile",
+        _fake_sync,
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_control_edit_profile_only_writes_reload_flag(monkeypatch):
+    home = isolated_home()
+    write_test_agent(home, "edit-bot")
+    cfg = AgentConfig.load("edit-bot")
+    cfg.display_name = "Edit Bot"
+    cfg.state = "running"
+    cfg.save()
+    _patch_sync(monkeypatch)
+
+    from puffo_agent.portal.control import client as ctrl
+
+    result = await ctrl.execute_command(
+        op="edit",
+        agent_slug="edit-bot",
+        params={"display_name": "Renamed Bot"},
+        server_url="https://example.test",
+        paired_root_pubkey="op-pk",
+    )
+    assert result == {"ok": True}
+
+    workspace = AgentConfig.load("edit-bot").resolve_workspace_dir()
+    reload_flag = workspace / ".puffo-agent" / "reload.flag"
+    restart_flag = Path(home) / "agents" / "edit-bot" / ".puffo-agent" / "restart.flag"
+    assert reload_flag.exists()
+    assert not restart_flag.exists()
+
+
+@pytest.mark.asyncio
+async def test_control_edit_runtime_writes_restart_flag(monkeypatch):
+    home = isolated_home()
+    write_test_agent(home, "rt-bot")
+    cfg = AgentConfig.load("rt-bot")
+    cfg.state = "running"
+    cfg.save()
+    _patch_sync(monkeypatch)
+
+    from puffo_agent.portal.control import client as ctrl
+
+    result = await ctrl.execute_command(
+        op="edit",
+        agent_slug="rt-bot",
+        params={"runtime": {"model": "claude-sonnet-4-7"}},
+        server_url="https://example.test",
+        paired_root_pubkey="op-pk",
+    )
+    assert result == {"ok": True}
+
+    workspace = AgentConfig.load("rt-bot").resolve_workspace_dir()
+    reload_flag = workspace / ".puffo-agent" / "reload.flag"
+    restart_flag = Path(home) / "agents" / "rt-bot" / ".puffo-agent" / "restart.flag"
+    assert restart_flag.exists()
+    assert not reload_flag.exists()
+
+
+@pytest.mark.asyncio
+async def test_full_sync_all_owned_agents_at_startup_fans_out(monkeypatch):
+    # The daemon-startup helper should call sync_full_profile once
+    # per agent that has a configured puffo_core block + keystore.
+    home = isolated_home()
+    write_test_agent(home, "alpha-bot")
+    write_test_agent(home, "beta-bot")
+
+    called: list[str] = []
+
+    async def _fake_sync(cfg):
+        called.append(cfg.id)
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.profile_sync.sync_full_profile",
+        _fake_sync,
+    )
+
+    # KeyStore.for_agent(...).load_session is the gate; stub it open.
+    class _FakeKS:
+        @staticmethod
+        def for_agent(agent_id):
+            class _Inst:
+                def load_session(self, slug):
+                    return object()
+            return _Inst()
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.keystore.KeyStore", _FakeKS,
+    )
+
+    from puffo_agent.portal import daemon as daemon_mod
+    await daemon_mod._full_sync_all_owned_agents_at_startup()
+    assert sorted(called) == ["alpha-bot", "beta-bot"]
+
+
+@pytest.mark.asyncio
+async def test_full_sync_skips_agents_without_keystore(monkeypatch):
+    # Agent dir exists but the keystore can't be loaded → skip
+    # silently. Common case for not-yet-finalised registrations.
+    home = isolated_home()
+    write_test_agent(home, "skeleton-bot")
+
+    called: list[str] = []
+
+    async def _fake_sync(cfg):
+        called.append(cfg.id)
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.profile_sync.sync_full_profile",
+        _fake_sync,
+    )
+
+    class _FakeKS:
+        @staticmethod
+        def for_agent(agent_id):
+            class _Inst:
+                def load_session(self, slug):
+                    raise RuntimeError("no session")
+            return _Inst()
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.keystore.KeyStore", _FakeKS,
+    )
+
+    from puffo_agent.portal import daemon as daemon_mod
+    await daemon_mod._full_sync_all_owned_agents_at_startup()
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_control_edit_paused_agent_drops_no_flag(monkeypatch):
+    # Paused workers have no live CLI subprocess to reload — flag drop
+    # would be a no-op anyway. Avoid the stale flag.
+    home = isolated_home()
+    write_test_agent(home, "paused-bot")
+    cfg = AgentConfig.load("paused-bot")
+    cfg.state = "paused"
+    cfg.save()
+    _patch_sync(monkeypatch)
+
+    from puffo_agent.portal.control import client as ctrl
+
+    await ctrl.execute_command(
+        op="edit",
+        agent_slug="paused-bot",
+        params={"soul": "fresh prompt"},
+        server_url="https://example.test",
+        paired_root_pubkey="op-pk",
+    )
+
+    workspace = AgentConfig.load("paused-bot").resolve_workspace_dir()
+    assert not (workspace / ".puffo-agent" / "reload.flag").exists()
+    assert not (Path(home) / "agents" / "paused-bot" / ".puffo-agent" / "restart.flag").exists()

--- a/tests/test_bridge_handlers.py
+++ b/tests/test_bridge_handlers.py
@@ -129,6 +129,57 @@ async def test_list_agents_empty(client):
     assert j["agents"] == []
 
 
+async def test_list_returns_empty_when_paired_operator_has_active_link():
+    # The bridge-paired operator also has a machine-link pairing —
+    # they manage agents through puffo-server's control channel,
+    # so the local bridge hides /agents to avoid double-reporting.
+    user = make_user()
+    home = isolated_home()
+    user_root_pk = base64url_encode(user.root_key.public_key_bytes())
+    write_test_agent(home, "linked-op-bot", owner_root_pubkey=user_root_pk)
+
+    # Stand up a matching link pairing for the same operator root.
+    from puffo_agent.portal.control.store import ControlPairing, save_pairing
+    save_pairing(ControlPairing(
+        operator_slug="op-slug",
+        operator_root_pubkey=user_root_pk,
+        control_cert={},
+        server_url="https://example.test",
+        name="test-machine",
+        created_at=0,
+    ))
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        h = signed_headers(user, "GET", "/v1/agents"); h.update(_HOST)
+        r = await c.get("/v1/agents", headers=h)
+        j = await r.json()
+    assert j["agents"] == []
+
+
+async def test_list_returned_normally_when_paired_operator_is_unlinked():
+    # Same setup minus the pairing — non-linked operators see their
+    # agents as usual.
+    user = make_user()
+    home = isolated_home()
+    user_root_pk = base64url_encode(user.root_key.public_key_bytes())
+    write_test_agent(home, "free-op-bot", owner_root_pubkey=user_root_pk)
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        h = signed_headers(user, "GET", "/v1/agents"); h.update(_HOST)
+        r = await c.get("/v1/agents", headers=h)
+        j = await r.json()
+    ids = [a["id"] for a in j["agents"]]
+    assert "free-op-bot" in ids
+
+
 async def test_list_marks_owned_correctly(client):
     user = make_user()
     home = isolated_home()  # fresh home so we control which agents exist
@@ -359,6 +410,52 @@ async def test_update_profile_accepts_summary_at_cap():
         assert r.status == 200, await r.text()
 
 
+async def test_soul_edit_writes_profile_md_and_drops_reload_flag(monkeypatch):
+    # Soul-only edit (no display_name) must rewrite profile.md AND
+    # drop reload.flag — earlier the flag was rename-only and pure
+    # soul edits never reloaded.
+    user = make_user()
+    home = isolated_home()
+    write_test_agent(
+        home,
+        "soul-only-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+    agent_dir = Path(home) / "agents" / "soul-only-bot"
+    flag_path = agent_dir / "workspace" / ".puffo-agent" / "reload.flag"
+    captured_patch: dict = {}
+
+    async def _spy_sync(cfg, patch):
+        captured_patch.update(patch)
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.api.handlers._sync_agent_profile", _spy_sync,
+    )
+
+    cfg = DaemonConfig().bridge
+    app = build_app(cfg)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await _pair(c, user)
+        body = json.dumps({
+            "profile_summary": "# Bot\n\nfresh prompt\n",
+        }).encode("utf-8")
+        h = signed_headers(user, "PATCH", "/v1/agents/soul-only-bot/profile", body)
+        h.update(_HOST)
+        h["content-type"] = "application/json"
+        r = await c.patch("/v1/agents/soul-only-bot/profile", data=body, headers=h)
+        assert r.status == 200, await r.text()
+
+    # profile.md updated to the new soul
+    md = (agent_dir / "profile.md").read_text(encoding="utf-8")
+    assert "fresh prompt" in md
+    # reload.flag dropped (the load-bearing fix)
+    assert flag_path.exists()
+    # soul made it into the server PATCH (Bug 1 fix). Handler strips
+    # trailing whitespace before sending.
+    assert captured_patch.get("soul") == "# Bot\n\nfresh prompt"
+
+
 async def test_update_profile_rejects_summary_over_cap():
     # MAX + 1 byte must reject with 400 + a body that fingers the
     # offending byte count + the configured cap, so the UI can map
@@ -502,7 +599,7 @@ async def test_rename_rewrites_profile_md_and_drops_reload_flag():
     flag_body = json.loads(flag_path.read_text(encoding="utf-8"))
     assert flag_body.get("version") == 1
     assert "requested_at" in flag_body
-    assert flag_body.get("reason") == "agent rename"
+    assert flag_body.get("reason") == "bridge profile edit"
 
 
 async def test_unchanged_display_name_is_a_noop():

--- a/tests/test_link_migrate_soul_sync.py
+++ b/tests/test_link_migrate_soul_sync.py
@@ -74,7 +74,8 @@ async def test_migrate_syncs_soul_after_machine_id(monkeypatch):
     home = isolated_home()
     write_test_agent(home, "scout", owner_root_pubkey=_OWNER_PK)
     Path(home, "agents", "scout", "profile.md").write_text(
-        "# Scout\n\nA fast scout agent.\n", encoding="utf-8",
+        "# Scout\n\nName header.\n\n# Soul\n\nA fast scout agent.\n",
+        encoding="utf-8",
     )
 
     _patch_machine_id(monkeypatch)
@@ -92,7 +93,8 @@ async def test_migrate_syncs_soul_after_machine_id(monkeypatch):
     assert len(soul_calls) == 1
     agent_id, patch = soul_calls[0]
     assert agent_id == "scout"
-    assert patch == {"soul": "# Scout\n\nA fast scout agent.\n"}
+    # Just the # Soul section body — not the entire profile.md.
+    assert patch == {"soul": "A fast scout agent."}
     assert _FakeHttp.close_calls == 1
 
 
@@ -143,6 +145,9 @@ async def test_migrate_handles_missing_profile_md_gracefully(monkeypatch):
 async def test_soul_sync_failure_logs_but_machine_id_remains(monkeypatch, caplog):
     home = isolated_home()
     write_test_agent(home, "scout", owner_root_pubkey=_OWNER_PK)
+    Path(home, "agents", "scout", "profile.md").write_text(
+        "# Soul\n\nscout soul body\n", encoding="utf-8",
+    )
 
     _patch_machine_id(monkeypatch)
     _patch_http(monkeypatch)
@@ -189,10 +194,10 @@ async def test_migrate_syncs_soul_for_every_owned_agent(monkeypatch):
     write_test_agent(home, "ranger", owner_root_pubkey=_OWNER_PK)
 
     Path(home, "agents", "scout", "profile.md").write_text(
-        "Scout body", encoding="utf-8",
+        "# Soul\n\nScout body\n", encoding="utf-8",
     )
     Path(home, "agents", "ranger", "profile.md").write_text(
-        "Ranger body", encoding="utf-8",
+        "# Soul\n\nRanger body\n", encoding="utf-8",
     )
 
     _patch_machine_id(monkeypatch)


### PR DESCRIPTION
## Summary

Reworks every agent-profile edit & sync path. Five problems addressed:

1. **Bridge UI soul edit silently no-ops the agent.** ``update_profile`` wrote profile.md but never PATCHed soul to ``/identities/self`` AND never dropped reload.flag — server soul stayed stale, worker kept the old system prompt. Both fixed; ``reload.flag`` now fires on any prompt-affecting change (soul / display_name / role).
2. **Three edit paths had three orderings.** Bridge was server-first, control-WS / CLI were disk-first. Unified to **disk-first**: a sync failure can't silently drop the local edit.
3. **No startup full-sync.** If the operator hand-edits agent.yml / profile.md while the daemon is offline, the server view stays stale forever. New ``sync_full_profile`` helper runs on daemon boot (all owned agents, parallel, independent of link state) + on per-worker post-warm (paused→running, restart respawn).
4. **CLI ``agent rename`` drifted.** Only updated agent.yml — didn't rewrite profile.md heading, didn't sync the new name to server, didn't reload the worker. Now mirrors the bridge flow.
5. **Control-WS ``op=edit`` always restart.flag-bombed.** Even pure soul edits triggered full worker respawn (drops WS, respawns MCP, respawns CLI). Now only runtime changes write restart.flag; prompt-only changes write reload.flag (lazy, preserves the AI ``session_id`` / ``conversation_id`` via ``--resume`` / ``thread/resume``).

Plus a new rule:

6. **Bridge ``list_agents`` returns empty for linked operators.** If the bridge-paired operator is also in ``control/pairings.json``, agent management is owned by the server's link channel — bridge would otherwise double-list.

## Test plan

- [x] Local: ``PYTHONPATH=src python -m pytest`` — **1680 passed / 9 skipped** (+11 new tests).
- [x] Live smoke: daemon restart logs ``startup: full-profile sync — ok=5 failed=0`` for the 5 owned agents. Round-trip UI soul edit verified.
- [ ] Verify in chat.puffo.ai web UI: after this lands + you reload, the bridge-source agent list should disappear (you'll see agents only through the server-source list via the link channel).
- [ ] Verify soul edit via UI: change profile_summary in UI → check ``reload.flag`` appears at ``<workspace>/.puffo-agent/reload.flag`` → next agent message → CLI subprocess respawns with new prompt via ``--resume`` (session continuity preserved).
- [ ] Verify control-WS op=edit on a runtime change (e.g. model swap from another linked machine): should see ``restart.flag`` written, full worker respawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)