### PR TITLE
T23 phase 1: opt-in keyless bridge transport foundation (HOLD)

### DIFF
--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -1,0 +1,290 @@
+"""Keyless cloud-bridge WS client (T23 phase 1, experimental).
+
+Ported from the thin runtime's
+``packages/puffo-agent-cloud/src/puffo_agent_cloud/cloud_client.py``
+(proven in E2B, PR #157) with frame semantics unchanged. The server
+holds all crypto — frames are plaintext JSON, authenticated by the
+``x-sandbox-token`` header. Wire spec:
+``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``.
+
+Selected per agent via ``puffo_core.transport: "bridge"`` in agent.yml;
+the default ``"native"`` transport keeps today's signed-crypto path and
+never imports this module. Deliberately does NOT import anything from
+``crypto/`` (slated for deletion once the bridge is the only transport).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import uuid
+from typing import Any, AsyncIterator, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+# Module constant (not class attribute) so tests can monkeypatch a
+# short interval. Server recv-timeout is 90s.
+_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+class BridgeError(Exception):
+    """Server-emitted ``error`` frame (code + message). Categories:
+    ``NO_SUBKEY``, ``NOT_AUTHORIZED``, ``DECRYPT_FAILED``,
+    ``BAD_FRAME``, ``INTERNAL``."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class BridgeClosed(Exception):
+    """Raised when ``send_*`` is called after the WS closed and
+    before reconnect."""
+
+
+class CloudBridgeClient:
+    """One-WS-per-agent plaintext bridge. ``send_*`` methods are
+    request/response (correlated by ``client_ref`` or FIFO);
+    ``frames()`` yields the inbound stream (``message`` /
+    ``pending_delivered`` / uncorrelated ``error``). A background
+    task pumps a heartbeat every 30s (server recv-timeout = 90s)."""
+
+    def __init__(
+        self, cloud_url: str, sandbox_token: str, agent_slug: str,
+    ) -> None:
+        ws_base = cloud_url.replace("http", "ws", 1)
+        self._url = f"{ws_base.rstrip('/')}/v2/cloud-agents/subscribe"
+        self._token = sandbox_token
+        self._slug = agent_slug
+        self._session: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+        # client_ref → Future for ack correlation (one ack per send).
+        self._send_acks: dict[str, asyncio.Future] = {}
+        # FIFO of futures awaiting ack_result / spaces (no client_ref
+        # in the spec — only one in-flight at a time).
+        self._ack_result_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+        self._spaces_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+
+    async def connect(self) -> None:
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=None),
+        )
+        headers = {"x-sandbox-token": self._token}
+        try:
+            self._ws = await self._session.ws_connect(
+                self._url, headers=headers, heartbeat=None,
+            )
+        except aiohttp.WSServerHandshakeError as exc:
+            await self._session.close()
+            self._session = None
+            raise BridgeError(
+                "HANDSHAKE",
+                f"WS upgrade failed (status={exc.status}): {exc.message}",
+            ) from exc
+        # Wait for the first frame — must be 'connected'.
+        first = await self._ws.receive(timeout=10.0)
+        if first.type != aiohttp.WSMsgType.TEXT:
+            await self.close()
+            raise BridgeError(
+                "HANDSHAKE",
+                f"expected text 'connected', got {first.type!r}",
+            )
+        try:
+            frame = json.loads(first.data)
+        except json.JSONDecodeError as exc:
+            await self.close()
+            raise BridgeError("HANDSHAKE", f"bad first frame: {exc}") from exc
+        if frame.get("type") != "connected":
+            await self.close()
+            raise BridgeError(
+                "HANDSHAKE",
+                f"expected 'connected', got {frame.get('type')!r}",
+            )
+        logger.info("cloud bridge: WS connected (slug=%s)", self._slug)
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def frames(self) -> AsyncIterator[dict]:
+        # Yields message / pending_delivered / uncorrelated error.
+        # ping swallowed (no reply per spec §5.1); ack / ack_result /
+        # spaces routed to send_*() futures.
+        if self._ws is None:
+            return
+        async for msg in self._ws:
+            if msg.type != aiohttp.WSMsgType.TEXT:
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.ERROR,
+                ):
+                    logger.info(
+                        "cloud bridge: WS closing (%s)", msg.type,
+                    )
+                    break
+                continue
+            try:
+                frame = json.loads(msg.data)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "cloud bridge: dropped non-JSON WS frame",
+                )
+                continue
+            kind = frame.get("type", "")
+            if kind == "ping":
+                # Server keepalive — no reply per spec §5.1.
+                continue
+            if kind == "ack":
+                client_ref = frame.get("client_ref")
+                if client_ref and client_ref in self._send_acks:
+                    fut = self._send_acks.pop(client_ref)
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                # Unsolicited ack (e.g. server-side resend / lost
+                # correlation) — surface it for diagnostics.
+                logger.debug(
+                    "cloud bridge: ack with unknown client_ref=%r",
+                    client_ref,
+                )
+                continue
+            if kind == "ack_result":
+                if not self._ack_result_waiters.empty():
+                    fut = self._ack_result_waiters.get_nowait()
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                logger.debug("cloud bridge: ack_result with no waiter")
+                continue
+            if kind == "spaces":
+                if not self._spaces_waiters.empty():
+                    fut = self._spaces_waiters.get_nowait()
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                logger.debug("cloud bridge: spaces with no waiter")
+                continue
+            if kind == "error" and frame.get("client_ref"):
+                # An error correlated to a send — route to that future
+                # as an exception.
+                client_ref = frame["client_ref"]
+                if client_ref in self._send_acks:
+                    fut = self._send_acks.pop(client_ref)
+                    if not fut.done():
+                        fut.set_exception(BridgeError(
+                            frame.get("code", "ERROR"),
+                            frame.get("message", ""),
+                        ))
+                    continue
+            yield frame
+
+    async def _heartbeat_loop(self) -> None:
+        while self._ws is not None and not self._ws.closed:
+            try:
+                await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                return
+            if self._ws is None or self._ws.closed:
+                return
+            try:
+                await self._ws.send_json({"type": "heartbeat"})
+            except (aiohttp.ClientError, ConnectionError) as exc:
+                logger.warning(
+                    "cloud bridge: heartbeat send failed: %s", exc,
+                )
+                return
+
+    async def _require_ws(self) -> aiohttp.ClientWebSocketResponse:
+        if self._ws is None or self._ws.closed:
+            raise BridgeClosed("WS is not connected")
+        return self._ws
+
+    async def send_send(
+        self,
+        *,
+        plaintext: str,
+        recipient_slug: Optional[str] = None,
+        space_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        # Pass EITHER recipient_slug (DM) OR space_id+channel_id
+        # (channel); spec rejects mixed-shape frames as BAD_FRAME.
+        ws = await self._require_ws()
+        client_ref = f"r_{uuid.uuid4().hex[:12]}"
+        frame: dict[str, Any] = {
+            "type": "send",
+            "plaintext": plaintext,
+            "client_ref": client_ref,
+        }
+        if recipient_slug:
+            frame["recipient_slug"] = recipient_slug
+        if space_id:
+            frame["space_id"] = space_id
+        if channel_id:
+            frame["channel_id"] = channel_id
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._send_acks[client_ref] = fut
+        await ws.send_json(frame)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        finally:
+            self._send_acks.pop(client_ref, None)
+
+    async def send_fetch_pending(self, *, limit: Optional[int] = None) -> None:
+        # Resulting message + pending_delivered surface via frames().
+        ws = await self._require_ws()
+        frame: dict[str, Any] = {"type": "fetch_pending"}
+        if limit is not None:
+            frame["limit"] = limit
+        await ws.send_json(frame)
+
+    async def send_ack(
+        self, envelope_ids: list[str], *, timeout: float = 30.0,
+    ) -> dict:
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        await self._ack_result_waiters.put(fut)
+        await ws.send_json({"type": "ack", "envelope_ids": envelope_ids})
+        return await asyncio.wait_for(fut, timeout=timeout)
+
+    async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        await self._spaces_waiters.put(fut)
+        await ws.send_json({"type": "list_spaces"})
+        return await asyncio.wait_for(fut, timeout=timeout)
+
+    async def close(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._heartbeat_task
+            self._heartbeat_task = None
+        if self._ws is not None and not self._ws.closed:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+        self._ws = None
+        if self._session is not None and not self._session.closed:
+            with contextlib.suppress(Exception):
+                await self._session.close()
+        self._session = None
+        # Cancel pending waiters with a clean BridgeClosed.
+        for fut in list(self._send_acks.values()):
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        self._send_acks.clear()
+        while not self._ack_result_waiters.empty():
+            fut = self._ack_result_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        while not self._spaces_waiters.empty():
+            fut = self._spaces_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -12,7 +12,7 @@ import random
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Coroutine, Optional
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional
 
 from ..crypto.encoding import base64url_decode
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
@@ -24,7 +24,10 @@ from ..crypto.message import (
     encrypt_message,
 )
 from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
-from ..crypto.ws_client import PuffoCoreWsClient
+from ..crypto.ws_client import INITIAL_BACKOFF, MAX_BACKOFF, PuffoCoreWsClient
+
+if TYPE_CHECKING:
+    from .bridge_client import CloudBridgeClient
 from . import disk_cache
 from ._invite_strings import format_invite_error, format_leave_error
 from .core import AgentAPIError
@@ -456,6 +459,8 @@ class PuffoCoreMessageClient:
         segment_chars: int = 2000,
         agent_created_at: int = 0,
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
+        *,
+        bridge_client: "CloudBridgeClient | None" = None,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -484,6 +489,10 @@ class PuffoCoreMessageClient:
         self.store = message_store
         self._key_cache = DeviceKeyCache(http_client)
         self._ws: Optional[PuffoCoreWsClient] = None
+        # T23: injected keyless bridge transport (experimental). When
+        # non-None, listen() runs the bridge lifecycle loop instead of
+        # the signed WS client — no identity file is ever loaded.
+        self._bridge = bridge_client
         # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
         # "reply to whoever just DMed me". Single-slot is fine since
         # the worker handles one envelope at a time; concurrent DM
@@ -587,6 +596,14 @@ class PuffoCoreMessageClient:
         turn exit (fresh dispatch AND kick-retry recovery).
         Invoked as ``on_turn_success(root_id, batch, channel_meta)``.
         """
+        if self._bridge is not None:
+            # T23 phase 1: keyless bridge transport. No identity file
+            # to load, and the consumer / invite-poll / warm tasks are
+            # skipped — they drive signed HTTP endpoints that can't
+            # work keyless until phase 2 rewires envelope flow.
+            await self._listen_bridge()
+            return
+
         identity = self.keystore.load_identity(self.slug)
         kem_kp = KemKeyPair.from_secret_bytes(
             decode_secret(identity.kem_secret_key)
@@ -938,6 +955,39 @@ class PuffoCoreMessageClient:
                     await task
                 except (asyncio.CancelledError, Exception):
                     pass
+
+    async def _listen_bridge(self) -> None:
+        """Bridge-transport lifecycle loop: connect → drain frames →
+        reconnect, with the same backoff schedule as the native
+        ``PuffoCoreWsClient.run()`` (start at INITIAL_BACKOFF, double
+        on failure, cap at MAX_BACKOFF, reset on successful connect).
+        """
+        bridge = self._bridge
+        assert bridge is not None  # guarded by listen()
+        backoff = INITIAL_BACKOFF
+        while True:
+            try:
+                try:
+                    await bridge.connect()
+                    backoff = INITIAL_BACKOFF
+                    async for frame in bridge.frames():
+                        # Phase 2 maps these into the message store +
+                        # thread queue; phase 1 logs and drops.
+                        self._log.info(
+                            "bridge frame dropped (phase 1): type=%s",
+                            frame.get("type", ""),
+                        )
+                finally:
+                    await bridge.close()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._log.warning(
+                    "bridge WS disconnected (%s: %s), reconnecting in %ds",
+                    type(exc).__name__, exc, backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, MAX_BACKOFF)
 
     async def _admit_thread_message(
         self,

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -243,6 +243,7 @@ def puffo_core_mcp_env(
     rpc_url: str = "http://127.0.0.1:63385",
     runtime_kind: str = "",
     harness: str = "",
+    transport: str = "",
 ) -> dict[str, str]:
     """Env dict for the puffo-core MCP subprocess. The MCP never
     touches ``messages.db`` or ``~/.claude.json`` directly — the
@@ -266,6 +267,10 @@ def puffo_core_mcp_env(
         env["PUFFO_RUNTIME_KIND"] = runtime_kind
     if harness:
         env["PUFFO_HARNESS"] = harness
+    # T23 bridge transport — no caller passes this yet; adapter env
+    # wiring lands with phase 2.
+    if transport:
+        env["PUFFO_CORE_TRANSPORT"] = transport
     # codex only forwards [mcp_servers.puffo.env] to the subprocess,
     # so CODEX_HOME must be pinned explicitly or list_mcp_servers
     # would read the operator's host config instead of the agent's.

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -221,6 +221,18 @@ def _register_local_tools(
         return "\n".join(lines)
 
 
+class _BridgeNoKeysStore(KeyStore):
+    """Bridge transport (T23): the agent holds no local keys. Tools
+    that still hit a signed path get a clear error instead of a
+    FileNotFoundError, until phase 2 rewires them keyless."""
+
+    def load_identity(self, slug: str):
+        raise RuntimeError("bridge transport: agent holds no local keys")
+
+    def load_session(self, slug: str):
+        raise RuntimeError("bridge transport: agent holds no local keys")
+
+
 def build_server(
     slug: str,
     device_id: str,
@@ -232,8 +244,12 @@ def build_server(
     data_service_url: str,
     runtime_kind: str = "",
     harness: str = "",
+    transport: str = "",
 ) -> FastMCP:
-    ks = KeyStore(keystore_dir)
+    ks = (
+        _BridgeNoKeysStore(keystore_dir) if transport == "bridge"
+        else KeyStore(keystore_dir)
+    )
     http = PuffoCoreHttpClient(server_url, ks, slug)
     data = DataClient(data_service_url, agent_id)
 
@@ -295,6 +311,7 @@ def _cfg_from_env() -> dict[str, str]:
         "data_service_url": data_service_url,
         "runtime_kind": os.environ.get("PUFFO_RUNTIME_KIND", ""),
         "harness": os.environ.get("PUFFO_HARNESS", ""),
+        "transport": os.environ.get("PUFFO_CORE_TRANSPORT", ""),
     }
 
 

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -941,6 +941,13 @@ class TriggerRules:
 DEFAULT_PUFFO_SERVER_URL = "https://chat.puffo.ai/relay"
 
 
+## Transports for the puffo-core backend (T23). ``native`` is today's
+## signed-crypto path; ``bridge`` is the experimental keyless WS bridge
+## (server holds all crypto, auth via sandbox_token). agent.yml only —
+## no UI knob while bridge is experimental.
+VALID_TRANSPORTS = ("native", "bridge")
+
+
 @dataclass
 class PuffoCoreConfig:
     """puffo-core signed API config — the agent's only chat backend."""
@@ -955,6 +962,13 @@ class PuffoCoreConfig:
     # Hidden knob (no UI, agent.yml only): when true, space invites from
     # non-operators are auto-accepted, then the operator is DM'd a report.
     auto_accept_space_invitations: bool = False
+    # One of VALID_TRANSPORTS. ``bridge`` (experimental) talks plaintext
+    # WS to ``server_url``'s /v2/cloud-agents/subscribe endpoint using
+    # ``sandbox_token`` instead of local key files. Absent from saved
+    # agent.yml unless set to bridge.
+    transport: str = "native"
+    # Bridge only — the keyless auth credential minted at provision time.
+    sandbox_token: str = ""
 
     def is_configured(self) -> bool:
         return bool(self.server_url and self.slug and self.device_id and self.space_id)
@@ -1068,6 +1082,22 @@ class AgentConfig:
                 f"agent {agent_id!r}: invalid runtime config — {result.error}"
             )
 
+        # Transport validation (T23). Absent key ⇒ native ⇒ identical
+        # to pre-transport configs; bridge requires its credential pair.
+        transport = pc.get("transport", "native")
+        sandbox_token = pc.get("sandbox_token", "")
+        server_url = pc.get("server_url") or DEFAULT_PUFFO_SERVER_URL
+        if transport not in VALID_TRANSPORTS:
+            raise RuntimeError(
+                f"agent {agent_id!r}: invalid puffo_core.transport "
+                f"{transport!r} — valid transports: {list(VALID_TRANSPORTS)}"
+            )
+        if transport == "bridge" and not (sandbox_token and server_url):
+            raise RuntimeError(
+                f"agent {agent_id!r}: puffo_core.transport 'bridge' "
+                "requires both server_url and sandbox_token"
+            )
+
         return cls(
             id=raw.get("id", agent_id),
             state=raw.get("state", "running"),
@@ -1076,7 +1106,7 @@ class AgentConfig:
             role=raw.get("role", ""),
             role_short=raw.get("role_short", ""),
             puffo_core=PuffoCoreConfig(
-                server_url=pc.get("server_url") or DEFAULT_PUFFO_SERVER_URL,
+                server_url=server_url,
                 slug=pc.get("slug", ""),
                 device_id=pc.get("device_id", ""),
                 space_id=pc.get("space_id", ""),
@@ -1084,6 +1114,8 @@ class AgentConfig:
                 auto_accept_space_invitations=bool(
                     pc.get("auto_accept_space_invitations", False)
                 ),
+                transport=transport,
+                sandbox_token=sandbox_token,
             ),
             runtime=RuntimeConfig(
                 kind=kind,
@@ -1114,6 +1146,12 @@ class AgentConfig:
     def save(self) -> None:
         path = agent_yml_path(self.id)
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Native agents (the default) keep a byte-identical agent.yml:
+        # the transport keys are only written for bridge agents.
+        pc_dict = asdict(self.puffo_core)
+        if self.puffo_core.transport == "native":
+            pc_dict.pop("transport", None)
+            pc_dict.pop("sandbox_token", None)
         data = {
             "id": self.id,
             "state": self.state,
@@ -1122,7 +1160,7 @@ class AgentConfig:
             "role": self.role,
             "role_short": self.role_short,
             "created_at": self.created_at,
-            "puffo_core": asdict(self.puffo_core),
+            "puffo_core": pc_dict,
             "runtime": asdict(self.runtime),
             "profile": self.profile,
             "memory_dir": self.memory_dir,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -359,7 +359,18 @@ def _build_puffo_core_client(
     from ..crypto.keystore import KeyStore
 
     pc = agent_cfg.puffo_core
-    _ensure_agent_identity_imported(agent_id, pc.slug)
+    bridge = None
+    if pc.transport == "bridge":
+        # T23 keyless transport: no identity file exists to import;
+        # the bridge authenticates with the sandbox token instead.
+        # Keystore/http below are still constructed (both lazy — they
+        # never touch disk/network in __init__); phase 2 replaces
+        # their call sites.
+        from ..agent.bridge_client import CloudBridgeClient
+
+        bridge = CloudBridgeClient(pc.server_url, pc.sandbox_token, pc.slug)
+    else:
+        _ensure_agent_identity_imported(agent_id, pc.slug)
     ks_dir = str(agent_dir(agent_id) / "keys")
     ks = KeyStore(ks_dir)
     http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
@@ -393,6 +404,7 @@ def _build_puffo_core_client(
         segment_chars=segment_chars,
         agent_created_at=agent_cfg.created_at,
         image_edge_px=max_image_edge_px(model),
+        bridge_client=bridge,
     )
 
 

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -1,0 +1,252 @@
+"""T23 phase 1: ``CloudBridgeClient`` vs. a local aiohttp WS server
+that speaks the bridge wire protocol (BRIDGE-WIRE-PROTOCOL.md) —
+``connected`` first frame, heartbeat-tolerant, ``send`` /
+``fetch_pending`` handlers. Loopback only, no real network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+from aiohttp import WSMsgType, web
+from aiohttp.test_utils import TestClient, TestServer
+
+import puffo_agent.agent.bridge_client as bridge_client_mod
+from puffo_agent.agent.bridge_client import (
+    BridgeClosed,
+    BridgeError,
+    CloudBridgeClient,
+)
+
+
+class _MockBridgeApp:
+    """Minimal bridge speaking just enough of the wire protocol to
+    drive the client. Records what the client sent."""
+
+    def __init__(self) -> None:
+        # Frames the server pushes in response to fetch_pending.
+        self.pending_messages: list[dict] = []
+        # Extra frames pushed right after 'connected' (e.g. an
+        # uncorrelated error for the frames() surfacing test).
+        self.push_after_connect: list[dict] = []
+        # First frame override — None means the normal 'connected'.
+        self.first_frame: dict | None = None
+        # When set, 'send' frames get an error reply (echoing
+        # client_ref) instead of an ack.
+        self.error_on_send: dict | None = None
+        self.recv_send: list[dict] = []
+        self.recv_heartbeats: list[dict] = []
+        self.token_seen: str | None = None
+        self.heartbeat_received = asyncio.Event()
+
+    async def ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        self.token_seen = request.headers.get("x-sandbox-token")
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.send_json(self.first_frame or {"type": "connected"})
+        for frame in self.push_after_connect:
+            await ws.send_json(frame)
+        async for msg in ws:
+            if msg.type != WSMsgType.TEXT:
+                break
+            frame = json.loads(msg.data)
+            kind = frame.get("type", "")
+            if kind == "heartbeat":
+                self.recv_heartbeats.append(frame)
+                self.heartbeat_received.set()
+            elif kind == "send":
+                self.recv_send.append(frame)
+                if self.error_on_send is not None:
+                    await ws.send_json({
+                        **self.error_on_send,
+                        "client_ref": frame.get("client_ref"),
+                    })
+                else:
+                    await ws.send_json({
+                        "type": "ack",
+                        "client_ref": frame.get("client_ref"),
+                        "envelope_id": f"msg_{uuid.uuid4().hex[:8]}",
+                        "devices_queued": 2,
+                    })
+            elif kind == "fetch_pending":
+                count = 0
+                while self.pending_messages:
+                    await ws.send_json(self.pending_messages.pop(0))
+                    count += 1
+                await ws.send_json({
+                    "type": "pending_delivered",
+                    "count": count,
+                    "more": False,
+                })
+        return ws
+
+
+def _build_app(bridge: _MockBridgeApp) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/v2/cloud-agents/subscribe", bridge.ws_handler)
+    return app
+
+
+async def _drain(c: CloudBridgeClient) -> None:
+    try:
+        async for _ in c.frames():
+            pass
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_handshake_connected_sends_x_sandbox_token_header():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_test_abc", "agent-slug")
+        try:
+            await c.connect()
+        finally:
+            await c.close()
+    assert bridge_app.token_seen == "sbx_test_abc"
+
+
+@pytest.mark.asyncio
+async def test_bad_handshake_first_frame_raises_bridge_error():
+    bridge_app = _MockBridgeApp()
+    bridge_app.first_frame = {"type": "definitely-not-connected"}
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.connect()
+        await c.close()
+    assert excinfo.value.code == "HANDSHAKE"
+
+
+@pytest.mark.asyncio
+async def test_send_send_correlates_ack_via_client_ref():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        # Ack correlation happens inside frames() — run the consumer
+        # in the background while send_send awaits its future.
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            ack = await c.send_send(
+                plaintext="hi alice", recipient_slug="alice",
+            )
+        finally:
+            await c.close()
+            consumer.cancel()
+    assert ack["type"] == "ack"
+    assert ack["envelope_id"].startswith("msg_")
+    assert len(bridge_app.recv_send) == 1
+    sent = bridge_app.recv_send[0]
+    assert sent["type"] == "send"
+    assert sent["plaintext"] == "hi alice"
+    assert sent["client_ref"] == ack["client_ref"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_yields_message_then_pending_delivered():
+    bridge_app = _MockBridgeApp()
+    bridge_app.pending_messages = [{
+        "type": "message",
+        "envelope_id": "env_1",
+        "sender_slug": "alice-0001",
+        "plaintext": "hello",
+    }]
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            await c.send_fetch_pending()
+            seen: list[dict] = []
+            async for frame in c.frames():
+                seen.append(frame)
+                if frame.get("type") == "pending_delivered":
+                    break
+        finally:
+            await c.close()
+    assert [f["type"] for f in seen] == ["message", "pending_delivered"]
+    assert seen[0]["envelope_id"] == "env_1"
+    assert seen[1]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_frame_reaches_server(monkeypatch):
+    monkeypatch.setattr(
+        bridge_client_mod, "_HEARTBEAT_INTERVAL_SECONDS", 0.05,
+    )
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            await asyncio.wait_for(
+                bridge_app.heartbeat_received.wait(), timeout=5.0,
+            )
+        finally:
+            await c.close()
+    assert bridge_app.recv_heartbeats[0] == {"type": "heartbeat"}
+
+
+@pytest.mark.asyncio
+async def test_correlated_error_frame_rejects_send_as_bridge_error():
+    bridge_app = _MockBridgeApp()
+    bridge_app.error_on_send = {
+        "type": "error",
+        "code": "NOT_AUTHORIZED",
+        "message": "token revoked",
+    }
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            with pytest.raises(BridgeError) as excinfo:
+                await c.send_send(plaintext="hi", recipient_slug="alice")
+        finally:
+            await c.close()
+            consumer.cancel()
+    assert excinfo.value.code == "NOT_AUTHORIZED"
+    assert "token revoked" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_uncorrelated_error_frame_surfaces_via_frames():
+    bridge_app = _MockBridgeApp()
+    bridge_app.push_after_connect = [{
+        "type": "error",
+        "code": "INTERNAL",
+        "message": "hiccup",
+    }]
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            frame = await asyncio.wait_for(
+                c.frames().__anext__(), timeout=5.0,
+            )
+        finally:
+            await c.close()
+    assert frame == {"type": "error", "code": "INTERNAL", "message": "hiccup"}
+
+
+@pytest.mark.asyncio
+async def test_send_after_close_raises_bridge_closed():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        await c.close()
+        with pytest.raises(BridgeClosed):
+            await c.send_send(plaintext="hi", recipient_slug="alice")

--- a/tests/test_cloud_bridge_seam.py
+++ b/tests/test_cloud_bridge_seam.py
@@ -1,0 +1,212 @@
+"""T23 phase 1: transport seam. An injected ``bridge_client`` flips
+``PuffoCoreMessageClient.listen()`` to the keyless bridge lifecycle
+(no ``PuffoCoreWsClient``, no ``keystore.load_identity``); default
+construction keeps the native signed path. ``build_server`` under
+``transport="bridge"`` builds with zero key files on disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+import puffo_agent.agent.puffo_core_client as pcc_mod
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import (
+    KeyStore,
+    Session,
+    StoredIdentity,
+    encode_secret,
+)
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+
+class _SpyKeyStore(KeyStore):
+    """Records load_identity calls; bridge mode must never make one."""
+
+    def __init__(self) -> None:
+        super().__init__(tempfile.mkdtemp(prefix="spy-keys-"))
+        self.load_identity_calls: list[str] = []
+
+    def load_identity(self, slug: str) -> StoredIdentity:
+        self.load_identity_calls.append(slug)
+        return super().load_identity(slug)
+
+
+class _StubBridge:
+    """Bridge stub: records the lifecycle calls listen() makes."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.connected = asyncio.Event()
+
+    async def connect(self) -> None:
+        self.calls.append("connect")
+        self.connected.set()
+
+    async def frames(self):
+        self.calls.append("frames")
+        await asyncio.Event().wait()  # block until the test cancels
+        yield {}  # pragma: no cover — makes this an async generator
+
+    async def close(self) -> None:
+        self.calls.append("close")
+
+
+class _RecordingWs:
+    """PuffoCoreWsClient stand-in — records construction, run() is a
+    no-op so listen() returns instead of blocking."""
+
+    instances: list["_RecordingWs"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.on_message = None
+        self.on_event = None
+        _RecordingWs.instances.append(self)
+
+    async def run(self) -> None:
+        return
+
+
+def _make_client(keystore: KeyStore, tmp_path, **kwargs) -> PuffoCoreMessageClient:
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", keystore, "bot-0001")
+    store = MessageStore(str(tmp_path / "messages.db"))
+    return PuffoCoreMessageClient(
+        slug="bot-0001",
+        device_id="dev_test",
+        space_id="sp_test",
+        keystore=keystore,
+        http_client=http,
+        message_store=store,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_injected_bridge_skips_ws_client_and_identity_load(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setattr(_RecordingWs, "instances", [])
+    monkeypatch.setattr(pcc_mod, "PuffoCoreWsClient", _RecordingWs)
+    spy_ks = _SpyKeyStore()
+    stub = _StubBridge()
+    client = _make_client(spy_ks, tmp_path, bridge_client=stub)
+
+    async def on_message(*args) -> None:
+        return
+
+    task = asyncio.create_task(client.listen(on_message))
+    await asyncio.wait_for(stub.connected.wait(), timeout=5.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stub.calls[:2] == ["connect", "frames"]
+    assert "close" in stub.calls
+    assert _RecordingWs.instances == []
+    assert spy_ks.load_identity_calls == []
+
+
+def test_default_construction_has_no_bridge(tmp_path):
+    client = _make_client(KeyStore(str(tmp_path / "keys")), tmp_path)
+    assert client._bridge is None
+
+
+@pytest.mark.asyncio
+async def test_native_path_reaches_ws_client_construction(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setattr(_RecordingWs, "instances", [])
+    monkeypatch.setattr(pcc_mod, "PuffoCoreWsClient", _RecordingWs)
+    ks = KeyStore(str(tmp_path / "keys"))
+    ks.save_identity(StoredIdentity(
+        slug="bot-0001",
+        device_id="dev_test",
+        root_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        device_signing_secret_key=encode_secret(
+            Ed25519KeyPair.generate().secret_bytes()
+        ),
+        kem_secret_key=encode_secret(KemKeyPair.generate().secret_bytes()),
+        server_url="http://127.0.0.1:1",
+    ))
+    ks.save_session(Session(
+        slug="bot-0001",
+        subkey_id="sk_test",
+        subkey_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        expires_at=32_503_680_000_000,
+    ))
+    client = _make_client(ks, tmp_path)
+
+    async def on_message(*args) -> None:
+        return
+
+    await client.listen(on_message)
+    assert len(_RecordingWs.instances) == 1
+    assert _RecordingWs.instances[0].kwargs["slug"] == "bot-0001"
+
+
+def test_build_server_bridge_transport_needs_no_key_files(tmp_path):
+    from mcp.server.fastmcp import FastMCP
+    from puffo_agent.mcp.puffo_core_server import build_server
+
+    server = build_server(
+        slug="bot-0001",
+        device_id="dev_test",
+        server_url="http://127.0.0.1:1",
+        space_id="",
+        keystore_dir="",  # zero key files anywhere
+        workspace=str(tmp_path),
+        agent_id="bot-0001",
+        data_service_url="http://127.0.0.1:1",
+        transport="bridge",
+    )
+    assert isinstance(server, FastMCP)
+
+
+def test_bridge_inert_keystore_raises_clear_error():
+    from puffo_agent.mcp.puffo_core_server import _BridgeNoKeysStore
+
+    ks = _BridgeNoKeysStore("")
+    with pytest.raises(RuntimeError, match="no local keys"):
+        ks.load_identity("bot-0001")
+    with pytest.raises(RuntimeError, match="no local keys"):
+        ks.load_session("bot-0001")
+
+
+def test_cfg_from_env_picks_up_transport(monkeypatch):
+    from puffo_agent.mcp.puffo_core_server import _cfg_from_env
+
+    monkeypatch.setenv("PUFFO_CORE_SLUG", "bot-0001")
+    monkeypatch.setenv("PUFFO_CORE_DEVICE_ID", "dev_test")
+    monkeypatch.setenv("PUFFO_CORE_SERVER_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("PUFFO_CORE_TRANSPORT", "bridge")
+    cfg = _cfg_from_env()
+    assert cfg["transport"] == "bridge"
+
+    monkeypatch.delenv("PUFFO_CORE_TRANSPORT")
+    assert _cfg_from_env()["transport"] == ""
+
+
+def test_puffo_core_mcp_env_transport_is_additive():
+    from puffo_agent.mcp.config import puffo_core_mcp_env
+
+    base = dict(
+        slug="bot-0001",
+        device_id="dev_test",
+        server_url="http://127.0.0.1:1",
+        keystore_dir="/keys",
+        workspace="/ws",
+    )
+    default_env = puffo_core_mcp_env(**base)
+    assert "PUFFO_CORE_TRANSPORT" not in default_env
+    bridge_env = puffo_core_mcp_env(**base, transport="bridge")
+    assert bridge_env["PUFFO_CORE_TRANSPORT"] == "bridge"
+    # Only the transport var differs — default output stays identical.
+    bridge_env.pop("PUFFO_CORE_TRANSPORT")
+    assert bridge_env == default_env

--- a/tests/test_cloud_bridge_transport_config.py
+++ b/tests/test_cloud_bridge_transport_config.py
@@ -1,0 +1,132 @@
+"""T23 phase 1: ``puffo_core.transport`` config parse / validate /
+round-trip. The flag-off (native) path must stay byte-identical:
+no new keys in saved agent.yml, every parsed field unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_agent_yml(agent_id: str, puffo_core_extra: str = "") -> Path:
+    from puffo_agent.portal.state import agent_yml_path
+    yml = agent_yml_path(agent_id)
+    yml.parent.mkdir(parents=True, exist_ok=True)
+    yml.write_text(
+        f"id: {agent_id}\n"
+        "state: running\n"
+        f"display_name: {agent_id}\n"
+        "created_at: 0\n"
+        "puffo_core:\n"
+        "  server_url: 'https://relay.example'\n"
+        "  slug: 'bot-1234'\n"
+        "  device_id: 'dev-1'\n"
+        "  space_id: 'sp-1'\n"
+        "  operator_slug: 'op-5678'\n"
+        f"{puffo_core_extra}"
+        "runtime: {kind: chat-local}\n"
+        "triggers: {on_mention: true, on_dm: true}\n",
+        encoding="utf-8",
+    )
+    return yml
+
+
+def test_absent_transport_key_defaults_to_native(home):
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml("agent-no-transport")
+    cfg = AgentConfig.load("agent-no-transport")
+    assert cfg.puffo_core.transport == "native"
+    assert cfg.puffo_core.sandbox_token == ""
+
+
+def test_absent_transport_key_leaves_every_other_field_unchanged(home):
+    # Control: an identical agent.yml under a different id. Loading
+    # the transport-less file must parse every non-transport field
+    # exactly as the control does.
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml("agent-a")
+    _write_agent_yml("agent-b")
+    a = asdict(AgentConfig.load("agent-a").puffo_core)
+    b = asdict(AgentConfig.load("agent-b").puffo_core)
+    assert a == b
+    assert a["server_url"] == "https://relay.example"
+    assert a["slug"] == "bot-1234"
+    assert a["device_id"] == "dev-1"
+    assert a["space_id"] == "sp-1"
+    assert a["operator_slug"] == "op-5678"
+    assert a["auto_accept_space_invitations"] is False
+
+
+def test_native_save_emits_no_transport_keys(home):
+    # Flag-off byte-identity: the saved puffo_core block carries the
+    # exact pre-T23 key-set — transport/sandbox_token never leak in.
+    from puffo_agent.portal.state import AgentConfig, agent_yml_path
+    cfg = AgentConfig(id="agent-native-save", display_name="n")
+    cfg.puffo_core.slug = "bot-1234"
+    cfg.save()
+    raw = yaml.safe_load(
+        agent_yml_path("agent-native-save").read_text(encoding="utf-8")
+    )
+    assert set(raw["puffo_core"].keys()) == {
+        "server_url",
+        "slug",
+        "device_id",
+        "space_id",
+        "operator_slug",
+        "auto_accept_space_invitations",
+    }
+
+
+def test_bridge_fields_parse_and_round_trip(home):
+    from puffo_agent.portal.state import AgentConfig, agent_yml_path
+    _write_agent_yml(
+        "agent-bridge",
+        puffo_core_extra=(
+            "  transport: bridge\n"
+            "  sandbox_token: 'sbx_secret_1'\n"
+        ),
+    )
+    cfg = AgentConfig.load("agent-bridge")
+    assert cfg.puffo_core.transport == "bridge"
+    assert cfg.puffo_core.sandbox_token == "sbx_secret_1"
+    assert cfg.puffo_core.server_url == "https://relay.example"
+    # Bridge agents DO persist the transport keys.
+    cfg.save()
+    raw = yaml.safe_load(
+        agent_yml_path("agent-bridge").read_text(encoding="utf-8")
+    )
+    assert raw["puffo_core"]["transport"] == "bridge"
+    assert raw["puffo_core"]["sandbox_token"] == "sbx_secret_1"
+    reloaded = AgentConfig.load("agent-bridge")
+    assert reloaded.puffo_core.transport == "bridge"
+    assert reloaded.puffo_core.sandbox_token == "sbx_secret_1"
+
+
+def test_bridge_without_sandbox_token_fails_fast(home):
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml(
+        "agent-bridge-no-token",
+        puffo_core_extra="  transport: bridge\n",
+    )
+    with pytest.raises(RuntimeError, match="sandbox_token"):
+        AgentConfig.load("agent-bridge-no-token")
+
+
+def test_unknown_transport_fails_fast_naming_valid_transports(home):
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml(
+        "agent-bad-transport",
+        puffo_core_extra="  transport: carrier-pigeon\n",
+    )
+    with pytest.raises(RuntimeError, match="native.*bridge"):
+        AgentConfig.load("agent-bad-transport")


### PR DESCRIPTION
## HOLD — do not merge (human review required)

T23 phase 1: opt-in keyless "bridge" transport seam for the fat agent. **Default behavior is byte-identical** — when `puffo_core.transport` is absent from agent.yml, every code path and the saved agent.yml key-set are exactly today's native signed-crypto behavior.

### What's in

- **`agent/bridge_client.py` (new)** — `CloudBridgeClient` + `BridgeError` + `BridgeClosed`, ported from the thin runtime's `packages/puffo-agent-cloud/src/puffo_agent_cloud/cloud_client.py` (proven in E2B, PR #157), frame semantics unchanged. Wire spec: `puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md`. No imports from `crypto/`. `CloudLlmClient` intentionally not ported (retired `/v1/llm/complete` endpoint).
- **`portal/state.py`** — `PuffoCoreConfig.transport` (`"native"` default | `"bridge"`) + `sandbox_token`, validated fail-fast in `AgentConfig.load`; `save()` pops both keys for native agents so existing agent.yml files stay byte-identical.
- **`agent/puffo_core_client.py`** — keyword-only `bridge_client=` injection seam; `listen()` branches to a bridge lifecycle loop (connect / heartbeat / reconnect with the native backoff schedule). Frames are logged and dropped; consumer/invite/warm tasks are skipped in bridge mode (they drive signed HTTP endpoints that can't work keyless yet).
- **`portal/worker.py`** — builds + injects `CloudBridgeClient` when `transport == "bridge"`, skipping the identity-file import. Native path: zero diff.
- **`mcp/puffo_core_server.py`** (19 changed lines; kept surgical for the PR #126 overlap) — inert keystore under `transport="bridge"` raising a clear `RuntimeError` instead of `FileNotFoundError`; `_cfg_from_env` reads `PUFFO_CORE_TRANSPORT`.
- **`mcp/config.py`** — additive `transport=""` param on `puffo_core_mcp_env`; no callers updated, default output byte-identical.
- **3 new test files** (21 tests): ported client vs. a local aiohttp WS server (handshake, ack correlation, fetch_pending ordering, heartbeat, error frames), config parse/validate/round-trip incl. flag-off key-set proof, and the constructor seam (bridge ⇒ no `PuffoCoreWsClient` / no `keystore.load_identity`; default ⇒ native).

### Out of scope (phases 2–4)

Envelope flow over the bridge (decrypt/encrypt removal, message-store mapping — bridge mode does not deliver messages yet), thread/attachment/reaction frames, any deletion/edit under `crypto/`, adapter env wiring, E2B provisioning, thin-runner retirement.

### Verification

- Full suite: `pytest --ignore=tests/test_host_credentials.py` → **1790 passed, 2 skipped** (baseline before change: 1769 passed, 2 skipped; ignored file's failures are pre-existing/environmental)
- `git diff --name-only origin/main` lists exactly the nine planned files; no deletions; `pyproject.toml` and `crypto/` untouched
- Provenance grep: thin-runtime reference appears only in the module docstring; no cross-branch imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
