### PR TITLE
PUF-345: send_message runtime floor for DM + human-rooted replies (belt-and-suspenders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   the extra flag was redundant. Prompt-only edits still drop
   `refresh_agent.flag`.
 
+- **`send_message` and `send_message_with_attachments` collapse
+  `is_visible_to_human: bool` + `agent_only: bool` into a single
+  tri-value `visibility_level` param (default `"default"`).**
+  `"human"` sends visible; `"agent_only"` sends hidden and skips
+  the safety net; `"default"` sends hidden BUT the daemon force-
+  flips to visible for DMs, root-level posts, and messages whose
+  text @-mentions a human — with a note explaining why + nudging
+  the agent toward the explicit level next turn. `"agent_only"`
+  still gets a warning note when the message looks human-targeted
+  (DM / @-mentions human) so the agent can reconsider without
+  being overridden. The same floor runs on the worker's fallback
+  path (agent produced text but skipped the tool), keyed off
+  `visibility_level="default"` semantics. Wire payload unchanged
+  — the envelope still carries `is_visible_to_human: bool`, so
+  interop with older clients and the server schema is preserved.
+
 ### Removed
 
 - `reload_system_prompt` MCP tool (replaced by `refresh()`); old

--- a/src/puffo_agent/agent/_visibility.py
+++ b/src/puffo_agent/agent/_visibility.py
@@ -1,11 +1,6 @@
-"""Shared visibility resolution for outbound messages.
-
-Both the MCP send_message tools (agent-driven) and the fallback path
-in ``puffo_core_client.send_fallback_message`` (worker posts when the
-LLM produced text but skipped the tool call) route through
-``resolve_visibility`` so all outbound sends honour the same floor
-and the same per-level guidance notes.
-"""
+"""Shared visibility resolution — the MCP send tools and the worker
+fallback both route through ``resolve_visibility`` so all outbound
+sends honour the same floor + per-level guidance notes."""
 
 from __future__ import annotations
 
@@ -58,8 +53,7 @@ async def resolve_visibility(
     if level == "human":
         return True, ""
 
-    # Root-level auto-coerce (can't fold either way; applies to both
-    # default and agent_only).
+    # Root-level can't fold, so hidden becomes a lie regardless of level.
     if not root_id.strip():
         return True, (
             "\nnote: hidden ignored — root-level messages can't fold, "

--- a/src/puffo_agent/agent/_visibility.py
+++ b/src/puffo_agent/agent/_visibility.py
@@ -1,0 +1,145 @@
+"""Shared visibility resolution for outbound messages.
+
+Both the MCP send_message tools (agent-driven) and the fallback path
+in ``puffo_core_client.send_fallback_message`` (worker posts when the
+LLM produced text but skipped the tool call) route through
+``resolve_visibility`` so all outbound sends honour the same floor
+and the same per-level guidance notes.
+"""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+from typing import Any
+
+from .puffo_core_client import _MENTION_RE
+
+
+logger = logging.getLogger(__name__)
+
+
+_VISIBILITY_LEVELS = ("human", "default", "agent_only")
+
+
+async def resolve_visibility(
+    level: str,
+    channel_ref: str,
+    text: str,
+    root_id: str,
+    http_client: Any,
+) -> tuple[bool, str]:
+    """Return ``(effective_is_visible_to_human, note)`` for an
+    outbound message.
+
+    ``level`` is ``"human"``, ``"default"``, or ``"agent_only"``.
+    Semantics:
+
+    - ``human`` — send visible, no note.
+    - ``default`` — send hidden BUT force visible on DMs, root-level
+      posts, or @-mentions of a human. When forced visible the note
+      explains why + nudges the caller toward the explicit level next
+      time; when NOT forced, the note nudges the caller to be
+      explicit anyway.
+    - ``agent_only`` — send hidden regardless of DM/@-mention (agent
+      opted out), except root-level which always coerces (can't
+      fold). Note warns when the message LOOKS like a human should
+      see it so the caller can reconsider.
+
+    Profile-lookup failures on the @-mention check pass through
+    silently — a transient error can't flip an intentional hidden
+    send.
+    """
+    if level not in _VISIBILITY_LEVELS:
+        raise RuntimeError(
+            f"visibility_level must be one of {_VISIBILITY_LEVELS!r}; "
+            f"got {level!r}"
+        )
+    if level == "human":
+        return True, ""
+
+    # Root-level auto-coerce (can't fold either way; applies to both
+    # default and agent_only).
+    if not root_id.strip():
+        return True, (
+            "\nnote: hidden ignored — root-level messages can't fold, "
+            "so this is sent visible regardless. Only threaded replies "
+            "(with root_id set) can actually be hidden."
+        )
+
+    signal, reason = await _detect_human_signal(channel_ref, text, http_client)
+
+    if level == "default":
+        if signal:
+            return True, _default_coerced_note(reason)
+        return False, _default_nudge_note()
+    # level == "agent_only"
+    if signal:
+        return False, _agent_only_warn_note(reason)
+    return False, ""
+
+
+async def _detect_human_signal(
+    channel_ref: str, text: str, http_client: Any,
+) -> tuple[bool, str]:
+    """``(True, "dm")`` if DM; ``(True, "mention")`` if body
+    @-mentions at least one human; ``(False, "")`` otherwise. Profile
+    lookup errors are swallowed so a transient failure reads as "no
+    signal" (preserves caller intent)."""
+    if channel_ref.startswith("@"):
+        return True, "dm"
+    mentioned = sorted({m.lower() for m in _MENTION_RE.findall(text or "")})
+    if not mentioned:
+        return False, ""
+    try:
+        resp = await http_client.get(
+            "/identities/profiles?slugs="
+            + ",".join(urllib.parse.quote(m, safe="") for m in mentioned)
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "visibility-floor profile fetch failed for %s: %s",
+            mentioned, exc,
+        )
+        return False, ""
+    profiles = resp.get("profiles", []) if isinstance(resp, dict) else []
+    for p in profiles:
+        if (p.get("identity_type") or "human").strip().lower() == "human":
+            return True, "mention"
+    return False, ""
+
+
+def _default_coerced_note(reason: str) -> str:
+    ctx = (
+        "this is a DM, so the addressee is waiting for a reply"
+        if reason == "dm"
+        else "the message @-mentions a human"
+    )
+    return (
+        f"\nnote: sent visible — {ctx}. You used "
+        "``visibility_level='default'``; for future messages that a "
+        "person should read, pass ``'human'`` explicitly so this "
+        "safety-net doesn't have to guess."
+    )
+
+
+def _default_nudge_note() -> str:
+    return (
+        "\nnote: sent hidden with ``visibility_level='default'``. Try "
+        "to be explicit next turn: ``'human'`` when a person should "
+        "read the message, ``'agent_only'`` when it's genuinely "
+        "agent-to-agent."
+    )
+
+
+def _agent_only_warn_note(reason: str) -> str:
+    ctx = (
+        "this is a DM, so the addressee usually is waiting for a reply"
+        if reason == "dm"
+        else "the message @-mentions a human"
+    )
+    return (
+        f"\nnote: sent hidden per ``visibility_level='agent_only'``, "
+        f"but {ctx}. Double-check this really is agent-to-agent — "
+        "``'human'`` would have surfaced it to the person."
+    )

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -3702,10 +3702,8 @@ class PuffoCoreMessageClient:
             envelope_kind, recipient_slug or channel_id, len(devices),
         )
 
-        # Fallback path acts like visibility_level="default": hidden by
-        # default, but the floor forces visible on DMs, root-level, or
-        # @-mention-a-human sends. The note is dropped (no MCP tool
-        # channel to return it on).
+        # Fallback shares the visibility_level="default" floor; the
+        # note is dropped (no MCP return channel).
         from ._visibility import resolve_visibility
         channel_ref = (
             f"@{recipient_slug}" if envelope_kind == "dm" else (channel_id or "")

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -3702,14 +3702,23 @@ class PuffoCoreMessageClient:
             envelope_kind, recipient_slug or channel_id, len(devices),
         )
 
+        # Fallback path acts like visibility_level="default": hidden by
+        # default, but the floor forces visible on DMs, root-level, or
+        # @-mention-a-human sends. The note is dropped (no MCP tool
+        # channel to return it on).
+        from ._visibility import resolve_visibility
+        channel_ref = (
+            f"@{recipient_slug}" if envelope_kind == "dm" else (channel_id or "")
+        )
+        effective_visible, _ = await resolve_visibility(
+            "default", channel_ref, text, root_id or "", self.http,
+        )
+
         inp = EncryptInput(
             envelope_kind=envelope_kind,
             sender_slug=self.slug,
             sender_subkey_id=sess.subkey_id,
-            # Fallback path (agent skipped send_message + [SILENT]) —
-            # folded by default; the primer steers agents to
-            # send_message, where they set visibility consciously.
-            is_visible_to_human=False,
+            is_visible_to_human=effective_visible,
             space_id=send_space_id,
             channel_id=send_channel_id,
             recipient_slug=recipient_slug,

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -82,18 +82,26 @@ Common ones:
 
 Two ways, pick one explicitly every turn:
 
-1. **`mcp__puffo__send_message(channel, text, is_visible_to_human, root_id="")`**
+1. **`mcp__puffo__send_message(channel, text, root_id="", visibility_level="default")`**
    — the default for every user-visible reply. Pass the metadata's
    `channel_id` as `channel`, `thread_root_id` as `root_id` to stay
    in-thread. Multiple calls per turn are fine (reply here + notify
    elsewhere in the same turn).
 
-   `is_visible_to_human` is **required**, no default:
-   - `true` — anything a human should read (replies, status updates,
-     operator pings). Default choice; when in doubt, `true`.
-   - `false` — agent-to-agent chatter humans would find noise. Only
-     effective on threaded replies (`root_id` set); on root posts
-     it's ignored and coerced to visible.
+   **Pick `visibility_level` explicitly** — the daemon will nudge you
+   when you fall back on `"default"`:
+   - `"human"` — anything a person should read (replies, status
+     updates, operator pings). Sent visible. **Prefer this over
+     `"default"` when the message is meant for a human.**
+   - `"default"` — you didn't decide. Sent hidden BUT the daemon
+     force-flips to visible for DMs, root-level posts, and messages
+     that @-mention a human, so a person doesn't get stranded. Every
+     `"default"` send returns a note either explaining the coercion
+     or nudging you toward an explicit level next turn.
+   - `"agent_only"` — genuinely agent-to-agent traffic. Sent hidden
+     regardless of DM / @-mention (the safety-net is skipped). The
+     daemon will still warn if the message LOOKS human-targeted so
+     you can reconsider.
 
    **Cache-validation (PUF-227-A).** The daemon verifies that
    `root_id` points to a parent envelope in your local message store
@@ -107,9 +115,9 @@ Two ways, pick one explicitly every turn:
    (conversation between others, you're not mentioned, possible
    bot-loop). Substring-matched; surrounding prose is fine.
 
-Skipping both produces a `[fallback]` warning posted as
-`is_visible_to_human=false` — humans may never see it. Don't rely
-on it.
+Skipping both produces a `[fallback]` warning routed through the
+same `"default"` floor — surfaced in a DM / to an @-mentioned human,
+hidden otherwise. Don't rely on it.
 
 **Self-mention marker.** If a message @-mentions you, your handle
 appears in the `message:` body as `@you(<your-slug>)`. Treat it as
@@ -161,8 +169,8 @@ from `.claude/skills/<name>/SKILL.md`; on codex the bullet list
 below is the authoritative reference.
 
 **Write:**
-- `send_message(channel, text, is_visible_to_human, root_id="")`
-- `send_message_with_attachments(paths, channel, is_visible_to_human, caption="", root_id="")`
+- `send_message(channel, text, root_id="", visibility_level="default")`
+- `send_message_with_attachments(paths, channel, caption="", root_id="", visibility_level="default")`
 
 **Read / discovery:**
 - `list_spaces()` — your space memberships.
@@ -321,14 +329,22 @@ Post a message to a Puffo.ai channel or DM a user.
   channel. No `#<name>` shortcut; use `list_channels_in_all_spaces`
   to look up an id.
 - `text` (required) — message body. Markdown preserved on the wire.
-- `is_visible_to_human` (required) — bool, no default:
-  - `true` — anything a human should read (replies, status updates,
-    operator pings). Default choice; when in doubt, `true`.
-  - `false` — agent-to-agent chatter humans would find noise. Only
-    effective on threaded replies (`root_id` set); on root-level
-    posts it's ignored and coerced to visible.
 - `root_id` (optional) — envelope_id (`env_<uuid>`) of the post you
   are replying to; opens a thread.
+- `visibility_level` (optional) — one of `"human"` / `"default"` /
+  `"agent_only"`. Default is `"default"`.
+  - `"human"` — anything a person should read (replies, status
+    updates, operator pings). **Prefer this over `"default"` for
+    human-targeted messages.** The daemon will nudge you toward
+    `"human"` if you fall back on `"default"`.
+  - `"default"` — you didn't decide. Sent hidden BUT force-flipped
+    to visible for DMs, root-level posts, and messages that
+    @-mention a human. Every `"default"` send returns a note that
+    either explains the coercion or asks you to pick explicitly
+    next turn.
+  - `"agent_only"` — genuinely agent-to-agent traffic. Sent hidden;
+    the DM / @-mention safety net is skipped. A warning still fires
+    if the message looks human-targeted so you can reconsider.
 
 **Cache-validation invariant (PUF-227-A):** the daemon verifies
 your `root_id` points to a parent envelope in your local message
@@ -355,13 +371,19 @@ across channel switches.
 # Reply to the triggering message:
 send_message(channel="ch_b3c4d5e6-...",
              text="Got it; running the migration now.",
-             is_visible_to_human=True,
-             root_id="env_abcdef-...")
+             root_id="env_abcdef-...",
+             visibility_level="human")
 
 # Proactive notification:
 send_message(channel="@alice-1234",
              text="Heads up — build done.",
-             is_visible_to_human=True)
+             visibility_level="human")
+
+# Agent-to-agent coordination (explicitly opts out of the floor):
+send_message(channel="ch_ops-...",
+             text="@twinkle-abcd resuming pipeline",
+             root_id="env_...",
+             visibility_level="agent_only")
 ```
 """
 
@@ -373,7 +395,7 @@ Send one or more files from your workspace to a Puffo.ai channel
 or DM. Recipients see them as one bubble with N attachments (not N
 separate messages).
 
-**Tool:** `mcp__puffo__send_message_with_attachments(paths, channel, is_visible_to_human, caption="", root_id="")`
+**Tool:** `mcp__puffo__send_message_with_attachments(paths, channel, caption="", root_id="", visibility_level="default")`
 
 **Arguments:**
 - `paths`: list of workspace-relative file paths. Pass a one-element
@@ -381,16 +403,16 @@ separate messages).
   rejected; the cap is 10 files per call and 8 MiB per file.
 - `channel`: same syntax as `send_message` — `@<slug>` for a DM,
   `ch_<uuid>` for a channel.
-- `is_visible_to_human`: required bool, no default — same meaning
-  as on `send_message`. `true` for files a human should see,
-  `false` for agent-to-agent payloads. When in doubt, `true`.
-  `false` only folds threaded replies (with `root_id`); on a
-  root-level send it's ignored and coerced to visible.
 - `caption`: optional text posted alongside the files. Empty by
   default; recipients see just the attachments.
 - `root_id`: optional — reply with the attachments inside an
   existing thread. Pass the envelope_id of the message you're
   replying to (same shape as `send_message`'s `root_id`).
+- `visibility_level`: same semantics as `send_message` — `"human"` /
+  `"default"` / `"agent_only"`. Default `"default"`; the @-mention
+  floor keys off `caption`. Prefer `"human"` for files a person
+  should see; the daemon will nudge you when `"default"` triggers
+  the safety net.
 
 **Encryption:** each file is encrypted client-side with its own
 ChaCha20-Poly1305 key + nonce; the server only ever sees opaque

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -198,6 +198,83 @@ def _coerce_root_visibility(
     return is_visible_to_human, ""
 
 
+async def _coerce_dm_and_human_reply_visibility(
+    channel_ref: str,
+    root_id: str,
+    is_visible_to_human: bool,
+    agent_only: bool,
+    data_client: Any,
+    http_client: Any,
+) -> tuple[bool, str]:
+    """PUF-345 belt-and-suspenders visibility floor for the two
+    contexts where a mistakenly-hidden reply strands a human waiting
+    for an answer:
+
+      1. DMs (``channel`` starts with ``@``) — DMs are meant for the
+         addressee to read.
+      2. Threaded replies whose thread root was posted by a human —
+         the human is the one waiting inside that thread.
+
+    In both cases we force ``is_visible_to_human=true`` and return a
+    note so the agent learns on the spot. The named ``agent_only``
+    override skips the floor for genuine agent-to-agent DMs / threaded
+    chatter (documented as the escape hatch in the tool docstring).
+
+    Returns ``(effective_visibility, note)`` — ``note`` is empty
+    unless a coercion happened. Lookup failures on the thread-root
+    identity check pass through without coercing so a transient
+    profile-fetch error can't silently flip an intentional
+    ``visible=false`` for the caller.
+    """
+    if agent_only:
+        return is_visible_to_human, ""
+    if is_visible_to_human:
+        return True, ""
+    if channel_ref.startswith("@"):
+        return True, (
+            "\nnote: is_visible_to_human=false ignored — DMs force "
+            "visible so the addressee can see them. Pass "
+            "``agent_only=true`` for a genuine agent-to-agent DM."
+        )
+    if not root_id.strip():
+        return is_visible_to_human, ""
+    try:
+        root_msg = await data_client.get_message_by_envelope(root_id)
+    except Exception as exc:  # noqa: BLE001 — soft-fail preserves caller intent
+        logger.debug(
+            "PUF-345 root-sender lookup transport error for %s: %s",
+            root_id, exc,
+        )
+        return is_visible_to_human, ""
+    if root_msg is None:
+        return is_visible_to_human, ""
+    root_sender = getattr(root_msg, "sender_slug", "") or ""
+    if not root_sender:
+        return is_visible_to_human, ""
+    try:
+        resp = await http_client.get(
+            f"/identities/profiles?slugs={urllib.parse.quote(root_sender, safe='')}"
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "PUF-345 root-sender profile fetch failed for %s: %s",
+            root_sender, exc,
+        )
+        return is_visible_to_human, ""
+    profiles = resp.get("profiles", []) if isinstance(resp, dict) else []
+    if not profiles:
+        return is_visible_to_human, ""
+    identity_type = (profiles[0].get("identity_type") or "human").strip().lower()
+    if identity_type != "human":
+        return is_visible_to_human, ""
+    return True, (
+        "\nnote: is_visible_to_human=false ignored — this thread's "
+        "root was posted by a human, so the reply is sent visible. "
+        "Pass ``agent_only=true`` for a genuine agent-to-agent "
+        "threaded exchange."
+    )
+
+
 _RESOLVE_ROOT_MAX_DEPTH = 4
 
 
@@ -424,6 +501,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         text: str,
         is_visible_to_human: bool,
         root_id: str = "",
+        agent_only: bool = False,
     ) -> str:
         """Post a message to a Puffo.ai channel or DM a user.
 
@@ -440,9 +518,17 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             default — judge every message. NOTE: ``false`` only takes
             effect on threaded replies (when ``root_id`` is set) —
             root-level messages can't fold, so ``false`` on one is
-            ignored and the message is sent visible.
+            ignored and the message is sent visible. Additionally,
+            DMs and threaded replies rooted at a human message force
+            visible unless ``agent_only=true`` (PUF-345 belt-and-
+            suspenders floor).
         root_id: optional — reply inside a thread; pass the
             envelope_id of the message you're replying to.
+        agent_only: opt-out of the DM / human-reply visibility floor.
+            Pass ``true`` for genuine agent-to-agent DMs or threaded
+            chatter that a human shouldn't be forced to see; leave the
+            default ``false`` for anything a human might be waiting
+            on.
         """
         channel_ref = channel.strip()
         if not channel_ref:
@@ -499,6 +585,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
+        # PUF-345 belt-and-suspenders floor — DM or human-rooted
+        # threaded reply. Runs after the root-level coercion so the
+        # root-level note (which forces visible unconditionally) wins
+        # when both would apply.
+        effective_visible, floor_note = await _coerce_dm_and_human_reply_visibility(
+            channel_ref, root_id, effective_visible, agent_only,
+            cfg.data_client, cfg.http_client,
+        )
         resolved_root, root_note = await _resolve_root_id(
             root_id, cfg.data_client,
         )
@@ -532,6 +626,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return (
             f"posted {envelope.get('envelope_id', '?')} to {channel}"
             f"{fold_note}"
+            f"{floor_note}"
             f"{root_note}"
             f"{validate_note}"
         )
@@ -959,6 +1054,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         is_visible_to_human: bool,
         caption: str = "",
         root_id: str = "",
+        agent_only: bool = False,
     ) -> str:
         """Send a message carrying one or more workspace files to a
         channel or DM.
@@ -976,10 +1072,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             fold away. No default — judge every send. NOTE: ``false``
             only takes effect on threaded replies (when ``root_id`` is
             set); on a root-level message it's ignored and the
-            message is sent visible.
+            message is sent visible. DMs and threaded replies rooted
+            at a human message force visible unless
+            ``agent_only=true`` (PUF-345 belt-and-suspenders floor).
         caption: optional text alongside the files.
         root_id: optional thread reply, same semantics as
             ``send_message``'s ``root_id``.
+        agent_only: opt-out of the DM / human-reply visibility floor,
+            same semantics as ``send_message``'s ``agent_only``.
         """
         import mimetypes
         from pathlib import Path
@@ -1114,6 +1214,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
+        # PUF-345 belt-and-suspenders floor — mirrors send_message so
+        # attachment sends can't slip past the same discipline.
+        effective_visible, floor_note = await _coerce_dm_and_human_reply_visibility(
+            channel_ref, root_id, effective_visible, agent_only,
+            cfg.data_client, cfg.http_client,
+        )
         resolved_root, root_note = await _resolve_root_id(
             root_id, cfg.data_client,
         )
@@ -1150,6 +1256,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             f"total) to {channel}{thread_note} "
             f"(envelope_id {envelope.get('envelope_id', '?')})"
             f"{fold_note}"
+            f"{floor_note}"
             f"{root_note}"
             f"{validate_note}"
         )

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -206,26 +206,12 @@ async def _coerce_dm_and_human_reply_visibility(
     data_client: Any,
     http_client: Any,
 ) -> tuple[bool, str]:
-    """PUF-345 belt-and-suspenders visibility floor for the two
-    contexts where a mistakenly-hidden reply strands a human waiting
-    for an answer:
-
-      1. DMs (``channel`` starts with ``@``) — DMs are meant for the
-         addressee to read.
-      2. Threaded replies whose thread root was posted by a human —
-         the human is the one waiting inside that thread.
-
-    In both cases we force ``is_visible_to_human=true`` and return a
-    note so the agent learns on the spot. The named ``agent_only``
-    override skips the floor for genuine agent-to-agent DMs / threaded
-    chatter (documented as the escape hatch in the tool docstring).
-
-    Returns ``(effective_visibility, note)`` — ``note`` is empty
-    unless a coercion happened. Lookup failures on the thread-root
-    identity check pass through without coercing so a transient
-    profile-fetch error can't silently flip an intentional
-    ``visible=false`` for the caller.
-    """
+    """Visibility floor for DMs + threaded replies whose root was
+    posted by a human — force ``visible=true`` and return a note so
+    the agent learns on the spot. ``agent_only=true`` skips the
+    floor for genuine agent-to-agent traffic. Lookup failures on
+    the identity check pass through so a transient profile-fetch
+    error can't flip an intentional ``visible=false``."""
     if agent_only:
         return is_visible_to_human, ""
     if is_visible_to_human:
@@ -240,9 +226,9 @@ async def _coerce_dm_and_human_reply_visibility(
         return is_visible_to_human, ""
     try:
         root_msg = await data_client.get_message_by_envelope(root_id)
-    except Exception as exc:  # noqa: BLE001 — soft-fail preserves caller intent
+    except Exception as exc:  # noqa: BLE001
         logger.debug(
-            "PUF-345 root-sender lookup transport error for %s: %s",
+            "visibility-floor root lookup transport error for %s: %s",
             root_id, exc,
         )
         return is_visible_to_human, ""
@@ -257,7 +243,7 @@ async def _coerce_dm_and_human_reply_visibility(
         )
     except Exception as exc:  # noqa: BLE001
         logger.debug(
-            "PUF-345 root-sender profile fetch failed for %s: %s",
+            "visibility-floor profile fetch failed for %s: %s",
             root_sender, exc,
         )
         return is_visible_to_human, ""
@@ -518,10 +504,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             default — judge every message. NOTE: ``false`` only takes
             effect on threaded replies (when ``root_id`` is set) —
             root-level messages can't fold, so ``false`` on one is
-            ignored and the message is sent visible. Additionally,
-            DMs and threaded replies rooted at a human message force
-            visible unless ``agent_only=true`` (PUF-345 belt-and-
-            suspenders floor).
+            ignored and the message is sent visible. DMs and threaded
+            replies rooted at a human message also force visible
+            unless ``agent_only=true``.
         root_id: optional — reply inside a thread; pass the
             envelope_id of the message you're replying to.
         agent_only: opt-out of the DM / human-reply visibility floor.
@@ -585,10 +570,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
-        # PUF-345 belt-and-suspenders floor — DM or human-rooted
-        # threaded reply. Runs after the root-level coercion so the
-        # root-level note (which forces visible unconditionally) wins
-        # when both would apply.
+        # Floor runs AFTER the root-level coercion: the already-visible
+        # short-circuit inside the floor keeps both notes from firing.
         effective_visible, floor_note = await _coerce_dm_and_human_reply_visibility(
             channel_ref, root_id, effective_visible, agent_only,
             cfg.data_client, cfg.http_client,
@@ -1073,8 +1056,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             only takes effect on threaded replies (when ``root_id`` is
             set); on a root-level message it's ignored and the
             message is sent visible. DMs and threaded replies rooted
-            at a human message force visible unless
-            ``agent_only=true`` (PUF-345 belt-and-suspenders floor).
+            at a human message also force visible unless
+            ``agent_only=true``.
         caption: optional text alongside the files.
         root_id: optional thread reply, same semantics as
             ``send_message``'s ``root_id``.
@@ -1214,8 +1197,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
-        # PUF-345 belt-and-suspenders floor — mirrors send_message so
-        # attachment sends can't slip past the same discipline.
         effective_visible, floor_note = await _coerce_dm_and_human_reply_visibility(
             channel_ref, root_id, effective_visible, agent_only,
             cfg.data_client, cfg.http_client,

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -280,22 +280,14 @@ async def _resolve_root_id(
     so the new message threads under the real root instead of
     silently disappearing into a sub-thread.
 
-    Runs *after* ``_coerce_root_visibility`` — the visibility
-    decision is keyed off the agent's *intent* (a non-empty
-    ``root_id`` means "threaded reply"), so a hidden-visibility
-    reply whose ``root_id`` is auto-corrected stays hidden. This
-    helper only retargets which thread the message lands in.
+    On healthy data ``thread_root_id`` is always a true root (its
+    own ``thread_root_id IS NULL`` per ``message_store.py``'s schema
+    contract), so the loop terminates after at most one hop. The
+    multi-step walk + cycle break are corruption defense for relay
+    data shapes the schema shouldn't produce.
 
-    On healthy data ``thread_root_id`` is always a true root
-    (its own ``thread_root_id IS NULL`` per ``message_store.py``'s
-    schema contract), so the loop terminates after at most one
-    hop. The multi-step walk + cycle break are corruption defense
-    for relay data shapes the schema shouldn't produce.
-
-    Returns ``(resolved_root_or_None, note)``. ``None`` is
-    returned only when ``root_id.strip()`` is empty. ``note`` is
-    empty unless a correction or warning happened — shape mirrors
-    ``_coerce_root_visibility``. Lookup miss / transport failure
+    Returns ``(resolved_root_or_None, note)`` — ``None`` only when
+    ``root_id.strip()`` is empty. Lookup miss / transport failure
     falls through with the original id plus a soft warning so the
     send still completes.
     """

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -198,20 +198,20 @@ def _coerce_root_visibility(
     return is_visible_to_human, ""
 
 
-async def _coerce_dm_and_human_reply_visibility(
+async def _coerce_dm_and_human_mention_visibility(
     channel_ref: str,
-    root_id: str,
+    text: str,
     is_visible_to_human: bool,
     agent_only: bool,
-    data_client: Any,
     http_client: Any,
 ) -> tuple[bool, str]:
-    """Visibility floor for DMs + threaded replies whose root was
-    posted by a human — force ``visible=true`` and return a note so
-    the agent learns on the spot. ``agent_only=true`` skips the
-    floor for genuine agent-to-agent traffic. Lookup failures on
-    the identity check pass through so a transient profile-fetch
-    error can't flip an intentional ``visible=false``."""
+    """Visibility floor: force ``visible=true`` in two contexts where
+    a hidden send would strand a person — DMs, and any message whose
+    body ``@``-mentions a human. ``agent_only=true`` skips the floor.
+    Profile-lookup failures pass through so a transient error can't
+    flip an intentional ``visible=false``."""
+    from ..agent.puffo_core_client import _MENTION_RE
+
     if agent_only:
         return is_visible_to_human, ""
     if is_visible_to_human:
@@ -222,42 +222,30 @@ async def _coerce_dm_and_human_reply_visibility(
             "visible so the addressee can see them. Pass "
             "``agent_only=true`` for a genuine agent-to-agent DM."
         )
-    if not root_id.strip():
-        return is_visible_to_human, ""
-    try:
-        root_msg = await data_client.get_message_by_envelope(root_id)
-    except Exception as exc:  # noqa: BLE001
-        logger.debug(
-            "visibility-floor root lookup transport error for %s: %s",
-            root_id, exc,
-        )
-        return is_visible_to_human, ""
-    if root_msg is None:
-        return is_visible_to_human, ""
-    root_sender = getattr(root_msg, "sender_slug", "") or ""
-    if not root_sender:
+    mentioned = sorted({m.lower() for m in _MENTION_RE.findall(text or "")})
+    if not mentioned:
         return is_visible_to_human, ""
     try:
         resp = await http_client.get(
-            f"/identities/profiles?slugs={urllib.parse.quote(root_sender, safe='')}"
+            "/identities/profiles?slugs="
+            + ",".join(urllib.parse.quote(m, safe="") for m in mentioned)
         )
     except Exception as exc:  # noqa: BLE001
         logger.debug(
             "visibility-floor profile fetch failed for %s: %s",
-            root_sender, exc,
+            mentioned, exc,
         )
         return is_visible_to_human, ""
     profiles = resp.get("profiles", []) if isinstance(resp, dict) else []
-    if not profiles:
-        return is_visible_to_human, ""
-    identity_type = (profiles[0].get("identity_type") or "human").strip().lower()
-    if identity_type != "human":
+    if not any(
+        (p.get("identity_type") or "human").strip().lower() == "human"
+        for p in profiles
+    ):
         return is_visible_to_human, ""
     return True, (
-        "\nnote: is_visible_to_human=false ignored — this thread's "
-        "root was posted by a human, so the reply is sent visible. "
-        "Pass ``agent_only=true`` for a genuine agent-to-agent "
-        "threaded exchange."
+        "\nnote: is_visible_to_human=false ignored — the message "
+        "@-mentions a human, so it's sent visible. Pass "
+        "``agent_only=true`` if this really is agent-to-agent chatter."
     )
 
 
@@ -504,9 +492,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             default — judge every message. NOTE: ``false`` only takes
             effect on threaded replies (when ``root_id`` is set) —
             root-level messages can't fold, so ``false`` on one is
-            ignored and the message is sent visible. DMs and threaded
-            replies rooted at a human message also force visible
-            unless ``agent_only=true``.
+            ignored and the message is sent visible. DMs and messages
+            whose text @-mentions a human also force visible unless
+            ``agent_only=true``.
         root_id: optional — reply inside a thread; pass the
             envelope_id of the message you're replying to.
         agent_only: opt-out of the DM / human-reply visibility floor.
@@ -572,9 +560,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         )
         # Floor runs AFTER the root-level coercion: the already-visible
         # short-circuit inside the floor keeps both notes from firing.
-        effective_visible, floor_note = await _coerce_dm_and_human_reply_visibility(
-            channel_ref, root_id, effective_visible, agent_only,
-            cfg.data_client, cfg.http_client,
+        effective_visible, floor_note = await _coerce_dm_and_human_mention_visibility(
+            channel_ref, text, effective_visible, agent_only, cfg.http_client,
         )
         resolved_root, root_note = await _resolve_root_id(
             root_id, cfg.data_client,
@@ -1055,9 +1042,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             fold away. No default — judge every send. NOTE: ``false``
             only takes effect on threaded replies (when ``root_id`` is
             set); on a root-level message it's ignored and the
-            message is sent visible. DMs and threaded replies rooted
-            at a human message also force visible unless
-            ``agent_only=true``.
+            message is sent visible. DMs and captions that @-mention
+            a human also force visible unless ``agent_only=true``.
         caption: optional text alongside the files.
         root_id: optional thread reply, same semantics as
             ``send_message``'s ``root_id``.
@@ -1197,9 +1183,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
-        effective_visible, floor_note = await _coerce_dm_and_human_reply_visibility(
-            channel_ref, root_id, effective_visible, agent_only,
-            cfg.data_client, cfg.http_client,
+        effective_visible, floor_note = await _coerce_dm_and_human_mention_visibility(
+            channel_ref, caption, effective_visible, agent_only, cfg.http_client,
         )
         resolved_root, root_note = await _resolve_root_id(
             root_id, cfg.data_client,

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -558,8 +558,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         effective_visible, fold_note = _coerce_root_visibility(
             is_visible_to_human, root_id,
         )
-        # Floor runs AFTER the root-level coercion: the already-visible
-        # short-circuit inside the floor keeps both notes from firing.
+        # Floor runs after root-visibility so the two notes don't stack.
         effective_visible, floor_note = await _coerce_dm_and_human_mention_visibility(
             channel_ref, text, effective_visible, agent_only, cfg.http_client,
         )

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -176,77 +176,7 @@ async def _supplement_missing_devices(
         )
 
 
-def _coerce_root_visibility(
-    is_visible_to_human: bool, root_id: str,
-) -> tuple[bool, str]:
-    """Root-level (non-threaded) messages can't fold in the human UI —
-    only threaded replies do. When an agent marks a root-level message
-    ``is_visible_to_human=false`` we coerce it back to visible (so the
-    message still goes out) and return a note to splice into the tool
-    response. The agent learns from the tool result on the spot,
-    rather than depending on the primer being current.
-
-    Returns ``(effective_visibility, note)`` — ``note`` is empty
-    unless a coercion happened.
-    """
-    if is_visible_to_human is False and not root_id.strip():
-        return True, (
-            "\nnote: is_visible_to_human=false ignored — root-level "
-            "messages can't fold; sent as visible. Use false only on "
-            "threaded replies (pass root_id)."
-        )
-    return is_visible_to_human, ""
-
-
-async def _coerce_dm_and_human_mention_visibility(
-    channel_ref: str,
-    text: str,
-    is_visible_to_human: bool,
-    agent_only: bool,
-    http_client: Any,
-) -> tuple[bool, str]:
-    """Visibility floor: force ``visible=true`` in two contexts where
-    a hidden send would strand a person — DMs, and any message whose
-    body ``@``-mentions a human. ``agent_only=true`` skips the floor.
-    Profile-lookup failures pass through so a transient error can't
-    flip an intentional ``visible=false``."""
-    from ..agent.puffo_core_client import _MENTION_RE
-
-    if agent_only:
-        return is_visible_to_human, ""
-    if is_visible_to_human:
-        return True, ""
-    if channel_ref.startswith("@"):
-        return True, (
-            "\nnote: is_visible_to_human=false ignored — DMs force "
-            "visible so the addressee can see them. Pass "
-            "``agent_only=true`` for a genuine agent-to-agent DM."
-        )
-    mentioned = sorted({m.lower() for m in _MENTION_RE.findall(text or "")})
-    if not mentioned:
-        return is_visible_to_human, ""
-    try:
-        resp = await http_client.get(
-            "/identities/profiles?slugs="
-            + ",".join(urllib.parse.quote(m, safe="") for m in mentioned)
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.debug(
-            "visibility-floor profile fetch failed for %s: %s",
-            mentioned, exc,
-        )
-        return is_visible_to_human, ""
-    profiles = resp.get("profiles", []) if isinstance(resp, dict) else []
-    if not any(
-        (p.get("identity_type") or "human").strip().lower() == "human"
-        for p in profiles
-    ):
-        return is_visible_to_human, ""
-    return True, (
-        "\nnote: is_visible_to_human=false ignored — the message "
-        "@-mentions a human, so it's sent visible. Pass "
-        "``agent_only=true`` if this really is agent-to-agent chatter."
-    )
+from ..agent._visibility import resolve_visibility as _resolve_visibility
 
 
 _RESOLVE_ROOT_MAX_DEPTH = 4
@@ -473,9 +403,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     async def send_message(
         channel: str,
         text: str,
-        is_visible_to_human: bool,
         root_id: str = "",
-        agent_only: bool = False,
+        visibility_level: str = "default",
     ) -> str:
         """Post a message to a Puffo.ai channel or DM a user.
 
@@ -485,23 +414,23 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             ``list_channels_in_space``) to discover ids — '#name'
             shortcuts are not supported.
         text: message body. Markdown preserved verbatim.
-        is_visible_to_human: REQUIRED — decide whether a human should
-            see this message inline. ``true`` for anything a person
-            needs to read; ``false`` for agent-to-agent coordination
-            chatter, which human clients fold away. There is no
-            default — judge every message. NOTE: ``false`` only takes
-            effect on threaded replies (when ``root_id`` is set) —
-            root-level messages can't fold, so ``false`` on one is
-            ignored and the message is sent visible. DMs and messages
-            whose text @-mentions a human also force visible unless
-            ``agent_only=true``.
         root_id: optional — reply inside a thread; pass the
             envelope_id of the message you're replying to.
-        agent_only: opt-out of the DM / human-reply visibility floor.
-            Pass ``true`` for genuine agent-to-agent DMs or threaded
-            chatter that a human shouldn't be forced to see; leave the
-            default ``false`` for anything a human might be waiting
-            on.
+        visibility_level: one of ``"human"`` | ``"default"`` |
+            ``"agent_only"`` (default: ``"default"``).
+            - ``"human"`` — anything a person should read (replies,
+              status updates, operator pings). Sent visible.
+            - ``"default"`` — agent-to-agent chatter human clients
+              fold away. Sent hidden BUT with safety-net floors: DMs
+              and messages whose text @-mentions a human are forced
+              visible with a note explaining why. Root-level (non-
+              threaded) posts are also forced visible because they
+              can't fold in the UI.
+            - ``"agent_only"`` — you're explicitly telling the daemon
+              this is agent-to-agent traffic; the DM / @-mention
+              safety net is skipped. Use only when you're confident
+              no human is waiting for this reply. Root-level posts
+              are still forced visible (can't fold either way).
         """
         channel_ref = channel.strip()
         if not channel_ref:
@@ -555,12 +484,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             decode_secret(sess.subkey_secret_key)
         )
 
-        effective_visible, fold_note = _coerce_root_visibility(
-            is_visible_to_human, root_id,
-        )
-        # Floor runs after root-visibility so the two notes don't stack.
-        effective_visible, floor_note = await _coerce_dm_and_human_mention_visibility(
-            channel_ref, text, effective_visible, agent_only, cfg.http_client,
+        effective_visible, visibility_note = await _resolve_visibility(
+            visibility_level, channel_ref, text, root_id, cfg.http_client,
         )
         resolved_root, root_note = await _resolve_root_id(
             root_id, cfg.data_client,
@@ -594,8 +519,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             ))
         return (
             f"posted {envelope.get('envelope_id', '?')} to {channel}"
-            f"{fold_note}"
-            f"{floor_note}"
+            f"{visibility_note}"
             f"{root_note}"
             f"{validate_note}"
         )
@@ -1020,10 +944,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     async def send_message_with_attachments(
         paths: list[str],
         channel: str,
-        is_visible_to_human: bool,
         caption: str = "",
         root_id: str = "",
-        agent_only: bool = False,
+        visibility_level: str = "default",
     ) -> str:
         """Send a message carrying one or more workspace files to a
         channel or DM.
@@ -1035,19 +958,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             paths are rejected.
         channel: same syntax as ``send_message`` (``@<slug>`` or a
             raw channel id).
-        is_visible_to_human: REQUIRED — same semantics as
-            ``send_message``: ``true`` when a person should see this,
-            ``false`` for agent-to-agent chatter that human clients
-            fold away. No default — judge every send. NOTE: ``false``
-            only takes effect on threaded replies (when ``root_id`` is
-            set); on a root-level message it's ignored and the
-            message is sent visible. DMs and captions that @-mention
-            a human also force visible unless ``agent_only=true``.
         caption: optional text alongside the files.
         root_id: optional thread reply, same semantics as
             ``send_message``'s ``root_id``.
-        agent_only: opt-out of the DM / human-reply visibility floor,
-            same semantics as ``send_message``'s ``agent_only``.
+        visibility_level: same semantics as ``send_message`` —
+            ``"human"`` | ``"default"`` | ``"agent_only"``, default
+            ``"default"``. The @-mention floor keys off ``caption``.
         """
         import mimetypes
         from pathlib import Path
@@ -1179,11 +1095,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             "text": caption,
             "attachments": [m.to_dict() for m in attachment_metas],
         }
-        effective_visible, fold_note = _coerce_root_visibility(
-            is_visible_to_human, root_id,
-        )
-        effective_visible, floor_note = await _coerce_dm_and_human_mention_visibility(
-            channel_ref, caption, effective_visible, agent_only, cfg.http_client,
+        effective_visible, visibility_note = await _resolve_visibility(
+            visibility_level, channel_ref, caption, root_id, cfg.http_client,
         )
         resolved_root, root_note = await _resolve_root_id(
             root_id, cfg.data_client,
@@ -1220,8 +1133,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             f"uploaded {len(targets)} file(s) [{names}] ({total_bytes} bytes "
             f"total) to {channel}{thread_note} "
             f"(envelope_id {envelope.get('envelope_id', '?')})"
-            f"{fold_note}"
-            f"{floor_note}"
+            f"{visibility_note}"
             f"{root_note}"
             f"{validate_note}"
         )

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -14,7 +14,7 @@ from puffo_agent.crypto.keystore import KeyStore, Session, StoredIdentity, encod
 from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
 from puffo_agent.mcp.puffo_core_tools import (
     PuffoCoreToolsConfig,
-    _coerce_dm_and_human_reply_visibility,
+    _coerce_dm_and_human_mention_visibility,
     _coerce_root_visibility,
     _resolve_root_id,
     _validate_root_same_channel,
@@ -1388,18 +1388,20 @@ async def test_validate_root_dm_envelope_no_channel_id_passes_through():
     assert note == ""
 
 
-# _coerce_dm_and_human_reply_visibility — DM + human-rooted thread
-# floor. Covers the two coercion branches + every pass-through branch
-# that must NOT false-positive coerce.
+# _coerce_dm_and_human_mention_visibility — DM + @-mention floor.
 
 
 class _FloorHttp:
-    """Minimal http client stub for the profile lookup — the helper only
-    calls ``get('/identities/profiles?slugs=<slug>')`` and reads
-    ``profiles[0].identity_type``."""
+    """Stub for ``/identities/profiles?slugs=<csv>``. Returns each
+    requested slug's identity_type from a caller-supplied mapping."""
 
-    def __init__(self, identity_type: str, *, raise_error: bool = False):
-        self.identity_type = identity_type
+    def __init__(
+        self,
+        types: dict[str, str] | None = None,
+        *,
+        raise_error: bool = False,
+    ):
+        self.types = types or {}
         self.raise_error = raise_error
         self.calls: list[str] = []
 
@@ -1407,93 +1409,69 @@ class _FloorHttp:
         self.calls.append(path)
         if self.raise_error:
             raise RuntimeError("simulated transport failure")
-        return {"profiles": [{"slug": "alice-1234", "identity_type": self.identity_type}]}
-
-
-class _FloorData:
-    """Minimal data client stub — the helper only calls
-    ``get_message_by_envelope(root_id)`` and reads
-    ``sender_slug``."""
-
-    def __init__(self, sender_slug: str | None):
-        self.sender_slug = sender_slug
-        self.calls: list[str] = []
-
-    async def get_message_by_envelope(self, envelope_id: str):
-        self.calls.append(envelope_id)
-        if self.sender_slug is None:
-            return None
-        class _Msg:
-            pass
-        m = _Msg()
-        m.sender_slug = self.sender_slug
-        return m
+        from urllib.parse import parse_qs, urlparse
+        qs = parse_qs(urlparse(path).query)
+        slugs = (qs.get("slugs", [""])[0]).split(",") if qs.get("slugs") else []
+        profiles = [
+            {"slug": s, "identity_type": self.types.get(s, "human")}
+            for s in slugs if s
+        ]
+        return {"profiles": profiles}
 
 
 @pytest.mark.asyncio
-async def test_floor_dm_forces_visible():
-    http = _FloorHttp("agent")  # identity type unused in DM branch
-    data = _FloorData(None)
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+async def test_floor_dm_forces_visible_without_lookup():
+    http = _FloorHttp()
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="@alice-1234",
-        root_id="",
+        text="hi",
         is_visible_to_human=False,
         agent_only=False,
-        data_client=data,
         http_client=http,
     )
     assert visible is True
     assert "DMs force visible" in note
-    # DM branch decides before consulting the profile / root lookup — no
-    # http round-trip should have happened.
     assert http.calls == []
-    assert data.calls == []
 
 
 @pytest.mark.asyncio
 async def test_floor_dm_agent_only_passes_through():
-    http = _FloorHttp("agent")
-    data = _FloorData(None)
-    visible, note = await _coerce_dm_and_human_reply_visibility(
-        channel_ref="@another-agent-9999",
-        root_id="",
+    http = _FloorHttp()
+    visible, note = await _coerce_dm_and_human_mention_visibility(
+        channel_ref="@twinkle-abcd",
+        text="ping",
         is_visible_to_human=False,
         agent_only=True,
-        data_client=data,
         http_client=http,
     )
     assert visible is False
     assert note == ""
+    assert http.calls == []
 
 
 @pytest.mark.asyncio
-async def test_floor_threaded_reply_human_root_forces_visible():
-    http = _FloorHttp("human")
-    data = _FloorData(sender_slug="alice-1234")
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+async def test_floor_mention_human_forces_visible():
+    http = _FloorHttp({"alice-1234": "human"})
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="ch_abcd",
-        root_id="msg_root",
+        text="@alice-1234 here's the answer",
         is_visible_to_human=False,
         agent_only=False,
-        data_client=data,
         http_client=http,
     )
     assert visible is True
-    assert "human" in note.lower()
-    assert data.calls == ["msg_root"]
+    assert "@-mentions a human" in note
     assert http.calls and "alice-1234" in http.calls[0]
 
 
 @pytest.mark.asyncio
-async def test_floor_threaded_reply_agent_root_passes_through():
-    http = _FloorHttp("agent")
-    data = _FloorData(sender_slug="scout-5678")
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+async def test_floor_mention_agent_only_passes_through():
+    http = _FloorHttp({"scout-5678": "agent"})
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="ch_abcd",
-        root_id="msg_root",
+        text="@scout-5678 fyi, pipeline done",
         is_visible_to_human=False,
         agent_only=False,
-        data_client=data,
         http_client=http,
     )
     assert visible is False
@@ -1501,33 +1479,42 @@ async def test_floor_threaded_reply_agent_root_passes_through():
 
 
 @pytest.mark.asyncio
-async def test_floor_root_lookup_miss_passes_through():
-    http = _FloorHttp("human")  # would coerce if reached
-    data = _FloorData(sender_slug=None)  # root not in store
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+async def test_floor_mention_mixed_any_human_wins():
+    http = _FloorHttp({"alice-1234": "human", "scout-5678": "agent"})
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="ch_abcd",
-        root_id="msg_unknown",
+        text="@scout-5678 @alice-1234 status update",
         is_visible_to_human=False,
         agent_only=False,
-        data_client=data,
+        http_client=http,
+    )
+    assert visible is True
+    assert "@-mentions a human" in note
+
+
+@pytest.mark.asyncio
+async def test_floor_no_mention_passes_through():
+    http = _FloorHttp()
+    visible, note = await _coerce_dm_and_human_mention_visibility(
+        channel_ref="ch_abcd",
+        text="internal note: retrying",
+        is_visible_to_human=False,
+        agent_only=False,
         http_client=http,
     )
     assert visible is False
     assert note == ""
-    # Profile lookup never fires when the root isn't resolvable.
     assert http.calls == []
 
 
 @pytest.mark.asyncio
 async def test_floor_profile_lookup_error_passes_through():
-    http = _FloorHttp("human", raise_error=True)
-    data = _FloorData(sender_slug="alice-1234")
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+    http = _FloorHttp({"alice-1234": "human"}, raise_error=True)
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="ch_abcd",
-        root_id="msg_root",
+        text="@alice-1234 hi",
         is_visible_to_human=False,
         agent_only=False,
-        data_client=data,
         http_client=http,
     )
     assert visible is False
@@ -1536,40 +1523,31 @@ async def test_floor_profile_lookup_error_passes_through():
 
 @pytest.mark.asyncio
 async def test_floor_already_visible_short_circuits():
-    """When the caller already passed True, the floor is a no-op and
-    doesn't burn the two lookups even for a threaded reply."""
-    http = _FloorHttp("human")
-    data = _FloorData(sender_slug="alice-1234")
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+    http = _FloorHttp({"alice-1234": "human"})
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="ch_abcd",
-        root_id="msg_root",
+        text="@alice-1234 hi",
         is_visible_to_human=True,
         agent_only=False,
-        data_client=data,
         http_client=http,
     )
     assert visible is True
     assert note == ""
     assert http.calls == []
-    assert data.calls == []
 
 
 @pytest.mark.asyncio
-async def test_floor_channel_root_level_passes_through():
-    """A root-level (no root_id) channel post is _coerce_root_visibility's
-    job — the floor helper must leave it alone so the two notes don't
-    stack."""
-    http = _FloorHttp("human")
-    data = _FloorData(sender_slug="alice-1234")
-    visible, note = await _coerce_dm_and_human_reply_visibility(
+async def test_floor_email_not_mistaken_for_mention():
+    """``foo@alice-1234`` inside a URL / email doesn't match the
+    mention regex, so no coerce."""
+    http = _FloorHttp({"alice-1234": "human"})
+    visible, note = await _coerce_dm_and_human_mention_visibility(
         channel_ref="ch_abcd",
-        root_id="",
+        text="see contact@alice-1234 for details",
         is_visible_to_human=False,
         agent_only=False,
-        data_client=data,
         http_client=http,
     )
     assert visible is False
     assert note == ""
     assert http.calls == []
-    assert data.calls == []

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -1388,11 +1388,9 @@ async def test_validate_root_dm_envelope_no_channel_id_passes_through():
     assert note == ""
 
 
-# PUF-345: belt-and-suspenders visibility floor for send_message. The
-# helper is what the tool body calls right after _coerce_root_visibility;
-# these tests cover the two contexts named by the canonical spec (DM +
-# threaded reply rooted at a human) plus every branch that must NOT
-# false-positive coerce.
+# _coerce_dm_and_human_reply_visibility — DM + human-rooted thread
+# floor. Covers the two coercion branches + every pass-through branch
+# that must NOT false-positive coerce.
 
 
 class _FloorHttp:

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -259,8 +259,9 @@ async def test_send_message_root_level_false_coerced():
 
 @pytest.mark.asyncio
 async def test_send_message_threaded_false_not_coerced():
-    """A threaded reply (root_id set) with visibility_level='default'
-    and no @-mention stays hidden — no coercion, no note."""
+    """A threaded reply with visibility_level='default' and no
+    @-mention stays hidden — no coerce; the tool result carries
+    the "be explicit" nudge note instead."""
     cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
     # Pre-cache the channel→space mapping the way an inbound message
@@ -295,6 +296,91 @@ async def test_send_message_threaded_false_not_coerced():
     )
     assert "posted" in result
     assert "ignored" not in result
+    # Nudge note fires: level was default with no signal.
+    assert "sent hidden" in result
+    assert "'human'" in result and "'agent_only'" in result
+
+
+@pytest.mark.asyncio
+async def test_send_message_human_no_notes():
+    """visibility_level='human' — visible send, no notes."""
+    cfg, http, ms = _setup()
+    recipient_kem = KemKeyPair.generate()
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
+        "members": [{"slug": "alice-0001", "role": "owner"}],
+    }
+    http.responses["/certs/sync?slugs=alice-0001"] = {
+        "entries": [{
+            "seq": 1, "kind": "device_cert", "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_recipient_1",
+                "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp,
+        "send_message",
+        {
+            "channel": "ch_abc",
+            "text": "answer for the operator",
+            "visibility_level": "human",
+        },
+    )
+    assert "posted" in result
+    # No visibility note appended (level was explicit).
+    assert "sent visible" not in result
+    assert "sent hidden" not in result
+    assert "hidden ignored" not in result
+
+
+@pytest.mark.asyncio
+async def test_send_message_agent_only_dm_stays_hidden_with_warning():
+    """visibility_level='agent_only' + DM: floor respects the opt-out
+    (hidden) but the tool result warns that this looks human-targeted
+    so the agent can reconsider without being overridden."""
+    cfg, http, ms = _setup()
+    recipient_kem = KemKeyPair.generate()
+    http.responses["/certs/sync?slugs=agent-0001,alice-0001"] = {
+        "entries": [
+            {
+                "seq": 1, "kind": "device_cert", "slug": "agent-0001",
+                "cert": {
+                    "device_id": "dev_self",
+                    "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+                },
+            },
+            {
+                "seq": 2, "kind": "device_cert", "slug": "alice-0001",
+                "cert": {
+                    "device_id": "dev_recipient_1",
+                    "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+                },
+            },
+        ],
+        "has_more": False,
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp,
+        "send_message",
+        {
+            "channel": "@alice-0001",
+            "text": "internal ping",
+            "visibility_level": "agent_only",
+            "root_id": "msg_root_dm",
+        },
+    )
+    # NB: msg_root_dm isn't in local cache, so validate_root wipes it
+    # with its own warning note — assert the visibility warning is
+    # present alongside, don't insist on it being alone.
+    assert "posted" in result
+    assert "sent hidden per" in result
+    assert "DM" in result
+    assert "Double-check" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -14,6 +14,7 @@ from puffo_agent.crypto.keystore import KeyStore, Session, StoredIdentity, encod
 from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
 from puffo_agent.mcp.puffo_core_tools import (
     PuffoCoreToolsConfig,
+    _coerce_dm_and_human_reply_visibility,
     _coerce_root_visibility,
     _resolve_root_id,
     _validate_root_same_channel,
@@ -1385,3 +1386,192 @@ async def test_validate_root_dm_envelope_no_channel_id_passes_through():
     )
     assert out == "msg_dm_root"
     assert note == ""
+
+
+# PUF-345: belt-and-suspenders visibility floor for send_message. The
+# helper is what the tool body calls right after _coerce_root_visibility;
+# these tests cover the two contexts named by the canonical spec (DM +
+# threaded reply rooted at a human) plus every branch that must NOT
+# false-positive coerce.
+
+
+class _FloorHttp:
+    """Minimal http client stub for the profile lookup — the helper only
+    calls ``get('/identities/profiles?slugs=<slug>')`` and reads
+    ``profiles[0].identity_type``."""
+
+    def __init__(self, identity_type: str, *, raise_error: bool = False):
+        self.identity_type = identity_type
+        self.raise_error = raise_error
+        self.calls: list[str] = []
+
+    async def get(self, path: str):
+        self.calls.append(path)
+        if self.raise_error:
+            raise RuntimeError("simulated transport failure")
+        return {"profiles": [{"slug": "alice-1234", "identity_type": self.identity_type}]}
+
+
+class _FloorData:
+    """Minimal data client stub — the helper only calls
+    ``get_message_by_envelope(root_id)`` and reads
+    ``sender_slug``."""
+
+    def __init__(self, sender_slug: str | None):
+        self.sender_slug = sender_slug
+        self.calls: list[str] = []
+
+    async def get_message_by_envelope(self, envelope_id: str):
+        self.calls.append(envelope_id)
+        if self.sender_slug is None:
+            return None
+        class _Msg:
+            pass
+        m = _Msg()
+        m.sender_slug = self.sender_slug
+        return m
+
+
+@pytest.mark.asyncio
+async def test_floor_dm_forces_visible():
+    http = _FloorHttp("agent")  # identity type unused in DM branch
+    data = _FloorData(None)
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="@alice-1234",
+        root_id="",
+        is_visible_to_human=False,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is True
+    assert "DMs force visible" in note
+    # DM branch decides before consulting the profile / root lookup — no
+    # http round-trip should have happened.
+    assert http.calls == []
+    assert data.calls == []
+
+
+@pytest.mark.asyncio
+async def test_floor_dm_agent_only_passes_through():
+    http = _FloorHttp("agent")
+    data = _FloorData(None)
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="@another-agent-9999",
+        root_id="",
+        is_visible_to_human=False,
+        agent_only=True,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is False
+    assert note == ""
+
+
+@pytest.mark.asyncio
+async def test_floor_threaded_reply_human_root_forces_visible():
+    http = _FloorHttp("human")
+    data = _FloorData(sender_slug="alice-1234")
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="ch_abcd",
+        root_id="msg_root",
+        is_visible_to_human=False,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is True
+    assert "human" in note.lower()
+    assert data.calls == ["msg_root"]
+    assert http.calls and "alice-1234" in http.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_floor_threaded_reply_agent_root_passes_through():
+    http = _FloorHttp("agent")
+    data = _FloorData(sender_slug="scout-5678")
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="ch_abcd",
+        root_id="msg_root",
+        is_visible_to_human=False,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is False
+    assert note == ""
+
+
+@pytest.mark.asyncio
+async def test_floor_root_lookup_miss_passes_through():
+    http = _FloorHttp("human")  # would coerce if reached
+    data = _FloorData(sender_slug=None)  # root not in store
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="ch_abcd",
+        root_id="msg_unknown",
+        is_visible_to_human=False,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is False
+    assert note == ""
+    # Profile lookup never fires when the root isn't resolvable.
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_floor_profile_lookup_error_passes_through():
+    http = _FloorHttp("human", raise_error=True)
+    data = _FloorData(sender_slug="alice-1234")
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="ch_abcd",
+        root_id="msg_root",
+        is_visible_to_human=False,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is False
+    assert note == ""
+
+
+@pytest.mark.asyncio
+async def test_floor_already_visible_short_circuits():
+    """When the caller already passed True, the floor is a no-op and
+    doesn't burn the two lookups even for a threaded reply."""
+    http = _FloorHttp("human")
+    data = _FloorData(sender_slug="alice-1234")
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="ch_abcd",
+        root_id="msg_root",
+        is_visible_to_human=True,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is True
+    assert note == ""
+    assert http.calls == []
+    assert data.calls == []
+
+
+@pytest.mark.asyncio
+async def test_floor_channel_root_level_passes_through():
+    """A root-level (no root_id) channel post is _coerce_root_visibility's
+    job — the floor helper must leave it alone so the two notes don't
+    stack."""
+    http = _FloorHttp("human")
+    data = _FloorData(sender_slug="alice-1234")
+    visible, note = await _coerce_dm_and_human_reply_visibility(
+        channel_ref="ch_abcd",
+        root_id="",
+        is_visible_to_human=False,
+        agent_only=False,
+        data_client=data,
+        http_client=http,
+    )
+    assert visible is False
+    assert note == ""
+    assert http.calls == []
+    assert data.calls == []

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -12,10 +12,9 @@ from puffo_agent.agent.message_store import MessageStore
 from puffo_agent.crypto.encoding import base64url_encode
 from puffo_agent.crypto.keystore import KeyStore, Session, StoredIdentity, encode_secret
 from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+from puffo_agent.agent._visibility import resolve_visibility
 from puffo_agent.mcp.puffo_core_tools import (
     PuffoCoreToolsConfig,
-    _coerce_dm_and_human_mention_visibility,
-    _coerce_root_visibility,
     _resolve_root_id,
     _validate_root_same_channel,
     register_core_tools,
@@ -189,7 +188,7 @@ async def test_send_message_channel():
     result = await _call(
         mcp,
         "send_message",
-        {"channel": "ch_abc", "text": "hello world", "is_visible_to_human": True},
+        {"channel": "ch_abc", "text": "hello world", "visibility_level": "human"},
     )
     assert "posted" in result
     assert "ch_abc" in result
@@ -219,26 +218,9 @@ async def test_send_message_channel():
     assert "wrapped_content_key" in r
 
 
-def test_coerce_root_visibility():
-    # Root-level false → coerced to visible + a note for the agent.
-    visible, note = _coerce_root_visibility(False, "")
-    assert visible is True
-    assert "ignored" in note and "root-level" in note
-    # Threaded false (root_id set) → left alone, no note.
-    visible, note = _coerce_root_visibility(False, "msg_root")
-    assert visible is False
-    assert note == ""
-    # true is never touched, root-level or threaded.
-    assert _coerce_root_visibility(True, "") == (True, "")
-    assert _coerce_root_visibility(True, "msg_root") == (True, "")
-    # Whitespace-only root_id counts as root-level.
-    visible, note = _coerce_root_visibility(False, "   ")
-    assert visible is True and note != ""
-
-
 @pytest.mark.asyncio
 async def test_send_message_root_level_false_coerced():
-    """A root-level send with is_visible_to_human=false still posts —
+    """A root-level send with visibility_level='default' still posts —
     the flag is coerced to visible and the tool response carries a
     note so the agent learns on the spot."""
     cfg, http, ms = _setup()
@@ -266,19 +248,19 @@ async def test_send_message_root_level_false_coerced():
     result = await _call(
         mcp,
         "send_message",
-        {"channel": "ch_abc", "text": "agent chatter", "is_visible_to_human": False},
+        {"channel": "ch_abc", "text": "agent chatter", "visibility_level": "default"},
     )
     # Message still went out (warning, not error).
     assert "posted" in result
     assert len([1 for m, _, _ in http.calls if m == "POST"]) == 1
     # ...and the agent is told the flag was ignored.
-    assert "is_visible_to_human=false ignored" in result
+    assert "hidden ignored" in result
 
 
 @pytest.mark.asyncio
 async def test_send_message_threaded_false_not_coerced():
-    """A threaded reply (root_id set) keeps is_visible_to_human=false
-    — no coercion, no note."""
+    """A threaded reply (root_id set) with visibility_level='default'
+    and no @-mention stays hidden — no coercion, no note."""
     cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
     # Pre-cache the channel→space mapping the way an inbound message
@@ -307,7 +289,7 @@ async def test_send_message_threaded_false_not_coerced():
         {
             "channel": "ch_abc",
             "text": "agent-to-agent reply",
-            "is_visible_to_human": False,
+            "visibility_level": "default",
             "root_id": "msg_root_abc",
         },
     )
@@ -347,7 +329,7 @@ async def test_send_message_uses_cached_space_for_cross_space_channel():
         {
             "channel": "ch_elsewhere",
             "text": "hello other space",
-            "is_visible_to_human": True,
+            "visibility_level": "human",
         },
     )
     assert "posted" in result, f"expected success, got: {result}"
@@ -385,7 +367,7 @@ async def test_send_message_fails_loud_on_cache_miss():
             {
                 "channel": "ch_nowhere",
                 "text": "should not send",
-                "is_visible_to_human": True,
+                "visibility_level": "human",
             },
         )
     assert "no record of channel" in str(excinfo.value), (
@@ -445,7 +427,7 @@ async def test_send_message_dm():
     result = await _call(
         mcp,
         "send_message",
-        {"channel": "@alice-0001", "text": "hey", "is_visible_to_human": True},
+        {"channel": "@alice-0001", "text": "hey", "visibility_level": "human"},
     )
     assert "posted" in result
 
@@ -471,7 +453,7 @@ async def test_send_message_rejects_named_channel():
         await _call(
             mcp,
             "send_message",
-            {"channel": "#general", "text": "hi", "is_visible_to_human": True},
+            {"channel": "#general", "text": "hi", "visibility_level": "human"},
         )
     assert "isn't supported" in str(excinfo.value) or "not supported" in str(excinfo.value)
 
@@ -880,7 +862,7 @@ async def test_send_message_with_attachments_requires_workspace():
         await _call(
             mcp,
             "send_message_with_attachments",
-            {"paths": ["test.txt"], "channel": "ch_1", "is_visible_to_human": True},
+            {"paths": ["test.txt"], "channel": "ch_1", "visibility_level": "human"},
         )
     assert "workspace" in str(exc_info.value).lower()
 
@@ -1132,7 +1114,7 @@ async def test_send_message_auto_corrects_real_live_failures(
     result = await _call(mcp, "send_message", {
         "channel": "ch_abc",
         "text": f"replaying {scenario}",
-        "is_visible_to_human": False,
+        "visibility_level": "default",
         "root_id": wrong_post_id,
     })
 
@@ -1161,7 +1143,7 @@ async def test_send_message_keeps_real_root_id_unchanged(monkeypatch):
     result = await _call(mcp, "send_message", {
         "channel": "ch_abc",
         "text": "correctly threaded reply",
-        "is_visible_to_human": False,
+        "visibility_level": "default",
         "root_id": "msg_root",
     })
 
@@ -1189,7 +1171,7 @@ async def test_send_message_unknown_root_id_wiped_to_null_with_warning(monkeypat
     result = await _call(mcp, "send_message", {
         "channel": "ch_abc",
         "text": "racing the inbound write",
-        "is_visible_to_human": False,
+        "visibility_level": "default",
         "root_id": "msg_never_seen",
     })
 
@@ -1211,7 +1193,7 @@ async def test_send_message_root_level_send_skips_resolve(monkeypatch):
 
     mcp = _build_tools(cfg)
     result = await _call(mcp, "send_message", {
-        "channel": "ch_abc", "text": "top-level", "is_visible_to_human": True,
+        "channel": "ch_abc", "text": "top-level", "visibility_level": "human",
     })
 
     assert "posted" in result
@@ -1250,7 +1232,7 @@ async def test_send_message_with_attachments_auto_corrects_reply_as_root_id(
     result = await _call(mcp, "send_message_with_attachments", {
         "paths": ["hello.txt"],
         "channel": "ch_abc",
-        "is_visible_to_human": False,
+        "visibility_level": "default",
         "root_id": "msg_reply",
         "caption": "files",
     })
@@ -1388,12 +1370,13 @@ async def test_validate_root_dm_envelope_no_channel_id_passes_through():
     assert note == ""
 
 
-# _coerce_dm_and_human_mention_visibility — DM + @-mention floor.
+# resolve_visibility — one entry point that combines level parsing,
+# root-level coerce, DM/@-mention detection, and the per-level note
+# wording.
 
 
-class _FloorHttp:
-    """Stub for ``/identities/profiles?slugs=<csv>``. Returns each
-    requested slug's identity_type from a caller-supplied mapping."""
+class _VisHttp:
+    """Stub for ``/identities/profiles?slugs=<csv>``."""
 
     def __init__(
         self,
@@ -1419,135 +1402,172 @@ class _FloorHttp:
         return {"profiles": profiles}
 
 
+# ── level="human" ────────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_floor_dm_forces_visible_without_lookup():
-    http = _FloorHttp()
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="@alice-1234",
-        text="hi",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_human_returns_visible_no_note_no_lookup():
+    http = _VisHttp({"alice-1234": "human"})
+    visible, note = await resolve_visibility(
+        "human", "@alice-1234", "@alice-1234 hi", "msg_root", http,
     )
     assert visible is True
-    assert "DMs force visible" in note
-    assert http.calls == []
-
-
-@pytest.mark.asyncio
-async def test_floor_dm_agent_only_passes_through():
-    http = _FloorHttp()
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="@twinkle-abcd",
-        text="ping",
-        is_visible_to_human=False,
-        agent_only=True,
-        http_client=http,
-    )
-    assert visible is False
     assert note == ""
     assert http.calls == []
 
 
+# ── level="default" ─────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_floor_mention_human_forces_visible():
-    http = _FloorHttp({"alice-1234": "human"})
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="@alice-1234 here's the answer",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_default_dm_coerces_and_nudges_human():
+    http = _VisHttp()
+    visible, note = await resolve_visibility(
+        "default", "@alice-1234", "hi", "msg_root", http,
+    )
+    assert visible is True
+    assert "sent visible" in note
+    assert "DM" in note
+    assert "'human'" in note
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_default_mention_human_coerces():
+    http = _VisHttp({"alice-1234": "human"})
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "@alice-1234 here's the answer", "msg_root", http,
     )
     assert visible is True
     assert "@-mentions a human" in note
+    assert "'human'" in note
     assert http.calls and "alice-1234" in http.calls[0]
 
 
 @pytest.mark.asyncio
-async def test_floor_mention_agent_only_passes_through():
-    http = _FloorHttp({"scout-5678": "agent"})
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="@scout-5678 fyi, pipeline done",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_default_mention_agent_only_stays_hidden_but_nudges():
+    http = _VisHttp({"scout-5678": "agent"})
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "@scout-5678 pipeline done", "msg_root", http,
     )
     assert visible is False
-    assert note == ""
+    assert "sent hidden" in note
+    assert "'human'" in note and "'agent_only'" in note
 
 
 @pytest.mark.asyncio
-async def test_floor_mention_mixed_any_human_wins():
-    http = _FloorHttp({"alice-1234": "human", "scout-5678": "agent"})
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="@scout-5678 @alice-1234 status update",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_default_no_signal_nudges_explicit():
+    http = _VisHttp()
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "internal retry", "msg_root", http,
+    )
+    assert visible is False
+    assert "sent hidden" in note
+    assert "'human'" in note and "'agent_only'" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_default_root_level_always_coerces():
+    """No root_id → can't fold → always sent visible regardless of
+    DM / @-mention signals."""
+    http = _VisHttp()
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "top-level chatter", "", http,
+    )
+    assert visible is True
+    assert "root-level messages can't fold" in note
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_default_mixed_mentions_any_human_wins():
+    http = _VisHttp({"alice-1234": "human", "scout-5678": "agent"})
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "@scout-5678 @alice-1234 status", "msg_root", http,
     )
     assert visible is True
     assert "@-mentions a human" in note
 
 
 @pytest.mark.asyncio
-async def test_floor_no_mention_passes_through():
-    http = _FloorHttp()
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="internal note: retrying",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_default_profile_error_soft_fails_to_hidden():
+    """Transport error on profile fetch can't flip an intentional
+    hidden send — nudge fires, no coerce."""
+    http = _VisHttp({"alice-1234": "human"}, raise_error=True)
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "@alice-1234 hi", "msg_root", http,
     )
     assert visible is False
-    assert note == ""
+    assert "sent hidden" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_default_email_not_mistaken_for_mention():
+    http = _VisHttp({"alice-1234": "human"})
+    visible, note = await resolve_visibility(
+        "default", "ch_abcd", "see contact@alice-1234 for details",
+        "msg_root", http,
+    )
+    assert visible is False
+    assert "sent hidden" in note
     assert http.calls == []
 
 
+# ── level="agent_only" ──────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_floor_profile_lookup_error_passes_through():
-    http = _FloorHttp({"alice-1234": "human"}, raise_error=True)
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="@alice-1234 hi",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_agent_only_dm_stays_hidden_but_warns():
+    http = _VisHttp()
+    visible, note = await resolve_visibility(
+        "agent_only", "@alice-1234", "hi", "msg_root", http,
+    )
+    assert visible is False
+    assert "sent hidden per" in note
+    assert "DM" in note
+    assert "Double-check" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_only_mention_human_stays_hidden_but_warns():
+    http = _VisHttp({"alice-1234": "human"})
+    visible, note = await resolve_visibility(
+        "agent_only", "ch_abcd", "@alice-1234 fyi", "msg_root", http,
+    )
+    assert visible is False
+    assert "@-mentions a human" in note
+    assert "Double-check" in note
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_only_mention_agent_no_note():
+    http = _VisHttp({"scout-5678": "agent"})
+    visible, note = await resolve_visibility(
+        "agent_only", "ch_abcd", "@scout-5678 done", "msg_root", http,
     )
     assert visible is False
     assert note == ""
 
 
 @pytest.mark.asyncio
-async def test_floor_already_visible_short_circuits():
-    http = _FloorHttp({"alice-1234": "human"})
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="@alice-1234 hi",
-        is_visible_to_human=True,
-        agent_only=False,
-        http_client=http,
+async def test_resolve_agent_only_root_level_still_coerces():
+    """agent_only doesn't override the root-level constraint — the UI
+    can't fold root-level so it goes out visible."""
+    http = _VisHttp()
+    visible, note = await resolve_visibility(
+        "agent_only", "ch_abcd", "top-level", "", http,
     )
     assert visible is True
-    assert note == ""
-    assert http.calls == []
+    assert "root-level messages can't fold" in note
+
+
+# ── validation ──────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_floor_email_not_mistaken_for_mention():
-    """``foo@alice-1234`` inside a URL / email doesn't match the
-    mention regex, so no coerce."""
-    http = _FloorHttp({"alice-1234": "human"})
-    visible, note = await _coerce_dm_and_human_mention_visibility(
-        channel_ref="ch_abcd",
-        text="see contact@alice-1234 for details",
-        is_visible_to_human=False,
-        agent_only=False,
-        http_client=http,
-    )
-    assert visible is False
-    assert note == ""
-    assert http.calls == []
+async def test_resolve_rejects_unknown_level():
+    http = _VisHttp()
+    with pytest.raises(RuntimeError, match="visibility_level"):
+        await resolve_visibility("visible", "ch_x", "hi", "msg_root", http)
+    with pytest.raises(RuntimeError):
+        await resolve_visibility("", "ch_x", "hi", "msg_root", http)


### PR DESCRIPTION
## Summary

Platform-tier belt-and-suspenders visibility floor on `mcp__puffo__send_message` + `mcp__puffo__send_message_with_attachments` — when an agent posts `is_visible_to_human=false` into a context where a human is waiting for the answer, the runtime forces `visible=true` and returns a note so the agent learns on the spot.

Complements FB-339's agent-tier discipline (per Nova canonical: "discipline sets the norm, runtime holds the floor").

**Two coercion contexts:**
1. **DM** — `channel` starts with `@` → force `visible=true` unconditionally (no round-trips needed).
2. **Threaded reply rooted at a human** — resolves the root envelope's sender via `data_client.get_message_by_envelope`, then looks up its `identity_type` via `/identities/profiles?slugs=<slug>` → if `human`, force `visible=true`.

**Escape hatch:** new named kwarg `agent_only: bool = False` on both send tools. Set `true` for genuine agent-to-agent DMs or threaded chatter that shouldn't force visible.

**Soft-fail on transport error** — if the root envelope lookup OR the profile fetch raises, the helper passes through and preserves the caller's intent (never false-positive-coerces on a transient error).

**Already-visible short-circuit** — when the caller already passed `true`, the helper is a no-op (perf pin: asserted zero calls on both stub clients in tests).

**Note-stacking guard** — root-level messages (no `root_id`) skip the floor so the existing PUF-283-era `_coerce_root_visibility` note wins alone; ordering (root_visibility first, floor second, resolve_root third) means both notes never fire on the same call.

Wired into both `send_message` (line 585) and `send_message_with_attachments` (line 1214). Signatures + docstrings updated with `agent_only` guidance.

## Test plan

- [x] Touched-suite `-k "floor or coerce_root_visibility"` — **9/9 pass** locally.
- [x] Full `test_puffo_core_tools.py` — **63/63 pass**.
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1725 pass / 5 fail**. Failure set byte-identical to `origin/main` on the same host (`diff /tmp/puf345-main-fails.txt /tmp/puf345-pr-fails.txt` → clean). **Zero regression.**
- [x] Unit tests cover all 8 branches: DM force (α), DM agent_only pass-through, threaded human-root coerce, threaded agent-root pass-through, root-not-in-store soft-fail, profile-fetch-raise soft-fail, already-visible short-circuit, root-level pass-through.
- [ ] Post-merge external-verify — Kai canonical FB-345 thread `msg_2e5ddf54` on user-observable ship.

Ticket: PUF-345