### PR TITLE
memory M2: low-level MemoryStore file API (stacked on #124)

### DIFF
--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -55,7 +55,46 @@ _MANAGED_BLOCK_RE = re.compile(
 )
 
 
-class BriefingCompileError(Exception):
+class MemoryStoreError(Exception):
+    """Structured memory-store error: the M1 ``{path, size, limit,
+    suggestion}`` shape extended with ``code`` (M3-aligned names such
+    as ``memory_invalid_path`` / ``memory_scope_readonly``).
+    ``size``/``limit`` only apply to size violations; errors without
+    them omit the keys from ``to_dict()``."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        suggestion: str,
+        size: int | None = None,
+        limit: int | None = None,
+    ):
+        self.code = code
+        self.path = path
+        self.size = size
+        self.limit = limit
+        self.suggestion = suggestion
+        if size is not None and limit is not None:
+            message = (
+                f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+            )
+        else:
+            message = f"{code}: {path}. {suggestion}"
+        super().__init__(message)
+
+    def to_dict(self) -> dict:
+        out: dict = {"code": self.code, "path": self.path}
+        if self.size is not None:
+            out["size"] = self.size
+        if self.limit is not None:
+            out["limit"] = self.limit
+        out["suggestion"] = self.suggestion
+        return out
+
+
+class BriefingCompileError(MemoryStoreError):
     """A briefing violates the compile budget. Fail closed — callers
     get no truncated/partial output. ``code`` is one of
     ``memory_file_too_large`` / ``memory_briefing_too_large``
@@ -70,23 +109,35 @@ class BriefingCompileError(Exception):
         limit: int,
         suggestion: str,
     ):
-        self.code = code
-        self.path = path
-        self.size = size
-        self.limit = limit
-        self.suggestion = suggestion
         super().__init__(
-            f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+            code, path=path, size=size, limit=limit, suggestion=suggestion,
         )
 
-    def to_dict(self) -> dict:
-        return {
-            "code": self.code,
-            "path": self.path,
-            "size": self.size,
-            "limit": self.limit,
-            "suggestion": self.suggestion,
-        }
+
+def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> None:
+    """Drop ``refresh_agent.flag`` so the worker rebuilds the prompt
+    artifacts on the next batch. Best-effort; same payload shape as
+    ``profile_sync.write_refresh_agent_flag``. No-op without a
+    workspace dir."""
+    if not workspace_dir:
+        return
+    from ..portal.state import refresh_agent_flag_path
+
+    flag_path = refresh_agent_flag_path(Path(workspace_dir))
+    try:
+        flag_path.parent.mkdir(parents=True, exist_ok=True)
+        flag_path.write_text(
+            json.dumps({
+                "version": 1,
+                "requested_at": int(time.time()),
+                "reason": reason,
+            }) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning(
+            "refresh_agent.flag write failed (%s): %s", reason, exc,
+        )
 
 
 def ensure_memory_tree(memory_root: Path) -> None:
@@ -333,9 +384,13 @@ def sync_profile_briefing(
             # Pre-existing user file without markers: identity framing
             # leads, user content follows untouched.
             new_text = block + "\n" + text
-        path.write_text(new_text, encoding="utf-8")
     else:
-        path.write_text(block, encoding="utf-8")
+        new_text = block
+    from .memory_store import MemoryStore
+
+    MemoryStore(memory_root)._put_memory_file(
+        f"{BRIEFING_DIR}/{PROFILE_BRIEFING_NAME}", new_text,
+    )
     return path
 
 
@@ -354,72 +409,22 @@ class MemoryManager:
         return compile_briefing(Path(self.memory_dir))
 
     def save(self, topic: str, content: str):
+        from .memory_store import MemoryStore
+
         safe_topic = topic.replace(" ", "_").replace("/", "-")
-        path = Path(self.memory_dir) / BRIEFING_DIR / f"{safe_topic}.md"
         # Aware-UTC with ``Z`` suffix (``datetime.utcnow`` is
         # deprecated in 3.12+).
         updated = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
         body = f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n"
-        size = _byte_size(body)
-        if size > PER_FILE_LIMIT:
-            raise BriefingCompileError(
-                "memory_file_too_large",
-                path=str(path),
-                size=size,
-                limit=PER_FILE_LIMIT,
-                suggestion=(
-                    "Save a shorter briefing topic; put the detail in "
-                    f"memory/{NOTES_DIR}/ instead."
-                ),
-            )
-        # Pre-validate the would-be compiled total so an oversized
-        # save never leaves partial state behind.
-        profile_body, entries = _read_briefing_entries(
-            Path(self.memory_dir), enforce_per_file=False,
+        # The store validates sizes (per-file + would-be compiled
+        # total, raising BriefingCompileError) before any write, so an
+        # oversized save never leaves partial state behind. The
+        # refresh flag stays owned by save() — the store gets no
+        # workspace_dir — so its reason keeps the M1 shape.
+        MemoryStore(self.memory_dir)._put_memory_file(
+            f"{BRIEFING_DIR}/{safe_topic}.md", body,
         )
-        entry_map = dict(entries)
-        if safe_topic == "profile":
-            profile_body = body.strip()
-        else:
-            entry_map[safe_topic] = body.strip()
-        total = _byte_size(
-            _compose_briefing(profile_body, sorted(entry_map.items()))
-        )
-        if total > TOTAL_LIMIT:
-            raise BriefingCompileError(
-                "memory_briefing_too_large",
-                path=str(path),
-                size=total,
-                limit=TOTAL_LIMIT,
-                suggestion=(
-                    "This save would push the compiled briefing over "
-                    f"budget; move topics to memory/{NOTES_DIR}/ first."
-                ),
-            )
-        path.write_text(body, encoding="utf-8")
         self._request_refresh(topic)
 
     def _request_refresh(self, topic: str) -> None:
-        """Drop ``refresh_agent.flag`` so the worker rebuilds the
-        prompt artifacts on the next batch. Best-effort; same payload
-        shape as ``profile_sync.write_refresh_agent_flag``."""
-        if not self.workspace_dir:
-            return
-        from ..portal.state import refresh_agent_flag_path
-
-        flag_path = refresh_agent_flag_path(Path(self.workspace_dir))
-        try:
-            flag_path.parent.mkdir(parents=True, exist_ok=True)
-            flag_path.write_text(
-                json.dumps({
-                    "version": 1,
-                    "requested_at": int(time.time()),
-                    "reason": f"memory.save:{topic}",
-                }) + "\n",
-                encoding="utf-8",
-            )
-        except OSError as exc:
-            logger.warning(
-                "refresh_agent.flag write failed after memory save (%s): %s",
-                topic, exc,
-            )
+        request_prompt_refresh(self.workspace_dir, f"memory.save:{topic}")

--- a/src/puffo_agent/agent/memory_store.py
+++ b/src/puffo_agent/agent/memory_store.py
@@ -1,0 +1,529 @@
+"""Low-level MemoryStore file API (M2).
+
+The seven primitives from the memory design doc operate on **logical
+memory paths** (``briefing/profile.md``, ``notes/topic.md``,
+``recollection/2026/06/2026-06-04.md``, ``imports/index.md``) — never
+physical filesystem paths. The store boundary enforces:
+
+- path grammar (relative, known scope, no traversal/hidden/symlink
+  escapes; ``briefing/`` stays flat because the compile globs
+  ``briefing/*.md`` non-recursively);
+- per-area scope rules (``imports/`` is importer-owned and read-only;
+  ``recollection/`` writes need the explicit maintenance scope);
+- per-area size limits, validated before any write commits;
+- atomic writes (sibling temp file + ``os.replace``);
+- briefing dirty/rebuild: successful ``briefing/`` mutations drop the
+  M1 ``refresh_agent.flag`` via ``memory.request_prompt_refresh``.
+
+Errors are ``memory.MemoryStoreError`` (briefing-scope size violations
+raise the ``BriefingCompileError`` subclass so M1 callers keep
+working). The primitives deliberately take no ``reason`` — semantic
+reason/audit metadata belongs to the M3 tools layered on top.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path, PurePosixPath
+
+from .memory import (
+    BRIEFING_DIR,
+    IMPORTS_DIR,
+    NOTES_DIR,
+    PER_FILE_LIMIT,
+    PROFILE_BRIEFING_NAME,
+    RECOLLECTION_DIR,
+    TOTAL_LIMIT,
+    BriefingCompileError,
+    MemoryStoreError,
+    _byte_size,
+    _compose_briefing,
+    _read_briefing_entries,
+    request_prompt_refresh,
+)
+
+# Per-file byte limits (top of the design ranges, like M1's briefing
+# budget). ``imports/`` is never written through the store; its entry
+# only bounds reads.
+NOTES_FILE_LIMIT = 64 * 1024
+RECOLLECTION_FILE_LIMIT = 128 * 1024
+IMPORTS_READ_LIMIT = RECOLLECTION_FILE_LIMIT
+
+READ_BATCH_LIMIT = 16
+
+_FILE_LIMITS = {
+    BRIEFING_DIR: PER_FILE_LIMIT,
+    NOTES_DIR: NOTES_FILE_LIMIT,
+    RECOLLECTION_DIR: RECOLLECTION_FILE_LIMIT,
+    IMPORTS_DIR: IMPORTS_READ_LIMIT,
+}
+
+_SCOPES = (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR, IMPORTS_DIR)
+
+_PATH_SUGGESTION = (
+    "Use a relative logical memory path like notes/topic.md under "
+    "briefing/, notes/, recollection/, or imports/."
+)
+
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
+class MemoryStore:
+    """Validated file operations under one agent's memory root.
+
+    ``workspace_dir`` (optional) enables the briefing dirty/rebuild
+    hook; ``maintenance`` is the explicit scope flag that unlocks
+    ``recollection/`` writes (daemon-owned maintenance, not ordinary
+    chat turns).
+    """
+
+    def __init__(
+        self,
+        memory_root: str | Path,
+        workspace_dir: str = "",
+        maintenance: bool = False,
+    ):
+        self.memory_root = Path(memory_root)
+        self.workspace_dir = workspace_dir
+        self.maintenance = maintenance
+
+    # ── the seven primitives ─────────────────────────────────────────
+
+    def create_memory_file(self, path: str, body: str) -> dict:
+        """Create a new file. Fails with ``memory_file_exists`` if the
+        target already exists — overwriting goes through patch/append."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        if physical.exists():
+            raise MemoryStoreError(
+                "memory_file_exists",
+                path=str(logical),
+                suggestion=(
+                    "The file already exists; change it with "
+                    "patch_memory_file or append_memory_file."
+                ),
+            )
+        size = self._validate_size(scope, logical, body)
+        self._write_atomic(physical, body)
+        self._mark_briefing_dirty(scope, "create", logical)
+        return {"path": str(logical), "changed": True, "size": size}
+
+    def read_memory_file(self, path: str) -> dict:
+        """Bounded read: ``body`` is capped at the area's file limit
+        (``truncated`` flags a cut); ``size`` is the real file size."""
+        scope, logical = self._validate_logical_path(path)
+        physical = self._physical_path(logical)
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion=(
+                    "Check the path with get_memory_file_status, or "
+                    "create the file with create_memory_file."
+                ),
+            )
+        limit = _FILE_LIMITS[scope]
+        data = physical.read_bytes()
+        size = len(data)
+        truncated = size > limit
+        if truncated:
+            # A byte cap can split a multi-byte sequence; drop the
+            # trailing partial character rather than emitting garbage.
+            body = data[:limit].decode("utf-8", errors="ignore")
+        else:
+            body = data.decode("utf-8")
+        return {
+            "path": str(logical),
+            "scope": scope,
+            "size": size,
+            "truncated": truncated,
+            "body": body,
+        }
+
+    def read_memory_files(self, paths: list) -> list[dict]:
+        """Pure read batch (≤ ``READ_BATCH_LIMIT`` paths). Each entry
+        is a ``read_memory_file`` result or ``{path, error}`` — one bad
+        path never fails the whole batch. Never writes."""
+        if not isinstance(paths, (list, tuple)):
+            raise MemoryStoreError(
+                "memory_invalid_arguments",
+                path="",
+                suggestion="Pass a list of logical memory paths.",
+            )
+        if len(paths) > READ_BATCH_LIMIT:
+            raise MemoryStoreError(
+                "memory_invalid_arguments",
+                path="",
+                suggestion=(
+                    f"read_memory_files accepts at most {READ_BATCH_LIMIT} "
+                    "paths per call; split the batch."
+                ),
+            )
+        results: list[dict] = []
+        for p in paths:
+            try:
+                results.append(self.read_memory_file(p))
+            except MemoryStoreError as exc:
+                results.append({
+                    "path": p if isinstance(p, str) else str(p),
+                    "error": exc.to_dict(),
+                })
+        return results
+
+    def patch_memory_file(self, path: str, patches: list) -> dict:
+        """Exact text replacement. Each ``{old_text, new_text}`` must
+        match exactly once; the patch list is all-or-nothing — nothing
+        is written unless every patch applies."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion="Create the file with create_memory_file first.",
+            )
+        original = physical.read_text(encoding="utf-8")
+        text = original
+        for patch in patches:
+            old_text = patch["old_text"]
+            matches = text.count(old_text) if old_text else 2
+            if matches == 0:
+                raise MemoryStoreError(
+                    "memory_patch_no_match",
+                    path=str(logical),
+                    suggestion=(
+                        "old_text was not found; read the file again and "
+                        "patch exact current text."
+                    ),
+                )
+            if matches > 1:
+                raise MemoryStoreError(
+                    "memory_patch_multiple_matches",
+                    path=str(logical),
+                    suggestion=(
+                        "old_text matched more than once; include more "
+                        "surrounding context so it matches exactly once."
+                    ),
+                )
+            text = text.replace(old_text, patch["new_text"])
+        size = self._validate_size(scope, logical, text)
+        changed = text != original
+        if changed:
+            self._write_atomic(physical, text)
+            self._mark_briefing_dirty(scope, "patch", logical)
+        return {"path": str(logical), "changed": changed, "size": size}
+
+    def append_memory_file(self, path: str, text: str) -> dict:
+        """Append to the end of an existing file (no separator magic,
+        no prepend/insert mode)."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion="Create the file with create_memory_file first.",
+            )
+        original = physical.read_text(encoding="utf-8")
+        combined = original + text
+        size = self._validate_size(scope, logical, combined)
+        changed = combined != original
+        if changed:
+            self._write_atomic(physical, combined)
+            self._mark_briefing_dirty(scope, "append", logical)
+        return {"path": str(logical), "changed": changed, "size": size}
+
+    def delete_memory_file(self, path: str) -> dict:
+        """Delete a safe memory file: validated writable path, regular
+        file, and never the managed ``briefing/profile.md``."""
+        scope, logical = self._validate_write_path(path)
+        if scope == BRIEFING_DIR and logical.name == PROFILE_BRIEFING_NAME:
+            raise MemoryStoreError(
+                "memory_scope_readonly",
+                path=str(logical),
+                suggestion=(
+                    "briefing/profile.md is the managed profile briefing "
+                    "and cannot be deleted; patch it instead."
+                ),
+            )
+        physical = self._physical_path(logical)
+        if not physical.exists():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion="Nothing to delete at this path.",
+            )
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="Only regular memory files can be deleted.",
+            )
+        physical.unlink()
+        self._mark_briefing_dirty(scope, "delete", logical)
+        return {"path": str(logical), "changed": True}
+
+    def get_memory_file_status(self, path: str) -> dict:
+        """Existence/scope/size/limit/briefing-inclusion metadata —
+        deliberately no ``body``. Works for missing files."""
+        scope, logical = self._validate_logical_path(path)
+        physical = self._physical_path(logical)
+        exists = physical.is_file()
+        writable = self._scope_writable(scope) and logical.suffix == ".md"
+        return {
+            "path": str(logical),
+            "exists": exists,
+            "scope": scope,
+            "size": physical.stat().st_size if exists else None,
+            "limit": _FILE_LIMITS[scope],
+            "writable": writable,
+            "briefing_included": (
+                exists and scope == BRIEFING_DIR and logical.suffix == ".md"
+            ),
+        }
+
+    # ── package-internal ─────────────────────────────────────────────
+
+    def _put_memory_file(self, path: str, body: str) -> dict:
+        """Overwrite-allowed create, for the daemon-owned M1 writers
+        (``MemoryManager.save`` / ``sync_profile_briefing``) — same
+        validation, sizing, atomicity, and briefing dirty hook. Not
+        part of the public seven: agent-facing callers must use
+        create/patch/append so overwrites stay deliberate."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        size = self._validate_size(scope, logical, body)
+        changed = not (
+            physical.is_file()
+            and physical.read_text(encoding="utf-8") == body
+        )
+        if changed:
+            self._write_atomic(physical, body)
+            self._mark_briefing_dirty(scope, "put", logical)
+        return {"path": str(logical), "changed": changed, "size": size}
+
+    # ── validation ───────────────────────────────────────────────────
+
+    def _validate_logical_path(
+        self, path: str,
+    ) -> tuple[str, PurePosixPath]:
+        """Enforce the logical path grammar; returns ``(scope, path)``."""
+        if not isinstance(path, str) or not path:
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(path or ""),
+                suggestion=_PATH_SUGGESTION,
+            )
+        if "\x00" in path or "\\" in path:
+            raise MemoryStoreError(
+                "memory_invalid_path", path=path, suggestion=_PATH_SUGGESTION,
+            )
+        if path.startswith("/") or _DRIVE_RE.match(path):
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=path,
+                suggestion="Memory paths are relative, not absolute. "
+                + _PATH_SUGGESTION,
+            )
+        segments = path.split("/")
+        for segment in segments:
+            if not segment:
+                raise MemoryStoreError(
+                    "memory_invalid_path",
+                    path=path,
+                    suggestion=_PATH_SUGGESTION,
+                )
+            if segment in (".", ".."):
+                raise MemoryStoreError(
+                    "memory_invalid_path",
+                    path=path,
+                    suggestion="Path traversal is not allowed. "
+                    + _PATH_SUGGESTION,
+                )
+            if segment.startswith("."):
+                raise MemoryStoreError(
+                    "memory_invalid_path",
+                    path=path,
+                    suggestion="Hidden path segments are not allowed. "
+                    + _PATH_SUGGESTION,
+                )
+        if len(segments) < 2:
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=path,
+                suggestion="Memory files live inside a memory area. "
+                + _PATH_SUGGESTION,
+            )
+        scope = segments[0]
+        if scope not in _SCOPES:
+            raise MemoryStoreError(
+                "memory_path_out_of_scope",
+                path=path,
+                suggestion=(
+                    "Memory paths must start with briefing/, notes/, "
+                    "recollection/, or imports/."
+                ),
+            )
+        if scope == BRIEFING_DIR and len(segments) != 2:
+            # The briefing compile globs briefing/*.md non-recursively;
+            # nested briefing files would be silent dead weight.
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=path,
+                suggestion="briefing/ is flat: use briefing/<topic>.md.",
+            )
+        return scope, PurePosixPath(path)
+
+    def _validate_write_path(
+        self, path: str,
+    ) -> tuple[str, PurePosixPath]:
+        scope, logical = self._validate_logical_path(path)
+        if scope == IMPORTS_DIR:
+            raise MemoryStoreError(
+                "memory_scope_readonly",
+                path=str(logical),
+                suggestion=(
+                    "imports/ is importer-owned and read-only; put your "
+                    f"own content in {NOTES_DIR}/."
+                ),
+            )
+        if scope == RECOLLECTION_DIR and not self.maintenance:
+            raise MemoryStoreError(
+                "memory_scope_readonly",
+                path=str(logical),
+                suggestion=(
+                    "recollection/ writes need the explicit maintenance "
+                    f"scope; ordinary turns should write {NOTES_DIR}/."
+                ),
+            )
+        if logical.suffix != ".md":
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="Memory write targets must end in .md.",
+            )
+        return scope, logical
+
+    def _scope_writable(self, scope: str) -> bool:
+        if scope == IMPORTS_DIR:
+            return False
+        if scope == RECOLLECTION_DIR:
+            return self.maintenance
+        return True
+
+    def _physical_path(self, logical: PurePosixPath) -> Path:
+        """Map a validated logical path onto the filesystem, rejecting
+        symlink targets and any resolution outside the memory root."""
+        root = self.memory_root.resolve()
+        physical = root.joinpath(*logical.parts)
+        if physical.is_symlink():
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="Symlinks are not valid memory files.",
+            )
+        resolved = physical.resolve()
+        if resolved == root or not resolved.is_relative_to(root):
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="The path resolves outside the memory root.",
+            )
+        return physical
+
+    def _validate_size(
+        self, scope: str, logical: PurePosixPath, body: str,
+    ) -> int:
+        """Per-file limit, plus the would-be compiled total for
+        ``briefing/`` (the M1 ``save()`` simulation). Briefing-scope
+        violations raise ``BriefingCompileError`` so M1 callers see
+        the error type they already handle."""
+        size = _byte_size(body)
+        limit = _FILE_LIMITS[scope]
+        if size > limit:
+            if scope == BRIEFING_DIR:
+                raise BriefingCompileError(
+                    "memory_file_too_large",
+                    path=str(logical),
+                    size=size,
+                    limit=limit,
+                    suggestion=(
+                        "Trim this briefing topic; move detail to "
+                        f"memory/{NOTES_DIR}/ (searchable, not injected)."
+                    ),
+                )
+            raise MemoryStoreError(
+                "memory_file_too_large",
+                path=str(logical),
+                size=size,
+                limit=limit,
+                suggestion=(
+                    "Split this file, or move detail into another "
+                    "memory area."
+                ),
+            )
+        if scope == BRIEFING_DIR:
+            self._validate_briefing_total(logical, body)
+        return size
+
+    def _validate_briefing_total(
+        self, logical: PurePosixPath, body: str,
+    ) -> None:
+        profile_body, entries = _read_briefing_entries(
+            self.memory_root, enforce_per_file=False,
+        )
+        entry_map = dict(entries)
+        stripped = body.strip()
+        if logical.name == PROFILE_BRIEFING_NAME:
+            profile_body = stripped
+        elif stripped:
+            entry_map[logical.stem] = stripped
+        else:
+            # The compile drops empty bodies; mirror that exactly.
+            entry_map.pop(logical.stem, None)
+        total = _byte_size(
+            _compose_briefing(profile_body, sorted(entry_map.items()))
+        )
+        if total > TOTAL_LIMIT:
+            raise BriefingCompileError(
+                "memory_briefing_too_large",
+                path=str(logical),
+                size=total,
+                limit=TOTAL_LIMIT,
+                suggestion=(
+                    "This write would push the compiled briefing over "
+                    f"budget; move topics to memory/{NOTES_DIR}/ first."
+                ),
+            )
+
+    # ── write plumbing ───────────────────────────────────────────────
+
+    def _write_atomic(self, physical: Path, body: str) -> None:
+        """Sibling temp file + ``os.replace``: the target is either
+        untouched or fully replaced, never half-written. The temp name
+        is non-``.md`` so a crashed write can't leak into the compile."""
+        physical.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(physical.parent), prefix=".puffo-mem-", suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(body)
+            os.replace(tmp_name, physical)
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    def _mark_briefing_dirty(
+        self, scope: str, op: str, logical: PurePosixPath,
+    ) -> None:
+        if scope != BRIEFING_DIR:
+            return
+        request_prompt_refresh(
+            self.workspace_dir, f"memory_store.{op}:{logical}",
+        )

--- a/tests/test_memory_m2.py
+++ b/tests/test_memory_m2.py
@@ -1,0 +1,494 @@
+"""M2 memory acceptance tests: the low-level MemoryStore file API —
+logical-path validation (invalid path / traversal / symlink escape),
+per-area scope rules, per-area size limits with structured errors,
+atomic writes with changed status, bounded batch reads, body-less
+status, and the briefing dirty/rebuild hook.
+
+One test (or small group) per M2 validation scenario in
+docs/user-lead-designs/memory-implementation.md, named after it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent.memory import (
+    PER_FILE_LIMIT,
+    TOTAL_LIMIT,
+    BriefingCompileError,
+    MemoryStoreError,
+    ensure_memory_tree,
+)
+from puffo_agent.agent.memory_store import (
+    NOTES_FILE_LIMIT,
+    READ_BATCH_LIMIT,
+    RECOLLECTION_FILE_LIMIT,
+    MemoryStore,
+)
+
+
+@pytest.fixture
+def root(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    return root
+
+
+@pytest.fixture
+def store(root):
+    return MemoryStore(root)
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def _all_ops(store: MemoryStore, path: str):
+    """Every primitive applied to one path, for reject-everywhere checks."""
+    yield lambda: store.create_memory_file(path, "x")
+    yield lambda: store.read_memory_file(path)
+    yield lambda: store.patch_memory_file(path, [{"old_text": "a", "new_text": "b"}])
+    yield lambda: store.append_memory_file(path, "x")
+    yield lambda: store.delete_memory_file(path)
+    yield lambda: store.get_memory_file_status(path)
+
+
+# ── scenario 1: invalid logical path is rejected ─────────────────────
+
+
+@pytest.mark.parametrize("bad", [
+    "foo.md",                 # top-level, no memory area
+    "briefing",               # a scope alone is not a file
+    "",                       # empty
+    "notes/.hidden.md",       # hidden segment
+    "notes\\evil.md",         # backslash
+    "notes//x.md",            # empty segment
+    "notes/x.md/",            # trailing slash
+    "briefing/sub/deep.md",   # briefing/ is flat (compile globs *.md)
+    "notes/x\x00.md",         # NUL
+])
+def test_invalid_logical_path_is_rejected(store, bad):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file(bad, "body")
+    assert ei.value.code == "memory_invalid_path"
+    assert ei.value.suggestion
+
+
+def test_invalid_logical_path_rejected_for_reads_too(store):
+    for op in _all_ops(store, "foo.md"):
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_invalid_path"
+
+
+def test_absolute_path_is_rejected(store):
+    for bad in ("/etc/passwd", "C:\\evil.md"):
+        with pytest.raises(MemoryStoreError) as ei:
+            store.create_memory_file(bad, "body")
+        assert ei.value.code == "memory_invalid_path"
+    assert Path("/etc/passwd").exists()  # and it was never touched
+
+
+def test_unknown_scope_is_out_of_scope(store):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("secrets/x.md", "body")
+    assert ei.value.code == "memory_path_out_of_scope"
+    assert ei.value.suggestion
+
+
+def test_non_md_write_target_is_rejected(store, root):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("notes/plain.txt", "body")
+    assert ei.value.code == "memory_invalid_path"
+    # …but reads of non-.md files (e.g. under imports/) stay allowed.
+    (root / "imports" / "blob.txt").write_text("raw", encoding="utf-8")
+    assert store.read_memory_file("imports/blob.txt")["body"] == "raw"
+
+
+# ── scenario 2: path traversal is rejected ───────────────────────────
+
+
+@pytest.mark.parametrize("bad", [
+    "notes/../briefing/profile.md",
+    "../outside.md",
+    "notes/../../etc/passwd",
+    "./notes/x.md",
+])
+def test_path_traversal_is_rejected(store, bad):
+    before = _tree_snapshot(store.memory_root)
+    for op in _all_ops(store, bad):
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_invalid_path"
+    assert _tree_snapshot(store.memory_root) == before
+
+
+def test_symlink_escape_is_rejected(tmp_path, root, store):
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret", encoding="utf-8")
+    (root / "notes" / "link.md").symlink_to(outside)
+    for op in _all_ops(store, "notes/link.md"):
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_invalid_path"
+    assert outside.read_text(encoding="utf-8") == "secret"
+    assert (root / "notes" / "link.md").is_symlink()  # left alone
+
+
+def test_symlinked_directory_escape_is_rejected(tmp_path, root, store):
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (root / "notes" / "sub").symlink_to(elsewhere)
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("notes/sub/x.md", "body")
+    assert ei.value.code == "memory_invalid_path"
+    assert list(elsewhere.iterdir()) == []  # nothing escaped the root
+
+
+# ── scenario 3: create existing file is rejected ─────────────────────
+
+
+def test_create_existing_file_is_rejected(store, root):
+    store.create_memory_file("notes/topic.md", "one")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("notes/topic.md", "two")
+    assert ei.value.code == "memory_file_exists"
+    assert ei.value.suggestion
+    assert (root / "notes" / "topic.md").read_text(encoding="utf-8") == "one"
+
+
+# ── scenario 4: oversized create/append/patch is rejected ────────────
+
+
+def _assert_oversize_shape(err: MemoryStoreError, path: str, limit: int):
+    d = err.to_dict()
+    assert d["code"] == "memory_file_too_large"
+    assert d["path"] == path
+    assert d["size"] > limit
+    assert d["limit"] == limit
+    assert d["suggestion"]
+
+
+def test_oversized_create_is_rejected_per_area(root):
+    cases = [
+        ("briefing/big.md", PER_FILE_LIMIT, MemoryStore(root)),
+        ("notes/big.md", NOTES_FILE_LIMIT, MemoryStore(root)),
+        (
+            "recollection/2026/07/2026-07-06.md",
+            RECOLLECTION_FILE_LIMIT,
+            MemoryStore(root, maintenance=True),
+        ),
+    ]
+    for path, limit, store in cases:
+        with pytest.raises(MemoryStoreError) as ei:
+            store.create_memory_file(path, "x" * (limit + 1))
+        _assert_oversize_shape(ei.value, path, limit)
+        assert not root.joinpath(*path.split("/")).exists()
+    # Briefing-scope size violations surface as BriefingCompileError so
+    # M1 callers keep their error handling.
+    with pytest.raises(BriefingCompileError):
+        MemoryStore(root).create_memory_file(
+            "briefing/big.md", "x" * (PER_FILE_LIMIT + 1),
+        )
+
+
+def test_oversized_append_is_rejected_and_file_unchanged(store, root):
+    store.create_memory_file("notes/n.md", "keep")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.append_memory_file("notes/n.md", "x" * NOTES_FILE_LIMIT)
+    _assert_oversize_shape(ei.value, "notes/n.md", NOTES_FILE_LIMIT)
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "keep"
+
+
+def test_oversized_patch_is_rejected_and_file_unchanged(store, root):
+    store.create_memory_file("notes/n.md", "small MARK end")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "MARK", "new_text": "y" * NOTES_FILE_LIMIT},
+        ])
+    _assert_oversize_shape(ei.value, "notes/n.md", NOTES_FILE_LIMIT)
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "small MARK end"
+
+
+def test_oversized_compiled_briefing_total_is_rejected(store, root):
+    # 4 × 15KB topics: each under the per-file limit, so an extra 8KB
+    # write busts only the 64KB compiled total.
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * (15 * 1024), encoding="utf-8",
+        )
+    with pytest.raises(BriefingCompileError) as ei:
+        store.create_memory_file("briefing/overflow.md", "o" * (8 * 1024))
+    d = ei.value.to_dict()
+    assert d["code"] == "memory_briefing_too_large"
+    assert d["path"] == "briefing/overflow.md"
+    assert d["size"] > TOTAL_LIMIT
+    assert d["limit"] == TOTAL_LIMIT
+    assert d["suggestion"]
+    assert not (root / "briefing" / "overflow.md").exists()
+
+
+# ── scenarios 5 & 6: exact patch match counts ────────────────────────
+
+
+def test_patch_with_zero_matches_is_rejected(store, root):
+    store.create_memory_file("notes/n.md", "alpha beta")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "gamma", "new_text": "delta"},
+        ])
+    assert ei.value.code == "memory_patch_no_match"
+    assert ei.value.suggestion
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "alpha beta"
+
+
+def test_patch_with_multiple_matches_is_rejected(store, root):
+    store.create_memory_file("notes/n.md", "dup thing dup")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "dup", "new_text": "one"},
+        ])
+    assert ei.value.code == "memory_patch_multiple_matches"
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "dup thing dup"
+
+
+def test_patch_list_is_all_or_nothing(store, root):
+    store.create_memory_file("notes/n.md", "alpha beta")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "alpha", "new_text": "ALPHA"},  # would apply…
+            {"old_text": "missing", "new_text": "x"},    # …but this fails
+        ])
+    assert ei.value.code == "memory_patch_no_match"
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "alpha beta"
+
+
+# ── scenario 7: successful create/append/patch/delete are atomic ─────
+
+
+def test_successful_create_append_patch_delete_return_changed_status(store, root):
+    res = store.create_memory_file("notes/log.md", "one\n")
+    assert res == {"path": "notes/log.md", "changed": True, "size": 4}
+
+    res = store.append_memory_file("notes/log.md", "two\n")
+    assert res == {"path": "notes/log.md", "changed": True, "size": 8}
+    assert (root / "notes" / "log.md").read_text(encoding="utf-8") == "one\ntwo\n"
+
+    res = store.patch_memory_file("notes/log.md", [
+        {"old_text": "two", "new_text": "2"},
+    ])
+    assert res == {"path": "notes/log.md", "changed": True, "size": 6}
+    assert (root / "notes" / "log.md").read_text(encoding="utf-8") == "one\n2\n"
+
+    # A patch that reproduces the current content reports changed=False.
+    res = store.patch_memory_file("notes/log.md", [
+        {"old_text": "one", "new_text": "one"},
+    ])
+    assert res == {"path": "notes/log.md", "changed": False, "size": 6}
+
+    res = store.delete_memory_file("notes/log.md")
+    assert res == {"path": "notes/log.md", "changed": True}
+    assert not (root / "notes" / "log.md").exists()
+
+    # Atomic temp+rename leaves no litter anywhere in the tree.
+    assert set(_tree_snapshot(root)) == {"imports/index.md"}
+
+
+def test_delete_refuses_profile_and_imports(store, root):
+    store.create_memory_file("briefing/profile.md", "# Me\n")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.delete_memory_file("briefing/profile.md")
+    assert ei.value.code == "memory_scope_readonly"
+    assert (root / "briefing" / "profile.md").is_file()
+
+    with pytest.raises(MemoryStoreError) as ei:
+        store.delete_memory_file("imports/index.md")
+    assert ei.value.code == "memory_scope_readonly"
+    assert (root / "imports" / "index.md").is_file()
+
+
+# ── scenario 8: read_memory_files is a pure bounded batch ────────────
+
+
+def test_read_memory_files_returns_bounded_reads_without_modifying_memory(store, root):
+    store.create_memory_file("notes/a.md", "note body")
+    store.create_memory_file("briefing/b.md", "briefing body")
+    # An over-limit file (placed out-of-band) proves reads are bounded.
+    (root / "notes" / "huge.md").write_text(
+        "h" * (NOTES_FILE_LIMIT + 512), encoding="utf-8",
+    )
+    before = _tree_snapshot(root)
+
+    results = store.read_memory_files([
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ])
+
+    assert [r["path"] for r in results] == [
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ]
+    assert results[0]["body"] == "note body"
+    assert results[0]["scope"] == "notes"
+    assert results[0]["truncated"] is False
+    assert results[1]["body"] == "briefing body"
+    assert results[2]["truncated"] is True
+    assert results[2]["size"] == NOTES_FILE_LIMIT + 512
+    assert len(results[2]["body"].encode("utf-8")) == NOTES_FILE_LIMIT
+    assert results[3]["error"]["code"] == "memory_file_not_found"
+    assert results[4]["error"]["code"] == "memory_invalid_path"
+    assert all("body" not in r for r in results[3:])
+
+    # Pure read: the tree is byte-identical afterwards.
+    assert _tree_snapshot(root) == before
+
+
+def test_read_memory_files_batch_over_limit_is_rejected(store):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.read_memory_files(
+            [f"notes/{i}.md" for i in range(READ_BATCH_LIMIT + 1)]
+        )
+    assert ei.value.code == "memory_invalid_arguments"
+    assert ei.value.suggestion
+
+
+# ── scenario 9: get_memory_file_status has no body ───────────────────
+
+
+def test_get_memory_file_status_reports_size_and_scope_without_body(store, root):
+    store.create_memory_file("briefing/facts.md", "hello")
+    st = store.get_memory_file_status("briefing/facts.md")
+    assert st == {
+        "path": "briefing/facts.md",
+        "exists": True,
+        "scope": "briefing",
+        "size": 5,
+        "limit": PER_FILE_LIMIT,
+        "writable": True,
+        "briefing_included": True,
+    }
+    assert "body" not in st
+
+    st = store.get_memory_file_status("notes/absent.md")
+    assert st["exists"] is False
+    assert st["size"] is None
+    assert st["limit"] == NOTES_FILE_LIMIT
+    assert st["writable"] is True
+    assert st["briefing_included"] is False
+
+    st = store.get_memory_file_status("imports/index.md")
+    assert st["exists"] is True
+    assert st["scope"] == "imports"
+    assert st["writable"] is False
+    assert st["briefing_included"] is False
+
+    path = "recollection/2026/07/2026-07-06.md"
+    assert store.get_memory_file_status(path)["writable"] is False
+    maint = MemoryStore(root, maintenance=True)
+    assert maint.get_memory_file_status(path)["writable"] is True
+    assert maint.get_memory_file_status(path)["limit"] == RECOLLECTION_FILE_LIMIT
+
+
+# ── scenario 10: briefing/ writes trigger dirty/rebuild ──────────────
+
+
+def _read_flag(workspace: Path) -> dict:
+    flag = workspace / ".puffo-agent" / "refresh_agent.flag"
+    assert flag.is_file()
+    payload = json.loads(flag.read_text(encoding="utf-8"))
+    flag.unlink()
+    return payload
+
+
+def test_briefing_writes_trigger_dirty_rebuild_flag(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    workspace = tmp_path / "workspace"
+    store = MemoryStore(root, workspace_dir=str(workspace))
+
+    store.create_memory_file("briefing/topic.md", "line one\n")
+    payload = _read_flag(workspace)
+    assert payload["version"] == 1
+    assert isinstance(payload["requested_at"], int)
+    assert payload["reason"] == "memory_store.create:briefing/topic.md"
+
+    store.patch_memory_file("briefing/topic.md", [
+        {"old_text": "one", "new_text": "1"},
+    ])
+    assert _read_flag(workspace)["reason"] == "memory_store.patch:briefing/topic.md"
+
+    store.append_memory_file("briefing/topic.md", "line two\n")
+    assert _read_flag(workspace)["reason"] == "memory_store.append:briefing/topic.md"
+
+    store.delete_memory_file("briefing/topic.md")
+    assert _read_flag(workspace)["reason"] == "memory_store.delete:briefing/topic.md"
+
+    # Non-briefing writes do not mark the briefing dirty…
+    store.create_memory_file("notes/n.md", "note\n")
+    assert not (workspace / ".puffo-agent" / "refresh_agent.flag").exists()
+
+    # …and neither does a briefing no-op (changed=False).
+    store.create_memory_file("briefing/topic.md", "body\n")
+    _read_flag(workspace)
+    res = store.patch_memory_file("briefing/topic.md", [
+        {"old_text": "body", "new_text": "body"},
+    ])
+    assert res["changed"] is False
+    assert not (workspace / ".puffo-agent" / "refresh_agent.flag").exists()
+
+
+def test_store_without_workspace_dir_drops_no_flag(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    MemoryStore(root).create_memory_file("briefing/topic.md", "body\n")
+    assert not list(tmp_path.rglob("refresh_agent.flag"))
+
+
+# ── scope rules ──────────────────────────────────────────────────────
+
+
+def test_recollection_write_requires_maintenance_scope(root):
+    path = "recollection/2026/07/2026-07-07.md"
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root).create_memory_file(path, "daily digest\n")
+    assert ei.value.code == "memory_scope_readonly"
+    assert ei.value.suggestion
+    assert not (root / "recollection" / "2026").exists()
+
+    maint = MemoryStore(root, maintenance=True)
+    res = maint.create_memory_file(path, "daily digest\n")
+    assert res == {"path": path, "changed": True, "size": 13}
+    physical = root / "recollection" / "2026" / "07" / "2026-07-07.md"
+    assert physical.read_text(encoding="utf-8") == "daily digest\n"
+    # Reads never need the maintenance scope.
+    assert MemoryStore(root).read_memory_file(path)["body"] == "daily digest\n"
+
+
+def test_imports_scope_is_read_only(store, root):
+    index_before = (root / "imports" / "index.md").read_bytes()
+    write_ops = [
+        lambda: store.create_memory_file("imports/new.md", "x"),
+        lambda: store.patch_memory_file(
+            "imports/index.md", [{"old_text": "a", "new_text": "b"}],
+        ),
+        lambda: store.append_memory_file("imports/index.md", "x"),
+        lambda: store.delete_memory_file("imports/index.md"),
+    ]
+    for op in write_ops:
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_scope_readonly"
+        assert ei.value.suggestion
+    assert (root / "imports" / "index.md").read_bytes() == index_before
+    assert not (root / "imports" / "new.md").exists()
+    # Maintenance scope does not unlock imports either.
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root, maintenance=True).create_memory_file(
+            "imports/new.md", "x",
+        )
+    assert ei.value.code == "memory_scope_readonly"


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR** — base is `fleet/pyagent-memory-m1` (PR #124). Review/merge #124 first; this PR is **held for human review** of M1+M2 together. Do not merge until #124 lands and the base is retargeted.

Implements §M2 of `docs/user-lead-designs/memory-implementation.md` (in the `puffo.ai/agent` repo): the low-level MemoryStore file API.

## What's in here

- **`src/puffo_agent/agent/memory_store.py`** (new) — `MemoryStore` with the seven doc primitives: `create_memory_file`, `read_memory_file`, `read_memory_files`, `patch_memory_file`, `append_memory_file`, `delete_memory_file`, `get_memory_file_status`, all on **logical memory paths** (`briefing/…`, `notes/…`, `recollection/…`, `imports/…`):
  - path grammar validation: relative-only, known scope, no traversal / hidden segments / backslashes / NUL, `briefing/` flat (the compile globs `briefing/*.md` non-recursively), `.md`-only write targets, symlink targets and symlink escapes rejected via physical resolution against the memory root;
  - scope rules: `imports/` read-only for every caller (importer flow is M3+); `recollection/` writes require the explicit `maintenance=True` scope; `briefing/profile.md` cannot be deleted;
  - size limits validated **before** any write commits: briefing 16KB/file + 64KB compiled-total (reused from M1, including the would-be-compile simulation), notes 64KB, recollection 128KB, imports reads capped at 128KB with a `truncated` flag;
  - atomic writes: sibling temp file + `os.replace`, temp removed on failure, no partial state ever visible;
  - results carry `changed` + `size`; `read_memory_files` is a pure ≤16-path batch with per-path structured errors;
  - successful `briefing/` mutations drop the M1 `refresh_agent.flag` (reason `memory_store.<op>:<path>`) via the shared helper — no new rebuild mechanism.
- **`src/puffo_agent/agent/memory.py`** — new `MemoryStoreError` base carrying the M1 `{code, path, size, limit, suggestion}` shape (`BriefingCompileError` re-based on it, constructor/message/`to_dict()` unchanged); `request_prompt_refresh(workspace_dir, reason)` extracted from `MemoryManager._request_refresh`; **single write path**: `MemoryManager.save()` (signature unchanged, refresh reason still `memory.save:<topic>`) and `sync_profile_briefing()`'s final write now route through the store's package-internal `_put_memory_file`.
- **`tests/test_memory_m2.py`** (new, 36 tests) — one test per doc M2 validation scenario (invalid path, traversal + symlink escape, create-existing, oversized create/append/patch per area + compiled-total, patch zero/multi match, atomic+changed, batch-read purity, status-without-body, briefing dirty/rebuild) plus the scope rules (recollection-requires-maintenance, imports-read-only).

Deliberately **not** here (M3/M4): `reason` params, semantic MCP tools, history/recall/status-rollup APIs, git tracking of memory, an importer write scope.

## Verification

- `pytest tests/test_memory_m2.py -v` → **36 passed**
- `pytest tests/test_memory_m1.py` → **19 passed** (file untouched: `git diff fleet/pyagent-memory-m1 -- tests/test_memory_m1.py` is empty)
- `pytest --ignore=tests/test_host_credentials.py` → **1824 passed, 2 skipped** (same green state as M1's verify; the 7 `test_host_credentials.py` failures are pre-existing/environmental on the dev machine — real macOS Keychain credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
