### PR TITLE
Memory M1: memory tree + bounded briefing compile in the fat Python agent

### DIFF
--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -94,7 +94,7 @@ class PuffoAgent:
         self.agent_id = agent_id
         self.logger = agent_logger(__name__, agent_id)
 
-        self.memory = MemoryManager(memory_dir)
+        self.memory = MemoryManager(memory_dir, workspace_dir=workspace_dir)
         self.memory_dir = memory_dir
 
         # Conversation log shared across all channels.

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -1,37 +1,425 @@
-import os
-import glob
+"""Agent memory tree (M1): bounded briefing compile + notes.
+
+Layout under an agent's memory root::
+
+    memory/
+      briefing/           # always-loaded; compiled (bounded) into the
+        profile.md        #   provider prompt artifacts. profile.md is
+        <topic>.md        #   identity framing, synced from agent.yml.
+      notes/              # durable detail; searchable, never injected
+      recollection/       # reserved (M4)
+      imports/index.md    # reserved; provenance of imported content
+
+The compile is deterministic (profile first, then sorted filenames)
+and fails closed: an over-limit briefing raises
+``BriefingCompileError`` rather than truncating.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
 from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+BRIEFING_DIR = "briefing"
+NOTES_DIR = "notes"
+RECOLLECTION_DIR = "recollection"
+IMPORTS_DIR = "imports"
+
+# Bounded-briefing budget (M1 ships the top of the design's ranges;
+# M2 may tighten). Byte sizes of the UTF-8 encoded content.
+PER_FILE_LIMIT = 16 * 1024
+TOTAL_LIMIT = 64 * 1024
+
+PROFILE_BRIEFING_NAME = "profile.md"
+MIGRATED_NOTES_TOPIC = "migrated-notes"
+
+_IMPORTS_INDEX_SEED = """\
+# Imports index
+
+Provenance of content imported into this agent's memory. Reserved —
+maintained by the platform; one entry per import.
+"""
+
+PROFILE_MANAGED_BEGIN = "<!-- puffo:managed-profile -->"
+PROFILE_MANAGED_END = "<!-- /puffo:managed-profile -->"
+
+_MANAGED_BLOCK_RE = re.compile(
+    re.escape(PROFILE_MANAGED_BEGIN) + r".*?" + re.escape(PROFILE_MANAGED_END),
+    re.DOTALL,
+)
+
+
+class BriefingCompileError(Exception):
+    """A briefing violates the compile budget. Fail closed — callers
+    get no truncated/partial output. ``code`` is one of
+    ``memory_file_too_large`` / ``memory_briefing_too_large``
+    (M3-aligned names)."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        size: int,
+        limit: int,
+        suggestion: str,
+    ):
+        self.code = code
+        self.path = path
+        self.size = size
+        self.limit = limit
+        self.suggestion = suggestion
+        super().__init__(
+            f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "path": self.path,
+            "size": self.size,
+            "limit": self.limit,
+            "suggestion": self.suggestion,
+        }
+
+
+def ensure_memory_tree(memory_root: Path) -> None:
+    """Create the M1 memory tree under ``memory_root``. Idempotent;
+    never touches existing content. All paths are built by joining
+    fixed names under the root — nothing is written outside it."""
+    memory_root = Path(memory_root)
+    for sub in (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR, IMPORTS_DIR):
+        (memory_root / sub).mkdir(parents=True, exist_ok=True)
+    index = memory_root / IMPORTS_DIR / "index.md"
+    if not index.exists():
+        index.write_text(_IMPORTS_INDEX_SEED, encoding="utf-8")
+
+
+def _byte_size(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def _is_briefing_topic(path: Path) -> bool:
+    return (
+        path.is_file()
+        and path.suffix == ".md"
+        and not path.name.startswith(".")
+    )
+
+
+def _read_briefing_entries(
+    memory_root: Path, *, enforce_per_file: bool = True,
+) -> tuple[str, list[tuple[str, str]]]:
+    """``(profile_body, [(stem, body), ...])`` in compile order:
+    profile first, remaining topics by sorted filename. Empty bodies
+    are dropped. Raises ``BriefingCompileError`` on a per-file limit
+    violation unless ``enforce_per_file`` is off."""
+    briefing = Path(memory_root) / BRIEFING_DIR
+    profile_body = ""
+    entries: list[tuple[str, str]] = []
+    if not briefing.is_dir():
+        return profile_body, entries
+    profile_path = briefing / PROFILE_BRIEFING_NAME
+    paths = [p for p in sorted(briefing.glob("*.md")) if _is_briefing_topic(p)]
+    if profile_path in paths:
+        paths.remove(profile_path)
+        paths.insert(0, profile_path)
+    for path in paths:
+        body = path.read_text(encoding="utf-8")
+        if enforce_per_file and _byte_size(body) > PER_FILE_LIMIT:
+            raise BriefingCompileError(
+                "memory_file_too_large",
+                path=str(path),
+                size=_byte_size(body),
+                limit=PER_FILE_LIMIT,
+                suggestion=(
+                    "Trim this briefing topic; move detail to "
+                    f"memory/{NOTES_DIR}/ (searchable, not injected)."
+                ),
+            )
+        body = body.strip()
+        if not body:
+            continue
+        if path == profile_path:
+            profile_body = body
+        else:
+            entries.append((path.stem, body))
+    return profile_body, entries
+
+
+def _compose_briefing(profile_body: str, entries: list[tuple[str, str]]) -> str:
+    parts: list[str] = []
+    if profile_body:
+        parts.append(profile_body)
+    for stem, body in entries:
+        parts.append(f"### {stem}\n\n{body}")
+    return "\n\n".join(parts)
+
+
+def compile_briefing(memory_root: Path) -> str:
+    """Deterministically compile ``briefing/`` into one prompt block:
+    profile.md body first (verbatim), then every other ``*.md`` as a
+    ``### <stem>`` section in sorted filename order. Enforces
+    ``PER_FILE_LIMIT`` per file and ``TOTAL_LIMIT`` on the joined
+    output; raises ``BriefingCompileError`` instead of truncating.
+    Returns ``""`` for an empty/missing briefing."""
+    memory_root = Path(memory_root)
+    profile_body, entries = _read_briefing_entries(memory_root)
+    compiled = _compose_briefing(profile_body, entries)
+    total = _byte_size(compiled)
+    if total > TOTAL_LIMIT:
+        raise BriefingCompileError(
+            "memory_briefing_too_large",
+            path=str(memory_root / BRIEFING_DIR),
+            size=total,
+            limit=TOTAL_LIMIT,
+            suggestion=(
+                "The compiled briefing exceeds the total budget; move "
+                f"topics to memory/{NOTES_DIR}/ or trim them."
+            ),
+        )
+    return compiled
+
+
+def migrate_flat_memory(memory_root: Path) -> list[str]:
+    """Migrate legacy flat ``memory/*.md`` files into the tree.
+
+    Deterministic rule: files are processed in sorted filename order
+    (``README.md`` and dotfiles excluded). A file moves to
+    ``briefing/<name>`` iff it is ≤ ``PER_FILE_LIMIT`` bytes, the
+    briefing slot is free, and the would-be compiled briefing
+    (current briefing + already-migrated files + this file) stays
+    ≤ ``TOTAL_LIMIT``; otherwise it moves to ``notes/<name>`` (or
+    ``notes/<stem>-migrated.md`` on collision) and a pointer line is
+    appended to ``briefing/migrated-notes.md``. Idempotent: a pass
+    leaves no flat ``*.md`` behind, so re-runs are no-ops.
+
+    Returns the migrated files' new memory-root-relative paths.
+    """
+    memory_root = Path(memory_root)
+    if not memory_root.is_dir():
+        return []
+    ensure_memory_tree(memory_root)
+    flat = [
+        p for p in sorted(memory_root.glob("*.md"))
+        if p.is_file() and p.name != "README.md" and not p.name.startswith(".")
+    ]
+    if not flat:
+        return []
+
+    briefing_dir = memory_root / BRIEFING_DIR
+    notes_dir = memory_root / NOTES_DIR
+    pointer_path = briefing_dir / f"{MIGRATED_NOTES_TOPIC}.md"
+
+    # Live simulation state: recomposing from these on every candidate
+    # keeps the fit check exact (section headers + join separators
+    # count toward the total, and so do appended pointer lines).
+    profile_body, entries = _read_briefing_entries(
+        memory_root, enforce_per_file=False,
+    )
+    entry_map: dict[str, str] = dict(entries)
+
+    def compiled_size_with(stem: str, body: str) -> int:
+        candidate = dict(entry_map)
+        candidate[stem] = body.strip()
+        composed = _compose_briefing(
+            profile_body, sorted(candidate.items()),
+        )
+        return _byte_size(composed)
+
+    moved: list[str] = []
+    for path in flat:
+        body = path.read_text(encoding="utf-8")
+        fits_briefing = (
+            _byte_size(body) <= PER_FILE_LIMIT
+            and path.name != PROFILE_BRIEFING_NAME
+            and not (briefing_dir / path.name).exists()
+            and compiled_size_with(path.stem, body) <= TOTAL_LIMIT
+        )
+        if fits_briefing:
+            dest = briefing_dir / path.name
+            path.rename(dest)
+            entry_map[path.stem] = body.strip()
+            moved.append(f"{BRIEFING_DIR}/{dest.name}")
+            continue
+        dest = notes_dir / path.name
+        if dest.exists():
+            dest = notes_dir / f"{path.stem}-migrated.md"
+            n = 2
+            while dest.exists():
+                dest = notes_dir / f"{path.stem}-migrated-{n}.md"
+                n += 1
+        path.rename(dest)
+        pointer_line = (
+            f"- {NOTES_DIR}/{dest.name} — migrated from flat memory\n"
+        )
+        existing = ""
+        if pointer_path.exists():
+            existing = pointer_path.read_text(encoding="utf-8")
+        elif not entry_map.get(MIGRATED_NOTES_TOPIC):
+            existing = "# Migrated notes\n\n"
+        pointer_path.write_text(existing + pointer_line, encoding="utf-8")
+        entry_map[MIGRATED_NOTES_TOPIC] = (existing + pointer_line).strip()
+        moved.append(f"{NOTES_DIR}/{dest.name}")
+    return moved
+
+
+def render_profile_briefing(
+    *,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+    soul: str = "",
+) -> str:
+    """Identity framing for ``briefing/profile.md``: display name,
+    role lines, soul body. Deliberately NO ``## Instructions`` and no
+    runtime-behavior sections — those live in the agent-root
+    profile.md / primer. Missing fields degrade to a minimal identity
+    line derived from agent id + display name."""
+    name = display_name or agent_id or "agent"
+    identity = f"You are {name}"
+    if agent_id:
+        identity += f" (agent `{agent_id}`)"
+    identity += "."
+    lines = [f"# {name}", "", identity]
+    if role:
+        lines += ["", f"Role: {role}"]
+    if role_short:
+        lines.append(f"Role (short): {role_short}")
+    if soul.strip():
+        lines += ["", "## Soul", "", soul.strip()]
+    return "\n".join(lines) + "\n"
+
+
+def sync_profile_briefing(
+    memory_root: Path,
+    *,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+    soul: str = "",
+) -> Path:
+    """(Re)write the managed block of ``briefing/profile.md`` from the
+    native profile surfaces (agent.yml identity fields + the ``# Soul``
+    body of agent-root profile.md). Content between the
+    ``puffo:managed-profile`` markers is regenerated on every managed
+    rebuild; user-authored text outside the markers is preserved."""
+    memory_root = Path(memory_root)
+    ensure_memory_tree(memory_root)
+    path = memory_root / BRIEFING_DIR / PROFILE_BRIEFING_NAME
+    rendered = render_profile_briefing(
+        agent_id=agent_id,
+        display_name=display_name,
+        role=role,
+        role_short=role_short,
+        soul=soul,
+    )
+    block = f"{PROFILE_MANAGED_BEGIN}\n{rendered}{PROFILE_MANAGED_END}\n"
+    if path.exists():
+        text = path.read_text(encoding="utf-8")
+        if _MANAGED_BLOCK_RE.search(text):
+            new_text = _MANAGED_BLOCK_RE.sub(
+                lambda _m: block.rstrip("\n"), text, count=1,
+            )
+        else:
+            # Pre-existing user file without markers: identity framing
+            # leads, user content follows untouched.
+            new_text = block + "\n" + text
+        path.write_text(new_text, encoding="utf-8")
+    else:
+        path.write_text(block, encoding="utf-8")
+    return path
 
 
 class MemoryManager:
-    def __init__(self, memory_dir: str):
-        self.memory_dir = memory_dir
-        self.memories: dict[str, str] = {}
-        self._load()
+    """Compat shim over the memory tree. ``save()`` keeps its historic
+    name/signature but writes a briefing topic (bounded, fail closed)
+    and marks the prompt artifacts for rebuild; ``get_context()``
+    returns the compiled briefing instead of a full join."""
 
-    def _load(self):
-        for path in glob.glob(os.path.join(self.memory_dir, "*.md")):
-            if os.path.basename(path) == "README.md":
-                continue
-            with open(path, "r", encoding="utf-8") as f:
-                content = f.read()
-            topic = os.path.splitext(os.path.basename(path))[0]
-            self.memories[topic] = content
+    def __init__(self, memory_dir: str, workspace_dir: str = ""):
+        self.memory_dir = memory_dir
+        self.workspace_dir = workspace_dir
+        ensure_memory_tree(Path(memory_dir))
 
     def get_context(self) -> str:
-        if not self.memories:
-            return ""
-        parts = ["## Memory\n"]
-        for topic, content in self.memories.items():
-            parts.append(f"### {topic}\n{content}\n")
-        return "\n".join(parts)
+        return compile_briefing(Path(self.memory_dir))
 
     def save(self, topic: str, content: str):
-        self.memories[topic] = content
         safe_topic = topic.replace(" ", "_").replace("/", "-")
-        path = os.path.join(self.memory_dir, f"{safe_topic}.md")
+        path = Path(self.memory_dir) / BRIEFING_DIR / f"{safe_topic}.md"
         # Aware-UTC with ``Z`` suffix (``datetime.utcnow`` is
         # deprecated in 3.12+).
         updated = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n")
+        body = f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n"
+        size = _byte_size(body)
+        if size > PER_FILE_LIMIT:
+            raise BriefingCompileError(
+                "memory_file_too_large",
+                path=str(path),
+                size=size,
+                limit=PER_FILE_LIMIT,
+                suggestion=(
+                    "Save a shorter briefing topic; put the detail in "
+                    f"memory/{NOTES_DIR}/ instead."
+                ),
+            )
+        # Pre-validate the would-be compiled total so an oversized
+        # save never leaves partial state behind.
+        profile_body, entries = _read_briefing_entries(
+            Path(self.memory_dir), enforce_per_file=False,
+        )
+        entry_map = dict(entries)
+        if safe_topic == "profile":
+            profile_body = body.strip()
+        else:
+            entry_map[safe_topic] = body.strip()
+        total = _byte_size(
+            _compose_briefing(profile_body, sorted(entry_map.items()))
+        )
+        if total > TOTAL_LIMIT:
+            raise BriefingCompileError(
+                "memory_briefing_too_large",
+                path=str(path),
+                size=total,
+                limit=TOTAL_LIMIT,
+                suggestion=(
+                    "This save would push the compiled briefing over "
+                    f"budget; move topics to memory/{NOTES_DIR}/ first."
+                ),
+            )
+        path.write_text(body, encoding="utf-8")
+        self._request_refresh(topic)
+
+    def _request_refresh(self, topic: str) -> None:
+        """Drop ``refresh_agent.flag`` so the worker rebuilds the
+        prompt artifacts on the next batch. Best-effort; same payload
+        shape as ``profile_sync.write_refresh_agent_flag``."""
+        if not self.workspace_dir:
+            return
+        from ..portal.state import refresh_agent_flag_path
+
+        flag_path = refresh_agent_flag_path(Path(self.workspace_dir))
+        try:
+            flag_path.parent.mkdir(parents=True, exist_ok=True)
+            flag_path.write_text(
+                json.dumps({
+                    "version": 1,
+                    "requested_at": int(time.time()),
+                    "reason": f"memory.save:{topic}",
+                }) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "refresh_agent.flag write failed after memory save (%s): %s",
+                topic, exc,
+            )

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -3,8 +3,8 @@
 The shared platform primer (``~/.puffo-agent/docker/shared/CLAUDE.md``)
 is folded into each agent's generated CLAUDE.md at worker startup.
 ``ensure_shared_primer`` syncs the baked-in primer to disk on every worker
-startup; ``assemble_claude_md``
-combines primer + profile + memory snapshot into the per-agent prompt.
+startup; ``assemble_claude_md`` combines primer + profile + the compiled
+memory briefing (bounded; see ``agent.memory``) into the per-agent prompt.
 """
 
 from __future__ import annotations
@@ -222,23 +222,35 @@ use filenames that identify you (e.g. `notes-from-<your-id>.md`).
 
 ## Memory
 
-`memory/` snapshot is folded into this prompt. Write markdown to
-`memory/<topic>.md` to remember across sessions; takes effect on
-the next worker restart.
+Your memory is a small tree under `memory/`:
+
+- `memory/briefing/<topic>.md` — durable facts you always want in
+  context. Compiled into this prompt, bounded: 16KB per file, 64KB
+  total. An over-budget briefing FAILS the prompt rebuild (no silent
+  truncation), so keep topics tight.
+- `memory/briefing/profile.md` — your identity framing; managed by
+  puffo-agent from your profile. Don't edit the managed block.
+- `memory/notes/` — unbounded detail; lives on disk for you to read
+  or grep, never injected into your prompt.
+- `memory/recollection/`, `memory/imports/` — reserved for the
+  platform.
+
+Write markdown, then call `refresh()`; briefing changes land in your
+prompt on the next turn.
 
 ## Your two CLAUDE.md layers (cli-local / cli-docker only)
 
 Claude Code concatenates two files:
 
 1. **`~/.claude/CLAUDE.md`** — managed by puffo-agent (this primer
-   + `profile.md` + `memory/` snapshot); overwritten every worker
-   start, don't edit.
+   + `profile.md` + compiled `memory/briefing/`); overwritten on
+   every rebuild, don't edit.
 2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace
    — yours to edit; puffo-agent never touches it.
 
-Use layer 2 for fast prompt updates; use `memory/*.md` (folds into
-layer 1 on next restart) when you want content labelled as memory.
-`sdk` and codex only have layer 1 — go through `memory/*.md`.
+Use layer 2 for fast prompt updates; use `memory/briefing/*.md` +
+`refresh()` when you want content labelled as memory. `sdk` and
+codex only have layer 1 — go through `memory/briefing/*.md`.
 Codex's equivalent is `$CODEX_HOME/AGENTS.md`.
 
 ## Permission prompts (cli-local only)
@@ -601,7 +613,7 @@ axes; combine them freely.
 | `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, full worker respawn. Implicit fresh session. |
 
 **When to use:**
-- Edited `CLAUDE.md`, `profile.md`, `memory/*.md` → `refresh()`.
+- Edited `CLAUDE.md`, `profile.md`, `memory/briefing/*.md` → `refresh()`.
 - Installed a new skill / MCP → `refresh()`.
 - Operator added a new skill to their `~/.claude/skills/` → tell them
   to call it "host-sync" and use `refresh(host_sync=True[, session=True])`.
@@ -1196,43 +1208,61 @@ def read_shared_primer(shared_dir: Path) -> str:
         return ""
 
 
-def read_memory_snapshot(memory_dir: Path) -> str:
-    """Concatenate every ``*.md`` in ``memory_dir`` (sorted, so output
-    is deterministic). Returns ``""`` when the directory is missing
-    or empty.
+def compile_agent_memory_briefing(
+    *,
+    memory_dir: Path,
+    profile_text: str,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+) -> str:
+    """Bring the memory tree up to date and return the compiled
+    bounded briefing: ensure the tree, migrate legacy flat
+    ``memory/*.md``, re-sync ``briefing/profile.md`` from the native
+    profile surfaces (agent.yml identity fields + the ``# Soul`` body
+    of agent-root profile.md), then compile ``briefing/``.
+
+    Raises ``memory.BriefingCompileError`` (fail closed — no
+    truncation) when the briefing violates its budget.
     """
-    if not memory_dir.is_dir():
-        return ""
-    parts: list[str] = []
-    for path in sorted(memory_dir.glob("*.md")):
-        if path.name == "README.md":
-            continue
-        try:
-            body = path.read_text(encoding="utf-8").strip()
-        except OSError:
-            continue
-        if not body:
-            continue
-        parts.append(f"### {path.stem}\n\n{body}")
-    return "\n\n".join(parts)
+    from ..portal.profile_sync import extract_soul_body
+    from .memory import (
+        compile_briefing,
+        ensure_memory_tree,
+        migrate_flat_memory,
+        sync_profile_briefing,
+    )
+
+    ensure_memory_tree(memory_dir)
+    migrate_flat_memory(memory_dir)
+    sync_profile_briefing(
+        memory_dir,
+        agent_id=agent_id,
+        display_name=display_name,
+        role=role,
+        role_short=role_short,
+        soul=extract_soul_body(profile_text),
+    )
+    return compile_briefing(memory_dir)
 
 
 def assemble_claude_md(
     *,
     shared_primer: str,
     profile: str,
-    memory_snapshot: str,
+    memory_briefing: str,
 ) -> str:
     """Produce the per-agent CLAUDE.md. Order: primer (platform
-    conventions) → role → memory.
+    conventions) → role → memory (the compiled bounded briefing).
     """
     parts: list[str] = []
     if shared_primer.strip():
         parts.append(shared_primer.strip())
     if profile.strip():
         parts.append("---\n\n# Your role\n\n" + profile.strip())
-    if memory_snapshot.strip():
-        parts.append("---\n\n# Your memory\n\n" + memory_snapshot.strip())
+    if memory_briefing.strip():
+        parts.append("---\n\n# Your memory\n\n" + memory_briefing.strip())
     return "\n\n".join(parts) + "\n"
 
 
@@ -1279,14 +1309,19 @@ def rebuild_agent_codex_md(
     memory_dir: Path,
     workspace_dir: Path,
     codex_user_dir: Path,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> str:
     """Assemble + write one codex agent's AGENTS.md.
 
     Same content shape as ``rebuild_agent_claude_md`` (shared primer +
-    agent profile + memory snapshot), targeting codex's instruction-
-    file path. Skill bodies mirror into ``workspace/.agents/skills/``
-    where codex's project-scope discovery walks; the SKILL.md +
-    frontmatter shape is identical to Claude Code's.
+    agent profile + compiled memory briefing), targeting codex's
+    instruction-file path. Skill bodies mirror into
+    ``workspace/.agents/skills/`` where codex's project-scope discovery
+    walks; the SKILL.md + frontmatter shape is identical to Claude
+    Code's.
     """
     ensure_shared_primer(shared_dir)
     sync_shared_skills_codex(shared_dir, workspace_dir)
@@ -1298,7 +1333,14 @@ def rebuild_agent_codex_md(
     agents_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
-        memory_snapshot=read_memory_snapshot(memory_dir),
+        memory_briefing=compile_agent_memory_briefing(
+            memory_dir=memory_dir,
+            profile_text=profile_text,
+            agent_id=agent_id,
+            display_name=display_name,
+            role=role,
+            role_short=role_short,
+        ),
     )
     write_agents_md(codex_user_dir, agents_md)
     return agents_md
@@ -1312,13 +1354,20 @@ def rebuild_agent_claude_md(
     workspace_dir: Path,
     claude_user_dir: Path,
     gemini_user_dir: Path,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> str:
     """Assemble + write one agent's managed CLAUDE.md / GEMINI.md.
 
     Seeds the shared primer if missing, mirrors shared skills into the
-    workspace, reads the agent's ``profile.md`` + memory snapshot, then
-    writes the combined prompt to the agent's USER-level ``.claude/`` /
-    ``.gemini/`` dirs. Returns the assembled CLAUDE.md string.
+    workspace, reads the agent's ``profile.md``, brings the memory tree
+    up to date (ensure/migrate/profile-sync) and compiles the bounded
+    briefing, then writes the combined prompt to the agent's USER-level
+    ``.claude/`` / ``.gemini/`` dirs. Returns the assembled CLAUDE.md
+    string. Raises ``memory.BriefingCompileError`` when the briefing
+    is over budget (fail closed — the previous artifact is kept).
 
     Shared by the worker's startup path and the ``agent reset-primer``
     CLI command so the assembly sequence lives in exactly one place.
@@ -1333,7 +1382,14 @@ def rebuild_agent_claude_md(
     claude_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
-        memory_snapshot=read_memory_snapshot(memory_dir),
+        memory_briefing=compile_agent_memory_briefing(
+            memory_dir=memory_dir,
+            profile_text=profile_text,
+            agent_id=agent_id,
+            display_name=display_name,
+            role=role,
+            role_short=role_short,
+        ),
     )
     write_claude_md(claude_user_dir, claude_md)
     write_gemini_md(gemini_user_dir, claude_md)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -525,7 +525,8 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     )
     cfg.save()
 
-    (target / "memory").mkdir(exist_ok=True)
+    from ..agent.memory import ensure_memory_tree
+    ensure_memory_tree(target / "memory")
 
     profile_path = target / "profile.md"
     if args.profile and Path(args.profile).exists():
@@ -1498,6 +1499,7 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
     """Re-sync the shared primer + rebuild the listed agents' CLAUDE.md.
     ensure_shared_primer runs on every worker startup, so this is only
     needed to force a rebuild without waiting for a message."""
+    from ..agent.memory import BriefingCompileError
     from ..agent.shared_content import (
         ensure_shared_primer,
         rebuild_agent_claude_md,
@@ -1522,14 +1524,23 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
             print(f"error: agent {agent_id!r}: {exc}", file=sys.stderr)
             rc = 2
             continue
-        rebuild_agent_claude_md(
-            shared_dir=shared_dir,
-            profile_path=cfg.resolve_profile_path(),
-            memory_dir=cfg.resolve_memory_dir(),
-            workspace_dir=cfg.resolve_workspace_dir(),
-            claude_user_dir=agent_claude_user_dir(agent_id),
-            gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
-        )
+        try:
+            rebuild_agent_claude_md(
+                shared_dir=shared_dir,
+                profile_path=cfg.resolve_profile_path(),
+                memory_dir=cfg.resolve_memory_dir(),
+                workspace_dir=cfg.resolve_workspace_dir(),
+                claude_user_dir=agent_claude_user_dir(agent_id),
+                gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
+                agent_id=agent_id,
+                display_name=cfg.display_name,
+                role=cfg.role,
+                role_short=cfg.role_short,
+            )
+        except BriefingCompileError as exc:
+            print(f"error: agent {agent_id!r}: {exc}", file=sys.stderr)
+            rc = 2
+            continue
         rebuilt.append(agent_id)
         print(f"rebuilt CLAUDE.md for {agent_id!r}")
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -57,12 +57,17 @@ def _rebuild_managed_system_prompt(
     profile_path: str,
     memory_path: str,
     workspace_path: str,
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> str:
     """Dispatch wrapper: write the right system-prompt file(s) for the
     agent's harness. Codex agents get ``$CODEX_HOME/AGENTS.md``; every
     other harness goes through the legacy claude-code path (which also
     writes GEMINI.md for the gemini-cli harness sharing the same body).
-    Returns the assembled prompt body either way.
+    Returns the assembled prompt body either way. The identity fields
+    feed the managed ``memory/briefing/profile.md`` re-sync inside the
+    rebuild.
     """
     if harness_name == "codex":
         return rebuild_agent_codex_md(
@@ -71,6 +76,10 @@ def _rebuild_managed_system_prompt(
             memory_dir=Path(memory_path),
             workspace_dir=Path(workspace_path),
             codex_user_dir=agent_codex_user_dir(agent_id),
+            agent_id=agent_id,
+            display_name=display_name,
+            role=role,
+            role_short=role_short,
         )
     return rebuild_agent_claude_md(
         shared_dir=shared_path,
@@ -79,6 +88,10 @@ def _rebuild_managed_system_prompt(
         workspace_dir=Path(workspace_path),
         claude_user_dir=agent_claude_user_dir(agent_id),
         gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
+        agent_id=agent_id,
+        display_name=display_name,
+        role=role,
+        role_short=role_short,
     )
 
 logger = logging.getLogger(__name__)
@@ -1042,16 +1055,19 @@ class Worker:
             memory_path = str(self.agent_cfg.resolve_memory_dir())
             workspace_path = str(self.agent_cfg.resolve_workspace_dir())
             claude_path = str(self.agent_cfg.resolve_claude_dir())
-            Path(memory_path).mkdir(parents=True, exist_ok=True)
             Path(workspace_path).mkdir(parents=True, exist_ok=True)
             _seed_claude_dir(Path(claude_path))
 
             # Assemble managed CLAUDE.md from shared primer + profile
-            # + memory snapshot. Written to user-level (.claude/
-            # CLAUDE.md) so Claude Code auto-discovers it. The
-            # project-level CLAUDE.md is left for the agent to edit.
-            # chat-local / sdk-local don't auto-discover, so the same
-            # string is passed as PuffoAgent's system_prompt.
+            # + compiled memory briefing. The rebuild ensures the
+            # memory tree + migrates legacy flat memory/*.md first.
+            # Written to user-level (.claude/CLAUDE.md) so Claude Code
+            # auto-discovers it. The project-level CLAUDE.md is left
+            # for the agent to edit. chat-local / sdk-local don't
+            # auto-discover, so the same string is passed as
+            # PuffoAgent's system_prompt. An over-budget briefing
+            # raises BriefingCompileError → caught below, worker init
+            # fails with runtime.status="error" (fail closed).
             shared_path = docker_shared_dir()
             claude_md = _rebuild_managed_system_prompt(
                 harness_name=(self.agent_cfg.runtime.harness or "").strip(),
@@ -1060,6 +1076,9 @@ class Worker:
                 profile_path=profile_path,
                 memory_path=memory_path,
                 workspace_path=workspace_path,
+                display_name=self.agent_cfg.display_name,
+                role=self.agent_cfg.role,
+                role_short=self.agent_cfg.role_short,
             )
 
             # One-time migration: remove an older project-level
@@ -1202,6 +1221,9 @@ class Worker:
                 profile_path=profile_path,
                 memory_path=memory_path,
                 workspace_path=workspace_path,
+                display_name=self.agent_cfg.display_name,
+                role=self.agent_cfg.role,
+                role_short=self.agent_cfg.role_short,
                 puffo=puffo,
                 adapter=self._adapter,
                 refresh_agent_flag=refresh_agent_flag_path,
@@ -1587,6 +1609,9 @@ async def _process_refresh_flags(
     refresh_agent_flag: Path,
     refresh_host_sync_flag: Path,
     refresh_session_flag: Path,
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> None:
     """Consume any worker-scope refresh flags into a single
     ``adapter.reload(prompt, with_session=…)`` call at turn start.
@@ -1627,6 +1652,9 @@ async def _process_refresh_flags(
                 profile_path=profile_path,
                 memory_path=memory_path,
                 workspace_path=workspace_path,
+                display_name=display_name,
+                role=role,
+                role_short=role_short,
             )
             puffo.system_prompt = new_prompt
             logger.info(

--- a/tests/test_memory_m1.py
+++ b/tests/test_memory_m1.py
@@ -1,0 +1,344 @@
+"""M1 memory acceptance tests: memory tree, bounded briefing compile
+(fail closed), managed profile briefing, flat-memory migration, and
+the MemoryManager compat surface (save → briefing topic + refresh
+flag)."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent.memory import (
+    PER_FILE_LIMIT,
+    TOTAL_LIMIT,
+    BriefingCompileError,
+    MemoryManager,
+    compile_briefing,
+    ensure_memory_tree,
+    migrate_flat_memory,
+    render_profile_briefing,
+    sync_profile_briefing,
+)
+from puffo_agent.agent.shared_content import rebuild_agent_claude_md
+
+
+# ── tree creation ────────────────────────────────────────────────────
+
+
+def test_ensure_memory_tree_creates_layout(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    assert (root / "briefing").is_dir()
+    assert (root / "notes").is_dir()
+    assert (root / "recollection").is_dir()
+    assert (root / "imports" / "index.md").is_file()
+    # Exactly the M1 tree, and every created path is inside the root.
+    created = {
+        p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*")
+    }
+    assert created == {
+        "memory",
+        "memory/briefing",
+        "memory/notes",
+        "memory/recollection",
+        "memory/imports",
+        "memory/imports/index.md",
+    }
+
+
+def test_memory_manager_init_seeds_tree(tmp_path):
+    root = tmp_path / "memory"
+    MemoryManager(str(root))
+    assert (root / "briefing").is_dir()
+    assert (root / "notes").is_dir()
+    assert (root / "recollection").is_dir()
+    assert (root / "imports" / "index.md").is_file()
+
+
+def test_ensure_memory_tree_is_idempotent_and_preserves_content(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "briefing" / "facts.md").write_text("kept", encoding="utf-8")
+    (root / "imports" / "index.md").write_text("edited", encoding="utf-8")
+    ensure_memory_tree(root)
+    assert (root / "briefing" / "facts.md").read_text(encoding="utf-8") == "kept"
+    assert (root / "imports" / "index.md").read_text(encoding="utf-8") == "edited"
+
+
+# ── bounded compile, fail closed ─────────────────────────────────────
+
+
+def test_compile_profile_first_then_sorted_topics(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "briefing" / "profile.md").write_text(
+        "# Ada\n\nidentity framing", encoding="utf-8",
+    )
+    (root / "briefing" / "zeta.md").write_text("zeta body", encoding="utf-8")
+    (root / "briefing" / "alpha.md").write_text("alpha body", encoding="utf-8")
+    (root / "notes" / "hidden.md").write_text("never injected", encoding="utf-8")
+    out = compile_briefing(root)
+    assert out.startswith("# Ada")
+    assert out.index("### alpha") < out.index("### zeta")
+    assert "never injected" not in out
+
+
+def test_compile_empty_briefing_is_empty_string(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    assert compile_briefing(root) == ""
+
+
+def test_compile_rejects_oversized_file(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    big = root / "briefing" / "big.md"
+    big.write_text("x" * (PER_FILE_LIMIT + 1), encoding="utf-8")
+    with pytest.raises(BriefingCompileError) as ei:
+        compile_briefing(root)
+    err = ei.value
+    assert err.code == "memory_file_too_large"
+    assert err.path == str(big)
+    assert err.size == PER_FILE_LIMIT + 1
+    assert err.limit == PER_FILE_LIMIT
+    assert err.suggestion
+    assert err.to_dict()["code"] == "memory_file_too_large"
+
+
+def test_compile_rejects_oversized_total(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    # 5 × 15KB topics: each under the per-file limit, 75KB total over
+    # the 64KB budget.
+    for i in range(5):
+        (root / "briefing" / f"topic-{i}.md").write_text(
+            "y" * (15 * 1024), encoding="utf-8",
+        )
+    with pytest.raises(BriefingCompileError) as ei:
+        compile_briefing(root)
+    err = ei.value
+    assert err.code == "memory_briefing_too_large"
+    assert err.path == str(root / "briefing")
+    assert err.size > TOTAL_LIMIT
+    assert err.limit == TOTAL_LIMIT
+
+
+# ── briefing/profile.md content ──────────────────────────────────────
+
+
+def test_profile_briefing_has_identity_and_no_instructions(tmp_path):
+    root = tmp_path / "memory"
+    path = sync_profile_briefing(
+        root,
+        agent_id="ada-0001",
+        display_name="Ada",
+        role="Research helper for the ops team",
+        role_short="Research",
+        soul="Curious and kind.",
+    )
+    assert path == root / "briefing" / "profile.md"
+    text = path.read_text(encoding="utf-8")
+    assert "Ada" in text
+    assert "Research helper for the ops team" in text
+    assert "Curious and kind." in text
+    assert re.search(r"^#{1,6}\s*Instructions", text, re.MULTILINE) is None
+
+
+def test_profile_briefing_minimal_default_with_empty_fields(tmp_path):
+    root = tmp_path / "memory"
+    path = sync_profile_briefing(root, agent_id="bot-42")
+    text = path.read_text(encoding="utf-8")
+    assert "You are bot-42 (agent `bot-42`)." in text
+    # Fully empty still renders a usable identity line.
+    assert "You are agent." in render_profile_briefing()
+
+
+def test_profile_briefing_resync_preserves_user_text_outside_markers(tmp_path):
+    root = tmp_path / "memory"
+    path = sync_profile_briefing(
+        root, agent_id="ada-0001", display_name="Ada", role="Old role",
+    )
+    path.write_text(
+        path.read_text(encoding="utf-8") + "\nUser-authored addendum.\n",
+        encoding="utf-8",
+    )
+    sync_profile_briefing(
+        root, agent_id="ada-0001", display_name="Ada", role="New role",
+    )
+    text = path.read_text(encoding="utf-8")
+    assert "New role" in text
+    assert "Old role" not in text
+    assert "User-authored addendum." in text
+
+
+# ── legacy flat-memory migration ─────────────────────────────────────
+
+
+def _tree_snapshot(root: Path) -> dict[str, str]:
+    return {
+        p.relative_to(root).as_posix(): p.read_text(encoding="utf-8")
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def test_migrate_flat_memory_small_to_briefing_big_to_notes(tmp_path):
+    root = tmp_path / "memory"
+    root.mkdir()
+    (root / "small.md").write_text("a small fact", encoding="utf-8")
+    (root / "big.md").write_text("x" * (PER_FILE_LIMIT + 1), encoding="utf-8")
+    (root / "README.md").write_text("readme stays", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)
+
+    assert (root / "briefing" / "small.md").read_text(encoding="utf-8") == "a small fact"
+    assert (root / "notes" / "big.md").is_file()
+    pointer = (root / "briefing" / "migrated-notes.md").read_text(encoding="utf-8")
+    assert "- notes/big.md — migrated from flat memory" in pointer
+    # No flat *.md remain except README.md.
+    assert [p.name for p in root.glob("*.md")] == ["README.md"]
+    assert (root / "README.md").read_text(encoding="utf-8") == "readme stays"
+    assert set(moved) == {"briefing/small.md", "notes/big.md"}
+    # The migrated tree still compiles within budget.
+    assert "a small fact" in compile_briefing(root)
+
+    # Idempotent: a second pass is a no-op.
+    before = _tree_snapshot(root)
+    assert migrate_flat_memory(root) == []
+    assert _tree_snapshot(root) == before
+
+
+def test_migrate_flat_memory_over_total_budget_goes_to_notes(tmp_path):
+    root = tmp_path / "memory"
+    root.mkdir()
+    ensure_memory_tree(root)
+    # Pre-existing briefing takes 60KB of the 64KB budget…
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * (15 * 1024), encoding="utf-8",
+        )
+    # …so a 10KB flat file (fine per-file) no longer fits the total.
+    (root / "overflow.md").write_text("o" * (10 * 1024), encoding="utf-8")
+
+    moved = migrate_flat_memory(root)
+
+    assert moved == ["notes/overflow.md"]
+    assert (root / "notes" / "overflow.md").is_file()
+    assert not (root / "briefing" / "overflow.md").exists()
+    assert "- notes/overflow.md — migrated from flat memory" in (
+        root / "briefing" / "migrated-notes.md"
+    ).read_text(encoding="utf-8")
+    compile_briefing(root)  # still within budget after migration
+
+
+def test_migrate_flat_memory_name_collision_falls_back(tmp_path):
+    root = tmp_path / "memory"
+    root.mkdir()
+    ensure_memory_tree(root)
+    (root / "briefing" / "facts.md").write_text("already here", encoding="utf-8")
+    (root / "notes" / "facts.md").write_text("also here", encoding="utf-8")
+    (root / "facts.md").write_text("flat version", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)
+
+    assert moved == ["notes/facts-migrated.md"]
+    assert (root / "notes" / "facts-migrated.md").read_text(encoding="utf-8") == "flat version"
+    assert (root / "briefing" / "facts.md").read_text(encoding="utf-8") == "already here"
+    assert (root / "notes" / "facts.md").read_text(encoding="utf-8") == "also here"
+
+
+# ── briefing change → artifact rebuilt ───────────────────────────────
+
+
+def _rebuild(root: Path) -> str:
+    return rebuild_agent_claude_md(
+        shared_dir=root / "shared",
+        profile_path=root / "profile.md",
+        memory_dir=root / "memory",
+        workspace_dir=root / "workspace",
+        claude_user_dir=root / ".claude",
+        gemini_user_dir=root / ".gemini",
+        agent_id="tester-0001",
+        display_name="Tester",
+        role="Tests the memory tree",
+        role_short="Tester",
+    )
+
+
+def test_rebuild_picks_up_new_briefing_topic_and_ignores_notes(tmp_path):
+    (tmp_path / "profile.md").write_text(
+        "# Soul\nI verify briefings.", encoding="utf-8",
+    )
+    (tmp_path / "workspace").mkdir()
+    memory = tmp_path / "memory"
+
+    first = _rebuild(tmp_path)
+    assert "I verify briefings." in first
+
+    (memory / "briefing" / "deploys.md").write_text(
+        "Deploy fact ZQX-77.", encoding="utf-8",
+    )
+    (memory / "notes" / "scratch.md").write_text(
+        "NOTE-ONLY-DETAIL-42", encoding="utf-8",
+    )
+    second = _rebuild(tmp_path)
+    assert "Deploy fact ZQX-77." in second
+    assert "NOTE-ONLY-DETAIL-42" not in second
+    assert (tmp_path / ".claude" / "CLAUDE.md").read_text(encoding="utf-8") == second
+    assert (tmp_path / ".gemini" / "GEMINI.md").read_text(encoding="utf-8") == second
+
+
+def test_rebuild_flag_dropped_by_memory_manager_save(tmp_path):
+    workspace = tmp_path / "workspace"
+    mm = MemoryManager(str(tmp_path / "memory"), workspace_dir=str(workspace))
+    mm.save("deploy notes", "The staging box is flaky.")
+    flag = workspace / ".puffo-agent" / "refresh_agent.flag"
+    assert flag.is_file()
+    payload = json.loads(flag.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert payload["reason"].startswith("memory.save:")
+    assert isinstance(payload["requested_at"], int)
+
+
+# ── MemoryManager.save() compat ──────────────────────────────────────
+
+
+def test_save_writes_briefing_topic_with_frontmatter(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    mm.save("deploy notes/prod", "The fact.")
+    path = root / "briefing" / "deploy_notes-prod.md"
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\ntopic: deploy notes/prod\nupdated: ")
+    assert text.endswith("The fact.\n")
+    assert "The fact." in mm.get_context()
+
+
+def test_save_oversized_file_fails_closed_without_partial_state(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    with pytest.raises(BriefingCompileError) as ei:
+        mm.save("big", "x" * (PER_FILE_LIMIT + 1))
+    assert ei.value.code == "memory_file_too_large"
+    assert not (root / "briefing" / "big.md").exists()
+
+
+def test_save_over_total_budget_fails_closed_without_partial_state(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * (15 * 1024), encoding="utf-8",
+        )
+    with pytest.raises(BriefingCompileError) as ei:
+        mm.save("overflow", "o" * (8 * 1024))
+    assert ei.value.code == "memory_briefing_too_large"
+    assert not (root / "briefing" / "overflow.md").exists()
+
+
+def test_save_without_workspace_dir_drops_no_flag(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    mm.save("topic", "content")
+    assert not list(tmp_path.rglob("refresh_agent.flag"))

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -87,7 +87,8 @@ def test_rebuild_agent_claude_md_assembles_primer_profile_memory():
     profile.write_text("# Soul\nI am a test agent.", encoding="utf-8")
     memory = root / "memory"
     memory.mkdir()
-    (memory / "notes.md").write_text("a remembered fact", encoding="utf-8")
+    # Legacy flat memory file — migrated into briefing/ on rebuild.
+    (memory / "facts.md").write_text("a remembered fact", encoding="utf-8")
     workspace = root / "workspace"
     workspace.mkdir()
     claude_user = root / ".claude"
@@ -100,15 +101,37 @@ def test_rebuild_agent_claude_md_assembles_primer_profile_memory():
         workspace_dir=workspace,
         claude_user_dir=claude_user,
         gemini_user_dir=gemini_user,
+        agent_id="tester-0001",
+        display_name="Tester",
     )
-    # Shared primer is seeded on demand, then primer + profile + memory
-    # all land in the assembled prompt.
+    # Shared primer is seeded on demand, then primer + profile + the
+    # compiled memory briefing all land in the assembled prompt.
     assert "Puffo.ai platform primer" in out
     assert "I am a test agent." in out
     assert "a remembered fact" in out
+    # The flat file was migrated into the briefing tree, and the
+    # managed profile briefing was synced from the identity fields.
+    assert (memory / "briefing" / "facts.md").is_file()
+    assert not (memory / "facts.md").exists()
+    assert (memory / "briefing" / "profile.md").is_file()
+    # notes/ content never lands in the artifact.
+    (memory / "notes" / "scratch.md").write_text(
+        "note-only detail", encoding="utf-8",
+    )
+    out2 = rebuild_agent_claude_md(
+        shared_dir=shared,
+        profile_path=profile,
+        memory_dir=memory,
+        workspace_dir=workspace,
+        claude_user_dir=claude_user,
+        gemini_user_dir=gemini_user,
+        agent_id="tester-0001",
+        display_name="Tester",
+    )
+    assert "note-only detail" not in out2
     # Written to both user-level dirs.
-    assert (claude_user / "CLAUDE.md").read_text(encoding="utf-8") == out
-    assert (gemini_user / "GEMINI.md").read_text(encoding="utf-8") == out
+    assert (claude_user / "CLAUDE.md").read_text(encoding="utf-8") == out2
+    assert (gemini_user / "GEMINI.md").read_text(encoding="utf-8") == out2
 
 
 # ── codex variants strip mcp__puffo__ prefix ───────────────────────


### PR DESCRIPTION
## What

Implements the M1 memory contract in `puffo-agent` (the fat Python agent): every agent gets a `memory/{briefing/,notes/,recollection/,imports/index.md}` tree, and the provider prompt artifacts (`~/.claude/CLAUDE.md`, `$CODEX_HOME/AGENTS.md`, `.gemini/GEMINI.md`, and the `system_prompt` string handed to sdk/chat adapters) are generated from a **bounded, deterministic briefing compile** instead of the previous concatenate-everything memory snapshot.

## M1 acceptance criteria (from the design docs)

- **Memory tree** — `ensure_memory_tree()` seeds `briefing/`, `notes/`, `recollection/`, `imports/index.md`; run by worker startup, per-turn refresh, `agent create`, and `MemoryManager.__init__`.
- **Bounded compile, fail closed** — `compile_briefing()` reads `briefing/profile.md` first, then remaining `briefing/*.md` in sorted filename order as `### <stem>` sections. Limits: 16KB per file, 64KB compiled total (module constants; top of the design's ranges, M2 may tighten). Violations raise `BriefingCompileError` (`code` in {`memory_file_too_large`, `memory_briefing_too_large`}, plus `path`/`size`/`limit`/`suggestion`, `to_dict()`) — no truncation, no partial output.
- **`briefing/profile.md` = identity framing only** — display_name / role / role_short (from `agent.yml`) + the `# Soul` body extracted from agent-root `profile.md`. No `## Instructions` and none of DEFAULT_PROFILE's runtime-behavior sections. Regenerated inside `<!-- puffo:managed-profile -->` markers on every managed rebuild; user text outside the markers is preserved. Missing fields degrade to a minimal identity line.
- **Legacy migration** — `migrate_flat_memory()`: flat `memory/*.md` (excluding `README.md`) processed in sorted order; a file moves to `briefing/<name>` iff it is <= 16KB, the slot is free, and the *would-be compiled* briefing (headers + separators included, exact simulation) stays <= 64KB; otherwise it moves to `notes/<name>` (collision -> `notes/<stem>-migrated.md`) and a pointer line is appended to `briefing/migrated-notes.md`. Idempotent — a pass leaves no flat `*.md`, so re-runs are no-ops.
- **Write API kept working** — `MemoryManager.save(topic, content)` keeps its name/signature + frontmatter format, now targets `briefing/<safe_topic>.md`, pre-validates both limits before writing (fail closed, no partial file), and drops `refresh_agent.flag` (same payload shape as `profile_sync.write_refresh_agent_flag`) so artifacts rebuild. `get_context()` returns the compiled briefing. The other agent-facing write surface — direct file writes per the primer + the MCP `refresh()` tool (`mcp/host_tools.py:340`) — keeps working unchanged; the primer now documents `memory/briefing/` (bounded, injected) vs `memory/notes/` (searchable, never injected).
- **Full-join injection gone** — `read_memory_snapshot()` deleted; `assemble_claude_md()` takes the compiled briefing; `grep -rn read_memory_snapshot src/` is empty.

## Investigation anchors

- Live injection path was `read_memory_snapshot()` -> `assemble_claude_md()` (`shared_content.py:1199/1220`), called from `rebuild_agent_claude_md()`/`rebuild_agent_codex_md()` (`shared_content.py:1307/1275`); `MemoryManager.get_context()` (`agent/memory.py:21`) was the same model but dead code — both replaced.
- No MCP memory-write tool exists (`mcp/puffo_core_tools.py`, `host_tools.py` have no memory tool); the write surfaces are direct file writes + `refresh()` (`host_tools.py:340-360`) and `MemoryManager.save()` (`agent/memory.py:29`, no callers).
- Rebuild call sites threaded with identity fields: worker startup (`worker.py:1056`) and per-turn flag consumption (`worker.py:1198` -> `_process_refresh_flags`, `worker.py:1577`), plus `agent reset-primer` (`cli.py`).

## Reload semantics (documented, unchanged)

The fat agent worker is resident; refresh flags are consumed at the start of the next message batch (`worker.py:1198` -> `_process_refresh_flags`), which rebuilds the artifacts from disk and calls `adapter.reload(prompt, with_session=...)`. The claude CLI harness keeps a resident subprocess (`agent/adapters/cli_session.py`) that only re-reads `$HOME/.claude/CLAUDE.md` on respawn; `reload()` forces a respawn with `--resume`. So: write briefing -> drop `refresh_agent.flag` -> next batch rebuilds + respawns -> the new briefing is live. Every native profile-edit path already drops the flag (e.g. `portal/api/handlers.py`, `portal/cli.py`), which is how `briefing/profile.md` stays in sync.

## Error handling

`BriefingCompileError` propagates from the compile: at worker start it fails init with the structured message (`runtime.status="error"`); at per-turn refresh the existing handler logs and keeps the previous prompt; `agent reset-primer` prints the structured error and returns rc 2.

## Tests

`tests/test_memory_m1.py` (18 tests) covers tree creation, compile ordering + both fail-closed limits, profile-briefing content (incl. the no-`## Instructions` regex), migration (fit rule, total-budget overflow, name collisions, idempotence), artifact rebuild picking up new briefing topics while `notes/` never appears, and the `save()` compat surface. `tests/test_shared_primer.py` updated to the briefing model.

Full suite: `1788 passed, 2 skipped` with `tests/test_host_credentials.py` excluded — that file has 7 failures that reproduce identically on unmodified `origin/main` on this machine (its sync path reads the real macOS Keychain via `_sync_credentials_from_keychain`, `portal/state.py:235`, so the "no host file" branches never trigger). Unrelated to this change.

**Held for human review — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
