### PR TITLE
memory: fix adversarial-review findings on the M1–M3 stack

### DIFF
--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -24,7 +24,14 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .memory_errors import BriefingCompileError, MemoryStoreError
+
 logger = logging.getLogger(__name__)
+
+# Re-exported so ``from .memory import MemoryStoreError`` /
+# ``BriefingCompileError`` keeps working now that the classes live in
+# the leaf ``memory_errors`` module.
+__all__ = ["BriefingCompileError", "MemoryStoreError"]
 
 BRIEFING_DIR = "briefing"
 NOTES_DIR = "notes"
@@ -53,65 +60,6 @@ _MANAGED_BLOCK_RE = re.compile(
     re.escape(PROFILE_MANAGED_BEGIN) + r".*?" + re.escape(PROFILE_MANAGED_END),
     re.DOTALL,
 )
-
-
-class MemoryStoreError(Exception):
-    """Structured memory-store error: the M1 ``{path, size, limit,
-    suggestion}`` shape extended with ``code`` (M3-aligned names such
-    as ``memory_invalid_path`` / ``memory_scope_readonly``).
-    ``size``/``limit`` only apply to size violations; errors without
-    them omit the keys from ``to_dict()``."""
-
-    def __init__(
-        self,
-        code: str,
-        *,
-        path: str,
-        suggestion: str,
-        size: int | None = None,
-        limit: int | None = None,
-    ):
-        self.code = code
-        self.path = path
-        self.size = size
-        self.limit = limit
-        self.suggestion = suggestion
-        if size is not None and limit is not None:
-            message = (
-                f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
-            )
-        else:
-            message = f"{code}: {path}. {suggestion}"
-        super().__init__(message)
-
-    def to_dict(self) -> dict:
-        out: dict = {"code": self.code, "path": self.path}
-        if self.size is not None:
-            out["size"] = self.size
-        if self.limit is not None:
-            out["limit"] = self.limit
-        out["suggestion"] = self.suggestion
-        return out
-
-
-class BriefingCompileError(MemoryStoreError):
-    """A briefing violates the compile budget. Fail closed — callers
-    get no truncated/partial output. ``code`` is one of
-    ``memory_file_too_large`` / ``memory_briefing_too_large``
-    (M3-aligned names)."""
-
-    def __init__(
-        self,
-        code: str,
-        *,
-        path: str,
-        size: int,
-        limit: int,
-        suggestion: str,
-    ):
-        super().__init__(
-            code, path=path, size=size, limit=limit, suggestion=suggestion,
-        )
 
 
 def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> bool:
@@ -159,9 +107,26 @@ def _byte_size(text: str) -> int:
     return len(text.encode("utf-8"))
 
 
+def _resolves_within_root(path: Path, memory_root: Path) -> bool:
+    """True iff ``path`` resolves to a location inside ``memory_root``.
+
+    The host-side compile / migration paths read the filesystem
+    directly (not through the M2 store), so a symlink under the memory
+    tree could otherwise pull in content from outside it. Resolving
+    both sides collapses symlinks in either the leaf or an ancestor
+    dir; a resolution failure is treated as "not contained"."""
+    try:
+        return path.resolve().is_relative_to(memory_root.resolve())
+    except OSError:
+        return False
+
+
 def _is_briefing_topic(path: Path) -> bool:
     return (
         path.is_file()
+        # ``is_file()`` follows symlinks; a symlinked briefing/<t>.md
+        # would inject its target's bytes, so exclude symlinks outright.
+        and not path.is_symlink()
         and path.suffix == ".md"
         and not path.name.startswith(".")
     )
@@ -174,7 +139,8 @@ def _read_briefing_entries(
     profile first, remaining topics by sorted filename. Empty bodies
     are dropped. Raises ``BriefingCompileError`` on a per-file limit
     violation unless ``enforce_per_file`` is off."""
-    briefing = Path(memory_root) / BRIEFING_DIR
+    memory_root = Path(memory_root)
+    briefing = memory_root / BRIEFING_DIR
     profile_body = ""
     entries: list[tuple[str, str]] = []
     if not briefing.is_dir():
@@ -185,6 +151,15 @@ def _read_briefing_entries(
         paths.remove(profile_path)
         paths.insert(0, profile_path)
     for path in paths:
+        # ``_is_briefing_topic`` already dropped leaf symlinks; this
+        # catches a topic that resolves outside the root through a
+        # symlinked ancestor dir (e.g. a symlinked briefing/).
+        if not _resolves_within_root(path, memory_root):
+            logger.warning(
+                "memory briefing: skipping %s — resolves outside the "
+                "memory root", path,
+            )
+            continue
         body = path.read_text(encoding="utf-8")
         if enforce_per_file and _byte_size(body) > PER_FILE_LIMIT:
             raise BriefingCompileError(
@@ -260,16 +235,30 @@ def migrate_flat_memory(memory_root: Path) -> list[str]:
     if not memory_root.is_dir():
         return []
     ensure_memory_tree(memory_root)
-    flat = [
-        p for p in sorted(memory_root.glob("*.md"))
-        if p.is_file() and p.name != "README.md" and not p.name.startswith(".")
-    ]
+    flat = []
+    for p in sorted(memory_root.glob("*.md")):
+        if not p.is_file() or p.name == "README.md" or p.name.startswith("."):
+            continue
+        # A symlinked flat file (or one resolving outside the root)
+        # must never be read or moved into the tree — that would fold
+        # arbitrary host content into the agent's memory.
+        if p.is_symlink() or not _resolves_within_root(p, memory_root):
+            logger.warning(
+                "memory migrate: skipping %s — symlink or resolves "
+                "outside the memory root", p,
+            )
+            continue
+        flat.append(p)
     if not flat:
         return []
 
     briefing_dir = memory_root / BRIEFING_DIR
     notes_dir = memory_root / NOTES_DIR
     pointer_path = briefing_dir / f"{MIGRATED_NOTES_TOPIC}.md"
+
+    from .memory_store import MemoryStore
+
+    store = MemoryStore(memory_root)
 
     # Live simulation state: recomposing from these on every candidate
     # keeps the fit check exact (section headers + join separators
@@ -310,6 +299,7 @@ def migrate_flat_memory(memory_root: Path) -> list[str]:
                 dest = notes_dir / f"{path.stem}-migrated-{n}.md"
                 n += 1
         path.rename(dest)
+        moved.append(f"{NOTES_DIR}/{dest.name}")
         pointer_line = (
             f"- {NOTES_DIR}/{dest.name} — migrated from flat memory\n"
         )
@@ -318,9 +308,25 @@ def migrate_flat_memory(memory_root: Path) -> list[str]:
             existing = pointer_path.read_text(encoding="utf-8")
         elif not entry_map.get(MIGRATED_NOTES_TOPIC):
             existing = "# Migrated notes\n\n"
-        pointer_path.write_text(existing + pointer_line, encoding="utf-8")
-        entry_map[MIGRATED_NOTES_TOPIC] = (existing + pointer_line).strip()
-        moved.append(f"{NOTES_DIR}/{dest.name}")
+        new_body = existing + pointer_line
+        try:
+            # Route the pointer through the store: same atomic write and
+            # per-file/total budget validation as any briefing topic, so
+            # a migration can never leave a briefing that fails the next
+            # compile.
+            store.put_memory_file(
+                f"{BRIEFING_DIR}/{MIGRATED_NOTES_TOPIC}.md", new_body,
+            )
+        except BriefingCompileError as exc:
+            # The note itself already migrated to notes/; only its
+            # pointer line is dropped so the briefing stays compilable.
+            logger.warning(
+                "memory migrate: pointer to %s skipped (%s) — the note "
+                "migrated but the briefing budget is full",
+                dest.name, exc.code,
+            )
+            continue
+        entry_map[MIGRATED_NOTES_TOPIC] = new_body.strip()
     return moved
 
 
@@ -391,7 +397,7 @@ def sync_profile_briefing(
         new_text = block
     from .memory_store import MemoryStore
 
-    MemoryStore(memory_root)._put_memory_file(
+    MemoryStore(memory_root).put_memory_file(
         f"{BRIEFING_DIR}/{PROFILE_BRIEFING_NAME}", new_text,
     )
     return path
@@ -424,7 +430,7 @@ class MemoryManager:
         # oversized save never leaves partial state behind. The
         # refresh flag stays owned by save() — the store gets no
         # workspace_dir — so its reason keeps the M1 shape.
-        MemoryStore(self.memory_dir)._put_memory_file(
+        MemoryStore(self.memory_dir).put_memory_file(
             f"{BRIEFING_DIR}/{safe_topic}.md", body,
         )
         self._request_refresh(topic)

--- a/src/puffo_agent/agent/memory_errors.py
+++ b/src/puffo_agent/agent/memory_errors.py
@@ -1,0 +1,69 @@
+"""Structured memory errors, hoisted out of ``memory.py``.
+
+These live in their own leaf module so every layer of the memory stack
+(``memory`` M1, ``memory_store`` M2, ``memory_tools`` M3, and the
+``portal`` callers) can import the error types without pulling in — or
+being pulled in by — the higher layers. ``memory`` re-exports both
+names, so ``from .memory import MemoryStoreError`` keeps working.
+"""
+
+from __future__ import annotations
+
+
+class MemoryStoreError(Exception):
+    """Structured memory-store error: the M1 ``{path, size, limit,
+    suggestion}`` shape extended with ``code`` (M3-aligned names such
+    as ``memory_invalid_path`` / ``memory_scope_readonly``).
+    ``size``/``limit`` only apply to size violations; errors without
+    them omit the keys from ``to_dict()``."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        suggestion: str,
+        size: int | None = None,
+        limit: int | None = None,
+    ):
+        self.code = code
+        self.path = path
+        self.size = size
+        self.limit = limit
+        self.suggestion = suggestion
+        if size is not None and limit is not None:
+            message = (
+                f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+            )
+        else:
+            message = f"{code}: {path}. {suggestion}"
+        super().__init__(message)
+
+    def to_dict(self) -> dict:
+        out: dict = {"code": self.code, "path": self.path}
+        if self.size is not None:
+            out["size"] = self.size
+        if self.limit is not None:
+            out["limit"] = self.limit
+        out["suggestion"] = self.suggestion
+        return out
+
+
+class BriefingCompileError(MemoryStoreError):
+    """A briefing violates the compile budget. Fail closed — callers
+    get no truncated/partial output. ``code`` is one of
+    ``memory_file_too_large`` / ``memory_briefing_too_large``
+    (M3-aligned names)."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        size: int,
+        limit: int,
+        suggestion: str,
+    ):
+        super().__init__(
+            code, path=path, size=size, limit=limit, suggestion=suggestion,
+        )

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -16,6 +16,7 @@ or a failed commit is logged and reported to the caller (``False`` /
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -26,24 +27,54 @@ logger = logging.getLogger(__name__)
 # guards against a wedged git process.
 _GIT_TIMEOUT = 30
 
+# Env vars that relocate git's repo/work-tree/index. A poisoned value
+# in the daemon's environment could otherwise redirect an audit commit
+# into an attacker-chosen repo, so they are scrubbed from every run.
+_GIT_LOCATION_ENV = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+
 
 def git_available() -> bool:
     """True when a ``git`` binary is on PATH."""
     return shutil.which("git") is not None
 
 
+def _scrubbed_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for var in _GIT_LOCATION_ENV:
+        env.pop(var, None)
+    return env
+
+
 def _run_git(
-    memory_root: Path, args: list[str],
+    memory_root: Path, args: list[str], *, pin_repo: bool = True,
 ) -> subprocess.CompletedProcess | None:
-    """Run one git command inside the memory root. ``None`` on any
-    launch/timeout failure; callers also check ``returncode``."""
+    """Run one git command against the audit repo at ``memory_root``.
+
+    The environment is scrubbed of git location overrides
+    (``GIT_DIR``/``GIT_WORK_TREE``/``GIT_INDEX_FILE``), and — when
+    ``pin_repo`` — ``--git-dir``/``--work-tree`` are passed explicitly
+    so the command can only ever touch ``<root>/.git``: never an
+    enclosing repo, never a repo an env var points at.
+    ``pin_repo=False`` is used only for ``git init``, which must run
+    before ``.git`` exists. ``None`` on any launch/timeout failure;
+    callers also check ``returncode``."""
+    root = Path(memory_root)
+    cmd = ["git"]
+    if pin_repo:
+        cmd += [
+            f"--git-dir={root / '.git'}",
+            f"--work-tree={root}",
+            "-c", f"safe.directory={root}",
+        ]
+    cmd += args
     try:
         return subprocess.run(
-            ["git", *args],
-            cwd=str(memory_root),
+            cmd,
+            cwd=str(root),
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            env=_scrubbed_env(),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         logger.warning("memory git %s failed to run: %s", args[:1], exc)
@@ -66,14 +97,16 @@ def ensure_memory_git(memory_root: str | Path) -> bool:
             "audit-committed", memory_root,
         )
         return False
+    # ``init`` runs before ``.git`` exists, so it can't pin --git-dir;
+    # the config steps that follow do (the repo is present by then).
     steps = [
-        ["init", "--quiet"],
-        ["config", "user.name", "puffo-agent"],
-        ["config", "user.email", "memory@puffo.local"],
-        ["config", "commit.gpgsign", "false"],
+        (["init", "--quiet"], False),
+        (["config", "user.name", "puffo-agent"], True),
+        (["config", "user.email", "memory@puffo.local"], True),
+        (["config", "commit.gpgsign", "false"], True),
     ]
-    for step in steps:
-        proc = _run_git(memory_root, step)
+    for step, pin_repo in steps:
+        proc = _run_git(memory_root, step, pin_repo=pin_repo)
         if proc is None or proc.returncode != 0:
             detail = (proc.stderr or proc.stdout).strip() if proc else "launch failed"
             logger.warning(
@@ -105,6 +138,15 @@ def commit_memory_change(
     that warrants a warning)."""
     memory_root = Path(memory_root)
     if not paths:
+        return None
+    # Only ever commit into our OWN audit repo. If the memory root sits
+    # inside an enclosing git repo but has no ``.git`` of its own, an
+    # unguarded add/commit would land in that outer repo — refuse.
+    if not (memory_root / ".git").is_dir():
+        logger.warning(
+            "memory git commit skipped at %s: no local .git audit repo",
+            memory_root,
+        )
         return None
     add = _run_git(memory_root, ["add", "--", *paths])
     if add is None or add.returncode != 0:

--- a/src/puffo_agent/agent/memory_store.py
+++ b/src/puffo_agent/agent/memory_store.py
@@ -36,13 +36,12 @@ from .memory import (
     PROFILE_BRIEFING_NAME,
     RECOLLECTION_DIR,
     TOTAL_LIMIT,
-    BriefingCompileError,
-    MemoryStoreError,
     _byte_size,
     _compose_briefing,
     _read_briefing_entries,
     request_prompt_refresh,
 )
+from .memory_errors import BriefingCompileError, MemoryStoreError
 
 # Per-file byte limits (top of the design ranges, like M1's briefing
 # budget). ``imports/`` is never written through the store; its entry
@@ -112,7 +111,10 @@ class MemoryStore:
 
     def read_memory_file(self, path: str) -> dict:
         """Bounded read: ``body`` is capped at the area's file limit
-        (``truncated`` flags a cut); ``size`` is the real file size."""
+        (``truncated`` flags a cut); ``size`` is the real file size.
+        ``lossy`` is True when the file wasn't valid UTF-8 and
+        replacement characters were substituted (the read never
+        raises on stored bytes)."""
         scope, logical = self._validate_logical_path(path)
         physical = self._physical_path(logical)
         if not physical.is_file():
@@ -132,13 +134,23 @@ class MemoryStore:
             # A byte cap can split a multi-byte sequence; drop the
             # trailing partial character rather than emitting garbage.
             body = data[:limit].decode("utf-8", errors="ignore")
+            lossy = False
         else:
-            body = data.decode("utf-8")
+            # Never raise on stored bytes: a non-UTF-8 file is surfaced
+            # with U+FFFD replacements and flagged ``lossy`` instead of
+            # crashing the read with UnicodeDecodeError.
+            try:
+                body = data.decode("utf-8")
+                lossy = False
+            except UnicodeDecodeError:
+                body = data.decode("utf-8", errors="replace")
+                lossy = True
         return {
             "path": str(logical),
             "scope": scope,
             "size": size,
             "truncated": truncated,
+            "lossy": lossy,
             "body": body,
         }
 
@@ -188,7 +200,19 @@ class MemoryStore:
         text = original
         for patch in patches:
             old_text = patch["old_text"]
-            matches = text.count(old_text) if old_text else 2
+            if not old_text:
+                # An empty old_text has no unambiguous match point;
+                # tell direct store callers the truth rather than
+                # faking a "multiple matches" count.
+                raise MemoryStoreError(
+                    "memory_invalid_arguments",
+                    path=str(logical),
+                    suggestion=(
+                        "old_text must be non-empty text that appears "
+                        "exactly once in the file."
+                    ),
+                )
+            matches = text.count(old_text)
             if matches == 0:
                 raise MemoryStoreError(
                     "memory_patch_no_match",
@@ -284,14 +308,15 @@ class MemoryStore:
             ),
         }
 
-    # ── package-internal ─────────────────────────────────────────────
+    # ── daemon-owned writer (not one of the public seven) ────────────
 
-    def _put_memory_file(self, path: str, body: str) -> dict:
+    def put_memory_file(self, path: str, body: str) -> dict:
         """Overwrite-allowed create, for the daemon-owned M1 writers
-        (``MemoryManager.save`` / ``sync_profile_briefing``) — same
-        validation, sizing, atomicity, and briefing dirty hook. Not
-        part of the public seven: agent-facing callers must use
-        create/patch/append so overwrites stay deliberate."""
+        (``MemoryManager.save`` / ``sync_profile_briefing`` /
+        ``migrate_flat_memory``) — same validation, sizing, atomicity,
+        and briefing dirty hook. Not part of the public seven:
+        agent-facing callers must use create/patch/append so overwrites
+        stay deliberate."""
         scope, logical = self._validate_write_path(path)
         physical = self._physical_path(logical)
         size = self._validate_size(scope, logical, body)

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -222,21 +222,24 @@ use filenames that identify you (e.g. `notes-from-<your-id>.md`).
 
 ## Memory
 
-Your memory is a small tree under `memory/`:
+A durable memory tree under `memory/`, managed through tools — never
+hand-edit these files:
 
-- `memory/briefing/<topic>.md` — durable facts you always want in
-  context. Compiled into this prompt, bounded: 16KB per file, 64KB
-  total. An over-budget briefing FAILS the prompt rebuild (no silent
-  truncation), so keep topics tight.
-- `memory/briefing/profile.md` — your identity framing; managed by
-  puffo-agent from your profile. Don't edit the managed block.
-- `memory/notes/` — unbounded detail; lives on disk for you to read
-  or grep, never injected into your prompt.
+- **Briefing topics** are always compiled into this prompt. Create and
+  edit them with `mcp__puffo__create_briefing_topic` /
+  `mcp__puffo__patch_briefing_topic`. Bounded: 16KB per topic, 64KB
+  compiled total; an over-budget write FAILS the rebuild (fail closed,
+  no silent truncation), so keep topics tight. A briefing write marks
+  the prompt for rebuild automatically — no `refresh()` step; it lands
+  at your next turn.
+- **Notes** are durable detail that never enters your prompt. Manage
+  them with `mcp__puffo__create_note` / `patch_note` / `append_note`;
+  recall with `mcp__puffo__search_memory` /
+  `mcp__puffo__read_memory_file`.
+- `memory/briefing/profile.md` — your identity framing, managed by
+  puffo-agent from your profile. Don't touch the managed block.
 - `memory/recollection/`, `memory/imports/` — reserved for the
   platform.
-
-Write markdown, then call `refresh()`; briefing changes land in your
-prompt on the next turn.
 
 ## Your two CLAUDE.md layers (cli-local / cli-docker only)
 
@@ -248,10 +251,10 @@ Claude Code concatenates two files:
 2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace
    — yours to edit; puffo-agent never touches it.
 
-Use layer 2 for fast prompt updates; use `memory/briefing/*.md` +
-`refresh()` when you want content labelled as memory. `sdk` and
-codex only have layer 1 — go through `memory/briefing/*.md`.
-Codex's equivalent is `$CODEX_HOME/AGENTS.md`.
+Use layer 2 for fast, free-form prompt notes you keep yourself. For
+durable content labelled as memory, use the briefing tools above —
+they work on every runtime, `sdk` and codex included (those only have
+layer 1). Codex's layer-1 equivalent is `$CODEX_HOME/AGENTS.md`.
 
 ## Permission prompts (cli-local only)
 
@@ -613,7 +616,8 @@ axes; combine them freely.
 | `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, full worker respawn. Implicit fresh session. |
 
 **When to use:**
-- Edited `CLAUDE.md`, `profile.md`, `memory/briefing/*.md` → `refresh()`.
+- Edited `CLAUDE.md` or `profile.md` → `refresh()`. (Briefing topics
+  written via the memory tools rebuild automatically — no `refresh()`.)
 - Installed a new skill / MCP → `refresh()`.
 - Operator added a new skill to their `~/.claude/skills/` → tell them
   to call it "host-sync" and use `refresh(host_sync=True[, session=True])`.

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -49,6 +49,20 @@ PUFFO_CORE_TOOL_NAMES = (
     "leave_space",
     "leave_channel",
     "refresh",
+    # M3 memory tools (registered by mcp.memory_tools). Kept in the
+    # core allowlist so the sdk adapter's gate auto-allows them like
+    # every other mcp__puffo__ tool — otherwise they register but are
+    # denied at call time on sdk-local.
+    "create_note",
+    "patch_note",
+    "append_note",
+    "create_briefing_topic",
+    "patch_briefing_topic",
+    "append_recollection",
+    "read_memory_file",
+    "read_memory_files",
+    "search_memory",
+    "search_imports",
 )
 PUFFO_CORE_TOOL_FQNS = tuple(
     f"mcp__{MCP_SERVER_NAME}__{t}" for t in PUFFO_CORE_TOOL_NAMES

--- a/src/puffo_agent/mcp/memory_tools.py
+++ b/src/puffo_agent/mcp/memory_tools.py
@@ -1,10 +1,13 @@
 """Semantic memory MCP tools (M3) over the M2 ``MemoryStore``.
 
-Ten agent-facing tools: six semantic writes (``create_note``,
-``patch_note``, ``append_note``, ``create_briefing_topic``,
-``patch_briefing_topic``, ``append_recollection``) and four
-read/search tools (``read_memory_file``, ``read_memory_files``,
-``search_memory``, ``search_imports``). The agent works with memory
+Ten tools: six semantic writes (``create_note``, ``patch_note``,
+``append_note``, ``create_briefing_topic``, ``patch_briefing_topic``,
+``append_recollection``) and four read/search tools
+(``read_memory_file``, ``read_memory_files``, ``search_memory``,
+``search_imports``). Nine are agent-facing; ``append_recollection``
+registers only under the maintenance scope (recollection/ is
+daemon-owned), so the agent-facing server exposes the other nine. The
+agent works with memory
 concepts — notes, briefing topics, recollections — never physical
 paths; semantic names are normalized onto logical paths
 (``notes/<name>.md``, ``briefing/<name>.md``, dated
@@ -61,10 +64,10 @@ from ..agent.memory import (
     IMPORTS_DIR,
     NOTES_DIR,
     RECOLLECTION_DIR,
-    MemoryStoreError,
     ensure_memory_tree,
     request_prompt_refresh,
 )
+from ..agent.memory_errors import MemoryStoreError
 from ..agent.memory_store import IMPORTS_READ_LIMIT, MemoryStore
 
 logger = logging.getLogger(__name__)
@@ -247,6 +250,15 @@ def _validate_patches(operation: str, patches: object) -> list[dict]:
                 f"{operation}: each patch needs string old_text and new_text.",
                 "Pass patches as [{old_text, new_text}, ...].",
             )
+        if patch["old_text"] == "":
+            # An empty old_text has no single, unambiguous match point;
+            # reject it here rather than letting it reach the store.
+            raise _args_error(
+                operation,
+                f"{operation}: old_text must be a non-empty string.",
+                "old_text must be text that appears exactly once in the "
+                "file; it cannot be empty.",
+            )
         out.append(
             {"old_text": patch["old_text"], "new_text": patch["new_text"]}
         )
@@ -285,13 +297,17 @@ def _run_write(cfg: MemoryToolsConfig, tool: str, op, reason: str) -> dict:
     warnings: list[dict] = []
 
     commit_id = None
+    root = Path(cfg.memory_root)
     if changed:
-        if memory_git.git_available():
+        # Only attempt an audit commit when git is available AND our own
+        # ``.git`` audit repo exists — never stage into an enclosing
+        # repo the memory root happens to sit inside.
+        if memory_git.git_available() and (root / ".git").is_dir():
             message = memory_git.format_commit_message(
                 tool, [logical], reason,
             )
             commit_id = memory_git.commit_memory_change(
-                Path(cfg.memory_root), [logical], message,
+                root, [logical], message,
             )
             if commit_id is None:
                 warnings.append({
@@ -420,7 +436,11 @@ def _validate_search_args(operation: str, query: object, limit: object) -> int:
 
 
 def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
-    """Register the ten M3 semantic memory tools on ``mcp``."""
+    """Register the M3 semantic memory tools on ``mcp``.
+
+    Nine tools always register; ``append_recollection`` registers only
+    when ``cfg.maintenance`` is set, since recollection/ writes need the
+    maintenance scope the agent-facing server never grants."""
 
     # -- write tools ---------------------------------------------------
 
@@ -519,7 +539,6 @@ def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
             lambda s: s.patch_memory_file(path, checked), reason,
         )
 
-    @mcp.tool()
     async def append_recollection(
         text: str,
         date: str = "",
@@ -558,6 +577,15 @@ def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
             return store.create_memory_file(path, f"# {day}\n" + entry)
 
         return _run_write(cfg, "append_recollection", op, reason)
+
+    # recollection/ is daemon-owned maintenance memory; the agent-facing
+    # server (maintenance=False) has no write scope there, so an agent
+    # calling append_recollection would only ever get a
+    # memory_scope_readonly error. Register the tool solely under the
+    # explicit maintenance scope, where it actually works — a future
+    # maintenance server flips ``maintenance`` on.
+    if cfg.maintenance:
+        mcp.tool()(append_recollection)
 
     # -- read tools ----------------------------------------------------
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -525,7 +525,7 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     )
     cfg.save()
 
-    from ..agent.memory import ensure_memory_tree
+    from ..agent.memory import ensure_memory_tree, sync_profile_briefing
     ensure_memory_tree(target / "memory")
 
     profile_path = target / "profile.md"
@@ -533,6 +533,20 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
         shutil.copy2(args.profile, profile_path)
     else:
         profile_path.write_text(DEFAULT_PROFILE, encoding="utf-8")
+
+    # Seed briefing/profile.md now so the agent's very first prompt
+    # rebuild has managed identity framing (the worker's memory sync
+    # re-syncs it, but a freshly created agent shouldn't ship without
+    # it). Mirrors shared_content.rebuild_agent_claude_md's profile sync.
+    from .profile_sync import extract_soul_body
+    sync_profile_briefing(
+        target / "memory",
+        agent_id=agent_id,
+        display_name=cfg.display_name,
+        role=role,
+        role_short=role_short,
+        soul=extract_soul_body(profile_path.read_text(encoding="utf-8")),
+    )
 
     print(f"created agent {agent_id!r} at {target}")
     print(
@@ -1499,7 +1513,7 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
     """Re-sync the shared primer + rebuild the listed agents' CLAUDE.md.
     ensure_shared_primer runs on every worker startup, so this is only
     needed to force a rebuild without waiting for a message."""
-    from ..agent.memory import BriefingCompileError
+    from ..agent.memory_errors import BriefingCompileError
     from ..agent.shared_content import (
         ensure_shared_primer,
         rebuild_agent_claude_md,

--- a/tests/test_agent_create_flow.py
+++ b/tests/test_agent_create_flow.py
@@ -115,3 +115,38 @@ def test_finalize_from_command_writes_profile(tmp_path, monkeypatch):
 def test_finalize_from_command_unknown_request():
     with pytest.raises(ValueError, match="no pending create"):
         asyncio.run(agent_create.finalize_from_command("acr_missing", {}))
+
+
+def test_cmd_agent_create_seeds_profile_briefing(tmp_path, monkeypatch):
+    """`puffo-agent agent create` seeds briefing/profile.md with the
+    managed identity block, so a freshly created agent's first prompt
+    rebuild already has managed identity framing."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.agent.memory import (
+        PROFILE_MANAGED_BEGIN,
+        PROFILE_MANAGED_END,
+    )
+    from puffo_agent.portal.cli import build_parser
+
+    # cli-local resolves the API key without prompting, so the create
+    # flow runs headless.
+    args = build_parser().parse_args([
+        "agent", "create",
+        "--id", "helper-0001",
+        "--display-name", "Helper",
+        "--role", "coder: writes code",
+        "--runtime", "cli-local",
+    ])
+    assert args.func(args) == 0
+
+    profile_briefing = (
+        tmp_path / "agents" / "helper-0001" / "memory" / "briefing"
+        / "profile.md"
+    )
+    assert profile_briefing.is_file()
+    text = profile_briefing.read_text(encoding="utf-8")
+    assert PROFILE_MANAGED_BEGIN in text
+    assert PROFILE_MANAGED_END in text
+    # Identity fields from the create args land inside the managed block.
+    assert "Helper" in text
+    assert "coder: writes code" in text

--- a/tests/test_memory_m1.py
+++ b/tests/test_memory_m1.py
@@ -232,6 +232,114 @@ def test_migrate_flat_memory_over_total_budget_goes_to_notes(tmp_path):
     compile_briefing(root)  # still within budget after migration
 
 
+# ── symlink injection (host-side compile & migration) ────────────────
+
+
+def test_compile_excludes_symlinked_briefing_topic_outside_root(tmp_path):
+    """A symlinked briefing topic pointing at a file OUTSIDE the memory
+    root must never fold that file's bytes into the compiled prompt."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "briefing" / "real.md").write_text("real fact", encoding="utf-8")
+    secret = tmp_path / "outside-secret.md"
+    secret.write_text("SECRET-OUTSIDE-CONTENT", encoding="utf-8")
+    (root / "briefing" / "evil.md").symlink_to(secret)
+
+    out = compile_briefing(root)  # succeeds, does not raise
+
+    assert "real fact" in out
+    assert "SECRET-OUTSIDE-CONTENT" not in out
+    # The symlink is left on disk untouched, just never compiled.
+    assert (root / "briefing" / "evil.md").is_symlink()
+    assert secret.read_text(encoding="utf-8") == "SECRET-OUTSIDE-CONTENT"
+
+
+def test_compile_excludes_symlinked_briefing_topic_inside_root(tmp_path):
+    """Even a symlink whose target sits inside the root is excluded —
+    briefing topics are never followed through symlinks."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "notes" / "target.md").write_text(
+        "NOTE-TARGET-BYTES", encoding="utf-8",
+    )
+    (root / "briefing" / "link.md").symlink_to(root / "notes" / "target.md")
+
+    out = compile_briefing(root)
+
+    assert "NOTE-TARGET-BYTES" not in out
+
+
+def test_compile_excludes_topic_reached_through_symlinked_briefing_dir(tmp_path):
+    """A real topic file that resolves outside the root through a
+    symlinked briefing/ dir is dropped by the resolve() containment
+    check — exercising the guard beyond leaf symlinks."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    external = tmp_path / "external-briefing"
+    external.mkdir()
+    (external / "leak.md").write_text("EXTERNAL-LEAK-BYTES", encoding="utf-8")
+    briefing = root / "briefing"
+    briefing.rmdir()  # ensure_memory_tree left it empty
+    briefing.symlink_to(external)
+
+    out = compile_briefing(root)  # succeeds, does not raise
+
+    assert "EXTERNAL-LEAK-BYTES" not in out
+
+
+def test_migrate_flat_memory_skips_symlinked_flat_file(tmp_path):
+    """A symlinked flat *.md is never read or migrated — its target's
+    bytes must not enter the tree."""
+    root = tmp_path / "memory"
+    root.mkdir()
+    secret = tmp_path / "host-secret.md"
+    secret.write_text("HOST-SECRET-BYTES", encoding="utf-8")
+    (root / "evil.md").symlink_to(secret)
+    (root / "real.md").write_text("real flat fact", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)  # does not raise
+
+    # The real flat file migrated; the symlink was skipped entirely.
+    assert "briefing/real.md" in moved
+    assert not any("evil" in m for m in moved)
+    # The symlink is left in place; its target was never read or moved.
+    assert (root / "evil.md").is_symlink()
+    assert secret.read_text(encoding="utf-8") == "HOST-SECRET-BYTES"
+    # No regular file in the tree carries the secret bytes.
+    for p in root.rglob("*.md"):
+        if p.is_symlink():
+            continue
+        assert "HOST-SECRET-BYTES" not in p.read_text(encoding="utf-8")
+
+
+def test_migrate_pointer_skipped_when_briefing_budget_full(tmp_path):
+    """When the briefing is so full that even the migrated-notes pointer
+    line would bust the total, the pointer is skipped (fail closed) — the
+    note still migrates and the result still compiles within budget."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    # Four ~16KB topics compile to ~10 bytes under the 64KB total,
+    # leaving no room for either the flat note or a pointer topic.
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * 16368, encoding="utf-8",
+        )
+    assert len(compile_briefing(root).encode("utf-8")) <= TOTAL_LIMIT
+    # A small flat note can't fit briefing (total is full) → notes/.
+    (root / "overflow.md").write_text("overflow note body\n", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)  # does not raise
+
+    assert moved == ["notes/overflow.md"]
+    assert (root / "notes" / "overflow.md").is_file()
+    # The pointer write was rejected by the store's budget check before
+    # any file was written, so no migrated-notes topic exists…
+    assert not (root / "briefing" / "migrated-notes.md").exists()
+    # …and the migrated tree still compiles within the total budget.
+    compiled = compile_briefing(root)  # must not raise
+    assert len(compiled.encode("utf-8")) <= TOTAL_LIMIT
+
+
 def test_migrate_flat_memory_name_collision_falls_back(tmp_path):
     root = tmp_path / "memory"
     root.mkdir()

--- a/tests/test_memory_m2.py
+++ b/tests/test_memory_m2.py
@@ -257,6 +257,20 @@ def test_patch_with_multiple_matches_is_rejected(store, root):
     assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "dup thing dup"
 
 
+def test_patch_with_empty_old_text_is_rejected(store, root):
+    """An empty old_text has no unambiguous match point; the store
+    rejects it with a truthful memory_invalid_arguments error rather
+    than the old ``count if old_text else 2`` fake-multiple-match hack."""
+    store.create_memory_file("notes/n.md", "content")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "", "new_text": "x"},
+        ])
+    assert ei.value.code == "memory_invalid_arguments"
+    assert ei.value.suggestion
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "content"
+
+
 def test_patch_list_is_all_or_nothing(store, root):
     store.create_memory_file("notes/n.md", "alpha beta")
     with pytest.raises(MemoryStoreError) as ei:
@@ -346,6 +360,26 @@ def test_read_memory_files_returns_bounded_reads_without_modifying_memory(store,
 
     # Pure read: the tree is byte-identical afterwards.
     assert _tree_snapshot(root) == before
+
+
+def test_read_non_utf8_file_is_lossy_not_crashing(store, root):
+    """A stored file that isn't valid UTF-8 is surfaced with U+FFFD
+    replacements and flagged ``lossy`` instead of raising
+    UnicodeDecodeError."""
+    (root / "notes" / "x.md").write_bytes(b"\xff\xfe garbage")
+
+    res = store.read_memory_file("notes/x.md")  # must not raise
+
+    assert res["lossy"] is True
+    assert res["truncated"] is False
+    assert "�" in res["body"]
+    assert "garbage" in res["body"]
+
+    # A clean UTF-8 file is not flagged lossy.
+    store.create_memory_file("notes/ok.md", "clean text")
+    ok = store.read_memory_file("notes/ok.md")
+    assert ok["lossy"] is False
+    assert ok["body"] == "clean text"
 
 
 def test_read_memory_files_batch_over_limit_is_rejected(store):

--- a/tests/test_memory_m3.py
+++ b/tests/test_memory_m3.py
@@ -10,6 +10,7 @@ docs/user-lead-designs/memory-implementation.md, named after it.
 """
 
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -39,6 +40,12 @@ M3_TOOLS = {
     "search_memory",
     "search_imports",
 }
+
+# append_recollection is daemon-owned maintenance memory: it registers
+# only under the explicit maintenance scope, so the agent-facing server
+# exposes the other nine.
+M3_MAINTENANCE_TOOLS = {"append_recollection"}
+M3_AGENT_TOOLS = M3_TOOLS - M3_MAINTENANCE_TOOLS
 
 
 @pytest.fixture
@@ -187,6 +194,23 @@ async def test_invalid_patches_are_rejected(root):
         assert err["code"] == "memory_invalid_arguments"
 
 
+@pytest.mark.asyncio
+async def test_patch_with_empty_old_text_is_rejected(root):
+    """An empty old_text is rejected at the tools layer with a
+    memory_invalid_arguments error before it ever reaches the store."""
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "n", "body": "content\n"})
+    err = await _call_err(mcp, "patch_note", {
+        "name": "n", "patches": [{"old_text": "", "new_text": "x"}],
+    })
+    assert err["code"] == "memory_invalid_arguments"
+    assert err["operation"] == "patch_note"
+    assert err["suggestion"]
+    # The note is untouched.
+    res = await _call(mcp, "read_memory_file", {"path": "notes/n.md"})
+    assert res["body"] == "content\n"
+
+
 # ── scenario 3: note tools cannot write outside notes/ ───────────────
 
 
@@ -245,18 +269,30 @@ async def test_briefing_topic_tools_cannot_write_outside_briefing(root):
 
 
 @pytest.mark.asyncio
-async def test_conversation_scope_cannot_write_recollection(root):
-    mcp = _build(root)
-    err = await _call_err(mcp, "append_recollection", {
-        "date": "2026-07-06", "text": "entry",
-    })
-    assert err["code"] == "memory_scope_readonly"
-    assert err["suggestion"]
+async def test_append_recollection_registered_only_under_maintenance(root):
+    # Agent-facing server (maintenance=False): the tool is not even
+    # registered — recollection/ is daemon-owned, so agent-side calls
+    # could only ever be scope-denied. The other nine tools are present.
+    agent_mcp = _build(root)
+    agent_tools = {t.name for t in await agent_mcp.list_tools()}
+    assert "append_recollection" not in agent_tools
+    assert M3_AGENT_TOOLS <= agent_tools
+
+    # Defense in depth: the store itself denies a conversation-scope
+    # recollection write with a structured scope error, touching nothing.
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root).create_memory_file(
+            "recollection/2026/07/2026-07-06.md", "entry\n",
+        )
+    assert ei.value.code == "memory_scope_readonly"
+    assert ei.value.suggestion
     assert not (root / "recollection" / "2026").exists()
 
-    # The same write under the explicit maintenance scope succeeds —
-    # the deny above is scope, not breakage.
+    # Maintenance server (maintenance=True): the tool IS registered and
+    # actually writes — the deny above is scope, not breakage.
     maint = _build(root, maintenance=True)
+    maint_tools = {t.name for t in await maint.list_tools()}
+    assert "append_recollection" in maint_tools
     res = await _call(maint, "append_recollection", {
         "date": "2026-07-06",
         "text": "learned a thing",
@@ -351,6 +387,97 @@ async def test_git_unavailable_degrades_gracefully(root, monkeypatch):
     assert res["warnings"] == []
     assert (root / "notes" / "n.md").is_file()
     assert not (root / ".git").exists()
+
+
+# ── git audit hygiene: containment + env scrubbing ───────────────────
+
+
+def _git_env_scrubbed(root: Path, *args: str) -> str:
+    """git for test assertions, with the location-override env vars
+    stripped so a poisoned ambient GIT_DIR can't skew the check."""
+    env = {
+        k: v for k, v in os.environ.items()
+        if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+    }
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True, text=True, check=True, env=env,
+    ).stdout.strip()
+
+
+def test_commit_refuses_when_memory_root_has_no_local_git(tmp_path):
+    """A memory root nested inside an enclosing repo but WITHOUT its own
+    .git must not have its writes staged/committed into the outer repo."""
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    for cmd in (
+        ["init", "-q"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+        ["config", "commit.gpgsign", "false"],
+    ):
+        subprocess.run(["git", "-C", str(outer), *cmd], check=True)
+    (outer / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(outer), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(outer), "commit", "-q", "-m", "seed"], check=True)
+    head_before = _git_env_scrubbed(outer, "rev-parse", "HEAD")
+
+    memory = outer / "memory"
+    ensure_memory_tree(memory)
+    (memory / "notes" / "n.md").write_text("note\n", encoding="utf-8")
+    assert not (memory / ".git").exists()
+
+    result = memory_git.commit_memory_change(
+        memory, ["notes/n.md"], "memory: create notes/n.md\n",
+    )
+
+    # Refused: no commit id, outer HEAD unchanged, nothing staged there.
+    assert result is None
+    assert _git_env_scrubbed(outer, "rev-parse", "HEAD") == head_before
+    assert _git_env_scrubbed(outer, "diff", "--cached", "--name-only") == ""
+
+
+def test_poisoned_git_env_cannot_redirect_audit_commit(tmp_path, monkeypatch):
+    """GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE pointed at a bait repo
+    must not redirect the audit commit: it lands in <root>/.git and the
+    bait repo is untouched."""
+    bait = tmp_path / "bait"
+    bait.mkdir()
+    for cmd in (
+        ["init", "-q"],
+        ["config", "user.email", "b@b"],
+        ["config", "user.name", "b"],
+    ):
+        subprocess.run(["git", "-C", str(bait), *cmd], check=True)
+
+    memory = tmp_path / "memory"
+    ensure_memory_tree(memory)
+    (memory / "notes" / "n.md").write_text("note\n", encoding="utf-8")
+
+    monkeypatch.setenv("GIT_DIR", str(bait / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(bait))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(bait / ".git" / "index"))
+
+    assert memory_git.ensure_memory_git(memory) is True
+    commit_id = memory_git.commit_memory_change(
+        memory, ["notes/n.md"], "memory: create notes/n.md\n",
+    )
+
+    # The audit repo materialised at the memory root and holds the commit.
+    assert commit_id
+    assert (memory / ".git").is_dir()
+    log = _git_env_scrubbed(memory, "log", "-1", "--name-only", "--format=%H")
+    assert "notes/n.md" in log
+    # The bait repo received nothing.
+    bait_head = subprocess.run(
+        ["git", "-C", str(bait), "rev-list", "-n", "1", "--all"],
+        capture_output=True, text=True,
+        env={
+            k: v for k, v in os.environ.items()
+            if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+        },
+    ).stdout.strip()
+    assert bait_head == ""
 
 
 # ── scenario 8: write result envelope ────────────────────────────────
@@ -501,7 +628,7 @@ async def test_read_memory_files_reads_bounded_files_and_never_writes(root):
 
 
 @pytest.mark.asyncio
-async def test_all_ten_m3_tools_are_registered_on_built_server(root, tmp_path):
+async def test_agent_facing_m3_tools_are_registered_on_built_server(root, tmp_path):
     from puffo_agent.mcp.puffo_core_server import build_server
 
     server = build_server(
@@ -516,7 +643,11 @@ async def test_all_ten_m3_tools_are_registered_on_built_server(root, tmp_path):
         memory_dir=str(root),
     )
     names = {t.name for t in await server.list_tools()}
-    assert M3_TOOLS <= names
+    # build_server constructs the memory tools with maintenance=False,
+    # so the nine agent-facing tools register and the daemon-owned
+    # append_recollection does not.
+    assert M3_AGENT_TOOLS <= names
+    assert "append_recollection" not in names
     # Building the server has no side effects: the memory tree and its
     # git repo are ensured lazily on first tool call, not at build time.
     assert not root.exists()

--- a/tests/test_sdk_gate_memory_tools.py
+++ b/tests/test_sdk_gate_memory_tools.py
@@ -1,0 +1,58 @@
+"""The sdk-local adapter runs every tool call through ``_gate``, which
+allows a call only if some configured pattern matches. Puffo MCP tools
+are auto-allowed by seeding the gate's patterns with
+``PUFFO_CORE_TOOL_FQNS``. This pins that the ten M3 memory tools are in
+that set — otherwise they register on the server but get denied at call
+time on sdk-local (the M3 finding this guards against).
+
+``claude_agent_sdk`` is an optional dep the dev extra does NOT install;
+``SDKAdapter.__init__`` defers that import, so the module (and
+``_pattern_matches``) import fine without it, and the gate logic can be
+pinned directly.
+"""
+
+from puffo_agent.agent.adapters.sdk import _pattern_matches
+from puffo_agent.mcp.config import (
+    MCP_SERVER_NAME,
+    PUFFO_CORE_TOOL_FQNS,
+    PUFFO_CORE_TOOL_NAMES,
+)
+
+M3_TOOL_NAMES = (
+    "create_note",
+    "patch_note",
+    "append_note",
+    "create_briefing_topic",
+    "patch_briefing_topic",
+    "append_recollection",
+    "read_memory_file",
+    "read_memory_files",
+    "search_memory",
+    "search_imports",
+)
+
+
+def test_m3_memory_tools_are_in_core_allowlist():
+    assert set(M3_TOOL_NAMES) <= set(PUFFO_CORE_TOOL_NAMES)
+
+
+def test_m3_memory_tool_fqns_pass_the_sdk_gate():
+    # The adapter seeds its gate patterns with PUFFO_CORE_TOOL_FQNS
+    # (see SDKAdapter.__init__ / _gate). Reproduce the exact allow
+    # check the gate performs for each M3 tool's FQN.
+    for name in M3_TOOL_NAMES:
+        fqn = f"mcp__{MCP_SERVER_NAME}__{name}"
+        allowed = any(
+            _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS
+        )
+        assert allowed, f"{fqn} would be denied by the sdk gate"
+
+
+def test_unknown_puffo_tool_is_not_auto_allowed():
+    # Guard the guard: an FQN NOT in the allowlist must not match, so
+    # the assertion above is meaningful rather than vacuously true.
+    fqn = "mcp__puffo__definitely_not_a_real_tool"
+    assert fqn not in PUFFO_CORE_TOOL_FQNS
+    assert not any(
+        _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS
+    )


### PR DESCRIPTION
4th PR in the PY memory stack (#124→#125→#126→this). Fixes the adversarial-review findings. Gating MAJORs: (1) M1 host-side briefing compile/migration reject symlinks + enforce realpath containment (blocks a cli-docker agent symlinking operator files into its own prompt); (2) sdk-local allowlist extended so the 10 M3 memory tools are actually callable (were hard-denied); (3) primer Memory section rewritten around the M3 tools (was teaching the pre-M2 direct-write bypass that could brick the agent). Plus git-audit env/enclosing-repo hygiene, migration pointer routed through the store, non-UTF-8 read tolerance, create-time profile.md seed. Verify: pytest --ignore=tests/test_host_credentials.py exit 0; new tests for findings. **Held for review — do not merge (review #124→#125→#126→this stack).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)