### PR TITLE
chore(changelog): date 1.0.5 as 2026-06-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.5] — 2026-06-29
+## [1.0.5] — 2026-06-30
 
 ### Added
 


### PR DESCRIPTION
Stamp the 1.0.5 changelog with the actual release date (2026-06-30) ahead of publishing 1.0.5 to PyPI. `pyproject.toml` is already at `1.0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)