### PR TITLE
docs: update ws-local SKILL to visibility_level (post-1.0.6)

### DIFF
--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -52,7 +52,7 @@ Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected`
 
 ```bash
 echo '{"type":"ack","bundle_id":"bdl_…"}'                                                                                            >> "$SESSION_DIR/commands.ndjson"
-echo '{"type":"tool_call","command_id":"c1","tool":"send_message","params":{"channel":"ch_…","text":"hi","is_visible_to_human":true}}' >> "$SESSION_DIR/commands.ndjson"
+echo '{"type":"tool_call","command_id":"c1","tool":"send_message","params":{"channel":"ch_…","text":"hi","visibility_level":"human"}}' >> "$SESSION_DIR/commands.ndjson"
 echo '{"type":"end","bundle_id":"bdl_…"}'                                                                                            >> "$SESSION_DIR/commands.ndjson"
 ```
 
@@ -87,8 +87,8 @@ Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is 
 
 | tool | params (req · opt) |
 |---|---|
-| `send_message` | `channel` (`ch_…` or `@slug`), `text`, `is_visible_to_human` · `root_id` |
-| `send_message_with_attachments` | `paths` (1–10), `channel`, `is_visible_to_human` · `caption`, `root_id` |
+| `send_message` | `channel` (`ch_…` or `@slug`), `text` · `root_id`, `visibility_level` (`human` / `default` / `agent_only`, default `default`) |
+| `send_message_with_attachments` | `paths` (1–10), `channel` · `caption`, `root_id`, `visibility_level` (same as above) |
 | `whoami` | — |
 | `get_user_info` | `username` |
 | `list_spaces` / `list_channels_in_all_spaces` | — |


### PR DESCRIPTION
## Summary

Small doc-only follow-up to 1.0.6 (PUF-345). The ws-local skill (`skills/use-puffo-agent-ws-local/SKILL.md`) still showed the old `is_visible_to_human` flag in both the example JSON and the tool-param table. Any tool driving ws-local via that skill hits the "unexpected keyword argument 'is_visible_to_human'" error the daemon now returns (I confirmed live by sending a release-note DM through Twinkle and seeing the tool_result reject the old param).

Updated three lines:
1. Example `send_message` `tool_call` uses `"visibility_level":"human"`.
2. `send_message` table row lists `visibility_level` (with the three enum values + default) instead of `is_visible_to_human`.
3. Same for `send_message_with_attachments`.

## Test plan

- [x] `grep is_visible_to_human skills/` → no matches remain.
- [x] Sent this release-note DM as Twinkle with `"visibility_level":"human"` — `ok:true` (`msg_49c6085f-…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)