### PR TITLE
PUF-343: align runtime.error auth-recovery strings with PUF-341 shape

### DIFF
--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1019,11 +1019,20 @@ class CredentialRefresher:
 
     def _flip_refresh_broken(self, outcome: RefreshOutcome) -> None:
         from .state import RuntimeState
+        # PUF-343: user-facing over engineer-log — same "run the CLI
+        # login command on the puffo-agent host" shape PUF-341 uses
+        # for the operator DM, so the CLI + web surfaces stay
+        # consistent with the DM the operator already saw. The debug
+        # counter belongs in the daemon log, not the runtime.error
+        # field the web pane renders verbatim.
+        logger.warning(
+            "flipping refresh_broken after %d consecutive %s outcome(s)",
+            self._consecutive_non_success, outcome.value,
+        )
         msg = (
-            f"daemon CredentialRefresher saw {self._consecutive_non_success} "
-            f"consecutive {outcome.value} outcome(s); on-disk token isn't "
-            f"advancing. Run `claude auth login`, then send the agent "
-            f"a message to recover."
+            "Claude Code sign-in couldn't be refreshed. On the computer "
+            "running puffo-agent, open a terminal and run "
+            "`claude auth login`, then send this agent a message."
         )
         for agent_home in self._agent_homes:
             agent_id = Path(agent_home).name

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -533,24 +533,25 @@ def _handle_suppressed_reply(
                 )
     if scope == "api-error-retry":
         if is_auth:
+            # PUF-343: same shape as the operator DM copy (PUF-341) so the
+            # web pane + CLI status don't drift back into engineer-log
+            # voice. The suppressed-from-channel-post detail already lives
+            # in the daemon log.
             runtime.error = (
-                "Worker emitted an auth-error string after an API "
-                "error; suppressed from channel post. Run "
-                "`claude auth login`, then send the agent a message "
-                "to recover."
+                "Claude Code sign-in expired. On the computer running "
+                "puffo-agent, open a terminal and run `claude auth "
+                "login`, then send this agent a message."
             )
         else:
             runtime.error = (
-                "Worker emitted a rate-limit / quota / server-error "
-                "string after an API error; suppressed from channel "
-                "post. Usually self-recovers — investigate the daemon "
-                "log if persistent."
+                "Rate-limit / quota / server error — usually self-"
+                "recovers. Check the puffo-agent daemon log if it "
+                "persists."
             )
     else:
         runtime.error = (
             "Worker emitted an auth / rate-limit / quota error string "
-            "instead of a real reply; suppressed from channel post. "
-            "Check daemon logs."
+            "instead of a real reply. Check the puffo-agent daemon log."
         )
     runtime.save(agent_id)
     return True, backoff
@@ -657,9 +658,12 @@ class Worker:
         if runtime.health != "ok":
             return
         runtime.health = "auth_failed"
+        # PUF-343: even the post-probe reassertion path renders in the
+        # web pane's health card, so keep the user-facing shape.
         runtime.error = (
-            "post-recovery health probe failed — provider still "
-            "unreachable; waiting for next credential refresh"
+            "Claude Code sign-in expired. On the computer running "
+            "puffo-agent, open a terminal and run `claude auth "
+            "login`, then send this agent a message."
         )
         runtime.save(agent_id)
         log.warning(
@@ -675,7 +679,14 @@ class Worker:
         rt = self.runtime
         was_ok = rt.health != "auth_failed"
         rt.health = "auth_failed"
-        rt.error = "auth error — run `claude auth login`, then send a message to recover"
+        # PUF-343: PUF-341's operator DM is the user's primary signal, but
+        # the same string surfaces in the web pane + CLI status; keep it
+        # user-facing so the two surfaces stay aligned.
+        rt.error = (
+            "Claude Code sign-in expired. On the computer running "
+            "puffo-agent, open a terminal and run `claude auth "
+            "login`, then send this agent a message."
+        )
         rt.save(agent_id)
         if self._notify_refresh_needed is not None:
             try:

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -347,20 +347,28 @@ def test_propagate_outcome_failed_increments_counter(tmp_path, monkeypatch):
     assert r._consecutive_non_success == 1
 
 
-def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch):
+def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch, caplog):
     from puffo_agent.portal.state import RuntimeState
+    import logging
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
     r._propagate_outcome(RefreshOutcome.UNCHANGED)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health != "refresh_broken"
     assert REFRESH_BROKEN_THRESHOLD == 2
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.credential_refresh"):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health == "refresh_broken"
+    # PUF-343: user-facing runtime.error shape mirrors PUF-341's DM;
+    # the outcome-class debug ("unchanged") lives in the daemon log.
+    assert "Claude Code sign-in couldn't be refreshed" in rs.error
     assert "claude auth login" in rs.error
-    assert "unchanged" in rs.error
+    assert any(
+        "flipping refresh_broken" in rec.getMessage() and "unchanged" in rec.getMessage()
+        for rec in caplog.records
+    )
 
 
 def test_refresh_broken_clears_on_next_refreshed(tmp_path, monkeypatch):
@@ -569,16 +577,25 @@ def test_refreshed_outcome_does_not_lift_unrelated_health_to_ok(
     assert rs_after.error == ""
 
 
-def test_refresh_broken_streak_mixes_unchanged_and_failed(tmp_path, monkeypatch):
+def test_refresh_broken_streak_mixes_unchanged_and_failed(tmp_path, monkeypatch, caplog):
     from puffo_agent.portal.state import RuntimeState
+    import logging
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
-    r._propagate_outcome(RefreshOutcome.FAILED)
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.credential_refresh"):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+        r._propagate_outcome(RefreshOutcome.FAILED)
     rs = RuntimeState.load(aid)
     assert rs.health == "refresh_broken"
-    # The flip message reports the LATEST outcome class — UNCHANGED
-    # then FAILED → "failed", not "unchanged".
-    assert "failed" in rs.error
+    # PUF-343: the user-visible runtime.error field is the operator-
+    # facing recovery instruction now (matching PUF-341's DM copy). The
+    # LATEST-outcome debug ("failed" vs "unchanged") lives in the daemon
+    # log where an engineer can see it without leaking into the UI.
+    assert "Claude Code sign-in couldn't be refreshed" in rs.error
+    assert "claude auth login" in rs.error
+    assert any(
+        "flipping refresh_broken" in rec.getMessage() and "failed" in rec.getMessage()
+        for rec in caplog.records
+    )
 
 
 # ── PUF-265 v2: Haiku probe model + rate-limit fast retry ────────────

--- a/tests/test_worker_error_suppress.py
+++ b/tests/test_worker_error_suppress.py
@@ -164,9 +164,9 @@ def test_handle_suppressed_reply_returns_true_on_leak_fallback_scope(tmp_path, m
     assert suppressed is True
     assert _SUPPRESSION_BACKOFF_MIN_SECONDS <= backoff <= _SUPPRESSION_BACKOFF_MAX_SECONDS
     # Operator-facing surface: runtime.error populated, NOT a channel
-    # post. The "Check daemon logs" copy is the fallback-scope variant.
-    assert "suppressed from channel post" in runtime.error
-    assert "Check daemon logs" in runtime.error
+    # post. Fallback-scope variant points at the daemon log for triage
+    # (PUF-343: user-facing tone without leaking the debug detail).
+    assert "Check the puffo-agent daemon log" in runtime.error
     # Auth-class leak is definitive evidence regardless of scope —
     # flips health so puffo-agent status surfaces it.
     assert runtime.health == "auth_failed"
@@ -186,9 +186,12 @@ def test_handle_suppressed_reply_returns_true_on_leak_api_retry_scope(tmp_path, 
     )
     assert suppressed is True
     assert _SUPPRESSION_BACKOFF_MIN_SECONDS <= backoff <= _SUPPRESSION_BACKOFF_MAX_SECONDS
-    # API-retry / auth-class branch: re-login + send-a-message copy.
+    # API-retry / auth-class branch: PUF-343 user-facing shape mirrors
+    # PUF-341's operator DM so the CLI/web + DM stay consistent.
+    assert "Claude Code sign-in expired" in runtime.error
     assert "claude auth login" in runtime.error
-    assert "send the agent a message" in runtime.error
+    assert "running puffo-agent" in runtime.error
+    assert "send this agent a message" in runtime.error
     assert runtime.health == "auth_failed"
 
 
@@ -207,8 +210,10 @@ def test_handle_suppressed_reply_api_retry_rate_limit_branches_message(tmp_path,
     assert suppressed is True
     assert _SUPPRESSION_BACKOFF_MIN_SECONDS <= backoff <= _SUPPRESSION_BACKOFF_MAX_SECONDS
     assert runtime.health == "unknown"  # NOT auth_failed
-    assert "rate-limit" in runtime.error
+    assert "Rate-limit" in runtime.error
     assert "self-recovers" in runtime.error
+    # PUF-343: rate-limit branch must NEVER instruct the operator to
+    # relogin — that's the auth branch's shape only.
     assert "claude auth login" not in runtime.error
     assert "agent resume" not in runtime.error
 
@@ -465,9 +470,9 @@ def test_call_site_skips_send_on_suppressed_leak(tmp_path, monkeypatch):
         sleeps=sleeps,
     ))
     assert client.calls == []  # NEVER called when filter suppresses
-    # Operator-side surface populated.
+    # Operator-side surface populated (PUF-343 user-facing shape).
     assert runtime.health == "auth_failed"
-    assert "send the agent a message" in runtime.error
+    assert "send this agent a message" in runtime.error
     # And the call site DID sleep with a backoff in range.
     assert len(sleeps) == 1
     assert _SUPPRESSION_BACKOFF_MIN_SECONDS <= sleeps[0] <= _SUPPRESSION_BACKOFF_MAX_SECONDS

--- a/tests/test_worker_health_probe_gate.py
+++ b/tests/test_worker_health_probe_gate.py
@@ -67,11 +67,18 @@ def test_reassert_flips_ok_back_to_auth_failed():
     )
 
     assert rt.health == "auth_failed"
-    assert "health probe failed" in rt.error
-    assert rt.saved == [("agent-a", "auth_failed",
-                         "post-recovery health probe failed — provider "
-                         "still unreachable; waiting for next credential "
-                         "refresh")]
+    # PUF-343: reassertion path shares the same user-facing shape as the
+    # rest of the auth-failed surfaces so the web pane / CLI status /
+    # DM copy stay aligned. The "post-warm probe failed" diagnostic lives
+    # in the daemon log (log.warning at the call site).
+    assert "Claude Code sign-in expired" in rt.error
+    assert "claude auth login" in rt.error
+    assert rt.saved == [(
+        "agent-a", "auth_failed",
+        "Claude Code sign-in expired. On the computer running "
+        "puffo-agent, open a terminal and run `claude auth "
+        "login`, then send this agent a message.",
+    )]
 
 
 def test_reassert_noop_when_already_auth_failed():


### PR DESCRIPTION
## Summary

Mirror PUF-341's operator DM shape into the five `runtime.error` sites that surface through `puffo-agent status` CLI + `/v1/agents/{id}/runtime` (web-pane health card), so ambient debugging surfaces stay aligned with the DM copy the operator already saw.

Five sites polished, all in the auth-recovery / suppression path:

1. **`CredentialRefresher._flip_refresh_broken`** (`credential_refresh.py:1032`) — `"Claude Code sign-in couldn't be refreshed. On the computer running puffo-agent, open a terminal and run \`claude auth login\`, then send this agent a message."` The consecutive-outcome counter now lives in a sibling `logger.warning` (`"flipping refresh_broken after N consecutive X outcome(s)"`) rather than leaking into the user-facing field.
2. **`_handle_suppressed_reply` api-error-retry auth branch** (`worker.py:540`) — same PUF-341-shaped string.
3. **`_handle_suppressed_reply` api-error-retry rate-limit branch** (`worker.py:546`) — `"Rate-limit / quota / server error — usually self-recovers. Check the puffo-agent daemon log if it persists."` Negative-guard preserved: this branch NEVER instructs `claude auth login`.
4. **`_handle_suppressed_reply` fallback branch** (`worker.py:552`) — points at the daemon log without leaking the debug detail.
5. **`Worker._reassert_auth_failed_after_failed_probe`** (`worker.py:663`) — same PUF-341-shaped string; probe-failure diagnostic stays in `log.warning`.
6. **`Worker._enter_auth_failed`** (`worker.py:685`) — same PUF-341-shaped string.

Composes with:
- **PUF-341 (PR #115, in Solution QA)** — DM copy. Same recovery instruction now consistent across DM + CLI + web pane.
- **PUF-303 (closed-without-merge)** — `refresh_broken` deliberately does NOT DM operator; that decision preserved (this PR only polishes ambient strings).

Out of scope per source-walk (Sam's diagnostic script `refresh-claude-oauth.sh` isn't in-repo; `claude auth status` false-positive is upstream Claude CLI; PUF-335 auto-trigger integration blocked on PR #111 merge).

## Test plan

- [x] Touched-tests suite (`test_worker_error_suppress.py`, `test_worker_health_probe_gate.py`, `test_credential_refresher.py`, `test_auth_failed_dm_notification.py`) — **133/133 pass** locally.
- [x] Full pytest excluding pre-existing env-gap collection errors (`test_puffo_core_tools.py`, `test_send_supplementation.py`, `test_ui_views.py` — need `mcp`/`PySide6`) — **1632 pass / 28 pre-existing failures**. Failure set byte-identical to `origin/main` on the same host (`diff /tmp/main-fails.txt /tmp/pr-fails.txt` → clean). Zero regression from PUF-343.
- [x] String-shape smoke: all five sites' final assembled strings verified — rate-limit branch never contains `claude auth login`; auth branches all contain "Claude Code sign-in expired" + `claude auth login` + `puffo-agent` WHERE clause; refresh_broken msg contains "Claude Code sign-in couldn't be refreshed" + logger.warning ("flipping refresh_broken") sibling.
- [x] Sibling audit for other `runtime.error` sites — one `codex_thread_wedged` string in `codex_session.py:539` is a different substrate (auto-recovery, no operator action needed) and already user-facing; `api_error_abandoned` string in `worker.py:1430` is a distinct health state, not part of the auth-recovery family. No siblings missed.
- [ ] Post-merge external-verify via Sam's re-encounter of `refresh_broken` state (closure-back to #Customer Voice thread `msg_75858fc1` per intake).

Ticket: PUF-343