### PR TITLE
memory M3: semantic memory MCP tools (stacked on #125)

### DIFF
--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -292,6 +292,7 @@ class DockerCLIAdapter(Adapter):
         # No PUFFO_CORE_DB_PATH — MCP routes data reads through the
         # daemon's data service at PUFFO_DATA_SERVICE_URL.
         env["PUFFO_WORKSPACE"] = "/workspace"
+        env["PUFFO_MEMORY_DIR"] = "/home/agent/.puffo-agent-state/memory"
         env["PUFFO_RUNTIME_KIND"] = "cli-docker"
         env["PUFFO_HARNESS"] = "hermes"
         env["PYTHONPATH"] = "/opt/puffoagent-pkg"
@@ -731,6 +732,7 @@ class DockerCLIAdapter(Adapter):
             # No PUFFO_CORE_DB_PATH — SQLite reads route via the
             # daemon's data service.
             env["PUFFO_WORKSPACE"] = "/workspace"
+            env["PUFFO_MEMORY_DIR"] = "/home/agent/.puffo-agent-state/memory"
             env["PUFFO_RUNTIME_KIND"] = "cli-docker"
             env["PUFFO_HARNESS"] = self.harness.name()
             env["PYTHONPATH"] = "/opt/puffoagent-pkg"
@@ -1166,6 +1168,7 @@ def _puffo_gemini_mcp_entry(
     env["PUFFO_CORE_KEYSTORE_DIR"] = "/home/agent/.puffo-agent-state/keys"
     # No PUFFO_CORE_DB_PATH — see mcp/data_client.py.
     env["PUFFO_WORKSPACE"] = "/workspace"
+    env["PUFFO_MEMORY_DIR"] = "/home/agent/.puffo-agent-state/memory"
     env["PUFFO_RUNTIME_KIND"] = "cli-docker"
     env["PUFFO_HARNESS"] = "gemini-cli"
     env["PYTHONPATH"] = "/opt/puffoagent-pkg"

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -114,13 +114,14 @@ class BriefingCompileError(MemoryStoreError):
         )
 
 
-def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> None:
+def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> bool:
     """Drop ``refresh_agent.flag`` so the worker rebuilds the prompt
     artifacts on the next batch. Best-effort; same payload shape as
     ``profile_sync.write_refresh_agent_flag``. No-op without a
-    workspace dir."""
+    workspace dir. Returns True iff the flag was written (the M3
+    tools layer maps this to the ``provider_reload`` post-effect)."""
     if not workspace_dir:
-        return
+        return False
     from ..portal.state import refresh_agent_flag_path
 
     flag_path = refresh_agent_flag_path(Path(workspace_dir))
@@ -138,6 +139,8 @@ def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> None:
         logger.warning(
             "refresh_agent.flag write failed (%s): %s", reason, exc,
         )
+        return False
+    return True
 
 
 def ensure_memory_tree(memory_root: Path) -> None:

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -1,0 +1,128 @@
+"""Local git audit layer for the agent memory tree (M3).
+
+Every successful semantic memory write is recorded as one commit in a
+git repository living at the memory root. The repo is strictly
+machine-local: this module only ever runs ``init`` / ``config`` /
+``add`` / ``commit`` / ``rev-parse`` inside the memory root, and the
+init step sets repo-local identity (``user.name`` / ``user.email``)
+plus ``commit.gpgsign=false`` so commits are hermetic regardless of
+the operator's global git configuration.
+
+Everything degrades gracefully: a missing git binary, a failed init,
+or a failed commit is logged and reported to the caller (``False`` /
+``None``) — memory writes never fail because the audit layer did.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Local plumbing commands finish in milliseconds; the bound only
+# guards against a wedged git process.
+_GIT_TIMEOUT = 30
+
+
+def git_available() -> bool:
+    """True when a ``git`` binary is on PATH."""
+    return shutil.which("git") is not None
+
+
+def _run_git(
+    memory_root: Path, args: list[str],
+) -> subprocess.CompletedProcess | None:
+    """Run one git command inside the memory root. ``None`` on any
+    launch/timeout failure; callers also check ``returncode``."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(memory_root),
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("memory git %s failed to run: %s", args[:1], exc)
+        return None
+
+
+def ensure_memory_git(memory_root: str | Path) -> bool:
+    """Initialise the local audit repo at ``memory_root`` (idempotent).
+
+    Existing ``.git/`` → no-op True. Otherwise ``git init`` plus
+    repo-local config. Returns False (degrade, logged) when git is
+    unavailable or any init step fails.
+    """
+    memory_root = Path(memory_root)
+    if (memory_root / ".git").exists():
+        return True
+    if not git_available():
+        logger.warning(
+            "git is not installed; memory changes at %s will not be "
+            "audit-committed", memory_root,
+        )
+        return False
+    steps = [
+        ["init", "--quiet"],
+        ["config", "user.name", "puffo-agent"],
+        ["config", "user.email", "memory@puffo.local"],
+        ["config", "commit.gpgsign", "false"],
+    ]
+    for step in steps:
+        proc = _run_git(memory_root, step)
+        if proc is None or proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout).strip() if proc else "launch failed"
+            logger.warning(
+                "memory git init failed at %s (%s): %s",
+                memory_root, " ".join(step), detail,
+            )
+            return False
+    return True
+
+
+def format_commit_message(tool: str, paths: list[str], reason: str = "") -> str:
+    """Audit commit message: subject ``memory: <tool> <logical path>``,
+    body ``tool:`` line plus a ``reason:`` line only when the semantic
+    caller supplied one."""
+    first = paths[0] if paths else ""
+    subject = f"memory: {tool} {first}".rstrip()
+    body = [f"tool: {tool}"]
+    if reason:
+        body.append(f"reason: {reason}")
+    return subject + "\n\n" + "\n".join(body) + "\n"
+
+
+def commit_memory_change(
+    memory_root: str | Path, paths: list[str], message: str,
+) -> str | None:
+    """Stage exactly ``paths`` (explicit pathspecs — stray files in the
+    tree are never swept in) and commit with ``message``. Returns the
+    short commit id, or ``None`` on any failure (caller decides whether
+    that warrants a warning)."""
+    memory_root = Path(memory_root)
+    if not paths:
+        return None
+    add = _run_git(memory_root, ["add", "--", *paths])
+    if add is None or add.returncode != 0:
+        detail = (add.stderr or add.stdout).strip() if add else "launch failed"
+        logger.warning(
+            "memory git add failed at %s for %s: %s",
+            memory_root, paths, detail,
+        )
+        return None
+    commit = _run_git(memory_root, ["commit", "--quiet", "-m", message])
+    if commit is None or commit.returncode != 0:
+        detail = (commit.stderr or commit.stdout).strip() if commit else "launch failed"
+        logger.warning(
+            "memory git commit failed at %s for %s: %s",
+            memory_root, paths, detail,
+        )
+        return None
+    head = _run_git(memory_root, ["rev-parse", "--short", "HEAD"])
+    if head is None or head.returncode != 0:
+        return None
+    return head.stdout.strip() or None

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -243,11 +243,14 @@ def puffo_core_mcp_env(
     rpc_url: str = "http://127.0.0.1:63385",
     runtime_kind: str = "",
     harness: str = "",
+    memory_dir: str = "",
 ) -> dict[str, str]:
     """Env dict for the puffo-core MCP subprocess. The MCP never
     touches ``messages.db`` or ``~/.claude.json`` directly — the
     daemon owns both. cli-docker rewrites the loopback URLs to
-    ``host.docker.internal``."""
+    ``host.docker.internal``. ``memory_dir`` (optional) pins the
+    memory root for the M3 memory tools; when empty the server falls
+    back to the workspace-sibling ``memory/`` dir."""
     env: dict[str, str] = {
         "PUFFO_CORE_SLUG": slug,
         "PUFFO_CORE_DEVICE_ID": device_id,
@@ -266,6 +269,8 @@ def puffo_core_mcp_env(
         env["PUFFO_RUNTIME_KIND"] = runtime_kind
     if harness:
         env["PUFFO_HARNESS"] = harness
+    if memory_dir:
+        env["PUFFO_MEMORY_DIR"] = memory_dir
     # codex only forwards [mcp_servers.puffo.env] to the subprocess,
     # so CODEX_HOME must be pinned explicitly or list_mcp_servers
     # would read the operator's host config instead of the agent's.
@@ -285,6 +290,7 @@ def puffo_core_stdio_sdk_config(
     keystore_dir: str,
     workspace: str,
     agent_id: str,
+    memory_dir: str = "",
 ) -> dict:
     """Return the ``mcp_servers`` config dict for the SDK adapter."""
     return {
@@ -301,6 +307,7 @@ def puffo_core_stdio_sdk_config(
                 workspace=workspace,
                 agent_id=agent_id,
                 runtime_kind="sdk-local",
+                memory_dir=memory_dir,
             ),
         }
     }

--- a/src/puffo_agent/mcp/memory_tools.py
+++ b/src/puffo_agent/mcp/memory_tools.py
@@ -1,0 +1,685 @@
+"""Semantic memory MCP tools (M3) over the M2 ``MemoryStore``.
+
+Ten agent-facing tools: six semantic writes (``create_note``,
+``patch_note``, ``append_note``, ``create_briefing_topic``,
+``patch_briefing_topic``, ``append_recollection``) and four
+read/search tools (``read_memory_file``, ``read_memory_files``,
+``search_memory``, ``search_imports``). The agent works with memory
+concepts — notes, briefing topics, recollections — never physical
+paths; semantic names are normalized onto logical paths
+(``notes/<name>.md``, ``briefing/<name>.md``, dated
+``recollection/YYYY/MM/YYYY-MM-DD.md``) and every write goes through
+the M2 store, which keeps path grammar, scope rules, size limits, and
+atomicity centralized.
+
+Every successful write is committed to the LOCAL git repo at the
+memory root (``memory_git``), with the caller's ``reason`` recorded in
+the commit body. Writes return the doc's result envelope::
+
+    {ok, tool, changed, paths, commit_id,
+     post_effects: {briefing_rebuilt, provider_reload}, warnings}
+
+``provider_reload`` mapping for the fat agent — which has no hot
+in-session provider reload; a "reload" means the M1
+``refresh_agent.flag`` was written, so the worker rebuilds provider
+prompt artifacts (CLAUDE.md / AGENTS.md) on the next batch and the
+provider picks them up at next spawn/turn:
+
+- ``"not_needed"`` — non-briefing write, or ``changed: false``;
+- ``"requested"`` — briefing changed and the refresh flag was written;
+- ``"failed"`` — briefing changed but the flag write failed (or no
+  workspace is configured): ``ok`` stays true and a
+  ``memory_provider_reload_failed`` warning is attached — post-effect
+  failures never masquerade as write failures.
+
+``briefing_rebuilt`` is true iff the write touched ``briefing/`` and
+changed it (the store revalidated the compiled-total budget before the
+write committed, and the rebuild was triggered via the refresh flag).
+
+Expected failures (validation, scope, size, patch mismatches) surface
+as structured tool errors whose text is the JSON envelope
+``{ok: false, error: {code, message, operation, path, suggestion,
+causes}}`` with M3 error codes; truly unexpected exceptions propagate
+as plain runtime errors.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date as date_type, datetime, timezone
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from ..agent import memory_git
+from ..agent.memory import (
+    BRIEFING_DIR,
+    IMPORTS_DIR,
+    NOTES_DIR,
+    RECOLLECTION_DIR,
+    MemoryStoreError,
+    ensure_memory_tree,
+    request_prompt_refresh,
+)
+from ..agent.memory_store import IMPORTS_READ_LIMIT, MemoryStore
+
+logger = logging.getLogger(__name__)
+
+NAME_MAX_LENGTH = 100
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+SEARCH_DEFAULT_LIMIT = 20
+SEARCH_MAX_LIMIT = 50
+SEARCH_SNIPPET_LIMIT = 200
+SEARCH_PER_FILE_LIMIT = 3
+
+# search_memory scans these, in this fixed order (deterministic
+# results). imports/ is deliberately absent — it is searchable only
+# via search_imports.
+_SEARCH_SCOPES = (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR)
+
+_NAME_SUGGESTION = (
+    "Use a short flat name like 'puffo-memory-mcp': letters, digits, "
+    "dots, dashes; no slashes, no leading dot, at most "
+    f"{NAME_MAX_LENGTH} characters."
+)
+
+
+@dataclass
+class MemoryToolsConfig:
+    """Config for the M3 memory tools.
+
+    ``maintenance`` is store-level and NOT agent-selectable:
+    ``build_server()`` always constructs it as False; the flag exists
+    so a future daemon-maintenance context can flip it and unlock
+    ``recollection/`` writes.
+    """
+
+    memory_root: str
+    workspace: str = ""
+    maintenance: bool = False
+
+
+# ── error envelopes ──────────────────────────────────────────────────
+
+
+def _tool_error(
+    *,
+    code: str,
+    message: str,
+    operation: str,
+    path: str,
+    suggestion: str,
+    causes: list[dict],
+    size: int | None = None,
+    limit: int | None = None,
+) -> ToolError:
+    """Structured tool error: the text IS the JSON envelope, so the
+    agent sees the M3 error shape instead of a transport failure."""
+    err: dict = {
+        "code": code,
+        "message": message,
+        "operation": operation,
+        "path": path,
+    }
+    if size is not None:
+        err["size"] = size
+    if limit is not None:
+        err["limit"] = limit
+    err["suggestion"] = suggestion
+    err["causes"] = causes
+    return ToolError(json.dumps({"ok": False, "error": err}))
+
+
+def _args_error(
+    operation: str,
+    message: str,
+    suggestion: str,
+    *,
+    code: str = "memory_invalid_arguments",
+    path: str = "",
+) -> ToolError:
+    return _tool_error(
+        code=code,
+        message=message,
+        operation=operation,
+        path=path,
+        suggestion=suggestion,
+        causes=[{"layer": "memory_tools", "code": code, "message": message}],
+    )
+
+
+def _store_error(operation: str, exc: MemoryStoreError) -> ToolError:
+    return _tool_error(
+        code=exc.code,
+        message=f"{operation} failed for {exc.path}: {exc.code}.",
+        operation=operation,
+        path=exc.path,
+        suggestion=exc.suggestion,
+        size=exc.size,
+        limit=exc.limit,
+        causes=[
+            {"layer": "memory_store", "code": exc.code, "message": str(exc)},
+        ],
+    )
+
+
+# ── semantic name / date handling ────────────────────────────────────
+
+
+def _invalid_name(operation: str, name: object) -> ToolError:
+    message = f"{operation}: {name!r} is not a valid memory name."
+    return _args_error(
+        operation, message, _NAME_SUGGESTION, code="memory_invalid_name",
+    )
+
+
+def _normalize_name(operation: str, name: object) -> str:
+    """Normalize a semantic name to a safe flat file stem.
+
+    Lowercase; one trailing ``.md`` dropped; spaces/underscores become
+    dashes (runs collapsed); leading/trailing dashes and trailing dots
+    stripped. The result must match ``^[a-z0-9][a-z0-9._-]*$`` and be
+    at most ``NAME_MAX_LENGTH`` chars — so slashes, hidden (dot-led)
+    names, and traversal shapes are all rejected, and the M2 store
+    re-validates the final logical path regardless (defense in depth).
+    """
+    if not isinstance(name, str):
+        raise _invalid_name(operation, name)
+    n = name.strip().lower()
+    if n.endswith(".md"):
+        n = n[:-3]
+    n = re.sub(r"[ _]+", "-", n)
+    n = re.sub(r"-{2,}", "-", n)
+    n = n.strip("-").rstrip(".")
+    if not n or len(n) > NAME_MAX_LENGTH or not _NAME_RE.fullmatch(n):
+        raise _invalid_name(operation, name)
+    return n
+
+
+def _recollection_path(operation: str, date: object) -> str:
+    """Map an optional ``YYYY-MM-DD`` string (default: today UTC) to
+    the dated logical path ``recollection/YYYY/MM/YYYY-MM-DD.md``."""
+    if date in (None, ""):
+        day = datetime.now(timezone.utc).date()
+    else:
+        if not isinstance(date, str) or not _DATE_RE.fullmatch(date):
+            raise _args_error(
+                operation,
+                f"{operation}: date must be a YYYY-MM-DD string, got {date!r}.",
+                "Pass date as YYYY-MM-DD, or omit it for today (UTC).",
+            )
+        try:
+            day = date_type.fromisoformat(date)
+        except ValueError:
+            raise _args_error(
+                operation,
+                f"{operation}: {date!r} is not a real calendar date.",
+                "Pass date as YYYY-MM-DD, or omit it for today (UTC).",
+            ) from None
+    return (
+        f"{RECOLLECTION_DIR}/{day.year:04d}/{day.month:02d}/"
+        f"{day.isoformat()}.md"
+    )
+
+
+def _validate_patches(operation: str, patches: object) -> list[dict]:
+    if not isinstance(patches, (list, tuple)) or not patches:
+        raise _args_error(
+            operation,
+            f"{operation}: patches must be a non-empty list.",
+            "Pass patches as [{old_text, new_text}, ...].",
+        )
+    out: list[dict] = []
+    for patch in patches:
+        if (
+            not isinstance(patch, dict)
+            or not isinstance(patch.get("old_text"), str)
+            or not isinstance(patch.get("new_text"), str)
+        ):
+            raise _args_error(
+                operation,
+                f"{operation}: each patch needs string old_text and new_text.",
+                "Pass patches as [{old_text, new_text}, ...].",
+            )
+        out.append(
+            {"old_text": patch["old_text"], "new_text": patch["new_text"]}
+        )
+    return out
+
+
+# ── shared write pipeline ────────────────────────────────────────────
+
+
+def _ensure(cfg: MemoryToolsConfig) -> None:
+    """Idempotent per-call init: memory tree + local audit repo. Runs
+    lazily on each tool call — never at registration/build time, so
+    ``build_server()`` stays side-effect free."""
+    root = Path(cfg.memory_root)
+    ensure_memory_tree(root)
+    memory_git.ensure_memory_git(root)
+
+
+def _store(cfg: MemoryToolsConfig) -> MemoryStore:
+    # No workspace_dir: the tools layer owns the briefing post-effect
+    # (and its provider_reload/warning mapping) instead of the store.
+    return MemoryStore(
+        cfg.memory_root, workspace_dir="", maintenance=cfg.maintenance,
+    )
+
+
+def _run_write(cfg: MemoryToolsConfig, tool: str, op, reason: str) -> dict:
+    """Primitive → git commit → post-effects → result envelope."""
+    _ensure(cfg)
+    try:
+        res = op(_store(cfg))
+    except MemoryStoreError as exc:
+        raise _store_error(tool, exc) from exc
+    logical = res["path"]
+    changed = bool(res["changed"])
+    warnings: list[dict] = []
+
+    commit_id = None
+    if changed:
+        if memory_git.git_available():
+            message = memory_git.format_commit_message(
+                tool, [logical], reason,
+            )
+            commit_id = memory_git.commit_memory_change(
+                Path(cfg.memory_root), [logical], message,
+            )
+            if commit_id is None:
+                warnings.append({
+                    "code": "memory_git_commit_failed",
+                    "message": (
+                        "Memory changed, but the audit commit failed; "
+                        "the change is saved but not committed."
+                    ),
+                })
+        else:
+            # Graceful degrade — the doc reserves warnings for
+            # post-effect failures; git being absent is just logged
+            # (by ensure_memory_git).
+            logger.info(
+                "memory git unavailable; %s %s left uncommitted",
+                tool, logical,
+            )
+
+    briefing_rebuilt = False
+    provider_reload = "not_needed"
+    if changed and logical.startswith(f"{BRIEFING_DIR}/"):
+        briefing_rebuilt = True
+        reload_ok = request_prompt_refresh(
+            cfg.workspace, f"memory_tools.{tool}:{logical}",
+        )
+        provider_reload = "requested" if reload_ok else "failed"
+        if not reload_ok:
+            warnings.append({
+                "code": "memory_provider_reload_failed",
+                "message": (
+                    "Memory changed, but the provider reload request "
+                    "failed. The next provider spawn will load the "
+                    "updated briefing."
+                ),
+            })
+
+    return {
+        "ok": True,
+        "tool": tool,
+        "changed": changed,
+        "paths": [logical],
+        "commit_id": commit_id,
+        "post_effects": {
+            "briefing_rebuilt": briefing_rebuilt,
+            "provider_reload": provider_reload,
+        },
+        "warnings": warnings,
+    }
+
+
+# ── deterministic search ─────────────────────────────────────────────
+
+
+def _scope_files(root: Path, scope: str, pattern: str) -> list[tuple[str, Path]]:
+    """(logical path, physical path) pairs under one scope, sorted for
+    deterministic scan order; hidden segments and symlinks skipped."""
+    base = root / scope
+    if not base.is_dir():
+        return []
+    out: list[tuple[str, Path]] = []
+    for p in sorted(base.rglob(pattern)):
+        rel = p.relative_to(root).as_posix()
+        if any(seg.startswith(".") for seg in rel.split("/")):
+            continue
+        if p.is_symlink() or not p.is_file():
+            continue
+        out.append((rel, p))
+    return out
+
+
+def _scan_files(
+    files: list[tuple[str, str, Path]],
+    query: str,
+    limit: int,
+    byte_cap: int | None = None,
+) -> tuple[list[dict], bool]:
+    """Case-insensitive substring scan, line by line. ≤
+    ``SEARCH_PER_FILE_LIMIT`` matches per file, ``limit`` total;
+    returns ``(results, truncated)``."""
+    needle = query.lower()
+    results: list[dict] = []
+    for rel, scope, path in files:
+        data = path.read_bytes()
+        if byte_cap is not None:
+            data = data[:byte_cap]
+        text = data.decode("utf-8", errors="ignore")
+        per_file = 0
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if needle not in line.lower():
+                continue
+            if len(results) >= limit:
+                return results, True
+            snippet = line.strip()
+            if len(snippet) > SEARCH_SNIPPET_LIMIT:
+                snippet = snippet[:SEARCH_SNIPPET_LIMIT]
+            results.append({
+                "path": rel,
+                "scope": scope,
+                "line": lineno,
+                "snippet": snippet,
+            })
+            per_file += 1
+            if per_file >= SEARCH_PER_FILE_LIMIT:
+                break
+    return results, False
+
+
+def _validate_search_args(operation: str, query: object, limit: object) -> int:
+    if not isinstance(query, str) or not query.strip():
+        raise _args_error(
+            operation,
+            f"{operation}: query must be a non-empty string.",
+            "Pass the text to look for.",
+        )
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        raise _args_error(
+            operation,
+            f"{operation}: limit must be a positive integer, got {limit!r}.",
+            f"Use 1 ≤ limit ≤ {SEARCH_MAX_LIMIT} (default "
+            f"{SEARCH_DEFAULT_LIMIT}).",
+        )
+    return min(limit, SEARCH_MAX_LIMIT)
+
+
+# ── registration ─────────────────────────────────────────────────────
+
+
+def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
+    """Register the ten M3 semantic memory tools on ``mcp``."""
+
+    # -- write tools ---------------------------------------------------
+
+    @mcp.tool()
+    async def create_note(name: str, body: str, reason: str = "") -> dict:
+        """Create a durable note at notes/<name>.md.
+
+        Notes are searchable long-term memory — detail that should
+        survive but not be injected into every prompt. ``name`` is a
+        semantic name (normalized to a flat lowercase slug), not a
+        path. Fails if the note already exists — change an existing
+        note with patch_note or append_note. ``reason`` (optional) is
+        recorded in the memory audit log.
+        """
+        slug = _normalize_name("create_note", name)
+        path = f"{NOTES_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "create_note",
+            lambda s: s.create_memory_file(path, body), reason,
+        )
+
+    @mcp.tool()
+    async def patch_note(
+        name: str, patches: list[dict], reason: str = "",
+    ) -> dict:
+        """Patch an existing note at notes/<name>.md by exact text
+        replacement.
+
+        ``patches`` is a list of ``{old_text, new_text}``; each
+        old_text must match the current content exactly once, and the
+        list applies all-or-nothing. ``reason`` (optional) is recorded
+        in the memory audit log.
+        """
+        slug = _normalize_name("patch_note", name)
+        checked = _validate_patches("patch_note", patches)
+        path = f"{NOTES_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "patch_note",
+            lambda s: s.patch_memory_file(path, checked), reason,
+        )
+
+    @mcp.tool()
+    async def append_note(name: str, text: str, reason: str = "") -> dict:
+        """Append text to the end of an existing note at
+        notes/<name>.md. ``reason`` (optional) is recorded in the
+        memory audit log.
+        """
+        slug = _normalize_name("append_note", name)
+        path = f"{NOTES_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "append_note",
+            lambda s: s.append_memory_file(path, text), reason,
+        )
+
+    @mcp.tool()
+    async def create_briefing_topic(
+        name: str, body: str, reason: str = "",
+    ) -> dict:
+        """Create a briefing topic at briefing/<name>.md.
+
+        Briefing topics are ALWAYS loaded into your prompt, so keep
+        them small — the store enforces per-file and compiled-total
+        budgets and rejects oversized writes. A successful change
+        marks the provider prompt artifacts for rebuild;
+        ``post_effects.provider_reload`` reports "requested" when the
+        rebuild flag was written (the provider picks it up at its next
+        spawn/turn) and "failed" (with a warning) when it could not
+        be. ``reason`` (optional) is recorded in the memory audit log.
+        """
+        slug = _normalize_name("create_briefing_topic", name)
+        path = f"{BRIEFING_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "create_briefing_topic",
+            lambda s: s.create_memory_file(path, body), reason,
+        )
+
+    @mcp.tool()
+    async def patch_briefing_topic(
+        name: str, patches: list[dict], reason: str = "",
+    ) -> dict:
+        """Patch an existing briefing topic at briefing/<name>.md by
+        exact text replacement (same rules as patch_note).
+
+        A successful change marks the provider prompt artifacts for
+        rebuild; ``post_effects.provider_reload`` reports "requested"
+        when the rebuild flag was written (picked up at the provider's
+        next spawn/turn) and "failed" (with a warning) when it could
+        not be. ``reason`` (optional) is recorded in the memory audit
+        log.
+        """
+        slug = _normalize_name("patch_briefing_topic", name)
+        checked = _validate_patches("patch_briefing_topic", patches)
+        path = f"{BRIEFING_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "patch_briefing_topic",
+            lambda s: s.patch_memory_file(path, checked), reason,
+        )
+
+    @mcp.tool()
+    async def append_recollection(
+        text: str,
+        date: str = "",
+        source_message_ids: list[str] | None = None,
+        related_paths: list[str] | None = None,
+        reason: str = "",
+    ) -> dict:
+        """Append an entry to the dated recollection journal at
+        recollection/YYYY/MM/YYYY-MM-DD.md (``date`` defaults to today
+        UTC; the file is created with a ``# <date>`` header when
+        missing).
+
+        recollection/ is daemon-owned maintenance memory: ordinary
+        conversation turns do NOT have write scope here and get a
+        structured memory_scope_readonly error — put durable detail in
+        notes/ instead. ``source_message_ids`` / ``related_paths``
+        (optional) are recorded as sources:/related: lines; ``reason``
+        (optional) goes to the memory audit log.
+        """
+        path = _recollection_path("append_recollection", date)
+        day = path.rsplit("/", 1)[-1][:-3]
+        lines = [text]
+        if source_message_ids:
+            lines.append(
+                "sources: " + ", ".join(str(i) for i in source_message_ids)
+            )
+        if related_paths:
+            lines.append(
+                "related: " + ", ".join(str(p) for p in related_paths)
+            )
+        entry = "\n" + "\n".join(lines) + "\n"
+
+        def op(store: MemoryStore) -> dict:
+            if store.get_memory_file_status(path)["exists"]:
+                return store.append_memory_file(path, entry)
+            return store.create_memory_file(path, f"# {day}\n" + entry)
+
+        return _run_write(cfg, "append_recollection", op, reason)
+
+    # -- read tools ----------------------------------------------------
+
+    @mcp.tool()
+    async def read_memory_file(path: str) -> dict:
+        """Read one memory file by logical path (briefing/…, notes/…,
+        recollection/…, imports/…). The body is bounded by the area's
+        file limit; ``truncated`` flags a cut read."""
+        _ensure(cfg)
+        try:
+            return _store(cfg).read_memory_file(path)
+        except MemoryStoreError as exc:
+            raise _store_error("read_memory_file", exc) from exc
+
+    @mcp.tool()
+    async def read_memory_files(paths: list[str]) -> dict:
+        """Read up to 16 memory files in one call (pure read, never
+        writes). Each entry is a read result or a per-path error — one
+        bad path does not fail the batch."""
+        _ensure(cfg)
+        try:
+            results = _store(cfg).read_memory_files(paths)
+        except MemoryStoreError as exc:
+            raise _store_error("read_memory_files", exc) from exc
+        return {"ok": True, "results": results}
+
+    # -- search tools --------------------------------------------------
+
+    @mcp.tool()
+    async def search_memory(
+        query: str,
+        scopes: list[str] | None = None,
+        limit: int = SEARCH_DEFAULT_LIMIT,
+    ) -> dict:
+        """Search memory for a case-insensitive substring, line by
+        line. ``scopes`` defaults to ["briefing", "notes",
+        "recollection"] (imports/ is searchable only via
+        search_imports). Deterministic order; at most 3 matches per
+        file; ``limit`` caps total results (default 20, max 50)."""
+        operation = "search_memory"
+        _ensure(cfg)
+        capped = _validate_search_args(operation, query, limit)
+        requested = list(_SEARCH_SCOPES) if scopes is None else list(scopes)
+        if not requested:
+            raise _args_error(
+                operation,
+                "search_memory: scopes must not be empty.",
+                "Omit scopes, or pick from: briefing, notes, recollection.",
+            )
+        for scope in requested:
+            if scope == IMPORTS_DIR:
+                raise _args_error(
+                    operation,
+                    "search_memory does not search imports/.",
+                    "Use search_imports for imported content.",
+                )
+            if scope not in _SEARCH_SCOPES:
+                raise _args_error(
+                    operation,
+                    f"search_memory: unknown scope {scope!r}.",
+                    "Pick scopes from: briefing, notes, recollection.",
+                )
+        root = Path(cfg.memory_root)
+        files = [
+            (rel, scope, p)
+            for scope in _SEARCH_SCOPES
+            if scope in requested
+            for rel, p in _scope_files(root, scope, "*.md")
+        ]
+        try:
+            results, truncated = _scan_files(files, query, capped)
+        except OSError as exc:
+            raise _tool_error(
+                code="memory_search_failed",
+                message=f"search_memory failed: {exc}",
+                operation=operation,
+                path="",
+                suggestion="Retry; if it persists, check the memory dir.",
+                causes=[{
+                    "layer": "memory_tools",
+                    "code": "memory_search_failed",
+                    "message": str(exc),
+                }],
+            ) from exc
+        return {
+            "ok": True, "query": query,
+            "results": results, "truncated": truncated,
+        }
+
+    @mcp.tool()
+    async def search_imports(
+        query: str, limit: int = SEARCH_DEFAULT_LIMIT,
+    ) -> dict:
+        """Search imported (read-only) content under imports/ for a
+        case-insensitive substring. Reads at most 128KB per file;
+        same match/limit rules as search_memory."""
+        operation = "search_imports"
+        _ensure(cfg)
+        capped = _validate_search_args(operation, query, limit)
+        root = Path(cfg.memory_root)
+        files = [
+            (rel, IMPORTS_DIR, p)
+            for rel, p in _scope_files(root, IMPORTS_DIR, "*")
+        ]
+        try:
+            results, truncated = _scan_files(
+                files, query, capped, byte_cap=IMPORTS_READ_LIMIT,
+            )
+        except OSError as exc:
+            raise _tool_error(
+                code="memory_search_failed",
+                message=f"search_imports failed: {exc}",
+                operation=operation,
+                path="",
+                suggestion="Retry; if it persists, check the memory dir.",
+                causes=[{
+                    "layer": "memory_tools",
+                    "code": "memory_search_failed",
+                    "message": str(exc),
+                }],
+            ) from exc
+        return {
+            "ok": True, "query": query,
+            "results": results, "truncated": truncated,
+        }

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -32,6 +32,7 @@ from .host_tools import (
     _uninstall_skill,
     _write_refresh_model_flag,
 )
+from .memory_tools import MemoryToolsConfig, register_memory_tools
 from .puffo_core_tools import PuffoCoreToolsConfig, register_core_tools
 
 logger = logging.getLogger(__name__)
@@ -232,6 +233,7 @@ def build_server(
     data_service_url: str,
     runtime_kind: str = "",
     harness: str = "",
+    memory_dir: str = "",
 ) -> FastMCP:
     ks = KeyStore(keystore_dir)
     http = PuffoCoreHttpClient(server_url, ks, slug)
@@ -263,6 +265,17 @@ def build_server(
     )
     register_core_tools(mcp, core_cfg)
     _register_local_tools(mcp, workspace, runtime_kind, harness)
+
+    # Memory root: PUFFO_MEMORY_DIR when set; otherwise the default
+    # AgentConfig layout where memory/ and workspace/ are siblings
+    # under the agent dir. ``maintenance`` stays False here — the
+    # agent-facing server never gets recollection/ write scope.
+    if not memory_dir:
+        memory_dir = str(Path(workspace).parent / "memory")
+    mem_cfg = MemoryToolsConfig(
+        memory_root=memory_dir, workspace=workspace, maintenance=False,
+    )
+    register_memory_tools(mcp, mem_cfg)
     return mcp
 
 
@@ -295,6 +308,7 @@ def _cfg_from_env() -> dict[str, str]:
         "data_service_url": data_service_url,
         "runtime_kind": os.environ.get("PUFFO_RUNTIME_KIND", ""),
         "harness": os.environ.get("PUFFO_HARNESS", ""),
+        "memory_dir": os.environ.get("PUFFO_MEMORY_DIR", ""),
     }
 
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -138,6 +138,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 keystore_dir=str(agent_dir(agent_cfg.id) / "keys"),
                 workspace=str(agent_cfg.resolve_workspace_dir()),
                 agent_id=agent_cfg.id,
+                memory_dir=str(agent_cfg.resolve_memory_dir()),
             )
         return adapter
 
@@ -220,6 +221,10 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 rpc_url=f"http://host.docker.internal:{daemon_cfg.rpc_service.port}",
                 runtime_kind="cli-docker",
                 harness=agent_cfg.runtime.harness,
+                # MCP runs in-container; the agent dir is bind-mounted
+                # at /home/agent/.puffo-agent-state (docker_cli also
+                # pins this at its env-override sites).
+                memory_dir="/home/agent/.puffo-agent-state/memory",
             )
         return adapter
 
@@ -268,6 +273,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 rpc_url=f"http://127.0.0.1:{daemon_cfg.rpc_service.port}",
                 runtime_kind="cli-local",
                 harness=agent_cfg.runtime.harness,
+                memory_dir=str(agent_cfg.resolve_memory_dir()),
             )
         return adapter
 

--- a/tests/test_memory_m3.py
+++ b/tests/test_memory_m3.py
@@ -1,0 +1,615 @@
+"""M3 memory acceptance tests: the semantic memory MCP tools layered
+on the M2 MemoryStore — name normalization onto safe logical paths,
+per-scope confinement (notes/, briefing/, recollection/, read-only
+imports/), the write result envelope with git/audit commit ids and
+post-effects, structured tool errors with M3 codes, pure bounded batch
+reads, and deterministic search.
+
+One test (or small group) per M3 validation scenario in
+docs/user-lead-designs/memory-implementation.md, named after it.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from puffo_agent.agent import memory_git
+from puffo_agent.agent.memory import MemoryStoreError, ensure_memory_tree
+from puffo_agent.agent.memory_store import NOTES_FILE_LIMIT, MemoryStore
+from puffo_agent.mcp import memory_tools
+from puffo_agent.mcp.memory_tools import (
+    MemoryToolsConfig,
+    register_memory_tools,
+)
+
+M3_TOOLS = {
+    "create_note",
+    "patch_note",
+    "append_note",
+    "create_briefing_topic",
+    "patch_briefing_topic",
+    "append_recollection",
+    "read_memory_file",
+    "read_memory_files",
+    "search_memory",
+    "search_imports",
+}
+
+
+@pytest.fixture
+def root(tmp_path):
+    # The tools ensure the tree + local git repo lazily on first call.
+    return tmp_path / "memory"
+
+
+def _build(root, workspace="", maintenance=False):
+    mcp = FastMCP("test")
+    register_memory_tools(mcp, MemoryToolsConfig(
+        memory_root=str(root),
+        workspace=str(workspace) if workspace else "",
+        maintenance=maintenance,
+    ))
+    return mcp
+
+
+async def _call(mcp, name, args):
+    result = await mcp.call_tool(name, args)
+    text = "".join(getattr(item, "text", "") for item in result)
+    return json.loads(text)
+
+
+async def _call_err(mcp, name, args):
+    """Call a tool expecting failure; return the structured M3 error
+    envelope extracted from the raised tool error's JSON text."""
+    with pytest.raises(ToolError) as ei:
+        await mcp.call_tool(name, args)
+    text = str(ei.value)
+    payload = json.loads(text[text.index("{"):])
+    assert payload["ok"] is False
+    return payload["error"]
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file() and ".git" not in p.relative_to(root).parts
+    }
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+# ── scenario 1: semantic names normalize to safe logical paths ───────
+
+
+@pytest.mark.asyncio
+async def test_semantic_names_normalize_to_safe_logical_paths(root):
+    mcp = _build(root)
+    res = await _call(mcp, "create_note", {
+        "name": "My Topic  Notes", "body": "body\n",
+    })
+    assert res["paths"] == ["notes/my-topic-notes.md"]
+    assert (root / "notes" / "my-topic-notes.md").is_file()
+
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "Team_Prefs.md", "body": "briefing\n",
+    })
+    assert res["paths"] == ["briefing/team-prefs.md"]
+    assert (root / "briefing" / "team-prefs.md").is_file()
+
+    maint = _build(root, maintenance=True)
+    res = await _call(maint, "append_recollection", {
+        "date": "2026-07-06", "text": "daily entry",
+    })
+    assert res["paths"] == ["recollection/2026/07/2026-07-06.md"]
+    assert (root / "recollection" / "2026" / "07" / "2026-07-06.md").is_file()
+
+    # Omitted date maps to today's (UTC) dated path shape.
+    res = await _call(maint, "append_recollection", {"text": "later entry"})
+    assert re.fullmatch(
+        r"recollection/\d{4}/\d{2}/\d{4}-\d{2}-\d{2}\.md", res["paths"][0],
+    )
+
+
+# ── scenario 2: invalid semantic names are rejected ──────────────────
+
+
+@pytest.mark.parametrize("bad", [
+    "",                # empty
+    ".",               # dot only
+    "../evil",         # traversal shape
+    "a/b",             # slashes: semantic names are flat
+    ".hidden",         # hidden (dot-led)
+    "x" * 101,         # too long
+])
+@pytest.mark.asyncio
+async def test_invalid_semantic_names_are_rejected(root, bad):
+    mcp = _build(root)
+    for tool, args in [
+        ("create_note", {"name": bad, "body": "b"}),
+        ("append_note", {"name": bad, "text": "b"}),
+        ("patch_note", {"name": bad, "patches": [
+            {"old_text": "a", "new_text": "b"},
+        ]}),
+        ("create_briefing_topic", {"name": bad, "body": "b"}),
+        ("patch_briefing_topic", {"name": bad, "patches": [
+            {"old_text": "a", "new_text": "b"},
+        ]}),
+    ]:
+        err = await _call_err(mcp, tool, args)
+        assert err["code"] == "memory_invalid_name"
+        assert err["operation"] == tool
+        assert err["suggestion"]
+
+
+def test_non_string_semantic_name_is_rejected():
+    # FastMCP's schema already blocks non-str args at the transport
+    # boundary; the tools layer still validates (defense in depth).
+    with pytest.raises(ToolError) as ei:
+        memory_tools._normalize_name("create_note", 123)
+    text = str(ei.value)
+    err = json.loads(text[text.index("{"):])["error"]
+    assert err["code"] == "memory_invalid_name"
+
+
+@pytest.mark.asyncio
+async def test_invalid_recollection_date_is_rejected(root):
+    mcp = _build(root, maintenance=True)
+    for bad in ("07/06/2026", "20260706", "2026-7-6", "2026-13-40"):
+        err = await _call_err(mcp, "append_recollection", {
+            "date": bad, "text": "x",
+        })
+        assert err["code"] == "memory_invalid_arguments"
+    assert not (root / "recollection").exists() or not any(
+        (root / "recollection").rglob("*.md")
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_patches_are_rejected(root):
+    mcp = _build(root)
+    # (Non-dict entries like ["nope"] are already rejected by the MCP
+    # schema for list[dict] before the tool body runs.)
+    for bad_patches in ([], [{"old_text": 1, "new_text": "x"}], [{}]):
+        err = await _call_err(mcp, "patch_note", {
+            "name": "n", "patches": bad_patches,
+        })
+        assert err["code"] == "memory_invalid_arguments"
+
+
+# ── scenario 3: note tools cannot write outside notes/ ───────────────
+
+
+@pytest.mark.asyncio
+async def test_note_tools_cannot_write_outside_notes(root):
+    mcp = _build(root)
+    ensure_memory_tree(root)
+    before = _tree_snapshot(root)
+    for bad in ("../evil", "notes/../../etc/passwd", "a/b", ".."):
+        err = await _call_err(mcp, "create_note", {"name": bad, "body": "b"})
+        assert err["code"] == "memory_invalid_name"
+    assert _tree_snapshot(root) == before
+
+    res = await _call(mcp, "create_note", {"name": "safe", "body": "b\n"})
+    assert res["paths"] == ["notes/safe.md"]
+    res = await _call(mcp, "append_note", {"name": "safe", "text": "more\n"})
+    assert res["paths"] == ["notes/safe.md"]
+    res = await _call(mcp, "patch_note", {"name": "safe", "patches": [
+        {"old_text": "more", "new_text": "MORE"},
+    ]})
+    assert res["paths"] == ["notes/safe.md"]
+    # Every new file the note tools produced lives under notes/.
+    new_paths = set(_tree_snapshot(root)) - set(before)
+    assert new_paths == {"notes/safe.md"}
+
+
+# ── scenario 4: briefing tools cannot write outside briefing/ ────────
+
+
+@pytest.mark.asyncio
+async def test_briefing_topic_tools_cannot_write_outside_briefing(root):
+    mcp = _build(root)
+    ensure_memory_tree(root)
+    before = _tree_snapshot(root)
+    for bad in ("../evil", "briefing/../notes/x", "a/b", "sub/topic"):
+        err = await _call_err(mcp, "create_briefing_topic", {
+            "name": bad, "body": "b",
+        })
+        assert err["code"] == "memory_invalid_name"
+    assert _tree_snapshot(root) == before
+
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "prefs", "body": "b\n",
+    })
+    assert res["paths"] == ["briefing/prefs.md"]
+    res = await _call(mcp, "patch_briefing_topic", {"name": "prefs", "patches": [
+        {"old_text": "b\n", "new_text": "B\n"},
+    ]})
+    assert res["paths"] == ["briefing/prefs.md"]
+    # Flat and confined: the only new file sits directly in briefing/.
+    new_paths = set(_tree_snapshot(root)) - set(before)
+    assert new_paths == {"briefing/prefs.md"}
+
+
+# ── scenario 5: recollection/ needs explicit scope ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_conversation_scope_cannot_write_recollection(root):
+    mcp = _build(root)
+    err = await _call_err(mcp, "append_recollection", {
+        "date": "2026-07-06", "text": "entry",
+    })
+    assert err["code"] == "memory_scope_readonly"
+    assert err["suggestion"]
+    assert not (root / "recollection" / "2026").exists()
+
+    # The same write under the explicit maintenance scope succeeds —
+    # the deny above is scope, not breakage.
+    maint = _build(root, maintenance=True)
+    res = await _call(maint, "append_recollection", {
+        "date": "2026-07-06",
+        "text": "learned a thing",
+        "source_message_ids": ["m1", "m2"],
+        "related_paths": ["notes/a.md"],
+    })
+    assert res["ok"] is True and res["changed"] is True
+    body = (
+        root / "recollection" / "2026" / "07" / "2026-07-06.md"
+    ).read_text(encoding="utf-8")
+    assert body.startswith("# 2026-07-06\n")
+    assert "learned a thing" in body
+    assert "sources: m1, m2" in body
+    assert "related: notes/a.md" in body
+
+    # A second entry appends to the same dated file.
+    await _call(maint, "append_recollection", {
+        "date": "2026-07-06", "text": "second entry",
+    })
+    body = (
+        root / "recollection" / "2026" / "07" / "2026-07-06.md"
+    ).read_text(encoding="utf-8")
+    assert body.count("# 2026-07-06") == 1
+    assert "second entry" in body
+
+
+# ── scenario 6: imports are read-only ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_imports_are_read_only(root):
+    mcp = _build(root)
+    res = await _call(mcp, "read_memory_file", {"path": "imports/index.md"})
+    assert res["scope"] == "imports"
+    assert "Imports index" in res["body"]
+
+    res = await _call(mcp, "search_imports", {"query": "provenance"})
+    assert res["results"]
+    assert all(m["path"].startswith("imports/") for m in res["results"])
+
+    # No semantic write tool can produce an imports/ path: names are
+    # flat, so "imports/…" never survives normalization.
+    for tool, args in [
+        ("create_note", {"name": "imports/evil", "body": "b"}),
+        ("append_note", {"name": "imports/index", "text": "b"}),
+        ("create_briefing_topic", {"name": "imports/evil", "body": "b"}),
+    ]:
+        err = await _call_err(mcp, tool, args)
+        assert err["code"] == "memory_invalid_name"
+    assert not (root / "imports" / "evil.md").exists()
+
+    # Store-level defense in depth: a direct imports/ write is denied.
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root).create_memory_file("imports/new.md", "x")
+    assert ei.value.code == "memory_scope_readonly"
+
+
+# ── scenario 7: reason? appears in git/audit metadata ────────────────
+
+
+@pytest.mark.asyncio
+async def test_reason_appears_in_git_audit_metadata(root):
+    mcp = _build(root)
+    res = await _call(mcp, "create_note", {
+        "name": "topic", "body": "body\n", "reason": "user asked",
+    })
+    assert res["commit_id"] == _git(root, "rev-parse", "--short", "HEAD")
+    message = _git(root, "log", "-1", "--format=%B")
+    assert "create_note" in message
+    assert "notes/topic.md" in message
+    assert "reason: user asked" in message
+
+    # A write WITHOUT reason commits with no reason line.
+    res2 = await _call(mcp, "append_note", {"name": "topic", "text": "more\n"})
+    assert res2["commit_id"] == _git(root, "rev-parse", "--short", "HEAD")
+    assert res2["commit_id"] != res["commit_id"]
+    message = _git(root, "log", "-1", "--format=%B")
+    assert "append_note" in message
+    assert "reason:" not in message
+
+
+@pytest.mark.asyncio
+async def test_git_unavailable_degrades_gracefully(root, monkeypatch):
+    monkeypatch.setattr(memory_git, "git_available", lambda: False)
+    mcp = _build(root)
+    res = await _call(mcp, "create_note", {"name": "n", "body": "b\n"})
+    assert res["ok"] is True
+    assert res["changed"] is True
+    assert res["commit_id"] is None
+    # Degrade is logged, not warned — warnings are for post-effect
+    # failures.
+    assert res["warnings"] == []
+    assert (root / "notes" / "n.md").is_file()
+    assert not (root / ".git").exists()
+
+
+# ── scenario 8: write result envelope ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_tools_return_changed_paths_commit_id_post_effects(
+    root, tmp_path,
+):
+    workspace = tmp_path / "workspace"
+    mcp = _build(root, workspace=workspace)
+
+    res = await _call(mcp, "create_note", {"name": "n", "body": "b\n"})
+    assert set(res) == {
+        "ok", "tool", "changed", "paths", "commit_id", "post_effects",
+        "warnings",
+    }
+    assert set(res["post_effects"]) == {"briefing_rebuilt", "provider_reload"}
+    assert res["tool"] == "create_note"
+    assert res["changed"] is True
+    assert isinstance(res["commit_id"], str) and res["commit_id"]
+    assert res["post_effects"] == {
+        "briefing_rebuilt": False, "provider_reload": "not_needed",
+    }
+    assert res["warnings"] == []
+
+    # Briefing write with a real workspace: rebuilt + reload requested,
+    # and the refresh flag actually exists.
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "prefs", "body": "x\n",
+    })
+    assert res["post_effects"] == {
+        "briefing_rebuilt": True, "provider_reload": "requested",
+    }
+    flag = workspace / ".puffo-agent" / "refresh_agent.flag"
+    assert flag.is_file()
+    payload = json.loads(flag.read_text(encoding="utf-8"))
+    assert payload["reason"] == (
+        "memory_tools.create_briefing_topic:briefing/prefs.md"
+    )
+
+    # No-op patch: changed False, nothing committed, no post-effects.
+    head = _git(root, "rev-parse", "HEAD")
+    res = await _call(mcp, "patch_briefing_topic", {"name": "prefs", "patches": [
+        {"old_text": "x", "new_text": "x"},
+    ]})
+    assert res["changed"] is False
+    assert res["commit_id"] is None
+    assert res["post_effects"] == {
+        "briefing_rebuilt": False, "provider_reload": "not_needed",
+    }
+    assert _git(root, "rev-parse", "HEAD") == head
+
+
+@pytest.mark.asyncio
+async def test_briefing_write_with_failed_reload_warns_but_stays_ok(
+    root, monkeypatch,
+):
+    monkeypatch.setattr(
+        memory_tools, "request_prompt_refresh", lambda ws, reason: False,
+    )
+    mcp = _build(root, workspace="")
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "t", "body": "b\n",
+    })
+    # Post-effect failure after a successful write never pretends the
+    # write failed.
+    assert res["ok"] is True
+    assert res["changed"] is True
+    assert res["post_effects"]["briefing_rebuilt"] is True
+    assert res["post_effects"]["provider_reload"] == "failed"
+    assert [w["code"] for w in res["warnings"]] == [
+        "memory_provider_reload_failed",
+    ]
+    assert res["warnings"][0]["message"]
+
+
+# ── scenario 9: expected failures are structured tool errors ─────────
+
+
+@pytest.mark.asyncio
+async def test_expected_failures_return_structured_tool_errors(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "n", "body": "alpha beta\n"})
+
+    err = await _call_err(mcp, "patch_note", {"name": "n", "patches": [
+        {"old_text": "gamma", "new_text": "delta"},
+    ]})
+    assert set(err) >= {
+        "code", "message", "operation", "path", "suggestion", "causes",
+    }
+    assert err["code"] == "memory_patch_no_match"
+    assert err["operation"] == "patch_note"
+    assert err["path"] == "notes/n.md"
+    assert err["suggestion"]
+    assert err["causes"][0]["layer"] == "memory_store"
+    assert err["causes"][0]["code"] == "memory_patch_no_match"
+
+    err = await _call_err(mcp, "create_note", {"name": "n", "body": "again"})
+    assert err["code"] == "memory_file_exists"
+
+    err = await _call_err(mcp, "create_note", {
+        "name": "big", "body": "x" * (NOTES_FILE_LIMIT + 1),
+    })
+    assert err["code"] == "memory_file_too_large"
+    assert err["limit"] == NOTES_FILE_LIMIT
+    assert err["size"] > err["limit"]
+
+
+# ── scenario 10: read_memory_files is a pure bounded batch ───────────
+
+
+@pytest.mark.asyncio
+async def test_read_memory_files_reads_bounded_files_and_never_writes(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "note a"})
+    await _call(mcp, "create_briefing_topic", {"name": "b", "body": "brief b"})
+    # Over-limit file placed out-of-band proves reads are bounded.
+    (root / "notes" / "huge.md").write_text(
+        "h" * (NOTES_FILE_LIMIT + 512), encoding="utf-8",
+    )
+    head_before = _git(root, "rev-parse", "HEAD")
+    before = _tree_snapshot(root)
+
+    res = await _call(mcp, "read_memory_files", {"paths": [
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ]})
+    results = res["results"]
+    assert [r["path"] for r in results] == [
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ]
+    assert results[0]["body"] == "note a"
+    assert results[1]["body"] == "brief b"
+    assert results[2]["truncated"] is True
+    assert len(results[2]["body"].encode("utf-8")) == NOTES_FILE_LIMIT
+    # One bad path yields a per-entry error, not a batch failure.
+    assert results[3]["error"]["code"] == "memory_file_not_found"
+    assert results[4]["error"]["code"] == "memory_invalid_path"
+
+    # Pure read: tree bytes and git HEAD are both untouched.
+    assert _tree_snapshot(root) == before
+    assert _git(root, "rev-parse", "HEAD") == head_before
+
+
+# ── registration ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_all_ten_m3_tools_are_registered_on_built_server(root, tmp_path):
+    from puffo_agent.mcp.puffo_core_server import build_server
+
+    server = build_server(
+        slug="agent-0001",
+        device_id="dev_test",
+        server_url="http://localhost:3000",
+        space_id="",
+        keystore_dir=str(tmp_path / "keys"),
+        workspace=str(tmp_path / "workspace"),
+        agent_id="agent-0001",
+        data_service_url="http://127.0.0.1:1",
+        memory_dir=str(root),
+    )
+    names = {t.name for t in await server.list_tools()}
+    assert M3_TOOLS <= names
+    # Building the server has no side effects: the memory tree and its
+    # git repo are ensured lazily on first tool call, not at build time.
+    assert not root.exists()
+
+
+# ── search ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_memory_bounded_deterministic_results(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "alpha",
+        "body": "needle one\nplain line\nNEEDLE two\nneedle three\nneedle four\n",
+    })
+    await _call(mcp, "create_note", {
+        "name": "beta", "body": ("x" * 400) + " needle tail\n",
+    })
+    await _call(mcp, "create_briefing_topic", {
+        "name": "gamma", "body": "needle brief\n",
+    })
+
+    res = await _call(mcp, "search_memory", {"query": "NeEdLe"})
+    assert res["ok"] is True and res["query"] == "NeEdLe"
+    paths = [m["path"] for m in res["results"]]
+    # Fixed scope order (briefing before notes), sorted files within.
+    assert paths[0] == "briefing/gamma.md"
+    assert res["results"][0]["scope"] == "briefing"
+    assert res["results"][0]["line"] == 1
+    # ≤ 3 matches per file: alpha has 4 matching lines.
+    assert paths.count("notes/alpha.md") == 3
+    # Snippets are bounded even for very long lines.
+    assert all(len(m["snippet"]) <= 200 for m in res["results"])
+    assert res["truncated"] is False
+
+    # Deterministic: an identical query returns identical results.
+    assert await _call(mcp, "search_memory", {"query": "NeEdLe"}) == res
+
+    # limit is enforced and reported via truncated.
+    res2 = await _call(mcp, "search_memory", {"query": "needle", "limit": 2})
+    assert len(res2["results"]) == 2
+    assert res2["truncated"] is True
+
+    # Scope filtering.
+    res3 = await _call(mcp, "search_memory", {
+        "query": "needle", "scopes": ["notes"],
+    })
+    assert res3["results"]
+    assert all(m["scope"] == "notes" for m in res3["results"])
+
+
+@pytest.mark.asyncio
+async def test_search_memory_rejects_imports_scope_and_bad_arguments(root):
+    mcp = _build(root)
+    err = await _call_err(mcp, "search_memory", {
+        "query": "x", "scopes": ["imports"],
+    })
+    assert err["code"] == "memory_invalid_arguments"
+    assert "search_imports" in err["suggestion"]
+
+    err = await _call_err(mcp, "search_memory", {
+        "query": "x", "scopes": ["bogus"],
+    })
+    assert err["code"] == "memory_invalid_arguments"
+
+    err = await _call_err(mcp, "search_memory", {"query": "x", "limit": 0})
+    assert err["code"] == "memory_invalid_arguments"
+
+    err = await _call_err(mcp, "search_memory", {"query": "   "})
+    assert err["code"] == "memory_invalid_arguments"
+
+    err = await _call_err(mcp, "search_imports", {"query": "x", "limit": -3})
+    assert err["code"] == "memory_invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_search_imports_hits_only_imports(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "n", "body": "provenance mentioned in a note\n",
+    })
+    (root / "imports" / "doc.txt").write_text(
+        "imported provenance data\n", encoding="utf-8",
+    )
+
+    res = await _call(mcp, "search_imports", {"query": "provenance"})
+    paths = [m["path"] for m in res["results"]]
+    assert paths
+    assert all(p.startswith("imports/") for p in paths)
+    assert "imports/doc.txt" in paths
+    assert all(m["scope"] == "imports" for m in res["results"])
+    assert "notes/n.md" not in paths
+
+    # …and search_memory never reaches into imports/.
+    res = await _call(mcp, "search_memory", {"query": "provenance"})
+    assert [m["path"] for m in res["results"]] == ["notes/n.md"]


### PR DESCRIPTION
## Summary

M3 of the memory design (`agent/docs/user-lead-designs/memory-implementation.md` §M3): the agent-facing **semantic memory surface** on the fat agent's puffo-core MCP server.

> **Stacked PR — do not merge before its base.** Stack: #124 (M1, base `main`) → #125 (M2, base `fleet/pyagent-memory-m1`) → **this PR (M3, base `fleet/pyagent-memory-m2`)**. Held for human review.

### What's in here

- **`mcp/memory_tools.py`** (new): `MemoryToolsConfig` + `register_memory_tools()` with the ten M3 tools —
  - writes: `create_note`, `patch_note`, `append_note`, `create_briefing_topic`, `patch_briefing_topic`, `append_recollection`
  - read/search: `read_memory_file`, `read_memory_files`, `search_memory`, `search_imports`
  - Semantic names normalize to flat logical paths (`notes/<name>.md`, `briefing/<name>.md`, dated `recollection/YYYY/MM/YYYY-MM-DD.md`); everything routes through the M2 `MemoryStore`, so path grammar, scope rules (`recollection/` maintenance-only, `imports/` read-only), size limits, and atomicity stay centralized. Expected failures surface as structured tool errors (`{ok:false, error:{code, message, operation, path, suggestion, causes}}`) with the doc's M3 codes.
- **`agent/memory_git.py`** (new): local-only git audit layer at the memory root — lazy `init` with repo-local identity + `gpgsign=false`, explicit-pathspec `add` + commit per successful write, `reason` recorded in the commit body. Graceful degrade to `commit_id: null` when git is unavailable; no network git operations of any kind.
- **Wiring**: `build_server(memory_dir=...)` + `PUFFO_MEMORY_DIR` env (workspace-sibling `memory/` fallback); worker passes `resolve_memory_dir()` on sdk-local/cli-local and the container path on cli-docker; `docker_cli` pins `PUFFO_MEMORY_DIR=/home/agent/.puffo-agent-state/memory` at its env-override sites.
- **`agent/memory.py`**: `request_prompt_refresh()` now returns `bool` (flag written or not) — return-value plumbing only, `MemoryManager.save()` untouched.

### provider_reload mapping (fat agent)

The fat agent has no hot in-session provider reload, so for briefing writes `post_effects.provider_reload` means:

- `"not_needed"` — non-briefing write, or `changed: false`
- `"requested"` — briefing changed and the `refresh_agent.flag` was written: the worker rebuilds prompt artifacts (CLAUDE.md / AGENTS.md) on the next batch; the provider picks them up at next spawn/turn
- `"failed"` — briefing changed but the flag write failed (or no workspace): `ok` stays `true` with a `memory_provider_reload_failed` warning — post-effect failures never masquerade as write failures

`briefing_rebuilt` is `true` iff the write touched `briefing/` and changed it.

### Tests

`tests/test_memory_m3.py` — 24 tests, one (or a small group) per doc M3 validation scenario, plus registration and search coverage.

- `pytest tests/test_memory_m3.py` → 24 passed
- `pytest tests/test_memory_m1.py tests/test_memory_m2.py` → 55 passed (M1/M2 regression)
- `pytest tests/ --ignore=tests/test_host_credentials.py` → **1848 passed, 2 skipped** (host-credentials failures are pre-existing/environmental)

### Notes for reviewers

- `PUFFO_CORE_TOOL_NAMES` / `PUFFO_CORE_TOOL_FQNS` (the sdk-local auto-allow list) was deliberately **not** extended with the memory tools — the plan scoped `mcp/config.py` to the `memory_dir` param only. On sdk-local the new tools exist but are not auto-allowed; follow-up if desired.
- Name normalization strips leading/trailing dashes and *trailing* dots but keeps leading dots un-stripped so `.hidden`-style names are rejected (matching the doc's "invalid semantic names are rejected" scenario) rather than silently laundered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
