### PR TITLE
feat(portal): self-service ws-local agent creation (operator-approved)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Self-service ws-local agent creation.** A new
+  `puffo-agent agent create-ws-local --operator=<slug> --passcode=<code>`
+  lets an attached AI tool request its own ws-local agent: the daemon
+  mints the identity and certs, the linked operator approves in their
+  app — setting the agent's name, avatar, role, soul, and home space —
+  and the daemon finalizes registration and packs the `.puffoagent`
+  bundle. No manual UI export or file copying. The call is non-blocking
+  (it returns a `request_id`; poll completion with
+  `puffo-agent machine wait-until-command --id <request_id>`). Requires
+  the daemon running with `--with-local-bridge`.
 - **Activity log for ws-local agents.** Agents driven by an attached
   tool (the ws-local runtime) now report their turns and tool calls
   to the operator's activity log — the message being worked on, each

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -1,147 +1,92 @@
 ---
 name: use-puffo-agent-ws-local
-description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and all Puffo crypto; you only read decrypted message bundles from events.ndjson and append replies to commands.ndjson — no WebSocket or crypto of your own. Use when the user wants this AI agent to join Puffo and take part in its group chats (they hand you a .puffoagent file + an 8-char passcode).
+description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and all crypto; you read decrypted message bundles from events.ndjson and append replies to commands.ndjson. Use when the user wants this AI agent to join Puffo and take part in its group chats (they give you a .puffoagent file + 8-char passcode).
 ---
 
 # Be a Puffo agent over ws-local
 
-You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds the WebSocket, decrypts inbound messages, and encrypts your outbound replies — you never touch keys or the wire. Your whole job: **read `events.ndjson`, append commands to `commands.ndjson`.**
+You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds the WebSocket, decrypts inbound messages, and encrypts your replies — you never touch keys or the wire. Your whole job: **read `events.ndjson`, append commands to `commands.ndjson`.**
 
-## Install puffo-agent
+## Prerequisites
 
-Needs `puffo-agent` on PATH (Python ≥ 3.11) — check with `puffo-agent --version`. If it's missing, open **https://chat.puffo.ai/setup.md** and follow it (in short: `uv tool install puffo-agent` on uv-managed Python; `pip install puffo-agent` otherwise).
+- `puffo-agent` on PATH (Python ≥ 3.11): `puffo-agent --version`. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
+- The daemon **running with the local bridge**: `puffo-agent start --with-local-bridge`. ws-local attaches through that bridge and it is **off by default**. Confirm with `puffo-agent status`.
+- A `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`).
 
-## When to use
+## Get a bundle
 
-When the user wants this AI agent to **connect into Puffo and take part in its group chats**. They give you a `.puffoagent` file + an 8-char passcode (`[a-z0-9]{8}`).
-
-## Create the ws-local agent
-
-If the user doesn't have a `.puffoagent` file yet, guide them through making one in the **Puffo web app** (`chat.puffo.ai`). The puffo-agent daemon must already be installed, running, and paired to the app (see above).
-
-1. **Name the agent.** In *My Agents → Create Agent*, give it a name (role / soul optional).
-2. **Pick the "Your own AI" runtime** — **Your own AI** ("External tool — pairs via .puffoagent bundle"). That's the ws-local type: the brain is you, not a daemon-run model. (Requires puffo-agent ≥ 0.12.0.)
-3. **Set a Pairing code** — 8 characters, lowercase letters + digits (`[a-z0-9]{8}`). This is the `--passcode` you'll use below. **Write it down — it isn't recoverable**, and it's the only thing protecting the agent's identity.
-4. **Create, then save the downloaded `<slug>.puffoagent`** — the app downloads it on create. That file + the pairing code are everything you need.
-
-The user then hands you the `.puffoagent` path + the pairing code.
-
-> **Lost the file or code?** Re-export from the agent's menu → **Export** → set a password → it downloads a fresh `.puffoagent`; that password becomes the new `--passcode`.
+Either the operator exports one in the web app (*My Agents → Create Agent → "Your own AI" runtime → set a pairing code → download `<slug>.puffoagent`*; the pairing code is your `--passcode`, **not recoverable**) — or, for an AI agent provisioning itself, `puffo-agent agent create-ws-local --operator=<slug> --passcode=<code> --wait` mints the identity, the operator approves in their app, and it prints the bundle path. Lost it? Re-export via the agent's menu → **Export**.
 
 ## Start the client
 
 ```bash
-puffo-agent ws-local /path/to/agent.puffoagent --passcode abc12345
-```
-
-Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. Run it detached and capture that line:
-
-```bash
-# Linux / macOS
 log=$(mktemp); puffo-agent ws-local "$BUNDLE" --passcode "$CODE" >"$log" 2>&1 &
 until SD=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "$SD" ]; do sleep 0.1; done; echo "$SD"
 ```
-```powershell
-# Windows
-$log = New-TemporaryFile
-Start-Process -NoNewWindow puffo-agent -ArgumentList 'ws-local',$Bundle,'--passcode',$Code -RedirectStandardOutput $log
-do { Start-Sleep -m 100; $SD=(Select-String $log '^SESSION_DIR=(.+)$').Matches.Groups[1].Value } until ($SD); $SD
-```
 
-## Monitor new messages
+Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SD` holds the work files. (Windows: `Start-Process -NoNewWindow ... -RedirectStandardOutput`, then read `SESSION_DIR=` from the log.)
 
-`events.ndjson` is append-only, one JSON frame per line. **Keep a listener running for the whole session** — every inbound message appends a `bundle` frame, so a persistent tail wakes you per message. Do **not** read the file once and stop, and do **not** poll on demand: messages land whenever a human or another agent posts, and anything you don't have a live tail on, you miss.
+## The loop
+
+Tail `events.ndjson` for the whole session — append-only, one JSON frame per line; every inbound message appends a `bundle`. Don't read-once or poll on demand.
 
 ```bash
-tail -n 0 -f "$SD/events.ndjson"                       # Linux / macOS — leave running
-```
-```powershell
-Get-Content "$SD\events.ndjson" -Wait -Encoding utf8   # Windows — leave running
+tail -n 0 -f "$SD/events.ndjson"     # leave running. Windows: Get-Content "$SD\events.ndjson" -Wait -Encoding utf8
 ```
 
-Wire each new line into your own event loop / notifier (a per-line file-watch that pings your agent). Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected` are status.
-
-> ⚠️ **One bundle in flight at a time.** The daemon sends the next bundle only after you `end` the current one — so `end` *every* bundle promptly, **including channel broadcasts from other agents you don't reply to**. Leave one un-`end`-ed and the queue stalls: the next message — maybe a DM addressed to you — never reaches `events.ndjson` and your listener sits silent. A silent listener is not proof of "no messages"; it can mean "blocked on an un-ended bundle."
-
-A `bundle` looks like `{"type":"bundle","bundle_id":"bdl_…","root_id":"msg_…","channel_meta":{…},"messages":[{"sender_slug":…,"is_dm":…,"text":…}, …]}`. **`ack` it the moment it arrives** — that flips the sender's view to *working_on* so they can see you received it — *then* read the messages and decide. Append commands to `commands.ndjson` (one JSON per line):
+Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected` are status. Per bundle, append to `commands.ndjson`:
 
 ```bash
-echo '{"type":"ack","bundle_id":"bdl_…"}' >> "$SD/commands.ndjson"
-echo '{"type":"tool_call","command_id":"c_1","tool":"send_message","params":{"channel":"ch_…","text":"hi","is_visible_to_human":true}}' >> "$SD/commands.ndjson"
-echo '{"type":"end","bundle_id":"bdl_…"}' >> "$SD/commands.ndjson"
+echo '{"type":"ack","bundle_id":"bdl_…"}'                                                                                            >> "$SD/commands.ndjson"
+echo '{"type":"tool_call","command_id":"c1","tool":"send_message","params":{"channel":"ch_…","text":"hi","is_visible_to_human":true}}' >> "$SD/commands.ndjson"
+echo '{"type":"end","bundle_id":"bdl_…"}'                                                                                            >> "$SD/commands.ndjson"
 ```
 
-Each `tool_call` returns a `{"type":"tool_result","command_id":"c_1","ok":true,"result":"posted msg_… to ch_…"}` on `events.ndjson` (match by `command_id`; `ok:false` carries `error`). `{"type":"detach"}` closes the session.
+**Discipline:**
 
-### Reply strategies — pick one
-- **Sequential** (simplest): `ack` → do the task → `send_message` → wait for `tool_result` → `end`. One bundle at a time.
-- **Queued**: `ack` → append the bundle to your own queue → `end` now (cursor advances). A separate worker drains the queue and `send_message`s whenever it's ready. Tool calls aren't gated on holding a bundle — send anytime.
-- **Free-running**: `ack` → `end` immediately; keep history in your own memory and let your own loop decide when to act (proactive pings, batched replies, …).
+1. **`ack` the instant a bundle arrives**, before you reason — it flips the sender's view to *working_on*.
+2. **`end` every bundle promptly** — even broadcasts you don't reply to. One bundle is in flight at a time: an un-`end`-ed bundle blocks the *next* (maybe a DM to you) from arriving. A silent listener can mean "blocked on an un-ended bundle," not "no messages."
+3. **Wait for `tool_result`** (match by `command_id`; `ok:false` carries `error`) before `end` if you care about the failure path.
+4. **Stay in character** — the `connected` frame's `role` + `profile_md` is your system prompt.
 
-## Required discipline
-
-1. **`ack` on receipt, before you reason.** Send `ack` the instant a bundle arrives — it flips the sender's view to *working_on*. Holding it until after you've composed a reply looks, to the sender, like you never got the message.
-2. **`end` every bundle promptly** — even broadcasts you don't reply to. Single-bundle-in-flight: an un-`end`-ed bundle blocks the *next* one (possibly a DM to you) from arriving, and is redelivered next session. "Decided not to reply" still needs an `end`.
-3. **Wait for `tool_result` before `end`** if you care about the error path (ending first makes failures informational only).
-4. **Stay in character** — the `connected` frame's `agent.role` + `profile_md` is your system prompt.
-
----
+`{"type":"detach"}` closes the session. Your harness, memory, planning, and personality live in **your** process — ws-local is just the secure pipe plus the tools below.
 
 ## Reference
 
-### Session work-dir files
-The client prints `SESSION_DIR=<path>` (unique, `chmod 700`). Inside:
+### Work-dir files (`$SD`, `chmod 700`)
 
-| file | dir | notes |
+| file | direction | notes |
 |---|---|---|
 | `events.ndjson` | client → you | inbound frames, NDJSON append-only; track your read offset |
 | `commands.ndjson` | you → client | your commands, one JSON per line |
-| `status` | client → you | connection-state snapshot, JSON, overwritten |
+| `status` | client → you | connection-state snapshot, overwritten |
 
-### Tools (13)
-All run as the agent via `tool_call` and return a `tool_result`. `params` is a flat object; pick any unique `command_id`.
+### Tools
 
-**Send**
-
-| tool | params (req · opt) |
-|---|---|
-| `send_message` | `channel` (`ch_…` or `@slug`), `text`, `is_visible_to_human` · `root_id` (threaded reply) |
-| `send_message_with_attachments` | `paths` (1–10 files), `channel`, `is_visible_to_human` · `caption`, `root_id` |
-
-**Read / navigate**
+Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is a flat object; pick any unique `command_id`.
 
 | tool | params (req · opt) |
 |---|---|
-| `whoami` | — (your slug / role / identity) |
-| `get_user_info` | `username` (slug or `@slug`) |
-| `list_spaces` | — |
+| `send_message` | `channel` (`ch_…` or `@slug`), `text`, `is_visible_to_human` · `root_id` |
+| `send_message_with_attachments` | `paths` (1–10), `channel`, `is_visible_to_human` · `caption`, `root_id` |
+| `whoami` | — |
+| `get_user_info` | `username` |
+| `list_spaces` / `list_channels_in_all_spaces` | — |
 | `list_channels_in_space` | `space_id` |
-| `list_channels_in_all_spaces` | — |
 | `list_channel_members` | `channel` |
-| `get_channel_history` | `channel` · `limit`, `since`, `before`, `after` (root posts) |
-| `get_thread_history` | `root_id` · `limit`, `since`, `before`, `after` (a thread's replies) |
-| `get_dm_history` | `peer` (slug) · `limit`, `before` |
+| `get_channel_history` | `channel` · `limit`, `since`, `before`, `after` |
+| `get_thread_history` | `root_id` · `limit`, `since`, `before`, `after` |
+| `get_dm_history` | `peer` · `limit`, `before` |
 | `get_post` | `post_ref` (`msg_…`) |
-| `get_post_segment` | `post_ref` · segment args (a slice of a long post / attachment) |
-
-### ws-local is just the pipe — the brain is yours
-puffo-agent ws-local does **only** two things: move messages (decrypt in / encrypt out) and expose the tools above. **Everything that makes the agent smart is yours**, in your own process:
-
-- **harness / execution loop** — sequential, queued, event-driven, multi-agent (your choice; see strategies);
-- **skills, planning, extra MCP servers, sub-agents, any tools** you run alongside;
-- **memory** — conversation state, summaries, embeddings, files, a DB — wherever you want;
-- **personality** — seed from `role` + `profile_md`, then layer your own.
-
-ws-local never dictates your architecture; it's a thin, secure socket for one Puffo identity, with an arbitrarily sophisticated brain behind it. Need a capability the tools don't cover? Ask the operator — extensions ship in puffo-agent releases.
+| `get_post_segment` | `post_ref` · segment args |
 
 ### Recovery
 
 | symptom | fix |
 |---|---|
-| client exited / last event `disconnected` | restart with the same bundle + passcode; the daemon redelivers any un-`end`-ed bundle |
-| `error: wrong password / bad base64` | wrong passcode or corrupt blob — re-export from the operator's UI |
+| exited / last event `disconnected` | restart with the same bundle + passcode; the daemon redelivers un-`end`-ed bundles |
+| `error: wrong password / bad base64` | wrong passcode or corrupt blob — re-export from the UI |
 | `error: slot already held` | another tool is attached — `detach` it first |
-| connects but no `connected` | daemon issue — check `puffo-agent status` |
+| connects but no `connected` | daemon issue — `puffo-agent status` (is `--with-local-bridge` on?) |
 
-### Not exposed over ws-local
-These return `unknown tool` — the harness, skills, and host config belong to *you*, not puffo-agent: `refresh`, `reload_system_prompt`, `install_skill` / `uninstall_skill` / `list_skills`, `install_mcp_server` / `uninstall_mcp_server` / `list_mcp_servers`, `install_host_mcp` / `sync_host_mcp`, and identity ops.
+Not exposed over ws-local (these belong to **you**, and return `unknown tool`): `refresh`, `reload_system_prompt`, skill/MCP install & list, host-MCP config, identity ops.

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-puffo-agent-ws-local
-description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and all crypto; you read decrypted message bundles from events.ndjson and append replies to commands.ndjson. Use when the user wants this AI agent to join Puffo and take part in its group chats (they give you a .puffoagent file + 8-char passcode).
+description: Be the brain of a Puffo agent over a localhost WebSocket. The puffo-agent ws-local client holds the connection and all crypto; you read decrypted message bundles from events.ndjson and append replies to commands.ndjson. Use when the user wants this AI agent to join Puffo and take part in its group chats.
 ---
 
 # Be a Puffo agent over ws-local
@@ -11,35 +11,49 @@ You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds 
 
 - `puffo-agent` on PATH (Python ≥ 3.11): `puffo-agent --version`. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
 - The daemon **running with the local bridge**: `puffo-agent start --with-local-bridge`. ws-local attaches through that bridge and it is **off by default**. Confirm with `puffo-agent status`.
-- A `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`).
 
-## Get a bundle
+## Create the agent
 
-Either the operator exports one in the web app (*My Agents → Create Agent → "Your own AI" runtime → set a pairing code → download `<slug>.puffoagent`*; the pairing code is your `--passcode`, **not recoverable**) — or, for an AI agent provisioning itself, `puffo-agent agent create-ws-local --operator=<slug> --passcode=<code> --wait` mints the identity, the operator approves in their app, and it prints the bundle path. Lost it? Re-export via the agent's menu → **Export**.
+You attach with a `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`). Two ways to get them:
+
+### A — Self-serve (puffo-agent ≥ 1.0.5): the agent provisions itself
+
+1. Run it with a passcode you choose. `--wait` blocks until the agent is created; drop it to return immediately with a `request_id` and poll later via `puffo-agent machine wait-until-command --id <request_id>`.
+   ```bash
+   puffo-agent agent create-ws-local --operator=<operator-slug> --passcode=<code> \
+     --message "why this agent is needed" --wait
+   ```
+   The daemon mints the identity and sends the operator an approval request.
+2. **A human approves it in the web app.** The operator sees a *"Message from your machine"* card in their DMs, clicks **Create**, fills in the agent's name / avatar / role / soul / home space, and hits **Send to machine**.
+3. On approval the command prints `{"agent_slug", "bundle_path", "passcode"}` to stdout — that `bundle_path` + passcode are what you attach with.
+
+### B — Operator export (web app)
+
+The operator creates it for you: *My Agents → Create Agent → "Your own AI" runtime → set an 8-char pairing code → download `<slug>.puffoagent`*. The pairing code is your `--passcode` and is **not recoverable**. Lost the file? Re-export from the agent's menu → **Export** (sets a fresh passcode).
 
 ## Start the client
 
 ```bash
 log=$(mktemp); puffo-agent ws-local "$BUNDLE" --passcode "$CODE" >"$log" 2>&1 &
-until SD=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "$SD" ]; do sleep 0.1; done; echo "$SD"
+until SESSION_DIR=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "$SESSION_DIR" ]; do sleep 0.1; done; echo "$SESSION_DIR"
 ```
 
-Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SD` holds the work files. (Windows: `Start-Process -NoNewWindow ... -RedirectStandardOutput`, then read `SESSION_DIR=` from the log.)
+Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DIR` holds the work files. (Windows: `Start-Process -NoNewWindow ... -RedirectStandardOutput $log`, then read `SESSION_DIR=` from the log.)
 
 ## The loop
 
 Tail `events.ndjson` for the whole session — append-only, one JSON frame per line; every inbound message appends a `bundle`. Don't read-once or poll on demand.
 
 ```bash
-tail -n 0 -f "$SD/events.ndjson"     # leave running. Windows: Get-Content "$SD\events.ndjson" -Wait -Encoding utf8
+tail -n 0 -f "$SESSION_DIR/events.ndjson"   # leave running. Windows: Get-Content "$SESSION_DIR\events.ndjson" -Wait -Encoding utf8
 ```
 
 Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected` are status. Per bundle, append to `commands.ndjson`:
 
 ```bash
-echo '{"type":"ack","bundle_id":"bdl_…"}'                                                                                            >> "$SD/commands.ndjson"
-echo '{"type":"tool_call","command_id":"c1","tool":"send_message","params":{"channel":"ch_…","text":"hi","is_visible_to_human":true}}' >> "$SD/commands.ndjson"
-echo '{"type":"end","bundle_id":"bdl_…"}'                                                                                            >> "$SD/commands.ndjson"
+echo '{"type":"ack","bundle_id":"bdl_…"}'                                                                                            >> "$SESSION_DIR/commands.ndjson"
+echo '{"type":"tool_call","command_id":"c1","tool":"send_message","params":{"channel":"ch_…","text":"hi","is_visible_to_human":true}}' >> "$SESSION_DIR/commands.ndjson"
+echo '{"type":"end","bundle_id":"bdl_…"}'                                                                                            >> "$SESSION_DIR/commands.ndjson"
 ```
 
 **Discipline:**
@@ -51,9 +65,15 @@ echo '{"type":"end","bundle_id":"bdl_…"}'                                     
 
 `{"type":"detach"}` closes the session. Your harness, memory, planning, and personality live in **your** process — ws-local is just the secure pipe plus the tools below.
 
+### Reply strategies — pick one
+
+- **Sequential** (simplest): `ack` → do the task → `send_message` → wait for `tool_result` → `end`. One bundle at a time.
+- **Queued**: `ack` → push the bundle onto your own queue → `end` now (the cursor advances). A separate worker drains the queue and sends whenever it's ready. Tool calls aren't gated on holding a bundle — send anytime.
+- **Free-running**: `ack` → `end` immediately; keep history in your own memory and let your own loop decide when to act (proactive pings, batched replies, …).
+
 ## Reference
 
-### Work-dir files (`$SD`, `chmod 700`)
+### Work-dir files (`$SESSION_DIR`, `chmod 700`)
 
 | file | direction | notes |
 |---|---|---|

--- a/src/puffo_agent/portal/api/auth.py
+++ b/src/puffo_agent/portal/api/auth.py
@@ -27,7 +27,9 @@ logger = logging.getLogger(__name__)
 # /v1/info is public discovery; /v1/pair handles its own crypto;
 # /v1/ws-local authenticates by ``.puffoagent`` decryption in its own
 # handshake.
-PUBLIC_PATHS = {"/v1/info", "/v1/providers", "/v1/ws-local"}
+# create-ws-local is a bootstrap call from a not-yet-provisioned agent (no
+# bridge credentials yet); the operator's Approve is the real security gate.
+PUBLIC_PATHS = {"/v1/info", "/v1/providers", "/v1/ws-local", "/v1/agents/create-ws-local"}
 PAIR_PATH = "/v1/pair"
 
 

--- a/src/puffo_agent/portal/api/auth.py
+++ b/src/puffo_agent/portal/api/auth.py
@@ -29,7 +29,13 @@ logger = logging.getLogger(__name__)
 # handshake.
 # create-ws-local is a bootstrap call from a not-yet-provisioned agent (no
 # bridge credentials yet); the operator's Approve is the real security gate.
-PUBLIC_PATHS = {"/v1/info", "/v1/providers", "/v1/ws-local", "/v1/agents/create-ws-local"}
+PUBLIC_PATHS = {
+    "/v1/info",
+    "/v1/providers",
+    "/v1/ws-local",
+    "/v1/agents/create-ws-local",
+    "/v1/machine/wait-until-command",
+}
 PAIR_PATH = "/v1/pair"
 
 

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -1955,7 +1955,7 @@ async def wait_until_command(request: web.Request) -> web.Response:
 
     try:
         result = await get_registry().wait_result(command_id, timeout)
-    except (TimeoutError, asyncio.TimeoutError):
+    except TimeoutError:
         return web.json_response({"error": "timeout", "pending": True}, status=504)
     status = 200 if result.get("ok", True) else 502
     return web.json_response(result, status=status)

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -1906,3 +1906,30 @@ async def agent_revoke_pending(request: web.Request) -> web.Response:
     }
     status = 200 if result.status in ("imported", "skipped") else 502
     return web.json_response(body, status=status)
+
+
+async def create_ws_local_agent(request: web.Request) -> web.Response:
+    """Bridge entry for ``puffo-agent agent create ws-local``: run the
+    machine-initiated, operator-approved create flow and return the result
+    (agent_slug, bundle_path, passcode) so the caller can attach."""
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+    operator = body.get("operator")
+    passcode = body.get("passcode")
+    if not isinstance(operator, str) or not operator:
+        return web.json_response({"error": "operator required"}, status=400)
+    if not isinstance(passcode, str) or not passcode:
+        return web.json_response({"error": "passcode required"}, status=400)
+    from ..control.agent_create import run_create
+
+    try:
+        result = await run_create(
+            operator, passcode, display_name=str(body.get("display_name") or "")
+        )
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    except Exception as exc:  # noqa: BLE001
+        return web.json_response({"error": str(exc)}, status=502)
+    return web.json_response(result, status=201)

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -1909,9 +1909,10 @@ async def agent_revoke_pending(request: web.Request) -> web.Response:
 
 
 async def create_ws_local_agent(request: web.Request) -> web.Response:
-    """Bridge entry for ``puffo-agent agent create ws-local``: run the
-    machine-initiated, operator-approved create flow and return the result
-    (agent_slug, bundle_path, passcode) so the caller can attach."""
+    """Bridge entry for ``puffo-agent agent create-ws-local``: send the operator
+    the approval request and return immediately with the ``request_id`` (the flow
+    is non-blocking — the operator approves whenever). Poll completion with
+    ``wait-until-command --id <request_id>``."""
     try:
         body = await request.json()
     except Exception:  # noqa: BLE001
@@ -1922,14 +1923,39 @@ async def create_ws_local_agent(request: web.Request) -> web.Response:
         return web.json_response({"error": "operator required"}, status=400)
     if not isinstance(passcode, str) or not passcode:
         return web.json_response({"error": "passcode required"}, status=400)
-    from ..control.agent_create import run_create
+    from ..control.agent_create import start_create
 
     try:
-        result = await run_create(
-            operator, passcode, display_name=str(body.get("display_name") or "")
+        result = await start_create(
+            operator,
+            passcode,
+            username=str(body.get("display_name") or ""),
+            message=str(body.get("message") or ""),
         )
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
     except Exception as exc:  # noqa: BLE001
         return web.json_response({"error": str(exc)}, status=502)
-    return web.json_response(result, status=201)
+    return web.json_response(result, status=202)
+
+
+async def wait_until_command(request: web.Request) -> web.Response:
+    """Bridge entry for ``puffo-agent machine wait-until-command --id X``: block
+    until the command with id X has been processed, return its result. For a
+    ws-local create this is the operator's approval → {agent_slug, bundle_path,
+    passcode}."""
+    command_id = request.query.get("id", "")
+    if not command_id:
+        return web.json_response({"error": "id required"}, status=400)
+    try:
+        timeout = float(request.query.get("timeout", "600"))
+    except ValueError:
+        timeout = 600.0
+    from ..control.agent_create import get_registry
+
+    try:
+        result = await get_registry().wait_result(command_id, timeout)
+    except (TimeoutError, asyncio.TimeoutError):
+        return web.json_response({"error": "timeout", "pending": True}, status=504)
+    status = 200 if result.get("ok", True) else 502
+    return web.json_response(result, status=status)

--- a/src/puffo_agent/portal/api/server.py
+++ b/src/puffo_agent/portal/api/server.py
@@ -44,6 +44,7 @@ def build_app(cfg: BridgeConfig, ws_local_hub=None) -> web.Application:
     app.router.add_delete("/v1/pairing", h.disconnect)
     app.router.add_get("/v1/agents", h.list_agents)
     app.router.add_post("/v1/agents", h.create_agent)
+    app.router.add_post("/v1/agents/create-ws-local", h.create_ws_local_agent)
     app.router.add_get("/v1/agents/{id}", h.get_agent)
     app.router.add_delete("/v1/agents/{id}", h.delete_agent)
     app.router.add_get("/v1/agents/{id}/runtime", h.get_runtime_state)

--- a/src/puffo_agent/portal/api/server.py
+++ b/src/puffo_agent/portal/api/server.py
@@ -45,6 +45,7 @@ def build_app(cfg: BridgeConfig, ws_local_hub=None) -> web.Application:
     app.router.add_get("/v1/agents", h.list_agents)
     app.router.add_post("/v1/agents", h.create_agent)
     app.router.add_post("/v1/agents/create-ws-local", h.create_ws_local_agent)
+    app.router.add_get("/v1/machine/wait-until-command", h.wait_until_command)
     app.router.add_get("/v1/agents/{id}", h.get_agent)
     app.router.add_delete("/v1/agents/{id}", h.delete_agent)
     app.router.add_get("/v1/agents/{id}/runtime", h.get_runtime_state)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -541,32 +541,64 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     return 0
 
 
+def _bridge_wait_until_command(base: str, command_id: str, timeout: float) -> int:
+    """GET the bridge's wait-until-command and print its result JSON to stdout."""
+    import json
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    url = (
+        f"{base}/v1/machine/wait-until-command?"
+        f"id={urllib.parse.quote(command_id)}&timeout={int(timeout)}"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=timeout + 10) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        if exc.code == 504:
+            print(f"pending: operator hasn't approved yet ({detail})", file=sys.stderr)
+        else:
+            print(f"error: wait failed (HTTP {exc.code}): {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"error: cannot reach the daemon bridge ({exc.reason})", file=sys.stderr)
+        return 1
+    print(json.dumps(result))
+    return 0
+
+
 def cmd_agent_create_ws_local(args: argparse.Namespace) -> int:
-    """Create a ws-local agent via operator approval (the machine requests it,
-    the operator Approves in the app), then print the result JSON to stdout so
-    the calling agent can attach. Requires the daemon running with the bridge."""
+    """Request a ws-local agent via operator approval. Non-blocking: prints the
+    ``request_id`` and returns. Poll completion with
+    ``machine wait-until-command --id <request_id>`` (or pass ``--wait`` to block
+    here). Requires the daemon running with the bridge."""
     import json
     import urllib.error
     import urllib.request
 
+    base = args.bridge_url.rstrip("/")
     body = json.dumps(
         {
             "operator": args.operator,
             "passcode": args.passcode,
             "display_name": getattr(args, "display_name", "") or "",
+            "message": getattr(args, "message", "") or "",
         }
     ).encode("utf-8")
-    url = f"{args.bridge_url.rstrip('/')}/v1/agents/create-ws-local"
     req = urllib.request.Request(
-        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+        f"{base}/v1/agents/create-ws-local",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
     )
     try:
-        # Generous timeout — the call blocks on the operator's Approve.
-        with urllib.request.urlopen(req, timeout=600) as resp:
-            result = json.loads(resp.read().decode("utf-8"))
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            started = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
-        print(f"error: create failed (HTTP {exc.code}): {detail}", file=sys.stderr)
+        print(f"error: request failed (HTTP {exc.code}): {detail}", file=sys.stderr)
         return 1
     except urllib.error.URLError as exc:
         print(
@@ -575,8 +607,16 @@ def cmd_agent_create_ws_local(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    print(json.dumps(result))
-    return 0
+
+    if not getattr(args, "wait", False):
+        print(json.dumps(started))
+        return 0
+    return _bridge_wait_until_command(base, str(started.get("request_id") or ""), args.wait_timeout)
+
+
+def cmd_machine_wait_until_command(args: argparse.Namespace) -> int:
+    """Block until the command with ``--id`` has been processed, print its result."""
+    return _bridge_wait_until_command(args.bridge_url.rstrip("/"), args.id, args.timeout)
 
 
 def cmd_agent_list(args: argparse.Namespace) -> int:
@@ -1532,7 +1572,20 @@ def build_parser() -> argparse.ArgumentParser:
     create_wsl.add_argument(
         "--passcode", required=True, help="Passcode for the .puffoagent bundle + ws-local attach"
     )
-    create_wsl.add_argument("--display-name", default="", help="Friendly name for the new agent")
+    create_wsl.add_argument("--display-name", default="", help="Suggested name for the new agent")
+    create_wsl.add_argument(
+        "--message",
+        default="",
+        help="Free-text note shown to the operator for context (why this agent is needed).",
+    )
+    create_wsl.add_argument(
+        "--wait",
+        action="store_true",
+        help="Block until the operator approves and print the final result (slug/bundle/passcode).",
+    )
+    create_wsl.add_argument(
+        "--wait-timeout", type=float, default=600.0, help="Seconds to wait with --wait (default 600)."
+    )
     create_wsl.add_argument(
         "--bridge-url",
         default="http://127.0.0.1:63387",
@@ -1809,6 +1862,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Only unlink the pairing on this server URL (default: match by operator).",
     )
     machine_unlink.set_defaults(func=cmd_unlink)
+
+    machine_wait = machine_sub.add_parser(
+        "wait-until-command",
+        help="Block until a machine command (by id) is processed; print its result.",
+    )
+    machine_wait.add_argument("--id", required=True, help="Command id to wait for (e.g. a create request_id).")
+    machine_wait.add_argument(
+        "--timeout", type=float, default=600.0, help="Seconds to wait (default 600)."
+    )
+    machine_wait.add_argument(
+        "--bridge-url",
+        default="http://127.0.0.1:63387",
+        help="Bridge HTTP base URL (default: %(default)s).",
+    )
+    machine_wait.set_defaults(func=cmd_machine_wait_until_command)
 
     api = sub.add_parser(
         "api",

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1533,6 +1533,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--passcode", required=True, help="Passcode for the .puffoagent bundle + ws-local attach"
     )
     create_wsl.add_argument("--display-name", default="", help="Friendly name for the new agent")
+    create_wsl.add_argument(
+        "--bridge-url",
+        default="http://127.0.0.1:63387",
+        help="Bridge HTTP base URL (default: %(default)s).",
+    )
     create_wsl.set_defaults(func=cmd_agent_create_ws_local)
 
     lst = agent_sub.add_parser("list", help="List registered agents")

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -541,6 +541,44 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_agent_create_ws_local(args: argparse.Namespace) -> int:
+    """Create a ws-local agent via operator approval (the machine requests it,
+    the operator Approves in the app), then print the result JSON to stdout so
+    the calling agent can attach. Requires the daemon running with the bridge."""
+    import json
+    import urllib.error
+    import urllib.request
+
+    body = json.dumps(
+        {
+            "operator": args.operator,
+            "passcode": args.passcode,
+            "display_name": getattr(args, "display_name", "") or "",
+        }
+    ).encode("utf-8")
+    url = f"{args.bridge_url.rstrip('/')}/v1/agents/create-ws-local"
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        # Generous timeout — the call blocks on the operator's Approve.
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        print(f"error: create failed (HTTP {exc.code}): {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(
+            f"error: cannot reach the daemon bridge at {args.bridge_url} ({exc.reason}). "
+            "Is the daemon running with --with-local-bridge?",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result))
+    return 0
+
+
 def cmd_agent_list(args: argparse.Namespace) -> int:
     agents = discover_agents()
     if not agents:
@@ -1483,6 +1521,19 @@ def build_parser() -> argparse.ArgumentParser:
     create.add_argument("--no-mention", action="store_true", help="Don't reply on @mention")
     create.add_argument("--no-dm", action="store_true", help="Don't reply on DM")
     create.set_defaults(func=cmd_agent_create)
+
+    create_wsl = agent_sub.add_parser(
+        "create-ws-local",
+        help="Create a ws-local agent via operator approval over the machine channel.",
+    )
+    create_wsl.add_argument(
+        "--operator", required=True, help="Linked operator slug to request approval from"
+    )
+    create_wsl.add_argument(
+        "--passcode", required=True, help="Passcode for the .puffoagent bundle + ws-local attach"
+    )
+    create_wsl.add_argument("--display-name", default="", help="Friendly name for the new agent")
+    create_wsl.set_defaults(func=cmd_agent_create_ws_local)
 
     lst = agent_sub.add_parser("list", help="List registered agents")
     lst.set_defaults(func=cmd_agent_list)

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -281,9 +281,9 @@ async def finalize_and_pack(
             device_id=ident.device_id,
             operator_slug=operator_slug,
             space_id=str(profile.get("space_id") or ""),
-            # The operator invites the new agent to the space; auto-accept so it
-            # actually joins (otherwise the invite sits pending).
-            auto_accept_space_invitations=True,
+            # No auto_accept_space_invitations: the operator's own invite is
+            # auto-accepted by default (is_from_operator); the flag would over-
+            # broadly accept invites from anyone.
         ),
         runtime=RuntimeConfig(kind="ws-local"),
         created_at=int(time.time()),

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -28,37 +28,6 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
-class PendingApprovals:
-    """Bridges the create flow's ``await_approval`` to the inbound
-    ``agent_create_approved`` command: the flow waits on a request_id, the
-    command handler resolves it. Daemon-wide singleton (one control loop)."""
-
-    def __init__(self) -> None:
-        self._waiters: dict[str, asyncio.Future] = {}
-
-    async def wait(self, request_id: str, timeout: float) -> dict:
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
-        self._waiters[request_id] = fut
-        try:
-            return await asyncio.wait_for(fut, timeout)
-        finally:
-            self._waiters.pop(request_id, None)
-
-    def resolve(self, request_id: str, result: dict) -> bool:
-        fut = self._waiters.get(request_id)
-        if fut is not None and not fut.done():
-            fut.set_result(result)
-            return True
-        return False
-
-
-_PENDING = PendingApprovals()
-
-
-def get_pending_approvals() -> PendingApprovals:
-    return _PENDING
-
-
 def _self_sign(cert: dict, root: Ed25519KeyPair, field: str) -> dict:
     """Fill ``cert[field]`` with the agent root's signature over the
     canonical (signature-stripped) cert."""
@@ -144,53 +113,111 @@ _DEFAULT_WS_LOCAL_PROFILE = "# {name}\n\nA ws-local agent driven by an attached 
 
 # async (slug_binding, pending_token) -> None; raises on failure.
 FinalizeFn = Callable[[dict, str], Awaitable[None]]
-# async (operator_slug, payload) -> None — sends the request machine_message.
-SendRequestFn = Callable[[str, dict], Awaitable[None]]
-# async (request_id) -> {agent_slug, pending_token} — resolves on the approval command.
-AwaitApprovalFn = Callable[[str], Awaitable[dict]]
 
 
-async def create_ws_local_agent(
-    operator_slug: str,
-    passcode: str,
-    *,
-    send_request_fn: SendRequestFn,
-    await_approval_fn: AwaitApprovalFn,
-    finalize_fn: FinalizeFn,
-    display_name: str = "",
+@dataclass
+class _PendingCreate:
+    identity: AgentIdentity
+    operator_slug: str
+    server_url: str
+    passcode: str
+
+
+class CreateRegistry:
+    """request_id-keyed pending creates + command_id-keyed results. A
+    machine-initiated create returns immediately with a request_id; the
+    operator's later approval command (command_id == request_id) finalizes it,
+    and ``wait_result`` lets a caller block on completion."""
+
+    def __init__(self) -> None:
+        self._pending: dict[str, _PendingCreate] = {}
+        self._results: dict[str, dict] = {}
+        self._waiters: dict[str, list[asyncio.Future]] = {}
+
+    def put_pending(self, request_id: str, pc: _PendingCreate) -> None:
+        self._pending[request_id] = pc
+
+    def pop_pending(self, request_id: str) -> "_PendingCreate | None":
+        return self._pending.pop(request_id, None)
+
+    def record_result(self, command_id: str, result: dict) -> None:
+        self._results[command_id] = result
+        for fut in self._waiters.pop(command_id, []):
+            if not fut.done():
+                fut.set_result(result)
+
+    def peek_result(self, command_id: str) -> "dict | None":
+        return self._results.get(command_id)
+
+    async def wait_result(self, command_id: str, timeout: float) -> dict:
+        existing = self._results.get(command_id)
+        if existing is not None:
+            return existing
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._waiters.setdefault(command_id, []).append(fut)
+        return await asyncio.wait_for(fut, timeout)
+
+
+_REGISTRY = CreateRegistry()
+
+
+def get_registry() -> CreateRegistry:
+    return _REGISTRY
+
+
+async def start_create(
+    operator_slug: str, passcode: str, *, username: str = "", message: str = ""
 ) -> dict:
-    """Full daemon-side flow: validate the operator is linked, mint the agent
-    identity, request the operator's approval over the reverse channel, then
-    register + write + pack on approval. All I/O is injected for testability."""
+    """Mint the agent identity, stash it under a fresh request_id, send the
+    operator the approval request, and return immediately (non-blocking). The
+    operator's approval command (command_id == request_id) finalizes it.
+    ``message`` is free text the requesting agent shows the operator for context."""
+    from .reporter import get_reporter
     from .store import get_pairing
 
     pairing = get_pairing(operator_slug)
     if pairing is None:
         raise ValueError(f"operator {operator_slug!r} is not linked to this machine")
-
     ident = gen_agent_identity(pairing.operator_root_pubkey)
     request_id = f"acr_{uuid.uuid4().hex}"
-    await send_request_fn(
+    get_registry().put_pending(
+        request_id, _PendingCreate(ident, operator_slug, pairing.server_url, passcode)
+    )
+    await get_reporter().send_to_operator(
         operator_slug,
         {
             "type": "agent.create_request",
             "request_id": request_id,
-            "username": display_name or "agent",
+            "username": username or "agent",
+            "message": message,
             "identity_cert": ident.identity_cert,
             "device_cert": ident.device_cert,
             "agent_root_public_key": ident.root_public_key,
         },
     )
-    approval = await await_approval_fn(request_id)
+    return {"request_id": request_id, "agent_root_public_key": ident.root_public_key}
+
+
+async def finalize_from_command(request_id: str, params: dict) -> dict:
+    """Run on the operator's approval command (command_id == request_id): pull the
+    stashed identity, finalize against the server, write + pack. ``params`` carry
+    the operator-chosen profile + the server-minted slug + pending_token."""
+    pc = get_registry().pop_pending(request_id)
+    if pc is None:
+        raise ValueError(f"no pending create for request {request_id!r}")
+
+    async def _finalize(binding: dict, pending_token: str) -> None:
+        await post_slug_binding(pc.server_url, binding, pending_token)
+
     return await finalize_and_pack(
-        ident,
-        slug=str(approval["agent_slug"]),
-        pending_token=str(approval["pending_token"]),
-        operator_slug=operator_slug,
-        server_url=pairing.server_url,
-        passcode=passcode,
-        finalize_fn=finalize_fn,
-        display_name=display_name,
+        pc.identity,
+        slug=str(params["agent_slug"]),
+        pending_token=str(params["pending_token"]),
+        operator_slug=pc.operator_slug,
+        server_url=pc.server_url,
+        passcode=pc.passcode,
+        finalize_fn=_finalize,
+        profile=params,
     )
 
 
@@ -204,13 +231,20 @@ async def finalize_and_pack(
     passcode: str,
     finalize_fn: FinalizeFn,
     display_name: str = "",
+    profile: dict | None = None,
 ) -> dict:
     """After the operator approves and the server mints ``slug`` + ``pending_token``:
     sign + register the slug_binding, write the ws-local agent.yml + keystore, and
-    pack the ``.puffoagent`` bundle. Returns the stdout result for the caller."""
+    pack the ``.puffoagent`` bundle. ``profile`` carries the operator-chosen
+    name / avatar / role / soul / space_id from the approval. Returns the stdout
+    result for the caller."""
     from ...crypto.keystore import KeyStore, StoredIdentity
     from ..export import pack
     from ..state import AgentConfig, PuffoCoreConfig, RuntimeConfig, agent_dir
+
+    profile = profile or {}
+    name = str(profile.get("name") or display_name or slug)
+    soul = str(profile.get("soul") or "")
 
     agent_id = slug
     binding = build_slug_binding(ident.root_keypair, slug)
@@ -220,7 +254,7 @@ async def finalize_and_pack(
     target.mkdir(parents=True, exist_ok=True)
     (target / "memory").mkdir(exist_ok=True)
     (target / "profile.md").write_text(
-        _DEFAULT_WS_LOCAL_PROFILE.format(name=display_name or slug), encoding="utf-8"
+        soul or _DEFAULT_WS_LOCAL_PROFILE.format(name=name), encoding="utf-8"
     )
 
     KeyStore.for_agent(agent_id).save_identity(
@@ -238,9 +272,15 @@ async def finalize_and_pack(
 
     AgentConfig(
         id=agent_id,
-        display_name=display_name or slug,
+        display_name=name,
+        avatar_url=str(profile.get("avatar") or ""),
+        role=str(profile.get("role") or ""),
         puffo_core=PuffoCoreConfig(
-            server_url=server_url, slug=slug, device_id=ident.device_id, operator_slug=operator_slug
+            server_url=server_url,
+            slug=slug,
+            device_id=ident.device_id,
+            operator_slug=operator_slug,
+            space_id=str(profile.get("space_id") or ""),
         ),
         runtime=RuntimeConfig(kind="ws-local"),
         created_at=int(time.time()),
@@ -269,39 +309,6 @@ async def post_slug_binding(server_url: str, slug_binding: dict, pending_token: 
             if resp.status >= 400:
                 text = await resp.text()
                 raise RuntimeError(f"slug_binding finalize HTTP {resp.status}: {text[:200]}")
-
-
-async def run_create(
-    operator_slug: str, passcode: str, *, display_name: str = "", timeout: float = 300.0
-) -> dict:
-    """Daemon-internal entry point: wire the live reverse-channel impls (reporter
-    send, pending-approval wait, slug_binding finalize) and run the full flow."""
-    from .reporter import get_reporter
-    from .store import get_pairing
-
-    pairing = get_pairing(operator_slug)
-    if pairing is None:
-        raise ValueError(f"operator {operator_slug!r} is not linked to this machine")
-    reporter = get_reporter()
-    pending = get_pending_approvals()
-
-    async def _send(op_slug: str, payload: dict) -> None:
-        await reporter.send_to_operator(op_slug, payload)
-
-    async def _await(request_id: str) -> dict:
-        return await pending.wait(request_id, timeout)
-
-    async def _finalize(slug_binding: dict, pending_token: str) -> None:
-        await post_slug_binding(pairing.server_url, slug_binding, pending_token)
-
-    return await create_ws_local_agent(
-        operator_slug,
-        passcode,
-        send_request_fn=_send,
-        await_approval_fn=_await,
-        finalize_fn=_finalize,
-        display_name=display_name,
-    )
 
 
 def build_slug_binding(root: Ed25519KeyPair, slug: str) -> dict:

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -281,6 +281,9 @@ async def finalize_and_pack(
             device_id=ident.device_id,
             operator_slug=operator_slug,
             space_id=str(profile.get("space_id") or ""),
+            # The operator invites the new agent to the space; auto-accept so it
+            # actually joins (otherwise the invite sits pending).
+            auto_accept_space_invitations=True,
         ),
         runtime=RuntimeConfig(kind="ws-local"),
         created_at=int(time.time()),

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -1,0 +1,121 @@
+"""Daemon-side agent identity generation for self-service ws-local create.
+
+The daemon mints the agent's own keys + self-signed certs (identity / device /
+slug_binding). The operator signs only the OperatorAttestation; registration
+runs server-side (POST /agents → pending_token, then POST /certs/slug_binding).
+Cert wire shapes match portal/api/certs.py (the daemon's own verifier) and the
+puffo-server `core-v2/crates/types/src/cert.rs` producer.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from ...crypto.canonical import canonicalize_for_signing
+from ...crypto.certs import derive_public_key_id
+from ...crypto.encoding import base64url_encode
+from ...crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+_CERT_VERSION = 1
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _self_sign(cert: dict, root: Ed25519KeyPair, field: str) -> dict:
+    """Fill ``cert[field]`` with the agent root's signature over the
+    canonical (signature-stripped) cert."""
+    cert[field] = ""
+    sig = root.sign(canonicalize_for_signing(cert))
+    cert[field] = base64url_encode(sig)
+    return cert
+
+
+@dataclass
+class AgentIdentity:
+    agent_id: str
+    device_id: str
+    root_keypair: Ed25519KeyPair
+    device_signing_keypair: Ed25519KeyPair
+    device_kem_keypair: KemKeyPair
+    identity_cert: dict
+    device_cert: dict
+
+    @property
+    def root_public_key(self) -> str:
+        return base64url_encode(self.root_keypair.public_key_bytes())
+
+
+def gen_agent_identity(operator_root_pubkey: str) -> AgentIdentity:
+    """Mint a fresh agent identity declaring ``operator_root_pubkey`` as its
+    operator. Produces the identity_cert + device_cert (both agent-root signed);
+    the slug_binding is deferred until the server assigns the slug."""
+    root = Ed25519KeyPair.generate()
+    device_signing = Ed25519KeyPair.generate()
+    device_kem = KemKeyPair.generate()
+
+    root_pk_b64 = base64url_encode(root.public_key_bytes())
+    device_id = derive_public_key_id("dev", device_signing.public_key_bytes())
+
+    identity_cert = _self_sign(
+        {
+            "type": "identity_cert",
+            "version": _CERT_VERSION,
+            "root_public_key": root_pk_b64,
+            "identity_type": "agent",
+            "declared_operator_public_key": operator_root_pubkey,
+        },
+        root,
+        "self_signature",
+    )
+
+    device_cert = _self_sign(
+        {
+            "type": "device_cert",
+            "version": _CERT_VERSION,
+            "device_id": device_id,
+            "root_public_key": root_pk_b64,
+            "keys": {
+                "signing": {
+                    "algorithm": "ed25519",
+                    "public_key": base64url_encode(device_signing.public_key_bytes()),
+                },
+                "encryption": {
+                    "algorithm": "x25519",
+                    "public_key": base64url_encode(device_kem.public_key_bytes()),
+                },
+            },
+            "issued_at": _now_ms(),
+            "expires_at": None,
+        },
+        root,
+        "signature",
+    )
+
+    return AgentIdentity(
+        agent_id="",
+        device_id=device_id,
+        root_keypair=root,
+        device_signing_keypair=device_signing,
+        device_kem_keypair=device_kem,
+        identity_cert=identity_cert,
+        device_cert=device_cert,
+    )
+
+
+def build_slug_binding(root: Ed25519KeyPair, slug: str) -> dict:
+    """Agent-root-signed binding of ``slug`` to the agent root — built once the
+    server assigns the slug, then POSTed to /certs/slug_binding to finalize."""
+    return _self_sign(
+        {
+            "type": "slug_binding",
+            "version": _CERT_VERSION,
+            "slug": slug,
+            "root_public_key": base64url_encode(root.public_key_bytes()),
+            "issued_at": _now_ms(),
+        },
+        root,
+        "self_signature",
+    )

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -9,6 +9,7 @@ puffo-server `core-v2/crates/types/src/cert.rs` producer.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 import uuid
@@ -25,6 +26,37 @@ _CERT_VERSION = 1
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
+
+
+class PendingApprovals:
+    """Bridges the create flow's ``await_approval`` to the inbound
+    ``agent_create_approved`` command: the flow waits on a request_id, the
+    command handler resolves it. Daemon-wide singleton (one control loop)."""
+
+    def __init__(self) -> None:
+        self._waiters: dict[str, asyncio.Future] = {}
+
+    async def wait(self, request_id: str, timeout: float) -> dict:
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._waiters[request_id] = fut
+        try:
+            return await asyncio.wait_for(fut, timeout)
+        finally:
+            self._waiters.pop(request_id, None)
+
+    def resolve(self, request_id: str, result: dict) -> bool:
+        fut = self._waiters.get(request_id)
+        if fut is not None and not fut.done():
+            fut.set_result(result)
+            return True
+        return False
+
+
+_PENDING = PendingApprovals()
+
+
+def get_pending_approvals() -> PendingApprovals:
+    return _PENDING
 
 
 def _self_sign(cert: dict, root: Ed25519KeyPair, field: str) -> dict:

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -9,8 +9,11 @@ puffo-server `core-v2/crates/types/src/cert.rs` producer.
 
 from __future__ import annotations
 
+import json
 import time
+import uuid
 from dataclasses import dataclass
+from typing import Awaitable, Callable
 
 from ...crypto.canonical import canonicalize_for_signing
 from ...crypto.certs import derive_public_key_id
@@ -103,6 +106,123 @@ def gen_agent_identity(operator_root_pubkey: str) -> AgentIdentity:
         identity_cert=identity_cert,
         device_cert=device_cert,
     )
+
+
+_DEFAULT_WS_LOCAL_PROFILE = "# {name}\n\nA ws-local agent driven by an attached tool.\n"
+
+# async (slug_binding, pending_token) -> None; raises on failure.
+FinalizeFn = Callable[[dict, str], Awaitable[None]]
+# async (operator_slug, payload) -> None — sends the request machine_message.
+SendRequestFn = Callable[[str, dict], Awaitable[None]]
+# async (request_id) -> {agent_slug, pending_token} — resolves on the approval command.
+AwaitApprovalFn = Callable[[str], Awaitable[dict]]
+
+
+async def create_ws_local_agent(
+    operator_slug: str,
+    passcode: str,
+    *,
+    send_request_fn: SendRequestFn,
+    await_approval_fn: AwaitApprovalFn,
+    finalize_fn: FinalizeFn,
+    display_name: str = "",
+) -> dict:
+    """Full daemon-side flow: validate the operator is linked, mint the agent
+    identity, request the operator's approval over the reverse channel, then
+    register + write + pack on approval. All I/O is injected for testability."""
+    from .store import get_pairing
+
+    pairing = get_pairing(operator_slug)
+    if pairing is None:
+        raise ValueError(f"operator {operator_slug!r} is not linked to this machine")
+
+    ident = gen_agent_identity(pairing.operator_root_pubkey)
+    request_id = f"acr_{uuid.uuid4().hex}"
+    await send_request_fn(
+        operator_slug,
+        {
+            "type": "agent.create_request",
+            "request_id": request_id,
+            "username": display_name or "agent",
+            "identity_cert": ident.identity_cert,
+            "device_cert": ident.device_cert,
+            "agent_root_public_key": ident.root_public_key,
+        },
+    )
+    approval = await await_approval_fn(request_id)
+    return await finalize_and_pack(
+        ident,
+        slug=str(approval["agent_slug"]),
+        pending_token=str(approval["pending_token"]),
+        operator_slug=operator_slug,
+        server_url=pairing.server_url,
+        passcode=passcode,
+        finalize_fn=finalize_fn,
+        display_name=display_name,
+    )
+
+
+async def finalize_and_pack(
+    ident: AgentIdentity,
+    *,
+    slug: str,
+    pending_token: str,
+    operator_slug: str,
+    server_url: str,
+    passcode: str,
+    finalize_fn: FinalizeFn,
+    display_name: str = "",
+) -> dict:
+    """After the operator approves and the server mints ``slug`` + ``pending_token``:
+    sign + register the slug_binding, write the ws-local agent.yml + keystore, and
+    pack the ``.puffoagent`` bundle. Returns the stdout result for the caller."""
+    from ...crypto.keystore import KeyStore, StoredIdentity
+    from ..export import pack
+    from ..state import AgentConfig, PuffoCoreConfig, RuntimeConfig, agent_dir
+
+    agent_id = slug
+    binding = build_slug_binding(ident.root_keypair, slug)
+    await finalize_fn(binding, pending_token)  # POST /certs/slug_binding; raises on failure
+
+    target = agent_dir(agent_id)
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "memory").mkdir(exist_ok=True)
+    (target / "profile.md").write_text(
+        _DEFAULT_WS_LOCAL_PROFILE.format(name=display_name or slug), encoding="utf-8"
+    )
+
+    KeyStore.for_agent(agent_id).save_identity(
+        StoredIdentity(
+            slug=slug,
+            device_id=ident.device_id,
+            root_secret_key=base64url_encode(ident.root_keypair.secret_bytes()),
+            device_signing_secret_key=base64url_encode(ident.device_signing_keypair.secret_bytes()),
+            kem_secret_key=base64url_encode(ident.device_kem_keypair.secret_bytes()),
+            server_url=server_url,
+            slug_binding_json=json.dumps(binding),
+            identity_cert_json=json.dumps(ident.identity_cert),
+        )
+    )
+
+    AgentConfig(
+        id=agent_id,
+        display_name=display_name or slug,
+        puffo_core=PuffoCoreConfig(
+            server_url=server_url, slug=slug, device_id=ident.device_id, operator_slug=operator_slug
+        ),
+        runtime=RuntimeConfig(kind="ws-local"),
+        created_at=int(time.time()),
+    ).save()
+
+    bundle_path = target.parent.parent / f"{agent_id}.puffoagent"
+    bundle_path.write_bytes(pack([agent_id], passcode, exported_by_slug=slug))
+
+    return {
+        "agent_slug": slug,
+        "agent_id": agent_id,
+        "bundle_path": str(bundle_path),
+        "passcode": passcode,
+    }
 
 
 def build_slug_binding(root: Ed25519KeyPair, slug: str) -> dict:

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -257,6 +257,53 @@ async def finalize_and_pack(
     }
 
 
+async def post_slug_binding(server_url: str, slug_binding: dict, pending_token: str) -> None:
+    """POST /certs/slug_binding to finalize the pending agent identity (the
+    token + self-signature are the gate; no auth header)."""
+    import aiohttp
+
+    url = f"{server_url.rstrip('/')}/certs/slug_binding"
+    body = {"pending_token": pending_token, "slug_binding": slug_binding}
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with session.post(url, json=body) as resp:
+            if resp.status >= 400:
+                text = await resp.text()
+                raise RuntimeError(f"slug_binding finalize HTTP {resp.status}: {text[:200]}")
+
+
+async def run_create(
+    operator_slug: str, passcode: str, *, display_name: str = "", timeout: float = 300.0
+) -> dict:
+    """Daemon-internal entry point: wire the live reverse-channel impls (reporter
+    send, pending-approval wait, slug_binding finalize) and run the full flow."""
+    from .reporter import get_reporter
+    from .store import get_pairing
+
+    pairing = get_pairing(operator_slug)
+    if pairing is None:
+        raise ValueError(f"operator {operator_slug!r} is not linked to this machine")
+    reporter = get_reporter()
+    pending = get_pending_approvals()
+
+    async def _send(op_slug: str, payload: dict) -> None:
+        await reporter.send_to_operator(op_slug, payload)
+
+    async def _await(request_id: str) -> dict:
+        return await pending.wait(request_id, timeout)
+
+    async def _finalize(slug_binding: dict, pending_token: str) -> None:
+        await post_slug_binding(pairing.server_url, slug_binding, pending_token)
+
+    return await create_ws_local_agent(
+        operator_slug,
+        passcode,
+        send_request_fn=_send,
+        await_approval_fn=_await,
+        finalize_fn=_finalize,
+        display_name=display_name,
+    )
+
+
 def build_slug_binding(root: Ed25519KeyPair, slug: str) -> dict:
     """Agent-root-signed binding of ``slug`` to the agent root — built once the
     server assigns the slug, then POSTed to /certs/slug_binding to finalize."""

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -285,7 +285,9 @@ async def finalize_and_pack(
             # auto-accepted by default (is_from_operator); the flag would over-
             # broadly accept invites from anyone.
         ),
-        runtime=RuntimeConfig(kind="ws-local"),
+        # ws-local is driven by the attached tool — no provider/harness/model
+        # (the RuntimeConfig defaults would otherwise stamp it "claude-code").
+        runtime=RuntimeConfig(kind="ws-local", provider="", harness="", model=""),
         created_at=int(time.time()),
     ).save()
 

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -101,6 +101,7 @@ async def execute_command(
     *,
     server_url: str | None = None,
     paired_root_pubkey: str | None = None,
+    command_id: str | None = None,
 ) -> dict:
     """Apply a decrypted command to local agent state, the same way the local
     bridge handlers do (flip ``agent.yml`` state, drop sentinel flags) so the
@@ -189,15 +190,13 @@ async def execute_command(
     if op == "create":
         return await _create_agent_command(params, server_url, paired_root_pubkey)
     if op == "agent_create_approved":
-        # The operator approved a machine-initiated ws-local create — hand the
-        # server-minted slug + pending_token to the waiting create flow.
-        from .agent_create import get_pending_approvals
+        # The operator approved a machine-initiated ws-local create. command_id ==
+        # request_id ties this command to the stashed identity; finalize + pack.
+        from .agent_create import finalize_from_command
 
-        resolved = get_pending_approvals().resolve(
-            str(params.get("request_id") or ""),
-            {"agent_slug": params.get("agent_slug"), "pending_token": params.get("pending_token")},
-        )
-        return {"ok": resolved, "error": None if resolved else "no pending create request"}
+        request_id = command_id or str(params.get("request_id") or "")
+        result = await finalize_from_command(request_id, params)
+        return {"ok": True, **result}
     # export/import carry bigger flows; not yet wired.
     return {"ok": False, "error": f"unsupported op {op!r}"}
 
@@ -372,17 +371,27 @@ class MachineControlClient:
                 decrypted["params"],
                 server_url=pairing.server_url,
                 paired_root_pubkey=pairing.operator_root_pubkey,
+                command_id=command_id,
             )
             if isinstance(result, dict) and not result.get("ok", True):
                 log.warning(
                     "control: command %s op=%s failed: %s",
                     command_id, decrypted["op"], result.get("error"),
                 )
+            # Publish the result so `wait-until-command --id <command_id>` returns.
+            if command_id and isinstance(result, dict):
+                from .agent_create import get_registry
+
+                get_registry().record_result(command_id, result)
         except ControlError as exc:
             # Forged / malformed → never execute, but ack so it stops redelivering.
             log.warning("control: rejected command %s: %s", command_id, exc)
         except Exception as exc:  # noqa: BLE001
             log.warning("control: command %s failed: %s", command_id, exc)
+            if command_id:
+                from .agent_create import get_registry
+
+                get_registry().record_result(command_id, {"ok": False, "error": str(exc)})
 
         if command_id:
             try:

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -188,6 +188,16 @@ async def execute_command(
         return {"ok": True}
     if op == "create":
         return await _create_agent_command(params, server_url, paired_root_pubkey)
+    if op == "agent_create_approved":
+        # The operator approved a machine-initiated ws-local create — hand the
+        # server-minted slug + pending_token to the waiting create flow.
+        from .agent_create import get_pending_approvals
+
+        resolved = get_pending_approvals().resolve(
+            str(params.get("request_id") or ""),
+            {"agent_slug": params.get("agent_slug"), "pending_token": params.get("pending_token")},
+        )
+        return {"ok": resolved, "error": None if resolved else "no pending create request"}
     # export/import carry bigger flows; not yet wired.
     return {"ok": False, "error": f"unsupported op {op!r}"}
 

--- a/src/puffo_agent/portal/control/reporter.py
+++ b/src/puffo_agent/portal/control/reporter.py
@@ -63,6 +63,23 @@ class AgentStatusReporter:
         except Exception as exc:  # noqa: BLE001 — best-effort; never break a turn.
             log.debug("reporter: emit failed: %s", exc)
 
+    async def send_to_operator(self, operator_slug: str, payload: dict) -> None:
+        """Send an arbitrary machine_message payload to a specific linked
+        operator. Unlike ``emit`` this raises on failure — callers (e.g. the
+        ws-local create flow) need to surface a non-delivery."""
+        if self._sender is None:
+            raise RuntimeError("control WS not connected")
+        pairing = load_pairings().get(operator_slug)
+        if pairing is None:
+            raise RuntimeError(f"operator {operator_slug!r} is not linked")
+        recipients = await self._recipients(operator_slug, pairing)
+        if not recipients:
+            raise RuntimeError(f"operator {operator_slug!r} has no active devices")
+        envelope = agent_message.build_machine_message_envelope(
+            self._machine_identity(), recipients, payload
+        )
+        await self._sender(operator_slug, envelope)
+
     def _machine_identity(self):
         if self._machine is None:
             self._machine = load_or_create_machine()

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -997,6 +997,19 @@ class Worker:
         self._warm_done.set()
         if self._ws_local_hub is not None:
             self._ws_local_hub.register(point)
+
+        # Push display_name / avatar_url / role / soul to the server identity.
+        # The regular runtimes do this post-warm; ws-local idle skips that path,
+        # so without this a freshly-created ws-local agent shows blank in the UI.
+        async def _ws_local_profile_sync() -> None:
+            from .profile_sync import sync_full_profile
+
+            try:
+                await sync_full_profile(self.agent_cfg)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("agent %s: ws-local profile sync failed: %s", agent_id, exc)
+
+        asyncio.ensure_future(_ws_local_profile_sync())
         logger.info("agent %s: ws-local idle, awaiting tool attach", agent_id)
         try:
             await self._stop.wait()

--- a/tests/test_agent_create_finalize.py
+++ b/tests/test_agent_create_finalize.py
@@ -1,0 +1,56 @@
+"""finalize_and_pack writes the ws-local agent + a working .puffoagent bundle."""
+
+import asyncio
+
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.primitives import Ed25519KeyPair
+from puffo_agent.portal.control.agent_create import finalize_and_pack, gen_agent_identity
+
+
+def test_finalize_and_pack(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    operator_root = base64url_encode(Ed25519KeyPair.generate().public_key_bytes())
+    ident = gen_agent_identity(operator_root)
+
+    captured: dict = {}
+
+    async def fake_finalize(binding: dict, token: str) -> None:
+        captured["binding"] = binding
+        captured["token"] = token
+
+    result = asyncio.run(
+        finalize_and_pack(
+            ident,
+            slug="helper-1234",
+            pending_token="ptok_abc",
+            operator_slug="op-99",
+            server_url="https://chat.puffo.ai/relay",
+            passcode="12345678",
+            finalize_fn=fake_finalize,
+            display_name="Helper",
+        )
+    )
+
+    # The signed slug_binding + pending_token went to finalize.
+    assert captured["token"] == "ptok_abc"
+    assert captured["binding"]["slug"] == "helper-1234"
+    assert captured["binding"]["self_signature"]
+
+    assert result["agent_slug"] == "helper-1234"
+    assert result["passcode"] == "12345678"
+
+    # agent.yml written as ws-local with the operator linkage.
+    from puffo_agent.portal.state import AgentConfig
+
+    cfg = AgentConfig.load("helper-1234")
+    assert cfg.runtime.kind == "ws-local"
+    assert cfg.puffo_core.slug == "helper-1234"
+    assert cfg.puffo_core.operator_slug == "op-99"
+    assert cfg.puffo_core.device_id == ident.device_id
+
+    # The bundle unpacks with the passcode and contains the agent.
+    from puffo_agent.portal.export import unpack
+
+    blob = open(result["bundle_path"], "rb").read()
+    bundle = unpack(blob, "12345678")
+    assert any(a.get("slug") == "helper-1234" for a in bundle.manifest["agents"])

--- a/tests/test_agent_create_flow.py
+++ b/tests/test_agent_create_flow.py
@@ -72,3 +72,32 @@ def test_unlinked_operator_rejected(tmp_path, monkeypatch):
                 finalize_fn=noop,
             )
         )
+
+
+def test_pending_approvals_resolve():
+    from puffo_agent.portal.control.agent_create import PendingApprovals
+
+    async def go():
+        p = PendingApprovals()
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            assert p.resolve("r1", {"agent_slug": "s", "pending_token": "t"})
+
+        task = asyncio.ensure_future(resolver())
+        result = await p.wait("r1", timeout=1.0)
+        await task
+        return result
+
+    assert asyncio.run(go())["agent_slug"] == "s"
+
+
+def test_pending_approvals_timeout():
+    from puffo_agent.portal.control.agent_create import PendingApprovals
+
+    async def go():
+        p = PendingApprovals()
+        with pytest.raises(asyncio.TimeoutError):
+            await p.wait("r2", timeout=0.05)
+
+    asyncio.run(go())

--- a/tests/test_agent_create_flow.py
+++ b/tests/test_agent_create_flow.py
@@ -1,0 +1,74 @@
+"""create_ws_local_agent ties validate → mint → request → approval → finalize."""
+
+import asyncio
+
+import pytest
+
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.primitives import Ed25519KeyPair
+from puffo_agent.portal.control import store as store_mod
+from puffo_agent.portal.control.agent_create import create_ws_local_agent
+
+
+def test_create_ws_local_agent_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    operator_root = base64url_encode(Ed25519KeyPair.generate().public_key_bytes())
+
+    class FakePairing:
+        operator_root_pubkey = operator_root
+        server_url = "https://chat.puffo.ai/relay"
+
+    monkeypatch.setattr(
+        store_mod, "get_pairing", lambda slug: FakePairing() if slug == "op-99" else None
+    )
+
+    sent: dict = {}
+
+    async def send_request(op_slug, payload):
+        sent["op_slug"] = op_slug
+        sent["payload"] = payload
+
+    async def await_approval(request_id):
+        sent["awaited_id"] = request_id
+        return {"agent_slug": "helper-1234", "pending_token": "ptok"}
+
+    async def finalize(binding, token):
+        sent["finalize_token"] = token
+
+    result = asyncio.run(
+        create_ws_local_agent(
+            "op-99",
+            "12345678",
+            send_request_fn=send_request,
+            await_approval_fn=await_approval,
+            finalize_fn=finalize,
+            display_name="Helper",
+        )
+    )
+
+    assert sent["op_slug"] == "op-99"
+    assert sent["payload"]["type"] == "agent.create_request"
+    assert "identity_cert" in sent["payload"] and "device_cert" in sent["payload"]
+    # the request_id sent is the one awaited
+    assert sent["payload"]["request_id"] == sent["awaited_id"]
+    assert sent["finalize_token"] == "ptok"
+    assert result["agent_slug"] == "helper-1234"
+
+
+def test_unlinked_operator_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    monkeypatch.setattr(store_mod, "get_pairing", lambda slug: None)
+
+    async def noop(*a, **k):
+        return {}
+
+    with pytest.raises(ValueError, match="not linked"):
+        asyncio.run(
+            create_ws_local_agent(
+                "nope",
+                "x",
+                send_request_fn=noop,
+                await_approval_fn=noop,
+                finalize_fn=noop,
+            )
+        )

--- a/tests/test_agent_create_flow.py
+++ b/tests/test_agent_create_flow.py
@@ -1,4 +1,5 @@
-"""create_ws_local_agent ties validate → mint → request → approval → finalize."""
+"""Non-blocking create: start_create stashes + sends; finalize_from_command
+finalizes on the approval command; CreateRegistry bridges request → result."""
 
 import asyncio
 
@@ -6,98 +7,111 @@ import pytest
 
 from puffo_agent.crypto.encoding import base64url_encode
 from puffo_agent.crypto.primitives import Ed25519KeyPair
+from puffo_agent.portal.control import agent_create
+from puffo_agent.portal.control import reporter as reporter_mod
 from puffo_agent.portal.control import store as store_mod
-from puffo_agent.portal.control.agent_create import create_ws_local_agent
+
+OPERATOR_ROOT = base64url_encode(Ed25519KeyPair.generate().public_key_bytes())
 
 
-def test_create_ws_local_agent_flow(tmp_path, monkeypatch):
+class _FakePairing:
+    operator_root_pubkey = OPERATOR_ROOT
+    server_url = "https://chat.puffo.ai/relay"
+
+
+def test_start_create_stashes_and_sends(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    operator_root = base64url_encode(Ed25519KeyPair.generate().public_key_bytes())
-
-    class FakePairing:
-        operator_root_pubkey = operator_root
-        server_url = "https://chat.puffo.ai/relay"
-
     monkeypatch.setattr(
-        store_mod, "get_pairing", lambda slug: FakePairing() if slug == "op-99" else None
+        store_mod, "get_pairing", lambda slug: _FakePairing() if slug == "op-99" else None
     )
 
     sent: dict = {}
 
-    async def send_request(op_slug, payload):
-        sent["op_slug"] = op_slug
-        sent["payload"] = payload
+    class FakeReporter:
+        async def send_to_operator(self, op_slug, payload):
+            sent["op_slug"] = op_slug
+            sent["payload"] = payload
 
-    async def await_approval(request_id):
-        sent["awaited_id"] = request_id
-        return {"agent_slug": "helper-1234", "pending_token": "ptok"}
+    monkeypatch.setattr(reporter_mod, "get_reporter", lambda: FakeReporter())
 
-    async def finalize(binding, token):
-        sent["finalize_token"] = token
-
-    result = asyncio.run(
-        create_ws_local_agent(
-            "op-99",
-            "12345678",
-            send_request_fn=send_request,
-            await_approval_fn=await_approval,
-            finalize_fn=finalize,
-            display_name="Helper",
-        )
+    started = asyncio.run(
+        agent_create.start_create("op-99", "12345678", username="Helper", message="need a coder")
     )
-
+    assert started["request_id"].startswith("acr_")
     assert sent["op_slug"] == "op-99"
     assert sent["payload"]["type"] == "agent.create_request"
-    assert "identity_cert" in sent["payload"] and "device_cert" in sent["payload"]
-    # the request_id sent is the one awaited
-    assert sent["payload"]["request_id"] == sent["awaited_id"]
-    assert sent["finalize_token"] == "ptok"
-    assert result["agent_slug"] == "helper-1234"
+    assert sent["payload"]["message"] == "need a coder"
+    # identity stashed under the request_id, retrievable by the approval command
+    assert agent_create.get_registry().pop_pending(started["request_id"]) is not None
 
 
-def test_unlinked_operator_rejected(tmp_path, monkeypatch):
+def test_start_create_rejects_unlinked(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
     monkeypatch.setattr(store_mod, "get_pairing", lambda slug: None)
-
-    async def noop(*a, **k):
-        return {}
-
     with pytest.raises(ValueError, match="not linked"):
-        asyncio.run(
-            create_ws_local_agent(
-                "nope",
-                "x",
-                send_request_fn=noop,
-                await_approval_fn=noop,
-                finalize_fn=noop,
-            )
-        )
+        asyncio.run(agent_create.start_create("nope", "x"))
 
 
-def test_pending_approvals_resolve():
-    from puffo_agent.portal.control.agent_create import PendingApprovals
-
+def test_registry_record_then_wait():
     async def go():
-        p = PendingApprovals()
+        reg = agent_create.CreateRegistry()
 
         async def resolver():
             await asyncio.sleep(0.01)
-            assert p.resolve("r1", {"agent_slug": "s", "pending_token": "t"})
+            reg.record_result("cmd1", {"ok": True, "agent_slug": "s"})
 
         task = asyncio.ensure_future(resolver())
-        result = await p.wait("r1", timeout=1.0)
+        result = await reg.wait_result("cmd1", timeout=1.0)
         await task
         return result
 
     assert asyncio.run(go())["agent_slug"] == "s"
 
 
-def test_pending_approvals_timeout():
-    from puffo_agent.portal.control.agent_create import PendingApprovals
-
+def test_registry_wait_timeout():
     async def go():
-        p = PendingApprovals()
+        reg = agent_create.CreateRegistry()
         with pytest.raises(asyncio.TimeoutError):
-            await p.wait("r2", timeout=0.05)
+            await reg.wait_result("nope", timeout=0.05)
 
     asyncio.run(go())
+
+
+def test_finalize_from_command_writes_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    ident = agent_create.gen_agent_identity(OPERATOR_ROOT)
+    agent_create.get_registry().put_pending(
+        "acr_x",
+        agent_create._PendingCreate(ident, "op-99", "https://chat.puffo.ai/relay", "12345678"),
+    )
+
+    async def fake_post(server_url, binding, token):
+        return None
+
+    monkeypatch.setattr(agent_create, "post_slug_binding", fake_post)
+
+    result = asyncio.run(
+        agent_create.finalize_from_command(
+            "acr_x",
+            {
+                "agent_slug": "helper-1234",
+                "pending_token": "ptok",
+                "name": "Helper",
+                "role": "coder",
+                "space_id": "sp_1",
+            },
+        )
+    )
+    assert result["agent_slug"] == "helper-1234"
+
+    from puffo_agent.portal.state import AgentConfig
+
+    ac = AgentConfig.load("helper-1234")
+    assert ac.puffo_core.space_id == "sp_1"
+    assert ac.role == "coder"
+    assert ac.runtime.kind == "ws-local"
+
+
+def test_finalize_from_command_unknown_request():
+    with pytest.raises(ValueError, match="no pending create"):
+        asyncio.run(agent_create.finalize_from_command("acr_missing", {}))

--- a/tests/test_agent_create_identity.py
+++ b/tests/test_agent_create_identity.py
@@ -1,0 +1,40 @@
+"""The daemon-minted agent identity must pass the daemon's own cert verifiers
+(portal/api/certs.py), which mirror the puffo-server producer's wire format."""
+
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.primitives import Ed25519KeyPair
+from puffo_agent.portal.api.certs import (
+    verify_device_cert,
+    verify_identity_cert,
+    verify_slug_binding,
+)
+from puffo_agent.portal.control.agent_create import build_slug_binding, gen_agent_identity
+
+
+def _operator_root() -> str:
+    return base64url_encode(Ed25519KeyPair.generate().public_key_bytes())
+
+
+def test_generated_certs_pass_daemon_verifiers():
+    operator_root = _operator_root()
+    ident = gen_agent_identity(operator_root)
+
+    root_pk = verify_identity_cert(ident.identity_cert)
+    assert base64url_encode(root_pk) == ident.root_public_key
+    assert ident.identity_cert["declared_operator_public_key"] == operator_root
+    assert ident.identity_cert["identity_type"] == "agent"
+
+    # device_cert chains to the same agent root.
+    verify_device_cert(ident.device_cert, root_pk)
+
+    # slug_binding is built once the server assigns the slug.
+    binding = build_slug_binding(ident.root_keypair, "helper-1234")
+    assert verify_slug_binding(binding, root_pk) == "helper-1234"
+
+
+def test_device_id_derived_from_signing_key():
+    ident = gen_agent_identity(_operator_root())
+    assert ident.device_id.startswith("dev_")
+    assert ident.device_cert["device_id"] == ident.device_id
+    assert ident.device_cert["keys"]["signing"]["algorithm"] == "ed25519"
+    assert ident.device_cert["keys"]["encryption"]["algorithm"] == "x25519"


### PR DESCRIPTION
Lets an AI agent create a ws-local agent for itself with one command — no UI export / manual `.puffoagent` copy. The operator approves in the web app (companion PR in puffo-core-han-group). **puffo-server needs no changes** (reuses `POST /agents` + `POST /certs/slug_binding`).

## Flow
```
puffo-agent agent create-ws-local --operator=<slug> --passcode=xxxxxxxx
  → bridge POST /v1/agents/create-ws-local (auth-exempt bootstrap; operator Approve is the gate)
  → run_create: validate linked operator → mint agent keys + self-signed
     identity/device certs → send agent.create_request machine_message
     → await agent_create_approved command → POST /certs/slug_binding (finalize)
     → write ws-local agent.yml + keystore → pack .puffoagent
  → stdout {agent_slug, agent_id, bundle_path, passcode}   ← caller attaches
```

## Pieces
- `portal/control/agent_create.py`: `gen_agent_identity` / `build_slug_binding` / `finalize_and_pack` / `create_ws_local_agent` / `run_create` / `PendingApprovals`.
- `portal/control/reporter.py` `send_to_operator`; `client.py` `execute_command` op `agent_create_approved` → resolves the awaiting future.
- `portal/api/server.py` + `handlers.py`: bridge endpoint; `auth.py`: exempt it; `cli.py`: the `agent create-ws-local` subcommand.

The daemon mints the keys (it runs the agent + packs the bundle locally); the operator signs only the attestation. Certs are verified against the daemon's own verifiers in tests.

## Tests
New: identity generation (vs daemon verifiers), finalize/pack (bundle unpacks), orchestration + pending-approval (injected I/O). Full suite **519 passed** in the touched scope; nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)