### PR TITLE
PUF-350: defer device revoke until the archived report settles

### DIFF
--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -427,11 +427,13 @@ class Daemon:
         except Exception as exc:  # noqa: BLE001
             logger.warning("agent %s: cfg load for revoke failed: %s", agent_id, exc)
         # Heartbeat must precede revoke — afterwards the device is 401'd.
+        report_settled = True
         if cfg_for_revoke is not None:
             try:
-                await _report_lifecycle(cfg_for_revoke, "archived")
+                report_settled = await _report_lifecycle(cfg_for_revoke, "archived")
             except Exception as exc:  # noqa: BLE001
                 logger.warning("agent %s: archived report failed: %s", agent_id, exc)
+                report_settled = False
         src = agent_dir(agent_id)
         if not src.exists():
             return
@@ -451,6 +453,32 @@ class Daemon:
         if cfg_for_revoke is None or not cfg_for_revoke.puffo_core.is_configured():
             return
         pc = cfg_for_revoke.puffo_core
+        # PUF-350: revoking with the archived report unsettled would 401
+        # every future report attempt — the server row would stay stale
+        # forever. Defer the revoke; the startup sweep re-reports first.
+        if not report_settled:
+            logger.warning(
+                "agent %s: archived report unsettled; deferring revoke to "
+                "the startup sweep (marker in %s)",
+                agent_id, dest,
+            )
+            try:
+                from ..crypto.keystore import KeyStore
+                identity = KeyStore(dest / "keys").load_identity(pc.slug)
+                write_archived_pending_revoke(
+                    dest,
+                    server_url=identity.server_url,
+                    slug=identity.slug,
+                    device_id=identity.device_id,
+                    last_error="archived report unsettled",
+                    report_status="archived",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent %s: failed to write pending_revoke marker: %s",
+                    agent_id, exc,
+                )
+            return
         try:
             await revoke_archived_device(dest, slug=pc.slug)
             logger.info("agent %s: device revoked server-side", agent_id)
@@ -493,6 +521,17 @@ class Daemon:
             cfg_for_revoke = AgentConfig.load(agent_id)
         except Exception as exc:  # noqa: BLE001
             logger.warning("agent %s: cfg load for revoke failed: %s", agent_id, exc)
+        # PUF-350: deleted agents left their server status row stale too
+        # ('archived' is the closest lifecycle state — the dashboard
+        # filters it the same way). Same report-before-revoke ordering
+        # as _archive_on_flag.
+        report_settled = True
+        if cfg_for_revoke is not None:
+            try:
+                report_settled = await _report_lifecycle(cfg_for_revoke, "archived")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("agent %s: archived report failed: %s", agent_id, exc)
+                report_settled = False
         src = agent_dir(agent_id)
         if not src.exists():
             return
@@ -519,6 +558,29 @@ class Daemon:
                 )
             return
         pc = cfg_for_revoke.puffo_core
+        if not report_settled:
+            logger.warning(
+                "agent %s: archived report unsettled; deferring revoke + "
+                "delete to the startup sweep (marker in %s)",
+                agent_id, dest,
+            )
+            try:
+                from ..crypto.keystore import KeyStore
+                identity = KeyStore(dest / "keys").load_identity(pc.slug)
+                write_archived_pending_revoke(
+                    dest,
+                    server_url=identity.server_url,
+                    slug=identity.slug,
+                    device_id=identity.device_id,
+                    last_error="archived report unsettled",
+                    report_status="archived",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent %s: failed to write pending_revoke marker: %s",
+                    agent_id, exc,
+                )
+            return
         try:
             await revoke_archived_device(dest, slug=pc.slug)
             logger.info("agent %s: device revoked server-side", agent_id)

--- a/src/puffo_agent/portal/import_agents.py
+++ b/src/puffo_agent/portal/import_agents.py
@@ -658,23 +658,66 @@ def write_archived_pending_revoke(
     slug: str,
     device_id: str,
     last_error: str,
+    report_status: str | None = None,
 ) -> None:
+    """``report_status`` (PUF-350): a lifecycle state (``archived``)
+    that still needs reporting BEFORE the revoke — revoking first
+    would 401 the report forever. The sweep re-reports, drops the
+    field, then revokes."""
     path = archived_pending_revoke_path(archived_agent_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(
-            {
-                "kind": "archive_self_revoke",
-                "server_url": server_url,
-                "slug": slug,
-                "device_id": device_id,
-                "last_error": last_error,
-                "attempted_at": int(time.time() * 1000),
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+    payload: dict = {
+        "kind": "archive_self_revoke",
+        "server_url": server_url,
+        "slug": slug,
+        "device_id": device_id,
+        "last_error": last_error,
+        "attempted_at": int(time.time() * 1000),
+    }
+    if report_status is not None:
+        payload["report_status"] = report_status
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+async def _report_lifecycle_from_dir(
+    archived_path: Path, *, server_url: str, slug: str, status: str,
+) -> bool:
+    """Report a lifecycle state from an archived agent dir's keystore.
+    Same settled semantics as ``daemon._report_lifecycle``: True when
+    delivered or rejected with a deterministic 4xx, False on a
+    transient failure worth retrying next sweep."""
+    from ..crypto.http_client import HttpError, PuffoCoreHttpClient
+    from .control.store import current_machine_id
+
+    http = PuffoCoreHttpClient(server_url, KeyStore(archived_path / "keys"), slug)
+    try:
+        body: dict = {"status": status}
+        machine_id = current_machine_id()
+        if machine_id:
+            body["machine_id"] = machine_id
+        await http.post("/agents/me/heartbeat", body)
+        return True
+    except HttpError as exc:
+        if 400 <= exc.status < 500:
+            logger.warning(
+                "pending lifecycle report %r for %s rejected (HTTP %s); "
+                "giving up: %s",
+                status, slug, exc.status, exc.body,
+            )
+            return True
+        logger.warning(
+            "pending lifecycle report %r for %s failed (HTTP %s); will retry",
+            status, slug, exc.status,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001 — transient (network); retry
+        logger.warning(
+            "pending lifecycle report %r for %s failed; will retry: %s",
+            status, slug, exc,
+        )
+        return False
+    finally:
+        await http.close()
 
 
 class _RetryOutcome(enum.Enum):
@@ -699,6 +742,26 @@ async def _retry_archived_pending_revoke(
         )
         _mark_pending_revoke_broken(marker, str(exc))
         return _RetryOutcome.UNRETRYABLE
+    # PUF-350: a deferred lifecycle report must land (or settle on a
+    # 4xx) before the revoke kills the device's auth. Once settled the
+    # field is dropped so later sweeps go straight to the revoke.
+    report_status = payload.get("report_status")
+    if isinstance(report_status, str) and report_status:
+        settled = await _report_lifecycle_from_dir(
+            archived_path,
+            server_url=server_url,
+            slug=slug,
+            status=report_status,
+        )
+        if not settled:
+            return _RetryOutcome.TRANSIENT
+        write_archived_pending_revoke(
+            archived_path,
+            server_url=server_url,
+            slug=slug,
+            device_id=device_id,
+            last_error=str(payload.get("last_error", "")),
+        )
     keystore = KeyStore(archived_path / "keys")
     try:
         identity = keystore.load_identity(slug)

--- a/tests/test_import_module.py
+++ b/tests/test_import_module.py
@@ -710,6 +710,48 @@ async def test_archive_on_flag_defers_revoke_when_report_unsettled(
     assert payload["slug"] == info["slug"]
 
 
+async def test_delete_on_flag_defers_revoke_when_report_unsettled(
+    mock_server, monkeypatch,
+):
+    """Same defer contract on the delete path: unsettled report keeps
+    the dir as an archive with the deferred marker instead of
+    revoking + rmtree'ing."""
+    from puffo_agent.portal import daemon as daemon_mod
+    from puffo_agent.portal import import_agents as imp
+    from puffo_agent.portal.state import archived_dir
+
+    server, _ = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_source_agent(
+        os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", url,
+    )
+
+    async def _unsettled(_cfg, _status):
+        return False
+
+    async def _must_not_revoke(*_a, **_k):
+        raise AssertionError("revoke must be deferred while the report is unsettled")
+
+    monkeypatch.setattr(daemon_mod, "_report_lifecycle", _unsettled)
+    monkeypatch.setattr(imp, "revoke_archived_device", _must_not_revoke)
+
+    d = daemon_mod.Daemon.__new__(daemon_mod.Daemon)
+
+    async def _noop_stop(_agent_id):
+        return None
+
+    d._stop_worker = _noop_stop
+    await d._delete_on_flag("alpha")
+
+    dests = [p for p in archived_dir().iterdir() if p.name.startswith("alpha-del-")]
+    assert len(dests) == 1, "dir must be kept as archive, not rmtree'd"
+    marker = imp.archived_pending_revoke_path(dests[0])
+    assert marker.exists()
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["report_status"] == "archived"
+    assert payload["slug"] == info["slug"]
+
+
 async def test_sweep_archived_pending_revokes_handles_empty_archived_dir():
     from puffo_agent.portal import import_agents as imp
 

--- a/tests/test_import_module.py
+++ b/tests/test_import_module.py
@@ -53,6 +53,7 @@ def _make_mock_app(state):
     app.router.add_post("/devices/enroll/init", record)
     app.router.add_post("/devices/enroll/{nonce}/complete", record)
     app.router.add_post("/devices/{device_id}/revoke", record)
+    app.router.add_post("/agents/me/heartbeat", record)
     return app
 
 
@@ -559,6 +560,154 @@ async def test_sweep_archived_pending_revokes_leaves_marker_on_transient_failure
     n = await imp.sweep_archived_pending_revokes()
     assert n == 0
     assert imp.archived_pending_revoke_path(dest).exists()
+
+
+# ── PUF-350: deferred lifecycle report (report must precede revoke) ──
+
+
+def _seed_archived_with_marker(url, info, **marker_kwargs):
+    from puffo_agent.portal import import_agents as imp
+    from puffo_agent.portal.state import agent_dir, archived_dir
+
+    archived_dir().mkdir(parents=True, exist_ok=True)
+    dest = archived_dir() / "alpha-20260702-120000"
+    Path(agent_dir("alpha")).rename(dest)
+    imp.write_archived_pending_revoke(
+        dest,
+        server_url=url,
+        slug=info["slug"],
+        device_id=info["old_device_id"],
+        **marker_kwargs,
+    )
+    return dest
+
+
+async def test_sweep_reports_deferred_lifecycle_then_revokes(mock_server):
+    """A marker carrying ``report_status`` heartbeats the state first,
+    then revokes — the report would 401 after the revoke."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_source_agent(
+        os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", url,
+    )
+    dest = _seed_archived_with_marker(
+        url, info,
+        last_error="archived report unsettled",
+        report_status="archived",
+    )
+
+    n = await imp.sweep_archived_pending_revokes()
+    assert n == 1
+    assert not imp.archived_pending_revoke_path(dest).exists()
+    ordered = [
+        p for (m, p) in state["calls"]
+        if p == "/agents/me/heartbeat"
+        or p == f"/devices/{info['old_device_id']}/revoke"
+    ]
+    assert ordered.index("/agents/me/heartbeat") < ordered.index(
+        f"/devices/{info['old_device_id']}/revoke"
+    )
+
+
+async def test_sweep_transient_report_failure_defers_revoke(mock_server):
+    """Heartbeat 500 → marker kept (report_status intact) and the
+    revoke is NOT attempted — auth must survive for the next retry."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    state["fail"] = {"heartbeat"}
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_source_agent(
+        os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", url,
+    )
+    dest = _seed_archived_with_marker(
+        url, info,
+        last_error="archived report unsettled",
+        report_status="archived",
+    )
+
+    n = await imp.sweep_archived_pending_revokes()
+    assert n == 0
+    marker = imp.archived_pending_revoke_path(dest)
+    assert marker.exists()
+    assert json.loads(marker.read_text(encoding="utf-8"))["report_status"] == "archived"
+    assert not any("revoke" in p for (_, p) in state["calls"])
+
+
+async def test_sweep_drops_report_status_once_settled(mock_server):
+    """Report lands but the revoke 500s → the rewritten marker drops
+    ``report_status`` so the next sweep goes straight to the revoke
+    without a duplicate heartbeat."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    state["fail"] = {"revoke"}
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_source_agent(
+        os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", url,
+    )
+    dest = _seed_archived_with_marker(
+        url, info,
+        last_error="archived report unsettled",
+        report_status="archived",
+    )
+
+    n = await imp.sweep_archived_pending_revokes()
+    assert n == 0
+    marker = imp.archived_pending_revoke_path(dest)
+    assert marker.exists()
+    assert "report_status" not in json.loads(marker.read_text(encoding="utf-8"))
+
+    state["fail"] = set()
+    heartbeats_before = sum(1 for (_, p) in state["calls"] if p == "/agents/me/heartbeat")
+    n = await imp.sweep_archived_pending_revokes()
+    assert n == 1
+    assert not marker.exists()
+    heartbeats_after = sum(1 for (_, p) in state["calls"] if p == "/agents/me/heartbeat")
+    assert heartbeats_after == heartbeats_before
+
+
+async def test_archive_on_flag_defers_revoke_when_report_unsettled(
+    mock_server, monkeypatch,
+):
+    """Daemon glue: an unsettled archived report writes the deferred
+    marker and skips the immediate revoke entirely."""
+    from puffo_agent.portal import daemon as daemon_mod
+    from puffo_agent.portal import import_agents as imp
+    from puffo_agent.portal.state import archived_dir
+
+    server, _ = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_source_agent(
+        os.environ["PUFFO_AGENT_HOME"], "alpha", "alpha-bot", url,
+    )
+
+    async def _unsettled(_cfg, _status):
+        return False
+
+    async def _must_not_revoke(*_a, **_k):
+        raise AssertionError("revoke must be deferred while the report is unsettled")
+
+    monkeypatch.setattr(daemon_mod, "_report_lifecycle", _unsettled)
+    monkeypatch.setattr(imp, "revoke_archived_device", _must_not_revoke)
+
+    d = daemon_mod.Daemon.__new__(daemon_mod.Daemon)
+
+    async def _noop_stop(_agent_id):
+        return None
+
+    d._stop_worker = _noop_stop
+    await d._archive_on_flag("alpha")
+
+    dests = [p for p in archived_dir().iterdir() if p.name.startswith("alpha-ws-")]
+    assert len(dests) == 1
+    marker = imp.archived_pending_revoke_path(dests[0])
+    assert marker.exists()
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["report_status"] == "archived"
+    assert payload["slug"] == info["slug"]
 
 
 async def test_sweep_archived_pending_revokes_handles_empty_archived_dir():


### PR DESCRIPTION
## Summary

Root-cause fix for FB-361's permanent-stale-row remnant. Previously the archive/delete flows always revoked the agent's device even when the preceding `archived` lifecycle report failed transiently. The revoke immediately 401s any future report attempt, so the row can never recover — it stays stale forever.

**Fix:** `_report_lifecycle` already returned `bool` (settled vs transient); the archive/delete flows now branch on it. On a transient failure they write the existing `archived_pending_revoke` marker with a new `report_status` field, defer the revoke, and let the startup sweep re-report first — then drop the field and proceed to revoke. Report → revoke ordering is preserved every path.

- `_archive_on_flag` — captures `_report_lifecycle` return; on unsettled, writes marker with `report_status="archived"` and skips the immediate revoke.
- `_delete_on_flag` — deleted agents left stale rows too (the daemon never sent an archived state for them). Added the same report-then-revoke ordering + defer-on-unsettled logic; "archived" is the closest lifecycle state and the dashboard filter treats it the same.
- `_retry_archived_pending_revoke` — reads `report_status`; if present, calls a new `_report_lifecycle_from_dir` (same settled semantics as `_report_lifecycle` but reads keys from the archived dir since the agent home is gone). If unsettled, keeps the marker. If settled, rewrites the marker without `report_status` so the next sweep goes straight to the revoke without a duplicate heartbeat.
- Legacy markers without the new field revoke immediately (backwards-compat).

Independent of the sibling puffo-server + client/web PUF-350 changes — this fixes the archive/delete self-report path, which uses the pre-existing `/agents/me/heartbeat` endpoint (unchanged).

## Test plan

- [x] `python3 -m pytest tests/test_import_module.py` — **28/28 pass** (4 new: `test_sweep_reports_deferred_lifecycle_then_revokes`, `test_sweep_transient_report_failure_defers_revoke`, `test_sweep_drops_report_status_once_settled`, `test_archive_on_flag_defers_revoke_when_report_unsettled`).
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1736 pass / 5 fail**. Failure set byte-identical to `origin/main` on the same host (`diff /tmp/puf350-agent-main-fails.txt /tmp/puf350-agent-pr-fails.txt` → clean). **Zero regression.**
- [x] Report-before-revoke ordering pinned by `test_sweep_reports_deferred_lifecycle_then_revokes` (asserts `/agents/me/heartbeat` index < `/devices/{id}/revoke` index in mock server call log).
- [ ] Post-merge external-verify: Vase reproduces FB-361 (or a simulated equivalent) — archive with server briefly 500'ing the report → marker persists → next sweep re-reports + revokes.

## Coverage gap noted for follow-up

- `_delete_on_flag`'s defer branch mirrors `_archive_on_flag`'s but has no dedicated test (only via the shared `_retry_archived_pending_revoke` path). Trivial to add; not blocking.

## Other side state

- **puffo-server** `puf-350-operator-archive` (PR opening now) — extends `PUT /v2/agents/{slug}/status` for the owner-forced archive safety-net. **Independent of this PR** (uses the existing `/agents/me/heartbeat` endpoint).
- **client/web** `puf-350-dashboard-archive` (PR opening now) — dashboard Mark Archived button + Nova AC δ guard. Depends on the puffo-server side.

Ticket: PUF-350 (tri-side)