### PR TITLE
fix: warm model catalog on foreground puffo-agent start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Machine now reports the live claude-code model list on foreground
+  `puffo-agent start`.** Previously the model catalog's Anthropic
+  `/v1/models` fetch was only triggered from `AgentDetail.__init__`
+  (the desktop-UI agent-detail widget), so a headless
+  `puffo-agent start` never warmed the in-process cache and the
+  control-WS `build_capabilities()` fell back to the hardcoded static
+  model list. `start --background` happened to work only because the
+  operator would eventually open the tray UI, filling the shared
+  cache the daemon thread reads. Fix: call
+  `model_catalog.prefetch()` from `Daemon.run()` at startup so both
+  paths report identically.
+
 ## [1.0.6] — 2026-07-01
 
 ### Added

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -109,11 +109,8 @@ class Daemon:
 
         # One-shot version check at startup; non-blocking, best-effort.
         asyncio.ensure_future(_log_outdated_version_warning())
-        # Warm the claude-code model catalog off-thread so control-WS
-        # ``build_capabilities`` has real data to report. Without this
-        # ``puffo-agent start`` (no --ui / --background) never triggers
-        # a fetch=True path, so the server sees only the static fallback
-        # model list until an operator opens the desktop UI.
+        # Foreground start has no other trigger for the fetch=True
+        # path, so capability reports fall back to the static list.
         from ..agent.model_catalog import prefetch as _prefetch_model_catalog
         _prefetch_model_catalog()
         # Retry any archived-dir pending revokes from a previous run.

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -109,6 +109,13 @@ class Daemon:
 
         # One-shot version check at startup; non-blocking, best-effort.
         asyncio.ensure_future(_log_outdated_version_warning())
+        # Warm the claude-code model catalog off-thread so control-WS
+        # ``build_capabilities`` has real data to report. Without this
+        # ``puffo-agent start`` (no --ui / --background) never triggers
+        # a fetch=True path, so the server sees only the static fallback
+        # model list until an operator opens the desktop UI.
+        from ..agent.model_catalog import prefetch as _prefetch_model_catalog
+        _prefetch_model_catalog()
         # Retry any archived-dir pending revokes from a previous run.
         asyncio.ensure_future(_sweep_archived_pending_revokes_at_startup())
         # Re-assert machine_id for already-linked operators' agents so agents

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -1,0 +1,74 @@
+"""Regression pin: ``puffo-agent start`` (foreground) must warm the
+claude-code model catalog on startup so control-WS
+``build_capabilities`` reports the live model list instead of the
+static fallback.
+
+Before this fix, the ``fetch=True`` path was only reachable through
+``AgentDetail.__init__.prefetch()`` — which only runs when an
+operator opens the desktop UI. Foreground ``start`` (no ``--ui`` /
+``--background``) never touched the UI code, so the on-disk cache
+stayed empty and the machine reported the hardcoded fallback list to
+puffo-server. ``start --background`` accidentally worked because the
+operator would open the tray UI at some point, filling the shared
+in-process cache the daemon thread reads."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from unittest.mock import patch
+
+from puffo_agent.portal import daemon as daemon_mod
+
+
+def test_daemon_run_calls_model_catalog_prefetch_at_startup():
+    """Source-level guard: ``Daemon.run`` must invoke
+    ``model_catalog.prefetch`` (or import it under an aliased name)
+    before entering the main reconcile loop.
+
+    Text-match test because the alternative — running ``Daemon.run``
+    for real — pulls in the API server, RPC service, credential
+    refresher, and control WS. All we care about here is that the
+    call site exists; the rest is covered by other suites."""
+    source = inspect.getsource(daemon_mod.Daemon.run)
+    assert (
+        "model_catalog" in source and "prefetch" in source
+    ), (
+        "Daemon.run must call model_catalog.prefetch on startup so the "
+        "control-WS capability report includes the live model list. "
+        "Foreground ``puffo-agent start`` has no other trigger for the "
+        "fetch=True path."
+    )
+
+
+def test_run_daemon_calls_prefetch_before_capability_report(monkeypatch):
+    """Functional guard: when ``run_daemon`` short-circuits because a
+    daemon is already alive, ``prefetch`` should NOT have fired (early
+    return happens before ``Daemon.run``). Symmetrically, when it
+    doesn't short-circuit, ``prefetch`` must fire from ``Daemon.run``.
+
+    We only assert the short-circuit half here (the positive path is
+    covered by the source guard above and by the observable behavior
+    downstream — capability reports carrying live model ids)."""
+    called: list[int] = []
+
+    def _spy_prefetch():
+        called.append(1)
+
+    monkeypatch.setattr(
+        "puffo_agent.agent.model_catalog.prefetch", _spy_prefetch,
+    )
+    # Short-circuit early: another daemon is "alive" (mock).
+    with patch(
+        "puffo_agent.portal.daemon.is_daemon_alive", return_value=True,
+    ), patch(
+        "puffo_agent.portal.daemon.read_daemon_pid", return_value=4242,
+    ):
+        rc = asyncio.run(daemon_mod.run_daemon())
+    assert rc == 0
+    assert called == [], (
+        "prefetch fired before the already-running short-circuit — "
+        "the fix should be inside ``Daemon.run``, not in ``run_daemon``, "
+        "so it doesn't spawn a stray HTTP fetch when a second daemon is "
+        "refused."
+    )

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -1,16 +1,6 @@
-"""Regression pin: ``puffo-agent start`` (foreground) must warm the
-claude-code model catalog on startup so control-WS
-``build_capabilities`` reports the live model list instead of the
-static fallback.
-
-Before this fix, the ``fetch=True`` path was only reachable through
-``AgentDetail.__init__.prefetch()`` — which only runs when an
-operator opens the desktop UI. Foreground ``start`` (no ``--ui`` /
-``--background``) never touched the UI code, so the on-disk cache
-stayed empty and the machine reported the hardcoded fallback list to
-puffo-server. ``start --background`` accidentally worked because the
-operator would open the tray UI at some point, filling the shared
-in-process cache the daemon thread reads."""
+"""``puffo-agent start`` (foreground) must warm the claude-code
+model catalog so control-WS ``build_capabilities`` reports the live
+list instead of the static fallback."""
 
 from __future__ import annotations
 
@@ -22,43 +12,22 @@ from puffo_agent.portal import daemon as daemon_mod
 
 
 def test_daemon_run_calls_model_catalog_prefetch_at_startup():
-    """Source-level guard: ``Daemon.run`` must invoke
-    ``model_catalog.prefetch`` (or import it under an aliased name)
-    before entering the main reconcile loop.
-
-    Text-match test because the alternative — running ``Daemon.run``
-    for real — pulls in the API server, RPC service, credential
-    refresher, and control WS. All we care about here is that the
-    call site exists; the rest is covered by other suites."""
+    """Source-level guard: text-match on ``Daemon.run`` so we don't
+    have to mock the API server, RPC service, refresher, and control
+    WS just to pin one call."""
     source = inspect.getsource(daemon_mod.Daemon.run)
-    assert (
-        "model_catalog" in source and "prefetch" in source
-    ), (
-        "Daemon.run must call model_catalog.prefetch on startup so the "
-        "control-WS capability report includes the live model list. "
-        "Foreground ``puffo-agent start`` has no other trigger for the "
-        "fetch=True path."
-    )
+    assert "model_catalog" in source and "prefetch" in source
 
 
-def test_run_daemon_calls_prefetch_before_capability_report(monkeypatch):
-    """Functional guard: when ``run_daemon`` short-circuits because a
-    daemon is already alive, ``prefetch`` should NOT have fired (early
-    return happens before ``Daemon.run``). Symmetrically, when it
-    doesn't short-circuit, ``prefetch`` must fire from ``Daemon.run``.
-
-    We only assert the short-circuit half here (the positive path is
-    covered by the source guard above and by the observable behavior
-    downstream — capability reports carrying live model ids)."""
+def test_run_daemon_short_circuit_does_not_prefetch(monkeypatch):
+    """The already-running short-circuit lives in ``run_daemon``, not
+    ``Daemon.run`` — so a second daemon getting refused mustn't fire a
+    stray /v1/models fetch."""
     called: list[int] = []
-
-    def _spy_prefetch():
-        called.append(1)
-
     monkeypatch.setattr(
-        "puffo_agent.agent.model_catalog.prefetch", _spy_prefetch,
+        "puffo_agent.agent.model_catalog.prefetch",
+        lambda: called.append(1),
     )
-    # Short-circuit early: another daemon is "alive" (mock).
     with patch(
         "puffo_agent.portal.daemon.is_daemon_alive", return_value=True,
     ), patch(
@@ -66,9 +35,4 @@ def test_run_daemon_calls_prefetch_before_capability_report(monkeypatch):
     ):
         rc = asyncio.run(daemon_mod.run_daemon())
     assert rc == 0
-    assert called == [], (
-        "prefetch fired before the already-running short-circuit — "
-        "the fix should be inside ``Daemon.run``, not in ``run_daemon``, "
-        "so it doesn't spawn a stray HTTP fetch when a second daemon is "
-        "refused."
-    )
+    assert called == []


### PR DESCRIPTION
## Summary

Machine capability reports (control-WS `build_capabilities`) list the harnesses installed on the machine + their model catalogs, so puffo-server can render a remote machine's provider dropdown just like a local one. The claude-code side of that catalog is populated by an Anthropic `/v1/models` fetch guarded behind `fetch=True` in `model_catalog.provider_models`.

**The bug** an operator flagged (\`puffo-agent start\` doesn't refresh the model list; \`puffo-agent start --background\` does):

- `puffo-agent start` (foreground) runs `Daemon.run` directly. It never imports any UI code, so `prefetch()` is never called. The in-process `_cache` dict stays empty, `build_capabilities` falls back to the hardcoded static list (`_CLAUDE_STATIC`), and the server sees only 4 models regardless of what the account can actually reach.
- `puffo-agent start --background` spawns a tray runner. The daemon runs in a thread of the same process. When the operator opens the tray UI at some point, `AgentDetail.__init__.prefetch()` fires and fills the shared cache. The daemon thread's next capability report picks it up — but only because the caches happen to share a process. Operators who never opened the UI would have seen the same bug.

**The fix**: call `model_catalog.prefetch()` from `Daemon.run()` alongside the existing best-effort startup coroutines (`_log_outdated_version_warning`, `_full_sync_all_owned_agents_at_startup`). `prefetch()` is already a daemon-threaded background fetch (returns immediately, warms cache off-thread), so this is one import + one call — no new lifecycle to manage.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_daemon_catalog_prefetch.py tests/test_model_catalog.py tests/test_run_daemon_already_running.py` — 23/23 pass.
- [x] Full suite: 1737 passed / 9 skipped.
- [ ] Live smoke: on a machine paired to a puffo-server, `puffo-agent stop && puffo-agent start` → check `puffo-server` sees the live model list within one capability heartbeat (~30s).

## Notes for review

- The new test file is deliberately conservative — a source-level guard (`inspect.getsource(Daemon.run)` checks for `prefetch`) plus a functional pin that verifies the call lives *inside* `Daemon.run` (so the already-running short-circuit doesn't spawn a stray HTTP fetch when a second daemon is refused). A full end-to-end test would need to mock every startup side-effect (API server, RPC service, credential refresher, control WS) — not worth the fixture cost for a one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)