### PR TITLE
feat(api-puffo): cloud-hosted agent runtime — bundle ingestion + WS receive + LLM tool loop

### DIFF
--- a/scripts/api_puffo_mock_cloud.py
+++ b/scripts/api_puffo_mock_cloud.py
@@ -1,47 +1,38 @@
 """Mock puffo-cloud-server for end-to-end smoke testing the
-api-puffo runtime.
+api-puffo runtime against the real bridge wire protocol
+(BRIDGE-WIRE-PROTOCOL.md).
 
 Run:
-    PYTHONPATH=src python scripts/api_puffo_mock_cloud.py \\
-        --port 9999 \\
-        --agent-slug smoke-bot-test01 \\
-        --recipient-device-id dev_smoke_cloud \\
-        --recipient-kem-secret-key AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    PYTHONPATH=src python scripts/api_puffo_mock_cloud.py --port 9999
 
-It:
-  * Listens for a WS connect from the agent and accepts any bearer.
-  * On '--inject-message <text>', encrypts a fake DM as a foreign
-    sender and pushes it over the WS as an ``envelope`` frame.
-  * Mocks the LLM by returning a fixed canned response that either
-    speaks plain text or calls ``send_message`` once with the text.
-  * Logs every tool POST to stdout so you can see the round-trip.
+  * Listens for a WS connect at ``/v2/cloud-agents/subscribe`` and
+    accepts any ``x-sandbox-token`` header.
+  * Sends ``connected`` immediately on upgrade.
+  * Responds to ``heartbeat`` (silently — no client-facing ack),
+    ``fetch_pending`` (returns 0 unless --inject is used),
+    ``ack`` (returns ack_result), ``list_spaces`` (returns a fixed
+    fixture), ``send`` (returns ack).
+  * ``POST /_admin/inject {"text": "..."}`` pushes a fake DM as a
+    ``message`` frame to the currently connected agent.
+  * Mocks LLM at ``POST /v1/llm/complete`` — returns a canned
+    response that either calls ``send_message`` once with an echo
+    or end-turns with plain text.
 
-This is a *dev tool*, not production code — no auth, no rate
-limits, no persistence. Lives under scripts/ so the package import
-graph stays clean.
-"""
+Dev tool, not production: no auth on the inject endpoint, no
+persistence, no rate limits."""
 
 from __future__ import annotations
 
 import argparse
-import asyncio
 import json
 import logging
-import os
 import sys
+import uuid
 from pathlib import Path
 
 from aiohttp import WSMsgType, web
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-
-from puffo_agent.crypto.encoding import base64url_decode, base64url_encode
-from puffo_agent.crypto.message import (
-    EncryptInput,
-    RecipientDevice,
-    encrypt_message,
-)
-from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
 
 logging.basicConfig(
     level=logging.INFO,
@@ -51,67 +42,100 @@ log = logging.getLogger("mock-cloud")
 
 
 class MockCloudState:
-    def __init__(self, agent_slug: str, recipient_device_id: str,
-                 recipient_kem_pubkey: bytes) -> None:
-        self.agent_slug = agent_slug
-        self.recipient_device_id = recipient_device_id
-        self.recipient_kem_pubkey = recipient_kem_pubkey
-        # Foreign sender identity — generated once per process; we'll
-        # use this to sign the canned inbound payload so the agent's
-        # decrypt-and-verify path is exercised end-to-end.
-        self.foreign_signing_key = Ed25519KeyPair.generate()
-        self.foreign_slug = "smoker"
-        self.foreign_subkey_id = "subkey_smoke_001"
+    def __init__(self) -> None:
         self.active_ws: web.WebSocketResponse | None = None
-        self.recv_tool_calls: list[tuple[str, dict]] = []
-
-    def sender_pubkey_b64(self) -> str:
-        return base64url_encode(self.foreign_signing_key.public_key_bytes())
-
-    def build_envelope_frame(self, text: str) -> dict:
-        device = RecipientDevice(
-            device_id=self.recipient_device_id,
-            kem_public_key=self.recipient_kem_pubkey,
-        )
-        inp = EncryptInput(
-            envelope_kind="dm",
-            sender_slug=self.foreign_slug,
-            sender_subkey_id=self.foreign_subkey_id,
-            is_visible_to_human=True,
-            recipient_slug=self.agent_slug,
-            content_type="text/plain",
-            content=text,
-            recipients=[device],
-        )
-        envelope = encrypt_message(inp, self.foreign_signing_key)
-        return {
-            "type": "envelope",
-            "envelope": envelope,
-            "sender_signing_public_key": self.sender_pubkey_b64(),
-        }
+        self.recv_send_frames: list[dict] = []
+        self.recv_ack_frames: list[dict] = []
+        self.pending_messages: list[dict] = []
+        self.spaces_fixture: list[dict] = [
+            {
+                "space_id": "sp_mock_001",
+                "name": "Engineering",
+                "channels": [
+                    {"channel_id": "ch_mock_001", "name": "general"},
+                    {"channel_id": "ch_mock_002", "name": "random"},
+                ],
+            },
+        ]
 
 
 async def ws_handler(request: web.Request) -> web.WebSocketResponse:
     state: MockCloudState = request.app["state"]
-    slug = request.match_info["slug"]
-    token = request.headers.get("Authorization", "")
-    log.info("WS connect: slug=%s auth=%s", slug, token[:24])
+    token = request.headers.get("x-sandbox-token", "")
+    log.info("WS connect (x-sandbox-token=%s…)", (token or "(missing)")[:24])
 
-    ws = web.WebSocketResponse(heartbeat=30)
+    ws = web.WebSocketResponse(heartbeat=None)
     await ws.prepare(request)
     state.active_ws = ws
-    log.info("WS ready; awaiting --inject calls")
+
+    # First frame after upgrade.
+    await ws.send_json({"type": "connected"})
+    log.info("sent: connected")
+
     try:
         async for msg in ws:
-            if msg.type == WSMsgType.TEXT:
-                log.info("WS client→server: %s", msg.data[:120])
-            elif msg.type == WSMsgType.ERROR:
-                log.warning("WS error: %s", ws.exception())
-                break
+            if msg.type != WSMsgType.TEXT:
+                if msg.type in (WSMsgType.ERROR, WSMsgType.CLOSE, WSMsgType.CLOSED):
+                    log.info("WS closing (%s)", msg.type)
+                    break
+                continue
+            try:
+                frame = json.loads(msg.data)
+            except json.JSONDecodeError as exc:
+                log.warning("dropped non-JSON frame: %s", exc)
+                continue
+            await _handle_client_frame(ws, state, frame)
     finally:
         state.active_ws = None
         log.info("WS closed")
     return ws
+
+
+async def _handle_client_frame(
+    ws: web.WebSocketResponse, state: MockCloudState, frame: dict,
+) -> None:
+    kind = frame.get("type", "")
+    if kind == "heartbeat":
+        # Silent — server's recv-timeout just gets re-armed.
+        return
+    if kind == "send":
+        state.recv_send_frames.append(frame)
+        log.info("recv: send (%s)", json.dumps(frame)[:160])
+        await ws.send_json({
+            "type": "ack",
+            "client_ref": frame.get("client_ref"),
+            "envelope_id": f"msg_mock_{uuid.uuid4().hex[:12]}",
+            "devices_queued": 2,
+        })
+        return
+    if kind == "fetch_pending":
+        log.info("recv: fetch_pending limit=%s", frame.get("limit"))
+        count = 0
+        # Drain whatever was queued via --admin-inject.
+        while state.pending_messages:
+            await ws.send_json(state.pending_messages.pop(0))
+            count += 1
+        await ws.send_json({
+            "type": "pending_delivered", "count": count, "more": False,
+        })
+        log.info("sent: pending_delivered count=%d more=False", count)
+        return
+    if kind == "ack":
+        state.recv_ack_frames.append(frame)
+        ids = frame.get("envelope_ids") or []
+        log.info("recv: ack count=%d", len(ids))
+        await ws.send_json({"type": "ack_result", "acked": len(ids)})
+        return
+    if kind == "list_spaces":
+        log.info("recv: list_spaces")
+        await ws.send_json({"type": "spaces", "spaces": state.spaces_fixture})
+        return
+    log.warning("unhandled client frame type=%r", kind)
+    await ws.send_json({
+        "type": "error",
+        "code": "BAD_FRAME",
+        "message": f"unknown frame type {kind!r}",
+    })
 
 
 async def llm_complete(request: web.Request) -> web.Response:
@@ -123,23 +147,26 @@ async def llm_complete(request: web.Request) -> web.Response:
     msgs = body.get("messages") or []
     last = msgs[-1] if msgs else {}
     last_content = last.get("content", "")
-    last_text = (
-        last_content if isinstance(last_content, str)
-        else " ".join(c.get("content", "") for c in last_content if isinstance(c, dict))
-    )
 
-    # If the last message is a tool_result we're in round 2+: emit a
+    # If the last message is a tool_result, we're in round 2+: emit a
     # final text reply.
     if isinstance(last_content, list) and any(
-        isinstance(c, dict) and c.get("type") == "tool_result" for c in last_content
+        isinstance(c, dict) and c.get("type") == "tool_result"
+        for c in last_content
     ):
         return web.json_response({
             "stop_reason": "end_turn",
-            "content": [{"type": "text", "text": "Done!"}],
+            "content": [{"type": "text", "text": "Done."}],
             "usage": {"input_tokens": 10, "output_tokens": 4},
         })
 
-    # First round: call send_message tool with an echo reply.
+    last_text = (
+        last_content if isinstance(last_content, str)
+        else " ".join(
+            c.get("content", "") for c in last_content if isinstance(c, dict)
+        )
+    )
+    # First round: ask to call send_message back to the user.
     return web.json_response({
         "stop_reason": "tool_use",
         "content": [
@@ -149,9 +176,8 @@ async def llm_complete(request: web.Request) -> web.Response:
                 "id": "tu_001",
                 "name": "send_message",
                 "input": {
-                    "channel": "@smoker",
-                    "text": f"echo: {last_text[:200]}",
-                    "is_visible_to_human": True,
+                    "plaintext": f"echo: {last_text[:200]}",
+                    "recipient_slug": "smoker",
                 },
             },
         ],
@@ -159,58 +185,35 @@ async def llm_complete(request: web.Request) -> web.Response:
     })
 
 
-async def tool_send_message(request: web.Request) -> web.Response:
-    body = await request.json()
-    state: MockCloudState = request.app["state"]
-    state.recv_tool_calls.append(("send_message", body))
-    log.info("TOOL send_message: %s", json.dumps(body)[:200])
-    return web.json_response({"ok": True, "envelope_id": "msg_mock_xxxx"})
-
-
-async def tool_get_channel_history(request: web.Request) -> web.Response:
-    body = await request.json()
-    log.info("TOOL get_channel_history: %s", body)
-    return web.json_response({"text": "(no history in mock)"})
-
-
-async def tool_get_thread_history(request: web.Request) -> web.Response:
-    body = await request.json()
-    log.info("TOOL get_thread_history: %s", body)
-    return web.json_response({"text": "(no thread history in mock)"})
-
-
-async def tool_whoami(request: web.Request) -> web.Response:
-    state: MockCloudState = request.app["state"]
-    return web.json_response({
-        "text": f"slug: {state.agent_slug}\ndisplay_name: Smoke Bot",
-    })
-
-
 async def admin_inject(request: web.Request) -> web.Response:
-    """POST /_admin/inject {"text": "..."} — pushes an encrypted DM
-    to the connected agent as an inbound WS frame."""
+    """POST /_admin/inject {"text": "..."} — enqueues an inbound
+    message frame. Pushes immediately if the agent is connected;
+    otherwise it surfaces on the next ``fetch_pending``."""
     state: MockCloudState = request.app["state"]
-    if state.active_ws is None or state.active_ws.closed:
-        return web.json_response(
-            {"ok": False, "error": "no agent WS connected"}, status=409,
-        )
     body = await request.json()
     text = body.get("text", "hello from mock cloud")
-    frame = state.build_envelope_frame(text)
-    await state.active_ws.send_str(json.dumps(frame))
-    log.info("INJECTED envelope to agent (text=%r)", text[:80])
-    return web.json_response({"ok": True})
+    frame = {
+        "type": "message",
+        "envelope_id": f"msg_inject_{uuid.uuid4().hex[:12]}",
+        "sender_slug": body.get("sender_slug", "smoker"),
+        "recipient_slug": body.get("recipient_slug", "smoke-bot"),
+        "sent_at": 0,
+        "plaintext": text,
+    }
+    if state.active_ws is not None and not state.active_ws.closed:
+        await state.active_ws.send_str(json.dumps(frame))
+        log.info("INJECTED live message → connected agent (text=%r)", text[:80])
+        return web.json_response({"ok": True, "mode": "live"})
+    state.pending_messages.append(frame)
+    log.info("QUEUED message (no live WS); will deliver on next fetch_pending")
+    return web.json_response({"ok": True, "mode": "queued"})
 
 
 def build_app(state: MockCloudState) -> web.Application:
     app = web.Application()
     app["state"] = state
-    app.router.add_get("/v1/ws/{slug}", ws_handler)
+    app.router.add_get("/v2/cloud-agents/subscribe", ws_handler)
     app.router.add_post("/v1/llm/complete", llm_complete)
-    app.router.add_post("/v1/send_message", tool_send_message)
-    app.router.add_post("/v1/get_channel_history", tool_get_channel_history)
-    app.router.add_post("/v1/get_thread_history", tool_get_thread_history)
-    app.router.add_post("/v1/whoami", tool_whoami)
     app.router.add_post("/_admin/inject", admin_inject)
     return app
 
@@ -218,30 +221,14 @@ def build_app(state: MockCloudState) -> web.Application:
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument("--port", type=int, default=9999)
-    p.add_argument("--agent-slug", required=True)
-    p.add_argument("--recipient-device-id", required=True)
-    p.add_argument("--recipient-kem-secret-key", required=True,
-                   help="base64url-encoded 32 bytes — same as bundle's kem_secret_key")
     return p.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    # We derive the recipient's KEM PUBLIC key from the SECRET so the
-    # mock doesn't need a separate pubkey input — the agent's
-    # decrypt with the matching secret will succeed.
-    secret_bytes = base64url_decode(args.recipient_kem_secret_key)
-    kp = KemKeyPair.from_secret_bytes(secret_bytes)
-    state = MockCloudState(
-        agent_slug=args.agent_slug,
-        recipient_device_id=args.recipient_device_id,
-        recipient_kem_pubkey=kp.public_key_bytes(),
-    )
+    state = MockCloudState()
     app = build_app(state)
-    log.info(
-        "starting mock cloud at 0.0.0.0:%d (agent=%s)",
-        args.port, args.agent_slug,
-    )
+    log.info("starting mock cloud at 127.0.0.1:%d", args.port)
     web.run_app(app, host="127.0.0.1", port=args.port, print=lambda *a: None)
 
 

--- a/scripts/api_puffo_mock_cloud.py
+++ b/scripts/api_puffo_mock_cloud.py
@@ -1,0 +1,249 @@
+"""Mock puffo-cloud-server for end-to-end smoke testing the
+api-puffo runtime.
+
+Run:
+    PYTHONPATH=src python scripts/api_puffo_mock_cloud.py \\
+        --port 9999 \\
+        --agent-slug smoke-bot-test01 \\
+        --recipient-device-id dev_smoke_cloud \\
+        --recipient-kem-secret-key AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+It:
+  * Listens for a WS connect from the agent and accepts any bearer.
+  * On '--inject-message <text>', encrypts a fake DM as a foreign
+    sender and pushes it over the WS as an ``envelope`` frame.
+  * Mocks the LLM by returning a fixed canned response that either
+    speaks plain text or calls ``send_message`` once with the text.
+  * Logs every tool POST to stdout so you can see the round-trip.
+
+This is a *dev tool*, not production code — no auth, no rate
+limits, no persistence. Lives under scripts/ so the package import
+graph stays clean.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from aiohttp import WSMsgType, web
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from puffo_agent.crypto.encoding import base64url_decode, base64url_encode
+from puffo_agent.crypto.message import (
+    EncryptInput,
+    RecipientDevice,
+    encrypt_message,
+)
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] mock-cloud: %(message)s",
+)
+log = logging.getLogger("mock-cloud")
+
+
+class MockCloudState:
+    def __init__(self, agent_slug: str, recipient_device_id: str,
+                 recipient_kem_pubkey: bytes) -> None:
+        self.agent_slug = agent_slug
+        self.recipient_device_id = recipient_device_id
+        self.recipient_kem_pubkey = recipient_kem_pubkey
+        # Foreign sender identity — generated once per process; we'll
+        # use this to sign the canned inbound payload so the agent's
+        # decrypt-and-verify path is exercised end-to-end.
+        self.foreign_signing_key = Ed25519KeyPair.generate()
+        self.foreign_slug = "smoker"
+        self.foreign_subkey_id = "subkey_smoke_001"
+        self.active_ws: web.WebSocketResponse | None = None
+        self.recv_tool_calls: list[tuple[str, dict]] = []
+
+    def sender_pubkey_b64(self) -> str:
+        return base64url_encode(self.foreign_signing_key.public_key_bytes())
+
+    def build_envelope_frame(self, text: str) -> dict:
+        device = RecipientDevice(
+            device_id=self.recipient_device_id,
+            kem_public_key=self.recipient_kem_pubkey,
+        )
+        inp = EncryptInput(
+            envelope_kind="dm",
+            sender_slug=self.foreign_slug,
+            sender_subkey_id=self.foreign_subkey_id,
+            is_visible_to_human=True,
+            recipient_slug=self.agent_slug,
+            content_type="text/plain",
+            content=text,
+            recipients=[device],
+        )
+        envelope = encrypt_message(inp, self.foreign_signing_key)
+        return {
+            "type": "envelope",
+            "envelope": envelope,
+            "sender_signing_public_key": self.sender_pubkey_b64(),
+        }
+
+
+async def ws_handler(request: web.Request) -> web.WebSocketResponse:
+    state: MockCloudState = request.app["state"]
+    slug = request.match_info["slug"]
+    token = request.headers.get("Authorization", "")
+    log.info("WS connect: slug=%s auth=%s", slug, token[:24])
+
+    ws = web.WebSocketResponse(heartbeat=30)
+    await ws.prepare(request)
+    state.active_ws = ws
+    log.info("WS ready; awaiting --inject calls")
+    try:
+        async for msg in ws:
+            if msg.type == WSMsgType.TEXT:
+                log.info("WS client→server: %s", msg.data[:120])
+            elif msg.type == WSMsgType.ERROR:
+                log.warning("WS error: %s", ws.exception())
+                break
+    finally:
+        state.active_ws = None
+        log.info("WS closed")
+    return ws
+
+
+async def llm_complete(request: web.Request) -> web.Response:
+    body = await request.json()
+    log.info(
+        "LLM /v1/llm/complete: provider=%s model=%s messages=%d",
+        body.get("provider"), body.get("model"), len(body.get("messages") or []),
+    )
+    msgs = body.get("messages") or []
+    last = msgs[-1] if msgs else {}
+    last_content = last.get("content", "")
+    last_text = (
+        last_content if isinstance(last_content, str)
+        else " ".join(c.get("content", "") for c in last_content if isinstance(c, dict))
+    )
+
+    # If the last message is a tool_result we're in round 2+: emit a
+    # final text reply.
+    if isinstance(last_content, list) and any(
+        isinstance(c, dict) and c.get("type") == "tool_result" for c in last_content
+    ):
+        return web.json_response({
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Done!"}],
+            "usage": {"input_tokens": 10, "output_tokens": 4},
+        })
+
+    # First round: call send_message tool with an echo reply.
+    return web.json_response({
+        "stop_reason": "tool_use",
+        "content": [
+            {"type": "text", "text": "Replying via tool..."},
+            {
+                "type": "tool_use",
+                "id": "tu_001",
+                "name": "send_message",
+                "input": {
+                    "channel": "@smoker",
+                    "text": f"echo: {last_text[:200]}",
+                    "is_visible_to_human": True,
+                },
+            },
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 20},
+    })
+
+
+async def tool_send_message(request: web.Request) -> web.Response:
+    body = await request.json()
+    state: MockCloudState = request.app["state"]
+    state.recv_tool_calls.append(("send_message", body))
+    log.info("TOOL send_message: %s", json.dumps(body)[:200])
+    return web.json_response({"ok": True, "envelope_id": "msg_mock_xxxx"})
+
+
+async def tool_get_channel_history(request: web.Request) -> web.Response:
+    body = await request.json()
+    log.info("TOOL get_channel_history: %s", body)
+    return web.json_response({"text": "(no history in mock)"})
+
+
+async def tool_get_thread_history(request: web.Request) -> web.Response:
+    body = await request.json()
+    log.info("TOOL get_thread_history: %s", body)
+    return web.json_response({"text": "(no thread history in mock)"})
+
+
+async def tool_whoami(request: web.Request) -> web.Response:
+    state: MockCloudState = request.app["state"]
+    return web.json_response({
+        "text": f"slug: {state.agent_slug}\ndisplay_name: Smoke Bot",
+    })
+
+
+async def admin_inject(request: web.Request) -> web.Response:
+    """POST /_admin/inject {"text": "..."} — pushes an encrypted DM
+    to the connected agent as an inbound WS frame."""
+    state: MockCloudState = request.app["state"]
+    if state.active_ws is None or state.active_ws.closed:
+        return web.json_response(
+            {"ok": False, "error": "no agent WS connected"}, status=409,
+        )
+    body = await request.json()
+    text = body.get("text", "hello from mock cloud")
+    frame = state.build_envelope_frame(text)
+    await state.active_ws.send_str(json.dumps(frame))
+    log.info("INJECTED envelope to agent (text=%r)", text[:80])
+    return web.json_response({"ok": True})
+
+
+def build_app(state: MockCloudState) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_get("/v1/ws/{slug}", ws_handler)
+    app.router.add_post("/v1/llm/complete", llm_complete)
+    app.router.add_post("/v1/send_message", tool_send_message)
+    app.router.add_post("/v1/get_channel_history", tool_get_channel_history)
+    app.router.add_post("/v1/get_thread_history", tool_get_thread_history)
+    app.router.add_post("/v1/whoami", tool_whoami)
+    app.router.add_post("/_admin/inject", admin_inject)
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=9999)
+    p.add_argument("--agent-slug", required=True)
+    p.add_argument("--recipient-device-id", required=True)
+    p.add_argument("--recipient-kem-secret-key", required=True,
+                   help="base64url-encoded 32 bytes — same as bundle's kem_secret_key")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    # We derive the recipient's KEM PUBLIC key from the SECRET so the
+    # mock doesn't need a separate pubkey input — the agent's
+    # decrypt with the matching secret will succeed.
+    secret_bytes = base64url_decode(args.recipient_kem_secret_key)
+    kp = KemKeyPair.from_secret_bytes(secret_bytes)
+    state = MockCloudState(
+        agent_slug=args.agent_slug,
+        recipient_device_id=args.recipient_device_id,
+        recipient_kem_pubkey=kp.public_key_bytes(),
+    )
+    app = build_app(state)
+    log.info(
+        "starting mock cloud at 0.0.0.0:%d (agent=%s)",
+        args.port, args.agent_slug,
+    )
+    web.run_app(app, host="127.0.0.1", port=args.port, print=lambda *a: None)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/puffo_agent/agent/api_puffo/__init__.py
+++ b/src/puffo_agent/agent/api_puffo/__init__.py
@@ -1,0 +1,7 @@
+"""api-puffo runtime: cloud-hosted agents.
+
+Bearer session_token auth + cloud-mediated RPC. Decrypt-inbound is
+local (KEM secret stays on the daemon), encrypt-outbound and LLM
+inference are cloud-side. No CLI subprocess, no MCP subprocess —
+the worker runs an in-process LLM loop calling cloud endpoints.
+"""

--- a/src/puffo_agent/agent/api_puffo/__init__.py
+++ b/src/puffo_agent/agent/api_puffo/__init__.py
@@ -1,7 +1,9 @@
 """api-puffo runtime: cloud-hosted agents.
 
-Bearer session_token auth + cloud-mediated RPC. Decrypt-inbound is
-local (KEM secret stays on the daemon), encrypt-outbound and LLM
-inference are cloud-side. No CLI subprocess, no MCP subprocess —
-the worker runs an in-process LLM loop calling cloud endpoints.
-"""
+Thin client. The runtime holds NO key material; puffo-server's
+``cloud_agent`` module owns the keystore and drives all seal/open.
+The runtime opens one WS (``/v2/cloud-agents/subscribe``) with a
+``x-sandbox-token`` bearer, sends/receives plaintext frames, and
+runs an in-process LLM loop against a cloud HTTP endpoint —
+no CLI subprocess, no MCP subprocess. Wire spec:
+``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``."""

--- a/src/puffo_agent/agent/api_puffo/bundle.py
+++ b/src/puffo_agent/agent/api_puffo/bundle.py
@@ -1,0 +1,231 @@
+"""Install-bundle ingestion for api-puffo agents.
+
+A bundle is a one-shot JSON file (placed by an installer / web-side
+flow) that contains everything a cloud-hosted agent needs:
+
+  - identity:    agent_slug, operator_slug, device_id
+  - crypto:      kem_secret_key, kem_cert
+  - auth:        session_token, puffo_cloud_server_url
+  - profile:     display_name, role, role_short, soul, avatar_url
+  - runtime:     api_key, provider, model
+
+On daemon startup we sweep ``~/.puffo-agent/api-puffo-install/`` for
+``<slug>.json`` files. Each is materialised into the standard
+agent_dir layout (agent.yml + profile.md + keys/<slug>.json) so the
+existing reconcile loop picks it up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ...portal.state import (
+    agent_dir,
+    agent_yml_path,
+    home_dir,
+    is_valid_agent_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_BUNDLE_REQUIRED_FIELDS = (
+    "agent_slug",
+    "operator_slug",
+    "device_id",
+    "kem_secret_key",
+    "kem_cert",
+    "session_token",
+    "puffo_cloud_server_url",
+    "display_name",
+    "soul",
+    "api_key",
+    "provider",
+    "model",
+)
+
+
+@dataclass
+class ApiPuffoBundle:
+    agent_slug: str
+    operator_slug: str
+    device_id: str
+    kem_secret_key: str
+    kem_cert: dict
+    session_token: str
+    puffo_cloud_server_url: str
+    display_name: str
+    role: str
+    role_short: str
+    soul: str
+    avatar_url: str
+    api_key: str
+    provider: str
+    model: str
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "ApiPuffoBundle":
+        missing = [f for f in _BUNDLE_REQUIRED_FIELDS if f not in raw]
+        if missing:
+            raise ValueError(f"bundle missing required fields: {missing}")
+        if not is_valid_agent_id(raw["agent_slug"]):
+            raise ValueError(f"invalid agent_slug: {raw['agent_slug']!r}")
+        return cls(
+            agent_slug=raw["agent_slug"],
+            operator_slug=raw["operator_slug"],
+            device_id=raw["device_id"],
+            kem_secret_key=raw["kem_secret_key"],
+            kem_cert=raw["kem_cert"],
+            session_token=raw["session_token"],
+            puffo_cloud_server_url=raw["puffo_cloud_server_url"].rstrip("/"),
+            display_name=raw["display_name"],
+            role=raw.get("role", ""),
+            role_short=raw.get("role_short", ""),
+            soul=raw["soul"],
+            avatar_url=raw.get("avatar_url", ""),
+            api_key=raw["api_key"],
+            provider=raw["provider"],
+            model=raw["model"],
+        )
+
+
+def install_dir() -> Path:
+    return home_dir() / "api-puffo-install"
+
+
+def archive_dir() -> Path:
+    return install_dir() / "archived"
+
+
+def discover_bundles() -> list[Path]:
+    d = install_dir()
+    if not d.exists():
+        return []
+    return sorted(p for p in d.iterdir() if p.is_file() and p.suffix == ".json")
+
+
+def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
+    """Write agent.yml + profile.md + keys/<slug>.json. Returns the
+    agent directory path."""
+    adir = agent_dir(bundle.agent_slug)
+    adir.mkdir(parents=True, exist_ok=True)
+    (adir / "workspace").mkdir(parents=True, exist_ok=True)
+    (adir / "memory").mkdir(parents=True, exist_ok=True)
+    keys_dir = adir / "keys"
+    keys_dir.mkdir(parents=True, exist_ok=True)
+
+    # profile.md — write the full soul into a single # Soul section so
+    # the standard extract_soul_body / _profile_summary readers work.
+    profile_md = (
+        f"# {bundle.display_name}\n\n"
+        f"{bundle.role}\n\n" if bundle.role else f"# {bundle.display_name}\n\n"
+    )
+    profile_md += f"# Soul\n\n{bundle.soul.strip()}\n"
+    (adir / "profile.md").write_text(profile_md, encoding="utf-8")
+
+    # keys/<slug>.json — KEM key + session token + cloud server URL.
+    keys = {
+        "slug": bundle.agent_slug,
+        "device_id": bundle.device_id,
+        "kem_secret_key": bundle.kem_secret_key,
+        "kem_cert_json": json.dumps(bundle.kem_cert),
+        "session_token": bundle.session_token,
+        "puffo_cloud_server_url": bundle.puffo_cloud_server_url,
+    }
+    keys_path = keys_dir / f"{bundle.agent_slug}.json"
+    tmp = keys_path.with_suffix(keys_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(keys, indent=2), encoding="utf-8")
+    tmp.replace(keys_path)
+
+    # agent.yml — minimal shape consumed by AgentConfig.load. We reuse
+    # puffo_core{slug, device_id, server_url} so existing helpers
+    # (resolve_workspace_dir, owner checks, etc.) work without
+    # special-casing api-puffo.
+    cfg: dict[str, Any] = {
+        "id": bundle.agent_slug,
+        "state": "running",
+        "display_name": bundle.display_name,
+        "avatar_url": bundle.avatar_url,
+        "role": bundle.role,
+        "role_short": bundle.role_short,
+        "created_at": int(time.time()),
+        "puffo_core": {
+            # Cloud server URL doubles as the "server_url" — the
+            # ApiPuffoMessageClient uses it as the bearer-auth target.
+            "server_url": bundle.puffo_cloud_server_url,
+            "slug": bundle.agent_slug,
+            "device_id": bundle.device_id,
+            "space_id": "",
+            "operator_slug": bundle.operator_slug,
+        },
+        "runtime": {
+            "kind": "api-puffo",
+            "provider": bundle.provider,
+            "model": bundle.model,
+            "api_key": bundle.api_key,
+            "harness": "",
+            "permission_mode": "bypassPermissions",
+            "max_turns": 10,
+        },
+        "triggers": {
+            "on_mention": True,
+            "on_dm": True,
+        },
+    }
+    import yaml
+    (adir / "agent.yml").write_text(
+        yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8",
+    )
+    return adir
+
+
+def ingest_bundle(bundle_path: Path) -> tuple[bool, str]:
+    """Read, validate, materialise, archive. Returns (ok, msg)."""
+    try:
+        raw = json.loads(bundle_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return False, f"unreadable bundle: {exc}"
+    try:
+        bundle = ApiPuffoBundle.from_dict(raw)
+    except ValueError as exc:
+        return False, f"invalid bundle: {exc}"
+    if agent_yml_path(bundle.agent_slug).exists():
+        # Already provisioned — archive the bundle without re-write so
+        # a re-issued bundle doesn't clobber operator-edited state.
+        _archive(bundle_path)
+        return True, f"already provisioned: {bundle.agent_slug}"
+    try:
+        materialise_agent_dir(bundle)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"materialise failed: {exc}"
+    _archive(bundle_path)
+    return True, f"provisioned: {bundle.agent_slug}"
+
+
+def _archive(bundle_path: Path) -> None:
+    arc = archive_dir()
+    arc.mkdir(parents=True, exist_ok=True)
+    dest = arc / f"{int(time.time())}-{bundle_path.name}"
+    try:
+        shutil.move(str(bundle_path), str(dest))
+    except OSError as exc:
+        logger.warning("bundle archive failed for %s: %s", bundle_path, exc)
+
+
+def sweep_install_dir() -> int:
+    """Ingest every pending bundle. Returns the count provisioned."""
+    bundles = discover_bundles()
+    provisioned = 0
+    for path in bundles:
+        ok, msg = ingest_bundle(path)
+        level = logger.info if ok else logger.warning
+        level("api-puffo install: %s — %s", path.name, msg)
+        if ok and msg.startswith("provisioned:"):
+            provisioned += 1
+    return provisioned

--- a/src/puffo_agent/agent/api_puffo/bundle.py
+++ b/src/puffo_agent/agent/api_puffo/bundle.py
@@ -1,13 +1,21 @@
 """Install-bundle ingestion for api-puffo agents.
 
 A bundle is a one-shot JSON file (placed by an installer / web-side
-flow) that contains everything a cloud-hosted agent needs:
+flow) that contains everything a cloud-hosted agent needs.
 
-  - identity:    agent_slug, operator_slug, device_id
-  - crypto:      kem_secret_key, kem_cert
-  - auth:        session_token, puffo_cloud_server_url
+**The thin model.** The runtime holds NO key material. Server-side
+``puffo-server/cloud_agent`` loads the agent's KMS-sealed keystore
+once per WS connection and drives all seal/open. Per
+``BRIDGE-WIRE-PROTOCOL.md`` the runtime only needs:
+
+  - identity:    agent_slug, operator_slug
+  - auth:        sandbox_token (bearer for the WS upgrade; in E2B
+                 the egress proxy injects it, in local dev we set
+                 it ourselves)
+  - cloud URL:   puffo_cloud_server_url
   - profile:     display_name, role, role_short, soul, avatar_url
-  - runtime:     api_key, provider, model
+  - runtime:     api_key, provider, model (LLM HTTP — separate from
+                 the bridge, scope unchanged)
 
 On daemon startup we sweep ``~/.puffo-agent/api-puffo-install/`` for
 ``<slug>.json`` files. Each is materialised into the standard
@@ -38,10 +46,7 @@ logger = logging.getLogger(__name__)
 _BUNDLE_REQUIRED_FIELDS = (
     "agent_slug",
     "operator_slug",
-    "device_id",
-    "kem_secret_key",
-    "kem_cert",
-    "session_token",
+    "sandbox_token",
     "puffo_cloud_server_url",
     "display_name",
     "soul",
@@ -55,10 +60,7 @@ _BUNDLE_REQUIRED_FIELDS = (
 class ApiPuffoBundle:
     agent_slug: str
     operator_slug: str
-    device_id: str
-    kem_secret_key: str
-    kem_cert: dict
-    session_token: str
+    sandbox_token: str
     puffo_cloud_server_url: str
     display_name: str
     role: str
@@ -79,10 +81,7 @@ class ApiPuffoBundle:
         return cls(
             agent_slug=raw["agent_slug"],
             operator_slug=raw["operator_slug"],
-            device_id=raw["device_id"],
-            kem_secret_key=raw["kem_secret_key"],
-            kem_cert=raw["kem_cert"],
-            session_token=raw["session_token"],
+            sandbox_token=raw["sandbox_token"],
             puffo_cloud_server_url=raw["puffo_cloud_server_url"].rstrip("/"),
             display_name=raw["display_name"],
             role=raw.get("role", ""),
@@ -120,22 +119,20 @@ def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
     keys_dir = adir / "keys"
     keys_dir.mkdir(parents=True, exist_ok=True)
 
-    # profile.md — write the full soul into a single # Soul section so
+    # profile.md — bundle's full soul into a single # Soul section so
     # the standard extract_soul_body / _profile_summary readers work.
-    profile_md = (
-        f"# {bundle.display_name}\n\n"
-        f"{bundle.role}\n\n" if bundle.role else f"# {bundle.display_name}\n\n"
-    )
+    if bundle.role:
+        profile_md = f"# {bundle.display_name}\n\n{bundle.role}\n\n"
+    else:
+        profile_md = f"# {bundle.display_name}\n\n"
     profile_md += f"# Soul\n\n{bundle.soul.strip()}\n"
     (adir / "profile.md").write_text(profile_md, encoding="utf-8")
 
-    # keys/<slug>.json — KEM key + session token + cloud server URL.
+    # keys/<slug>.json — only auth state. Server resolves identity
+    # from sandbox_token on every WS upgrade.
     keys = {
         "slug": bundle.agent_slug,
-        "device_id": bundle.device_id,
-        "kem_secret_key": bundle.kem_secret_key,
-        "kem_cert_json": json.dumps(bundle.kem_cert),
-        "session_token": bundle.session_token,
+        "sandbox_token": bundle.sandbox_token,
         "puffo_cloud_server_url": bundle.puffo_cloud_server_url,
     }
     keys_path = keys_dir / f"{bundle.agent_slug}.json"
@@ -143,10 +140,7 @@ def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
     tmp.write_text(json.dumps(keys, indent=2), encoding="utf-8")
     tmp.replace(keys_path)
 
-    # agent.yml — minimal shape consumed by AgentConfig.load. We reuse
-    # puffo_core{slug, device_id, server_url} so existing helpers
-    # (resolve_workspace_dir, owner checks, etc.) work without
-    # special-casing api-puffo.
+    # agent.yml — minimal shape consumed by AgentConfig.load.
     cfg: dict[str, Any] = {
         "id": bundle.agent_slug,
         "state": "running",
@@ -156,11 +150,9 @@ def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
         "role_short": bundle.role_short,
         "created_at": int(time.time()),
         "puffo_core": {
-            # Cloud server URL doubles as the "server_url" — the
-            # ApiPuffoMessageClient uses it as the bearer-auth target.
             "server_url": bundle.puffo_cloud_server_url,
             "slug": bundle.agent_slug,
-            "device_id": bundle.device_id,
+            "device_id": "",
             "space_id": "",
             "operator_slug": bundle.operator_slug,
         },
@@ -196,8 +188,6 @@ def ingest_bundle(bundle_path: Path) -> tuple[bool, str]:
     except ValueError as exc:
         return False, f"invalid bundle: {exc}"
     if agent_yml_path(bundle.agent_slug).exists():
-        # Already provisioned — archive the bundle without re-write so
-        # a re-issued bundle doesn't clobber operator-edited state.
         _archive(bundle_path)
         return True, f"already provisioned: {bundle.agent_slug}"
     try:

--- a/src/puffo_agent/agent/api_puffo/bundle.py
+++ b/src/puffo_agent/agent/api_puffo/bundle.py
@@ -1,27 +1,11 @@
 """Install-bundle ingestion for api-puffo agents.
 
-A bundle is a one-shot JSON file (placed by an installer / web-side
-flow) that contains everything a cloud-hosted agent needs.
-
-**The thin model.** The runtime holds NO key material. Server-side
-``puffo-server/cloud_agent`` loads the agent's KMS-sealed keystore
-once per WS connection and drives all seal/open. Per
-``BRIDGE-WIRE-PROTOCOL.md`` the runtime only needs:
-
-  - identity:    agent_slug, operator_slug
-  - auth:        sandbox_token (bearer for the WS upgrade; in E2B
-                 the egress proxy injects it, in local dev we set
-                 it ourselves)
-  - cloud URL:   puffo_cloud_server_url
-  - profile:     display_name, role, role_short, soul, avatar_url
-  - runtime:     api_key, provider, model (LLM HTTP — separate from
-                 the bridge, scope unchanged)
-
-On daemon startup we sweep ``~/.puffo-agent/api-puffo-install/`` for
-``<slug>.json`` files. Each is materialised into the standard
-agent_dir layout (agent.yml + profile.md + keys/<slug>.json) so the
-existing reconcile loop picks it up.
-"""
+A bundle is a one-shot JSON file dropped by the installer / web-side
+flow. The runtime holds NO key material; the bundle only carries
+identity, the sandbox_token (WS bearer), the cloud URL, the profile,
+and LLM credentials. Daemon startup sweeps
+``~/.puffo-agent/api-puffo-install/<slug>.json`` and materialises each
+into the standard agent_dir so the reconcile loop picks them up."""
 
 from __future__ import annotations
 
@@ -110,8 +94,6 @@ def discover_bundles() -> list[Path]:
 
 
 def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
-    """Write agent.yml + profile.md + keys/<slug>.json. Returns the
-    agent directory path."""
     adir = agent_dir(bundle.agent_slug)
     adir.mkdir(parents=True, exist_ok=True)
     (adir / "workspace").mkdir(parents=True, exist_ok=True)
@@ -119,8 +101,8 @@ def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
     keys_dir = adir / "keys"
     keys_dir.mkdir(parents=True, exist_ok=True)
 
-    # profile.md — bundle's full soul into a single # Soul section so
-    # the standard extract_soul_body / _profile_summary readers work.
+    # Soul lands in a single # Soul section so the standard
+    # extract_soul_body / _profile_summary readers work.
     if bundle.role:
         profile_md = f"# {bundle.display_name}\n\n{bundle.role}\n\n"
     else:
@@ -128,8 +110,6 @@ def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
     profile_md += f"# Soul\n\n{bundle.soul.strip()}\n"
     (adir / "profile.md").write_text(profile_md, encoding="utf-8")
 
-    # keys/<slug>.json — only auth state. Server resolves identity
-    # from sandbox_token on every WS upgrade.
     keys = {
         "slug": bundle.agent_slug,
         "sandbox_token": bundle.sandbox_token,
@@ -140,7 +120,6 @@ def materialise_agent_dir(bundle: ApiPuffoBundle) -> Path:
     tmp.write_text(json.dumps(keys, indent=2), encoding="utf-8")
     tmp.replace(keys_path)
 
-    # agent.yml — minimal shape consumed by AgentConfig.load.
     cfg: dict[str, Any] = {
         "id": bundle.agent_slug,
         "state": "running",

--- a/src/puffo_agent/agent/api_puffo/cloud_client.py
+++ b/src/puffo_agent/agent/api_puffo/cloud_client.py
@@ -1,26 +1,8 @@
-"""Cloud-agent bridge WebSocket client + LLM HTTP client.
+"""Cloud-agent bridge WS client + LLM HTTP client.
 
-Bridge implementation per
-``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``:
-
-  - URL:    ``<cloud>/v2/cloud-agents/subscribe`` (ws/wss)
-  - Auth:   ``x-sandbox-token`` header on the HTTP upgrade. The
-            runtime sets it itself in dev; in production E2B's
-            egress proxy injects it (we still set it to keep dev
-            self-contained).
-  - Frames: plaintext JSON, ``serde``-tagged on ``"type"``. Server
-            does ALL E2E crypto — runtime never sees ciphertext.
-  - Cadence: client-side ``heartbeat`` every 30s
-            (``HEARTBEAT_TIMEOUT_SECS = 90`` server-side).
-  - On-connect: wait ``connected`` → ``fetch_pending`` → drain
-            ``message``+``pending_delivered`` → ``ack`` envelopes →
-            enter main loop.
-
-This module covers the WS protocol + the request/response
-correlation needed to make WS frames look like RPC for the LLM
-tool loop. The LLM HTTP endpoint (``/v1/llm/complete``) lives
-alongside but is structurally separate — the bridge spec is mute
-on inference."""
+Bridge wire spec: ``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``.
+Server holds all crypto — frames are plaintext JSON. LLM HTTP
+is a separate endpoint (the spec is mute on inference)."""
 
 from __future__ import annotations
 
@@ -51,9 +33,7 @@ class CloudHttpError(Exception):
 
 
 class CloudLlmClient:
-    """Thin HTTP client for ``POST /v1/llm/complete``. The bridge
-    spec does not cover inference; this is its own endpoint, also
-    bearer-authed by the sandbox_token (placeholder convention)."""
+    """Bearer-authed HTTP client for ``POST /v1/llm/complete``."""
 
     def __init__(self, base_url: str, sandbox_token: str) -> None:
         self.base_url = base_url.rstrip("/")
@@ -75,9 +55,9 @@ class CloudLlmClient:
         messages: list[dict],
         tools: list[dict] | None = None,
     ) -> dict:
-        """One LLM turn. Cloud forwards to the named provider using
-        the bundle's ``api_key``. Response shape mirrors Anthropic's
-        tool-using messages API (cloud normalises across providers)."""
+        # Cloud forwards to the named provider using the bundle's
+        # api_key; response shape is Anthropic's tool-using messages
+        # API (cloud normalises across providers).
         body: dict[str, Any] = {
             "api_key": api_key,
             "provider": provider,
@@ -125,27 +105,11 @@ class BridgeClosed(Exception):
 
 
 class CloudBridgeClient:
-    """One-WS-per-agent bidirectional plaintext bridge.
-
-    Public surface for the runner:
-      - ``connect()`` — open + wait for the ``connected`` frame
-      - ``frames()`` async iterator — yields ``message`` /
-        ``pending_delivered`` / ``error`` frames the runner needs
-        to react to. ``ping`` is swallowed (no client reply per
-        spec §5.1). ``ack`` / ``ack_result`` / ``spaces`` go to
-        request/response correlation instead and are NOT yielded.
-      - ``send_send(...)`` — fire a ``send`` frame, await the
-        matching ``ack`` by ``client_ref``
-      - ``send_fetch_pending(limit)`` — fire ``fetch_pending``;
-        message + pending_delivered frames surface via frames()
-      - ``send_ack(envelope_ids)`` — fire ``ack``, await
-        ``ack_result``
-      - ``send_list_spaces()`` — fire ``list_spaces``, await the
-        ``spaces`` reply
-      - ``close()``
-
-    A background heartbeat coroutine pumps ``{"type":"heartbeat"}``
-    every 30s while the WS is open (server's recv-timeout is 90s)."""
+    """One-WS-per-agent plaintext bridge. ``send_*`` methods are
+    request/response (correlated by ``client_ref`` or FIFO);
+    ``frames()`` yields the inbound stream (``message`` /
+    ``pending_delivered`` / uncorrelated ``error``). A background
+    task pumps a heartbeat every 30s (server recv-timeout = 90s)."""
 
     def __init__(
         self, cloud_url: str, sandbox_token: str, agent_slug: str,
@@ -165,8 +129,6 @@ class CloudBridgeClient:
         self._spaces_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
 
     async def connect(self) -> None:
-        """Open the WS + heartbeat task. Raises on 401 / handshake
-        failure; the caller decides whether to retry."""
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=None),
         )
@@ -205,10 +167,9 @@ class CloudBridgeClient:
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
     async def frames(self) -> AsyncIterator[dict]:
-        """Yield frames the runner needs to react to: ``message``,
-        ``pending_delivered``, ``error`` (uncorrelated). Swallow
-        ``ping`` (no reply per spec). Route ``ack`` / ``ack_result``
-        / ``spaces`` to their correlation futures."""
+        # Yields message / pending_delivered / uncorrelated error.
+        # ping swallowed (no reply per spec §5.1); ack / ack_result /
+        # spaces routed to send_*() futures.
         if self._ws is None:
             return
         async for msg in self._ws:
@@ -309,11 +270,8 @@ class CloudBridgeClient:
         channel_id: Optional[str] = None,
         timeout: float = 30.0,
     ) -> dict:
-        """Send a plaintext message + await the matching ack. Pass
-        EITHER ``recipient_slug`` (DM) OR ``space_id``+``channel_id``
-        (channel) — spec rejects mixed-shape frames as ``BAD_FRAME``.
-        Returns the ack frame as-is. Raises ``BridgeError`` on
-        server-side rejection or ``TimeoutError`` on missing ack."""
+        # Pass EITHER recipient_slug (DM) OR space_id+channel_id
+        # (channel); spec rejects mixed-shape frames as BAD_FRAME.
         ws = await self._require_ws()
         client_ref = f"r_{uuid.uuid4().hex[:12]}"
         frame: dict[str, Any] = {
@@ -327,7 +285,7 @@ class CloudBridgeClient:
             frame["space_id"] = space_id
         if channel_id:
             frame["channel_id"] = channel_id
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._send_acks[client_ref] = fut
         await ws.send_json(frame)
         try:
@@ -336,8 +294,7 @@ class CloudBridgeClient:
             self._send_acks.pop(client_ref, None)
 
     async def send_fetch_pending(self, *, limit: Optional[int] = None) -> None:
-        """Fire the request; the resulting ``message`` +
-        ``pending_delivered`` frames surface via ``frames()``."""
+        # Resulting message + pending_delivered surface via frames().
         ws = await self._require_ws()
         frame: dict[str, Any] = {"type": "fetch_pending"}
         if limit is not None:
@@ -347,18 +304,15 @@ class CloudBridgeClient:
     async def send_ack(
         self, envelope_ids: list[str], *, timeout: float = 30.0,
     ) -> dict:
-        """Mark envelopes read; await ``ack_result``. Empty list and
-        oversized batches are rejected server-side as BAD_FRAME — we
-        let the server enforce."""
         ws = await self._require_ws()
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
         await self._ack_result_waiters.put(fut)
         await ws.send_json({"type": "ack", "envelope_ids": envelope_ids})
         return await asyncio.wait_for(fut, timeout=timeout)
 
     async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
         ws = await self._require_ws()
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
         await self._spaces_waiters.put(fut)
         await ws.send_json({"type": "list_spaces"})
         return await asyncio.wait_for(fut, timeout=timeout)

--- a/src/puffo_agent/agent/api_puffo/cloud_client.py
+++ b/src/puffo_agent/agent/api_puffo/cloud_client.py
@@ -1,0 +1,179 @@
+"""HTTP + WS client to puffo-cloud-server, authenticated by a
+bearer ``session_token``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+_TIMEOUT = aiohttp.ClientTimeout(total=60)
+
+
+class CloudHttpError(Exception):
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"HTTP {status}: {body}")
+        self.status = status
+        self.body = body
+
+
+class CloudHttpClient:
+    """``Authorization: Bearer <session_token>`` wrapper. One session
+    per agent, shared across the worker's lifetime."""
+
+    def __init__(self, base_url: str, session_token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._token = session_token
+        self._session: aiohttp.ClientSession | None = None
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=_TIMEOUT)
+        return self._session
+
+    async def post(self, path: str, body: dict) -> dict:
+        sess = await self._ensure_session()
+        url = f"{self.base_url}{path}"
+        async with sess.post(url, json=body, headers=self._headers()) as resp:
+            text = await resp.text()
+            if resp.status >= 400:
+                raise CloudHttpError(resp.status, text)
+            return json.loads(text) if text else {}
+
+    async def get(self, path: str) -> dict:
+        sess = await self._ensure_session()
+        url = f"{self.base_url}{path}"
+        async with sess.get(url, headers=self._headers()) as resp:
+            text = await resp.text()
+            if resp.status >= 400:
+                raise CloudHttpError(resp.status, text)
+            return json.loads(text) if text else {}
+
+    async def close(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+
+class CloudWsClient:
+    """WS connection that forwards inbound envelopes. Auth via
+    ``Authorization: Bearer`` on the connect handshake (same shape
+    aiohttp ws_connect accepts via ``headers=``). Exponential
+    reconnect on disconnect; ``listen()`` yields raw frames."""
+
+    def __init__(self, base_url: str, session_token: str, agent_slug: str) -> None:
+        # http→ws / https→wss
+        ws_base = base_url.replace("http", "ws", 1)
+        self._url = f"{ws_base}/v1/ws/{agent_slug}"
+        self._token = session_token
+        self._stop = asyncio.Event()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    async def listen(self) -> AsyncIterator[dict]:
+        """Yield each inbound JSON frame. Auto-reconnects on
+        transport errors with exponential backoff up to 30s."""
+        backoff = 1.0
+        while not self._stop.is_set():
+            session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=None))
+            try:
+                async with session.ws_connect(
+                    self._url,
+                    headers={"Authorization": f"Bearer {self._token}"},
+                    heartbeat=30,
+                ) as ws:
+                    logger.info("api-puffo: WS connected to %s", self._url)
+                    backoff = 1.0
+                    async for msg in ws:
+                        if self._stop.is_set():
+                            break
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            try:
+                                yield json.loads(msg.data)
+                            except json.JSONDecodeError as exc:
+                                logger.warning(
+                                    "api-puffo: dropped malformed WS frame: %s", exc,
+                                )
+                        elif msg.type in (
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED,
+                            aiohttp.WSMsgType.ERROR,
+                        ):
+                            break
+            except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
+                logger.warning(
+                    "api-puffo: WS disconnected (%s: %s); reconnect in %.1fs",
+                    type(exc).__name__, exc, backoff,
+                )
+            finally:
+                await session.close()
+            if self._stop.is_set():
+                return
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=backoff)
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2, 30.0)
+
+
+# ── Cloud endpoint shapes (placeholders) ─────────────────────────────
+
+
+async def llm_complete(
+    http: CloudHttpClient,
+    *,
+    api_key: str,
+    provider: str,
+    model: str,
+    system_prompt: str,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+) -> dict:
+    """``POST /v1/llm/complete`` — forward an LLM call. Cloud uses
+    the provided api_key against the named provider. Response shape
+    mirrors Anthropic's tool-using messages API for now (cloud is
+    expected to normalise across providers)."""
+    body: dict[str, Any] = {
+        "api_key": api_key,
+        "provider": provider,
+        "model": model,
+        "system_prompt": system_prompt,
+        "messages": messages,
+    }
+    if tools:
+        body["tools"] = tools
+    return await http.post("/v1/llm/complete", body)
+
+
+async def send_message(
+    http: CloudHttpClient,
+    *,
+    channel: str,
+    text: str,
+    root_id: str = "",
+    is_visible_to_human: bool = True,
+) -> dict:
+    """``POST /v1/send_message`` — cloud handles encrypt + sign +
+    post. ``channel`` is either ``@<slug>`` for DM or ``ch_<uuid>``
+    for a channel."""
+    body = {
+        "channel": channel,
+        "text": text,
+        "root_id": root_id,
+        "is_visible_to_human": is_visible_to_human,
+    }
+    return await http.post("/v1/send_message", body)

--- a/src/puffo_agent/agent/api_puffo/cloud_client.py
+++ b/src/puffo_agent/agent/api_puffo/cloud_client.py
@@ -1,19 +1,43 @@
-"""HTTP + WS client to puffo-cloud-server, authenticated by a
-bearer ``session_token``."""
+"""Cloud-agent bridge WebSocket client + LLM HTTP client.
+
+Bridge implementation per
+``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``:
+
+  - URL:    ``<cloud>/v2/cloud-agents/subscribe`` (ws/wss)
+  - Auth:   ``x-sandbox-token`` header on the HTTP upgrade. The
+            runtime sets it itself in dev; in production E2B's
+            egress proxy injects it (we still set it to keep dev
+            self-contained).
+  - Frames: plaintext JSON, ``serde``-tagged on ``"type"``. Server
+            does ALL E2E crypto — runtime never sees ciphertext.
+  - Cadence: client-side ``heartbeat`` every 30s
+            (``HEARTBEAT_TIMEOUT_SECS = 90`` server-side).
+  - On-connect: wait ``connected`` → ``fetch_pending`` → drain
+            ``message``+``pending_delivered`` → ``ack`` envelopes →
+            enter main loop.
+
+This module covers the WS protocol + the request/response
+correlation needed to make WS frames look like RPC for the LLM
+tool loop. The LLM HTTP endpoint (``/v1/llm/complete``) lives
+alongside but is structurally separate — the bridge spec is mute
+on inference."""
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
-from typing import Any, AsyncIterator
+import uuid
+from typing import Any, AsyncIterator, Callable, Optional
 
 import aiohttp
 
 logger = logging.getLogger(__name__)
 
 
-_TIMEOUT = aiohttp.ClientTimeout(total=60)
+_LLM_TIMEOUT = aiohttp.ClientTimeout(total=120)
+_HEARTBEAT_INTERVAL_SECONDS = 30.0
 
 
 class CloudHttpError(Exception):
@@ -23,39 +47,53 @@ class CloudHttpError(Exception):
         self.body = body
 
 
-class CloudHttpClient:
-    """``Authorization: Bearer <session_token>`` wrapper. One session
-    per agent, shared across the worker's lifetime."""
+# ── LLM HTTP (separate from the bridge) ──────────────────────────
 
-    def __init__(self, base_url: str, session_token: str) -> None:
+
+class CloudLlmClient:
+    """Thin HTTP client for ``POST /v1/llm/complete``. The bridge
+    spec does not cover inference; this is its own endpoint, also
+    bearer-authed by the sandbox_token (placeholder convention)."""
+
+    def __init__(self, base_url: str, sandbox_token: str) -> None:
         self.base_url = base_url.rstrip("/")
-        self._token = session_token
+        self._token = sandbox_token
         self._session: aiohttp.ClientSession | None = None
-
-    def _headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self._token}",
-            "Content-Type": "application/json",
-        }
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession(timeout=_TIMEOUT)
+            self._session = aiohttp.ClientSession(timeout=_LLM_TIMEOUT)
         return self._session
 
-    async def post(self, path: str, body: dict) -> dict:
+    async def complete(
+        self,
+        *,
+        api_key: str,
+        provider: str,
+        model: str,
+        system_prompt: str,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> dict:
+        """One LLM turn. Cloud forwards to the named provider using
+        the bundle's ``api_key``. Response shape mirrors Anthropic's
+        tool-using messages API (cloud normalises across providers)."""
+        body: dict[str, Any] = {
+            "api_key": api_key,
+            "provider": provider,
+            "model": model,
+            "system_prompt": system_prompt,
+            "messages": messages,
+        }
+        if tools:
+            body["tools"] = tools
         sess = await self._ensure_session()
-        url = f"{self.base_url}{path}"
-        async with sess.post(url, json=body, headers=self._headers()) as resp:
-            text = await resp.text()
-            if resp.status >= 400:
-                raise CloudHttpError(resp.status, text)
-            return json.loads(text) if text else {}
-
-    async def get(self, path: str) -> dict:
-        sess = await self._ensure_session()
-        url = f"{self.base_url}{path}"
-        async with sess.get(url, headers=self._headers()) as resp:
+        url = f"{self.base_url}/v1/llm/complete"
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+        async with sess.post(url, json=body, headers=headers) as resp:
             text = await resp.text()
             if resp.status >= 400:
                 raise CloudHttpError(resp.status, text)
@@ -67,113 +105,288 @@ class CloudHttpClient:
         self._session = None
 
 
-class CloudWsClient:
-    """WS connection that forwards inbound envelopes. Auth via
-    ``Authorization: Bearer`` on the connect handshake (same shape
-    aiohttp ws_connect accepts via ``headers=``). Exponential
-    reconnect on disconnect; ``listen()`` yields raw frames."""
+# ── Bridge WS protocol ───────────────────────────────────────────
 
-    def __init__(self, base_url: str, session_token: str, agent_slug: str) -> None:
-        # http→ws / https→wss
-        ws_base = base_url.replace("http", "ws", 1)
-        self._url = f"{ws_base}/v1/ws/{agent_slug}"
-        self._token = session_token
-        self._stop = asyncio.Event()
 
-    def stop(self) -> None:
-        self._stop.set()
+class BridgeError(Exception):
+    """Server-emitted ``error`` frame (code + message). Categories:
+    ``NO_SUBKEY``, ``NOT_AUTHORIZED``, ``DECRYPT_FAILED``,
+    ``BAD_FRAME``, ``INTERNAL``."""
 
-    async def listen(self) -> AsyncIterator[dict]:
-        """Yield each inbound JSON frame. Auto-reconnects on
-        transport errors with exponential backoff up to 30s."""
-        backoff = 1.0
-        while not self._stop.is_set():
-            session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=None))
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class BridgeClosed(Exception):
+    """Raised when ``send_*`` is called after the WS closed and
+    before reconnect."""
+
+
+class CloudBridgeClient:
+    """One-WS-per-agent bidirectional plaintext bridge.
+
+    Public surface for the runner:
+      - ``connect()`` — open + wait for the ``connected`` frame
+      - ``frames()`` async iterator — yields ``message`` /
+        ``pending_delivered`` / ``error`` frames the runner needs
+        to react to. ``ping`` is swallowed (no client reply per
+        spec §5.1). ``ack`` / ``ack_result`` / ``spaces`` go to
+        request/response correlation instead and are NOT yielded.
+      - ``send_send(...)`` — fire a ``send`` frame, await the
+        matching ``ack`` by ``client_ref``
+      - ``send_fetch_pending(limit)`` — fire ``fetch_pending``;
+        message + pending_delivered frames surface via frames()
+      - ``send_ack(envelope_ids)`` — fire ``ack``, await
+        ``ack_result``
+      - ``send_list_spaces()`` — fire ``list_spaces``, await the
+        ``spaces`` reply
+      - ``close()``
+
+    A background heartbeat coroutine pumps ``{"type":"heartbeat"}``
+    every 30s while the WS is open (server's recv-timeout is 90s)."""
+
+    def __init__(
+        self, cloud_url: str, sandbox_token: str, agent_slug: str,
+    ) -> None:
+        ws_base = cloud_url.replace("http", "ws", 1)
+        self._url = f"{ws_base.rstrip('/')}/v2/cloud-agents/subscribe"
+        self._token = sandbox_token
+        self._slug = agent_slug
+        self._session: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+        # client_ref → Future for ack correlation (one ack per send).
+        self._send_acks: dict[str, asyncio.Future] = {}
+        # FIFO of futures awaiting ack_result / spaces (no client_ref
+        # in the spec — only one in-flight at a time).
+        self._ack_result_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+        self._spaces_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+
+    async def connect(self) -> None:
+        """Open the WS + heartbeat task. Raises on 401 / handshake
+        failure; the caller decides whether to retry."""
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=None),
+        )
+        headers = {"x-sandbox-token": self._token}
+        try:
+            self._ws = await self._session.ws_connect(
+                self._url, headers=headers, heartbeat=None,
+            )
+        except aiohttp.WSServerHandshakeError as exc:
+            await self._session.close()
+            self._session = None
+            raise BridgeError(
+                "HANDSHAKE",
+                f"WS upgrade failed (status={exc.status}): {exc.message}",
+            ) from exc
+        # Wait for the first frame — must be 'connected'.
+        first = await self._ws.receive(timeout=10.0)
+        if first.type != aiohttp.WSMsgType.TEXT:
+            await self.close()
+            raise BridgeError(
+                "HANDSHAKE",
+                f"expected text 'connected', got {first.type!r}",
+            )
+        try:
+            frame = json.loads(first.data)
+        except json.JSONDecodeError as exc:
+            await self.close()
+            raise BridgeError("HANDSHAKE", f"bad first frame: {exc}") from exc
+        if frame.get("type") != "connected":
+            await self.close()
+            raise BridgeError(
+                "HANDSHAKE",
+                f"expected 'connected', got {frame.get('type')!r}",
+            )
+        logger.info("api-puffo bridge: WS connected (slug=%s)", self._slug)
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def frames(self) -> AsyncIterator[dict]:
+        """Yield frames the runner needs to react to: ``message``,
+        ``pending_delivered``, ``error`` (uncorrelated). Swallow
+        ``ping`` (no reply per spec). Route ``ack`` / ``ack_result``
+        / ``spaces`` to their correlation futures."""
+        if self._ws is None:
+            return
+        async for msg in self._ws:
+            if msg.type != aiohttp.WSMsgType.TEXT:
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.ERROR,
+                ):
+                    logger.info(
+                        "api-puffo bridge: WS closing (%s)", msg.type,
+                    )
+                    break
+                continue
             try:
-                async with session.ws_connect(
-                    self._url,
-                    headers={"Authorization": f"Bearer {self._token}"},
-                    heartbeat=30,
-                ) as ws:
-                    logger.info("api-puffo: WS connected to %s", self._url)
-                    backoff = 1.0
-                    async for msg in ws:
-                        if self._stop.is_set():
-                            break
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            try:
-                                yield json.loads(msg.data)
-                            except json.JSONDecodeError as exc:
-                                logger.warning(
-                                    "api-puffo: dropped malformed WS frame: %s", exc,
-                                )
-                        elif msg.type in (
-                            aiohttp.WSMsgType.CLOSE,
-                            aiohttp.WSMsgType.CLOSING,
-                            aiohttp.WSMsgType.CLOSED,
-                            aiohttp.WSMsgType.ERROR,
-                        ):
-                            break
-            except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
+                frame = json.loads(msg.data)
+            except json.JSONDecodeError:
                 logger.warning(
-                    "api-puffo: WS disconnected (%s: %s); reconnect in %.1fs",
-                    type(exc).__name__, exc, backoff,
+                    "api-puffo bridge: dropped non-JSON WS frame",
                 )
-            finally:
-                await session.close()
-            if self._stop.is_set():
+                continue
+            kind = frame.get("type", "")
+            if kind == "ping":
+                # Server keepalive — no reply per spec §5.1.
+                continue
+            if kind == "ack":
+                client_ref = frame.get("client_ref")
+                if client_ref and client_ref in self._send_acks:
+                    fut = self._send_acks.pop(client_ref)
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                # Unsolicited ack (e.g. server-side resend / lost
+                # correlation) — surface it for diagnostics.
+                logger.debug(
+                    "api-puffo bridge: ack with unknown client_ref=%r",
+                    client_ref,
+                )
+                continue
+            if kind == "ack_result":
+                if not self._ack_result_waiters.empty():
+                    fut = self._ack_result_waiters.get_nowait()
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                logger.debug("api-puffo bridge: ack_result with no waiter")
+                continue
+            if kind == "spaces":
+                if not self._spaces_waiters.empty():
+                    fut = self._spaces_waiters.get_nowait()
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                logger.debug("api-puffo bridge: spaces with no waiter")
+                continue
+            if kind == "error" and frame.get("client_ref"):
+                # An error correlated to a send — route to that future
+                # as an exception.
+                client_ref = frame["client_ref"]
+                if client_ref in self._send_acks:
+                    fut = self._send_acks.pop(client_ref)
+                    if not fut.done():
+                        fut.set_exception(BridgeError(
+                            frame.get("code", "ERROR"),
+                            frame.get("message", ""),
+                        ))
+                    continue
+            yield frame
+
+    async def _heartbeat_loop(self) -> None:
+        while self._ws is not None and not self._ws.closed:
+            try:
+                await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                return
+            if self._ws is None or self._ws.closed:
                 return
             try:
-                await asyncio.wait_for(self._stop.wait(), timeout=backoff)
-            except asyncio.TimeoutError:
-                pass
-            backoff = min(backoff * 2, 30.0)
+                await self._ws.send_json({"type": "heartbeat"})
+            except (aiohttp.ClientError, ConnectionError) as exc:
+                logger.warning(
+                    "api-puffo bridge: heartbeat send failed: %s", exc,
+                )
+                return
 
+    async def _require_ws(self) -> aiohttp.ClientWebSocketResponse:
+        if self._ws is None or self._ws.closed:
+            raise BridgeClosed("WS is not connected")
+        return self._ws
 
-# ── Cloud endpoint shapes (placeholders) ─────────────────────────────
+    async def send_send(
+        self,
+        *,
+        plaintext: str,
+        recipient_slug: Optional[str] = None,
+        space_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        """Send a plaintext message + await the matching ack. Pass
+        EITHER ``recipient_slug`` (DM) OR ``space_id``+``channel_id``
+        (channel) — spec rejects mixed-shape frames as ``BAD_FRAME``.
+        Returns the ack frame as-is. Raises ``BridgeError`` on
+        server-side rejection or ``TimeoutError`` on missing ack."""
+        ws = await self._require_ws()
+        client_ref = f"r_{uuid.uuid4().hex[:12]}"
+        frame: dict[str, Any] = {
+            "type": "send",
+            "plaintext": plaintext,
+            "client_ref": client_ref,
+        }
+        if recipient_slug:
+            frame["recipient_slug"] = recipient_slug
+        if space_id:
+            frame["space_id"] = space_id
+        if channel_id:
+            frame["channel_id"] = channel_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._send_acks[client_ref] = fut
+        await ws.send_json(frame)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        finally:
+            self._send_acks.pop(client_ref, None)
 
+    async def send_fetch_pending(self, *, limit: Optional[int] = None) -> None:
+        """Fire the request; the resulting ``message`` +
+        ``pending_delivered`` frames surface via ``frames()``."""
+        ws = await self._require_ws()
+        frame: dict[str, Any] = {"type": "fetch_pending"}
+        if limit is not None:
+            frame["limit"] = limit
+        await ws.send_json(frame)
 
-async def llm_complete(
-    http: CloudHttpClient,
-    *,
-    api_key: str,
-    provider: str,
-    model: str,
-    system_prompt: str,
-    messages: list[dict],
-    tools: list[dict] | None = None,
-) -> dict:
-    """``POST /v1/llm/complete`` — forward an LLM call. Cloud uses
-    the provided api_key against the named provider. Response shape
-    mirrors Anthropic's tool-using messages API for now (cloud is
-    expected to normalise across providers)."""
-    body: dict[str, Any] = {
-        "api_key": api_key,
-        "provider": provider,
-        "model": model,
-        "system_prompt": system_prompt,
-        "messages": messages,
-    }
-    if tools:
-        body["tools"] = tools
-    return await http.post("/v1/llm/complete", body)
+    async def send_ack(
+        self, envelope_ids: list[str], *, timeout: float = 30.0,
+    ) -> dict:
+        """Mark envelopes read; await ``ack_result``. Empty list and
+        oversized batches are rejected server-side as BAD_FRAME — we
+        let the server enforce."""
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        await self._ack_result_waiters.put(fut)
+        await ws.send_json({"type": "ack", "envelope_ids": envelope_ids})
+        return await asyncio.wait_for(fut, timeout=timeout)
 
+    async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        await self._spaces_waiters.put(fut)
+        await ws.send_json({"type": "list_spaces"})
+        return await asyncio.wait_for(fut, timeout=timeout)
 
-async def send_message(
-    http: CloudHttpClient,
-    *,
-    channel: str,
-    text: str,
-    root_id: str = "",
-    is_visible_to_human: bool = True,
-) -> dict:
-    """``POST /v1/send_message`` — cloud handles encrypt + sign +
-    post. ``channel`` is either ``@<slug>`` for DM or ``ch_<uuid>``
-    for a channel."""
-    body = {
-        "channel": channel,
-        "text": text,
-        "root_id": root_id,
-        "is_visible_to_human": is_visible_to_human,
-    }
-    return await http.post("/v1/send_message", body)
+    async def close(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._heartbeat_task
+            self._heartbeat_task = None
+        if self._ws is not None and not self._ws.closed:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+        self._ws = None
+        if self._session is not None and not self._session.closed:
+            with contextlib.suppress(Exception):
+                await self._session.close()
+        self._session = None
+        # Cancel pending waiters with a clean BridgeClosed.
+        for fut in list(self._send_acks.values()):
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        self._send_acks.clear()
+        while not self._ack_result_waiters.empty():
+            fut = self._ack_result_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        while not self._spaces_waiters.empty():
+            fut = self._spaces_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))

--- a/src/puffo_agent/agent/api_puffo/keystore.py
+++ b/src/puffo_agent/agent/api_puffo/keystore.py
@@ -1,0 +1,37 @@
+"""Keystore loader for api-puffo agents.
+
+The on-disk shape (``<agent_dir>/keys/<slug>.json``) is a strict
+superset of the legacy puffo-core keystore: KEM secret + session
+token + cloud server URL replace the Ed25519 signing material.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...portal.state import agent_dir
+
+
+@dataclass
+class ApiPuffoKeystore:
+    slug: str
+    device_id: str
+    kem_secret_key: str  # base64url-encoded 32 bytes
+    kem_cert: dict
+    session_token: str
+    puffo_cloud_server_url: str
+
+    @classmethod
+    def for_agent(cls, agent_id: str) -> "ApiPuffoKeystore":
+        path = agent_dir(agent_id) / "keys" / f"{agent_id}.json"
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            slug=raw["slug"],
+            device_id=raw["device_id"],
+            kem_secret_key=raw["kem_secret_key"],
+            kem_cert=json.loads(raw["kem_cert_json"]),
+            session_token=raw["session_token"],
+            puffo_cloud_server_url=raw["puffo_cloud_server_url"],
+        )

--- a/src/puffo_agent/agent/api_puffo/keystore.py
+++ b/src/puffo_agent/agent/api_puffo/keystore.py
@@ -1,15 +1,15 @@
 """Keystore loader for api-puffo agents.
 
-The on-disk shape (``<agent_dir>/keys/<slug>.json``) is a strict
-superset of the legacy puffo-core keystore: KEM secret + session
-token + cloud server URL replace the Ed25519 signing material.
+Server-side ``puffo-server/cloud_agent`` holds all crypto; the
+runtime needs only the sandbox_token (bearer for the WS upgrade)
+and the cloud server URL. ``slug`` is included for symmetry with
+the legacy keystore + as a sanity check when constructing WS URLs.
 """
 
 from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
 
 from ...portal.state import agent_dir
 
@@ -17,10 +17,7 @@ from ...portal.state import agent_dir
 @dataclass
 class ApiPuffoKeystore:
     slug: str
-    device_id: str
-    kem_secret_key: str  # base64url-encoded 32 bytes
-    kem_cert: dict
-    session_token: str
+    sandbox_token: str
     puffo_cloud_server_url: str
 
     @classmethod
@@ -29,9 +26,6 @@ class ApiPuffoKeystore:
         raw = json.loads(path.read_text(encoding="utf-8"))
         return cls(
             slug=raw["slug"],
-            device_id=raw["device_id"],
-            kem_secret_key=raw["kem_secret_key"],
-            kem_cert=json.loads(raw["kem_cert_json"]),
-            session_token=raw["session_token"],
+            sandbox_token=raw["sandbox_token"],
             puffo_cloud_server_url=raw["puffo_cloud_server_url"],
         )

--- a/src/puffo_agent/agent/api_puffo/keystore.py
+++ b/src/puffo_agent/agent/api_puffo/keystore.py
@@ -1,10 +1,5 @@
-"""Keystore loader for api-puffo agents.
-
-Server-side ``puffo-server/cloud_agent`` holds all crypto; the
-runtime needs only the sandbox_token (bearer for the WS upgrade)
-and the cloud server URL. ``slug`` is included for symmetry with
-the legacy keystore + as a sanity check when constructing WS URLs.
-"""
+"""Keystore loader for api-puffo agents — sandbox_token + cloud
+URL only; server-side holds the actual crypto."""
 
 from __future__ import annotations
 

--- a/src/puffo_agent/agent/api_puffo/runner.py
+++ b/src/puffo_agent/agent/api_puffo/runner.py
@@ -1,0 +1,265 @@
+"""api-puffo worker loop.
+
+Replaces the regular ``PuffoCoreMessageClient`` + adapter flow for
+cloud-hosted agents. Connects to puffo-cloud-server via WS (bearer
+auth), receives encrypted envelopes inline with the sender's
+signing pubkey, decrypts locally with the agent's KEM key, and
+per-turn calls ``POST /v1/llm/complete`` with the assembled system
+prompt + decrypted text. Tool calls returned by the LLM are
+dispatched to the matching cloud endpoint via session-token RPC.
+
+Per-envelope handling is single-turn (no thread queue, no
+messages.db) until the wider Phase 5 work lands; this is enough
+for end-to-end smoke against a mock cloud server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from ...crypto.encoding import base64url_decode
+from ...crypto.message import decrypt_message
+from ...crypto.primitives import KemKeyPair
+from ...portal.profile_sync import extract_soul_body
+from ...portal.state import AgentConfig
+from .cloud_client import CloudHttpClient, CloudWsClient, llm_complete
+from .keystore import ApiPuffoKeystore
+from .tools import TOOL_SCHEMAS, dispatch_tool
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_TOOL_ROUNDS = 8
+
+
+class ApiPuffoRunner:
+    def __init__(self, agent_id: str, stop_event: asyncio.Event) -> None:
+        self.agent_id = agent_id
+        self._stop = stop_event
+        self._keys: ApiPuffoKeystore | None = None
+        self._kem_kp: KemKeyPair | None = None
+        self._cfg: AgentConfig | None = None
+        self._http: CloudHttpClient | None = None
+        self._ws: CloudWsClient | None = None
+
+    async def run(self) -> None:
+        try:
+            self._keys = ApiPuffoKeystore.for_agent(self.agent_id)
+            self._cfg = AgentConfig.load(self.agent_id)
+        except FileNotFoundError:
+            logger.error(
+                "api-puffo runner %s: keystore missing; bundle ingestion failed?",
+                self.agent_id,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "api-puffo runner %s: init failed: %s",
+                self.agent_id, exc,
+            )
+            return
+
+        self._kem_kp = KemKeyPair.from_secret_bytes(
+            base64url_decode(self._keys.kem_secret_key),
+        )
+        self._http = CloudHttpClient(
+            self._keys.puffo_cloud_server_url, self._keys.session_token,
+        )
+        self._ws = CloudWsClient(
+            self._keys.puffo_cloud_server_url,
+            self._keys.session_token,
+            self._keys.slug,
+        )
+        logger.info(
+            "api-puffo runner %s: started (cloud=%s)",
+            self.agent_id, self._keys.puffo_cloud_server_url,
+        )
+
+        try:
+            await self._listen_loop()
+        finally:
+            await self._cleanup()
+
+    async def _listen_loop(self) -> None:
+        assert self._ws is not None
+        listen_task = asyncio.create_task(self._consume_ws())
+        stop_task = asyncio.create_task(self._stop.wait())
+        try:
+            await asyncio.wait(
+                {listen_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            self._ws.stop()
+            for t in (listen_task, stop_task):
+                if not t.done():
+                    t.cancel()
+                    try:
+                        await t
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+    async def _consume_ws(self) -> None:
+        assert self._ws is not None
+        try:
+            async for frame in self._ws.listen():
+                try:
+                    await self._handle_frame(frame)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "api-puffo runner %s: frame handler raised: %s",
+                        self.agent_id, exc,
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "api-puffo runner %s: WS loop exited: %s",
+                self.agent_id, exc,
+            )
+
+    async def _handle_frame(self, frame: dict[str, Any]) -> None:
+        kind = frame.get("type", "")
+        if kind == "envelope":
+            await self._handle_envelope_frame(frame)
+            return
+        if kind == "ping":
+            return
+        logger.debug(
+            "api-puffo runner %s: unhandled frame type %r", self.agent_id, kind,
+        )
+
+    async def _handle_envelope_frame(self, frame: dict[str, Any]) -> None:
+        """Frame shape from cloud:
+            {"type": "envelope",
+             "envelope": <MessageEnvelope dict>,
+             "sender_signing_public_key": "<base64url 32 bytes>"}
+
+        Sender pubkey is inlined by the cloud (which already
+        authenticated the sender) — saves the agent a /certs/sync
+        round-trip per inbound message. Full cert-sync remains the
+        long-term answer when certs rotate or trust needs to be
+        re-anchored client-side.
+        """
+        assert self._keys is not None and self._kem_kp is not None and self._http is not None
+        envelope = frame.get("envelope")
+        sender_pk_b64 = frame.get("sender_signing_public_key", "")
+        if not isinstance(envelope, dict) or not sender_pk_b64:
+            logger.warning(
+                "api-puffo runner %s: malformed envelope frame; skipping",
+                self.agent_id,
+            )
+            return
+        try:
+            sender_pk = base64url_decode(sender_pk_b64)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "api-puffo runner %s: sender pubkey decode failed: %s",
+                self.agent_id, exc,
+            )
+            return
+
+        try:
+            payload = decrypt_message(
+                envelope, self._keys.device_id, self._kem_kp, sender_pk,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "api-puffo runner %s: decrypt failed for envelope_id=%s: %s",
+                self.agent_id, envelope.get("envelope_id"), exc,
+            )
+            return
+
+        if payload.content_type != "text/plain":
+            logger.info(
+                "api-puffo runner %s: skipping non-text content_type=%r",
+                self.agent_id, payload.content_type,
+            )
+            return
+
+        user_text = payload.content if isinstance(payload.content, str) else str(payload.content)
+        logger.info(
+            "api-puffo runner %s: dispatching turn (envelope_id=%s, sender=%s, %d chars)",
+            self.agent_id, payload.envelope_id, payload.sender_slug, len(user_text),
+        )
+        await self._run_turn(user_text)
+
+    async def _run_turn(self, user_text: str) -> None:
+        """One LLM turn with tool calling. Loops up to
+        ``_MAX_TOOL_ROUNDS`` until the model returns a final text
+        reply. Errors are logged + the turn is dropped (no auto-
+        post on failure — operator tails the audit log)."""
+        assert self._http is not None and self._cfg is not None and self._keys is not None
+        try:
+            soul = extract_soul_body(
+                self._cfg.resolve_profile_path().read_text(encoding="utf-8"),
+            )
+        except Exception:
+            soul = ""
+        system_prompt = soul or f"You are {self._cfg.display_name}."
+
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": user_text},
+        ]
+        for round_idx in range(_MAX_TOOL_ROUNDS):
+            try:
+                resp = await llm_complete(
+                    self._http,
+                    api_key=self._cfg.runtime.api_key,
+                    provider=self._cfg.runtime.provider or "anthropic",
+                    model=self._cfg.runtime.model,
+                    system_prompt=system_prompt,
+                    messages=messages,
+                    tools=TOOL_SCHEMAS,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "api-puffo runner %s: llm_complete failed (round %d): %s",
+                    self.agent_id, round_idx, exc,
+                )
+                return
+
+            content = resp.get("content") or []
+            stop_reason = resp.get("stop_reason", "")
+            tool_uses = [c for c in content if c.get("type") == "tool_use"]
+            text_blocks = [c.get("text", "") for c in content if c.get("type") == "text"]
+
+            messages.append({"role": "assistant", "content": content})
+
+            if not tool_uses or stop_reason == "end_turn":
+                reply = "".join(text_blocks).strip()
+                if reply:
+                    logger.info(
+                        "api-puffo runner %s: turn complete (rounds=%d, %d chars)",
+                        self.agent_id, round_idx + 1, len(reply),
+                    )
+                return
+
+            tool_results: list[dict[str, Any]] = []
+            for tu in tool_uses:
+                name = tu.get("name", "")
+                args = tu.get("input", {}) or {}
+                tu_id = tu.get("id", "")
+                result = await dispatch_tool(self._http, name, args)
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tu_id,
+                    "content": result,
+                })
+            messages.append({"role": "user", "content": tool_results})
+
+        logger.warning(
+            "api-puffo runner %s: turn hit %d-round cap without end_turn",
+            self.agent_id, _MAX_TOOL_ROUNDS,
+        )
+
+    async def _cleanup(self) -> None:
+        if self._http is not None:
+            try:
+                await self._http.close()
+            except Exception:  # noqa: BLE001
+                pass
+        logger.info("api-puffo runner %s: stopped", self.agent_id)

--- a/src/puffo_agent/agent/api_puffo/runner.py
+++ b/src/puffo_agent/agent/api_puffo/runner.py
@@ -1,31 +1,38 @@
 """api-puffo worker loop.
 
 Replaces the regular ``PuffoCoreMessageClient`` + adapter flow for
-cloud-hosted agents. Connects to puffo-cloud-server via WS (bearer
-auth), receives encrypted envelopes inline with the sender's
-signing pubkey, decrypts locally with the agent's KEM key, and
-per-turn calls ``POST /v1/llm/complete`` with the assembled system
-prompt + decrypted text. Tool calls returned by the LLM are
-dispatched to the matching cloud endpoint via session-token RPC.
+cloud-hosted agents. Per the bridge wire-protocol spec:
 
-Per-envelope handling is single-turn (no thread queue, no
-messages.db) until the wider Phase 5 work lands; this is enough
-for end-to-end smoke against a mock cloud server.
-"""
+  1. Connect WS at ``<cloud>/v2/cloud-agents/subscribe`` with
+     ``x-sandbox-token`` on the upgrade. Wait for ``connected``.
+  2. ``fetch_pending`` → drain ``message`` + ``pending_delivered``
+     frames → ack the batch. Loop on ``more = true``.
+  3. Main loop: every inbound ``message`` frame fires one LLM turn;
+     the LLM's tool calls dispatch to bridge frames (``send``,
+     ``list_spaces``); ack the envelope after the turn returns
+     (success OR failure — server already routes; ack just stops
+     re-delivery). Heartbeat is handled by the bridge client
+     background task.
+
+Single-turn per envelope for now (no thread queue / no local DB).
+Conversation history is the live WS stream; ``fetch_pending`` is
+the only backfill primitive."""
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import Any
 
-from ...crypto.encoding import base64url_decode
-from ...crypto.message import decrypt_message
-from ...crypto.primitives import KemKeyPair
 from ...portal.profile_sync import extract_soul_body
 from ...portal.state import AgentConfig
-from .cloud_client import CloudHttpClient, CloudWsClient, llm_complete
+from .cloud_client import (
+    BridgeClosed,
+    BridgeError,
+    CloudBridgeClient,
+    CloudHttpError,
+    CloudLlmClient,
+)
 from .keystore import ApiPuffoKeystore
 from .tools import TOOL_SCHEMAS, dispatch_tool
 
@@ -33,6 +40,8 @@ logger = logging.getLogger(__name__)
 
 
 _MAX_TOOL_ROUNDS = 8
+_RECONNECT_BACKOFF_MIN = 1.0
+_RECONNECT_BACKOFF_MAX = 30.0
 
 
 class ApiPuffoRunner:
@@ -40,10 +49,14 @@ class ApiPuffoRunner:
         self.agent_id = agent_id
         self._stop = stop_event
         self._keys: ApiPuffoKeystore | None = None
-        self._kem_kp: KemKeyPair | None = None
         self._cfg: AgentConfig | None = None
-        self._http: CloudHttpClient | None = None
-        self._ws: CloudWsClient | None = None
+        self._llm: CloudLlmClient | None = None
+        # Set during each connection epoch.
+        self._bridge: CloudBridgeClient | None = None
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self._inbox_consumer: asyncio.Task | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._backfill_done = asyncio.Event()
 
     async def run(self) -> None:
         try:
@@ -57,21 +70,12 @@ class ApiPuffoRunner:
             return
         except Exception as exc:  # noqa: BLE001
             logger.error(
-                "api-puffo runner %s: init failed: %s",
-                self.agent_id, exc,
+                "api-puffo runner %s: init failed: %s", self.agent_id, exc,
             )
             return
 
-        self._kem_kp = KemKeyPair.from_secret_bytes(
-            base64url_decode(self._keys.kem_secret_key),
-        )
-        self._http = CloudHttpClient(
-            self._keys.puffo_cloud_server_url, self._keys.session_token,
-        )
-        self._ws = CloudWsClient(
-            self._keys.puffo_cloud_server_url,
-            self._keys.session_token,
-            self._keys.slug,
+        self._llm = CloudLlmClient(
+            self._keys.puffo_cloud_server_url, self._keys.sandbox_token,
         )
         logger.info(
             "api-puffo runner %s: started (cloud=%s)",
@@ -79,120 +83,217 @@ class ApiPuffoRunner:
         )
 
         try:
-            await self._listen_loop()
+            await self._connect_and_serve_loop()
         finally:
             await self._cleanup()
 
-    async def _listen_loop(self) -> None:
-        assert self._ws is not None
-        listen_task = asyncio.create_task(self._consume_ws())
-        stop_task = asyncio.create_task(self._stop.wait())
-        try:
-            await asyncio.wait(
-                {listen_task, stop_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-        finally:
-            self._ws.stop()
-            for t in (listen_task, stop_task):
-                if not t.done():
-                    t.cancel()
+    async def _connect_and_serve_loop(self) -> None:
+        """Reconnect with exponential backoff on transport errors.
+        Authentication failures (BridgeError code=HANDSHAKE on 401)
+        log loud + back off — operator action required."""
+        backoff = _RECONNECT_BACKOFF_MIN
+        while not self._stop.is_set():
+            try:
+                self._bridge = CloudBridgeClient(
+                    self._keys.puffo_cloud_server_url,
+                    self._keys.sandbox_token,
+                    self._keys.slug,
+                )
+                await self._bridge.connect()
+                backoff = _RECONNECT_BACKOFF_MIN
+                await self._on_connect_flow()
+                await self._consume_frames()
+            except BridgeError as exc:
+                logger.warning(
+                    "api-puffo runner %s: bridge error (%s); reconnect in %.1fs",
+                    self.agent_id, exc, backoff,
+                )
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "api-puffo runner %s: bridge loop crashed (%s: %s); "
+                    "reconnect in %.1fs",
+                    self.agent_id, type(exc).__name__, exc, backoff,
+                )
+            finally:
+                for t_name in ("_reader_task", "_inbox_consumer"):
+                    t = getattr(self, t_name)
+                    if t is not None:
+                        t.cancel()
+                        try:
+                            await t
+                        except (asyncio.CancelledError, Exception):
+                            pass
+                        setattr(self, t_name, None)
+                while not self._inbox.empty():
                     try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
+                        self._inbox.get_nowait()
+                        self._inbox.task_done()
+                    except (asyncio.QueueEmpty, ValueError):
+                        break
+                self._backfill_done = asyncio.Event()
+                if self._bridge is not None:
+                    try:
+                        await self._bridge.close()
+                    except Exception:  # noqa: BLE001
                         pass
+                    self._bridge = None
+            if self._stop.is_set():
+                return
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=backoff)
+                return
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2, _RECONNECT_BACKOFF_MAX)
 
-    async def _consume_ws(self) -> None:
-        assert self._ws is not None
+    async def _on_connect_flow(self) -> None:
+        """Spec §5.4: backfill via ``fetch_pending`` → process →
+        ack. Reader/worker split so frame consumption never blocks
+        on the LLM turn (``send_send``'s ack needs the iterator
+        free). Both reader + worker run as concurrent tasks; the
+        reader puts ALL relevant frames on the inbox and the worker
+        is the single state owner (backfill batch accumulator + ack
+        cadence)."""
+        assert self._bridge is not None
+        self._inbox_consumer = asyncio.create_task(self._inbox_loop())
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        await self._bridge.send_fetch_pending()
+        # Wait until the worker reports "backfill drained" or stop fires.
         try:
-            async for frame in self._ws.listen():
-                try:
-                    await self._handle_frame(frame)
-                except Exception as exc:  # noqa: BLE001
+            await asyncio.wait_for(
+                self._backfill_done.wait(), timeout=300.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "api-puffo runner %s: backfill drain timeout; proceeding",
+                self.agent_id,
+            )
+
+    async def _reader_loop(self) -> None:
+        """Pulls every relevant frame off the bridge into the inbox.
+        Errors are logged inline (they don't tear down the WS)."""
+        assert self._bridge is not None
+        try:
+            async for frame in self._bridge.frames():
+                if self._stop.is_set():
+                    return
+                kind = frame.get("type", "")
+                if kind == "message":
+                    await self._inbox.put(("message", frame))
+                elif kind == "pending_delivered":
+                    await self._inbox.put(("pending_delivered", frame))
+                elif kind == "error":
                     logger.warning(
-                        "api-puffo runner %s: frame handler raised: %s",
-                        self.agent_id, exc,
+                        "api-puffo runner %s: bridge error frame: %s",
+                        self.agent_id, frame,
                     )
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "api-puffo runner %s: WS loop exited: %s",
+                "api-puffo runner %s: reader loop exited: %s",
                 self.agent_id, exc,
             )
+        finally:
+            # Sentinel to wake the consumer for clean shutdown.
+            try:
+                self._inbox.put_nowait(("close", {}))
+            except asyncio.QueueFull:
+                pass
 
-    async def _handle_frame(self, frame: dict[str, Any]) -> None:
-        kind = frame.get("type", "")
-        if kind == "envelope":
-            await self._handle_envelope_frame(frame)
+    async def _inbox_loop(self) -> None:
+        """Serial worker: process frames in arrival order. Accumulates
+        backfill envelope_ids and acks them in one shot when
+        ``pending_delivered`` lands; live messages are acked one at a
+        time after each turn."""
+        assert self._bridge is not None
+        in_backfill = True
+        backfill_ids: list[str] = []
+        while not self._stop.is_set():
+            kind, frame = await self._inbox.get()
+            try:
+                if kind == "close":
+                    return
+                if kind == "message":
+                    envelope_id = frame.get("envelope_id", "")
+                    try:
+                        await self._run_turn_for_frame(frame)
+                    finally:
+                        if envelope_id:
+                            if in_backfill:
+                                backfill_ids.append(envelope_id)
+                            else:
+                                try:
+                                    await self._bridge.send_ack([envelope_id])
+                                except Exception as exc:  # noqa: BLE001
+                                    logger.warning(
+                                        "api-puffo runner %s: live ack "
+                                        "failed for %s: %s",
+                                        self.agent_id, envelope_id, exc,
+                                    )
+                elif kind == "pending_delivered":
+                    if backfill_ids:
+                        try:
+                            await self._bridge.send_ack(backfill_ids)
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "api-puffo runner %s: backfill ack "
+                                "failed: %s",
+                                self.agent_id, exc,
+                            )
+                        backfill_ids = []
+                    if frame.get("more"):
+                        await self._bridge.send_fetch_pending()
+                    else:
+                        in_backfill = False
+                        logger.info(
+                            "api-puffo runner %s: backfill drained, "
+                            "entering main loop",
+                            self.agent_id,
+                        )
+                        self._backfill_done.set()
+            finally:
+                self._inbox.task_done()
+
+    async def _consume_frames(self) -> None:
+        """Main loop wait — the reader + inbox tasks do the work.
+        Block until stop or reader exits."""
+        if self._reader_task is None:
             return
-        if kind == "ping":
-            return
-        logger.debug(
-            "api-puffo runner %s: unhandled frame type %r", self.agent_id, kind,
-        )
+        stop_task = asyncio.create_task(self._stop.wait())
+        try:
+            await asyncio.wait(
+                {self._reader_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            if not stop_task.done():
+                stop_task.cancel()
 
-    async def _handle_envelope_frame(self, frame: dict[str, Any]) -> None:
-        """Frame shape from cloud:
-            {"type": "envelope",
-             "envelope": <MessageEnvelope dict>,
-             "sender_signing_public_key": "<base64url 32 bytes>"}
-
-        Sender pubkey is inlined by the cloud (which already
-        authenticated the sender) — saves the agent a /certs/sync
-        round-trip per inbound message. Full cert-sync remains the
-        long-term answer when certs rotate or trust needs to be
-        re-anchored client-side.
-        """
-        assert self._keys is not None and self._kem_kp is not None and self._http is not None
-        envelope = frame.get("envelope")
-        sender_pk_b64 = frame.get("sender_signing_public_key", "")
-        if not isinstance(envelope, dict) or not sender_pk_b64:
-            logger.warning(
-                "api-puffo runner %s: malformed envelope frame; skipping",
+    async def _run_turn_for_frame(self, frame: dict[str, Any]) -> None:
+        sender = frame.get("sender_slug", "?")
+        text = frame.get("plaintext", "")
+        if not isinstance(text, str) or not text:
+            logger.info(
+                "api-puffo runner %s: skipping frame with empty plaintext",
                 self.agent_id,
             )
             return
-        try:
-            sender_pk = base64url_decode(sender_pk_b64)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "api-puffo runner %s: sender pubkey decode failed: %s",
-                self.agent_id, exc,
-            )
-            return
-
-        try:
-            payload = decrypt_message(
-                envelope, self._keys.device_id, self._kem_kp, sender_pk,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "api-puffo runner %s: decrypt failed for envelope_id=%s: %s",
-                self.agent_id, envelope.get("envelope_id"), exc,
-            )
-            return
-
-        if payload.content_type != "text/plain":
-            logger.info(
-                "api-puffo runner %s: skipping non-text content_type=%r",
-                self.agent_id, payload.content_type,
-            )
-            return
-
-        user_text = payload.content if isinstance(payload.content, str) else str(payload.content)
         logger.info(
-            "api-puffo runner %s: dispatching turn (envelope_id=%s, sender=%s, %d chars)",
-            self.agent_id, payload.envelope_id, payload.sender_slug, len(user_text),
+            "api-puffo runner %s: turn (envelope_id=%s, sender=%s, %d chars)",
+            self.agent_id, frame.get("envelope_id", "?"), sender, len(text),
         )
-        await self._run_turn(user_text)
+        await self._run_turn(text)
 
     async def _run_turn(self, user_text: str) -> None:
-        """One LLM turn with tool calling. Loops up to
-        ``_MAX_TOOL_ROUNDS`` until the model returns a final text
-        reply. Errors are logged + the turn is dropped (no auto-
-        post on failure — operator tails the audit log)."""
-        assert self._http is not None and self._cfg is not None and self._keys is not None
+        """One LLM turn with tool-loop. Caps at ``_MAX_TOOL_ROUNDS``
+        rounds before logging a hard cap warning + returning."""
+        assert (
+            self._llm is not None and self._cfg is not None
+            and self._keys is not None and self._bridge is not None
+        )
         try:
             soul = extract_soul_body(
                 self._cfg.resolve_profile_path().read_text(encoding="utf-8"),
@@ -206,8 +307,7 @@ class ApiPuffoRunner:
         ]
         for round_idx in range(_MAX_TOOL_ROUNDS):
             try:
-                resp = await llm_complete(
-                    self._http,
+                resp = await self._llm.complete(
                     api_key=self._cfg.runtime.api_key,
                     provider=self._cfg.runtime.provider or "anthropic",
                     model=self._cfg.runtime.model,
@@ -215,9 +315,15 @@ class ApiPuffoRunner:
                     messages=messages,
                     tools=TOOL_SCHEMAS,
                 )
+            except CloudHttpError as exc:
+                logger.warning(
+                    "api-puffo runner %s: LLM call failed (round %d): %s",
+                    self.agent_id, round_idx, exc,
+                )
+                return
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
-                    "api-puffo runner %s: llm_complete failed (round %d): %s",
+                    "api-puffo runner %s: LLM transport (round %d): %s",
                     self.agent_id, round_idx, exc,
                 )
                 return
@@ -225,15 +331,17 @@ class ApiPuffoRunner:
             content = resp.get("content") or []
             stop_reason = resp.get("stop_reason", "")
             tool_uses = [c for c in content if c.get("type") == "tool_use"]
-            text_blocks = [c.get("text", "") for c in content if c.get("type") == "text"]
-
+            text_blocks = [
+                c.get("text", "") for c in content if c.get("type") == "text"
+            ]
             messages.append({"role": "assistant", "content": content})
 
             if not tool_uses or stop_reason == "end_turn":
                 reply = "".join(text_blocks).strip()
                 if reply:
                     logger.info(
-                        "api-puffo runner %s: turn complete (rounds=%d, %d chars)",
+                        "api-puffo runner %s: turn complete "
+                        "(rounds=%d, %d chars)",
                         self.agent_id, round_idx + 1, len(reply),
                     )
                 return
@@ -243,7 +351,10 @@ class ApiPuffoRunner:
                 name = tu.get("name", "")
                 args = tu.get("input", {}) or {}
                 tu_id = tu.get("id", "")
-                result = await dispatch_tool(self._http, name, args)
+                try:
+                    result = await dispatch_tool(self._bridge, name, args)
+                except BridgeClosed:
+                    result = "error: bridge closed mid-turn"
                 tool_results.append({
                     "type": "tool_result",
                     "tool_use_id": tu_id,
@@ -257,9 +368,15 @@ class ApiPuffoRunner:
         )
 
     async def _cleanup(self) -> None:
-        if self._http is not None:
+        if self._bridge is not None:
             try:
-                await self._http.close()
+                await self._bridge.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._bridge = None
+        if self._llm is not None:
+            try:
+                await self._llm.close()
             except Exception:  # noqa: BLE001
                 pass
         logger.info("api-puffo runner %s: stopped", self.agent_id)

--- a/src/puffo_agent/agent/api_puffo/runner.py
+++ b/src/puffo_agent/agent/api_puffo/runner.py
@@ -1,22 +1,9 @@
 """api-puffo worker loop.
 
-Replaces the regular ``PuffoCoreMessageClient`` + adapter flow for
-cloud-hosted agents. Per the bridge wire-protocol spec:
-
-  1. Connect WS at ``<cloud>/v2/cloud-agents/subscribe`` with
-     ``x-sandbox-token`` on the upgrade. Wait for ``connected``.
-  2. ``fetch_pending`` → drain ``message`` + ``pending_delivered``
-     frames → ack the batch. Loop on ``more = true``.
-  3. Main loop: every inbound ``message`` frame fires one LLM turn;
-     the LLM's tool calls dispatch to bridge frames (``send``,
-     ``list_spaces``); ack the envelope after the turn returns
-     (success OR failure — server already routes; ack just stops
-     re-delivery). Heartbeat is handled by the bridge client
-     background task.
-
-Single-turn per envelope for now (no thread queue / no local DB).
-Conversation history is the live WS stream; ``fetch_pending`` is
-the only backfill primitive."""
+Single-turn per envelope (no thread queue / no local DB) —
+conversation history is the live WS stream, ``fetch_pending`` is
+the only backfill primitive. On-connect / dispatch / ack cadence
+follows BRIDGE-WIRE-PROTOCOL.md §5."""
 
 from __future__ import annotations
 
@@ -88,9 +75,6 @@ class ApiPuffoRunner:
             await self._cleanup()
 
     async def _connect_and_serve_loop(self) -> None:
-        """Reconnect with exponential backoff on transport errors.
-        Authentication failures (BridgeError code=HANDSHAKE on 401)
-        log loud + back off — operator action required."""
         backoff = _RECONNECT_BACKOFF_MIN
         while not self._stop.is_set():
             try:
@@ -149,18 +133,13 @@ class ApiPuffoRunner:
             backoff = min(backoff * 2, _RECONNECT_BACKOFF_MAX)
 
     async def _on_connect_flow(self) -> None:
-        """Spec §5.4: backfill via ``fetch_pending`` → process →
-        ack. Reader/worker split so frame consumption never blocks
-        on the LLM turn (``send_send``'s ack needs the iterator
-        free). Both reader + worker run as concurrent tasks; the
-        reader puts ALL relevant frames on the inbox and the worker
-        is the single state owner (backfill batch accumulator + ack
-        cadence)."""
+        # Reader + worker split: send_send's ack arrives on the same
+        # WS the reader is pumping, so the reader must never block on
+        # LLM-turn work or dispatch_tool deadlocks.
         assert self._bridge is not None
         self._inbox_consumer = asyncio.create_task(self._inbox_loop())
         self._reader_task = asyncio.create_task(self._reader_loop())
         await self._bridge.send_fetch_pending()
-        # Wait until the worker reports "backfill drained" or stop fires.
         try:
             await asyncio.wait_for(
                 self._backfill_done.wait(), timeout=300.0,
@@ -172,8 +151,6 @@ class ApiPuffoRunner:
             )
 
     async def _reader_loop(self) -> None:
-        """Pulls every relevant frame off the bridge into the inbox.
-        Errors are logged inline (they don't tear down the WS)."""
         assert self._bridge is not None
         try:
             async for frame in self._bridge.frames():
@@ -204,10 +181,8 @@ class ApiPuffoRunner:
                 pass
 
     async def _inbox_loop(self) -> None:
-        """Serial worker: process frames in arrival order. Accumulates
-        backfill envelope_ids and acks them in one shot when
-        ``pending_delivered`` lands; live messages are acked one at a
-        time after each turn."""
+        # Backfill envelopes batch into one ack on pending_delivered;
+        # live messages ack one at a time after each turn.
         assert self._bridge is not None
         in_backfill = True
         backfill_ids: list[str] = []
@@ -258,8 +233,6 @@ class ApiPuffoRunner:
                 self._inbox.task_done()
 
     async def _consume_frames(self) -> None:
-        """Main loop wait — the reader + inbox tasks do the work.
-        Block until stop or reader exits."""
         if self._reader_task is None:
             return
         stop_task = asyncio.create_task(self._stop.wait())
@@ -288,8 +261,6 @@ class ApiPuffoRunner:
         await self._run_turn(text)
 
     async def _run_turn(self, user_text: str) -> None:
-        """One LLM turn with tool-loop. Caps at ``_MAX_TOOL_ROUNDS``
-        rounds before logging a hard cap warning + returning."""
         assert (
             self._llm is not None and self._cfg is not None
             and self._keys is not None and self._bridge is not None

--- a/src/puffo_agent/agent/api_puffo/tools.py
+++ b/src/puffo_agent/agent/api_puffo/tools.py
@@ -1,23 +1,8 @@
 """Tool schemas + dispatch for the api-puffo runtime.
 
-The LLM (Anthropic messages API shape) returns tool_use blocks
-naming one of these tools; the runner dispatches each call into a
-WebSocket bridge frame and waits for the matching ack / spaces
-reply. Cloud does all crypto + persistence + delivery.
-
-Day-1 surface (bounded by what the bridge protocol exposes):
-
-  - ``send_message``   → bridge ``send`` (DM via recipient_slug;
-                         channel via space_id + channel_id)
-  - ``list_spaces``    → bridge ``list_spaces``
-
-History / whoami tools from the legacy MCP surface are NOT here.
-The bridge spec doesn't expose a history query (cloud-agents are
-expected to ride ``fetch_pending`` backfill at connect + react to
-live ``message`` frames; persistent per-thread storage will land
-in a later spec revision). Adding them now would route through a
-separate REST surface that doesn't exist yet.
-"""
+Day-1 surface is what BRIDGE-WIRE-PROTOCOL.md exposes: send_message
+(bridge ``send``) and list_spaces (bridge ``list_spaces``). History /
+whoami land when the spec grows the matching frames."""
 
 from __future__ import annotations
 
@@ -82,10 +67,8 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
 async def dispatch_tool(
     bridge: CloudBridgeClient, name: str, args: dict[str, Any],
 ) -> str:
-    """Translate a tool_use block into a bridge frame, await reply,
-    return a string for the LLM tool_result block. All transport /
-    server errors are normalised to a leading ``error:`` so the LLM
-    can react inside its tool loop."""
+    # Errors normalised to a leading "error:" so the LLM can react
+    # inside its tool loop instead of crashing the turn.
     if name == "send_message":
         plaintext = args.get("plaintext", "")
         if not isinstance(plaintext, str) or not plaintext:
@@ -93,8 +76,8 @@ async def dispatch_tool(
         recipient_slug = args.get("recipient_slug") or None
         space_id = args.get("space_id") or None
         channel_id = args.get("channel_id") or None
-        # Enforce the spec's one-shape-only rule client-side too so
-        # the operator sees a clean message rather than BAD_FRAME.
+        # Mirror the spec's one-shape-only rule client-side for a
+        # cleaner error than the server's BAD_FRAME.
         if recipient_slug and (space_id or channel_id):
             return (
                 "error: send_message accepts EITHER recipient_slug "

--- a/src/puffo_agent/agent/api_puffo/tools.py
+++ b/src/puffo_agent/agent/api_puffo/tools.py
@@ -1,18 +1,31 @@
-"""Tool schemas + handlers for the api-puffo runtime.
+"""Tool schemas + dispatch for the api-puffo runtime.
 
 The LLM (Anthropic messages API shape) returns tool_use blocks
-naming one of these tools; the runner dispatches the call to the
-matching cloud RPC. Cloud handles the heavy crypto / signing on
-behalf of the agent — daemon just translates plaintext args into
-a session-token-authenticated POST.
+naming one of these tools; the runner dispatches each call into a
+WebSocket bridge frame and waits for the matching ack / spaces
+reply. Cloud does all crypto + persistence + delivery.
+
+Day-1 surface (bounded by what the bridge protocol exposes):
+
+  - ``send_message``   → bridge ``send`` (DM via recipient_slug;
+                         channel via space_id + channel_id)
+  - ``list_spaces``    → bridge ``list_spaces``
+
+History / whoami tools from the legacy MCP surface are NOT here.
+The bridge spec doesn't expose a history query (cloud-agents are
+expected to ride ``fetch_pending`` backfill at connect + react to
+live ``message`` frames; persistent per-thread storage will land
+in a later spec revision). Adding them now would route through a
+separate REST surface that doesn't exist yet.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
-from .cloud_client import CloudHttpClient, CloudHttpError
+from .cloud_client import BridgeClosed, BridgeError, CloudBridgeClient
 
 logger = logging.getLogger(__name__)
 
@@ -22,84 +35,41 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "name": "send_message",
         "description": (
             "Post a message to a Puffo.ai channel or DM a user. "
-            "Use '@<slug>' for DMs (e.g. '@alice-1234'); use the raw "
-            "channel id (e.g. 'ch_<uuid>') for channels."
+            "Use 'recipient_slug' for a DM (e.g. 'alice-1234'); "
+            "use 'space_id' + 'channel_id' (e.g. 'sp_<uuid>' + "
+            "'ch_<uuid>') for a channel. Provide EXACTLY ONE of "
+            "the two shapes — the bridge rejects mixed frames."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
-                "channel": {
-                    "type": "string",
-                    "description": "'@<slug>' for DM, or 'ch_<uuid>' for a channel.",
-                },
-                "text": {
+                "plaintext": {
                     "type": "string",
                     "description": "Message body. Markdown preserved verbatim.",
                 },
-                "is_visible_to_human": {
-                    "type": "boolean",
-                    "description": (
-                        "REQUIRED. true for anything a person should read; "
-                        "false for agent-to-agent coordination chatter (only "
-                        "takes effect on threaded replies)."
-                    ),
-                },
-                "root_id": {
+                "recipient_slug": {
                     "type": "string",
-                    "description": (
-                        "Optional. Reply inside a thread: pass the envelope_id "
-                        "of the root post."
-                    ),
+                    "description": "DM target slug (no '@' prefix). Omit for channel send.",
+                },
+                "space_id": {
+                    "type": "string",
+                    "description": "Channel target space id. Provide with channel_id.",
+                },
+                "channel_id": {
+                    "type": "string",
+                    "description": "Channel target id. Provide with space_id.",
                 },
             },
-            "required": ["channel", "text", "is_visible_to_human"],
+            "required": ["plaintext"],
         },
     },
     {
-        "name": "get_channel_history",
+        "name": "list_spaces",
         "description": (
-            "List recent root posts in a channel from local storage, "
-            "with reply count per thread. Replies are NOT inlined."
+            "Enumerate the spaces (and their channels) the agent is "
+            "a member of. Read-only, membership-scoped — never "
+            "returns spaces the agent isn't in."
         ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "channel": {
-                    "type": "string",
-                    "description": "ch_<uuid>",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Default 20, max 200.",
-                },
-            },
-            "required": ["channel"],
-        },
-    },
-    {
-        "name": "get_thread_history",
-        "description": (
-            "Messages in a thread (root + every reply), filtered "
-            "oldest-first up to limit."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "root_id": {
-                    "type": "string",
-                    "description": "envelope_id of the root post.",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Default 50, max 200.",
-                },
-            },
-            "required": ["root_id"],
-        },
-    },
-    {
-        "name": "whoami",
-        "description": "Return your own identity: display name, slug, device_id.",
         "input_schema": {
             "type": "object",
             "properties": {},
@@ -109,37 +79,77 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
 ]
 
 
-# Map tool name → cloud endpoint path (mocked until cloud is real).
-_TOOL_CLOUD_PATHS: dict[str, str] = {
-    "send_message": "/v1/send_message",
-    "get_channel_history": "/v1/get_channel_history",
-    "get_thread_history": "/v1/get_thread_history",
-    "whoami": "/v1/whoami",
-}
-
-
 async def dispatch_tool(
-    http: CloudHttpClient, name: str, args: dict[str, Any],
+    bridge: CloudBridgeClient, name: str, args: dict[str, Any],
 ) -> str:
-    """POST the tool args to its cloud endpoint, return the response
-    body as a string (Anthropic tool_result accepts strings)."""
-    path = _TOOL_CLOUD_PATHS.get(name)
-    if path is None:
-        return f"error: unknown tool {name!r}"
-    try:
-        resp = await http.post(path, args)
-    except CloudHttpError as exc:
-        logger.warning(
-            "api-puffo tool %s: cloud error HTTP %d: %s",
-            name, exc.status, exc.body,
-        )
-        return f"error: HTTP {exc.status}: {exc.body[:200]}"
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("api-puffo tool %s: transport error: %s", name, exc)
-        return f"error: transport: {exc}"
-    # Normalise to string for tool_result.
-    text = resp.get("text") if isinstance(resp, dict) else None
-    if isinstance(text, str):
-        return text
-    import json
-    return json.dumps(resp)
+    """Translate a tool_use block into a bridge frame, await reply,
+    return a string for the LLM tool_result block. All transport /
+    server errors are normalised to a leading ``error:`` so the LLM
+    can react inside its tool loop."""
+    if name == "send_message":
+        plaintext = args.get("plaintext", "")
+        if not isinstance(plaintext, str) or not plaintext:
+            return "error: send_message requires non-empty 'plaintext'"
+        recipient_slug = args.get("recipient_slug") or None
+        space_id = args.get("space_id") or None
+        channel_id = args.get("channel_id") or None
+        # Enforce the spec's one-shape-only rule client-side too so
+        # the operator sees a clean message rather than BAD_FRAME.
+        if recipient_slug and (space_id or channel_id):
+            return (
+                "error: send_message accepts EITHER recipient_slug "
+                "(DM) OR space_id+channel_id (channel), not both"
+            )
+        if not recipient_slug and not (space_id and channel_id):
+            return (
+                "error: send_message requires recipient_slug "
+                "(DM) OR space_id+channel_id (channel)"
+            )
+        try:
+            ack = await bridge.send_send(
+                plaintext=plaintext,
+                recipient_slug=recipient_slug,
+                space_id=space_id,
+                channel_id=channel_id,
+            )
+        except BridgeError as exc:
+            return f"error: {exc.code}: {exc.message}"
+        except BridgeClosed:
+            return "error: bridge is not connected; message not sent"
+        except Exception as exc:  # noqa: BLE001
+            return f"error: send_message failed: {exc}"
+        envelope_id = ack.get("envelope_id", "?")
+        queued = ack.get("devices_queued", 0)
+        missing = ack.get("missing_devices", []) or []
+        note = ""
+        if missing:
+            note = (
+                f" (note: {len(missing)} recipient device(s) missed — "
+                f"server will retry via supplementation)"
+            )
+        return f"posted {envelope_id} to {queued} device(s){note}"
+
+    if name == "list_spaces":
+        try:
+            resp = await bridge.send_list_spaces()
+        except BridgeError as exc:
+            return f"error: {exc.code}: {exc.message}"
+        except BridgeClosed:
+            return "error: bridge is not connected"
+        except Exception as exc:  # noqa: BLE001
+            return f"error: list_spaces failed: {exc}"
+        spaces = resp.get("spaces") or []
+        if not spaces:
+            return "(no spaces — agent is not a member of any)"
+        lines: list[str] = []
+        for sp in spaces:
+            sname = sp.get("name", "") or sp.get("space_id", "?")
+            sid = sp.get("space_id", "?")
+            lines.append(f"# {sname} ({sid})")
+            for ch in sp.get("channels") or []:
+                cname = ch.get("name", "") or ch.get("channel_id", "?")
+                cid = ch.get("channel_id", "?")
+                lines.append(f"  - {cname} ({cid})")
+        return "\n".join(lines)
+
+    return f"error: unknown tool {name!r}"

--- a/src/puffo_agent/agent/api_puffo/tools.py
+++ b/src/puffo_agent/agent/api_puffo/tools.py
@@ -1,0 +1,145 @@
+"""Tool schemas + handlers for the api-puffo runtime.
+
+The LLM (Anthropic messages API shape) returns tool_use blocks
+naming one of these tools; the runner dispatches the call to the
+matching cloud RPC. Cloud handles the heavy crypto / signing on
+behalf of the agent — daemon just translates plaintext args into
+a session-token-authenticated POST.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .cloud_client import CloudHttpClient, CloudHttpError
+
+logger = logging.getLogger(__name__)
+
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "name": "send_message",
+        "description": (
+            "Post a message to a Puffo.ai channel or DM a user. "
+            "Use '@<slug>' for DMs (e.g. '@alice-1234'); use the raw "
+            "channel id (e.g. 'ch_<uuid>') for channels."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "'@<slug>' for DM, or 'ch_<uuid>' for a channel.",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message body. Markdown preserved verbatim.",
+                },
+                "is_visible_to_human": {
+                    "type": "boolean",
+                    "description": (
+                        "REQUIRED. true for anything a person should read; "
+                        "false for agent-to-agent coordination chatter (only "
+                        "takes effect on threaded replies)."
+                    ),
+                },
+                "root_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional. Reply inside a thread: pass the envelope_id "
+                        "of the root post."
+                    ),
+                },
+            },
+            "required": ["channel", "text", "is_visible_to_human"],
+        },
+    },
+    {
+        "name": "get_channel_history",
+        "description": (
+            "List recent root posts in a channel from local storage, "
+            "with reply count per thread. Replies are NOT inlined."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "ch_<uuid>",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Default 20, max 200.",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "get_thread_history",
+        "description": (
+            "Messages in a thread (root + every reply), filtered "
+            "oldest-first up to limit."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "root_id": {
+                    "type": "string",
+                    "description": "envelope_id of the root post.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Default 50, max 200.",
+                },
+            },
+            "required": ["root_id"],
+        },
+    },
+    {
+        "name": "whoami",
+        "description": "Return your own identity: display name, slug, device_id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+]
+
+
+# Map tool name → cloud endpoint path (mocked until cloud is real).
+_TOOL_CLOUD_PATHS: dict[str, str] = {
+    "send_message": "/v1/send_message",
+    "get_channel_history": "/v1/get_channel_history",
+    "get_thread_history": "/v1/get_thread_history",
+    "whoami": "/v1/whoami",
+}
+
+
+async def dispatch_tool(
+    http: CloudHttpClient, name: str, args: dict[str, Any],
+) -> str:
+    """POST the tool args to its cloud endpoint, return the response
+    body as a string (Anthropic tool_result accepts strings)."""
+    path = _TOOL_CLOUD_PATHS.get(name)
+    if path is None:
+        return f"error: unknown tool {name!r}"
+    try:
+        resp = await http.post(path, args)
+    except CloudHttpError as exc:
+        logger.warning(
+            "api-puffo tool %s: cloud error HTTP %d: %s",
+            name, exc.status, exc.body,
+        )
+        return f"error: HTTP {exc.status}: {exc.body[:200]}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("api-puffo tool %s: transport error: %s", name, exc)
+        return f"error: transport: {exc}"
+    # Normalise to string for tool_result.
+    text = resp.get("text") if isinstance(resp, dict) else None
+    if isinstance(text, str):
+        return text
+    import json
+    return json.dumps(resp)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -104,6 +104,17 @@ class Daemon:
         logger.info("puffo-agent portal starting; home=%s", home_dir())
         interval = max(0.5, self.daemon_cfg.reconcile_interval_seconds)
 
+        # api-puffo: ingest any pending install bundles into agent_dir
+        # layout BEFORE reconcile picks them up, so the first tick
+        # already sees the new agents.
+        try:
+            from ..agent.api_puffo.bundle import sweep_install_dir
+            n_new = sweep_install_dir()
+            if n_new:
+                logger.info("api-puffo: ingested %d new bundle(s)", n_new)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("api-puffo: install sweep failed: %s", exc)
+
         # One-shot version check at startup; non-blocking, best-effort.
         asyncio.ensure_future(_log_outdated_version_warning())
         # Re-assert machine_id for already-linked operators' agents so agents

--- a/src/puffo_agent/portal/runtime_matrix.py
+++ b/src/puffo_agent/portal/runtime_matrix.py
@@ -22,6 +22,7 @@ RUNTIME_SDK_LOCAL   = "sdk-local"
 RUNTIME_CLI_LOCAL   = "cli-local"
 RUNTIME_CLI_DOCKER  = "cli-docker"
 RUNTIME_WS_LOCAL    = "ws-local"  # external tool consumes over localhost WS
+RUNTIME_API_PUFFO   = "api-puffo"  # cloud-hosted; bearer session_token, no subkey signing
 RUNTIME_CLI_SANDBOX = "cli-sandbox"  # reserved; not yet implemented
 
 VALID_RUNTIMES: frozenset[str] = frozenset({
@@ -30,6 +31,7 @@ VALID_RUNTIMES: frozenset[str] = frozenset({
     RUNTIME_CLI_LOCAL,
     RUNTIME_CLI_DOCKER,
     RUNTIME_WS_LOCAL,
+    RUNTIME_API_PUFFO,
 })
 
 RESERVED_RUNTIMES: frozenset[str] = frozenset({
@@ -100,6 +102,7 @@ DEFAULT_PROVIDER_FOR_RUNTIME: dict[str, str] = {
     RUNTIME_CLI_LOCAL:  PROVIDER_ANTHROPIC,
     RUNTIME_CLI_DOCKER: PROVIDER_ANTHROPIC,
     RUNTIME_WS_LOCAL:   PROVIDER_ANTHROPIC,
+    RUNTIME_API_PUFFO:  PROVIDER_ANTHROPIC,
 }
 
 DEFAULT_HARNESS_FOR_PROVIDER: dict[str, str] = {

--- a/src/puffo_agent/portal/runtime_matrix.py
+++ b/src/puffo_agent/portal/runtime_matrix.py
@@ -221,7 +221,7 @@ __all__ = [
     # runtime constants
     "RUNTIME_CHAT_LOCAL", "RUNTIME_SDK_LOCAL",
     "RUNTIME_CLI_LOCAL", "RUNTIME_CLI_DOCKER", "RUNTIME_WS_LOCAL",
-    "RUNTIME_CLI_SANDBOX",
+    "RUNTIME_API_PUFFO", "RUNTIME_CLI_SANDBOX",
     # provider constants
     "PROVIDER_ANTHROPIC", "PROVIDER_OPENAI", "PROVIDER_GOOGLE",
     # harness constants

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -22,7 +22,7 @@ from typing import Callable, Optional
 from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
 from ..agent.status_reporter import StatusReporter
-from .runtime_matrix import RUNTIME_WS_LOCAL
+from .runtime_matrix import RUNTIME_API_PUFFO, RUNTIME_WS_LOCAL
 from .ws_local.hub import AttachPoint
 from ..agent.shared_content import (
     looks_like_managed_claude_md,
@@ -1006,9 +1006,34 @@ class Worker:
             self.runtime.status = "stopped"
             self.runtime.save(agent_id)
 
+    async def _run_api_puffo(self) -> None:
+        """api-puffo agents skip the PuffoCoreMessageClient entirely
+        and run an in-process loop against puffo-cloud-server. Bearer
+        auth, cloud-mediated LLM + outbound, KEM-decrypt inbound."""
+        from ..agent.api_puffo.runner import ApiPuffoRunner
+        agent_id = self.agent_cfg.id
+        self.runtime.status = "running"
+        self.runtime.save(agent_id)
+        self._warm_done.set()
+        runner = ApiPuffoRunner(agent_id, self._stop)
+        try:
+            await runner.run()
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "agent %s: api-puffo runner crashed: %s",
+                agent_id, exc, exc_info=True,
+            )
+            self.runtime.error = str(exc)
+        finally:
+            self.runtime.status = "stopped"
+            self.runtime.save(agent_id)
+
     async def _run(self) -> None:
         if (self.agent_cfg.runtime.kind or "") == RUNTIME_WS_LOCAL:
             await self._run_ws_local()
+            return
+        if (self.agent_cfg.runtime.kind or "") == RUNTIME_API_PUFFO:
+            await self._run_api_puffo()
             return
         agent_id = self.agent_cfg.id
         try:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1007,9 +1007,10 @@ class Worker:
             self.runtime.save(agent_id)
 
     async def _run_api_puffo(self) -> None:
-        """api-puffo agents skip the PuffoCoreMessageClient entirely
-        and run an in-process loop against puffo-cloud-server. Bearer
-        auth, cloud-mediated LLM + outbound, KEM-decrypt inbound."""
+        """Cloud-hosted runner: bypasses PuffoCoreMessageClient and
+        speaks the puffo-server bridge directly. Server holds all
+        crypto; runtime exchanges plaintext WS frames + cloud-hosted
+        LLM HTTP."""
         from ..agent.api_puffo.runner import ApiPuffoRunner
         agent_id = self.agent_cfg.id
         self.runtime.status = "running"

--- a/tests/test_api_puffo_bundle.py
+++ b/tests/test_api_puffo_bundle.py
@@ -1,0 +1,176 @@
+"""api-puffo bundle ingestion: validates schema + materialises into
+the standard agent_dir layout."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.api_puffo.bundle import (
+    ApiPuffoBundle,
+    ingest_bundle,
+    install_dir,
+    materialise_agent_dir,
+    sweep_install_dir,
+)
+from puffo_agent.agent.api_puffo.keystore import ApiPuffoKeystore
+from puffo_agent.portal.state import AgentConfig, agent_dir, agent_yml_path
+
+
+def _isolated_home() -> str:
+    home = tempfile.mkdtemp(prefix="puffo-api-puffo-")
+    os.environ["PUFFO_AGENT_HOME"] = home
+    os.environ["PUFFO_HOME"] = home
+    Path(home, "agents").mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _valid_bundle_dict(slug: str = "cloud-bot-1234") -> dict:
+    return {
+        "agent_slug": slug,
+        "operator_slug": "user-5678",
+        "device_id": "dev_cloud_xyz",
+        "kem_secret_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "kem_cert": {
+            "type": "device_cert",
+            "version": 1,
+            "device_id": "dev_cloud_xyz",
+        },
+        "session_token": "tok_abcdef123456",
+        "puffo_cloud_server_url": "https://cloud.puffo.ai",
+        "display_name": "Cloud Bot",
+        "role": "Cloud-hosted helper",
+        "role_short": "helper",
+        "soul": "I help test the api-puffo runtime.",
+        "avatar_url": "",
+        "api_key": "sk-test-llm-key",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+    }
+
+
+def test_bundle_from_dict_round_trips():
+    raw = _valid_bundle_dict()
+    bundle = ApiPuffoBundle.from_dict(raw)
+    assert bundle.agent_slug == "cloud-bot-1234"
+    assert bundle.puffo_cloud_server_url == "https://cloud.puffo.ai"
+    assert bundle.session_token == "tok_abcdef123456"
+    assert bundle.provider == "anthropic"
+
+
+def test_bundle_rejects_missing_fields():
+    raw = _valid_bundle_dict()
+    del raw["session_token"]
+    with pytest.raises(ValueError, match="session_token"):
+        ApiPuffoBundle.from_dict(raw)
+
+
+def test_bundle_rejects_invalid_slug():
+    raw = _valid_bundle_dict(slug="bad slug with spaces")
+    with pytest.raises(ValueError, match="invalid agent_slug"):
+        ApiPuffoBundle.from_dict(raw)
+
+
+def test_materialise_writes_full_agent_dir():
+    _isolated_home()
+    bundle = ApiPuffoBundle.from_dict(_valid_bundle_dict())
+    adir = materialise_agent_dir(bundle)
+
+    # agent.yml round-trips through AgentConfig.load.
+    cfg = AgentConfig.load(bundle.agent_slug)
+    assert cfg.display_name == "Cloud Bot"
+    assert cfg.role == "Cloud-hosted helper"
+    assert cfg.runtime.kind == "api-puffo"
+    assert cfg.runtime.provider == "anthropic"
+    assert cfg.runtime.model == "claude-sonnet-4-6"
+    assert cfg.puffo_core.server_url == "https://cloud.puffo.ai"
+    assert cfg.puffo_core.slug == bundle.agent_slug
+    assert cfg.puffo_core.operator_slug == "user-5678"
+
+    # profile.md has the soul body inside a # Soul section.
+    profile_md = (adir / "profile.md").read_text(encoding="utf-8")
+    assert "# Soul" in profile_md
+    assert "I help test the api-puffo runtime." in profile_md
+    # extract_soul_body round-trips faithfully.
+    from puffo_agent.portal.profile_sync import extract_soul_body
+    assert extract_soul_body(profile_md) == "I help test the api-puffo runtime."
+
+    # keystore loads back via ApiPuffoKeystore.
+    ks = ApiPuffoKeystore.for_agent(bundle.agent_slug)
+    assert ks.slug == bundle.agent_slug
+    assert ks.session_token == "tok_abcdef123456"
+    assert ks.puffo_cloud_server_url == "https://cloud.puffo.ai"
+    assert ks.kem_cert["device_id"] == "dev_cloud_xyz"
+
+
+def test_ingest_archives_bundle_after_provision():
+    home = _isolated_home()
+    bundle_path = install_dir() / "cloud-bot-1234.json"
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    bundle_path.write_text(
+        json.dumps(_valid_bundle_dict()), encoding="utf-8",
+    )
+
+    ok, msg = ingest_bundle(bundle_path)
+    assert ok, msg
+    assert msg.startswith("provisioned:")
+
+    # Original bundle moved to archived/, agent_dir created.
+    assert not bundle_path.exists()
+    assert agent_yml_path("cloud-bot-1234").exists()
+    archived = list((install_dir() / "archived").iterdir())
+    assert len(archived) == 1
+    assert archived[0].name.endswith("cloud-bot-1234.json")
+
+
+def test_ingest_skips_when_agent_already_provisioned():
+    _isolated_home()
+    # Pre-provision.
+    bundle = ApiPuffoBundle.from_dict(_valid_bundle_dict())
+    materialise_agent_dir(bundle)
+
+    # Drop a fresh bundle for the same slug; ingest should NOT clobber.
+    profile_md_before = (
+        agent_dir(bundle.agent_slug) / "profile.md"
+    ).read_text(encoding="utf-8")
+
+    bundle_path = install_dir() / "cloud-bot-1234.json"
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    raw2 = _valid_bundle_dict()
+    raw2["soul"] = "OVERWRITTEN SOUL"
+    bundle_path.write_text(json.dumps(raw2), encoding="utf-8")
+
+    ok, msg = ingest_bundle(bundle_path)
+    assert ok, msg
+    assert msg.startswith("already provisioned")
+
+    profile_md_after = (
+        agent_dir(bundle.agent_slug) / "profile.md"
+    ).read_text(encoding="utf-8")
+    assert profile_md_before == profile_md_after  # untouched
+    assert not bundle_path.exists()  # archived
+
+
+def test_sweep_install_dir_processes_all_pending():
+    _isolated_home()
+    install_dir().mkdir(parents=True, exist_ok=True)
+
+    for i in range(3):
+        slug = f"sweep-bot-{i:04d}"
+        raw = _valid_bundle_dict(slug=slug)
+        raw["device_id"] = f"dev_{i}"
+        (install_dir() / f"{slug}.json").write_text(
+            json.dumps(raw), encoding="utf-8",
+        )
+
+    n = sweep_install_dir()
+    assert n == 3
+    for i in range(3):
+        assert agent_yml_path(f"sweep-bot-{i:04d}").exists()

--- a/tests/test_api_puffo_bundle.py
+++ b/tests/test_api_puffo_bundle.py
@@ -1,5 +1,5 @@
 """api-puffo bundle ingestion: validates schema + materialises into
-the standard agent_dir layout."""
+the standard agent_dir layout. Thin-client model — no KEM fields."""
 
 from __future__ import annotations
 
@@ -36,14 +36,7 @@ def _valid_bundle_dict(slug: str = "cloud-bot-1234") -> dict:
     return {
         "agent_slug": slug,
         "operator_slug": "user-5678",
-        "device_id": "dev_cloud_xyz",
-        "kem_secret_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        "kem_cert": {
-            "type": "device_cert",
-            "version": 1,
-            "device_id": "dev_cloud_xyz",
-        },
-        "session_token": "tok_abcdef123456",
+        "sandbox_token": "sbx_abcdef123456",
         "puffo_cloud_server_url": "https://cloud.puffo.ai",
         "display_name": "Cloud Bot",
         "role": "Cloud-hosted helper",
@@ -61,14 +54,14 @@ def test_bundle_from_dict_round_trips():
     bundle = ApiPuffoBundle.from_dict(raw)
     assert bundle.agent_slug == "cloud-bot-1234"
     assert bundle.puffo_cloud_server_url == "https://cloud.puffo.ai"
-    assert bundle.session_token == "tok_abcdef123456"
+    assert bundle.sandbox_token == "sbx_abcdef123456"
     assert bundle.provider == "anthropic"
 
 
 def test_bundle_rejects_missing_fields():
     raw = _valid_bundle_dict()
-    del raw["session_token"]
-    with pytest.raises(ValueError, match="session_token"):
+    del raw["sandbox_token"]
+    with pytest.raises(ValueError, match="sandbox_token"):
         ApiPuffoBundle.from_dict(raw)
 
 
@@ -83,7 +76,6 @@ def test_materialise_writes_full_agent_dir():
     bundle = ApiPuffoBundle.from_dict(_valid_bundle_dict())
     adir = materialise_agent_dir(bundle)
 
-    # agent.yml round-trips through AgentConfig.load.
     cfg = AgentConfig.load(bundle.agent_slug)
     assert cfg.display_name == "Cloud Bot"
     assert cfg.role == "Cloud-hosted helper"
@@ -94,49 +86,37 @@ def test_materialise_writes_full_agent_dir():
     assert cfg.puffo_core.slug == bundle.agent_slug
     assert cfg.puffo_core.operator_slug == "user-5678"
 
-    # profile.md has the soul body inside a # Soul section.
     profile_md = (adir / "profile.md").read_text(encoding="utf-8")
     assert "# Soul" in profile_md
     assert "I help test the api-puffo runtime." in profile_md
-    # extract_soul_body round-trips faithfully.
     from puffo_agent.portal.profile_sync import extract_soul_body
     assert extract_soul_body(profile_md) == "I help test the api-puffo runtime."
 
-    # keystore loads back via ApiPuffoKeystore.
     ks = ApiPuffoKeystore.for_agent(bundle.agent_slug)
     assert ks.slug == bundle.agent_slug
-    assert ks.session_token == "tok_abcdef123456"
+    assert ks.sandbox_token == "sbx_abcdef123456"
     assert ks.puffo_cloud_server_url == "https://cloud.puffo.ai"
-    assert ks.kem_cert["device_id"] == "dev_cloud_xyz"
 
 
 def test_ingest_archives_bundle_after_provision():
-    home = _isolated_home()
+    _isolated_home()
     bundle_path = install_dir() / "cloud-bot-1234.json"
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
-    bundle_path.write_text(
-        json.dumps(_valid_bundle_dict()), encoding="utf-8",
-    )
+    bundle_path.write_text(json.dumps(_valid_bundle_dict()), encoding="utf-8")
 
     ok, msg = ingest_bundle(bundle_path)
     assert ok, msg
     assert msg.startswith("provisioned:")
-
-    # Original bundle moved to archived/, agent_dir created.
     assert not bundle_path.exists()
     assert agent_yml_path("cloud-bot-1234").exists()
     archived = list((install_dir() / "archived").iterdir())
     assert len(archived) == 1
-    assert archived[0].name.endswith("cloud-bot-1234.json")
 
 
 def test_ingest_skips_when_agent_already_provisioned():
     _isolated_home()
-    # Pre-provision.
     bundle = ApiPuffoBundle.from_dict(_valid_bundle_dict())
     materialise_agent_dir(bundle)
-
-    # Drop a fresh bundle for the same slug; ingest should NOT clobber.
     profile_md_before = (
         agent_dir(bundle.agent_slug) / "profile.md"
     ).read_text(encoding="utf-8")
@@ -150,26 +130,22 @@ def test_ingest_skips_when_agent_already_provisioned():
     ok, msg = ingest_bundle(bundle_path)
     assert ok, msg
     assert msg.startswith("already provisioned")
-
     profile_md_after = (
         agent_dir(bundle.agent_slug) / "profile.md"
     ).read_text(encoding="utf-8")
-    assert profile_md_before == profile_md_after  # untouched
-    assert not bundle_path.exists()  # archived
+    assert profile_md_before == profile_md_after
+    assert not bundle_path.exists()
 
 
 def test_sweep_install_dir_processes_all_pending():
     _isolated_home()
     install_dir().mkdir(parents=True, exist_ok=True)
-
     for i in range(3):
         slug = f"sweep-bot-{i:04d}"
         raw = _valid_bundle_dict(slug=slug)
-        raw["device_id"] = f"dev_{i}"
         (install_dir() / f"{slug}.json").write_text(
             json.dumps(raw), encoding="utf-8",
         )
-
     n = sweep_install_dir()
     assert n == 3
     for i in range(3):

--- a/tests/test_api_puffo_runner.py
+++ b/tests/test_api_puffo_runner.py
@@ -1,0 +1,301 @@
+"""api-puffo runner: envelope decrypt + LLM turn + tool dispatch.
+
+Uses an aiohttp TestServer as the mock cloud and drives one
+end-to-end turn — verifies decrypt → llm_complete → tool_use →
+dispatch_tool round-trips correctly."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.api_puffo.bundle import (
+    ApiPuffoBundle,
+    materialise_agent_dir,
+)
+from puffo_agent.agent.api_puffo.cloud_client import CloudHttpClient
+from puffo_agent.agent.api_puffo.tools import TOOL_SCHEMAS, dispatch_tool
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.message import (
+    EncryptInput,
+    RecipientDevice,
+    encrypt_message,
+)
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+
+def _isolated_home() -> str:
+    home = tempfile.mkdtemp(prefix="puffo-api-puffo-run-")
+    os.environ["PUFFO_AGENT_HOME"] = home
+    os.environ["PUFFO_HOME"] = home
+    Path(home, "agents").mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _make_bundle_with_real_kem(
+    agent_slug: str, cloud_url: str,
+) -> tuple[ApiPuffoBundle, KemKeyPair]:
+    kp = KemKeyPair.generate()
+    raw = {
+        "agent_slug": agent_slug,
+        "operator_slug": "user-test",
+        "device_id": "dev_test_cloud",
+        "kem_secret_key": base64url_encode(kp.secret_bytes()),
+        "kem_cert": {"type": "device_cert", "version": 1, "device_id": "dev_test_cloud"},
+        "session_token": "tok_test_xyz",
+        "puffo_cloud_server_url": cloud_url,
+        "display_name": "Test Bot",
+        "role": "tester: api-puffo runtime",
+        "role_short": "tester",
+        "soul": "I am the api-puffo end-to-end test bot.",
+        "avatar_url": "",
+        "api_key": "sk-mock",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+    }
+    return ApiPuffoBundle.from_dict(raw), kp
+
+
+# ── tool dispatch ────────────────────────────────────────────────
+
+
+def test_tool_schemas_cover_4_load_bearing_tools():
+    names = {t["name"] for t in TOOL_SCHEMAS}
+    assert names == {"send_message", "get_channel_history",
+                     "get_thread_history", "whoami"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_posts_to_cloud_endpoint():
+    received: list[tuple[str, dict]] = []
+
+    async def send_message(request: web.Request) -> web.Response:
+        received.append(("send_message", await request.json()))
+        return web.json_response({"text": "posted msg_xxxx"})
+
+    app = web.Application()
+    app.router.add_post("/v1/send_message", send_message)
+    async with TestClient(TestServer(app)) as client:
+        url = str(client.make_url(""))
+        http = CloudHttpClient(url, "tok_test")
+        try:
+            result = await dispatch_tool(http, "send_message", {
+                "channel": "@alice",
+                "text": "hello",
+                "is_visible_to_human": True,
+            })
+        finally:
+            await http.close()
+    assert result == "posted msg_xxxx"
+    assert len(received) == 1
+    name, body = received[0]
+    assert body == {"channel": "@alice", "text": "hello", "is_visible_to_human": True}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_returns_error_string_on_http_failure():
+    async def boom(request: web.Request) -> web.Response:
+        return web.json_response({"error": "nope"}, status=503)
+
+    app = web.Application()
+    app.router.add_post("/v1/whoami", boom)
+    async with TestClient(TestServer(app)) as client:
+        url = str(client.make_url(""))
+        http = CloudHttpClient(url, "tok_test")
+        try:
+            result = await dispatch_tool(http, "whoami", {})
+        finally:
+            await http.close()
+    assert result.startswith("error: HTTP 503")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_unknown_name():
+    http = CloudHttpClient("http://127.0.0.1:1", "tok_test")
+    try:
+        result = await dispatch_tool(http, "nonexistent_tool", {})
+    finally:
+        await http.close()
+    assert result == "error: unknown tool 'nonexistent_tool'"
+
+
+# ── runner end-to-end: decrypt + LLM turn + tool call ────────────
+
+
+@pytest.mark.asyncio
+async def test_runner_end_to_end_decrypt_llm_tool():
+    _isolated_home()
+
+    # Mock cloud: implements /v1/llm/complete + /v1/send_message.
+    llm_calls: list[dict] = []
+    tool_calls: list[dict] = []
+
+    async def llm_complete(request: web.Request) -> web.Response:
+        body = await request.json()
+        llm_calls.append(body)
+        msgs = body.get("messages") or []
+        last = msgs[-1] if msgs else {}
+        last_content = last.get("content")
+        # Round 2: tool_result came back → emit final text.
+        if isinstance(last_content, list) and any(
+            isinstance(c, dict) and c.get("type") == "tool_result"
+            for c in last_content
+        ):
+            return web.json_response({
+                "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "all done"}],
+            })
+        # Round 1: ask to call send_message.
+        return web.json_response({
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu_001",
+                    "name": "send_message",
+                    "input": {
+                        "channel": "@smoker",
+                        "text": "echo: hi",
+                        "is_visible_to_human": True,
+                    },
+                },
+            ],
+        })
+
+    async def send_message(request: web.Request) -> web.Response:
+        tool_calls.append(await request.json())
+        return web.json_response({"text": "posted msg_xxxx"})
+
+    app = web.Application()
+    app.router.add_post("/v1/llm/complete", llm_complete)
+    app.router.add_post("/v1/send_message", send_message)
+
+    async with TestClient(TestServer(app)) as client:
+        cloud_url = str(client.make_url("")).rstrip("/")
+
+        # Provision the api-puffo agent on disk using a bundle.
+        bundle, agent_kem = _make_bundle_with_real_kem(
+            agent_slug="rb-bot", cloud_url=cloud_url,
+        )
+        materialise_agent_dir(bundle)
+
+        # Build a fake inbound envelope from a foreign sender.
+        sender_signing = Ed25519KeyPair.generate()
+        device = RecipientDevice(
+            device_id=bundle.device_id,
+            kem_public_key=agent_kem.public_key_bytes(),
+        )
+        envelope = encrypt_message(
+            EncryptInput(
+                envelope_kind="dm",
+                sender_slug="smoker",
+                sender_subkey_id="subkey_test_001",
+                is_visible_to_human=True,
+                recipient_slug=bundle.agent_slug,
+                content_type="text/plain",
+                content="hi",
+                recipients=[device],
+            ),
+            sender_signing,
+        )
+
+        # Drive the runner one frame deep — skip the WS by calling
+        # ``_handle_envelope_frame`` directly.
+        from puffo_agent.agent.api_puffo.runner import ApiPuffoRunner
+        from puffo_agent.agent.api_puffo.keystore import ApiPuffoKeystore
+        from puffo_agent.crypto.primitives import KemKeyPair
+        from puffo_agent.crypto.encoding import base64url_decode
+        from puffo_agent.portal.state import AgentConfig
+
+        runner = ApiPuffoRunner("rb-bot", asyncio.Event())
+        runner._keys = ApiPuffoKeystore.for_agent("rb-bot")
+        runner._cfg = AgentConfig.load("rb-bot")
+        runner._kem_kp = KemKeyPair.from_secret_bytes(
+            base64url_decode(runner._keys.kem_secret_key),
+        )
+        runner._http = CloudHttpClient(cloud_url, runner._keys.session_token)
+        try:
+            await runner._handle_envelope_frame({
+                "type": "envelope",
+                "envelope": envelope,
+                "sender_signing_public_key": base64url_encode(
+                    sender_signing.public_key_bytes(),
+                ),
+            })
+        finally:
+            await runner._http.close()
+
+    # Two LLM rounds, one tool POST.
+    assert len(llm_calls) == 2
+    assert llm_calls[0]["provider"] == "anthropic"
+    assert llm_calls[0]["model"] == "claude-sonnet-4-6"
+    assert llm_calls[0]["api_key"] == "sk-mock"
+    assert "I am the api-puffo end-to-end test bot." in llm_calls[0]["system_prompt"]
+    assert llm_calls[0]["messages"][0]["content"] == "hi"
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["channel"] == "@smoker"
+    assert tool_calls[0]["text"] == "echo: hi"
+
+
+@pytest.mark.asyncio
+async def test_runner_skips_non_text_content_type():
+    _isolated_home()
+    # No mock cloud needed — the early return should fire before any
+    # HTTP traffic.
+    bundle, agent_kem = _make_bundle_with_real_kem(
+        agent_slug="nt-bot", cloud_url="http://127.0.0.1:1",
+    )
+    materialise_agent_dir(bundle)
+
+    sender_signing = Ed25519KeyPair.generate()
+    envelope = encrypt_message(
+        EncryptInput(
+            envelope_kind="dm",
+            sender_slug="smoker",
+            sender_subkey_id="subkey_test_002",
+            is_visible_to_human=True,
+            recipient_slug=bundle.agent_slug,
+            content_type="image/png",
+            content="binary blob placeholder",
+            recipients=[RecipientDevice(
+                device_id=bundle.device_id,
+                kem_public_key=agent_kem.public_key_bytes(),
+            )],
+        ),
+        sender_signing,
+    )
+
+    from puffo_agent.agent.api_puffo.runner import ApiPuffoRunner
+    from puffo_agent.agent.api_puffo.keystore import ApiPuffoKeystore
+    from puffo_agent.crypto.encoding import base64url_decode
+    from puffo_agent.portal.state import AgentConfig
+
+    runner = ApiPuffoRunner("nt-bot", asyncio.Event())
+    runner._keys = ApiPuffoKeystore.for_agent("nt-bot")
+    runner._cfg = AgentConfig.load("nt-bot")
+    runner._kem_kp = KemKeyPair.from_secret_bytes(
+        base64url_decode(runner._keys.kem_secret_key),
+    )
+    runner._http = CloudHttpClient("http://127.0.0.1:1", "tok")
+    try:
+        # Should NOT raise (we'd see ClientConnectorError if the
+        # runner tried to call _run_turn → llm_complete).
+        await runner._handle_envelope_frame({
+            "type": "envelope",
+            "envelope": envelope,
+            "sender_signing_public_key": base64url_encode(
+                sender_signing.public_key_bytes(),
+            ),
+        })
+    finally:
+        await runner._http.close()

--- a/tests/test_api_puffo_runner.py
+++ b/tests/test_api_puffo_runner.py
@@ -1,8 +1,9 @@
-"""api-puffo runner: envelope decrypt + LLM turn + tool dispatch.
+"""api-puffo runner: bridge WS protocol + LLM tool loop.
 
-Uses an aiohttp TestServer as the mock cloud and drives one
-end-to-end turn — verifies decrypt → llm_complete → tool_use →
-dispatch_tool round-trips correctly."""
+Spins up an aiohttp test server that speaks the real bridge wire
+protocol (BRIDGE-WIRE-PROTOCOL.md) — ``connected`` first frame,
+heartbeat-tolerant, ``send`` / ``fetch_pending`` / ``ack`` /
+``list_spaces`` handlers — and drives a full end-to-end turn."""
 
 from __future__ import annotations
 
@@ -11,10 +12,11 @@ import json
 import os
 import sys
 import tempfile
+import uuid
 from pathlib import Path
 
 import pytest
-from aiohttp import web
+from aiohttp import WSMsgType, web
 from aiohttp.test_utils import TestClient, TestServer
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -23,15 +25,12 @@ from puffo_agent.agent.api_puffo.bundle import (
     ApiPuffoBundle,
     materialise_agent_dir,
 )
-from puffo_agent.agent.api_puffo.cloud_client import CloudHttpClient
-from puffo_agent.agent.api_puffo.tools import TOOL_SCHEMAS, dispatch_tool
-from puffo_agent.crypto.encoding import base64url_encode
-from puffo_agent.crypto.message import (
-    EncryptInput,
-    RecipientDevice,
-    encrypt_message,
+from puffo_agent.agent.api_puffo.cloud_client import (
+    BridgeError,
+    CloudBridgeClient,
+    CloudLlmClient,
 )
-from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+from puffo_agent.agent.api_puffo.tools import dispatch_tool
 
 
 def _isolated_home() -> str:
@@ -42,103 +41,245 @@ def _isolated_home() -> str:
     return home
 
 
-def _make_bundle_with_real_kem(
-    agent_slug: str, cloud_url: str,
-) -> tuple[ApiPuffoBundle, KemKeyPair]:
-    kp = KemKeyPair.generate()
-    raw = {
-        "agent_slug": agent_slug,
+def _valid_bundle(slug: str, cloud_url: str) -> ApiPuffoBundle:
+    return ApiPuffoBundle.from_dict({
+        "agent_slug": slug,
         "operator_slug": "user-test",
-        "device_id": "dev_test_cloud",
-        "kem_secret_key": base64url_encode(kp.secret_bytes()),
-        "kem_cert": {"type": "device_cert", "version": 1, "device_id": "dev_test_cloud"},
-        "session_token": "tok_test_xyz",
+        "sandbox_token": "sbx_test_xyz",
         "puffo_cloud_server_url": cloud_url,
         "display_name": "Test Bot",
-        "role": "tester: api-puffo runtime",
+        "role": "tester",
         "role_short": "tester",
         "soul": "I am the api-puffo end-to-end test bot.",
         "avatar_url": "",
         "api_key": "sk-mock",
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
-    }
-    return ApiPuffoBundle.from_dict(raw), kp
+    })
 
 
-# ── tool dispatch ────────────────────────────────────────────────
+# ── tools.py shape ───────────────────────────────────────────────
 
 
-def test_tool_schemas_cover_4_load_bearing_tools():
+def test_tool_schemas_match_bridge_protocol_surface():
+    from puffo_agent.agent.api_puffo.tools import TOOL_SCHEMAS
     names = {t["name"] for t in TOOL_SCHEMAS}
-    assert names == {"send_message", "get_channel_history",
-                     "get_thread_history", "whoami"}
+    assert names == {"send_message", "list_spaces"}
+
+
+# ── Mock bridge ──────────────────────────────────────────────────
+
+
+class _MockBridgeApp:
+    """Minimal bridge that speaks the wire protocol just enough to
+    drive the runner. Holds a queue of pending messages + records
+    what the client sent."""
+
+    def __init__(self) -> None:
+        self.pending_messages: list[dict] = []
+        self.spaces_fixture: list[dict] = []
+        self.recv_send: list[dict] = []
+        self.recv_ack: list[dict] = []
+        self.token_seen: str | None = None
+
+    async def ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        self.token_seen = request.headers.get("x-sandbox-token")
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.send_json({"type": "connected"})
+        async for msg in ws:
+            if msg.type != WSMsgType.TEXT:
+                break
+            frame = json.loads(msg.data)
+            kind = frame.get("type", "")
+            if kind == "heartbeat":
+                continue
+            if kind == "send":
+                self.recv_send.append(frame)
+                await ws.send_json({
+                    "type": "ack",
+                    "client_ref": frame.get("client_ref"),
+                    "envelope_id": f"msg_{uuid.uuid4().hex[:8]}",
+                    "devices_queued": 2,
+                })
+            elif kind == "fetch_pending":
+                count = 0
+                while self.pending_messages:
+                    await ws.send_json(self.pending_messages.pop(0))
+                    count += 1
+                await ws.send_json({
+                    "type": "pending_delivered",
+                    "count": count,
+                    "more": False,
+                })
+            elif kind == "ack":
+                self.recv_ack.append(frame)
+                await ws.send_json({
+                    "type": "ack_result",
+                    "acked": len(frame.get("envelope_ids", [])),
+                })
+            elif kind == "list_spaces":
+                await ws.send_json({
+                    "type": "spaces",
+                    "spaces": self.spaces_fixture,
+                })
+        return ws
+
+
+def _build_app(bridge: _MockBridgeApp, llm_handler=None) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/v2/cloud-agents/subscribe", bridge.ws_handler)
+    if llm_handler is not None:
+        app.router.add_post("/v1/llm/complete", llm_handler)
+    return app
+
+
+# ── Bridge client ────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_dispatch_tool_posts_to_cloud_endpoint():
-    received: list[tuple[str, dict]] = []
-
-    async def send_message(request: web.Request) -> web.Response:
-        received.append(("send_message", await request.json()))
-        return web.json_response({"text": "posted msg_xxxx"})
-
-    app = web.Application()
-    app.router.add_post("/v1/send_message", send_message)
+async def test_bridge_connects_and_sends_x_sandbox_token_header():
+    bridge_app = _MockBridgeApp()
+    app = _build_app(bridge_app)
     async with TestClient(TestServer(app)) as client:
-        url = str(client.make_url(""))
-        http = CloudHttpClient(url, "tok_test")
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_test_abc", "agent-slug")
         try:
-            result = await dispatch_tool(http, "send_message", {
-                "channel": "@alice",
-                "text": "hello",
-                "is_visible_to_human": True,
+            await c.connect()
+        finally:
+            await c.close()
+    assert bridge_app.token_seen == "sbx_test_abc"
+
+
+@pytest.mark.asyncio
+async def test_bridge_send_send_correlates_ack_via_client_ref():
+    bridge_app = _MockBridgeApp()
+    app = _build_app(bridge_app)
+    async with TestClient(TestServer(app)) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        # Run the frame consumer in the background; ack correlation
+        # happens inside frames() before yielding non-correlated frames.
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            ack = await c.send_send(
+                plaintext="hi alice", recipient_slug="alice",
+            )
+        finally:
+            await c.close()
+            consumer.cancel()
+    assert ack["envelope_id"].startswith("msg_")
+    assert ack["devices_queued"] == 2
+    assert len(bridge_app.recv_send) == 1
+    sent = bridge_app.recv_send[0]
+    assert sent["plaintext"] == "hi alice"
+    assert sent["recipient_slug"] == "alice"
+    assert sent.get("client_ref")
+
+
+@pytest.mark.asyncio
+async def test_bridge_list_spaces_returns_fixture():
+    bridge_app = _MockBridgeApp()
+    bridge_app.spaces_fixture = [
+        {"space_id": "sp_1", "name": "Eng", "channels": [
+            {"channel_id": "ch_1", "name": "general"},
+        ]},
+    ]
+    app = _build_app(bridge_app)
+    async with TestClient(TestServer(app)) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            resp = await c.send_list_spaces()
+        finally:
+            await c.close()
+            consumer.cancel()
+    assert resp["spaces"] == bridge_app.spaces_fixture
+
+
+async def _drain(c: CloudBridgeClient) -> None:
+    try:
+        async for _ in c.frames():
+            pass
+    except Exception:
+        pass
+
+
+# ── dispatch_tool ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_send_message_dm():
+    bridge_app = _MockBridgeApp()
+    app = _build_app(bridge_app)
+    async with TestClient(TestServer(app)) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            result = await dispatch_tool(c, "send_message", {
+                "plaintext": "hi", "recipient_slug": "alice",
             })
         finally:
-            await http.close()
-    assert result == "posted msg_xxxx"
-    assert len(received) == 1
-    name, body = received[0]
-    assert body == {"channel": "@alice", "text": "hello", "is_visible_to_human": True}
+            await c.close()
+            consumer.cancel()
+    assert result.startswith("posted msg_")
+    assert len(bridge_app.recv_send) == 1
 
 
 @pytest.mark.asyncio
-async def test_dispatch_tool_returns_error_string_on_http_failure():
-    async def boom(request: web.Request) -> web.Response:
-        return web.json_response({"error": "nope"}, status=503)
+async def test_dispatch_tool_rejects_mixed_shape():
+    c = CloudBridgeClient("http://unused:1", "sbx", "slug")
+    # No connect — error fires client-side before any WS frame.
+    result = await dispatch_tool(c, "send_message", {
+        "plaintext": "hi",
+        "recipient_slug": "alice",
+        "space_id": "sp_1",
+        "channel_id": "ch_1",
+    })
+    assert result.startswith("error:")
+    assert "recipient_slug" in result
+    assert "space_id+channel_id" in result
 
-    app = web.Application()
-    app.router.add_post("/v1/whoami", boom)
-    async with TestClient(TestServer(app)) as client:
-        url = str(client.make_url(""))
-        http = CloudHttpClient(url, "tok_test")
-        try:
-            result = await dispatch_tool(http, "whoami", {})
-        finally:
-            await http.close()
-    assert result.startswith("error: HTTP 503")
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_rejects_missing_route():
+    c = CloudBridgeClient("http://unused:1", "sbx", "slug")
+    result = await dispatch_tool(c, "send_message", {"plaintext": "hi"})
+    assert result.startswith("error:")
+    assert "requires" in result
 
 
 @pytest.mark.asyncio
 async def test_dispatch_tool_unknown_name():
-    http = CloudHttpClient("http://127.0.0.1:1", "tok_test")
-    try:
-        result = await dispatch_tool(http, "nonexistent_tool", {})
-    finally:
-        await http.close()
+    c = CloudBridgeClient("http://unused:1", "sbx", "slug")
+    result = await dispatch_tool(c, "nonexistent_tool", {})
     assert result == "error: unknown tool 'nonexistent_tool'"
 
 
-# ── runner end-to-end: decrypt + LLM turn + tool call ────────────
+# ── End-to-end runner with real bridge + canned LLM ─────────────
 
 
 @pytest.mark.asyncio
-async def test_runner_end_to_end_decrypt_llm_tool():
+async def test_runner_end_to_end_message_llm_tool_ack():
     _isolated_home()
+    bridge_app = _MockBridgeApp()
+    # Inject a fake DM that will surface during the fetch_pending
+    # backfill on connect.
+    bridge_app.pending_messages.append({
+        "type": "message",
+        "envelope_id": "msg_inject_001",
+        "sender_slug": "smoker",
+        "recipient_slug": "rb-bot",
+        "sent_at": 0,
+        "plaintext": "hi",
+    })
 
-    # Mock cloud: implements /v1/llm/complete + /v1/send_message.
     llm_calls: list[dict] = []
-    tool_calls: list[dict] = []
 
     async def llm_complete(request: web.Request) -> web.Response:
         body = await request.json()
@@ -146,16 +287,14 @@ async def test_runner_end_to_end_decrypt_llm_tool():
         msgs = body.get("messages") or []
         last = msgs[-1] if msgs else {}
         last_content = last.get("content")
-        # Round 2: tool_result came back → emit final text.
         if isinstance(last_content, list) and any(
             isinstance(c, dict) and c.get("type") == "tool_result"
             for c in last_content
         ):
             return web.json_response({
                 "stop_reason": "end_turn",
-                "content": [{"type": "text", "text": "all done"}],
+                "content": [{"type": "text", "text": "done"}],
             })
-        # Round 1: ask to call send_message.
         return web.json_response({
             "stop_reason": "tool_use",
             "content": [
@@ -164,138 +303,51 @@ async def test_runner_end_to_end_decrypt_llm_tool():
                     "id": "tu_001",
                     "name": "send_message",
                     "input": {
-                        "channel": "@smoker",
-                        "text": "echo: hi",
-                        "is_visible_to_human": True,
+                        "plaintext": "echo: hi",
+                        "recipient_slug": "smoker",
                     },
                 },
             ],
         })
 
-    async def send_message(request: web.Request) -> web.Response:
-        tool_calls.append(await request.json())
-        return web.json_response({"text": "posted msg_xxxx"})
-
-    app = web.Application()
-    app.router.add_post("/v1/llm/complete", llm_complete)
-    app.router.add_post("/v1/send_message", send_message)
-
+    app = _build_app(bridge_app, llm_handler=llm_complete)
     async with TestClient(TestServer(app)) as client:
-        cloud_url = str(client.make_url("")).rstrip("/")
-
-        # Provision the api-puffo agent on disk using a bundle.
-        bundle, agent_kem = _make_bundle_with_real_kem(
-            agent_slug="rb-bot", cloud_url=cloud_url,
-        )
+        url = str(client.make_url("")).rstrip("/")
+        bundle = _valid_bundle(slug="rb-bot", cloud_url=url)
         materialise_agent_dir(bundle)
 
-        # Build a fake inbound envelope from a foreign sender.
-        sender_signing = Ed25519KeyPair.generate()
-        device = RecipientDevice(
-            device_id=bundle.device_id,
-            kem_public_key=agent_kem.public_key_bytes(),
-        )
-        envelope = encrypt_message(
-            EncryptInput(
-                envelope_kind="dm",
-                sender_slug="smoker",
-                sender_subkey_id="subkey_test_001",
-                is_visible_to_human=True,
-                recipient_slug=bundle.agent_slug,
-                content_type="text/plain",
-                content="hi",
-                recipients=[device],
-            ),
-            sender_signing,
-        )
-
-        # Drive the runner one frame deep — skip the WS by calling
-        # ``_handle_envelope_frame`` directly.
         from puffo_agent.agent.api_puffo.runner import ApiPuffoRunner
-        from puffo_agent.agent.api_puffo.keystore import ApiPuffoKeystore
-        from puffo_agent.crypto.primitives import KemKeyPair
-        from puffo_agent.crypto.encoding import base64url_decode
-        from puffo_agent.portal.state import AgentConfig
+        stop = asyncio.Event()
+        runner = ApiPuffoRunner("rb-bot", stop)
 
-        runner = ApiPuffoRunner("rb-bot", asyncio.Event())
-        runner._keys = ApiPuffoKeystore.for_agent("rb-bot")
-        runner._cfg = AgentConfig.load("rb-bot")
-        runner._kem_kp = KemKeyPair.from_secret_bytes(
-            base64url_decode(runner._keys.kem_secret_key),
-        )
-        runner._http = CloudHttpClient(cloud_url, runner._keys.session_token)
+        # Kick the runner; wait until the turn loop has finished
+        # both LLM rounds AND the tool send + ack landed, then stop.
+        run_task = asyncio.create_task(runner.run())
+        for _ in range(80):
+            await asyncio.sleep(0.1)
+            if (
+                len(llm_calls) >= 2
+                and bridge_app.recv_send
+                and bridge_app.recv_ack
+            ):
+                break
+        stop.set()
         try:
-            await runner._handle_envelope_frame({
-                "type": "envelope",
-                "envelope": envelope,
-                "sender_signing_public_key": base64url_encode(
-                    sender_signing.public_key_bytes(),
-                ),
-            })
-        finally:
-            await runner._http.close()
+            await asyncio.wait_for(run_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
 
-    # Two LLM rounds, one tool POST.
+    # 2 LLM rounds: initial (tool_use) + post-tool-result (end_turn).
     assert len(llm_calls) == 2
     assert llm_calls[0]["provider"] == "anthropic"
-    assert llm_calls[0]["model"] == "claude-sonnet-4-6"
-    assert llm_calls[0]["api_key"] == "sk-mock"
-    assert "I am the api-puffo end-to-end test bot." in llm_calls[0]["system_prompt"]
     assert llm_calls[0]["messages"][0]["content"] == "hi"
-    assert len(tool_calls) == 1
-    assert tool_calls[0]["channel"] == "@smoker"
-    assert tool_calls[0]["text"] == "echo: hi"
-
-
-@pytest.mark.asyncio
-async def test_runner_skips_non_text_content_type():
-    _isolated_home()
-    # No mock cloud needed — the early return should fire before any
-    # HTTP traffic.
-    bundle, agent_kem = _make_bundle_with_real_kem(
-        agent_slug="nt-bot", cloud_url="http://127.0.0.1:1",
+    # 1 tool send + 1 ack of the injected envelope.
+    assert len(bridge_app.recv_send) == 1
+    sent = bridge_app.recv_send[0]
+    assert sent["plaintext"] == "echo: hi"
+    assert sent["recipient_slug"] == "smoker"
+    assert any(
+        "msg_inject_001" in (a.get("envelope_ids") or [])
+        for a in bridge_app.recv_ack
     )
-    materialise_agent_dir(bundle)
-
-    sender_signing = Ed25519KeyPair.generate()
-    envelope = encrypt_message(
-        EncryptInput(
-            envelope_kind="dm",
-            sender_slug="smoker",
-            sender_subkey_id="subkey_test_002",
-            is_visible_to_human=True,
-            recipient_slug=bundle.agent_slug,
-            content_type="image/png",
-            content="binary blob placeholder",
-            recipients=[RecipientDevice(
-                device_id=bundle.device_id,
-                kem_public_key=agent_kem.public_key_bytes(),
-            )],
-        ),
-        sender_signing,
-    )
-
-    from puffo_agent.agent.api_puffo.runner import ApiPuffoRunner
-    from puffo_agent.agent.api_puffo.keystore import ApiPuffoKeystore
-    from puffo_agent.crypto.encoding import base64url_decode
-    from puffo_agent.portal.state import AgentConfig
-
-    runner = ApiPuffoRunner("nt-bot", asyncio.Event())
-    runner._keys = ApiPuffoKeystore.for_agent("nt-bot")
-    runner._cfg = AgentConfig.load("nt-bot")
-    runner._kem_kp = KemKeyPair.from_secret_bytes(
-        base64url_decode(runner._keys.kem_secret_key),
-    )
-    runner._http = CloudHttpClient("http://127.0.0.1:1", "tok")
-    try:
-        # Should NOT raise (we'd see ClientConnectorError if the
-        # runner tried to call _run_turn → llm_complete).
-        await runner._handle_envelope_frame({
-            "type": "envelope",
-            "envelope": envelope,
-            "sender_signing_public_key": base64url_encode(
-                sender_signing.public_key_bytes(),
-            ),
-        })
-    finally:
-        await runner._http.close()


### PR DESCRIPTION
## Summary

PR #102 was built against a placeholder cloud-server shape. The real `puffo-server/cloud_agent` (on the `dev` branch) ships a documented WS wire protocol — [`BRIDGE-WIRE-PROTOCOL.md`](https://github.com/puffo-ai/puffo-server/blob/dev/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md). The two diverge on every load-bearing decision:

| | placeholder (old) | real spec (this PR) |
|---|---|---|
| URL | `<base>/v1/ws/<slug>` | `<base>/v2/cloud-agents/subscribe` |
| Auth | `Authorization: Bearer …` | `x-sandbox-token: …` on the upgrade only |
| Client crypto | KEM secret + decrypt_message locally | **NONE** — server holds keys; frames are plaintext |
| Tools | HTTP POST per tool | All WS frames: `send` / `fetch_pending` / `ack` / `list_spaces` |
| Inbound | encrypted envelope + sender pubkey | `message` frame with `plaintext` already opened |
| Heartbeat | aiohttp default ping/pong | client-driven `heartbeat` every 30s; `HEARTBEAT_TIMEOUT_SECS = 90` server-side |
| On-connect | passive | wait `connected` → `fetch_pending` → drain → `ack` → main loop |

### What changes

**Bundle / keystore** drop `kem_secret_key` / `kem_cert` / `device_id`. Server resolves identity from `sandbox_token` on the WS upgrade alone.

**`cloud_client.py`** splits into:
- `CloudLlmClient` (HTTP `POST /v1/llm/complete`) — bridge spec is mute on LLM; this endpoint is the placeholder convention we already use, kept bearer-authed.
- `CloudBridgeClient` (WS) — implements the wire protocol end to end: `x-sandbox-token` upgrade header, first-frame `connected` handshake, 30s `heartbeat`, per-call ack correlation via `client_ref` UUID, `BridgeError` carrying server `code` + `message`.

**`runner.py`** — reader task + inbox worker task **decoupled**. The reader/worker split is the load-bearing fix: `send_send`'s ack arrives on the same WS the reader is pumping, so the reader must never block on LLM-turn work (else `dispatch_tool` deadlocks waiting for an ack the reader can't deliver). On-connect flow follows spec §5.4 exactly (backfill accumulator → `pending_delivered` batch ack → live mode → per-message ack).

**`tools.py`** trimmed to what the bridge spec supports day-1: `send_message` (DM via `recipient_slug` or channel via `space_id`+`channel_id`; we mirror the spec's one-shape-only rule client-side for a cleaner error string) and `list_spaces`. History / whoami tools come back when a later spec revision adds frames for them.

**Mock cloud server** (`scripts/api_puffo_mock_cloud.py`) — rewritten to speak the real wire protocol end-to-end so smoke testing doesn't depend on a live puffo-server.

---

## Smoke testing

### Path A — mock cloud (fully self-contained, recommended for CI / quick checks)

No puffo-server required. The repo ships `scripts/api_puffo_mock_cloud.py` that speaks the real wire protocol — handshake, heartbeat, send/ack correlation, fetch_pending drain, list_spaces, and a canned `/v1/llm/complete` that issues one `send_message` tool_use then end-turns.

1. **Start the mock cloud** (terminal 1, leave running):
   ```bash
   cd /path/to/puffo-agent
   PYTHONPATH=src python scripts/api_puffo_mock_cloud.py --port 9999
   ```
   You should see `starting mock cloud at 127.0.0.1:9999`.

2. **Drop a bundle** that points at the mock:
   ```bash
   mkdir -p ~/.puffo-agent/api-puffo-install
   cat > ~/.puffo-agent/api-puffo-install/smoke-bot-v2.json <<'JSON'
   {
     "agent_slug": "smoke-bot-v2",
     "operator_slug": "your-operator-slug",
     "sandbox_token": "sbx_smoke_v2_test_token",
     "puffo_cloud_server_url": "http://127.0.0.1:9999",
     "display_name": "Smoke Bot V2",
     "role": "smoke-tester: api-puffo runtime",
     "role_short": "smoke-tester",
     "soul": "I am the smoke test bot for api-puffo.",
     "avatar_url": "",
     "api_key": "sk-anything-the-mock-llm-ignores-it",
     "provider": "anthropic",
     "model": "claude-sonnet-4-6"
   }
   JSON
   ```

3. **Restart the daemon**:
   ```bash
   PYTHONPATH=src python -m puffo_agent.portal.cli stop --timeout 30
   PYTHONPATH=src python -m puffo_agent.portal.cli start --background --with-local-bridge
   ```
   Tail `~/.puffo-agent/background.log` for:
   - `api-puffo install: smoke-bot-v2.json — provisioned: smoke-bot-v2`
   - `agent smoke-bot-v2: starting worker`
   - `api-puffo runner smoke-bot-v2: started (cloud=http://127.0.0.1:9999)`

   In the mock cloud terminal:
   - `WS connect (x-sandbox-token=sbx_smoke_v2_test…)`
   - `sent: connected`
   - `recv: fetch_pending limit=None`
   - `sent: pending_delivered count=0 more=False`

4. **Inject a fake DM** into the agent (terminal 3):
   ```bash
   curl -X POST http://127.0.0.1:9999/_admin/inject \
     -H 'Content-Type: application/json' \
     -d '{"text": "hello smoke bot"}'
   ```
   You should see (mock cloud terminal):
   - `INJECTED live message → connected agent (text='hello smoke bot')`
   - `LLM /v1/llm/complete: provider=anthropic model=claude-sonnet-4-6 messages=1` (round 1)
   - `recv: send (... "plaintext": "echo: hello smoke bot", "recipient_slug": "smoker" ...)`
   - `LLM /v1/llm/complete: ... messages=3` (round 2 with the tool_result)
   - `recv: ack count=1`

5. **Tear down**:
   ```bash
   PYTHONPATH=src python -m puffo_agent.portal.cli stop
   # Ctrl-C the mock cloud terminal
   rm -rf ~/.puffo-agent/agents/smoke-bot-v2
   rm -f ~/.puffo-agent/api-puffo-install/archived/*smoke-bot-v2*
   ```

### Path B — real puffo-server locally (validates the actual wire bytes)

Needs the puffo-server `dev` branch + Docker + a cloud-agent provisioned through the cert-chain create flow.

1. **Bring up puffo-server locally** (per `LOCAL-DEV.md`):
   ```bash
   cd /path/to/puffo-server
   git checkout dev
   make local-up   # blocks until Postgres + LocalStack + KMS provision + migrations + server up
   make local-logs # follow in another terminal
   curl -i http://localhost:8080/v1/ping  # expect 200
   ```

2. **Provision a cloud-agent** via `POST /v2/cloud-agents` — the request body needs the operator's identity + an agent cert chain (identity / device / subkey) + a KMS-wrapped keystore. Server-side flow lives in `server/src/cloud_agent/create.rs`; the operator-side flow that mints all of this lives in puffo-cli / the web client and is out of scope here. **The response carries the `sandbox_token`** (`server/src/cloud_agent/repo.rs::mint_sandbox_token`, TTL `SANDBOX_CREDENTIAL_TTL_DAYS`) — drop that token + the agent's slug into the bundle below.

3. **Drop a bundle** pointing at `http://localhost:8080`:
   ```bash
   cat > ~/.puffo-agent/api-puffo-install/<agent-slug>.json <<'JSON'
   {
     "agent_slug": "<agent-slug-from-create-response>",
     "operator_slug": "<your-operator-slug>",
     "sandbox_token": "<sandbox_token-from-create-response>",
     "puffo_cloud_server_url": "http://localhost:8080",
     "display_name": "...",
     "role": "...",
     "role_short": "...",
     "soul": "...",
     "avatar_url": "",
     "api_key": "<your-anthropic-key>",
     "provider": "anthropic",
     "model": "claude-sonnet-4-6"
   }
   JSON
   ```

4. **Start the daemon + send a DM** from another identity (puffo-cli or web client). Watch `~/.puffo-agent/background.log`:
   - `api-puffo runner <slug>: started (cloud=http://localhost:8080)`
   - `api-puffo bridge: WS connected (slug=<slug>)` — confirms the `x-sandbox-token` upgrade was accepted
   - `api-puffo runner <slug>: backfill drained, entering main loop`
   - On inbound message: `api-puffo runner <slug>: turn (envelope_id=… sender=… N chars)` → eventually `turn complete (rounds=N, M chars)`
   - The cloud's `POST /v2/cloud-agents/.../messages` (or whatever the server-side test path exposes) shows the agent's reply landing.

5. **What an unhappy path looks like**:
   - `bridge error (HANDSHAKE: WS upgrade failed (status=401))` → bad / expired `sandbox_token`. Mint a new one via `POST /v2/cloud-agents`.
   - `bridge error (NO_SUBKEY: …)` on a tool send → agent has a keystore but no subkey yet; inbound still works. Spec §4.7.
   - `bridge error (DECRYPT_FAILED: …)` → server-side seal/open failed. Open a server log.
   - Repeated `bridge loop crashed … reconnect in N.Ns` → transport flap; expected if the cloud goes down. Backoff doubles to 30s then stays there.

---

## Test plan

- [x] `PYTHONPATH=src python -m pytest` — **1702 passed / 9 skipped**. 16 api-puffo tests: bundle round-trip + ingest + sweep (7), tool schemas + dispatch (4), bridge connect / send-ack correlation / list_spaces (3), runner end-to-end against the in-process mock (1). The e2e test drives the full `connect → fetch_pending → backfill → LLM round 1 → tool_use → send_send → ack → LLM round 2 → end_turn → ack envelope` path.
- [x] Live smoke (Path A): bundle drop + daemon restart → `api-puffo: ingested 1 new bundle(s)` + worker spawn + WS reconnect backoff (the mock wasn't running). No crashes.
- [ ] Live smoke (Path B) — needs an operator-side cert-chain provisioning flow. Will pair with whoever owns that to drive the first real round-trip.

## Out of scope (follow-ups)

- Per-thread conversation history — each `message` frame is one turn; persistent `messages.db` integration lands when the bridge gets a history-query frame.
- Audit log + status-reporter heartbeat parity with the cli-local workers.
- OpenAI / Google providers — cloud is expected to normalise across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
