### PR TITLE
feat(portal): report turn errors + fix claude-code input token count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   client renders this as a per-agent activity log. Covers both the
   claude-code and codex harnesses. Best-effort and ephemeral: the
   updates no-op when the operator isn't linked and never affect the
-  agent's own processing. `[SILENT]` turns and the cached portion of
-  codex's input token count are excluded.
+  agent's own processing. `[SILENT]` turns are excluded, and the
+  reported input token count excludes the re-sent cached context on
+  both harnesses so it reflects the turn's new work.
+- **Turn errors reported to the operator.** When a turn fails (auth
+  error, API error, or an unexpected exception), the daemon streams
+  an `agent.status` error event so it surfaces in the operator's
+  activity log, not only in the heartbeat status.
 
 ## [1.0.3] — 2026-06-27
 

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -20,13 +20,10 @@ logger = logging.getLogger(__name__)
 ProgressCallback = Callable[[str], Awaitable[None]]
 
 
-# Agent-emitted marker meaning "I'm deliberately not replying". The shell
-# suppresses both the auto-post fallback and the reverse-channel report when it
-# appears anywhere in the assistant text.
+# Agent marker for "deliberately not replying" — suppresses fallback + report.
 SILENT_MARKER = "[SILENT]"
 
-# Cap on text previews (message body, send content) put in agent.status
-# payloads — the operator UI truncates further for display.
+# Cap on text previews in agent.status payloads (the UI truncates further).
 STATUS_PREVIEW_CHARS = 200
 
 

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -788,7 +788,12 @@ class ClaudeSession:
                 if sid and sid != self._session_id:
                     self._save_session_id(sid)
                 usage = event.get("usage") or {}
-                input_tokens = int(usage.get("input_tokens", 0) or 0)
+                # input_tokens is only the uncached delta (often single digits);
+                # add the newly-cached input for the real non-cache-read figure,
+                # matching codex's cache-excluded input.
+                input_tokens = int(usage.get("input_tokens", 0) or 0) + int(
+                    usage.get("cache_creation_input_tokens", 0) or 0
+                )
                 output_tokens = int(usage.get("output_tokens", 0) or 0)
                 # Fallback for CLI versions where the assembled text
                 # reply only appears on ``result.result``.

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -788,9 +788,8 @@ class ClaudeSession:
                 if sid and sid != self._session_id:
                     self._save_session_id(sid)
                 usage = event.get("usage") or {}
-                # input_tokens is only the uncached delta (often single digits);
-                # add the newly-cached input for the real non-cache-read figure,
-                # matching codex's cache-excluded input.
+                # input_tokens is just the uncached delta; add newly-cached input
+                # for the real non-cache-read figure (matches codex).
                 input_tokens = int(usage.get("input_tokens", 0) or 0) + int(
                     usage.get("cache_creation_input_tokens", 0) or 0
                 )

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -1069,13 +1069,11 @@ class CodexSession:
         turn = self._active_turn
 
         if m.startswith("thread/tokenusage/updated") and turn is not None:
-            # codex reports per-turn tokens here, NOT on turn/completed.
-            # ``last`` is the current turn; it refreshes a few times — the
-            # value standing when turn/completed fires is the final tally.
+            # codex reports per-turn tokens here (not turn/completed); ``last``
+            # refreshes during the turn, final value stands at turn/completed.
             last = ((params or {}).get("tokenUsage") or {}).get("last") or {}
             try:
-                # ``inputTokens`` includes the (re-sent) cached context; subtract
-                # it so the figure matches claude-code's cache-excluded input.
+                # Subtract the re-sent cached context (matches claude-code).
                 inp = int(last.get("inputTokens") or 0)
                 cached = int(last.get("cachedInputTokens") or 0)
                 turn.input_tokens = max(0, inp - cached)

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -42,9 +42,7 @@ def _format_assistant_fallback(text_parts: list[str], joined_reply: str) -> str:
 
 
 def _user_message_preview(messages: list[dict]) -> str:
-    """Body of the latest user message (whitespace-collapsed, followups
-    dropped) for the turn_start status — the log entry is otherwise a
-    metadata block."""
+    """Body of the latest user message (the log entry is a metadata block)."""
     for m in reversed(messages):
         content = m.get("content")
         if m.get("role") == "user" and isinstance(content, str) and "- message: " in content:
@@ -304,9 +302,8 @@ class PuffoAgent:
             memory_dir=self.memory_dir,
             on_progress=on_progress,
         )
-        # Reverse channel: turn_start, then the adapter streams
-        # assistant_text / tool_use, then turn_complete carries the tokens.
-        # Best-effort — the reporter no-ops if the WS is down / owner unlinked.
+        # Reverse channel: turn_start → adapter streams assistant_text/tool_use
+        # → turn_complete (tokens). Best-effort; no-ops if the owner isn't linked.
         from ..portal.control.reporter import get_reporter
 
         asyncio.ensure_future(

--- a/src/puffo_agent/portal/control/agent_message.py
+++ b/src/puffo_agent/portal/control/agent_message.py
@@ -1,14 +1,7 @@
-"""Machine → operator reverse-channel messages (Agent Portal v0.4).
-
-Mirrors the puffo message envelope: one content-key AEAD-seals the Layer-2
-payload, the content-key is HPKE-wrapped per operator device, and the machine
-signs the canonical envelope. The relay only sees opaque ciphertext. Used to
-stream ``agent.status`` (LLM logs) to the agent's owner operator.
-
-AAD contract (the web receiver must mirror it):
-  * content AEAD aad = ``message_id`` (utf-8)
-  * per-device wrap aad = ``f"{message_id}:{device_id}"`` (utf-8)
-  * HPKE info = ``MACHINE_MSG_HPKE_INFO``
+"""Machine → operator reverse-channel envelope: content-key AEAD over the
+payload + per-device HPKE wrap + machine signature (the relay sees only
+ciphertext). AAD must match the web receiver: content aad = message_id, wrap
+aad = f"{message_id}:{device_id}", HPKE info = MACHINE_MSG_HPKE_INFO.
 """
 
 from __future__ import annotations
@@ -44,8 +37,7 @@ class Recipient:
 def recipients_from_device_list(
     devices: list[dict], operator_root_pubkey: str
 ) -> list[Recipient]:
-    """KEM keys from ``/devices/active``, keeping only certs that chain to the
-    pinned operator root — so the relay can't inject a rogue recipient."""
+    """KEM keys from active device certs that chain to the pinned root."""
     try:
         root_pk = base64url_decode(operator_root_pubkey)
     except Exception:  # noqa: BLE001
@@ -86,8 +78,7 @@ def build_machine_message_envelope(
     message_id: str | None = None,
     ts: int | None = None,
 ) -> dict:
-    """Layer-1 transport envelope: content-key AEAD over ``payload`` + per-device
-    HPKE-wrapped content-key + machine signature."""
+    """Build the Layer-1 transport envelope."""
     if not recipients:
         raise ValueError("no recipients")
     message_id = message_id or f"mmsg_{uuid.uuid4()}"
@@ -131,8 +122,7 @@ async def fetch_active_recipients(
     operator_slug: str,
     operator_root_pubkey: str,
 ) -> list[Recipient]:
-    """GET the operator's active device certs (machine-authed) → verified
-    recipients. Returns [] on any error so callers can no-op cleanly."""
+    """Machine-authed GET of the operator's active devices → recipients ([] on error)."""
     path = f"/v2/machines/{machine.machine_id}/operators/{operator_slug}/devices/active"
     headers = machine_auth.signed_headers(machine, "GET", path)
     try:

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -281,8 +281,7 @@ class MachineControlClient:
                 await self._send(ws, {"type": "capabilities", "capabilities": last_caps})
                 sender = asyncio.create_task(self._heartbeat_loop(ws, stop, last_caps))
 
-                # Register the reverse-channel sender so the agent processing
-                # path can stream agent.status up this live socket.
+                # Register the reverse-channel sender on this live socket.
                 from .reporter import get_reporter
 
                 async def _report(operator_slug: str, envelope: dict) -> None:

--- a/src/puffo_agent/portal/control/reporter.py
+++ b/src/puffo_agent/portal/control/reporter.py
@@ -1,9 +1,6 @@
-"""Daemon-wide singleton that streams ``agent.status`` messages up the control
-WS to an agent's owner operator.
-
-The agent processing path calls ``emit(agent_slug, event, payload)``; the control
-client registers its WS sender while connected. Best-effort + ephemeral: if the
-WS is down, the owner isn't linked, or no active devices, the event is dropped.
+"""Daemon-wide singleton: streams agent.status events up the control WS to an
+agent's owner. Best-effort + ephemeral — drops the event if the WS is down, the
+owner isn't linked, or there are no active devices.
 """
 
 from __future__ import annotations

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1265,6 +1265,12 @@ class Worker:
                 turn_succeeded = False
                 turn_error = f"{type(exc).__name__}: {exc}"
             finally:
+                if turn_error:
+                    from .control.reporter import get_reporter
+
+                    asyncio.ensure_future(
+                        get_reporter().emit(agent_id, "error", {"error": turn_error})
+                    )
                 if run_id is not None and first_post_id:
                     # Build the batch payload: first row reuses the
                     # /start run_id (server UPDATEs its row); the

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -159,6 +159,32 @@ def test_one_turn_reads_line_larger_than_default_asyncio_limit(tmp_path):
     assert out.output_tokens == 20
 
 
+def test_input_tokens_include_cache_creation(tmp_path):
+    """``input_tokens`` alone is just the uncached delta (often single digits);
+    the recorded figure adds newly-cached input, excluding the cache read."""
+    result = {
+        "type": "result",
+        "subtype": "success",
+        "session_id": "sess-1",
+        "usage": {
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 331,
+            "cache_read_input_tokens": 142928,
+            "output_tokens": 26,
+        },
+    }
+    lines = [(json.dumps(result) + "\n").encode("utf-8")]
+    session = _make_session(tmp_path, audit=False)
+
+    async def drive():
+        session._proc = _FakeProc(stdout_lines=lines)
+        return await session._one_turn("hi")
+
+    out = asyncio.run(drive())
+    assert out.input_tokens == 3 + 331  # cache read (142928) excluded
+    assert out.output_tokens == 26
+
+
 # ── Test 2: stream overflow recovery ─────────────────────────────────────────
 
 


### PR DESCRIPTION
Two follow-ups to the agent.status reverse channel (#104), folded into the still-unreleased 1.0.4.

## Turn errors → operator
When a turn fails — auth error, API error, or an unexpected exception — the worker now streams an `agent.status` `error` event up the reverse channel from its `finally` block (one point, covers every failure path). Previously errors only reached the operator via the heartbeat status, which the client suppresses for own agents on a linked machine — so their Log never showed the error. The web client renders it as an error row.

## claude-code input token count
`usage.input_tokens` from claude-code's `result` event is only the *uncached* delta — for a cached conversation it's single digits (looked like a turn counter). Add `cache_creation_input_tokens` so the reported input is the turn's real non-cache-read work, matching codex's cache-excluded figure. (Live `usage`: `input_tokens: 3, cache_creation: 331, cache_read: 142928` → reports 334, not 3.)

## Tests
`test_input_tokens_include_cache_creation` + the existing worker error suite. cli_session recovery 20 passed; worker 88 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)