### PR TITLE
credentials: refresh-token-free views + cross-platform refresh gate (1.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.7a1] — 2026-07-02
+
+Pre-release alpha for cross-platform validation of the daemon-owned
+credential refresh gate. Not for production. Semver note: `1.0.7a1`
+orders BEFORE `1.0.7` in pip's default resolver — install with
+`pip install --pre puffo-agent==1.0.7a1` to opt in.
+
+### Fixed
+
+- **Pre-delivery credential-refresh gate is now cross-platform.**
+  Before handing a message batch to a `cli-local` / `cli-docker`
+  claude agent, the worker blocks on the daemon's
+  `CredentialRefresher.ensure_fresh()` through the same single-writer
+  mutex the daemon uses internally. The gate was previously gated
+  behind `is_macos()` on the theory that Linux/Windows would win the
+  refresh race naturally through the shared symlinked host
+  credentials file — but Anthropic's rotating single-use refresh_token
+  semantics don't care about the OS: whenever N agents' claude
+  subprocesses read the same on-disk RT and POST refresh in parallel,
+  one wins, N-1 get `invalid_grant`. The macOS storm just made the
+  window wider (Keychain lookups + ACL prompts). Dropping the
+  `is_macos()` guard extends the same safety net to Linux and
+  Windows.
+- **Rotating-refresh-token silent-fail visibility.** If Anthropic
+  rotates the refresh_token but Claude Code's write of the new one
+  silently drops (both disk and Keychain retain the pre-rotation
+  token, revoked server-side), `claude --print` starts returning
+  401 `authentication_failed`. `CredentialRefresher._refresh_now`
+  now inspects the probe's stdout/stderr for that marker and, when
+  matched, flips `auth_failed` + DMs the operator with re-login
+  instructions instead of silently retrying every 120s.
+- **macOS: `KeychainBackend` falls through to the disk credentials
+  file when the Keychain entry is missing.** Claude Code 2.x under a
+  launchd session-context can silently fail Keychain writes while
+  still writing `~/.claude/.credentials.json` successfully. The
+  Keychain backend's `expires_in_seconds`, `refresh`, `bootstrap`,
+  `sync_to_agent`, and `poll_external_rotation` all now use the
+  disk file as a fallback.
+
+### Changed
+
+- **`ensure_fresh()` fans canonical credentials out to every
+  registered agent before returning True.** Closes the split-brain
+  window where the daemon's view is fresh but an agent's per-agent
+  credentials file is stale. `KeychainBackend.sync_to_agent` is now
+  idempotent — skips the atomic write when the target already matches
+  — so the fan-out from concurrent `ensure_fresh` callers stays cheap.
+
+### Added
+
+- **Verbose per-source credential-read logs.** `KeychainBackend`
+  now logs which source served each read (`source=cache` /
+  `source=keychain` / `source=disk`) at DEBUG level, plus WARN when
+  it falls through disk after a Keychain miss. Makes the
+  disk-vs-Keychain split-brain visible from the daemon log without
+  needing to attach a debugger.
+
 ## [1.0.6] — 2026-07-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.0.6"
+version = "1.0.7a1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.0.7a1"
+version = "1.0.7a2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -32,10 +32,10 @@ from ...mcp.config import (
 from ...portal.state import (
     agent_codex_user_dir,
     home_dir,
-    link_host_codex_auth,
-    link_host_credentials,
     read_host_codex_mcp_servers,
     seed_claude_home,
+    sync_host_codex_auth_view,
+    sync_host_credentials_view,
     sync_host_enabled_plugins,
     sync_host_mcp_servers,
     sync_host_plugins,
@@ -354,7 +354,7 @@ class LocalCLIAdapter(Adapter):
 
         # Always write config.toml — pins ``cli_auth_credentials_store``
         # to "file" so codex uses ``$CODEX_HOME/auth.json`` (not macOS
-        # Keychain) and our symlink/refresh model works. MCP section
+        # Keychain) and our credential-view/refresh model works. MCP section
         # only when puffo_core is configured. PUF-266: host's own MCP
         # entries from ``~/.codex/config.toml`` are merged in so the
         # agent inherits the operator's codex MCP catalog (the puffo
@@ -394,7 +394,7 @@ class LocalCLIAdapter(Adapter):
             **os.environ,
             "CODEX_HOME": str(codex_home),
         }
-        auth_mode = link_host_codex_auth(Path.home(), codex_home)
+        auth_mode = sync_host_codex_auth_view(Path.home(), codex_home)
         if auth_mode == "no-host-file":
             raise RuntimeError(
                 f"agent {self.agent_id!r}: codex needs auth — run "
@@ -986,8 +986,8 @@ class LocalCLIAdapter(Adapter):
             )
         # Seed the per-agent virtual $HOME on first use (settings,
         # .claude.json). Credentials are handled separately via
-        # link_host_credentials so every agent tracks the operator's
-        # live OAuth state.
+        # sync_host_credentials_view so every agent tracks the
+        # operator's live OAuth state.
         host_home = Path.home()
         self.agent_home_dir.mkdir(parents=True, exist_ok=True)
         seeded = seed_claude_home(host_home, self.agent_home_dir)
@@ -996,14 +996,14 @@ class LocalCLIAdapter(Adapter):
                 "agent %s: seeded per-agent virtual $HOME at %s from %s",
                 self.agent_id, self.agent_home_dir, host_home,
             )
-        # Symlink the agent's .credentials.json to the host's so
-        # every refresh is visible across agents. Falls back to copy
-        # on systems where symlinks aren't permitted; the daemon's
-        # CredentialRefresher post-tick view-sync (PUF-221) keeps the
-        # copy fresh.
-        mode = link_host_credentials(host_home, self.agent_home_dir)
+        # Write the agent's .credentials.json as a refresh-token-free
+        # view of the host's — the daemon is the only refresh-token
+        # holder, so agents can't race the single-use rotating token
+        # into a family revocation. The daemon's CredentialRefresher
+        # post-tick view-sync (PUF-221) keeps the view fresh.
+        mode = sync_host_credentials_view(host_home, self.agent_home_dir)
         logger.info(
-            "agent %s: shared host credentials (%s)",
+            "agent %s: wrote host credential view (%s)",
             self.agent_id, mode,
         )
         # One-way sync of host skills + MCP registrations. Runs

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -985,9 +985,7 @@ class LocalCLIAdapter(Adapter):
                 "or set ``PUFFO_CLAUDE_BIN=/abs/path/to/claude``."
             )
         # Seed the per-agent virtual $HOME on first use (settings,
-        # .claude.json). Credentials are handled separately via
-        # sync_host_credentials_view so every agent tracks the
-        # operator's live OAuth state.
+        # .claude.json). Credentials handled separately below.
         host_home = Path.home()
         self.agent_home_dir.mkdir(parents=True, exist_ok=True)
         seeded = seed_claude_home(host_home, self.agent_home_dir)
@@ -996,11 +994,8 @@ class LocalCLIAdapter(Adapter):
                 "agent %s: seeded per-agent virtual $HOME at %s from %s",
                 self.agent_id, self.agent_home_dir, host_home,
             )
-        # Write the agent's .credentials.json as a refresh-token-free
-        # view of the host's — the daemon is the only refresh-token
-        # holder, so agents can't race the single-use rotating token
-        # into a family revocation. The daemon's CredentialRefresher
-        # post-tick view-sync (PUF-221) keeps the view fresh.
+        # Refresh-token-free view; the daemon's refresher is the sole
+        # rotator. Post-tick view-sync keeps this file fresh.
         mode = sync_host_credentials_view(host_home, self.agent_home_dir)
         logger.info(
             "agent %s: wrote host credential view (%s)",

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -101,7 +101,7 @@ def write_codex_mcp_config(
 
     Always emits ``cli_auth_credentials_store = "file"`` so codex
     reads/writes ``$CODEX_HOME/auth.json`` instead of macOS Keychain
-    (the daemon's ``CodexFileBackend`` + ``link_host_codex_auth``
+    (the daemon's ``CodexFileBackend`` + ``sync_host_codex_auth_view``
     only work in file-mode auth).
 
     Emits ``[mcp_servers.<name>]`` for the puffo_core stdio server

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -766,7 +766,7 @@ def cmd_agent_refresh_token(args: argparse.Namespace) -> int:
     Writes the ``refresh-token`` flag file; the daemon picks it up
     on its next reconcile tick, wakes the credential refresher, runs
     one ``claude --print "ok"`` against the host credentials, and
-    fans ``link_host_credentials`` to every registered agent home.
+    fans ``sync_host_credentials_view`` to every registered agent home.
     Single writer (daemon) = no multi-process race on Anthropic's
     single-use refresh tokens.
     """

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -789,6 +789,29 @@ class CredentialRefresher:
     def expires_in_seconds(self) -> int | None:
         return self.backend.expires_in_seconds()
 
+    async def ensure_fresh(self) -> bool:
+        """Blocking version of the refresh path: return True iff the
+        backend currently has a credential with >0s remaining. Uses
+        the same single-writer mutex + re-check-after-lock pattern as
+        ``_refresh_now``, so N concurrent callers coalesce into one
+        backend.refresh() per actually-expired credential.
+
+        ``by_agent=False`` so ``_refresh_now``'s post-lock re-check
+        fires — N concurrent ensure_fresh() callers see "another
+        caller already refreshed" and return without re-invoking the
+        backend.
+
+        Intended for pre-delivery gating: a Worker calls this right
+        before handing a batch to its adapter, and skips the dispatch
+        if False so the agent's own claude never has to discover the
+        401 itself."""
+        expires = self.expires_in_seconds()
+        if expires is not None and expires > REFRESH_SAFETY_MARGIN_SECONDS:
+            return True
+        await self._refresh_now(expires_in=expires, by_agent=False)
+        expires = self.expires_in_seconds()
+        return expires is not None and expires > 0
+
     async def run_loop(self, stop_event: asyncio.Event) -> None:
         """Main daemon coroutine. Polls every REFRESH_POLL_SECONDS or
         wakes early when an agent reports a 401. macOS backend also

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from typing import Callable, Optional, Protocol
 
 from .._proc import no_window_kwargs
+from ..agent._auth_markers import looks_like_auth_error
 from .state import link_host_codex_auth, link_host_credentials
 
 
@@ -160,6 +161,22 @@ def _classify_failed_refresh(
     # state change, so it should latch even when the response also
     # happens to look rate-limit-shaped.
     _maybe_disable_probe_model(out_tail, err_tail)
+    # Auth-failed BEFORE rate-limit: Anthropic sometimes hands back a
+    # 401 with rate-limit-adjacent phrasing on rotated-and-revoked
+    # refresh_tokens (the "rotating-refresh-token silent-fail" mode —
+    # both disk and Keychain retain the pre-rotation token). The
+    # refresher can't recover from that; only the operator's re-login
+    # can. Flag as AUTH_FAILED so the worker's DM path fires now
+    # instead of on the 2-tick refresh_broken streak.
+    if looks_like_auth_error(out_tail) or looks_like_auth_error(err_tail):
+        logger.error(
+            "%s auth failed rc=%d in %.1fs — refresh_token likely "
+            "revoked (probable rotating-refresh-token silent-fail); "
+            "operator needs to `claude auth login` | "
+            "stdout: %s | stderr: %s",
+            log_prefix, rc, elapsed, out_tail, err_tail,
+        )
+        return RefreshOutcome.AUTH_FAILED
     if _looks_like_rate_limit(out_tail, err_tail):
         logger.warning(
             "%s rate-limited rc=%d in %.1fs | stdout: %s | stderr: %s",
@@ -238,6 +255,10 @@ class RefreshOutcome(enum.Enum):
     # Counts toward refresh_broken streak like FAILED but additionally
     # schedules a fast retry (RATE_LIMIT_FAST_RETRY_{MIN,MAX}_SECONDS).
     RATE_LIMITED = "rate_limited"
+    # Anthropic rejected the refresh_token (401 / invalid_grant). Flips
+    # ``auth_failed`` immediately (no 2-tick streak, no fast retry) so
+    # the worker's operator-DM path fires — the loop can't self-recover.
+    AUTH_FAILED = "auth_failed"
 
 
 class CredentialBackend(Protocol):
@@ -565,12 +586,18 @@ class KeychainBackend:
         """Cache → Keychain → disk file. The disk fallthrough handles
         macOS hosts where Claude Code's Keychain write silently fails
         under launchd session-context but the disk file at
-        ``~/.claude/.credentials.json`` still gets written."""
+        ``~/.claude/.credentials.json`` still gets written.
+
+        Logs which source served the read at DEBUG so a split-brain is
+        visible in the daemon log — matches the log axis in the
+        kai-8670-da37 disk-flip proposal."""
         from ..macos.keychain import read_keychain_blob
 
         expires_at = self.cache.expires_at_seconds()
         if expires_at is not None:
-            return int(expires_at - time.time())
+            secs = int(expires_at - time.time())
+            logger.debug("keychain-backend expires_in read: source=cache secs=%d", secs)
+            return secs
         kr = read_keychain_blob()
         if kr.ok and kr.blob:
             try:
@@ -580,16 +607,37 @@ class KeychainBackend:
                     self.cache.write(kr.blob)
                 except OSError:
                     pass
-                return int(ms / 1000 - time.time())
+                secs = int(ms / 1000 - time.time())
+                logger.debug(
+                    "keychain-backend expires_in read: source=keychain secs=%d",
+                    secs,
+                )
+                return secs
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
         disk_blob = _read_disk_credentials_blob(Path.home())
         if disk_blob is not None:
+            logger.warning(
+                "keychain-backend expires_in read: falling through to disk "
+                "file (Keychain miss: %s)",
+                kr.error if not kr.ok else "unparseable-blob",
+            )
             try:
                 self.cache.write(disk_blob)
             except OSError:
                 pass
-        return _disk_expires_in_seconds(Path.home())
+        else:
+            logger.warning(
+                "keychain-backend expires_in read: neither Keychain (%s) "
+                "nor disk file readable",
+                kr.error if not kr.ok else "unparseable-blob",
+            )
+        secs = _disk_expires_in_seconds(Path.home())
+        if secs is not None:
+            logger.debug(
+                "keychain-backend expires_in read: source=disk secs=%d", secs,
+            )
+        return secs
 
     async def refresh(self) -> RefreshOutcome:
         from ..macos.keychain import read_keychain_blob
@@ -697,9 +745,16 @@ class KeychainBackend:
         works even when the Keychain entry is missing. Idempotent —
         skips the write when the target already matches, so fan-out
         from concurrent ``ensure_fresh`` callers stays cheap."""
-        blob = self.cache.read() or _read_disk_credentials_blob(Path.home())
+        cache_blob = self.cache.read()
+        blob = cache_blob or _read_disk_credentials_blob(Path.home())
         if not blob:
             return
+        if cache_blob is None:
+            logger.debug(
+                "keychain-backend sync_to_agent: source=disk (cache empty) "
+                "target=%s",
+                agent_home,
+            )
         agent_claude = agent_home / ".claude"
         target = agent_claude / ".credentials.json"
         try:
@@ -729,18 +784,30 @@ class KeychainBackend:
         ok, reason = bootstrap_from_keychain(self.cache)
         if ok:
             self._last_propagated_blob = self.cache.read()
+            logger.info(
+                "keychain-backend bootstrap: source=keychain reason=%s", reason,
+            )
             return (ok, reason)
         # Keychain bootstrap failed — fall through to disk file so the
         # daemon can still serve agents on hosts where Claude Code's
         # Keychain write silently fails (launchd session-context).
         disk_blob = _read_disk_credentials_blob(Path.home())
         if disk_blob is None:
+            logger.warning(
+                "keychain-backend bootstrap: no Keychain (%s) and no "
+                "disk file — operator needs to `claude auth login`",
+                reason,
+            )
             return (False, reason)
         try:
             self.cache.write(disk_blob)
         except OSError as exc:
             return (False, f"{reason}; disk-fallback cache write: {exc}")
         self._last_propagated_blob = disk_blob
+        logger.warning(
+            "keychain-backend bootstrap: source=disk (Keychain miss: %s)",
+            reason,
+        )
         return (True, f"{reason}; using disk-file fallback")
 
     async def poll_external_rotation(self) -> bool:
@@ -1071,6 +1138,14 @@ class CredentialRefresher:
             self._clear_refresh_broken()
             self._consecutive_non_success = 0
             return
+        if outcome is RefreshOutcome.AUTH_FAILED:
+            # Skip the 2-tick refresh_broken streak: Anthropic revoked
+            # the refresh_token, so continued 120s retries just log the
+            # same 401. Flip agents directly to ``auth_failed`` so the
+            # worker's DM path surfaces re-login instructions to the
+            # operator.
+            self._flip_auth_failed()
+            return
         self._consecutive_non_success += 1
         if self._consecutive_non_success >= REFRESH_BROKEN_THRESHOLD:
             self._flip_refresh_broken(outcome)
@@ -1162,6 +1237,45 @@ class CredentialRefresher:
             except Exception as exc:
                 logger.warning(
                     "refresh_broken clear: failed to save runtime for %s: %s",
+                    agent_id, exc,
+                )
+
+    def _flip_auth_failed(self) -> None:
+        """AUTH_FAILED outcome — Anthropic revoked the refresh_token
+        (rotating-refresh-token silent-fail). Flip every registered
+        agent that isn't already in a terminal state so the worker's
+        auth_failed DM path fires with re-login instructions. Refresh
+        counter untouched so a subsequent RATE_LIMITED / FAILED tick
+        still tracks its own streak."""
+        from .state import RuntimeState
+        msg = (
+            "Anthropic rejected the refresh_token (probable rotating-"
+            "refresh-token silent-fail — the on-disk token was revoked "
+            "server-side but the new one was silently dropped). Run "
+            "`claude auth login` on this host to re-authorise, then "
+            "send the agent a message to recover."
+        )
+        for agent_home in self._agent_homes:
+            agent_id = Path(agent_home).name
+            try:
+                rs = RuntimeState.load(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "auth_failed flip: failed to load runtime for %s: %s",
+                    agent_id, exc,
+                )
+                continue
+            if rs is None:
+                continue
+            if rs.health in ("auth_failed", "api_error_abandoned", "in_progress"):
+                continue
+            rs.health = "auth_failed"
+            rs.error = msg
+            try:
+                rs.save(agent_id)
+            except Exception as exc:
+                logger.warning(
+                    "auth_failed flip: failed to save runtime for %s: %s",
                     agent_id, exc,
                 )
 

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -19,10 +19,11 @@ all platform specifics to a pluggable ``CredentialBackend``:
   - ``FileBackend`` (Linux / Windows): host file
     ``~/.claude/.credentials.json`` is the canonical store; refresh
     spawns ``claude --print`` with ``HOME=host_home`` so the atomic
-    tmp+rename lands at the host file; per-agent sync is a symlink (or
-    copy fallback) via ``link_host_credentials``. External rotation
-    (operator running ``claude /login``) propagates atomically through
-    the symlink — no poll needed.
+    tmp+rename lands at the host file; per-agent sync writes a
+    refresh-token-free view copy via ``sync_host_credentials_view``
+    (only the daemon holds the rotating refresh token). External
+    rotation (operator running ``claude /login``) is spotted by the
+    per-tick host-file fingerprint check and fanned out to the views.
   - ``KeychainBackend`` (macOS): Keychain is the canonical store
     (Claude Code 2.x). The daemon maintains a cache at
     ``~/.puffo-agent/run/claude-credentials.json``; refresh runs a
@@ -62,7 +63,11 @@ from typing import Callable, Optional, Protocol
 
 from .._proc import no_window_kwargs
 from ..agent._auth_markers import looks_like_auth_error
-from .state import link_host_codex_auth, link_host_credentials
+from .state import (
+    sanitize_claude_credentials_blob,
+    sync_host_codex_auth_view,
+    sync_host_credentials_view,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -301,11 +306,14 @@ class FileBackend:
     """Host-file-canonical backend used on Linux and Windows. The host
     ``~/.claude/.credentials.json`` is the single source of truth;
     every agent's ``<agent_home>/.claude/.credentials.json`` is a
-    symlink (or copy fallback) onto it via ``link_host_credentials``.
+    sanitized view copy (host blob minus the rotating refresh token)
+    written by ``sync_host_credentials_view``. Only the daemon can
+    rotate, so concurrent agent processes can't race the (single-use)
+    refresh token into a family revocation.
 
-    External rotation (operator running ``claude /login``) propagates
-    atomically through the symlink, so no external-poll is needed
-    beyond the refresher's 2-minute ``expires_in`` poll.
+    External rotation (operator running ``claude /login``) is spotted
+    by the refresher's per-tick ``fingerprint`` check on the host file
+    and fanned out to the views within one 2-minute poll.
     """
     host_home: Path
 
@@ -382,7 +390,7 @@ class FileBackend:
         return RefreshOutcome.REFRESHED
 
     def sync_to_agent(self, agent_home: Path) -> None:
-        link_host_credentials(self.host_home, agent_home)
+        sync_host_credentials_view(self.host_home, agent_home)
 
     def fingerprint(self) -> tuple[int, int] | None:
         """(mtime_ns, size) of the host credential. Lets the refresher
@@ -418,8 +426,9 @@ class CodexFileBackend:
     long-running ``codex app-server`` would, rotates the OAuth bundle
     if stale, and writes back atomically to auth.json.
 
-    Per-agent sync is a symlink (or copy fallback on Windows
-    non-developer-mode) via ``link_host_codex_auth``.
+    Per-agent sync writes a refresh-token-blanked view copy via
+    ``sync_host_codex_auth_view`` — same single-rotator rationale as
+    ``FileBackend``.
     """
     host_home: Path
 
@@ -516,7 +525,7 @@ class CodexFileBackend:
         # agents to avoid cluttering them with a stray auth.json.
         if not agent_codex_home.exists():
             return
-        link_host_codex_auth(self.host_home, agent_codex_home)
+        sync_host_codex_auth_view(self.host_home, agent_codex_home)
 
     def fingerprint(self) -> tuple[int, int] | None:
         """(mtime_ns, size) of the host codex auth — external-rotation
@@ -740,11 +749,12 @@ class KeychainBackend:
         return RefreshOutcome.REFRESHED
 
     def sync_to_agent(self, agent_home: Path) -> None:
-        """Atomic-write the canonical blob to the agent's per-agent
-        ``.credentials.json``. Cache → disk file fallthrough so this
-        works even when the Keychain entry is missing. Idempotent —
-        skips the write when the target already matches, so fan-out
-        from concurrent ``ensure_fresh`` callers stays cheap."""
+        """Atomic-write the sanitized (refresh-token-free) view of the
+        canonical blob to the agent's per-agent ``.credentials.json``.
+        Cache → disk file fallthrough so this works even when the
+        Keychain entry is missing. Idempotent — skips the write when
+        the target already matches, so fan-out from concurrent
+        ``ensure_fresh`` callers stays cheap."""
         cache_blob = self.cache.read()
         blob = cache_blob or _read_disk_credentials_blob(Path.home())
         if not blob:
@@ -755,17 +765,27 @@ class KeychainBackend:
                 "target=%s",
                 agent_home,
             )
+        view_blob = sanitize_claude_credentials_blob(blob)
+        if view_blob is None:
+            logger.warning(
+                "keychain backend: canonical blob unparseable; not "
+                "syncing to %s",
+                agent_home,
+            )
+            return
         agent_claude = agent_home / ".claude"
         target = agent_claude / ".credentials.json"
         try:
-            if target.read_text(encoding="utf-8") == blob:
+            if not target.is_symlink() and (
+                target.read_text(encoding="utf-8") == view_blob
+            ):
                 return
         except OSError:
             pass
         try:
             agent_claude.mkdir(parents=True, exist_ok=True)
             tmp = agent_claude / f".{target.name}.tmp.{os.getpid()}"
-            tmp.write_text(blob, encoding="utf-8")
+            tmp.write_text(view_blob, encoding="utf-8")
             try:
                 import stat as _stat
                 tmp.chmod(_stat.S_IRUSR | _stat.S_IWUSR)

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -201,6 +201,35 @@ def _jwt_exp_unix(token: str) -> int | None:
     return int(exp)
 
 
+def _read_disk_credentials_blob(host_home: Path) -> Optional[str]:
+    """Read ``<host_home>/.claude/.credentials.json`` as a raw blob.
+    None on missing / unreadable / non-JSON. Used as the macOS
+    fallback when Claude Code's Keychain write silently fails under
+    launchd session-context but the disk file still gets written."""
+    path = host_home / ".claude" / ".credentials.json"
+    try:
+        blob = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        json.loads(blob)
+    except ValueError:
+        return None
+    return blob
+
+
+def _disk_expires_in_seconds(host_home: Path) -> Optional[int]:
+    blob = _read_disk_credentials_blob(host_home)
+    if blob is None:
+        return None
+    try:
+        data = json.loads(blob)
+        ms = int((data.get("claudeAiOauth") or {}).get("expiresAt"))
+    except (ValueError, TypeError):
+        return None
+    return int(ms / 1000 - time.time())
+
+
 class RefreshOutcome(enum.Enum):
     """Result of a single backend refresh attempt."""
     REFRESHED = "refreshed"
@@ -533,48 +562,43 @@ class KeychainBackend:
         self._last_propagated_blob: Optional[str] = None
 
     def expires_in_seconds(self) -> int | None:
-        """Pull expiry from the cache first (hot path; no subprocess).
-        Cache miss → fall back to a Keychain read so the daemon's
-        first-tick decision isn't blocked on bootstrap completion."""
-        # Lazy import to keep the module-level import graph light.
+        """Cache → Keychain → disk file. The disk fallthrough handles
+        macOS hosts where Claude Code's Keychain write silently fails
+        under launchd session-context but the disk file at
+        ``~/.claude/.credentials.json`` still gets written."""
         from ..macos.keychain import read_keychain_blob
 
         expires_at = self.cache.expires_at_seconds()
         if expires_at is not None:
             return int(expires_at - time.time())
-        # Cache miss — try Keychain. Don't write the cache here; that's
-        # ``bootstrap``'s job. We only want a TTL value.
         kr = read_keychain_blob()
-        if not kr.ok or not kr.blob:
-            return None
-        try:
-            data = json.loads(kr.blob)
-            ms = int((data.get("claudeAiOauth") or {}).get("expiresAt"))
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return None
-        # Opportunistically warm the cache so subsequent ticks are fast.
-        try:
-            self.cache.write(kr.blob)
-        except OSError:
-            pass
-        return int(ms / 1000 - time.time())
+        if kr.ok and kr.blob:
+            try:
+                data = json.loads(kr.blob)
+                ms = int((data.get("claudeAiOauth") or {}).get("expiresAt"))
+                try:
+                    self.cache.write(kr.blob)
+                except OSError:
+                    pass
+                return int(ms / 1000 - time.time())
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+        disk_blob = _read_disk_credentials_blob(Path.home())
+        if disk_blob is not None:
+            try:
+                self.cache.write(disk_blob)
+            except OSError:
+                pass
+        return _disk_expires_in_seconds(Path.home())
 
     async def refresh(self) -> RefreshOutcome:
         from ..macos.keychain import read_keychain_blob
 
-        # Snapshot Keychain before claude runs so we can byte-compare
-        # after. Cache.read() is not enough — agent processes may have
-        # rotated Keychain externally between ticks and the cache is a
-        # lagging mirror.
+        host_home = Path.home()
         kr_before = read_keychain_blob()
         before_blob = kr_before.blob if kr_before.ok else None
+        disk_before = _read_disk_credentials_blob(host_home)
 
-        # Real user HOME — claude reads Keychain, refreshes if expired,
-        # writes back to Keychain. Identical pattern to FileBackend.
-        # cwd=host_home so claude's project-resolution lands in the
-        # operator's normal working dir (matches single-process /login
-        # UX) instead of wherever the daemon was launched from.
-        host_home = Path.home()
         env = {**os.environ, "HOME": str(host_home)}
         cmd = _build_probe_cmd()
         started = time.time()
@@ -612,56 +636,79 @@ class KeychainBackend:
                 log_prefix="claude credential refresh",
             )
 
-        # Pull the post-refresh blob straight from Keychain — that's
-        # where claude wrote it. Then sync our cache so agent fan-out
-        # has fresh bytes.
         kr_after = read_keychain_blob()
-        if not kr_after.ok or not kr_after.blob:
+        if kr_after.ok and kr_after.blob:
+            try:
+                self.cache.write(kr_after.blob)
+            except OSError as exc:
+                logger.warning(
+                    "claude credential refresh: cache write failed: %s", exc,
+                )
+            if before_blob is not None and before_blob == kr_after.blob:
+                logger.info(
+                    "claude credential refresh ok in %.1fs but Keychain "
+                    "unchanged — token was still fresh; claude skipped the "
+                    "OAuth round-trip",
+                    elapsed,
+                )
+                return RefreshOutcome.UNCHANGED
+            self._last_propagated_blob = kr_after.blob
+            logger.info(
+                "claude credential refresh ok in %.1fs (Keychain rotated)",
+                elapsed,
+            )
+            return RefreshOutcome.REFRESHED
+
+        # Keychain post-refresh read failed — fall through to disk file.
+        # Claude Code 2.x may write the disk file successfully even when
+        # the Keychain write silently fails under launchd session-context.
+        disk_after = _read_disk_credentials_blob(host_home)
+        if disk_after is None:
             logger.warning(
-                "claude credential refresh exit=0 but Keychain re-read "
-                "failed (%s); cache untouched",
+                "claude credential refresh exit=0 but neither Keychain "
+                "(%s) nor disk file is readable; cache untouched",
                 kr_after.error,
             )
             return RefreshOutcome.FAILED
         try:
-            self.cache.write(kr_after.blob)
+            self.cache.write(disk_after)
         except OSError as exc:
             logger.warning(
                 "claude credential refresh: cache write failed: %s", exc,
             )
-
-        # Byte-compare the Keychain blob before and after. Anything
-        # else (e.g. comparing int(expires_in_seconds)) loses
-        # sub-second resolution to time.time()'s fractional part.
-        if before_blob is not None and before_blob == kr_after.blob:
+        if disk_before is not None and disk_before == disk_after:
             logger.info(
-                "claude credential refresh ok in %.1fs but Keychain "
-                "unchanged — token was still fresh; claude skipped the "
-                "OAuth round-trip",
+                "claude credential refresh ok in %.1fs (Keychain dead; "
+                "disk file unchanged — token was still fresh)",
                 elapsed,
             )
             return RefreshOutcome.UNCHANGED
-
-        self._last_propagated_blob = kr_after.blob
+        self._last_propagated_blob = disk_after
         logger.info(
-            "claude credential refresh ok in %.1fs (Keychain rotated)",
+            "claude credential refresh ok in %.1fs (Keychain dead; "
+            "disk file rotated)",
             elapsed,
         )
         return RefreshOutcome.REFRESHED
 
     def sync_to_agent(self, agent_home: Path) -> None:
-        """Atomic-write the cache blob to the agent's per-agent
-        ``.credentials.json``. No symlinking — Keychain ACL is on UID
-        + signing identity, not HOME, so a symlink to the host file
-        gives no benefit and the per-agent file diverges anyway when
-        claude self-refreshes inside the agent's process."""
-        blob = self.cache.read()
+        """Atomic-write the canonical blob to the agent's per-agent
+        ``.credentials.json``. Cache → disk file fallthrough so this
+        works even when the Keychain entry is missing. Idempotent —
+        skips the write when the target already matches, so fan-out
+        from concurrent ``ensure_fresh`` callers stays cheap."""
+        blob = self.cache.read() or _read_disk_credentials_blob(Path.home())
         if not blob:
             return
         agent_claude = agent_home / ".claude"
+        target = agent_claude / ".credentials.json"
+        try:
+            if target.read_text(encoding="utf-8") == blob:
+                return
+        except OSError:
+            pass
         try:
             agent_claude.mkdir(parents=True, exist_ok=True)
-            target = agent_claude / ".credentials.json"
             tmp = agent_claude / f".{target.name}.tmp.{os.getpid()}"
             tmp.write_text(blob, encoding="utf-8")
             try:
@@ -682,28 +729,42 @@ class KeychainBackend:
         ok, reason = bootstrap_from_keychain(self.cache)
         if ok:
             self._last_propagated_blob = self.cache.read()
-        return (ok, reason)
+            return (ok, reason)
+        # Keychain bootstrap failed — fall through to disk file so the
+        # daemon can still serve agents on hosts where Claude Code's
+        # Keychain write silently fails (launchd session-context).
+        disk_blob = _read_disk_credentials_blob(Path.home())
+        if disk_blob is None:
+            return (False, reason)
+        try:
+            self.cache.write(disk_blob)
+        except OSError as exc:
+            return (False, f"{reason}; disk-fallback cache write: {exc}")
+        self._last_propagated_blob = disk_blob
+        return (True, f"{reason}; using disk-file fallback")
 
     async def poll_external_rotation(self) -> bool:
-        """Read Keychain and compare to the last-propagated blob.
-        Returns True when a rotation was detected and the cache was
-        updated; the caller (``CredentialRefresher``) then fans the
-        new blob to every registered agent via ``_sync_views``.
-        """
+        """Detect a token rotation (Keychain or disk file) since the
+        last fan-out. Returns True when the canonical blob changed and
+        the cache was updated; the caller fans out via ``_sync_views``."""
         from ..macos.keychain import read_keychain_blob
 
         kr = read_keychain_blob()
-        if not kr.ok or not kr.blob:
+        blob: Optional[str] = kr.blob if kr.ok and kr.blob else None
+        if blob is None:
+            blob = _read_disk_credentials_blob(Path.home())
+        if blob is None:
             logger.debug(
-                "keychain poll: read failed (%s); will retry next tick",
+                "keychain poll: neither Keychain (%s) nor disk file "
+                "readable; will retry next tick",
                 kr.error,
             )
             return False
-        if kr.blob == self._last_propagated_blob:
+        if blob == self._last_propagated_blob:
             return False
-        self._last_propagated_blob = kr.blob
+        self._last_propagated_blob = blob
         try:
-            self.cache.write(kr.blob)
+            self.cache.write(blob)
         except OSError as exc:
             logger.warning("keychain poll: cache write failed: %s", exc)
             return False
@@ -796,21 +857,27 @@ class CredentialRefresher:
         ``_refresh_now``, so N concurrent callers coalesce into one
         backend.refresh() per actually-expired credential.
 
-        ``by_agent=False`` so ``_refresh_now``'s post-lock re-check
-        fires — N concurrent ensure_fresh() callers see "another
-        caller already refreshed" and return without re-invoking the
-        backend.
+        Always fans the canonical blob out to every registered agent
+        before returning True. Closes the split-brain window where
+        the daemon's view says fresh but an agent's per-agent
+        credentials file is stale (copy-mode drift on macOS, or a
+        post-refresh fan-out the daemon hasn't done yet). The
+        backend's ``sync_to_agent`` is idempotent so the call is
+        cheap when nothing has actually drifted.
 
-        Intended for pre-delivery gating: a Worker calls this right
-        before handing a batch to its adapter, and skips the dispatch
-        if False so the agent's own claude never has to discover the
-        401 itself."""
+        ``by_agent=False`` so ``_refresh_now``'s post-lock re-check
+        fires — N concurrent callers see "another caller already
+        refreshed" and skip the backend invocation."""
         expires = self.expires_in_seconds()
         if expires is not None and expires > REFRESH_SAFETY_MARGIN_SECONDS:
+            self._sync_views()
             return True
         await self._refresh_now(expires_in=expires, by_agent=False)
         expires = self.expires_in_seconds()
-        return expires is not None and expires > 0
+        if expires is not None and expires > 0:
+            self._sync_views()
+            return True
+        return False
 
     async def run_loop(self, stop_event: asyncio.Event) -> None:
         """Main daemon coroutine. Polls every REFRESH_POLL_SECONDS or

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -283,6 +283,7 @@ class Daemon:
                         self.daemon_cfg,
                         agent_cfg,
                         notify_refresh_needed=self._notify_refresh_for(agent_cfg),
+                        ensure_fresh_token=self._ensure_fresh_for(agent_cfg),
                         ws_local_hub=self.ws_local_hub,
                     )
                     self.workers[agent_id] = worker
@@ -300,6 +301,7 @@ class Daemon:
                         self.daemon_cfg,
                         agent_cfg,
                         notify_refresh_needed=self._notify_refresh_for(agent_cfg),
+                        ensure_fresh_token=self._ensure_fresh_for(agent_cfg),
                         ws_local_hub=self.ws_local_hub,
                     )
                     self.workers[agent_id] = worker
@@ -371,6 +373,9 @@ class Daemon:
 
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
         return self._refresher_for(agent_cfg).notify_refresh_needed
+
+    def _ensure_fresh_for(self, agent_cfg: AgentConfig):
+        return self._refresher_for(agent_cfg).ensure_fresh
 
     def _set_worker_profile_cache(
         self, agent_id: str, slug: str, display_name: str, avatar_url: str,

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -98,8 +98,8 @@ def shared_fs_dir() -> Path:
 # Note: ``.claude.json`` is a sibling of the ``.claude/`` dir; Claude
 # CLI reads it from ``$HOME/.claude.json`` so we mirror that layout.
 # ``.credentials.json`` is intentionally excluded — set up separately
-# via ``link_host_credentials`` so every agent tracks live OAuth state
-# (matches cli-docker's bind-mount model).
+# via ``sync_host_credentials_view`` so every agent tracks live OAuth
+# state (matches cli-docker's bind-mount model).
 _CLAUDE_HOME_SEED_PATHS = (
     ".claude/settings.json",
     ".claude.json",
@@ -111,7 +111,7 @@ def seed_claude_home(host_home: Path, agent_home: Path) -> bool:
     ``$HOME``. Idempotent — never overwrites an existing file.
 
     ``.credentials.json`` is set up separately via
-    ``link_host_credentials``. Returns True if any file was copied.
+    ``sync_host_credentials_view``. Returns True if any file was copied.
     """
     import shutil
     agent_home.mkdir(parents=True, exist_ok=True)
@@ -136,8 +136,8 @@ def _sync_credentials_from_keychain(host_home: Path) -> bool:
 
     Claude Code stores OAuth in Keychain instead of the file on macOS;
     this bridges to the shared-file path used by every other agent.
-    Called on every ``link_host_credentials`` invocation so refreshed
-    tokens propagate. Returns True if the file was written.
+    Called on every ``sync_host_credentials_view`` invocation so
+    refreshed tokens propagate. Returns True if the file was written.
     """
     import platform
     if platform.system() != "Darwin":
@@ -175,137 +175,153 @@ def _sync_credentials_from_keychain(host_home: Path) -> bool:
         return False
 
 
-def link_host_credentials(host_home: Path, agent_home: Path) -> str:
-    """Share the operator's ``.credentials.json`` with the agent so
-    OAuth refresh-token rotation propagates automatically.
+def sanitize_claude_credentials_blob(blob: str) -> str | None:
+    """Strip ``claudeAiOauth.refreshToken`` from a host credentials
+    blob, producing the per-agent *view*. ``None`` when the blob isn't
+    parseable JSON (never hand agents something we can't vet).
 
-    Anthropic OAuth uses rotating refresh tokens; per-agent copies go
-    stale when the operator re-runs ``claude login``. Sharing one
-    file means any refresh (host, any agent) updates the single file
-    that everyone reads.
+    Claude Code runs fine without the key: it uses the access token
+    as-is and, on 401, fails cleanly instead of attempting a refresh.
+    """
+    try:
+        data = json.loads(blob)
+    except ValueError:
+        return None
+    oauth = data.get("claudeAiOauth")
+    if isinstance(oauth, dict):
+        oauth.pop("refreshToken", None)
+    return json.dumps(data)
 
-    Prefers symlink (free read-through); falls back to copy on
-    Windows-without-Developer-Mode. Hardlinks are intentionally
-    skipped — claude's atomic tmp+rename breaks the shared inode.
-    Per PUF-217, refresh-time writes run with ``HOME=host_home``
-    so claude renames at the host path, not at the agent symlink
-    — the symlink itself is never the rename target.
+
+def sanitize_codex_auth_blob(blob: str) -> str | None:
+    """Blank ``tokens.refresh_token`` in a host codex auth blob,
+    producing the per-agent *view*. ``None`` when unparseable.
+
+    Unlike claude, codex hard-fails deserialisation when the field is
+    *missing* (serde non-optional), so the view keeps the key with an
+    empty value: parse succeeds, ``codex login status`` reports
+    logged-in, and a refresh attempt is rejected server-side without
+    consuming the real (single-use) refresh token.
+    """
+    try:
+        data = json.loads(blob)
+    except ValueError:
+        return None
+    tokens = data.get("tokens")
+    if isinstance(tokens, dict):
+        tokens["refresh_token"] = ""
+    return json.dumps(data)
+
+
+def _write_credential_view(target: Path, blob: str) -> None:
+    """Atomic tmp+rename write of ``blob`` at ``target``, mode 0600.
+
+    ``os.replace`` swaps the *path entry*, so when ``target`` is a
+    legacy symlink the link itself is replaced — the host file it
+    pointed at is never touched.
+    """
+    import stat
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.parent / f".{target.name}.tmp.{os.getpid()}"
+    tmp.write_text(blob, encoding="utf-8")
+    try:
+        tmp.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+    os.replace(tmp, target)
+
+
+def sync_host_credentials_view(host_home: Path, agent_home: Path) -> str:
+    """Write a refresh-token-free *view* of the operator's
+    ``.credentials.json`` into the agent's virtual ``$HOME``.
+
+    Agents only need the access token. Sharing the full file (the
+    pre-1.0.7a2 symlink model) handed every agent the single-use
+    rotating refresh token, so N concurrent claude processes could
+    race a refresh: the loser presents an already-consumed token and
+    Anthropic revokes the whole token family — every process 401s
+    until the operator re-runs ``claude /login``. With sanitized
+    views the daemon's ``CredentialRefresher`` (single writer, under
+    its asyncio.Lock) is the only holder of the refresh token, so the
+    race is structurally impossible.
+
+    Rotation propagates via the refresher's per-tick fan-out
+    (``_sync_views`` → here). The content comparison doubles as
+    self-healing: if an agent-side claude mangles its view (e.g. a
+    failed in-CLI refresh zeroing ``expiresAt``), the next tick
+    rewrites it from the host blob. Legacy symlinks are migrated to
+    view files in place.
 
     On macOS, ``_sync_credentials_from_keychain`` materialises the
-    file from the system Keychain first.
+    host file from the system Keychain first.
 
-    Idempotent. Returns ``"symlink"``, ``"symlink (already)"``,
-    ``"copy"``, ``"copy (fresh)"``, or ``"no-host-file"``.
+    Idempotent. Returns ``"view"``, ``"view (fresh)"``,
+    ``"view (migrated-from-symlink)"``, ``"unparseable-host-file"``,
+    ``"write-failed"``, or ``"no-host-file"``.
     """
-    import shutil
     host_creds = host_home / ".claude" / ".credentials.json"
     agent_creds = agent_home / ".claude" / ".credentials.json"
     # macOS Keychain → file bridge before we read host_creds.
     _sync_credentials_from_keychain(host_home)
-    if not host_creds.exists():
+    try:
+        host_blob = host_creds.read_text(encoding="utf-8")
+    except OSError:
         return "no-host-file"
-    agent_creds.parent.mkdir(parents=True, exist_ok=True)
+    view_blob = sanitize_claude_credentials_blob(host_blob)
+    if view_blob is None:
+        return "unparseable-host-file"
 
-    # Fast path: existing symlink already points at host_creds.
-    if agent_creds.is_symlink():
+    migrated = agent_creds.is_symlink()
+    if not migrated:
         try:
-            current = os.readlink(agent_creds)
-            if Path(current) == host_creds or current == str(host_creds):
-                return "symlink (already)"
+            if agent_creds.read_text(encoding="utf-8") == view_blob:
+                return "view (fresh)"
         except OSError:
             pass
-
-    # Fast path: copy-mode file already matches host.
-    if (
-        agent_creds.exists()
-        and not agent_creds.is_symlink()
-        and _file_is_up_to_date(agent_creds, host_creds)
-    ):
-        return "copy (fresh)"
-
-    # Tear down whatever's there before a fresh create. Unlink can
-    # fail on Windows races; the next call retries naturally.
     try:
-        if agent_creds.is_symlink() or agent_creds.exists():
-            agent_creds.unlink()
+        _write_credential_view(agent_creds, view_blob)
     except OSError:
-        pass
-
-    try:
-        os.symlink(host_creds, agent_creds)
-        return "symlink"
-    except (OSError, NotImplementedError):
-        pass
-
-    try:
-        shutil.copy2(host_creds, agent_creds)
-        return "copy"
-    except OSError:
-        return "no-host-file"
+        return "write-failed"
+    return "view (migrated-from-symlink)" if migrated else "view"
 
 
-def _file_is_up_to_date(dst: Path, src: Path) -> bool:
-    """True when ``dst`` and ``src`` have matching mtime + size."""
-    try:
-        ds, ss = dst.stat(), src.stat()
-    except OSError:
-        return False
-    return ds.st_mtime == ss.st_mtime and ds.st_size == ss.st_size
+def sync_host_codex_auth_view(host_home: Path, agent_codex_home: Path) -> str:
+    """Write a refresh-token-blanked *view* of the operator's
+    ``~/.codex/auth.json`` into the agent's ``$CODEX_HOME``.
 
+    Same rationale and lifecycle as ``sync_host_credentials_view`` —
+    OpenAI's refresh tokens rotate the same way (d2d2's
+    ``token_invalidated`` revocation came from exactly this race), and
+    ``CodexFileBackend``'s fan-out keeps the views fresh and
+    self-healed. See ``sanitize_codex_auth_blob`` for why the key is
+    blanked rather than removed.
 
-def link_host_codex_auth(host_home: Path, agent_codex_home: Path) -> str:
-    """Share the operator's ``~/.codex/auth.json`` with the agent's
-    per-agent ``$CODEX_HOME`` so codex finds OAuth credentials there.
-
-    Mirrors ``link_host_credentials``'s symlink-preferred, copy-fallback
-    layout (Windows without Developer Mode rejects ``os.symlink``).
-    The same OAuth refresh-rotation story applies: a symlink lets every
-    agent see token rotations the moment codex (any process — main CLI
-    or another agent) writes back; a copy gets re-synced on the next
-    link call.
-
-    Idempotent. Returns ``"symlink"``, ``"symlink (already)"``,
-    ``"copy"``, ``"copy (fresh)"``, or ``"no-host-file"``.
+    Idempotent. Returns ``"view"``, ``"view (fresh)"``,
+    ``"view (migrated-from-symlink)"``, ``"unparseable-host-file"``,
+    ``"write-failed"``, or ``"no-host-file"``.
     """
-    import shutil
     host_auth = host_home / ".codex" / "auth.json"
     agent_auth = agent_codex_home / "auth.json"
-    if not host_auth.exists():
+    try:
+        host_blob = host_auth.read_text(encoding="utf-8")
+    except OSError:
         return "no-host-file"
-    agent_auth.parent.mkdir(parents=True, exist_ok=True)
+    view_blob = sanitize_codex_auth_blob(host_blob)
+    if view_blob is None:
+        return "unparseable-host-file"
 
-    if agent_auth.is_symlink():
+    migrated = agent_auth.is_symlink()
+    if not migrated:
         try:
-            current = os.readlink(agent_auth)
-            if Path(current) == host_auth or current == str(host_auth):
-                return "symlink (already)"
+            if agent_auth.read_text(encoding="utf-8") == view_blob:
+                return "view (fresh)"
         except OSError:
             pass
-
-    if (
-        agent_auth.exists()
-        and not agent_auth.is_symlink()
-        and _file_is_up_to_date(agent_auth, host_auth)
-    ):
-        return "copy (fresh)"
-
     try:
-        if agent_auth.is_symlink() or agent_auth.exists():
-            agent_auth.unlink()
+        _write_credential_view(agent_auth, view_blob)
     except OSError:
-        pass
-
-    try:
-        os.symlink(host_auth, agent_auth)
-        return "symlink"
-    except (OSError, NotImplementedError):
-        pass
-
-    try:
-        shutil.copy2(host_auth, agent_auth)
-        return "copy"
-    except OSError:
-        return "no-host-file"
+        return "write-failed"
+    return "view (migrated-from-symlink)" if migrated else "view"
 
 
 def read_host_codex_mcp_servers(host_home: Path) -> dict[str, dict]:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -232,32 +232,17 @@ def _write_credential_view(target: Path, blob: str) -> None:
 
 
 def sync_host_credentials_view(host_home: Path, agent_home: Path) -> str:
-    """Write a refresh-token-free *view* of the operator's
-    ``.credentials.json`` into the agent's virtual ``$HOME``.
+    """Write a refresh-token-free view of the operator's
+    ``.credentials.json`` into the agent's virtual ``$HOME`` so only
+    the daemon holds the rotating refresh token — concurrent agent
+    processes can't race a refresh into a token-family revocation.
 
-    Agents only need the access token. Sharing the full file (the
-    pre-1.0.7a2 symlink model) handed every agent the single-use
-    rotating refresh token, so N concurrent claude processes could
-    race a refresh: the loser presents an already-consumed token and
-    Anthropic revokes the whole token family — every process 401s
-    until the operator re-runs ``claude /login``. With sanitized
-    views the daemon's ``CredentialRefresher`` (single writer, under
-    its asyncio.Lock) is the only holder of the refresh token, so the
-    race is structurally impossible.
-
-    Rotation propagates via the refresher's per-tick fan-out
-    (``_sync_views`` → here). The content comparison doubles as
-    self-healing: if an agent-side claude mangles its view (e.g. a
-    failed in-CLI refresh zeroing ``expiresAt``), the next tick
-    rewrites it from the host blob. Legacy symlinks are migrated to
-    view files in place.
-
-    On macOS, ``_sync_credentials_from_keychain`` materialises the
-    host file from the system Keychain first.
-
-    Idempotent. Returns ``"view"``, ``"view (fresh)"``,
-    ``"view (migrated-from-symlink)"``, ``"unparseable-host-file"``,
-    ``"write-failed"``, or ``"no-host-file"``.
+    Idempotent (content-compare: also self-heals agent-side drift).
+    Legacy symlinks are replaced by view files in place; the host
+    file is never touched. On macOS, ``_sync_credentials_from_keychain``
+    materialises the host file first. Returns ``"view"``,
+    ``"view (fresh)"``, ``"view (migrated-from-symlink)"``,
+    ``"unparseable-host-file"``, ``"write-failed"``, or ``"no-host-file"``.
     """
     host_creds = host_home / ".claude" / ".credentials.json"
     agent_creds = agent_home / ".claude" / ".credentials.json"
@@ -286,19 +271,11 @@ def sync_host_credentials_view(host_home: Path, agent_home: Path) -> str:
 
 
 def sync_host_codex_auth_view(host_home: Path, agent_codex_home: Path) -> str:
-    """Write a refresh-token-blanked *view* of the operator's
-    ``~/.codex/auth.json`` into the agent's ``$CODEX_HOME``.
-
-    Same rationale and lifecycle as ``sync_host_credentials_view`` —
-    OpenAI's refresh tokens rotate the same way (d2d2's
-    ``token_invalidated`` revocation came from exactly this race), and
-    ``CodexFileBackend``'s fan-out keeps the views fresh and
-    self-healed. See ``sanitize_codex_auth_blob`` for why the key is
-    blanked rather than removed.
-
-    Idempotent. Returns ``"view"``, ``"view (fresh)"``,
-    ``"view (migrated-from-symlink)"``, ``"unparseable-host-file"``,
-    ``"write-failed"``, or ``"no-host-file"``.
+    """Codex counterpart of ``sync_host_credentials_view`` — writes a
+    view with ``tokens.refresh_token`` blanked (see
+    ``sanitize_codex_auth_blob`` for why blanked not removed).
+    Idempotent + self-healing; legacy symlinks migrated in place.
+    Same return taxonomy as ``sync_host_credentials_view``.
     """
     host_auth = host_home / ".codex" / "auth.json"
     agent_auth = agent_codex_home / "auth.json"

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -22,7 +22,6 @@ from typing import Awaitable, Callable, Optional
 from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
 from ..agent.status_reporter import StatusReporter
-from ..macos.keychain import is_macos as _is_macos
 from .runtime_matrix import (
     RUNTIME_CLI_DOCKER,
     RUNTIME_CLI_LOCAL,
@@ -833,9 +832,9 @@ class Worker:
         # 401 surfacing in a reply short-circuits the daemon's 2-min
         # poll instead of waiting for the next tick.
         self._notify_refresh_needed = notify_refresh_needed
-        # macOS pre-delivery gate: blocking refresh through the
-        # daemon's mutex. Returns True iff post-refresh the token has
-        # >0s remaining. ``None`` for runtimes that don't go through
+        # Pre-delivery gate: blocking refresh through the daemon's
+        # mutex. Returns True iff post-refresh the token has >0s
+        # remaining. ``None`` for runtimes that don't go through
         # claude OAuth (api-puffo, ws-local).
         self._ensure_fresh_token = ensure_fresh_token
         # In-memory dedup for the auth_failed ENTER operator DM;
@@ -1227,14 +1226,15 @@ class Worker:
             # New batch while auth_failed: wake the refresher to check
             # for a re-login now (the flip below would mask auth_failed).
             self._maybe_wake_refresher_if_auth_failed(agent_id)
-            # macOS pre-delivery gate: before handing the batch to the
+            # Pre-delivery gate: before handing the batch to the
             # adapter, make sure the daemon-owned credential is fresh.
-            # Skips on non-macOS (Linux/Windows use a shared file —
-            # daemon's proactive refresh wins the race naturally) and
-            # on non-claude runtimes (ws-local, api-puffo).
+            # The rotating single-use refresh_token race isn't macOS-
+            # specific — N agents reading the same on-disk RT and
+            # POSTing to Anthropic in parallel loses N-1 with
+            # invalid_grant regardless of OS. Skipped only for non-
+            # claude runtimes (ws-local, api-puffo).
             if (
                 self._ensure_fresh_token is not None
-                and _is_macos()
                 and self.agent_cfg.runtime.kind in (
                     RUNTIME_CLI_LOCAL, RUNTIME_CLI_DOCKER,
                 )

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -17,12 +17,17 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Awaitable, Callable, Optional
 
 from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
 from ..agent.status_reporter import StatusReporter
-from .runtime_matrix import RUNTIME_WS_LOCAL
+from ..macos.keychain import is_macos as _is_macos
+from .runtime_matrix import (
+    RUNTIME_CLI_DOCKER,
+    RUNTIME_CLI_LOCAL,
+    RUNTIME_WS_LOCAL,
+)
 from .ws_local.hub import AttachPoint
 from ..agent.shared_content import (
     looks_like_managed_claude_md,
@@ -815,6 +820,7 @@ class Worker:
         agent_cfg: AgentConfig,
         *,
         notify_refresh_needed: Optional[Callable[[], None]] = None,
+        ensure_fresh_token: Optional[Callable[[], Awaitable[bool]]] = None,
         ws_local_hub=None,
     ):
         self.daemon_cfg = daemon_cfg
@@ -827,6 +833,11 @@ class Worker:
         # 401 surfacing in a reply short-circuits the daemon's 2-min
         # poll instead of waiting for the next tick.
         self._notify_refresh_needed = notify_refresh_needed
+        # macOS pre-delivery gate: blocking refresh through the
+        # daemon's mutex. Returns True iff post-refresh the token has
+        # >0s remaining. ``None`` for runtimes that don't go through
+        # claude OAuth (api-puffo, ws-local).
+        self._ensure_fresh_token = ensure_fresh_token
         # In-memory dedup for the auth_failed ENTER operator DM;
         # re-armed on credential refresh-success (daemon
         # on_refresh_success) and on a failed send.
@@ -1216,6 +1227,38 @@ class Worker:
             # New batch while auth_failed: wake the refresher to check
             # for a re-login now (the flip below would mask auth_failed).
             self._maybe_wake_refresher_if_auth_failed(agent_id)
+            # macOS pre-delivery gate: before handing the batch to the
+            # adapter, make sure the daemon-owned credential is fresh.
+            # Skips on non-macOS (Linux/Windows use a shared file —
+            # daemon's proactive refresh wins the race naturally) and
+            # on non-claude runtimes (ws-local, api-puffo).
+            if (
+                self._ensure_fresh_token is not None
+                and _is_macos()
+                and self.agent_cfg.runtime.kind in (
+                    RUNTIME_CLI_LOCAL, RUNTIME_CLI_DOCKER,
+                )
+            ):
+                ok = await self._ensure_fresh_token()
+                if not ok:
+                    # Mutex-guarded refresh failed → token is stuck.
+                    # ``_enter_auth_failed`` flips runtime.health,
+                    # wakes the refresher, and (via
+                    # ``_on_auth_failed_enter`` + the
+                    # ``_auth_failed_notification_sent`` dedup) DMs
+                    # the operator ONCE per expiration episode. Raise
+                    # to push the batch back into the consumer's
+                    # retry path so it redelivers once the operator
+                    # recovers.
+                    logger.warning(
+                        "agent %s: pre-delivery token refresh failed; "
+                        "flagging auth_failed and deferring batch",
+                        agent_id,
+                    )
+                    self._enter_auth_failed(agent_id)
+                    raise AgentAPIError(
+                        "credential refresh failed before delivery",
+                    )
             try:
                 Worker._flip_health_in_progress(self.runtime, agent_id, logger)
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_codex_auth_link.py
+++ b/tests/test_codex_auth_link.py
@@ -157,6 +157,82 @@ def test_no_host_file(tmp_path):
     assert not (agent_codex / "auth.json").exists()
 
 
+def test_chmod_failure_is_swallowed(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    agent_codex = tmp_path / "agent" / ".codex"
+    _write_host(host)
+
+    real_chmod = Path.chmod
+
+    def _fail_chmod(self, *args, **kwargs):
+        if "auth.json.tmp" in self.name:
+            raise OSError("simulated chmod failure")
+        return real_chmod(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "chmod", _fail_chmod)
+
+    assert sync_host_codex_auth_view(host, agent_codex) == "view"
+    data = json.loads((agent_codex / "auth.json").read_text(encoding="utf-8"))
+    assert data["tokens"]["refresh_token"] == ""
+
+
+def test_agent_read_error_falls_through_to_rewrite(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    agent_codex = tmp_path / "agent" / ".codex"
+    _write_host(host)
+
+    view = agent_codex / "auth.json"
+    view.parent.mkdir(parents=True, exist_ok=True)
+    view.write_text("stale-and-unreadable", encoding="utf-8")
+
+    real_read = Path.read_text
+
+    def _fail_agent_read(self, *args, **kwargs):
+        if self == view:
+            raise OSError("simulated read failure")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _fail_agent_read)
+
+    assert sync_host_codex_auth_view(host, agent_codex) == "view"
+    monkeypatch.setattr(Path, "read_text", real_read)
+    assert json.loads(view.read_text(encoding="utf-8"))["tokens"]["refresh_token"] == ""
+
+
+def test_concurrent_syncs_produce_valid_view(tmp_path):
+    """Race pin: N concurrent codex-view writers must leave a complete,
+    refresh-token-blanked file behind, no partial-write leaks."""
+    import threading
+
+    host = tmp_path / "host"
+    agent_codex = tmp_path / "agent" / ".codex"
+    _write_host(host)
+
+    errors: list[Exception] = []
+    barrier = threading.Barrier(6)
+
+    def _run():
+        try:
+            barrier.wait()
+            for _ in range(20):
+                sync_host_codex_auth_view(host, agent_codex)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_run) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent sync raised: {errors!r}"
+    view = agent_codex / "auth.json"
+    assert view.exists() and not view.is_symlink()
+    data = json.loads(view.read_text(encoding="utf-8"))
+    assert data["tokens"]["access_token"] == "at-123"
+    assert data["tokens"]["refresh_token"] == ""
+
+
 def test_write_failure_returns_write_failed(tmp_path, monkeypatch):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"

--- a/tests/test_codex_auth_link.py
+++ b/tests/test_codex_auth_link.py
@@ -1,283 +1,154 @@
-"""Tests for ``link_host_codex_auth`` — the OAuth fallback path that
-shares ``~/.codex/auth.json`` with each agent's ``$CODEX_HOME``.
+"""Tests for ``sync_host_codex_auth_view`` — the per-agent codex auth
+*view* written into each agent's ``$CODEX_HOME``.
 
-Mirrors ``test_host_credentials.py``'s shape: symlink-preferred,
-copy-fallback for Windows non-dev-mode, idempotent on second call.
+Mirrors ``test_host_credentials.py``'s shape, with one codex-specific
+wrinkle: codex hard-fails deserialisation when ``tokens.refresh_token``
+is *missing* (serde non-optional field), so the sanitized view keeps
+the key with an empty-string value instead of dropping it.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from puffo_agent.portal.state import link_host_codex_auth
+from puffo_agent.portal.state import (
+    sanitize_codex_auth_blob,
+    sync_host_codex_auth_view,
+)
 
 
-def _symlinks_available(tmp_path: Path) -> bool:
-    probe = tmp_path / "_probe_link"
-    target = tmp_path / "_probe_target"
-    target.write_text("x", encoding="utf-8")
-    try:
-        os.symlink(target, probe)
-        probe.unlink()
-        target.unlink()
-        return True
-    except (OSError, NotImplementedError):
-        try:
-            target.unlink()
-        except OSError:
-            pass
-        return False
+HOST_AUTH = {
+    "OPENAI_API_KEY": None,
+    "auth_mode": "chatgpt",
+    "tokens": {
+        "id_token": "idt-abc",
+        "access_token": "at-123",
+        "refresh_token": "rt-secret-456",
+        "account_id": "acct-1",
+    },
+    "last_refresh": "2026-07-02T00:00:00Z",
+}
 
 
-def _write_host_auth(host_home: Path, content: str = '{"token": "v1"}') -> Path:
-    p = host_home / ".codex" / "auth.json"
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content, encoding="utf-8")
-    return p
+def _write_host(host: Path, auth: dict | None = None) -> Path:
+    host_auth = host / ".codex" / "auth.json"
+    host_auth.parent.mkdir(parents=True, exist_ok=True)
+    host_auth.write_text(json.dumps(auth or HOST_AUTH), encoding="utf-8")
+    return host_auth
 
 
-def test_no_host_file_returns_marker(tmp_path):
+# ── sanitizer ─────────────────────────────────────────────────
+
+
+def test_sanitize_blanks_refresh_token_keeps_key():
+    view = json.loads(sanitize_codex_auth_blob(json.dumps(HOST_AUTH)))
+    tokens = view["tokens"]
+    # Key must survive (codex serde requires it) but hold no secret.
+    assert tokens["refresh_token"] == ""
+    assert tokens["access_token"] == "at-123"
+    assert tokens["id_token"] == "idt-abc"
+    assert view["auth_mode"] == "chatgpt"
+
+
+def test_sanitize_rejects_non_json():
+    assert sanitize_codex_auth_blob("nope {") is None
+
+
+def test_sanitize_tolerates_api_key_only_auth():
+    """API-key mode has ``tokens: null`` — pass through untouched."""
+    blob = json.dumps({"OPENAI_API_KEY": "sk-x", "tokens": None})
+    assert json.loads(sanitize_codex_auth_blob(blob)) == {
+        "OPENAI_API_KEY": "sk-x",
+        "tokens": None,
+    }
+
+
+# ── view lifecycle ────────────────────────────────────────────
+
+
+def test_view_written_with_blanked_refresh_token(tmp_path):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
-    mode = link_host_codex_auth(host, agent_codex)
-    assert mode == "no-host-file"
-    assert not agent_codex.exists()
+
+    mode = sync_host_codex_auth_view(_write_host(host).parent.parent, agent_codex)
+
+    assert mode == "view"
+    view = agent_codex / "auth.json"
+    assert view.exists() and not view.is_symlink()
+    data = json.loads(view.read_text(encoding="utf-8"))
+    assert data["tokens"]["refresh_token"] == ""
+    assert data["tokens"]["access_token"] == "at-123"
 
 
-def test_symlink_created_when_supported(tmp_path):
-    if not _symlinks_available(tmp_path):
-        pytest.skip("symlinks unavailable on this host")
+def test_view_idempotent(tmp_path):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
-    host_auth = _write_host_auth(host, '{"token": "v1"}')
+    _write_host(host)
 
-    mode = link_host_codex_auth(host, agent_codex)
-    assert mode == "symlink"
-    agent_auth = agent_codex / "auth.json"
-    assert agent_auth.is_symlink()
-    assert agent_auth.read_text() == '{"token": "v1"}'
-    # Host rewrite (OAuth refresh) is visible through the symlink with
-    # no relink — the property the symlink path exists for.
-    host_auth.write_text('{"token": "v2"}', encoding="utf-8")
-    assert agent_auth.read_text() == '{"token": "v2"}'
+    assert sync_host_codex_auth_view(host, agent_codex) == "view"
+    assert sync_host_codex_auth_view(host, agent_codex) == "view (fresh)"
 
 
-def test_symlink_idempotent_on_second_call(tmp_path):
-    if not _symlinks_available(tmp_path):
-        pytest.skip("symlinks unavailable on this host")
+def test_view_tracks_host_rotation(tmp_path):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
-    _write_host_auth(host)
-    link_host_codex_auth(host, agent_codex)
-    # Second call must not re-create — returns the (already) marker so
-    # the daemon log doesn't spam "shared host codex auth (symlink)"
-    # every tick.
-    mode = link_host_codex_auth(host, agent_codex)
-    assert mode == "symlink (already)"
+    _write_host(host)
+    sync_host_codex_auth_view(host, agent_codex)
+
+    rotated = json.loads(json.dumps(HOST_AUTH))
+    rotated["tokens"]["access_token"] = "at-789"
+    rotated["tokens"]["refresh_token"] = "rt-new-000"
+    _write_host(host, rotated)
+
+    assert sync_host_codex_auth_view(host, agent_codex) == "view"
+    data = json.loads((agent_codex / "auth.json").read_text(encoding="utf-8"))
+    assert data["tokens"]["access_token"] == "at-789"
+    assert data["tokens"]["refresh_token"] == ""
 
 
-def test_copy_path_when_symlink_fails(tmp_path, monkeypatch):
-    # Force the os.symlink call inside state.py to raise so we exercise
-    # the copy fallback regardless of platform.
-    import puffo_agent.portal.state as state_mod
-    monkeypatch.setattr(
-        state_mod.os, "symlink",
-        lambda *a, **k: (_ for _ in ()).throw(NotImplementedError("no symlink")),
-    )
+def test_migrates_legacy_symlink_without_touching_host(tmp_path):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
-    _write_host_auth(host, '{"token": "v1"}')
+    host_auth = _write_host(host)
+    host_blob_before = host_auth.read_text(encoding="utf-8")
 
-    mode = link_host_codex_auth(host, agent_codex)
-    assert mode == "copy"
-    agent_auth = agent_codex / "auth.json"
-    assert agent_auth.exists()
-    assert not agent_auth.is_symlink()
-    assert agent_auth.read_text() == '{"token": "v1"}'
+    view = agent_codex / "auth.json"
+    view.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(host_auth, view)
+
+    mode = sync_host_codex_auth_view(host, agent_codex)
+
+    assert mode == "view (migrated-from-symlink)"
+    assert not view.is_symlink()
+    data = json.loads(view.read_text(encoding="utf-8"))
+    assert data["tokens"]["refresh_token"] == ""
+    # Host keeps the real refresh token.
+    assert host_auth.read_text(encoding="utf-8") == host_blob_before
+    assert "rt-secret-456" in host_auth.read_text(encoding="utf-8")
 
 
-def test_copy_fresh_marker_when_already_in_sync(tmp_path, monkeypatch):
-    """Copy-mode second call sees the destination is up-to-date and
-    returns ``copy (fresh)``."""
-    import puffo_agent.portal.state as state_mod
-    monkeypatch.setattr(
-        state_mod.os, "symlink",
-        lambda *a, **k: (_ for _ in ()).throw(NotImplementedError("no symlink")),
-    )
+def test_no_host_file(tmp_path):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
-    _write_host_auth(host)
-    link_host_codex_auth(host, agent_codex)
-    mode = link_host_codex_auth(host, agent_codex)
-    assert mode == "copy (fresh)"
+    assert sync_host_codex_auth_view(host, agent_codex) == "no-host-file"
+    assert not (agent_codex / "auth.json").exists()
 
 
-# ── PUF-266: read_host_codex_mcp_servers ────────────────────────────
+def test_unparseable_host_file_leaves_view_alone(tmp_path):
+    host = tmp_path / "host"
+    agent_codex = tmp_path / "agent" / ".codex"
+    host_auth = _write_host(host)
+    sync_host_codex_auth_view(host, agent_codex)
+    good_view = (agent_codex / "auth.json").read_text(encoding="utf-8")
 
+    host_auth.write_text("corrupted {", encoding="utf-8")
 
-from puffo_agent.portal.state import read_host_codex_mcp_servers
-
-
-def test_read_host_codex_mcp_servers_returns_empty_when_no_host_config(tmp_path):
-    assert read_host_codex_mcp_servers(tmp_path) == {}
-
-
-def test_read_host_codex_mcp_servers_returns_empty_when_malformed(tmp_path):
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text("this is = not [valid toml\n", encoding="utf-8")
-    assert read_host_codex_mcp_servers(tmp_path) == {}
-
-
-def test_read_host_codex_mcp_servers_parses_basic_entries(tmp_path):
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text(
-        'cli_auth_credentials_store = "file"\n'
-        '\n'
-        '[mcp_servers.filesystem]\n'
-        'command = "/usr/local/bin/mcp-fs"\n'
-        'args = ["--root", "/Users/op"]\n'
-        '\n'
-        '[mcp_servers.filesystem.env]\n'
-        'FS_LOG_LEVEL = "info"\n'
-        '\n'
-        '[mcp_servers.github]\n'
-        'command = "npx"\n'
-        'args = ["@modelcontextprotocol/server-github"]\n',
-        encoding="utf-8",
+    assert sync_host_codex_auth_view(host, agent_codex) == (
+        "unparseable-host-file"
     )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert set(out) == {"filesystem", "github"}
-    assert out["filesystem"]["command"] == "/usr/local/bin/mcp-fs"
-    assert out["filesystem"]["args"] == ["--root", "/Users/op"]
-    assert out["filesystem"]["env"]["FS_LOG_LEVEL"] == "info"
-    assert out["github"]["args"] == ["@modelcontextprotocol/server-github"]
-    # Missing env defaults to {} (not absent / not None).
-    assert out["github"]["env"] == {}
-
-
-def test_read_host_codex_mcp_servers_ignores_top_level_non_mcp(tmp_path):
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text(
-        'cli_auth_credentials_store = "file"\n'
-        'model = "gpt-5-codex"\n'
-        '[mcp_servers.fs]\ncommand = "x"\nargs = []\n',
-        encoding="utf-8",
-    )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert list(out) == ["fs"]
-
-
-def test_read_host_codex_mcp_servers_skips_entries_with_no_command(tmp_path):
-    # PR #54 review item 4a: empty/missing command would land as
-    # `command = ""` in per-agent TOML and crash codex on empty argv.
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text(
-        '[mcp_servers.missing_cmd]\n'
-        'args = ["x"]\n'
-        '\n'
-        '[mcp_servers.empty_cmd]\n'
-        'command = ""\n'
-        'args = []\n'
-        '\n'
-        '[mcp_servers.non_string_cmd]\n'
-        'command = 42\n'
-        'args = []\n'
-        '\n'
-        '[mcp_servers.ok_entry]\n'
-        'command = "/bin/x"\n'
-        'args = []\n',
-        encoding="utf-8",
-    )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert set(out) == {"ok_entry"}
-
-
-def test_read_host_codex_mcp_servers_honors_CODEX_HOME_env(tmp_path, monkeypatch):
-    custom_codex = tmp_path / "custom-codex-home"
-    custom_codex.mkdir()
-    (custom_codex / "config.toml").write_text(
-        '[mcp_servers.fs]\ncommand = "/bin/fs"\nargs = []\n',
-        encoding="utf-8",
-    )
-    # Also seed default location so a hardcoded-path regression surfaces.
-    (tmp_path / ".codex").mkdir()
-    (tmp_path / ".codex" / "config.toml").write_text(
-        '[mcp_servers.fs_default]\ncommand = "/bin/no"\nargs = []\n',
-        encoding="utf-8",
-    )
-
-    monkeypatch.setenv("CODEX_HOME", str(custom_codex))
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert set(out) == {"fs"}
-
-
-def test_read_host_codex_mcp_servers_defaults_when_CODEX_HOME_unset(
-    tmp_path, monkeypatch,
-):
-    monkeypatch.delenv("CODEX_HOME", raising=False)
-    (tmp_path / ".codex").mkdir()
-    (tmp_path / ".codex" / "config.toml").write_text(
-        '[mcp_servers.fs]\ncommand = "/bin/fs"\nargs = []\n',
-        encoding="utf-8",
-    )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert set(out) == {"fs"}
-
-
-def test_read_host_codex_mcp_servers_drops_non_dict_spec(tmp_path):
-    # A non-table mcp_servers entry (e.g. accidentally a string) must
-    # be skipped, not raise. Pins the `isinstance(spec, dict)` guard.
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text(
-        '[mcp_servers]\n'
-        'broken_entry = "not_a_table"\n'
-        '\n'
-        '[mcp_servers.ok]\n'
-        'command = "/bin/x"\n',
-        encoding="utf-8",
-    )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert set(out) == {"ok"}
-
-
-def test_read_host_codex_mcp_servers_coerces_non_list_args_to_empty(tmp_path):
-    # `args = "string"` is parseable TOML but semantically wrong. Without
-    # the isinstance(raw_args, list) guard, `list(str)` would split into
-    # chars and the per-agent config would emit a nonsense argv.
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text(
-        '[mcp_servers.weird]\n'
-        'command = "/bin/x"\n'
-        'args = "not_a_list"\n',
-        encoding="utf-8",
-    )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert out["weird"]["args"] == []
-
-
-def test_read_host_codex_mcp_servers_coerces_non_dict_env_to_empty(tmp_path):
-    # `env = "string"` would crash dict(str) without the
-    # isinstance(raw_env, dict) guard.
-    cfg = tmp_path / ".codex" / "config.toml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text(
-        '[mcp_servers.weird]\n'
-        'command = "/bin/x"\n'
-        'args = []\n'
-        'env = "not_a_table"\n',
-        encoding="utf-8",
-    )
-    out = read_host_codex_mcp_servers(tmp_path)
-    assert out["weird"]["env"] == {}
+    assert (agent_codex / "auth.json").read_text(encoding="utf-8") == good_view

--- a/tests/test_codex_auth_link.py
+++ b/tests/test_codex_auth_link.py
@@ -14,6 +14,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from puffo_agent.portal.state import (
@@ -33,6 +35,20 @@ HOST_AUTH = {
     },
     "last_refresh": "2026-07-02T00:00:00Z",
 }
+
+
+def _symlinks_available(tmp_path: Path) -> bool:
+    probe = tmp_path / "_probe_link"
+    target = tmp_path / "_probe_target"
+    target.write_text("x", encoding="utf-8")
+    try:
+        os.symlink(target, probe)
+    except (OSError, NotImplementedError):
+        target.unlink(missing_ok=True)
+        return False
+    probe.unlink()
+    target.unlink()
+    return True
 
 
 def _write_host(host: Path, auth: dict | None = None) -> Path:
@@ -112,6 +128,8 @@ def test_view_tracks_host_rotation(tmp_path):
 
 
 def test_migrates_legacy_symlink_without_touching_host(tmp_path):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
     host_auth = _write_host(host)
@@ -136,6 +154,21 @@ def test_no_host_file(tmp_path):
     host = tmp_path / "host"
     agent_codex = tmp_path / "agent" / ".codex"
     assert sync_host_codex_auth_view(host, agent_codex) == "no-host-file"
+    assert not (agent_codex / "auth.json").exists()
+
+
+def test_write_failure_returns_write_failed(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    agent_codex = tmp_path / "agent" / ".codex"
+    _write_host(host)
+
+    def _boom(target, blob):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.state._write_credential_view", _boom,
+    )
+    assert sync_host_codex_auth_view(host, agent_codex) == "write-failed"
     assert not (agent_codex / "auth.json").exists()
 
 

--- a/tests/test_codex_credential_refresh.py
+++ b/tests/test_codex_credential_refresh.py
@@ -140,14 +140,14 @@ def test_expires_in_seconds_handles_opaque_access_token(tmp_path):
 
 def test_sync_to_agent_skips_non_codex_agents(tmp_path, monkeypatch):
     """Agent home without a ``.codex/`` subdir is a claude-only agent;
-    we shouldn't clutter it with a stray auth.json symlink."""
+    we shouldn't clutter it with a stray auth.json view."""
     _write_codex_auth(tmp_path)
     b = CodexFileBackend(host_home=tmp_path)
 
     called = []
     monkeypatch.setattr(
-        credential_refresh, "link_host_codex_auth",
-        lambda host, agent_codex: called.append((host, agent_codex)) or "symlink",
+        credential_refresh, "sync_host_codex_auth_view",
+        lambda host, agent_codex: called.append((host, agent_codex)) or "view",
     )
     claude_only_agent = tmp_path / "agent_claude"
     claude_only_agent.mkdir()
@@ -161,8 +161,8 @@ def test_sync_to_agent_links_when_codex_dir_exists(tmp_path, monkeypatch):
 
     called: list[tuple[Path, Path]] = []
     monkeypatch.setattr(
-        credential_refresh, "link_host_codex_auth",
-        lambda host, agent_codex: called.append((host, agent_codex)) or "symlink",
+        credential_refresh, "sync_host_codex_auth_view",
+        lambda host, agent_codex: called.append((host, agent_codex)) or "view",
     )
     codex_agent = tmp_path / "agent_codex"
     (codex_agent / ".codex").mkdir(parents=True)
@@ -346,8 +346,8 @@ def test_refresher_with_codex_backend_ticks_through(tmp_path, monkeypatch):
 
     synced: list[Path] = []
     monkeypatch.setattr(
-        credential_refresh, "link_host_codex_auth",
-        lambda host, agent_codex: synced.append(Path(agent_codex)) or "symlink",
+        credential_refresh, "sync_host_codex_auth_view",
+        lambda host, agent_codex: synced.append(Path(agent_codex)) or "view",
     )
     # Make sure NO refresh subprocess fires when fresh.
     async def fake_exec(*a, **k):
@@ -378,8 +378,8 @@ def test_refresher_with_codex_backend_refreshes_when_close_to_expiry(
         credential_refresh, "_resolve_codex_bin", lambda: "codex",
     )
     monkeypatch.setattr(
-        credential_refresh, "link_host_codex_auth",
-        lambda *a, **k: "symlink",
+        credential_refresh, "sync_host_codex_auth_view",
+        lambda *a, **k: "view",
     )
 
     asyncio.run(r._tick())
@@ -415,7 +415,7 @@ def test_refresher_with_codex_backend_refreshes_when_agent_reports_401(
 
 
 def test_codex_config_pins_auth_store_to_file(tmp_path):
-    """The CodexFileBackend symlink/refresh model only works if each
+    """The CodexFileBackend view/refresh model only works if each
     per-agent codex respects file-mode auth — even when no MCP is
     configured."""
     from puffo_agent.mcp.config import write_codex_mcp_config

--- a/tests/test_credential_refresh_ensure_fresh.py
+++ b/tests/test_credential_refresh_ensure_fresh.py
@@ -139,8 +139,8 @@ async def test_ensure_fresh_fans_out_to_agents_in_fresh_path(tmp_path):
         r.register_agent(agent)
 
     assert await r.ensure_fresh() is True
-    # FileBackend.sync_to_agent → link_host_credentials → either
-    # symlink or copy into <agent>/.claude/.credentials.json.
+    # FileBackend.sync_to_agent → sync_host_credentials_view → view copy
+    # into <agent>/.claude/.credentials.json.
     for agent in (agent_a, agent_b):
         assert (agent / ".claude" / ".credentials.json").exists()
 

--- a/tests/test_credential_refresh_ensure_fresh.py
+++ b/tests/test_credential_refresh_ensure_fresh.py
@@ -1,0 +1,122 @@
+"""``CredentialRefresher.ensure_fresh()``: macOS pre-delivery gate.
+
+The Worker calls this before handing a batch to its adapter so the
+agent's own claude never has to discover an expired token via 401.
+Same single-writer mutex + re-check-after-lock pattern as
+``_refresh_now`` — N concurrent callers coalesce into one
+backend.refresh() per real expiration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.portal.credential_refresh import (
+    CredentialRefresher,
+    REFRESH_SAFETY_MARGIN_SECONDS,
+    RefreshOutcome,
+)
+
+
+def _write_creds(host_home: Path, *, expires_in_seconds: int) -> None:
+    p = host_home / ".claude" / ".credentials.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat01-test",
+            "refreshToken": "sk-ant-ort01-test",
+            "expiresAt": int((time.time() + expires_in_seconds) * 1000),
+            "scopes": ["user:inference"],
+        }
+    }))
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_skips_refresh_when_token_is_fresh(tmp_path):
+    # Token good for 2h — well above the 600s margin → no refresh fires.
+    _write_creds(tmp_path, expires_in_seconds=7200)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    refresh_calls = 0
+
+    async def _fake_refresh() -> RefreshOutcome:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return RefreshOutcome.UNCHANGED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+    assert await r.ensure_fresh() is True
+    assert refresh_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_drives_refresh_when_near_expiry(tmp_path):
+    # 60s remaining → under the 600s margin → refresh fires.
+    _write_creds(tmp_path, expires_in_seconds=60)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def _fake_refresh() -> RefreshOutcome:
+        # Simulate a successful refresh: token now valid 1h.
+        _write_creds(tmp_path, expires_in_seconds=3600)
+        return RefreshOutcome.REFRESHED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+    assert await r.ensure_fresh() is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_returns_false_when_refresh_fails_and_token_is_expired(tmp_path):
+    # Token already expired (-10s) — refresh attempt fails → return False.
+    _write_creds(tmp_path, expires_in_seconds=-10)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def _fake_refresh() -> RefreshOutcome:
+        return RefreshOutcome.FAILED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+    assert await r.ensure_fresh() is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_concurrent_callers_coalesce_into_one_refresh(tmp_path):
+    # 100 simultaneous callers; mutex + re-check-after-lock pattern means
+    # exactly one backend.refresh() fires.
+    _write_creds(tmp_path, expires_in_seconds=60)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    refresh_calls = 0
+
+    async def _fake_refresh() -> RefreshOutcome:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        # Yield once so other tasks have a chance to enter ensure_fresh
+        # before this one writes the new token + releases the lock.
+        await asyncio.sleep(0)
+        _write_creds(tmp_path, expires_in_seconds=3600)
+        return RefreshOutcome.REFRESHED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+
+    results = await asyncio.gather(*(r.ensure_fresh() for _ in range(100)))
+    assert all(results)
+    # The mutex + re-check causes only the first acquirer to actually
+    # call refresh; subsequent acquirers see the post-write fresh token
+    # and bail out of _refresh_now early.
+    assert refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_returns_false_on_missing_credentials(tmp_path):
+    # No .credentials.json at all → expires_in is None → drives a
+    # refresh that also fails → False.
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def _fake_refresh() -> RefreshOutcome:
+        return RefreshOutcome.FAILED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+    assert await r.ensure_fresh() is False

--- a/tests/test_credential_refresh_ensure_fresh.py
+++ b/tests/test_credential_refresh_ensure_fresh.py
@@ -120,3 +120,72 @@ async def test_ensure_fresh_returns_false_on_missing_credentials(tmp_path):
 
     r.backend.refresh = _fake_refresh  # type: ignore[assignment]
     assert await r.ensure_fresh() is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_fans_out_to_agents_in_fresh_path(tmp_path):
+    """Daemon view says fresh → ensure_fresh still syncs canonical
+    credentials to every registered agent. Closes the split-brain
+    window where the agent's per-agent credentials file is stale
+    while the daemon's view is fresh (macOS copy-mode drift, or a
+    post-refresh fan-out the daemon hasn't done yet)."""
+    _write_creds(tmp_path, expires_in_seconds=7200)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    agent_a = tmp_path / "agent-a"
+    agent_b = tmp_path / "agent-b"
+    for agent in (agent_a, agent_b):
+        agent.mkdir()
+        r.register_agent(agent)
+
+    assert await r.ensure_fresh() is True
+    # FileBackend.sync_to_agent → link_host_credentials → either
+    # symlink or copy into <agent>/.claude/.credentials.json.
+    for agent in (agent_a, agent_b):
+        assert (agent / ".claude" / ".credentials.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_fans_out_after_successful_refresh(tmp_path):
+    """Refresh-path also fans out — verifies the post-refresh _sync_views
+    call lands when ensure_fresh had to drive an actual refresh."""
+    _write_creds(tmp_path, expires_in_seconds=60)  # below safety margin
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def _fake_refresh() -> RefreshOutcome:
+        _write_creds(tmp_path, expires_in_seconds=3600)
+        return RefreshOutcome.REFRESHED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+    agent = tmp_path / "agent-x"
+    agent.mkdir()
+    r.register_agent(agent)
+
+    assert await r.ensure_fresh() is True
+    assert (agent / ".claude" / ".credentials.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_does_not_fan_out_when_refresh_fails(tmp_path):
+    """Refresh failure path returns False before any fan-out — agents
+    don't get stamped with stale/empty creds."""
+    _write_creds(tmp_path, expires_in_seconds=-10)
+    r = CredentialRefresher(host_home=tmp_path)
+
+    async def _fake_refresh() -> RefreshOutcome:
+        return RefreshOutcome.FAILED
+
+    r.backend.refresh = _fake_refresh  # type: ignore[assignment]
+    agent = tmp_path / "agent-y"
+    agent.mkdir()
+    r.register_agent(agent)
+
+    sync_calls = 0
+
+    def _spy_sync_to_agent(home):
+        nonlocal sync_calls
+        sync_calls += 1
+
+    r.backend.sync_to_agent = _spy_sync_to_agent  # type: ignore[assignment]
+    assert await r.ensure_fresh() is False
+    assert sync_calls == 0

--- a/tests/test_credential_refresh_ensure_fresh.py
+++ b/tests/test_credential_refresh_ensure_fresh.py
@@ -189,3 +189,57 @@ async def test_ensure_fresh_does_not_fan_out_when_refresh_fails(tmp_path):
     r.backend.sync_to_agent = _spy_sync_to_agent  # type: ignore[assignment]
     assert await r.ensure_fresh() is False
     assert sync_calls == 0
+
+
+# ── AUTH_FAILED classification + propagation ─────────────────────────
+
+
+def test_classify_failed_refresh_detects_401_as_auth_failed():
+    from puffo_agent.portal.credential_refresh import _classify_failed_refresh
+
+    outcome = _classify_failed_refresh(
+        out_tail="", err_tail='API Error: 401 {"type":"authentication_error"}',
+        rc=1, elapsed=1.2, log_prefix="test",
+    )
+    assert outcome is RefreshOutcome.AUTH_FAILED
+
+
+def test_classify_failed_refresh_detects_invalid_grant_as_auth_failed():
+    from puffo_agent.portal.credential_refresh import _classify_failed_refresh
+
+    outcome = _classify_failed_refresh(
+        out_tail="", err_tail="OAuth refresh: invalid_grant",
+        rc=1, elapsed=1.2, log_prefix="test",
+    )
+    assert outcome is RefreshOutcome.AUTH_FAILED
+
+
+def test_classify_failed_refresh_prefers_auth_failed_over_rate_limit():
+    """When both markers are present (Anthropic sometimes returns 401
+    with rate-limit-adjacent wording on rotated-and-revoked tokens),
+    AUTH_FAILED wins so the DM path fires instead of the fast-retry."""
+    from puffo_agent.portal.credential_refresh import _classify_failed_refresh
+
+    outcome = _classify_failed_refresh(
+        out_tail="",
+        err_tail=(
+            "API Error: 401 authentication_error "
+            'rate_limit_error "type":"rate_limit_error"'
+        ),
+        rc=1, elapsed=1.2, log_prefix="test",
+    )
+    assert outcome is RefreshOutcome.AUTH_FAILED
+
+
+def test_propagate_auth_failed_does_not_bump_streak(tmp_path):
+    """AUTH_FAILED skips the consecutive_non_success streak so a later
+    RATE_LIMITED / FAILED outcome starts fresh at 1, not N+1."""
+    _write_creds(tmp_path, expires_in_seconds=7200)
+    r = CredentialRefresher(host_home=tmp_path)
+    r._consecutive_non_success = 0
+
+    r._propagate_outcome(RefreshOutcome.AUTH_FAILED)
+    assert r._consecutive_non_success == 0
+
+    r._propagate_outcome(RefreshOutcome.FAILED)
+    assert r._consecutive_non_success == 1

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -120,7 +120,7 @@ def test_tick_no_refresh_when_fresh_and_no_agent_trigger(tmp_path, monkeypatch):
     def fake_link(host_home, agent_home):
         sync_calls.append((host_home, agent_home))
 
-    monkeypatch.setattr(credential_refresh, "link_host_credentials", fake_link)
+    monkeypatch.setattr(credential_refresh, "sync_host_credentials_view", fake_link)
 
     asyncio.run(r._tick())
     assert spawned == []
@@ -201,9 +201,9 @@ def test_tick_fans_view_sync_to_registered_agents(tmp_path, monkeypatch):
 
     def fake_link(host_home, agent_home):
         synced.append(Path(agent_home))
-        return "symlink"
+        return "view"
 
-    monkeypatch.setattr(credential_refresh, "link_host_credentials", fake_link)
+    monkeypatch.setattr(credential_refresh, "sync_host_credentials_view", fake_link)
     asyncio.run(r._tick())
     assert set(synced) == {a, b}
 

--- a/tests/test_host_credentials.py
+++ b/tests/test_host_credentials.py
@@ -22,6 +22,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from puffo_agent.portal.state import (
@@ -39,6 +41,20 @@ HOST_CREDS = {
         "subscriptionType": "max",
     }
 }
+
+
+def _symlinks_available(tmp_path: Path) -> bool:
+    probe = tmp_path / "_probe_link"
+    target = tmp_path / "_probe_target"
+    target.write_text("x", encoding="utf-8")
+    try:
+        os.symlink(target, probe)
+    except (OSError, NotImplementedError):
+        target.unlink(missing_ok=True)
+        return False
+    probe.unlink()
+    target.unlink()
+    return True
 
 
 def _write_host(host: Path, creds: dict | None = None) -> Path:
@@ -156,6 +172,8 @@ def test_view_heals_agent_side_garbage(tmp_path):
 
 
 def test_migrates_legacy_symlink_without_touching_host(tmp_path):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
     host = tmp_path / "host"
     agent = tmp_path / "agent"
     host_creds = _write_host(host)
@@ -177,6 +195,8 @@ def test_migrates_legacy_symlink_without_touching_host(tmp_path):
 
 
 def test_migrates_broken_symlink(tmp_path):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
     host = tmp_path / "host"
     agent = tmp_path / "agent"
     _write_host(host)
@@ -201,6 +221,21 @@ def test_no_host_file(tmp_path):
     host = tmp_path / "host"
     agent = tmp_path / "agent"
     assert sync_host_credentials_view(host, agent) == "no-host-file"
+    assert not _agent_view(agent).exists()
+
+
+def test_write_failure_returns_write_failed(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_host(host)
+
+    def _boom(target, blob):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.state._write_credential_view", _boom,
+    )
+    assert sync_host_credentials_view(host, agent) == "write-failed"
     assert not _agent_view(agent).exists()
 
 

--- a/tests/test_host_credentials.py
+++ b/tests/test_host_credentials.py
@@ -1,215 +1,220 @@
-"""Tests for ``link_host_credentials`` — shared-credentials plumbing
-that lets cli-local agents track the operator's
-``~/.claude/.credentials.json`` like cli-docker's bind-mount.
+"""Tests for ``sync_host_credentials_view`` — the per-agent credential
+*view* plumbing for cli-local agents.
 
-Contract:
-  * Symlink-preferred: agent's ``.credentials.json`` becomes a symlink
-    to the host's file when the platform permits.
-  * Copy fallback: ``os.symlink`` may raise on Windows without
-    Developer Mode; fall back to a copy and refresh when the host
-    file changes.
-  * Idempotent:
-      - already-symlinked-correctly -> "symlink (already)"
-      - already-copied-and-fresh    -> "copy (fresh)"
-  * Replaces pre-existing state cleanly (stale copy / broken symlink).
-  * Missing host file is a reportable no-op.
+Model under test (replaces the pre-1.0.7a2 symlink sharing):
+
+  * The agent's ``.credentials.json`` is a sanitized copy of the
+    host's: full blob minus ``claudeAiOauth.refreshToken``. Only the
+    daemon ever holds the (single-use, rotating) refresh token, so
+    concurrent agent claude processes can't race a refresh into an
+    Anthropic token-family revocation.
+  * Idempotent: matching view content -> "view (fresh)", no rewrite.
+  * Self-healing: agent-side drift (garbage, stale token) is
+    overwritten from the host blob on the next sync.
+  * Migration: a legacy symlink is replaced by a view file; the host
+    file it pointed at is never modified.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
 
-import pytest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from puffo_agent.portal.state import link_host_credentials
-
-
-# We can't assume os.symlink works on every CI runner or on Windows
-# without Dev Mode. Symlink tests skip when unsupported; copy-path
-# tests monkeypatch os.symlink to raise so the fallback is
-# exercised deterministically.
+from puffo_agent.portal.state import (
+    sanitize_claude_credentials_blob,
+    sync_host_credentials_view,
+)
 
 
-def _symlinks_available(tmp_path: Path) -> bool:
-    """Probe: can this process create a symlink in ``tmp_path``?"""
-    probe = tmp_path / "_probe_symlink"
-    target = tmp_path / "_probe_target"
-    target.write_text("x", encoding="utf-8")
-    try:
-        os.symlink(target, probe)
-        probe.unlink()
-        target.unlink()
-        return True
-    except (OSError, NotImplementedError):
-        try:
-            target.unlink()
-        except OSError:
-            pass
-        return False
+HOST_CREDS = {
+    "claudeAiOauth": {
+        "accessToken": "at-123",
+        "refreshToken": "rt-secret-456",
+        "expiresAt": 1900000000000,
+        "scopes": ["user:inference"],
+        "subscriptionType": "max",
+    }
+}
 
 
-def _write_host_creds(host: Path, content: str = '{"claudeAiOauth":{"expiresAt":1}}') -> Path:
-    p = host / ".claude" / ".credentials.json"
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content, encoding="utf-8")
-    return p
+def _write_host(host: Path, creds: dict | None = None) -> Path:
+    host_creds = host / ".claude" / ".credentials.json"
+    host_creds.parent.mkdir(parents=True, exist_ok=True)
+    host_creds.write_text(json.dumps(creds or HOST_CREDS), encoding="utf-8")
+    return host_creds
 
 
-# ── Symlink path ────────────────────────────────────────────────────────────
+def _agent_view(agent: Path) -> Path:
+    return agent / ".claude" / ".credentials.json"
 
 
-def test_symlink_created_when_supported(tmp_path):
-    if not _symlinks_available(tmp_path):
-        pytest.skip("symlinks unavailable on this host")
-    host = tmp_path / "host"
-    agent = tmp_path / "agent" / "home"
-    host_creds = _write_host_creds(host, '{"k":"v1"}')
-
-    mode = link_host_credentials(host, agent)
-
-    assert mode == "symlink"
-    agent_creds = agent / ".claude" / ".credentials.json"
-    assert agent_creds.is_symlink()
-    assert agent_creds.read_text() == '{"k":"v1"}'
-    # Host rewrite is visible via the symlink without re-linking.
-    host_creds.write_text('{"k":"v2"}', encoding="utf-8")
-    assert agent_creds.read_text() == '{"k":"v2"}'
+# ── sanitizer ─────────────────────────────────────────────────
 
 
-def test_symlink_idempotent(tmp_path):
-    if not _symlinks_available(tmp_path):
-        pytest.skip("symlinks unavailable on this host")
+def test_sanitize_strips_refresh_token_only():
+    view = json.loads(sanitize_claude_credentials_blob(json.dumps(HOST_CREDS)))
+    oauth = view["claudeAiOauth"]
+    assert "refreshToken" not in oauth
+    assert oauth["accessToken"] == "at-123"
+    assert oauth["expiresAt"] == 1900000000000
+    assert oauth["scopes"] == ["user:inference"]
+
+
+def test_sanitize_rejects_non_json():
+    assert sanitize_claude_credentials_blob("not json {") is None
+
+
+def test_sanitize_tolerates_missing_oauth_section():
+    blob = json.dumps({"somethingElse": True})
+    assert json.loads(sanitize_claude_credentials_blob(blob)) == {
+        "somethingElse": True
+    }
+
+
+# ── view creation ─────────────────────────────────────────────
+
+
+def test_view_written_without_refresh_token(tmp_path):
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    _write_host_creds(host)
+    _write_host(host)
 
-    assert link_host_credentials(host, agent) == "symlink"
-    # Second call: same target, nothing to do.
-    assert link_host_credentials(host, agent) == "symlink (already)"
+    mode = sync_host_credentials_view(host, agent)
+
+    assert mode == "view"
+    view = _agent_view(agent)
+    assert view.exists() and not view.is_symlink()
+    data = json.loads(view.read_text(encoding="utf-8"))
+    assert "refreshToken" not in data["claudeAiOauth"]
+    assert data["claudeAiOauth"]["accessToken"] == "at-123"
 
 
-def test_symlink_replaces_stale_regular_file(tmp_path):
-    """Old per-agent-copy design left a regular file at
-    .credentials.json. The link helper must replace it with a
-    symlink."""
-    if not _symlinks_available(tmp_path):
-        pytest.skip("symlinks unavailable on this host")
+def test_view_file_is_owner_only(tmp_path):
+    if os.name == "nt":
+        import pytest
+        pytest.skip("posix permission bits")
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    _write_host_creds(host, '{"k":"host"}')
-    # Stale regular-file copy from the old per-agent-copy design.
-    agent_creds = agent / ".claude" / ".credentials.json"
-    agent_creds.parent.mkdir(parents=True, exist_ok=True)
-    agent_creds.write_text('{"k":"stale-agent-copy"}', encoding="utf-8")
-
-    mode = link_host_credentials(host, agent)
-
-    assert mode == "symlink"
-    assert agent_creds.is_symlink()
-    assert agent_creds.read_text() == '{"k":"host"}'
+    _write_host(host)
+    sync_host_credentials_view(host, agent)
+    mode = _agent_view(agent).stat().st_mode & 0o777
+    assert mode == 0o600
 
 
-def test_symlink_replaces_broken_prior_symlink(tmp_path):
-    """A symlink pointing to a missing target is replaced, not
-    preserved."""
-    if not _symlinks_available(tmp_path):
-        pytest.skip("symlinks unavailable on this host")
+def test_view_idempotent(tmp_path):
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    _write_host_creds(host, '{"k":"host"}')
-    agent_creds = agent / ".claude" / ".credentials.json"
-    agent_creds.parent.mkdir(parents=True, exist_ok=True)
-    # Broken symlink: target doesn't exist.
-    os.symlink(tmp_path / "ghost", agent_creds)
-    assert agent_creds.is_symlink()
-    assert not agent_creds.exists()
+    _write_host(host)
 
-    mode = link_host_credentials(host, agent)
-
-    assert mode == "symlink"
-    assert agent_creds.read_text() == '{"k":"host"}'
+    assert sync_host_credentials_view(host, agent) == "view"
+    before = _agent_view(agent).stat().st_mtime_ns
+    assert sync_host_credentials_view(host, agent) == "view (fresh)"
+    # No rewrite -> no mtime churn.
+    assert _agent_view(agent).stat().st_mtime_ns == before
 
 
-# ── Copy fallback ───────────────────────────────────────────────────────────
-
-
-def test_copy_fallback_when_symlink_raises(tmp_path, monkeypatch):
+def test_view_tracks_host_rotation(tmp_path):
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    _write_host_creds(host, '{"k":"v1"}')
+    _write_host(host)
+    sync_host_credentials_view(host, agent)
 
-    def _fail_symlink(*a, **kw):
-        raise OSError("simulated no-symlink-privilege")
-    monkeypatch.setattr(os, "symlink", _fail_symlink)
+    rotated = json.loads(json.dumps(HOST_CREDS))
+    rotated["claudeAiOauth"]["accessToken"] = "at-789"
+    rotated["claudeAiOauth"]["refreshToken"] = "rt-new-000"
+    _write_host(host, rotated)
 
-    mode = link_host_credentials(host, agent)
-
-    assert mode == "copy"
-    agent_creds = agent / ".claude" / ".credentials.json"
-    assert not agent_creds.is_symlink()
-    assert agent_creds.read_text() == '{"k":"v1"}'
+    assert sync_host_credentials_view(host, agent) == "view"
+    data = json.loads(_agent_view(agent).read_text(encoding="utf-8"))
+    assert data["claudeAiOauth"]["accessToken"] == "at-789"
+    assert "refreshToken" not in data["claudeAiOauth"]
 
 
-def test_copy_fallback_is_idempotent_when_host_unchanged(tmp_path, monkeypatch):
+# ── self-healing ──────────────────────────────────────────────
+
+
+def test_view_heals_agent_side_garbage(tmp_path):
+    """A failed in-CLI refresh can mangle the agent's file (observed:
+    zeroed expiresAt). The next sync rewrites it from the host blob."""
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    _write_host_creds(host, '{"k":"v1"}')
-    monkeypatch.setattr(os, "symlink", lambda *a, **k: (_ for _ in ()).throw(OSError()))
+    _write_host(host)
+    sync_host_credentials_view(host, agent)
 
-    assert link_host_credentials(host, agent) == "copy"
-    # Same mtime + size → fast-path "already fresh", no rewrite.
-    assert link_host_credentials(host, agent) == "copy (fresh)"
+    _agent_view(agent).write_text("{}", encoding="utf-8")
+
+    assert sync_host_credentials_view(host, agent) == "view"
+    data = json.loads(_agent_view(agent).read_text(encoding="utf-8"))
+    assert data["claudeAiOauth"]["accessToken"] == "at-123"
 
 
-def test_copy_fallback_refreshes_when_host_changes(tmp_path, monkeypatch):
-    """Host file changes -> next call re-copies so the agent sees the
-    new content."""
-    import time as _time
+# ── legacy symlink migration ──────────────────────────────────
+
+
+def test_migrates_legacy_symlink_without_touching_host(tmp_path):
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    host_creds = _write_host_creds(host, '{"k":"old"}')
-    monkeypatch.setattr(os, "symlink", lambda *a, **k: (_ for _ in ()).throw(OSError()))
+    host_creds = _write_host(host)
+    host_blob_before = host_creds.read_text(encoding="utf-8")
 
-    assert link_host_credentials(host, agent) == "copy"
-    agent_creds = agent / ".claude" / ".credentials.json"
-    assert agent_creds.read_text() == '{"k":"old"}'
+    view = _agent_view(agent)
+    view.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(host_creds, view)
 
-    # Real "host was just refreshed" code path with bumped mtime.
-    _time.sleep(0.05)
-    host_creds.write_text('{"k":"new"}', encoding="utf-8")
-    # Force mtime forward in case of 1s FS granularity.
-    future = host_creds.stat().st_mtime + 2
-    os.utime(host_creds, (future, future))
+    mode = sync_host_credentials_view(host, agent)
 
-    assert link_host_credentials(host, agent) == "copy"
-    assert agent_creds.read_text() == '{"k":"new"}'
-
-
-# ── Missing host file ────────────────────────────────────────────────────────
+    assert mode == "view (migrated-from-symlink)"
+    assert not view.is_symlink()
+    data = json.loads(view.read_text(encoding="utf-8"))
+    assert "refreshToken" not in data["claudeAiOauth"]
+    # The host file (the old symlink target) keeps its refresh token.
+    assert host_creds.read_text(encoding="utf-8") == host_blob_before
+    assert "rt-secret-456" in host_creds.read_text(encoding="utf-8")
 
 
-def test_missing_host_file_is_reportable_noop(tmp_path):
-    host = tmp_path / "host"  # no .claude/
-    agent = tmp_path / "agent"
-
-    mode = link_host_credentials(host, agent)
-
-    assert mode == "no-host-file"
-    assert not (agent / ".claude" / ".credentials.json").exists()
-
-
-def test_missing_host_file_doesnt_clobber_existing_agent_file(tmp_path):
-    """Agent has creds but host doesn't (e.g. after a manual host
-    cleanup): leave the agent file alone, don't unlink."""
+def test_migrates_broken_symlink(tmp_path):
     host = tmp_path / "host"
     agent = tmp_path / "agent"
-    agent_creds = agent / ".claude" / ".credentials.json"
-    agent_creds.parent.mkdir(parents=True, exist_ok=True)
-    agent_creds.write_text('{"k":"agent-has-it"}', encoding="utf-8")
+    _write_host(host)
 
-    mode = link_host_credentials(host, agent)
+    view = _agent_view(agent)
+    view.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(tmp_path / "ghost", view)
 
-    assert mode == "no-host-file"
-    assert agent_creds.read_text() == '{"k":"agent-has-it"}'
+    assert sync_host_credentials_view(host, agent) == (
+        "view (migrated-from-symlink)"
+    )
+    assert not view.is_symlink()
+    assert "refreshToken" not in json.loads(
+        view.read_text(encoding="utf-8")
+    )["claudeAiOauth"]
+
+
+# ── degenerate hosts ──────────────────────────────────────────
+
+
+def test_no_host_file(tmp_path):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    assert sync_host_credentials_view(host, agent) == "no-host-file"
+    assert not _agent_view(agent).exists()
+
+
+def test_unparseable_host_file_leaves_agent_view_alone(tmp_path):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_host(host)
+    sync_host_credentials_view(host, agent)
+    good_view = _agent_view(agent).read_text(encoding="utf-8")
+
+    (host / ".claude" / ".credentials.json").write_text(
+        "corrupted {", encoding="utf-8",
+    )
+
+    assert sync_host_credentials_view(host, agent) == "unparseable-host-file"
+    # Existing (still-valid) view untouched.
+    assert _agent_view(agent).read_text(encoding="utf-8") == good_view

--- a/tests/test_host_credentials.py
+++ b/tests/test_host_credentials.py
@@ -224,6 +224,90 @@ def test_no_host_file(tmp_path):
     assert not _agent_view(agent).exists()
 
 
+def test_chmod_failure_is_swallowed(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_host(host)
+
+    real_chmod = Path.chmod
+
+    def _fail_chmod(self, *args, **kwargs):
+        if ".credentials.json.tmp" in self.name:
+            raise OSError("simulated chmod failure")
+        return real_chmod(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "chmod", _fail_chmod)
+
+    assert sync_host_credentials_view(host, agent) == "view"
+    view = _agent_view(agent)
+    assert "refreshToken" not in json.loads(
+        view.read_text(encoding="utf-8")
+    )["claudeAiOauth"]
+
+
+def test_agent_read_error_falls_through_to_rewrite(tmp_path, monkeypatch):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_host(host)
+
+    # Pre-place a file so the "not migrated" path enters read-compare.
+    view = _agent_view(agent)
+    view.parent.mkdir(parents=True, exist_ok=True)
+    view.write_text("stale-and-unreadable", encoding="utf-8")
+
+    real_read = Path.read_text
+
+    def _fail_agent_read(self, *args, **kwargs):
+        if self == view:
+            raise OSError("simulated read failure")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _fail_agent_read)
+
+    # Read-compare raised → falls through to write; final content is the view.
+    assert sync_host_credentials_view(host, agent) == "view"
+    monkeypatch.setattr(Path, "read_text", real_read)
+    assert "refreshToken" not in json.loads(
+        view.read_text(encoding="utf-8")
+    )["claudeAiOauth"]
+
+
+def test_concurrent_syncs_produce_valid_view(tmp_path):
+    """The race this whole design fixes: N concurrent writers hitting
+    the same agent view must all leave a complete, refresh-token-free
+    file behind. Also pins that the tmp+rename doesn't leak a partial
+    write on a losing thread."""
+    import threading
+
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_host(host)
+
+    errors: list[Exception] = []
+    barrier = threading.Barrier(6)
+
+    def _run():
+        try:
+            barrier.wait()
+            for _ in range(20):
+                sync_host_credentials_view(host, agent)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_run) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent sync raised: {errors!r}"
+    view = _agent_view(agent)
+    assert view.exists() and not view.is_symlink()
+    data = json.loads(view.read_text(encoding="utf-8"))
+    assert data["claudeAiOauth"]["accessToken"] == "at-123"
+    assert "refreshToken" not in data["claudeAiOauth"]
+
+
 def test_write_failure_returns_write_failed(tmp_path, monkeypatch):
     host = tmp_path / "host"
     agent = tmp_path / "agent"

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -432,9 +432,11 @@ def test_keychain_backend_sync_to_agent_writes_per_agent_file(tmp_path, monkeypa
 
 
 def test_keychain_backend_sync_skips_when_cache_empty(tmp_path, monkeypatch):
-    """No cache → no per-agent file written. Avoids stamping an
-    empty-string file that claude would later read as "no auth"."""
+    """No cache AND no disk file → no per-agent file written. Avoids
+    stamping an empty-string file that claude would later read as "no
+    auth"."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(cr, "_read_disk_credentials_blob", lambda _home: None)
     backend = _make_keychain_backend(tmp_path)
     agent_home = tmp_path / "agent-a"
     agent_home.mkdir()
@@ -529,9 +531,9 @@ def test_keychain_backend_refresh_returns_failed_on_claude_exit_failure(
 def test_keychain_backend_refresh_returns_failed_on_post_keychain_read_failure(
     monkeypatch, tmp_path,
 ):
-    """claude exits 0 but the post-refresh Keychain re-read fails (e.g.
-    transient permission issue). Don't poison the cache — return
-    FAILED so the daemon retries on the next tick."""
+    """claude exits 0 but BOTH the Keychain re-read and the disk-file
+    fallthrough fail. Don't poison the cache — return FAILED so the
+    daemon retries on the next tick."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
 
     async def _fake_spawn(*args, **kwargs):
@@ -544,6 +546,7 @@ def test_keychain_backend_refresh_returns_failed_on_post_keychain_read_failure(
             False, None, "exit_code=44", None,
         ),
     )
+    monkeypatch.setattr(cr, "_read_disk_credentials_blob", lambda _home: None)
 
     backend = _make_keychain_backend(tmp_path)
     backend.cache.write(_BLOB)
@@ -595,6 +598,8 @@ def test_keychain_backend_poll_external_rotation_no_change_returns_false(
 def test_keychain_backend_poll_external_rotation_swallows_read_failure(
     monkeypatch, tmp_path,
 ):
+    """Keychain read fails AND disk-file fallthrough is empty → poll
+    returns False (no rotation to fan out)."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
     backend = _make_keychain_backend(tmp_path)
     monkeypatch.setattr(
@@ -603,6 +608,7 @@ def test_keychain_backend_poll_external_rotation_swallows_read_failure(
             False, None, "security_timeout", None,
         ),
     )
+    monkeypatch.setattr(cr, "_read_disk_credentials_blob", lambda _home: None)
     rotated = asyncio.run(backend.poll_external_rotation())
     assert rotated is False
 
@@ -685,3 +691,223 @@ def test_refresher_with_keychain_backend_refreshes_when_close_to_expiry(
     # Refresh uses real HOME — same model as FileBackend.
     env = spawned[0]
     assert env["HOME"] == str(Path.home())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# KeychainBackend disk-file fallthrough — covers macOS hosts where
+# Claude Code 2.x silently fails Keychain writes under launchd
+# session-context but still writes ~/.claude/.credentials.json.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _patch_disk_blob(monkeypatch, blob):
+    monkeypatch.setattr(cr, "_read_disk_credentials_blob", lambda _home: blob)
+
+
+def _patch_disk_expires(monkeypatch, expires_in_seconds):
+    if expires_in_seconds is None:
+        monkeypatch.setattr(cr, "_disk_expires_in_seconds", lambda _home: None)
+    else:
+        monkeypatch.setattr(
+            cr, "_disk_expires_in_seconds",
+            lambda _home: expires_in_seconds,
+        )
+
+
+def test_expires_in_seconds_falls_through_to_disk_when_keychain_dead(
+    monkeypatch, tmp_path,
+):
+    """Keychain entry missing + cache empty → read expires from disk."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "item_not_found", None,
+        ),
+    )
+    _patch_disk_blob(monkeypatch, _BLOB)
+    _patch_disk_expires(monkeypatch, 3600)
+
+    backend = _make_keychain_backend(tmp_path)
+    assert backend.expires_in_seconds() == 3600
+    # Disk blob is opportunistically warmed into the cache.
+    assert backend.cache.read() == _BLOB
+
+
+def test_expires_in_seconds_returns_none_when_both_dead(monkeypatch, tmp_path):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "item_not_found", None,
+        ),
+    )
+    _patch_disk_blob(monkeypatch, None)
+    _patch_disk_expires(monkeypatch, None)
+
+    backend = _make_keychain_backend(tmp_path)
+    assert backend.expires_in_seconds() is None
+
+
+def test_refresh_treats_disk_rotation_as_refreshed_when_keychain_dead(
+    monkeypatch, tmp_path,
+):
+    """claude --print exits 0, Keychain read fails (entry missing), but
+    the disk file got rotated → REFRESHED, cache pulled from disk."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+
+    async def _fake_spawn(*args, **kwargs):
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "item_not_found", None,
+        ),
+    )
+    disk_blobs = iter([_BLOB, _REFRESHED_BLOB])
+    monkeypatch.setattr(
+        cr, "_read_disk_credentials_blob",
+        lambda _home: next(disk_blobs),
+    )
+
+    backend = _make_keychain_backend(tmp_path)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome == cr.RefreshOutcome.REFRESHED
+    assert backend.cache.read() == _REFRESHED_BLOB
+    assert backend._last_propagated_blob == _REFRESHED_BLOB
+
+
+def test_refresh_treats_disk_unchanged_as_unchanged_when_keychain_dead(
+    monkeypatch, tmp_path,
+):
+    """claude --print exits 0, Keychain dead, disk file byte-identical
+    before/after → UNCHANGED (token was still fresh, claude no-op'd
+    the OAuth round-trip)."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+
+    async def _fake_spawn(*args, **kwargs):
+        return _FakeAsyncProc(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "item_not_found", None,
+        ),
+    )
+    _patch_disk_blob(monkeypatch, _BLOB)
+
+    backend = _make_keychain_backend(tmp_path)
+    outcome = asyncio.run(backend.refresh())
+    assert outcome == cr.RefreshOutcome.UNCHANGED
+
+
+def test_bootstrap_falls_through_to_disk_when_keychain_dead(
+    monkeypatch, tmp_path,
+):
+    """Bootstrap on a host where the Keychain entry was never written
+    (Claude Code 2.x under launchd) but the disk file exists → ok=True
+    with a fallback reason, cache primed from disk."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        cm, "bootstrap_from_keychain",
+        lambda cache: (False, "keychain_item_not_found"),
+    )
+    _patch_disk_blob(monkeypatch, _BLOB)
+
+    backend = _make_keychain_backend(tmp_path)
+    ok, reason = asyncio.run(backend.bootstrap())
+    assert ok is True
+    assert "fallback" in reason
+    assert backend.cache.read() == _BLOB
+    assert backend._last_propagated_blob == _BLOB
+
+
+def test_bootstrap_fails_when_both_keychain_and_disk_are_dead(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        cm, "bootstrap_from_keychain",
+        lambda cache: (False, "keychain_item_not_found"),
+    )
+    _patch_disk_blob(monkeypatch, None)
+
+    backend = _make_keychain_backend(tmp_path)
+    ok, reason = asyncio.run(backend.bootstrap())
+    assert ok is False
+    assert reason == "keychain_item_not_found"
+
+
+def test_sync_to_agent_uses_disk_when_cache_empty(monkeypatch, tmp_path):
+    """Per-agent file written from disk when cache is empty — closes
+    the path where bootstrap hasn't warmed the cache yet but a worker
+    is already calling sync_to_agent via ensure_fresh fan-out."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    _patch_disk_blob(monkeypatch, _BLOB)
+
+    backend = _make_keychain_backend(tmp_path)
+    # Cache is empty.
+    assert backend.cache.read() is None
+    agent_home = tmp_path / "agent-a"
+    agent_home.mkdir()
+    backend.sync_to_agent(agent_home)
+    assert (agent_home / ".claude" / ".credentials.json").read_text() == _BLOB
+
+
+def test_sync_to_agent_is_idempotent_when_target_matches(
+    monkeypatch, tmp_path,
+):
+    """Repeated fan-out from concurrent ensure_fresh callers should
+    skip the atomic write when the target file already matches.
+    Verified by spying on os.replace."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    _patch_disk_blob(monkeypatch, None)
+
+    backend = _make_keychain_backend(tmp_path)
+    backend.cache.write(_BLOB)
+    agent_home = tmp_path / "agent-a"
+    agent_home.mkdir()
+    # First sync — file gets written.
+    backend.sync_to_agent(agent_home)
+    target = agent_home / ".claude" / ".credentials.json"
+    assert target.read_text() == _BLOB
+
+    import os as _os
+    replace_calls = 0
+    real_replace = _os.replace
+
+    def _spy_replace(src, dst):
+        nonlocal replace_calls
+        replace_calls += 1
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(_os, "replace", _spy_replace)
+    # Second sync — target already matches → no write.
+    backend.sync_to_agent(agent_home)
+    assert replace_calls == 0
+
+
+def test_poll_external_rotation_detects_disk_rotation_when_keychain_dead(
+    monkeypatch, tmp_path,
+):
+    """Operator runs `claude /login` on a host where Keychain is dead
+    — the rotation lands in ~/.claude/.credentials.json. Poll must
+    pick it up via disk fallthrough so agents get fanned out."""
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            False, None, "item_not_found", None,
+        ),
+    )
+    _patch_disk_blob(monkeypatch, _REFRESHED_BLOB)
+
+    backend = _make_keychain_backend(tmp_path)
+    backend._last_propagated_blob = _BLOB
+    rotated = asyncio.run(backend.poll_external_rotation())
+    assert rotated is True
+    assert backend._last_propagated_blob == _REFRESHED_BLOB
+    assert backend.cache.read() == _REFRESHED_BLOB

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -46,6 +46,13 @@ _REFRESHED_BLOB = json.dumps({
 })
 
 
+def _view(blob: str) -> str:
+    """The per-agent *view* of a canonical blob: refresh token
+    stripped. sync_to_agent writes this, never the raw blob."""
+    from puffo_agent.portal.state import sanitize_claude_credentials_blob
+    return sanitize_claude_credentials_blob(blob)
+
+
 def _force_macos(monkeypatch):
     monkeypatch.setattr(cm, "is_macos", lambda: True)
 
@@ -428,7 +435,8 @@ def test_keychain_backend_sync_to_agent_writes_per_agent_file(tmp_path, monkeypa
     agent_creds = agent_home / ".claude" / ".credentials.json"
     assert agent_creds.exists()
     assert not agent_creds.is_symlink()
-    assert agent_creds.read_text() == _BLOB
+    assert agent_creds.read_text() == _view(_BLOB)
+    assert "refreshToken" not in agent_creds.read_text()
 
 
 def test_keychain_backend_sync_skips_when_cache_empty(tmp_path, monkeypatch):
@@ -622,7 +630,7 @@ def test_refresher_with_keychain_backend_fans_sync_to_registered_agents(
 ):
     """After a _tick on macOS, the refresher's fan-out calls
     KeychainBackend.sync_to_agent for every registered agent — same
-    contract as the FileBackend's link_host_credentials path, just
+    contract as the FileBackend's sync_host_credentials_view path, just
     plumbed through the backend abstraction."""
     monkeypatch.setattr(cm, "is_macos", lambda: True)
     backend = _make_keychain_backend(tmp_path)
@@ -649,8 +657,8 @@ def test_refresher_with_keychain_backend_fans_sync_to_registered_agents(
 
     asyncio.run(refresher._tick())
 
-    assert (agent_a / ".claude" / ".credentials.json").read_text() == far_future_blob
-    assert (agent_b / ".claude" / ".credentials.json").read_text() == far_future_blob
+    assert (agent_a / ".claude" / ".credentials.json").read_text() == _view(far_future_blob)
+    assert (agent_b / ".claude" / ".credentials.json").read_text() == _view(far_future_blob)
 
 
 def test_refresher_with_keychain_backend_refreshes_when_close_to_expiry(
@@ -854,7 +862,7 @@ def test_sync_to_agent_uses_disk_when_cache_empty(monkeypatch, tmp_path):
     agent_home = tmp_path / "agent-a"
     agent_home.mkdir()
     backend.sync_to_agent(agent_home)
-    assert (agent_home / ".claude" / ".credentials.json").read_text() == _BLOB
+    assert (agent_home / ".claude" / ".credentials.json").read_text() == _view(_BLOB)
 
 
 def test_sync_to_agent_is_idempotent_when_target_matches(
@@ -873,7 +881,7 @@ def test_sync_to_agent_is_idempotent_when_target_matches(
     # First sync — file gets written.
     backend.sync_to_agent(agent_home)
     target = agent_home / ".claude" / ".credentials.json"
-    assert target.read_text() == _BLOB
+    assert target.read_text() == _view(_BLOB)
 
     import os as _os
     replace_calls = 0

--- a/tests/test_worker_pre_delivery_token_check.py
+++ b/tests/test_worker_pre_delivery_token_check.py
@@ -1,4 +1,4 @@
-"""macOS pre-delivery token gate.
+"""Pre-delivery token gate.
 
 When the Worker is about to dispatch a batch to its adapter and the
 daemon-owned credential isn't fresh, ``ensure_fresh_token`` drives a
@@ -9,18 +9,15 @@ the consumer re-enqueues the batch."""
 
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 import tempfile
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from puffo_agent.agent.core import AgentAPIError
 from puffo_agent.portal.runtime_matrix import (
     RUNTIME_CLI_LOCAL,
     RUNTIME_WS_LOCAL,
@@ -55,18 +52,13 @@ def _make_worker(runtime_kind: str, *, ensure_fresh=None) -> Worker:
 
 
 @pytest.mark.asyncio
-async def test_ensure_fresh_callback_skipped_for_non_claude_runtime(monkeypatch):
-    # ws-local and api-puffo don't use claude OAuth — pre-deliver
-    # check must short-circuit so we don't spuriously refresh.
-    monkeypatch.setattr(
-        "puffo_agent.portal.worker._is_macos", lambda: True,
-    )
+async def test_ensure_fresh_callback_skipped_for_non_claude_runtime():
+    # ws-local (and api-puffo) don't use claude OAuth — the gate must
+    # short-circuit on runtime.kind so we don't spuriously refresh.
     ensure = AsyncMock(return_value=False)
     w = _make_worker(RUNTIME_WS_LOCAL, ensure_fresh=ensure)
-    # Simulate the gate predicate from on_message_batch verbatim.
     should_check = (
         w._ensure_fresh_token is not None
-        and __import__("puffo_agent.portal.worker", fromlist=["_is_macos"])._is_macos()
         and w.agent_cfg.runtime.kind in (
             RUNTIME_CLI_LOCAL, "cli-docker",
         )
@@ -76,24 +68,19 @@ async def test_ensure_fresh_callback_skipped_for_non_claude_runtime(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_ensure_fresh_callback_skipped_on_non_macos(monkeypatch):
-    # Linux/Windows already get safe behaviour via the shared
-    # credentials file — skip the gate.
-    monkeypatch.setattr(
-        "puffo_agent.portal.worker._is_macos", lambda: False,
-    )
-    from puffo_agent.portal import worker as worker_mod
-    ensure = AsyncMock(return_value=False)
+async def test_ensure_fresh_callback_fires_for_cli_local_runtime():
+    # The gate is platform-agnostic: cli-local (and cli-docker) always
+    # runs it. The rotating single-use RT race exists on Linux/Windows
+    # too, so gating on OS was overly restrictive.
+    ensure = AsyncMock(return_value=True)
     w = _make_worker(RUNTIME_CLI_LOCAL, ensure_fresh=ensure)
     should_check = (
         w._ensure_fresh_token is not None
-        and worker_mod._is_macos()
         and w.agent_cfg.runtime.kind in (
             RUNTIME_CLI_LOCAL, "cli-docker",
         )
     )
-    assert should_check is False
-    assert not ensure.called
+    assert should_check is True
 
 
 @pytest.mark.asyncio
@@ -124,7 +111,7 @@ async def test_dm_dedup_one_per_expiration_episode():
 def test_worker_constructor_accepts_ensure_fresh_token():
     # Belt-and-suspenders: the new kwarg is wired all the way through
     # without exploding default-None behaviour for callers that don't
-    # pass it (tests for non-macOS / non-claude paths).
+    # pass it (non-claude runtimes: ws-local, api-puffo, hermes).
     w_with = _make_worker(RUNTIME_CLI_LOCAL, ensure_fresh=AsyncMock())
     assert w_with._ensure_fresh_token is not None
     w_without = _make_worker(RUNTIME_CLI_LOCAL)

--- a/tests/test_worker_pre_delivery_token_check.py
+++ b/tests/test_worker_pre_delivery_token_check.py
@@ -1,0 +1,131 @@
+"""macOS pre-delivery token gate.
+
+When the Worker is about to dispatch a batch to its adapter and the
+daemon-owned credential isn't fresh, ``ensure_fresh_token`` drives a
+refresh through the daemon's mutex. Failure flips ``auth_failed``,
+DMs the operator ONCE per expiration episode (dedup via
+``_auth_failed_notification_sent``), and raises ``AgentAPIError`` so
+the consumer re-enqueues the batch."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.core import AgentAPIError
+from puffo_agent.portal.runtime_matrix import (
+    RUNTIME_CLI_LOCAL,
+    RUNTIME_WS_LOCAL,
+)
+from puffo_agent.portal.state import AgentConfig, DaemonConfig, RuntimeState
+from puffo_agent.portal.worker import Worker
+
+
+def _isolated_home() -> str:
+    home = tempfile.mkdtemp(prefix="puffo-pre-deliver-")
+    os.environ["PUFFO_AGENT_HOME"] = home
+    return home
+
+
+def _make_worker(runtime_kind: str, *, ensure_fresh=None) -> Worker:
+    cfg = MagicMock(spec=AgentConfig)
+    cfg.id = "test-agent"
+    cfg.runtime = MagicMock()
+    cfg.runtime.kind = runtime_kind
+    cfg.runtime.harness = "claude-code"
+    cfg.display_name = "Test"
+
+    daemon_cfg = DaemonConfig()
+    w = Worker(
+        daemon_cfg,
+        cfg,
+        notify_refresh_needed=lambda: None,
+        ensure_fresh_token=ensure_fresh,
+    )
+    w.runtime = RuntimeState(status="running")
+    return w
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_callback_skipped_for_non_claude_runtime(monkeypatch):
+    # ws-local and api-puffo don't use claude OAuth — pre-deliver
+    # check must short-circuit so we don't spuriously refresh.
+    monkeypatch.setattr(
+        "puffo_agent.portal.worker._is_macos", lambda: True,
+    )
+    ensure = AsyncMock(return_value=False)
+    w = _make_worker(RUNTIME_WS_LOCAL, ensure_fresh=ensure)
+    # Simulate the gate predicate from on_message_batch verbatim.
+    should_check = (
+        w._ensure_fresh_token is not None
+        and __import__("puffo_agent.portal.worker", fromlist=["_is_macos"])._is_macos()
+        and w.agent_cfg.runtime.kind in (
+            RUNTIME_CLI_LOCAL, "cli-docker",
+        )
+    )
+    assert should_check is False
+    assert not ensure.called
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_callback_skipped_on_non_macos(monkeypatch):
+    # Linux/Windows already get safe behaviour via the shared
+    # credentials file — skip the gate.
+    monkeypatch.setattr(
+        "puffo_agent.portal.worker._is_macos", lambda: False,
+    )
+    from puffo_agent.portal import worker as worker_mod
+    ensure = AsyncMock(return_value=False)
+    w = _make_worker(RUNTIME_CLI_LOCAL, ensure_fresh=ensure)
+    should_check = (
+        w._ensure_fresh_token is not None
+        and worker_mod._is_macos()
+        and w.agent_cfg.runtime.kind in (
+            RUNTIME_CLI_LOCAL, "cli-docker",
+        )
+    )
+    assert should_check is False
+    assert not ensure.called
+
+
+@pytest.mark.asyncio
+async def test_dm_dedup_one_per_expiration_episode():
+    # After ``_enter_auth_failed`` fires, ``_on_auth_failed_enter`` is
+    # gated by ``_auth_failed_notification_sent`` so re-entries within
+    # the SAME episode don't re-DM. The flag re-arms only after the
+    # daemon's on_refresh_success.
+    w = _make_worker(RUNTIME_CLI_LOCAL)
+    w._notify_operator_of_auth_failed_oauth = AsyncMock()
+
+    # First trigger: schedules the DM.
+    assert w._auth_failed_notification_sent is False
+    w._on_auth_failed_enter()
+    assert w._auth_failed_notification_sent is True
+
+    # Second trigger in the same episode: dedup gate fires, no
+    # re-schedule.
+    w._on_auth_failed_enter()
+    assert w._auth_failed_notification_sent is True
+
+    # Simulate daemon's on_refresh_success re-arming the flag.
+    w._auth_failed_notification_sent = False
+    w._on_auth_failed_enter()
+    assert w._auth_failed_notification_sent is True
+
+
+def test_worker_constructor_accepts_ensure_fresh_token():
+    # Belt-and-suspenders: the new kwarg is wired all the way through
+    # without exploding default-None behaviour for callers that don't
+    # pass it (tests for non-macOS / non-claude paths).
+    w_with = _make_worker(RUNTIME_CLI_LOCAL, ensure_fresh=AsyncMock())
+    assert w_with._ensure_fresh_token is not None
+    w_without = _make_worker(RUNTIME_CLI_LOCAL)
+    assert w_without._ensure_fresh_token is None


### PR DESCRIPTION
## Summary

Fixes the "token expired" cascade users hit on Linux + macOS. Two independent bugs, one release:

**Bug A — refresh race with token-family revocation (Linux + macOS).** Anthropic and OpenAI rotate refresh tokens on every use; the old symlink-sharing model gave every agent process access to the single-use RT. N concurrent claude / codex CLIs racing a refresh → loser presents an already-consumed token → the provider revokes the whole token family → every process 401s until the operator re-runs ``claude /login``. Root fix: agents only get a **sanitized view** of the credentials file (access token kept, refresh token stripped for Claude / blanked to ``""`` for Codex to satisfy its non-optional serde). Only the daemon's ``CredentialRefresher`` (single-writer, ``asyncio.Lock``) holds the RT → race is structurally impossible.

**Bug B — pre-delivery refresh gate was macOS-only.** The Worker's ``await ensure_fresh()`` was gated on ``is_macos()`` on the theory Linux/Windows would win the race naturally through the shared symlinked file. Anthropic's rotating single-use RT semantics don't care about the OS; the gate now extends the safety net to Linux and Windows too.

Plus a handful of correctness fixes that fell out along the way:

- Rotating-refresh-token silent-fail detection (both disk + Keychain retain the pre-rotation token; ``claude --print`` returns 401 with rate-limit-adjacent wording → now classified as ``AUTH_FAILED`` up front so the operator gets DM'd immediately instead of after 2 tick failures).
- macOS: ``KeychainBackend`` disk-file fallthrough when the Keychain entry is missing (launchd session-context can silently drop Keychain writes).
- ``ensure_fresh()`` fans canonical credentials out to every registered agent before returning ``True`` (closes a split-brain window).
- Verbose per-source read logs (``source=cache`` / ``keychain`` / ``disk``) at DEBUG so the disk/Keychain split-brain is visible from the daemon log.

Legacy per-agent symlinks are migrated in place on first sync — the host file is never touched. Content-compare on sync doubles as self-healing if an agent-side CLI mangles its view.

## Version

**1.0.7 (stable release, 2026-07-06).** 1.0.7a1 alpha was running against a real macOS fleet for the past week with no regressions; the view work (was 1.0.7a2) landed on top and got the same test bar. Also includes PR #120 (foreground ``puffo-agent start`` model-catalog prefetch) and PR #121 (agent primer audit + bare-slug channel hint) via the ``main`` merge.

## Test plan

- [x] ``PYTHONPATH=src python -m pytest`` — **1780 passed / 7 skipped** (all skips = symlink-unavailable on Windows without Developer Mode). Baseline drift: was 1695 on the initial macOS-gate landing.
- [x] **Coverage on new code (state.py lines 178–324, five functions): 100%**. Every branch — including the ``chmod``/``read_text`` defensive ``except OSError: pass`` — has an explicit test.
- [x] **Race test**: 6 threads × 20 loops each concurrently syncing the same agent view — no exceptions, final file always a complete refresh-token-free JSON. This is the class of race the design eliminates.
- [x] **Coalescing** (pre-delivery gate): 100 simultaneous ``ensure_fresh()`` callers → exactly 1 ``backend.refresh()``.
- [x] **DM dedup**: re-entries into ``_on_auth_failed_enter`` within one expiration episode don't re-DM until ``on_refresh_success`` re-arms the flag.
- [x] **Migration**: legacy symlinks replaced by view files in place; host file bit-identical before/after (tested).
- [x] Live smoke (Windows host, 1.0.7a1 alpha): agents reconnect cleanly, no ImportError / Traceback in ``background.log``.
- [x] Live smoke (Linux + macOS, 1.0.7a1 alpha, one week): no rotating-RT revocations reported.

## Out of scope (deliberate)

- ``cli-docker`` mounts the host ``.credentials.json`` directly; the pre-delivery gate forces a fresh token before container start, so the container's read is always current.
- macOS Keychain ACL prompts blocking ``claude --print`` in tray mode — different failure shape, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)