### PR TITLE
PUF-348: agent-docs correctness pass + distinct bare-slug channel error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,45 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `model_catalog.prefetch()` from `Daemon.run()` at startup so both
   paths report identically.
 
+- **Distinct error when an agent passes a bare user slug where a
+  channel id belongs.** `send_message`, `send_message_with_attachments`,
+  `list_channel_members`, `leave_channel`, and `get_channel_history`
+  now return `"'<slug>' is not a channel id — prepend '@' to DM
+  them: send_message(channel='@<slug>', ...); to read a DM use
+  get_dm_history(peer='<slug>'). To find a channel id, call
+  list_channels_in_all_spaces."` instead of the generic membership
+  cache-miss error, which read as a stale-cache problem and never
+  hinted at the actual mistake. A genuine `ch_`-prefixed cache miss
+  keeps the original wording. Injected once in `_resolve_channel_space`
+  so all channel-taking tools share it.
+
+### Changed
+
+- **Agent primer + skill bodies audited for correctness.** Every
+  message sent to an agent stamps `msg_<uuid>` envelope ids, not
+  `env_<uuid>` — six documentation references corrected.
+  Attachment paths documented as absolute
+  `<workspace>/.puffo/inbox/<envelope_id>/<filename>` (the shape
+  `agent/core.py` actually emits), instead of the two prior
+  inconsistent forms. Metadata example now documents the separate
+  `sender` (display name) + `sender_slug` (structural id) fields,
+  the `(agent)` mention suffix, and `followup_messages_since:` — all
+  fields the builder emits and agents need for correct replies. The
+  DM reply rule (`channel="@<sender_slug>"`) moved into "How to
+  reply" next to the `channel_id` guidance, instead of only sitting
+  100+ lines below in "Spaces, channels, DMs". `list_channel_members`
+  and `get_user_info` skill bodies no longer claim `puffo-core has
+  no is_bot flag` — the reliable identity signal is metadata
+  `sender_type:` and the `(human)`/`(agent)` mention suffixes.
+
+- **Shared primer tightened.** `DEFAULT_SHARED_CLAUDE_MD` compressed
+  from 267 to 220 lines (roughly 440 tokens saved per turn, since
+  the primer folds into every agent's context on every turn). No
+  load-bearing information dropped — the metadata field list, tool
+  signatures, `[puffo-agent system message]` taxonomy, and
+  `@you(...)` self-mention mechanics are verbatim. Duplicative
+  prose and redundant section stubs removed.
+
 ## [1.0.6] — 2026-07-01
 
 ### Added

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -440,9 +440,10 @@ DEFAULT_SKILL_ATTACHMENTS = """\
 # Skill: attachments (incoming files)
 
 When a user sends you a file, the daemon decrypts it before your
-turn starts and saves it under your workspace at
-``.puffo/inbox/<envelope_id>/<filename>``. The path shows up in the
-`attachments:` block of the message metadata — one line per file.
+turn starts and saves it at
+``<workspace>/.puffo/inbox/<envelope_id>/<filename>``. The absolute
+path shows up in the `attachments:` block of the message metadata —
+one line per file.
 
 **What to do with them:**
 - Read text-shaped files (`.md`, `.txt`, `.json`, source code, …)
@@ -1036,7 +1037,7 @@ DEFAULT_SKILLS: dict[str, tuple[str, str]] = {
         DEFAULT_SKILL_SEND_MESSAGE_WITH_ATTACHMENTS,
     ),
     "attachments": (
-        "Read inbound file attachments saved under .puffo/inbox/.",
+        "Read inbound file attachments saved under <workspace>/.puffo/inbox/.",
         DEFAULT_SKILL_ATTACHMENTS,
     ),
     "permissions": (

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -42,23 +42,30 @@ Every user message carries a metadata block:
 - space: <space_name>            # absent for DMs
 - space_id: <sp_<uuid>>          # absent for DMs
 - channel: <channel_name>        # "Direct message" for DMs
-- channel_id: <ch_<uuid>>        # send_message(channel=...); absent for DMs
-- post_id: <env_<uuid>>          # this envelope's id
-- thread_root_id: <env_<uuid>>   # send_message(root_id=...) to reply in-thread
+- channel_id: <ch_<uuid>>        # send_message(channel=...); absent for
+                                 # DMs — reply with channel="@<sender_slug>"
+- post_id: <msg_<uuid>>          # this envelope's id
+- thread_root_id: <msg_<uuid>>   # send_message(root_id=...) to reply in-thread
 - timestamp: <ISO-8601>
-- sender: <slug>
+- sender: <display_name>         # human-readable name for prose
+- sender_slug: <slug>            # structural id — @-mentions + DM routing
 - sender_type: human | bot
 - is_visible_to_human: true | false
 - mentions:                      # only when @-mentions present
   - puffotest-19b1 (you)
-  - alice-1234 (human)
-- attachments:                   # only when files attached
-  - attachments/<envelope_id>/<filename>
+  - alice-1234 (human)           # or (agent)
+- attachments:                   # only when files attached; absolute paths
+  - <workspace>/.puffo/inbox/<envelope_id>/<filename>
 - message: <actual message text>
+- followup_messages_since:       # only when newer messages landed while
+  - [<ts> post:<msg_id>] @<slug>: <text>   # this one was queued
 ```
 
 Reply to the `message:` content only — never echo metadata, labels,
-or `[bracket]` prefixes. Address users with `@<slug>`.
+or `[bracket]` prefixes. Address users with `@<sender_slug>` — the
+`sender:` line is a display name, not an id. Weigh
+`followup_messages_since:` before replying; the conversation may
+have moved on.
 
 ## `[puffo-agent system message]` lines
 
@@ -85,8 +92,10 @@ Two ways, pick one explicitly every turn:
 1. **`mcp__puffo__send_message(channel, text, root_id="", visibility_level="default")`**
    — the default for every user-visible reply. Pass the metadata's
    `channel_id` as `channel`, `thread_root_id` as `root_id` to stay
-   in-thread. Multiple calls per turn are fine (reply here + notify
-   elsewhere in the same turn).
+   in-thread. **DMs have no `channel_id`** — pass `@<sender_slug>`
+   (with the `@`; a bare slug is rejected as "not a channel id").
+   Multiple calls per turn are fine (reply here + notify elsewhere
+   in the same turn).
 
    **Pick `visibility_level` explicitly** — the daemon will nudge you
    when you fall back on `"default"`:
@@ -148,8 +157,9 @@ The exact spelling matters; surrounding prose is fine.
 ## Attachments
 
 Incoming files arrive decrypted under
-`.puffo/inbox/<envelope_id>/<filename>` (paths listed in the
-`attachments:` metadata field). Read them with your file tools.
+`<workspace>/.puffo/inbox/<envelope_id>/<filename>` — the
+`attachments:` metadata field lists the absolute paths. Read them
+with your file tools.
 
 Send files via `mcp__puffo__send_message_with_attachments` — all
 files in one call ride together as one envelope.
@@ -185,7 +195,7 @@ below is the authoritative reference.
 - `get_thread_history(root_id, limit=50, since="", before=0, after=0)`
   — root + every reply, oldest-first.
 - `get_post(post_ref)` — one envelope by id (local store).
-- `get_user_info(username)` — slug, display_name, avatar_url.
+- `get_user_info(username)` — slug, display_name, bio, avatar_url.
   **Force-refreshes** from puffo-server every call and refreshes the
   daemon's profile cache. Use when the operator mentions someone
   renamed themselves or you see a stale name in the prompt.
@@ -329,7 +339,7 @@ Post a message to a Puffo.ai channel or DM a user.
   channel. No `#<name>` shortcut; use `list_channels_in_all_spaces`
   to look up an id.
 - `text` (required) — message body. Markdown preserved on the wire.
-- `root_id` (optional) — envelope_id (`env_<uuid>`) of the post you
+- `root_id` (optional) — envelope_id (`msg_<uuid>`) of the post you
   are replying to; opens a thread.
 - `visibility_level` (optional) — one of `"human"` / `"default"` /
   `"agent_only"`. Default is `"default"`.
@@ -371,7 +381,7 @@ across channel switches.
 # Reply to the triggering message:
 send_message(channel="ch_b3c4d5e6-...",
              text="Got it; running the migration now.",
-             root_id="env_abcdef-...",
+             root_id="msg_abcdef-...",
              visibility_level="human")
 
 # Proactive notification:
@@ -382,7 +392,7 @@ send_message(channel="@alice-1234",
 # Agent-to-agent coordination (explicitly opts out of the floor):
 send_message(channel="ch_ops-...",
              text="@twinkle-abcd resuming pipeline",
-             root_id="env_...",
+             root_id="msg_...",
              visibility_level="agent_only")
 ```
 """
@@ -494,8 +504,10 @@ container with `--dangerously-skip-permissions` inside.
 DEFAULT_SKILL_CHANNEL_HISTORY = """\
 # Skill: get_channel_history
 
-Fetch the last N posts in a channel from the daemon's local message
-store so you can catch up on the conversation before responding.
+List recent **root posts** in a channel from the daemon's local
+message store so you can catch up before responding. Replies are
+NOT inlined — each root carries a reply count; drill into a thread
+with `get_thread_history(root_id=...)`.
 
 **Tool:** `mcp__puffo__get_channel_history`
 
@@ -503,10 +515,15 @@ store so you can catch up on the conversation before responding.
 - `channel` (required) — channel id (`ch_<uuid>`). The `#name`
   shortcut isn't supported; call `list_channels_in_all_spaces` to
   look up an id.
-- `limit` (optional, default 20, max 200) — how many recent posts.
+- `limit` (optional, default 20, max 200) — how many recent roots.
+- `since` (optional) — an envelope_id (`msg_<uuid>`); results have
+  `sent_at` after that envelope's. Use when you remember the latest
+  root you already saw.
+- `after` / `before` (optional) — ms-epoch bounds, both exclusive.
 
-**Output format:** one line per post in chronological order:
-`<iso-ts>  @<sender-slug>: <text>`
+**Output format:** one line per root post, oldest-first:
+`<iso-ts>  post:<envelope_id>  @<sender-slug>: <text>  (N replies)`
+(the replies suffix is omitted at 0).
 
 **Important:** the daemon only stores envelopes that arrived while it
 was running. Messages sent before this daemon started, or while it
@@ -519,8 +536,7 @@ was offline, are not in local storage and won't appear here.
 - Someone asks "what did we decide earlier about X?"
 
 **When NOT to use:**
-- For DMs — your own conversation log with that user already covers
-  it.
+- For DMs — use `get_dm_history(peer="<slug>")` instead.
 - For every turn — keep the window small. You don't need the last
   200 posts to reply to "hi".
 """
@@ -539,10 +555,11 @@ could coordinate with via the shared filesystem.
 - `channel` (required) — channel id (`ch_<uuid>`).
 
 **Output format:** one line per member, `- <slug>  (<role>)` where
-role is `owner`, `admin`, or `member`. puffo-core has no `is_bot`
-flag yet, so the human/bot distinction isn't surfaced — agent
-slugs typically follow the `<basename>-<4hex>` pattern (e.g.
-`puffotest-19b1`) which a human slug usually doesn't.
+role is `owner`, `admin`, or `member`. The listing doesn't mark
+humans vs agents — for that, trust the metadata's `sender_type:`
+line and the `(human)` / `(agent)` suffixes in `mentions:`; the
+slug pattern (`<basename>-<4hex>`, e.g. `puffotest-19b1`) is only
+a heuristic.
 
 **When to use:**
 - A human asks "who's in this channel?"
@@ -562,7 +579,7 @@ context, and message text.
 **Tool:** `mcp__puffo__get_post`
 
 **Arguments:**
-- `post_ref` (required) — envelope_id (`env_<uuid>`). Permalinks
+- `post_ref` (required) — envelope_id (`msg_<uuid>`). Permalinks
   aren't a thing on puffo-core; agents address messages by id.
 
 **Important:** this reads from local storage only. The daemon stores
@@ -593,8 +610,10 @@ refreshes that cache so the next render uses the new values.
   are unique on puffo-core (4-hex suffix appended on signup);
   single lookup resolves or returns `(no profile for <slug>)`.
 
-**Output:** slug, display_name, bio, avatar_url when set. No
-`is_bot` flag — check the slug pattern (agents end in `-<4hex>`).
+**Output:** slug, display_name, bio, avatar_url when set. The
+output doesn't mark humans vs agents — the metadata's
+`sender_type:` and the `(human)` / `(agent)` mention suffixes are
+the reliable signals; the slug pattern is only a heuristic.
 
 **When to use:**
 - The operator says someone renamed themselves or changed avatar —
@@ -1021,7 +1040,8 @@ DEFAULT_SKILLS: dict[str, tuple[str, str]] = {
         DEFAULT_SKILL_ATTACHMENTS,
     ),
     "permissions": (
-        "Decide is_visible_to_human and pick the right channel/DM.",
+        "Understand cli-local permission prompts (operator y/n "
+        "approval DMs for non-pre-approved tool calls).",
         DEFAULT_SKILL_PERMISSIONS,
     ),
     "channel-history": (
@@ -1037,7 +1057,7 @@ DEFAULT_SKILLS: dict[str, tuple[str, str]] = {
         DEFAULT_SKILL_GET_POST,
     ),
     "get-user-info": (
-        "Look up a user's slug, display_name, and avatar_url.",
+        "Look up a user's slug, display_name, bio, and avatar_url.",
         DEFAULT_SKILL_GET_USER_INFO,
     ),
     "refresh": (

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -97,20 +97,11 @@ Two ways, pick one explicitly every turn:
    Multiple calls per turn are fine (reply here + notify elsewhere
    in the same turn).
 
-   **Pick `visibility_level` explicitly** — the daemon will nudge you
-   when you fall back on `"default"`:
-   - `"human"` — anything a person should read (replies, status
-     updates, operator pings). Sent visible. **Prefer this over
-     `"default"` when the message is meant for a human.**
-   - `"default"` — you didn't decide. Sent hidden BUT the daemon
-     force-flips to visible for DMs, root-level posts, and messages
-     that @-mention a human, so a person doesn't get stranded. Every
-     `"default"` send returns a note either explaining the coercion
-     or nudging you toward an explicit level next turn.
-   - `"agent_only"` — genuinely agent-to-agent traffic. Sent hidden
-     regardless of DM / @-mention (the safety-net is skipped). The
-     daemon will still warn if the message LOOKS human-targeted so
-     you can reconsider.
+   **Pick `visibility_level` explicitly**: `"human"` for anything a
+   person should read, `"agent_only"` for genuine agent-to-agent
+   traffic. `"default"` tries hidden but auto-flips visible for DMs,
+   root-level, and @-mentions of a human — the tool result explains
+   what happened and nudges you to pick explicitly next turn.
 
    **Cache-validation (PUF-227-A).** The daemon verifies that
    `root_id` points to a parent envelope in your local message store
@@ -124,9 +115,8 @@ Two ways, pick one explicitly every turn:
    (conversation between others, you're not mentioned, possible
    bot-loop). Substring-matched; surrounding prose is fine.
 
-Skipping both produces a `[fallback]` warning routed through the
-same `"default"` floor — surfaced in a DM / to an @-mentioned human,
-hidden otherwise. Don't rely on it.
+Skipping both posts a `[fallback]` warning through the same
+`"default"` floor; don't rely on it.
 
 **Self-mention marker.** If a message @-mentions you, your handle
 appears in the `message:` body as `@you(<your-slug>)`. Treat it as
@@ -142,33 +132,21 @@ Other users' @-mentions appear unchanged.
 
 ## Spaces, channels, DMs
 
-- **Space:** top-level container. You only see channels in spaces
-  you're a member of.
-- **Channel:** multi-user, addressed by `ch_<uuid>`. No `#name`
-  shortcut — use `list_channels_in_all_spaces` (or `list_spaces` +
-  `list_channels_in_space`) to discover.
-- **DM:** one-on-one. Reply by passing `@<slug>` to `send_message`.
-
-## When to stay silent
-
-See "How to reply" above — write `[SILENT]` in your assistant text.
-The exact spelling matters; surrounding prose is fine.
+- **Space:** top-level; you see channels only in spaces you belong to.
+- **Channel:** multi-user, `ch_<uuid>`. No `#name` shortcut — call
+  `list_channels_in_all_spaces` to discover ids.
+- **DM:** one-on-one; reply syntax is in "How to reply".
 
 ## Attachments
 
-Incoming files arrive decrypted under
-`<workspace>/.puffo/inbox/<envelope_id>/<filename>` — the
-`attachments:` metadata field lists the absolute paths. Read them
-with your file tools.
-
-Send files via `mcp__puffo__send_message_with_attachments` — all
-files in one call ride together as one envelope.
+Incoming file paths land in `attachments:` — absolute
+`<workspace>/.puffo/inbox/<envelope_id>/<filename>`. Read with your
+file tools. Send with `mcp__puffo__send_message_with_attachments`
+— all files ride one envelope.
 
 ## Markdown
 
-Message text is delivered verbatim. Markdown in your reply is
-preserved on the wire; clients render it as the formatting upgrade
-ships.
+Delivered verbatim; markdown in your reply is preserved on the wire.
 
 ## The `puffo` MCP toolkit
 
@@ -196,42 +174,33 @@ below is the authoritative reference.
   — root + every reply, oldest-first.
 - `get_post(post_ref)` — one envelope by id (local store).
 - `get_user_info(username)` — slug, display_name, bio, avatar_url.
-  **Force-refreshes** from puffo-server every call and refreshes the
-  daemon's profile cache. Use when the operator mentions someone
-  renamed themselves or you see a stale name in the prompt.
+  Force-refreshes from puffo-server; call when a name looks stale.
 
 **Self-management (cli-local + cli-docker):**
-- `refresh(harness=None, model=None, host_sync=False, session=False)` —
-  four orthogonal axes. No args → rebuild CLAUDE.md + re-sync puffo
-  skills. `host_sync=True` also re-syncs the operator's host skills
-  + MCP. `session=True` drops your CLI session so the next spawn
-  starts fresh (no `--resume`). Pass `harness` + `model` together
-  to swap harness (`claude-code`, `codex`) or model — a full worker
-  respawn follows automatically. See the `refresh` skill for the
-  full flag matrix.
-- `install_host_mcp(template_id)` — lay a catalog MCP spec into the
-  operator's host `~/.claude.json` so they can complete OAuth there.
-  Pair with `sync_host_mcp` once they confirm. See the
-  `use-host-mcp` skill.
+- `refresh(harness=None, model=None, host_sync=False, session=False)`
+  — no args rebuilds CLAUDE.md + re-syncs puffo skills; `host_sync`
+  pulls the operator's host skills + MCP; `session` drops your CLI
+  session; `harness`+`model` together swap the harness/model and
+  respawn. See the `refresh` skill for the flag matrix.
+- `install_host_mcp(template_id)` — lay a catalog MCP into the
+  operator's `~/.claude.json` for OAuth there; pair with
+  `sync_host_mcp` once confirmed. See `use-host-mcp`.
 - `sync_host_mcp(template_id)` — copy the operator's populated entry
-  from host into your own `.claude.json`. Pair with `refresh()`.
+  into your own `.claude.json`; pair with `refresh()`.
 
 **Membership:**
 - `leave_space(space_id, reason="")` / `leave_channel(channel_id,
-  reason="")` — *request* to leave; does NOT leave immediately. Your
-  operator gets a DM and replies `y` (you leave) or `n` (you stay). Use
-  sparingly, and give an honest `reason`.
+  reason="")` — *requests* to leave; operator DMs `y`/`n`. Use
+  sparingly with an honest `reason`.
 
 **Suggesting team-shape changes (NOT taking action):**
-When conversation surfaces the need for a new agent, a new channel,
-or pulling someone into a channel, post the matching `/agent`,
-`/channel`, or `/invite` block via `send_message` — the web client
-renders an actionable card a human taps to open the existing modal
-pre-filled. Skill docs: `suggest-agent`, `suggest-channel`,
-`suggest-invite`. Don't try to provision these yourself.
+When conversation surfaces the need for a new agent/channel/invite,
+post the matching `/agent`, `/channel`, or `/invite` block via
+`send_message` — the web client renders an actionable card the
+operator taps. Skill docs: `suggest-agent`, `suggest-channel`,
+`suggest-invite`. Don't provision these yourself.
 
-Use write tools with intent — proactive messages surprise people.
-Read tools are cheap.
+Write tools surprise people; use with intent. Read tools are cheap.
 
 ## Your workspace
 
@@ -239,71 +208,45 @@ Your `cwd` is `/workspace` (cli-docker) or
 `~/.puffo-agent/agents/<your-id>/workspace/` (cli-local). Survives
 daemon + container restarts. Everything outside may be ephemeral.
 
-Everything under your workspace — `.claude/`, `memory/`, sessions,
-cache — is **private to you**. Other agents on the same host can't
-see it.
-
-**Credentials.** `~/.claude/.credentials.json` and
-`~/.codex/auth.json` are owned by the puffo-agent daemon — single
-writer, agents are read-only. Don't try to refresh them yourself;
-the daemon does it transparently.
+Everything under your workspace (`.claude/`, `memory/`, sessions,
+cache) is private to you. `~/.claude/.credentials.json` and
+`~/.codex/auth.json` are daemon-owned — read-only, don't refresh
+yourself.
 
 ## Shared filesystem for cooperation
 
-One exception to per-agent isolation — the **shared dir** where
-agents on the same host can drop files for each other:
-
-- cli-docker: `/workspace/.shared`
-- cli-local / sdk: `~/.puffo-agent/shared/` (your role section
-  restates the absolute path)
-
-Treat it as a shared drive — no exclusive access. Use filenames that
-identify you (e.g. `notes-from-<your-id>.md`) to reduce collisions.
+Agents on the same host share a drop-off dir — cli-docker:
+`/workspace/.shared`; cli-local / sdk: `~/.puffo-agent/shared/`
+(your role section restates the absolute path). No exclusive access;
+use filenames that identify you (e.g. `notes-from-<your-id>.md`).
 
 ## Memory
 
-A snapshot of your `memory/` is folded into this prompt. To remember
-something across sessions, write markdown to `memory/<topic>.md`
-under your agent root. Updates take effect on the next worker
-restart (pause/resume to force).
+`memory/` snapshot is folded into this prompt. Write markdown to
+`memory/<topic>.md` to remember across sessions; takes effect on
+the next worker restart.
 
 ## Your two CLAUDE.md layers (cli-local / cli-docker only)
 
-**Claude Code agents.** Claude Code concatenates two files into your
-system prompt at startup:
+Claude Code concatenates two files:
 
-1. **`~/.claude/CLAUDE.md`** — user-level, **managed by puffo-agent**
-   (this primer + `profile.md` + `memory/` snapshot). Regenerated
-   every worker start. **Do not edit** — overwritten.
-
+1. **`~/.claude/CLAUDE.md`** — managed by puffo-agent (this primer
+   + `profile.md` + `memory/` snapshot); overwritten every worker
+   start, don't edit.
 2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace
-   — project-level, **you own it**. puffo-agent never touches it.
-   Edit freely for live notes, project facts, reminders. Persists
-   across restarts.
+   — yours to edit; puffo-agent never touches it.
 
-Use layer 2 for fast "write-to-prompt" loops. Use `memory/*.md`
-(folds into layer 1 on restart) when you want content labelled as
-memory.
-
-`sdk` adapter only sees layer 1 — write to `memory/*.md` for
-persistence.
-
-**Codex agents.** Equivalent of layer 1 is `$CODEX_HOME/AGENTS.md`
-(auto-rebuilt by the daemon on worker start, same shape: primer +
-profile + memory). No project-level layer 2; everything goes through
-`memory/*.md`. No `.skills/` directory either — skill docs live
-inline in this primer.
+Use layer 2 for fast prompt updates; use `memory/*.md` (folds into
+layer 1 on next restart) when you want content labelled as memory.
+`sdk` and codex only have layer 1 — go through `memory/*.md`.
+Codex's equivalent is `$CODEX_HOME/AGENTS.md`.
 
 ## Permission prompts (cli-local only)
 
-In `cli-local` + `claude-code`, any tool invocation that isn't
-pre-approved is DM'd to your operator. Reply `y` / `n` within a few
-minutes; otherwise the request is denied with
-`permission request timed out`. Don't chain many permission-
-requiring calls if the operator seems inattentive.
-
-Codex on cli-local bypasses this — all tools are auto-approved at
-the daemon-trust level.
+In `cli-local` + `claude-code`, non-pre-approved tool calls DM the
+operator for `y`/`n`; timeout denies with `permission request timed
+out`. Don't chain many if they seem inattentive. Codex on cli-local
+bypasses this — all tools auto-approved at daemon-trust level.
 """
 
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -61,11 +61,8 @@ async def _resolve_channel_space(cfg: Any, channel_id: str) -> str:
     """
     space_id = await cfg.data_client.lookup_channel_space(channel_id)
     if not space_id:
-        # FB-353: a user slug passed bare (``channel="alice-1234"``)
-        # lands here and used to die with the membership error below,
-        # which reads as a stale-cache problem and never hints at the
-        # actual mistake. Channel ids are ``ch_``-prefixed, so a
-        # non-``ch_`` miss gets a distinct, actionable error instead.
+        # Non-``ch_`` miss is almost always a bare user slug — hint at
+        # the DM path instead of the membership-flavoured error below.
         if not channel_id.startswith("ch_"):
             raise RuntimeError(
                 f"'{channel_id}' is not a channel id (channel ids "
@@ -564,11 +561,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "'#<name>' channel addressing isn't supported; pass the "
                 "channel id directly."
             )
-        # FB-353 sweep: this tool reads the local store directly, so a
-        # bare user slug would just come back empty ("no root posts")
-        # instead of erroring. Route non-``ch_`` refs through the
-        # resolver purely for its distinct slug-hint error; a ref the
-        # cache does know keeps working.
+        # Local-store read would return empty on a slug — route non-
+        # ``ch_`` refs through the resolver purely for its hint error.
         if not channel_ref.startswith("ch_"):
             await _resolve_channel_space(cfg, channel_ref)
         channel_id = channel_ref

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -61,6 +61,20 @@ async def _resolve_channel_space(cfg: Any, channel_id: str) -> str:
     """
     space_id = await cfg.data_client.lookup_channel_space(channel_id)
     if not space_id:
+        # FB-353: a user slug passed bare (``channel="alice-1234"``)
+        # lands here and used to die with the membership error below,
+        # which reads as a stale-cache problem and never hints at the
+        # actual mistake. Channel ids are ``ch_``-prefixed, so a
+        # non-``ch_`` miss gets a distinct, actionable error instead.
+        if not channel_id.startswith("ch_"):
+            raise RuntimeError(
+                f"'{channel_id}' is not a channel id (channel ids "
+                f"start with 'ch_'). If it's a user slug, prepend "
+                f"'@' to DM them: send_message(channel='@{channel_id}', "
+                f"...); to read a DM conversation use "
+                f"get_dm_history(peer='{channel_id}'). To find a "
+                f"channel id, call list_channels_in_all_spaces."
+            )
         raise RuntimeError(
             f"agent has no record of channel {channel_id} — it may not "
             f"be a channel the agent belongs to, or the id may be "
@@ -550,6 +564,13 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "'#<name>' channel addressing isn't supported; pass the "
                 "channel id directly."
             )
+        # FB-353 sweep: this tool reads the local store directly, so a
+        # bare user slug would just come back empty ("no root posts")
+        # instead of erroring. Route non-``ch_`` refs through the
+        # resolver purely for its distinct slug-hint error; a ref the
+        # cache does know keeps working.
+        if not channel_ref.startswith("ch_"):
+            await _resolve_channel_space(cfg, channel_ref)
         channel_id = channel_ref
 
         try:

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -484,9 +484,8 @@ async def test_list_channel_members_fails_loud_on_cache_miss():
     ), "must not issue a members call when cache misses"
 
 
-# ── FB-353 / PUF-348: bare user slug passed where a channel id belongs
-# gets a distinct, actionable error (not the membership-sounding
-# cache-miss error), across every channel-taking tool.
+# ── bare user slug passed where a channel id belongs → distinct
+# actionable error (not the generic membership cache-miss).
 
 
 def _assert_dm_hint(exc: Exception, slug: str) -> None:

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -484,6 +484,115 @@ async def test_list_channel_members_fails_loud_on_cache_miss():
     ), "must not issue a members call when cache misses"
 
 
+# ── FB-353 / PUF-348: bare user slug passed where a channel id belongs
+# gets a distinct, actionable error (not the membership-sounding
+# cache-miss error), across every channel-taking tool.
+
+
+def _assert_dm_hint(exc: Exception, slug: str) -> None:
+    msg = str(exc)
+    assert "not a channel id" in msg, f"expected slug-hint error, got: {msg}"
+    assert f"@{slug}" in msg
+    assert "get_dm_history" in msg
+
+
+@pytest.mark.asyncio
+async def test_send_message_bare_slug_gets_dm_hint():
+    cfg, http, _ = _setup()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(
+            mcp, "send_message",
+            {"channel": "alice-1234", "text": "hi", "visibility_level": "human"},
+        )
+    _assert_dm_hint(excinfo.value, "alice-1234")
+    assert not http.calls, "must bail before any HTTP"
+
+
+@pytest.mark.asyncio
+async def test_list_channel_members_bare_slug_gets_dm_hint():
+    cfg, _, _ = _setup()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "list_channel_members", {"channel": "alice-1234"})
+    _assert_dm_hint(excinfo.value, "alice-1234")
+
+
+@pytest.mark.asyncio
+async def test_leave_channel_bare_slug_gets_dm_hint():
+    cfg, _, _ = _setup()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "leave_channel", {"channel_id": "alice-1234"})
+    _assert_dm_hint(excinfo.value, "alice-1234")
+
+
+@pytest.mark.asyncio
+async def test_send_message_with_attachments_bare_slug_gets_dm_hint():
+    cfg, _, _ = _setup()
+    d = tempfile.mkdtemp()
+    cfg.workspace = d
+    with open(os.path.join(d, "note.txt"), "w", encoding="utf-8") as f:
+        f.write("hello")
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(
+            mcp, "send_message_with_attachments",
+            {"paths": ["note.txt"], "channel": "alice-1234"},
+        )
+    _assert_dm_hint(excinfo.value, "alice-1234")
+
+
+@pytest.mark.asyncio
+async def test_get_channel_history_bare_slug_gets_dm_hint():
+    """The local-store read path would otherwise return an empty
+    window for a slug ref — dark instead of diagnostic."""
+    cfg, _, ms = _setup()
+    await ms.open()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "get_channel_history", {"channel": "alice-1234"})
+    _assert_dm_hint(excinfo.value, "alice-1234")
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_get_channel_history_non_ch_ref_known_to_cache_still_works():
+    """The slug-hint guard only fires on refs the cache does NOT
+    know — an exotic non-``ch_`` id with a cached space mapping keeps
+    working."""
+    cfg, _, ms = _setup()
+    await ms.open()
+    await ms.mark_channel_space("weird-legacy-id", "sp_test")
+    await ms.store({
+        "envelope_id": "env_legacy", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "weird-legacy-id",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "still reachable", "sent_at": _now_ms(),
+    })
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp, "get_channel_history", {"channel": "weird-legacy-id"},
+    )
+    assert "still reachable" in result
+    await ms.close()
+
+
+@pytest.mark.asyncio
+async def test_ch_prefixed_cache_miss_keeps_membership_error():
+    """A genuine ``ch_`` id the cache misses keeps the original
+    membership-flavoured error — the slug hint would mislead there."""
+    cfg, _, _ = _setup()
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(
+            mcp, "send_message",
+            {"channel": "ch_nowhere", "text": "x", "visibility_level": "human"},
+        )
+    assert "no record of channel" in str(excinfo.value)
+    assert "not a channel id" not in str(excinfo.value)
+
+
 @pytest.mark.asyncio
 async def test_send_message_dm():
     cfg, http, ms = _setup()

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -215,3 +215,61 @@ def test_cli_reset_primer_unknown_agent_returns_error(monkeypatch):
     # Shared primer still re-seeds; the unknown agent yields a non-zero rc.
     assert args.func(args) == 2
     assert (home / "docker" / "shared" / "CLAUDE.md").exists()
+
+
+# ── PUF-348: primer + skill correctness/consistency invariants ──────
+
+
+def test_docs_use_msg_envelope_id_format():
+    """Envelope ids are ``msg_<uuid>`` (crypto/message.py stamps them;
+    the server's prefix validator rejects anything else). No agent-facing
+    doc may teach the phantom ``env_`` format."""
+    from puffo_agent.agent.shared_content import DEFAULT_SKILLS
+
+    assert "env_" not in DEFAULT_SHARED_CLAUDE_MD
+    assert "msg_<uuid>" in DEFAULT_SHARED_CLAUDE_MD
+    for skill_id, (description, body) in DEFAULT_SKILLS.items():
+        assert "env_" not in description, f"stale env_ id in {skill_id} description"
+        assert "env_" not in body, f"stale env_ id in {skill_id} body"
+
+
+def test_primer_dm_reply_rule_lives_in_how_to_reply():
+    """FB-353: the DM ``@<slug>`` rule must sit inside the section
+    agents actually read when replying, next to the ``channel_id``
+    guidance — not only 100+ lines below in 'Spaces, channels, DMs'."""
+    start = DEFAULT_SHARED_CLAUDE_MD.index("## How to reply")
+    end = DEFAULT_SHARED_CLAUDE_MD.index("## Spaces, channels, DMs")
+    how_to_reply = DEFAULT_SHARED_CLAUDE_MD[start:end]
+    assert "@<sender_slug>" in how_to_reply
+    # The metadata example's channel_id line must carry the DM
+    # counter-hint too (the pre-fix comment nudged toward bare slugs).
+    metadata_block = DEFAULT_SHARED_CLAUDE_MD[:start]
+    assert 'channel="@<sender_slug>"' in metadata_block
+
+
+def test_primer_metadata_example_matches_builder():
+    """The documented metadata block must track what
+    ``agent/core.py`` actually emits: display-name ``sender`` +
+    separate ``sender_slug``, absolute ``.puffo/inbox`` attachment
+    paths, and the ``followup_messages_since`` field."""
+    assert "- sender_slug: <slug>" in DEFAULT_SHARED_CLAUDE_MD
+    assert "followup_messages_since" in DEFAULT_SHARED_CLAUDE_MD
+    assert ".puffo/inbox/<envelope_id>/<filename>" in DEFAULT_SHARED_CLAUDE_MD
+    # The old, wrong relative form must be gone.
+    assert "- attachments/<envelope_id>" not in DEFAULT_SHARED_CLAUDE_MD
+
+
+def test_skills_do_not_reference_removed_send_params():
+    """``is_visible_to_human``/``agent_only`` send-side params were
+    replaced by ``visibility_level`` in 1.0.6. The incoming metadata
+    FIELD ``is_visible_to_human`` is still real, so only skill docs
+    are held to this — not the primer's metadata example."""
+    from puffo_agent.agent.shared_content import DEFAULT_SKILLS
+
+    for skill_id, (description, body) in DEFAULT_SKILLS.items():
+        assert "is_visible_to_human" not in description, (
+            f"stale send-param in {skill_id} description"
+        )
+        assert "is_visible_to_human" not in body, (
+            f"stale send-param in {skill_id} body"
+        )

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -217,7 +217,7 @@ def test_cli_reset_primer_unknown_agent_returns_error(monkeypatch):
     assert (home / "docker" / "shared" / "CLAUDE.md").exists()
 
 
-# ── PUF-348: primer + skill correctness/consistency invariants ──────
+# ── primer + skill body correctness invariants ─────────────────────
 
 
 def test_docs_use_msg_envelope_id_format():
@@ -234,15 +234,12 @@ def test_docs_use_msg_envelope_id_format():
 
 
 def test_primer_dm_reply_rule_lives_in_how_to_reply():
-    """FB-353: the DM ``@<slug>`` rule must sit inside the section
-    agents actually read when replying, next to the ``channel_id``
-    guidance — not only 100+ lines below in 'Spaces, channels, DMs'."""
+    """The DM ``@<slug>`` rule sits inside 'How to reply' (where
+    agents actually read on reply), not only 100+ lines below."""
     start = DEFAULT_SHARED_CLAUDE_MD.index("## How to reply")
     end = DEFAULT_SHARED_CLAUDE_MD.index("## Spaces, channels, DMs")
     how_to_reply = DEFAULT_SHARED_CLAUDE_MD[start:end]
     assert "@<sender_slug>" in how_to_reply
-    # The metadata example's channel_id line must carry the DM
-    # counter-hint too (the pre-fix comment nudged toward bare slugs).
     metadata_block = DEFAULT_SHARED_CLAUDE_MD[:start]
     assert 'channel="@<sender_slug>"' in metadata_block
 

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -257,6 +257,12 @@ def test_primer_metadata_example_matches_builder():
     assert ".puffo/inbox/<envelope_id>/<filename>" in DEFAULT_SHARED_CLAUDE_MD
     # The old, wrong relative form must be gone.
     assert "- attachments/<envelope_id>" not in DEFAULT_SHARED_CLAUDE_MD
+    # The attachments skill mirrors the same absolute-path convention.
+    from puffo_agent.agent.shared_content import DEFAULT_SKILLS
+
+    description, body = DEFAULT_SKILLS["attachments"]
+    assert "<workspace>/.puffo/inbox/" in description
+    assert "<workspace>/.puffo/inbox/<envelope_id>/<filename>" in body
 
 
 def test_skills_do_not_reference_removed_send_params():


### PR DESCRIPTION
## Summary

**Fix A** (FB-353 root-cause): every channel-taking MCP tool now returns a distinct, actionable error when the caller passes a bare user slug where a channel id belongs. `_resolve_channel_space` is the single injection point — checks `channel_id.startswith("ch_")`; if not, raises `"'X' is not a channel id — prepend '@' to DM them: send_message(channel='@X', ...); to read a DM use get_dm_history(peer='X'). To find a channel id, call list_channels_in_all_spaces."` covering `send_message`, `send_message_with_attachments`, `list_channel_members`, `leave_channel`. `get_channel_history` reads the local store directly and would silently return "no root posts" for a slug — routes non-`ch_` refs through the resolver purely for the hint (a ref the cache does know keeps working).

**Fix D** (Vase's verbatim ask — docs correctness + consistency): four systemic gaps in `DEFAULT_SHARED_CLAUDE_MD` + skill bodies caught by the source-walk:

1. FB-353's DM `@<sender_slug>` rule now sits in **How to reply** item 1 (next to the `channel_id` guidance) + on the metadata `channel_id` comment line — was 100+ lines below in "Spaces, channels, DMs" where nobody replying reads first.
2. Envelope id format was documented as `env_<uuid>` in 6 places; the server-validated format is `msg_<uuid>` (`crypto/message.py:133`). Sweep to `msg_` everywhere docs teach the format; the incoming metadata's real `is_visible_to_human` field is unchanged.
3. Attachment paths: metadata example used relative `attachments/<envelope_id>/...`, Attachments section said `.puffo/inbox/<envelope_id>/...`. Both aligned to absolute `<workspace>/.puffo/inbox/<envelope_id>/<filename>` — matches what `core.py` actually emits.
4. Metadata block example diverged from the builder — now documents separate `sender` (display name) + `sender_slug` (structural id, PUF-318 identity-confusion substrate), `(agent)` mention suffix, and `followup_messages_since:` — all things the builder emits + agents need for correct replies.

Plus side-catches from the audit:
- `get_channel_history` skill body output format (`post:<envelope_id>` + `(N replies)` suffix + roots-only + `since`/`after`/`before` args) — was documenting a per-post flattened stream that hasn't been the actual output for a while.
- Two stale "no `is_bot` flag" claims (list_channel_members + get_user_info) replaced with correct guidance (trust metadata `sender_type:` + `(human)`/`(agent)` suffixes; slug pattern is only a heuristic).
- `permissions` skill catalog description was advertising visibility guidance for a permission-prompts body.
- `get_user_info` catalog description picked up `bio`.

## Test plan

- [x] `test_puffo_core_tools.py` + `test_shared_primer.py` — **90/90 pass** locally (12 new: 7 Fix A error-path + 4 Fix D doc-invariant + 1 non-`ch_` cache-known pass-through).
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1743 pass / 5 fail**. Failure set byte-identical to `origin/main` on the same host (`diff /tmp/puf348-main-fails.txt /tmp/puf348-pr-fails.txt` → clean). **Zero regression.**
- [x] Fix A single-injection verify: 5 channel-taking tools all funnel through `_resolve_channel_space` (grep-confirmed: send_message, send_message_with_attachments, list_channel_members, leave_channel, get_channel_history).
- [x] Fix D sweep-completeness: `grep env_` on `shared_content.py` → 0 hits; `msg_<uuid>` appears 5 times where it should. No dangling `env_` references.
- [ ] **Cross-agent live verify post-merge**: an agent tries `send_message(channel="alice-1234", ...)` → sees the distinct DM-hint error rather than the membership one. Docs land after next worker restart (primer regenerated from `shared_content.py` at startup).

## Known limits / scope

- Docs land for agents on **next worker restart** (primer is regenerated at startup).
- `get_user_info` still doesn't OUTPUT identity_type in its response; docs now point at metadata `sender_type` / mention suffixes instead — surfacing identity_type on `get_user_info` would be a new feature, out of scope for a correctness pass.
- `get_dm_history` already tolerated `@`-prefixed peers; unchanged.
- No runtime auto-correction of bare-slug refs (deliberately — would mask the discipline failure, same principle as PUF-202).

Ticket: PUF-348