### PR TITLE
feat(portal): ws-local activity log + codex per-turn token fix (1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.5] — 2026-06-29
+
+### Added
+
+- **Activity log for ws-local agents.** Agents driven by an attached
+  tool (the ws-local runtime) now report their turns and tool calls
+  to the operator's activity log — the message being worked on, each
+  tool call (with the message body for sends), and turn completion.
+  These agents have no token usage to report, so only the activity is
+  shown.
+
+### Fixed
+
+- **codex per-turn token count.** A turn that makes several model
+  requests now reports the whole turn's tokens (taken from the thread
+  total's delta) instead of only the last request, so the figure no
+  longer looks far too small for multi-step turns.
+
 ## [1.0.4] — 2026-06-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.0.4"
+version = "1.0.5"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -187,9 +187,12 @@ class _PendingTurn:
     # posted; don't run the [SILENT]-fallback path". Each entry mirrors
     # the claude-code adapter's shape: ``{channel, root_id}``.
     send_message_targets: list[dict] = field(default_factory=list)
-    # Usage stats lifted from the final ``turn/completed`` envelope.
+    # Per-turn usage = delta of codex's per-thread cumulative totals from the
+    # value standing when this turn's first request completed.
     input_tokens: int = 0
     output_tokens: int = 0
+    _in_base: int | None = None
+    _out_base: int | None = None
     # ``turn/completed`` resolves this; ``turn/failed`` rejects it.
     completed: asyncio.Future = field(default_factory=asyncio.Future)
     # Optional progress callback for in-turn UI updates.
@@ -1071,13 +1074,20 @@ class CodexSession:
         if m.startswith("thread/tokenusage/updated") and turn is not None:
             # codex reports per-turn tokens here (not turn/completed); ``last``
             # refreshes during the turn, final value stands at turn/completed.
-            last = ((params or {}).get("tokenUsage") or {}).get("last") or {}
+            tu = (params or {}).get("tokenUsage") or {}
+            last = tu.get("last") or {}
+            total = tu.get("total") or {}
             try:
-                # Subtract the re-sent cached context (matches claude-code).
-                inp = int(last.get("inputTokens") or 0)
-                cached = int(last.get("cachedInputTokens") or 0)
-                turn.input_tokens = max(0, inp - cached)
-                turn.output_tokens = int(last.get("outputTokens") or 0)
+                # ``last`` is a single request; sum the whole turn via the
+                # thread total's delta. Input excludes the re-sent cached read.
+                cum_out = int(total.get("outputTokens") or 0)
+                cum_in = max(0, int(total.get("inputTokens") or 0) - int(total.get("cachedInputTokens") or 0))
+                if turn._out_base is None:
+                    last_in = max(0, int(last.get("inputTokens") or 0) - int(last.get("cachedInputTokens") or 0))
+                    turn._out_base = cum_out - int(last.get("outputTokens") or 0)
+                    turn._in_base = cum_in - last_in
+                turn.output_tokens = max(0, cum_out - turn._out_base)
+                turn.input_tokens = max(0, cum_in - turn._in_base)
             except (TypeError, ValueError):
                 pass
             return

--- a/src/puffo_agent/portal/ws_local/session.py
+++ b/src/puffo_agent/portal/ws_local/session.py
@@ -152,6 +152,15 @@ class WsLocalSession:
         elif isinstance(frame, Pong):
             pass
 
+    def _report_status(self, event: str, payload: dict) -> None:
+        """Best-effort agent.status to the operator — never break the loop."""
+        try:
+            from ..control.reporter import get_reporter
+
+            asyncio.ensure_future(get_reporter().emit(self.slug, event, payload))
+        except Exception:  # noqa: BLE001
+            pass
+
     async def _run_tool_call(self, call: ToolCall) -> None:
         handler = self._tool_dispatch.get(call.tool)
         if handler is None:
@@ -160,6 +169,10 @@ class WsLocalSession:
                 error=f"unknown tool: {call.tool!r}",
             )))
             return
+        tool_event = {"tool": call.tool}
+        if "send_message" in call.tool and isinstance(call.params.get("text"), str):
+            tool_event["content"] = call.params["text"][:200]
+        self._report_status("tool_use", tool_event)
         try:
             result = await handler(**call.params)
         except Exception as exc:
@@ -199,6 +212,10 @@ class WsLocalSession:
         first = inflight.envelope_ids()[0] if inflight.messages else ""
         if first:
             self._inflight_run_id = await self._reporter.begin_turn(first)
+            text = inflight.messages[0].get("text") if inflight.messages else ""
+            self._report_status(
+                "turn_start", {"message": text[:200] if isinstance(text, str) else ""}
+            )
 
     async def _on_end(self, bundle_id: str) -> None:
         """Close the turn, advance the cursor, pump next. Mints
@@ -212,6 +229,7 @@ class WsLocalSession:
             if first:
                 self._inflight_run_id = await self._reporter.begin_turn(first)
         await self._reporter.end_turn_batch(self._runs_for(bundle))
+        self._report_status("turn_complete", {})  # ws-local has no token usage
         await self._on_acked(bundle)
         self._inflight_run_id = None
         await self._pump()

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -320,6 +320,50 @@ while True:
     assert result.output_tokens == 21
 
 
+def test_token_usage_sums_multi_request_turn(tmp_path):
+    """A turn with several model requests reports the whole turn's usage (the
+    thread total's delta), not just the last request."""
+    fake = _write_fake(tmp_path, '''\
+absorb_initialize()
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "c1"}}})
+msg = r()  # turn/start
+turn_id = msg["id"]
+
+w({"jsonrpc": "2.0", "method": "thread/tokenUsage/updated",
+   "params": {"tokenUsage": {
+       "last": {"inputTokens": 1005, "cachedInputTokens": 1000, "outputTokens": 100},
+       "total": {"inputTokens": 5005, "cachedInputTokens": 5000, "outputTokens": 100}}}})
+w({"jsonrpc": "2.0", "method": "thread/tokenUsage/updated",
+   "params": {"tokenUsage": {
+       "last": {"inputTokens": 1008, "cachedInputTokens": 1000, "outputTokens": 110},
+       "total": {"inputTokens": 6013, "cachedInputTokens": 6000, "outputTokens": 210}}}})
+
+w({"jsonrpc": "2.0", "id": turn_id, "result": None})
+w({"jsonrpc": "2.0", "method": "turn/completed", "params": {"turn": {"status": "completed"}}})
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+    async def _run():
+        await cs.warm("system prompt")
+        result = await cs.run_turn("hi", "system prompt")
+        await cs.aclose()
+        return result
+
+    result = asyncio.run(_run())
+    assert result.output_tokens == 210  # 100 + 110, not just the last request's 110
+    assert result.input_tokens == 13    # cumulative non-cached, not just the last
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Resume happy path — second instance picks up the persisted id
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-ups to the agent activity log, for the 1.0.5 release.

## ws-local agents now report activity
Agents on the ws-local runtime (driven by an attached tool, e.g. Twinkle) had no activity in the operator's log — they don't go through the harness path that emits agent.status. The session frame loop now emits `turn_start` (on ack), `tool_use` (per dispatched tool call, with the body for sends), and `turn_complete` (on end). These agents have no token usage, so only the activity is shown.

## codex per-turn token count
codex reports usage on `thread/tokenUsage/updated`, where `last` is a **single model request**. A turn that makes several requests was keeping only the last one's count — e.g. a turn whose requests output 110 then 4 reported **4**, not 114. Now the per-turn figure is the delta of codex's per-thread cumulative `total` (input excludes the cached read), so it covers the whole turn. claude-code's `result` usage already aggregates per turn, so it's unchanged.

## Tests
`test_token_usage_sums_multi_request_turn` (110+110 across two requests → 210, not the last 110) + the existing codex/ws-local suites. Full suite **1698 passed / 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)