### PR TITLE
memory M4: read-only recall/status/history APIs

### DIFF
--- a/src/puffo_agent/agent/memory_errors.py
+++ b/src/puffo_agent/agent/memory_errors.py
@@ -67,3 +67,29 @@ class BriefingCompileError(MemoryStoreError):
         super().__init__(
             code, path=path, size=size, limit=limit, suggestion=suggestion,
         )
+
+
+class MemoryHistoryError(Exception):
+    """Structured memory-history error: the M4 read-only audit query
+    analogue of ``MemoryStoreError``. Carries ``code`` (one of the M4
+    history codes such as ``memory_history_unavailable`` /
+    ``memory_history_not_initialized`` / ``memory_invalid_history_query``
+    / ``memory_history_query_too_large`` / ``memory_history_read_failed``),
+    plus a human ``message`` and a ``suggestion``. Unlike
+    ``MemoryStoreError`` it carries no ``path``/``size``/``limit`` — a
+    history query is over the audit log, not a single file — so the
+    tools layer maps it to the ``{code, message, suggestion}`` envelope
+    with a ``memory_git`` cause layer."""
+
+    def __init__(self, code: str, *, message: str, suggestion: str):
+        self.code = code
+        self.message = message
+        self.suggestion = suggestion
+        super().__init__(f"{code}: {message} {suggestion}".rstrip())
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "suggestion": self.suggestion,
+        }

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -17,9 +17,18 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
+
+from .memory import (
+    BRIEFING_DIR,
+    IMPORTS_DIR,
+    NOTES_DIR,
+    RECOLLECTION_DIR,
+)
+from .memory_errors import MemoryHistoryError
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +40,33 @@ _GIT_TIMEOUT = 30
 # in the daemon's environment could otherwise redirect an audit commit
 # into an attacker-chosen repo, so they are scrubbed from every run.
 _GIT_LOCATION_ENV = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+
+# ── M4 read-only history query bounds ────────────────────────────────
+HISTORY_DEFAULT_LIMIT = 20
+HISTORY_MAX_LIMIT = 100
+# include_diff attaches a diff per returned commit, so its limit is
+# tighter than a metadata-only query.
+HISTORY_DIFF_MAX_LIMIT = 20
+HISTORY_DIFF_BYTE_CAP = 4000
+# Unified-context lines for include_diff excerpts. Small on purpose —
+# the diff is a bounded audit excerpt, not a full patch.
+_HISTORY_DIFF_CONTEXT = 3
+
+# The four memory areas a history query may be scoped to.
+_HISTORY_SCOPES = (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR, IMPORTS_DIR)
+
+# git log field/record separators (ASCII US / RS): control chars that
+# never occur in a memory path or commit subject, so record parsing is
+# unambiguous and no user-supplied filter value can be mistaken for a
+# delimiter. The %b body is the LAST field, so the trailing --numstat
+# block is peeled off it in Python (see _split_body_numstat).
+_HISTORY_REC_SEP = "\x1e"
+_HISTORY_FIELD_SEP = "\x1f"
+_HISTORY_LOG_FORMAT = "%x1e%H%x1f%h%x1f%cI%x1f%an%x1f%s%x1f%b"
+
+# A --numstat line: "<added>\t<deleted>\t<path>" where added/deleted are
+# digits or "-" (binary files).
+_NUMSTAT_RE = re.compile(r"^(\d+|-)\t(\d+|-)\t(.+)$")
 
 
 def git_available() -> bool:
@@ -168,3 +204,406 @@ def commit_memory_change(
     if head is None or head.returncode != 0:
         return None
     return head.stdout.strip() or None
+
+
+# ── M4 read-only audit history queries ───────────────────────────────
+#
+# These NEVER init the tree or the repo (unlike the M3 read tools' lazy
+# ensure): a status/history read on an uninitialised root reports the
+# truth (unavailable / not initialised) rather than materialising it.
+# Only whitelisted, glued/``--``-guarded git args are ever built — no
+# arbitrary flags, refs, revision ranges, or rollback are exposed.
+
+
+def _history_unavailable() -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_unavailable",
+        message="git is not installed, so the memory audit history is unavailable.",
+        suggestion=(
+            "Install git to enable memory history; memory reads and writes "
+            "still work without it."
+        ),
+    )
+
+
+def _history_not_initialized(root: Path) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_not_initialized",
+        message=f"No local memory audit repo exists yet at {root}.",
+        suggestion="History appears once the first memory write is audit-committed.",
+    )
+
+
+def _history_read_failed(detail: str) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_read_failed",
+        message=f"Reading the memory audit history failed: {detail}.",
+        suggestion="Retry; if it persists, check the memory git repo.",
+    )
+
+
+def _history_invalid_query(detail: str, suggestion: str) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_invalid_history_query", message=detail, suggestion=suggestion,
+    )
+
+
+def _history_too_large(detail: str, suggestion: str) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_query_too_large", message=detail, suggestion=suggestion,
+    )
+
+
+def _history_env_ok(memory_root: str | Path) -> Path:
+    """Guard every history entry point: a git binary AND a local audit
+    repo must both exist. Returns the root; raises the matching
+    MemoryHistoryError otherwise. Never creates anything."""
+    root = Path(memory_root)
+    if not git_available():
+        raise _history_unavailable()
+    if not (root / ".git").is_dir():
+        raise _history_not_initialized(root)
+    return root
+
+
+def _porcelain_paths(text: str) -> list[str]:
+    """Work-tree/index paths from ``git status --porcelain`` output.
+    Rename/copy entries (``old -> new``) report the new path."""
+    out: list[str] = []
+    for line in text.splitlines():
+        if len(line) < 4:
+            continue
+        entry = line[3:]
+        if " -> " in entry:
+            entry = entry.split(" -> ", 1)[1]
+        out.append(entry)
+    return out
+
+
+def history_status(
+    memory_root: str | Path, path: str | None = None,
+) -> dict:
+    """Read-only health of the local audit repo: HEAD id, clean/dirty
+    work tree, and — when ``path`` is given (a logical memory path,
+    pre-validated by the caller) — whether that path is tracked and
+    when it last changed. Operates on committed history and tolerates a
+    dirty work tree (dirtiness is reported via ``clean`` /
+    ``uncommitted_paths``, never raised)."""
+    root = _history_env_ok(memory_root)
+    # HEAD short id — None (not an error) on an unborn/empty repo, where
+    # ``--verify --quiet`` exits nonzero with empty output.
+    head = _run_git(
+        root, ["rev-parse", "--verify", "--quiet", "--short", "HEAD"],
+    )
+    if head is None:
+        raise _history_read_failed("git rev-parse failed to run")
+    if head.returncode == 0:
+        head_id = head.stdout.strip() or None
+    elif not head.stdout.strip():
+        head_id = None
+    else:
+        raise _history_read_failed(
+            (head.stderr or head.stdout).strip() or "git rev-parse failed"
+        )
+
+    status = _run_git(root, ["status", "--porcelain"])
+    if status is None or status.returncode != 0:
+        detail = (
+            (status.stderr or status.stdout).strip()
+            if status else "git status failed to run"
+        )
+        raise _history_read_failed(detail or "git status failed")
+    uncommitted = _porcelain_paths(status.stdout)
+
+    result: dict = {
+        "git_enabled": True,
+        "repo_initialized": True,
+        "head_commit_id": head_id,
+        "clean": not uncommitted,
+        "uncommitted_paths": uncommitted,
+    }
+    if path is not None:
+        result["path"] = path
+        if head_id is None:
+            # No commits yet: nothing is tracked (a bare `git log` on an
+            # unborn HEAD would exit nonzero — treat as not-tracked).
+            result.update({
+                "path_tracked": False,
+                "last_changed_commit_id": None,
+                "last_changed_at": None,
+            })
+        else:
+            log = _run_git(
+                root, ["log", "-1", "--format=%h%x1f%cI", "--", path],
+            )
+            if log is None or log.returncode != 0:
+                detail = (
+                    (log.stderr or log.stdout).strip()
+                    if log else "git log failed to run"
+                )
+                raise _history_read_failed(detail or "git log failed")
+            out = log.stdout.strip()
+            if out:
+                short, _, iso = out.partition(_HISTORY_FIELD_SEP)
+                result.update({
+                    "path_tracked": True,
+                    "last_changed_commit_id": short or None,
+                    "last_changed_at": iso or None,
+                })
+            else:
+                result.update({
+                    "path_tracked": False,
+                    "last_changed_commit_id": None,
+                    "last_changed_at": None,
+                })
+    return result
+
+
+def _parse_commit_body(body: str) -> tuple[str | None, str | None]:
+    """Pull ``operation`` (from the ``tool:`` line) and ``reason`` (from
+    the ``reason:`` line) out of a commit body written by
+    ``format_commit_message``. Either may be absent."""
+    operation: str | None = None
+    reason: str | None = None
+    for line in body.splitlines():
+        stripped = line.strip()
+        if operation is None and stripped.startswith("tool:"):
+            operation = stripped[len("tool:"):].strip() or None
+        elif reason is None and stripped.startswith("reason:"):
+            reason = stripped[len("reason:"):].strip() or None
+    return operation, reason
+
+
+def _split_body_numstat(rest: str) -> tuple[str, list[str], int, int]:
+    """Peel the trailing ``--numstat`` block off the last (%b) field of
+    a log record. Returns ``(body, changed_paths, insertions,
+    deletions)``. The numstat lines are contiguous at the tail, so we
+    walk backward collecting rows that match ``_NUMSTAT_RE`` until the
+    first non-numstat line — everything above (minus trailing blanks) is
+    the commit body."""
+    lines = rest.split("\n")
+    while lines and lines[-1] == "":
+        lines.pop()
+    insertions = 0
+    deletions = 0
+    changed: list[str] = []
+    i = len(lines)
+    while i > 0:
+        m = _NUMSTAT_RE.match(lines[i - 1])
+        if not m:
+            break
+        i -= 1
+        added, removed, pth = m.group(1), m.group(2), m.group(3)
+        changed.append(pth)
+        if added != "-":
+            insertions += int(added)
+        if removed != "-":
+            deletions += int(removed)
+    changed.reverse()
+    body_lines = lines[:i]
+    while body_lines and body_lines[-1] == "":
+        body_lines.pop()
+    return "\n".join(body_lines), changed, insertions, deletions
+
+
+def _parse_history_records(output: str) -> list[dict]:
+    """Parse ``git log`` record-separated output into commit dicts.
+    ``_full`` (the full %H hash) is kept for a follow-up diff and popped
+    before the result is returned to the caller."""
+    commits: list[dict] = []
+    for raw in output.split(_HISTORY_REC_SEP):
+        if not raw.strip():
+            continue
+        fields = raw.split(_HISTORY_FIELD_SEP, 5)
+        if len(fields) < 6:
+            continue
+        full, short, iso, actor, subject, rest = fields
+        body, changed, insertions, deletions = _split_body_numstat(rest)
+        operation, reason = _parse_commit_body(body)
+        commits.append({
+            "_full": full,
+            "commit_id": short,
+            "time": iso,
+            "actor": actor,
+            "operation": operation,
+            "reason": reason,
+            "message": subject,
+            "changed_paths": changed,
+            "summary": {
+                "files_changed": len(changed),
+                "insertions": insertions,
+                "deletions": deletions,
+            },
+        })
+    return commits
+
+
+def _history_diff(
+    root: Path, full_hash: str, pathspec: list[str],
+) -> tuple[str, bool]:
+    """Bounded diff excerpt for one commit, scoped to the same
+    pathspec. ``full_hash`` is git-generated (%H), never user input.
+    Byte-capped at ``HISTORY_DIFF_BYTE_CAP``; returns ``(diff,
+    truncated)``. A diff we can't read degrades to an empty excerpt
+    rather than failing the whole query."""
+    args = [
+        "show", "--format=", f"--unified={_HISTORY_DIFF_CONTEXT}",
+        full_hash, "--", *pathspec,
+    ]
+    proc = _run_git(root, args)
+    if proc is None or proc.returncode != 0:
+        return "", False
+    data = proc.stdout.encode("utf-8")
+    if len(data) > HISTORY_DIFF_BYTE_CAP:
+        return data[:HISTORY_DIFF_BYTE_CAP].decode("utf-8", errors="ignore"), True
+    return proc.stdout, False
+
+
+def _normalize_history_filter(value: object, name: str) -> str | None:
+    """Empty/absent → None (no filter); a non-empty string passes
+    through; anything else is an invalid query."""
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise _history_invalid_query(
+            f"{name} must be a string.",
+            f"Pass {name} as a string, or omit it.",
+        )
+    return value
+
+
+def query_history(
+    memory_root: str | Path,
+    *,
+    path: str | None = None,
+    scopes: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    actor: str | None = None,
+    operation: str | None = None,
+    query: str | None = None,
+    limit: int = HISTORY_DEFAULT_LIMIT,
+    include_diff: bool = False,
+) -> dict:
+    """Bounded read-only audit query over the local git history — NOT a
+    ``git log`` passthrough. Only the whitelisted filters are honoured,
+    each built as a glued option (``--since=…``) or a ``--``-guarded
+    pathspec, so no value can be reinterpreted as a git flag, ref, or
+    revision range. ``operation`` (substring of the recorded ``tool:``)
+    and ``query`` (case-insensitive substring over subject + reason +
+    changed paths — never a diff grep) are applied as Python
+    post-filters. Returns ``{entries, truncated}``; ``include_diff``
+    attaches a byte-capped ``diff`` excerpt per entry."""
+    root = _history_env_ok(memory_root)
+
+    # -- arg validation (memory_invalid_history_query) -----------------
+    since = _normalize_history_filter(since, "since")
+    until = _normalize_history_filter(until, "until")
+    actor = _normalize_history_filter(actor, "actor")
+    operation = _normalize_history_filter(operation, "operation")
+    query = _normalize_history_filter(query, "query")
+    if path is not None and not isinstance(path, str):
+        raise _history_invalid_query(
+            "path must be a string.",
+            "Pass a logical memory path, or omit it.",
+        )
+    path = path or None
+    if scopes is not None:
+        if not isinstance(scopes, (list, tuple)):
+            raise _history_invalid_query(
+                "scopes must be a list of memory areas.",
+                "Pass scopes like ['briefing','notes'], or omit it.",
+            )
+        for sc in scopes:
+            if sc not in _HISTORY_SCOPES:
+                raise _history_invalid_query(
+                    f"unknown scope {sc!r}.",
+                    "Pick scopes from: briefing, notes, recollection, imports.",
+                )
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        raise _history_invalid_query(
+            f"limit must be a positive integer, got {limit!r}.",
+            f"Use 1 <= limit <= {HISTORY_MAX_LIMIT}.",
+        )
+
+    # -- size bounds (memory_history_query_too_large) ------------------
+    if limit > HISTORY_MAX_LIMIT:
+        raise _history_too_large(
+            f"limit {limit} exceeds the maximum {HISTORY_MAX_LIMIT}.",
+            f"Use limit <= {HISTORY_MAX_LIMIT}.",
+        )
+    if include_diff and limit > HISTORY_DIFF_MAX_LIMIT:
+        raise _history_too_large(
+            f"include_diff caps limit at {HISTORY_DIFF_MAX_LIMIT}; got {limit}.",
+            f"Use limit <= {HISTORY_DIFF_MAX_LIMIT} with include_diff, or "
+            "drop include_diff.",
+        )
+
+    # -- pathspec: always after `--`, one entry per scope or the path --
+    if path is not None:
+        pathspec = [path]
+    elif scopes:
+        pathspec = [f"{sc}/" for sc in scopes]
+    else:
+        pathspec = []
+
+    # -- git log: glued options only; no ref/revision-range ever built.
+    # Over-fetch a bounded window so the Python post-filters can drop
+    # commits and still fill `limit` / detect truncation.
+    fetch = HISTORY_MAX_LIMIT + 1
+    args = [
+        "log", f"--max-count={fetch}", f"--format={_HISTORY_LOG_FORMAT}",
+        "--numstat",
+    ]
+    if since is not None:
+        args.append(f"--since={since}")
+    if until is not None:
+        args.append(f"--until={until}")
+    if actor is not None:
+        args.append(f"--author={actor}")
+    args.append("--")
+    args.extend(pathspec)
+
+    proc = _run_git(root, args)
+    if proc is None or proc.returncode != 0:
+        # An unborn/empty repo makes `git log` exit nonzero with a
+        # "does not have any commits yet" message — that's simply no
+        # history, not a read failure.
+        stderr = (proc.stderr if proc else "") or ""
+        if proc is not None and "does not have any commits" in stderr:
+            return {"entries": [], "truncated": False}
+        detail = (
+            (proc.stderr or proc.stdout).strip()
+            if proc else "git log failed to run"
+        )
+        raise _history_read_failed(detail or "git log failed")
+
+    commits = _parse_history_records(proc.stdout)
+
+    def _passes(c: dict) -> bool:
+        if operation is not None:
+            if operation.lower() not in (c["operation"] or "").lower():
+                return False
+        if query is not None:
+            haystack = " ".join([
+                c["message"] or "",
+                c["reason"] or "",
+                " ".join(c["changed_paths"]),
+            ]).lower()
+            if query.lower() not in haystack:
+                return False
+        return True
+
+    filtered = [c for c in commits if _passes(c)]
+    truncated = len(filtered) > limit
+    entries = filtered[:limit]
+
+    if include_diff:
+        for entry in entries:
+            entry["diff"], entry["diff_truncated"] = _history_diff(
+                root, entry["_full"], pathspec,
+            )
+    for entry in entries:
+        entry.pop("_full", None)
+
+    return {"entries": entries, "truncated": truncated}

--- a/src/puffo_agent/agent/memory_store.py
+++ b/src/puffo_agent/agent/memory_store.py
@@ -39,6 +39,7 @@ from .memory import (
     _byte_size,
     _compose_briefing,
     _read_briefing_entries,
+    compile_briefing,
     request_prompt_refresh,
 )
 from .memory_errors import BriefingCompileError, MemoryStoreError
@@ -51,6 +52,11 @@ RECOLLECTION_FILE_LIMIT = 128 * 1024
 IMPORTS_READ_LIMIT = RECOLLECTION_FILE_LIMIT
 
 READ_BATCH_LIMIT = 16
+
+# list_memory_files bounds (M4 recall): default page size and the hard
+# cap the requested limit is clamped to.
+LIST_DEFAULT_LIMIT = 100
+LIST_MAX_LIMIT = 500
 
 _FILE_LIMITS = {
     BRIEFING_DIR: PER_FILE_LIMIT,
@@ -307,6 +313,111 @@ class MemoryStore:
                 exists and scope == BRIEFING_DIR and logical.suffix == ".md"
             ),
         }
+
+    # ── M4 status + recall (pure filesystem reads, no git) ───────────
+
+    def _iter_scope_files(self, scope: str) -> list[tuple[str, Path]]:
+        """``(logical posix path, physical path)`` pairs under one
+        scope, sorted for deterministic order; hidden segments and
+        symlinks are skipped (same rules as ``memory_tools._scope_files``).
+        Uses ``rglob('*')`` filtered to real files — ``briefing/`` is
+        flat, ``recollection/`` is nested, ``imports/`` may hold
+        non-``.md`` files."""
+        base = self.memory_root / scope
+        if not base.is_dir():
+            return []
+        out: list[tuple[str, Path]] = []
+        for p in sorted(base.rglob("*")):
+            rel = p.relative_to(self.memory_root).as_posix()
+            if any(seg.startswith(".") for seg in rel.split("/")):
+                continue
+            if p.is_symlink() or not p.is_file():
+                continue
+            out.append((rel, p))
+        return out
+
+    def get_memory_status(self) -> dict:
+        """Root health + compiled-briefing size + per-scope
+        ``{files, total_size_bytes}`` — a pure filesystem read (no git,
+        no bodies). The compiled size is computed defensively: an
+        over-budget briefing reports the offending size with
+        ``over_budget=True`` rather than raising, because a status read
+        must never fail closed the way a write does."""
+        try:
+            compiled_size = _byte_size(compile_briefing(self.memory_root))
+            over_budget = False
+        except BriefingCompileError as exc:
+            compiled_size = exc.size or 0
+            over_budget = True
+        scopes: dict = {}
+        for scope in _SCOPES:
+            files = self._iter_scope_files(scope)
+            scopes[scope] = {
+                "files": len(files),
+                "total_size_bytes": sum(p.stat().st_size for _, p in files),
+            }
+        return {
+            "memory_root": str(self.memory_root),
+            "root_exists": self.memory_root.is_dir(),
+            "briefing": {
+                "compiled_size_bytes": compiled_size,
+                "limit_bytes": TOTAL_LIMIT,
+                "over_budget": over_budget,
+            },
+            "scopes": scopes,
+        }
+
+    def list_memory_files(
+        self, scope: str | None = None, limit: int = LIST_DEFAULT_LIMIT,
+    ) -> dict:
+        """Logical paths + lightweight metadata for the requested scope
+        (or all scopes in fixed order), **never** a body. Each entry is
+        ``{path, scope, size, writable, briefing_included}``; the list
+        is capped at ``min(limit, LIST_MAX_LIMIT)`` and ``truncated``
+        flags that more files exist beyond the cap."""
+        if scope is not None and scope not in _SCOPES:
+            raise MemoryStoreError(
+                "memory_path_out_of_scope",
+                path=str(scope),
+                suggestion=(
+                    "scope must be one of briefing, notes, recollection, "
+                    "imports — or omitted to list every scope."
+                ),
+            )
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            raise MemoryStoreError(
+                "memory_invalid_arguments",
+                path="",
+                suggestion=(
+                    f"limit must be a positive integer (default "
+                    f"{LIST_DEFAULT_LIMIT}, max {LIST_MAX_LIMIT})."
+                ),
+            )
+        cap = min(limit, LIST_MAX_LIMIT)
+        files: list[dict] = []
+        truncated = False
+        for sc in _SCOPES:
+            if scope is not None and sc != scope:
+                continue
+            for rel, physical in self._iter_scope_files(sc):
+                if len(files) >= cap:
+                    truncated = True
+                    break
+                logical = PurePosixPath(rel)
+                files.append({
+                    "path": rel,
+                    "scope": sc,
+                    "size": physical.stat().st_size,
+                    "writable": (
+                        self._scope_writable(sc) and logical.suffix == ".md"
+                    ),
+                    "briefing_included": (
+                        sc == BRIEFING_DIR and logical.suffix == ".md"
+                    ),
+                })
+            if truncated:
+                break
+        return {"files": files, "truncated": truncated}
 
     # ── daemon-owned writer (not one of the public seven) ────────────
 

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -63,6 +63,15 @@ PUFFO_CORE_TOOL_NAMES = (
     "read_memory_files",
     "search_memory",
     "search_imports",
+    # M4 memory status / recall / history tools (read-only; registered
+    # by mcp.memory_tools). Same reason as the M3 block — the sdk gate
+    # auto-allows every mcp__puffo__ tool in this list, so leaving them
+    # out would register them but deny them at call time on sdk-local.
+    "get_memory_status",
+    "get_memory_file_status",
+    "list_memory_files",
+    "get_memory_history_status",
+    "get_memory_history",
 )
 PUFFO_CORE_TOOL_FQNS = tuple(
     f"mcp__{MCP_SERVER_NAME}__{t}" for t in PUFFO_CORE_TOOL_NAMES

--- a/src/puffo_agent/mcp/memory_tools.py
+++ b/src/puffo_agent/mcp/memory_tools.py
@@ -67,8 +67,12 @@ from ..agent.memory import (
     ensure_memory_tree,
     request_prompt_refresh,
 )
-from ..agent.memory_errors import MemoryStoreError
-from ..agent.memory_store import IMPORTS_READ_LIMIT, MemoryStore
+from ..agent.memory_errors import MemoryHistoryError, MemoryStoreError
+from ..agent.memory_store import (
+    IMPORTS_READ_LIMIT,
+    LIST_DEFAULT_LIMIT,
+    MemoryStore,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +174,50 @@ def _store_error(operation: str, exc: MemoryStoreError) -> ToolError:
             {"layer": "memory_store", "code": exc.code, "message": str(exc)},
         ],
     )
+
+
+def _history_error(operation: str, exc: MemoryHistoryError) -> ToolError:
+    """Map an M4 history-query error to the same structured envelope as
+    ``_store_error``, tagged with a ``memory_git`` cause layer. History
+    errors carry no path, so ``path`` is empty."""
+    return _tool_error(
+        code=exc.code,
+        message=f"{operation} failed: {exc.message}",
+        operation=operation,
+        path="",
+        suggestion=exc.suggestion,
+        causes=[
+            {"layer": "memory_git", "code": exc.code, "message": str(exc)},
+        ],
+    )
+
+
+def _validate_history_path(
+    cfg: MemoryToolsConfig, operation: str, path: str,
+) -> str:
+    """Validate a history path through the store's logical-path grammar
+    (grammar/scope only — a history query can legitimately reference a
+    since-deleted file, so there is no existence check). Store errors
+    (``memory_invalid_path`` / ``memory_path_out_of_scope``) re-raise as
+    tool errors."""
+    try:
+        _, logical = MemoryStore(cfg.memory_root)._validate_logical_path(path)
+    except MemoryStoreError as exc:
+        raise _store_error(operation, exc) from exc
+    return str(logical)
+
+
+def _briefing_refresh_pending(cfg: MemoryToolsConfig) -> bool:
+    """Whether a briefing change is awaiting a provider rebuild. In the
+    fat-agent model there is one provider-reload signal — the
+    ``refresh_agent.flag`` under ``<workspace>/.puffo-agent/`` — so both
+    ``briefing.dirty`` and ``briefing.provider_reload_required`` derive
+    from its presence. No workspace ⇒ nothing pending."""
+    if not cfg.workspace:
+        return False
+    from ..portal.state import refresh_agent_flag_path
+
+    return refresh_agent_flag_path(Path(cfg.workspace)).is_file()
 
 
 # ── semantic name / date handling ────────────────────────────────────
@@ -711,3 +759,161 @@ def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
             "ok": True, "query": query,
             "results": results, "truncated": truncated,
         }
+
+    # -- M4 status / recall / history (all read-only, agent-facing) ----
+    #
+    # Unlike the M3 read tools, these NEVER call _ensure: a status or
+    # history read must report an uninitialised tree/repo honestly
+    # rather than creating it. None of them expose any write, rollback,
+    # or raw git flag/ref surface.
+
+    @mcp.tool()
+    async def get_memory_status() -> dict:
+        """Read-only health of this agent's memory (no file bodies).
+
+        Reports root existence, whether the local git audit repo is
+        available, the compiled-briefing size with its budget and
+        dirty/reload flags, and per-scope ``{files, total_size_bytes}``.
+        Never creates the memory tree or the audit repo.
+        """
+        root = Path(cfg.memory_root)
+        status = _store(cfg).get_memory_status()
+        status["ok"] = True
+        status["git_enabled"] = (
+            memory_git.git_available() and (root / ".git").is_dir()
+        )
+        pending = _briefing_refresh_pending(cfg)
+        status["briefing"]["dirty"] = pending
+        status["briefing"]["provider_reload_required"] = pending
+        return status
+
+    @mcp.tool()
+    async def get_memory_file_status(path: str) -> dict:
+        """Existence / scope / size / limit / briefing-inclusion for one
+        logical memory path — deliberately NO body.
+
+        Extended (best-effort) with git last-change metadata
+        (``git_tracked`` / ``last_changed_commit_id`` /
+        ``last_changed_at``); when git is unavailable or the audit repo
+        is not initialised those fields are null and file status still
+        works. Read-only; never creates the tree or repo.
+        """
+        try:
+            status = _store(cfg).get_memory_file_status(path)
+        except MemoryStoreError as exc:
+            raise _store_error("get_memory_file_status", exc) from exc
+        git_tracked = None
+        last_commit = None
+        last_at = None
+        try:
+            hist = memory_git.history_status(
+                Path(cfg.memory_root), status["path"],
+            )
+            git_tracked = hist["path_tracked"]
+            last_commit = hist["last_changed_commit_id"]
+            last_at = hist["last_changed_at"]
+        except MemoryHistoryError as exc:
+            # No git / no audit repo just leaves the git fields null;
+            # any other failure is a real error worth surfacing.
+            if exc.code not in (
+                "memory_history_unavailable",
+                "memory_history_not_initialized",
+            ):
+                raise _history_error("get_memory_file_status", exc) from exc
+        status["git_tracked"] = git_tracked
+        status["last_changed_commit_id"] = last_commit
+        status["last_changed_at"] = last_at
+        status["ok"] = True
+        # M4 status is body-less by contract (recall bodies go through
+        # read_memory_file / read_memory_files).
+        assert "body" not in status
+        return status
+
+    @mcp.tool()
+    async def list_memory_files(
+        scope: str = "", limit: int = LIST_DEFAULT_LIMIT,
+    ) -> dict:
+        """List logical memory paths + lightweight metadata — never a
+        body.
+
+        Each entry carries ``path`` / ``scope`` / ``size`` /
+        ``writable`` / ``briefing_included``. ``scope`` (optional)
+        restricts to one area (briefing, notes, recollection, imports);
+        ``limit`` bounds the count and ``truncated`` flags that more
+        files exist. Read-only.
+        """
+        try:
+            result = _store(cfg).list_memory_files(scope or None, limit)
+        except MemoryStoreError as exc:
+            raise _store_error("list_memory_files", exc) from exc
+        return {"ok": True, **result}
+
+    @mcp.tool()
+    async def get_memory_history_status(path: str = "") -> dict:
+        """Read-only health of the memory audit history.
+
+        Reports git availability, whether the audit repo is
+        initialised, the HEAD commit id, and the clean/dirty state of
+        the work tree. When ``path`` (a logical memory path) is given it
+        also reports whether that path is tracked and when it last
+        changed. NOT a git passthrough — no raw git flags or refs are
+        accepted, and this never creates the repo.
+        """
+        logical = (
+            _validate_history_path(cfg, "get_memory_history_status", path)
+            if path else None
+        )
+        try:
+            result = memory_git.history_status(Path(cfg.memory_root), logical)
+        except MemoryHistoryError as exc:
+            raise _history_error("get_memory_history_status", exc) from exc
+        return {"ok": True, **result}
+
+    @mcp.tool()
+    async def get_memory_history(
+        path: str = "",
+        scopes: list[str] | None = None,
+        since: str = "",
+        until: str = "",
+        actor: str = "",
+        operation: str = "",
+        query: str = "",
+        limit: int = memory_git.HISTORY_DEFAULT_LIMIT,
+        include_diff: bool = False,
+    ) -> dict:
+        """Bounded read-only audit query over the local memory git
+        history. NOT a ``git log`` passthrough.
+
+        Only the whitelisted filters are honoured — ``path`` / ``scopes``
+        (which areas), ``since`` / ``until`` (dates), ``actor`` (commit
+        author), ``operation`` (matches the recorded write tool),
+        ``query`` (case-insensitive substring over commit
+        subject/reason/changed-paths — never the diff text), ``limit``,
+        and ``include_diff``. No raw git flags, refs, revision ranges,
+        or rollback are ever accepted: a filter value that looks like a
+        flag (``--all``) or a ref range (``HEAD~5..HEAD``) is treated as
+        a literal value. Each entry carries ``commit_id`` / ``time`` /
+        ``actor`` / ``operation`` / ``reason`` / ``message`` /
+        ``changed_paths`` / ``summary``; ``include_diff`` adds a
+        byte-capped ``diff`` excerpt with a ``diff_truncated`` flag.
+        """
+        logical = (
+            _validate_history_path(cfg, "get_memory_history", path)
+            if path else None
+        )
+        try:
+            result = memory_git.query_history(
+                Path(cfg.memory_root),
+                path=logical,
+                scopes=scopes,
+                since=since,
+                until=until,
+                actor=actor,
+                operation=operation,
+                query=query,
+                limit=limit,
+                include_diff=include_diff,
+            )
+        except MemoryHistoryError as exc:
+            raise _history_error("get_memory_history", exc) from exc
+        return {"ok": True, **result}

--- a/tests/test_memory_m4.py
+++ b/tests/test_memory_m4.py
@@ -1,0 +1,571 @@
+"""M4 memory acceptance tests: the read-only recall + observability MCP
+tools layered on the M2 store and the M3 local git audit — status
+(``get_memory_status`` / ``get_memory_file_status``), recall
+(``list_memory_files``), and history (``get_memory_history_status`` /
+``get_memory_history``, a bounded audit query that is NOT a ``git log``
+passthrough). M4 adds no write, rollback, or generic git surface.
+
+One test (or small group) per §M4 validation scenario in
+docs/user-lead-designs/memory-implementation.md, named after it.
+"""
+
+import json
+import subprocess
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from puffo_agent.agent import memory_git
+from puffo_agent.agent.memory import (
+    TOTAL_LIMIT,
+    _byte_size,
+    compile_briefing,
+    ensure_memory_tree,
+)
+from puffo_agent.agent.memory_errors import MemoryHistoryError
+from puffo_agent.agent.memory_git import (
+    HISTORY_DIFF_BYTE_CAP,
+    HISTORY_DIFF_MAX_LIMIT,
+    HISTORY_MAX_LIMIT,
+)
+from puffo_agent.agent.memory_store import LIST_MAX_LIMIT
+from puffo_agent.mcp.memory_tools import (
+    MemoryToolsConfig,
+    register_memory_tools,
+)
+
+# The five read-only tools M4 adds. All are agent-facing (unlike the
+# maintenance-only append_recollection).
+M4_TOOLS = {
+    "get_memory_status",
+    "get_memory_file_status",
+    "list_memory_files",
+    "get_memory_history_status",
+    "get_memory_history",
+}
+
+
+@pytest.fixture
+def root(tmp_path):
+    # M4 read tools never ensure the tree/repo; tests that need one seed
+    # it via the M3 write tools (which do).
+    return tmp_path / "memory"
+
+
+def _build(root, workspace="", maintenance=False):
+    mcp = FastMCP("test")
+    register_memory_tools(mcp, MemoryToolsConfig(
+        memory_root=str(root),
+        workspace=str(workspace) if workspace else "",
+        maintenance=maintenance,
+    ))
+    return mcp
+
+
+async def _call(mcp, name, args):
+    result = await mcp.call_tool(name, args)
+    text = "".join(getattr(item, "text", "") for item in result)
+    return json.loads(text)
+
+
+async def _call_err(mcp, name, args):
+    """Call a tool expecting failure; return the structured M4 error
+    envelope extracted from the raised tool error's JSON text."""
+    with pytest.raises(ToolError) as ei:
+        await mcp.call_tool(name, args)
+    text = str(ei.value)
+    payload = json.loads(text[text.index("{"):])
+    assert payload["ok"] is False
+    return payload["error"]
+
+
+def _tree_snapshot(root):
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file() and ".git" not in p.relative_to(root).parts
+    }
+
+
+def _git(root, *args):
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _scope_stats(root, scope):
+    """Independent (files, total_size_bytes) recomputation for a scope —
+    mirrors the store's walk so status numbers are checked, not trusted."""
+    base = root / scope
+    n = 0
+    total = 0
+    if base.is_dir():
+        for p in sorted(base.rglob("*")):
+            rel = p.relative_to(root).as_posix()
+            if any(seg.startswith(".") for seg in rel.split("/")):
+                continue
+            if p.is_symlink() or not p.is_file():
+                continue
+            n += 1
+            total += p.stat().st_size
+    return n, total
+
+
+# ── registration: the five M4 tools register on the real server ──────
+
+
+@pytest.mark.asyncio
+async def test_m4_tools_registered_on_built_server(root, tmp_path):
+    from puffo_agent.mcp.puffo_core_server import build_server
+
+    server = build_server(
+        slug="agent-0001",
+        device_id="dev_test",
+        server_url="http://localhost:3000",
+        space_id="",
+        keystore_dir=str(tmp_path / "keys"),
+        workspace=str(tmp_path / "workspace"),
+        agent_id="agent-0001",
+        data_service_url="http://127.0.0.1:1",
+        memory_dir=str(root),
+    )
+    names = {t.name for t in await server.list_tools()}
+    assert M4_TOOLS <= names
+    # Building the server has no side effects: the memory tree and its
+    # git repo are ensured lazily on first WRITE, never at build time
+    # and never by an M4 read.
+    assert not root.exists()
+
+
+# ── M4 reads are side-effect-free (never create the tree/repo) ───────
+
+
+@pytest.mark.asyncio
+async def test_m4_reads_never_create_tree_or_repo(root):
+    mcp = _build(root)
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["ok"] is True
+    assert status["root_exists"] is False
+    assert status["git_enabled"] is False
+    assert all(v["files"] == 0 for v in status["scopes"].values())
+
+    fs = await _call(mcp, "get_memory_file_status", {"path": "notes/x.md"})
+    assert fs["exists"] is False
+    assert fs["git_tracked"] is None
+
+    lst = await _call(mcp, "list_memory_files", {})
+    assert lst["files"] == [] and lst["truncated"] is False
+
+    # A history read on an uninitialised root reports the truth rather
+    # than materialising a repo (this is what makes
+    # memory_history_not_initialized reachable).
+    err = await _call_err(mcp, "get_memory_history_status", {})
+    assert err["code"] == "memory_history_not_initialized"
+
+    assert not root.exists()
+
+
+# ── scenario: get_memory_status dirty / rebuild / reload ─────────────
+
+
+@pytest.mark.asyncio
+async def test_get_memory_status_dirty_rebuild_reload(root, tmp_path):
+    workspace = tmp_path / "workspace"
+    mcp = _build(root, workspace=workspace)
+
+    # Clean tree, no briefing change pending: dirty/reload both False,
+    # and the budget fields are present.
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["briefing"]["dirty"] is False
+    assert status["briefing"]["provider_reload_required"] is False
+    assert status["briefing"]["limit_bytes"] == TOTAL_LIMIT
+    assert status["briefing"]["over_budget"] is False
+
+    # A note write does not touch the briefing → still not dirty.
+    await _call(mcp, "create_note", {"name": "n1", "body": "hello\n"})
+    await _call(mcp, "create_note", {"name": "n2", "body": "world!\n"})
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["briefing"]["dirty"] is False
+    assert status["scopes"]["notes"]["files"] == 2
+
+    # A briefing write flips dirty + provider_reload_required and drops
+    # the refresh flag under the real workspace.
+    await _call(mcp, "create_briefing_topic", {"name": "prefs", "body": "pb\n"})
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["briefing"]["dirty"] is True
+    assert status["briefing"]["provider_reload_required"] is True
+    assert (workspace / ".puffo-agent" / "refresh_agent.flag").is_file()
+
+    # git is available and the audit repo now exists.
+    assert status["git_enabled"] is True
+
+    # Compiled size + per-scope numbers are numerically correct for the
+    # seeded tree.
+    assert status["briefing"]["compiled_size_bytes"] == _byte_size(
+        compile_briefing(root)
+    )
+    for scope in ("briefing", "notes", "recollection", "imports"):
+        n, total = _scope_stats(root, scope)
+        assert status["scopes"][scope]["files"] == n
+        assert status["scopes"][scope]["total_size_bytes"] == total
+    assert status["scopes"]["briefing"]["files"] == 1
+    assert status["scopes"]["imports"]["files"] == 1
+    assert status["scopes"]["recollection"]["files"] == 0
+
+
+# ── scenario: get_memory_file_status has size/limit and NO body ──────
+
+
+@pytest.mark.asyncio
+async def test_get_memory_file_status_size_limit_no_body(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "topic", "body": "content\n", "reason": "seeded",
+    })
+
+    fs = await _call(mcp, "get_memory_file_status", {"path": "notes/topic.md"})
+    assert "body" not in fs
+    for key in ("size", "limit", "scope", "exists", "briefing_included"):
+        assert key in fs
+    assert fs["exists"] is True
+    assert fs["scope"] == "notes"
+    # A committed write reports non-null last-change git metadata.
+    assert fs["git_tracked"] is True
+    assert fs["last_changed_commit_id"]
+    assert fs["last_changed_at"]
+
+    # A never-written path exists=False with null last-change fields.
+    fs2 = await _call(mcp, "get_memory_file_status", {"path": "notes/nope.md"})
+    assert "body" not in fs2
+    assert fs2["exists"] is False
+    assert fs2["git_tracked"] is False
+    assert fs2["last_changed_commit_id"] is None
+    assert fs2["last_changed_at"] is None
+
+
+# ── scenario: list_memory_files bounded metadata by scope, no bodies ─
+
+
+@pytest.mark.asyncio
+async def test_list_memory_files_bounded_metadata_by_scope(root):
+    # A maintenance server can seed recollection/ too, so all four scopes
+    # carry files.
+    maint = _build(root, maintenance=True)
+    await _call(maint, "create_note", {"name": "a", "body": "note a\n"})
+    await _call(maint, "create_briefing_topic", {"name": "b", "body": "b\n"})
+    await _call(maint, "append_recollection", {
+        "date": "2026-07-06", "text": "an entry",
+    })
+    # imports/index.md exists from ensure_memory_tree.
+
+    lst = await _call(maint, "list_memory_files", {})
+    assert lst["ok"] is True
+    paths = [f["path"] for f in lst["files"]]
+    for f in lst["files"]:
+        assert set(f) == {
+            "path", "scope", "size", "writable", "briefing_included",
+        }
+        assert "body" not in f
+    assert "notes/a.md" in paths
+    assert "briefing/b.md" in paths
+    assert any(p.startswith("recollection/") for p in paths)
+    assert "imports/index.md" in paths
+
+    # scope filter returns only that scope.
+    notes_only = await _call(maint, "list_memory_files", {"scope": "notes"})
+    assert [f["path"] for f in notes_only["files"]] == ["notes/a.md"]
+    assert all(f["scope"] == "notes" for f in notes_only["files"])
+
+    # limit=1 bounds to one entry and flags truncated.
+    one = await _call(maint, "list_memory_files", {"limit": 1})
+    assert len(one["files"]) == 1
+    assert one["truncated"] is True
+
+    # writable / briefing_included are set per-scope.
+    by_path = {f["path"]: f for f in lst["files"]}
+    assert by_path["briefing/b.md"]["briefing_included"] is True
+    assert by_path["briefing/b.md"]["writable"] is True
+    assert by_path["imports/index.md"]["writable"] is False
+    assert by_path["imports/index.md"]["briefing_included"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_memory_files_rejects_bad_scope_and_limit(root):
+    mcp = _build(root)
+    err = await _call_err(mcp, "list_memory_files", {"scope": "bogus"})
+    assert err["code"] == "memory_path_out_of_scope"
+    err = await _call_err(mcp, "list_memory_files", {"limit": 0})
+    assert err["code"] == "memory_invalid_arguments"
+
+
+# ── scenario: search_memory / search_imports unchanged and read-only ─
+
+
+@pytest.mark.asyncio
+async def test_search_tools_unchanged_and_read_only(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "n", "body": "needle here\n"})
+    ensure_memory_tree(root)
+    (root / "imports" / "doc.txt").write_text(
+        "imported needle\n", encoding="utf-8",
+    )
+    before = _tree_snapshot(root)
+
+    res = await _call(mcp, "search_memory", {"query": "needle"})
+    assert res["results"]
+    assert all("path" in m and "scope" in m for m in res["results"])
+    assert all(len(m["snippet"]) <= 200 for m in res["results"])
+
+    imp = await _call(mcp, "search_imports", {"query": "needle"})
+    assert imp["results"]
+    assert all(m["path"].startswith("imports/") for m in imp["results"])
+
+    # Search never writes: tree bytes are unchanged.
+    assert _tree_snapshot(root) == before
+
+
+# ── scenario: get_memory_history_status health + tracked path ────────
+
+
+@pytest.mark.asyncio
+async def test_get_memory_history_status_health_and_tracked_path(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    # Commit the seeded imports/index.md too so the work tree is clean.
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "-m", "seed imports")
+
+    hs = await _call(mcp, "get_memory_history_status", {"path": "notes/a.md"})
+    assert hs["ok"] is True
+    assert hs["git_enabled"] is True
+    assert hs["repo_initialized"] is True
+    assert hs["clean"] is True
+    assert hs["uncommitted_paths"] == []
+    assert hs["head_commit_id"]
+    assert hs["path_tracked"] is True
+    assert hs["last_changed_commit_id"]
+    assert hs["last_changed_at"]
+
+    # An unknown path is not tracked, with null last-change fields.
+    hs2 = await _call(mcp, "get_memory_history_status", {
+        "path": "notes/unknown.md",
+    })
+    assert hs2["path_tracked"] is False
+    assert hs2["last_changed_commit_id"] is None
+    assert hs2["last_changed_at"] is None
+
+    # A dirty work tree is reported, not raised.
+    (root / "notes" / "dirty.md").write_text("uncommitted\n", encoding="utf-8")
+    hs3 = await _call(mcp, "get_memory_history_status", {})
+    assert hs3["clean"] is False
+    assert hs3["uncommitted_paths"]
+
+
+# ── scenario: get_memory_history bounded entries + diff + truncation ─
+
+
+@pytest.mark.asyncio
+async def test_get_memory_history_entries_diff_and_filters(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "a", "body": "one\n", "reason": "first reason",
+    })
+    await _call(mcp, "append_note", {
+        "name": "a", "text": "two\n", "reason": "second reason",
+    })
+    await _call(mcp, "create_note", {"name": "b", "body": "bee\n"})
+
+    hist = await _call(mcp, "get_memory_history", {})
+    assert hist["ok"] is True
+    for e in hist["entries"]:
+        assert set(e) >= {
+            "commit_id", "time", "actor", "operation", "reason", "message",
+            "changed_paths", "summary",
+        }
+        assert set(e["summary"]) == {
+            "files_changed", "insertions", "deletions",
+        }
+        assert "diff" not in e  # no diff unless include_diff
+
+    # Newest first; operation equals the recorded write tool.
+    assert [e["operation"] for e in hist["entries"]] == [
+        "create_note", "append_note", "create_note",
+    ]
+    # reason reflects the write's reason (or None when omitted).
+    assert hist["entries"][0]["reason"] is None            # create b
+    assert hist["entries"][1]["reason"] == "second reason"  # append a
+    assert hist["entries"][2]["reason"] == "first reason"   # create a
+    # summary numbers are populated for a real change.
+    assert hist["entries"][2]["summary"]["files_changed"] == 1
+    assert hist["entries"][2]["changed_paths"] == ["notes/a.md"]
+
+    # limit=1 bounds to one entry and flags truncated.
+    one = await _call(mcp, "get_memory_history", {"limit": 1})
+    assert len(one["entries"]) == 1
+    assert one["truncated"] is True
+
+    # include_diff attaches a bounded diff excerpt + a truncation flag.
+    diffed = await _call(mcp, "get_memory_history", {
+        "path": "notes/b.md", "include_diff": True, "limit": 1,
+    })
+    e = diffed["entries"][0]
+    assert isinstance(e["diff"], str) and e["diff"]
+    assert e["diff_truncated"] is False
+    assert len(e["diff"].encode("utf-8")) <= HISTORY_DIFF_BYTE_CAP
+
+    # A large write's diff is length-capped and flagged truncated.
+    await _call(mcp, "create_note", {"name": "big", "body": "x" * 5000 + "\n"})
+    big = await _call(mcp, "get_memory_history", {
+        "path": "notes/big.md", "include_diff": True, "limit": 1,
+    })
+    eb = big["entries"][0]
+    assert eb["diff_truncated"] is True
+    assert len(eb["diff"].encode("utf-8")) <= HISTORY_DIFF_BYTE_CAP
+
+    # Each filter narrows the result set.
+    op = await _call(mcp, "get_memory_history", {"operation": "append_note"})
+    assert op["entries"] and all(
+        e["operation"] == "append_note" for e in op["entries"]
+    )
+    by_path = await _call(mcp, "get_memory_history", {"path": "notes/b.md"})
+    assert by_path["entries"] and all(
+        "notes/b.md" in e["changed_paths"] for e in by_path["entries"]
+    )
+    by_scope = await _call(mcp, "get_memory_history", {"scopes": ["notes"]})
+    assert by_scope["entries"]
+    by_query = await _call(mcp, "get_memory_history", {"query": "first reason"})
+    assert by_query["entries"] and all(
+        "notes/a.md" in e["changed_paths"] for e in by_query["entries"]
+    )
+    # actor maps to the recorded commit author (puffo-agent).
+    actor_hit = await _call(mcp, "get_memory_history", {"actor": "puffo-agent"})
+    assert len(actor_hit["entries"]) == len(hist["entries"]) + 1  # +big
+    actor_miss = await _call(mcp, "get_memory_history", {"actor": "nobody-xyz"})
+    assert actor_miss["entries"] == []
+
+
+# ── scenario: raw git is NOT exposed ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_raw_git_is_not_exposed(root):
+    mcp = _build(root)
+    tools = {t.name for t in await mcp.list_tools()}
+    # No registered tool resembles a raw git operation.
+    forbidden = (
+        "git", "checkout", "reset", "revert", "rollback", "stash",
+        "cherry", "rebase", "merge", "push", "log",
+    )
+    for name in tools:
+        assert not any(tok in name for tok in forbidden), name
+
+    for i in range(4):
+        await _call(mcp, "create_note", {"name": f"n{i}", "body": f"b{i}\n"})
+    plain = await _call(mcp, "get_memory_history", {"limit": 100})
+    n_plain = len(plain["entries"])
+    assert n_plain == 4
+
+    # A filter value that looks like a flag or a ref range is a LITERAL,
+    # never a git flag/ref: it can only narrow (never exceed) the plain
+    # committed set, and never injects commits from outside it.
+    for filt in (
+        {"query": "--all"},
+        {"query": "HEAD~5..HEAD"},
+        {"since": "--all"},
+        {"since": "HEAD~5..HEAD"},
+        {"actor": "--all"},
+    ):
+        res = await _call(mcp, "get_memory_history", {**filt, "limit": 100})
+        assert len(res["entries"]) <= n_plain
+        for e in res["entries"]:
+            assert e["commit_id"]
+    # The substring post-filters treat "--all" as literal text (no match).
+    assert await _call(mcp, "get_memory_history", {"query": "--all"}) == {
+        "ok": True, "entries": [], "truncated": False,
+    }
+
+
+# ── scenario: expected failures are structured tool errors ───────────
+
+
+@pytest.mark.asyncio
+async def test_history_git_unavailable_is_structured(root, monkeypatch):
+    ensure_memory_tree(root)
+    memory_git.ensure_memory_git(root)
+    monkeypatch.setattr(memory_git, "git_available", lambda: False)
+    mcp = _build(root)
+    for tool in ("get_memory_history", "get_memory_history_status"):
+        err = await _call_err(mcp, tool, {})
+        assert err["code"] == "memory_history_unavailable"
+        assert err["causes"][0]["layer"] == "memory_git"
+        assert err["suggestion"]
+
+
+@pytest.mark.asyncio
+async def test_history_not_initialized_is_structured(root):
+    # A memory root with no local .git audit repo (M4 reads never
+    # create one).
+    ensure_memory_tree(root)
+    assert not (root / ".git").exists()
+    mcp = _build(root)
+    err = await _call_err(mcp, "get_memory_history", {})
+    assert err["code"] == "memory_history_not_initialized"
+    err = await _call_err(mcp, "get_memory_history_status", {})
+    assert err["code"] == "memory_history_not_initialized"
+
+
+@pytest.mark.asyncio
+async def test_history_bad_args_are_invalid_query(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    for args in ({"limit": 0}, {"scopes": ["bogus"]}, {"limit": -5}):
+        err = await _call_err(mcp, "get_memory_history", {**args})
+        assert err["code"] == "memory_invalid_history_query"
+
+
+def test_query_history_rejects_non_str_filter(root):
+    # FastMCP's schema blocks a non-str query at the transport boundary;
+    # the git layer still validates it (defense in depth).
+    ensure_memory_tree(root)
+    memory_git.ensure_memory_git(root)
+    with pytest.raises(MemoryHistoryError) as ei:
+        memory_git.query_history(root, query=123)
+    assert ei.value.code == "memory_invalid_history_query"
+
+
+@pytest.mark.asyncio
+async def test_history_too_large_is_structured(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    err = await _call_err(mcp, "get_memory_history", {
+        "limit": HISTORY_MAX_LIMIT + 1,
+    })
+    assert err["code"] == "memory_history_query_too_large"
+    err = await _call_err(mcp, "get_memory_history", {
+        "include_diff": True, "limit": HISTORY_DIFF_MAX_LIMIT + 1,
+    })
+    assert err["code"] == "memory_history_query_too_large"
+
+
+@pytest.mark.asyncio
+async def test_history_bad_path_is_structured(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    for tool in ("get_memory_history", "get_memory_history_status"):
+        err = await _call_err(mcp, tool, {"path": "../evil"})
+        assert err["code"] == "memory_invalid_path"
+        err = await _call_err(mcp, tool, {"path": "/etc/passwd"})
+        assert err["code"] == "memory_invalid_path"
+        err = await _call_err(mcp, tool, {"path": "bogus/x.md"})
+        assert err["code"] == "memory_path_out_of_scope"
+
+
+# ── constant sanity: the M4 bounds are what the doc/tools advertise ──
+
+
+def test_list_and_history_bounds_are_sane():
+    assert LIST_MAX_LIMIT >= 1
+    assert HISTORY_DIFF_MAX_LIMIT <= HISTORY_MAX_LIMIT
+    assert HISTORY_DIFF_BYTE_CAP > 0

--- a/tests/test_sdk_gate_memory_tools.py
+++ b/tests/test_sdk_gate_memory_tools.py
@@ -1,9 +1,10 @@
 """The sdk-local adapter runs every tool call through ``_gate``, which
 allows a call only if some configured pattern matches. Puffo MCP tools
 are auto-allowed by seeding the gate's patterns with
-``PUFFO_CORE_TOOL_FQNS``. This pins that the ten M3 memory tools are in
-that set — otherwise they register on the server but get denied at call
-time on sdk-local (the M3 finding this guards against).
+``PUFFO_CORE_TOOL_FQNS``. This pins that the ten M3 memory tools and the
+five M4 read-only tools are in that set — otherwise they register on the
+server but get denied at call time on sdk-local (the finding this
+guards against).
 
 ``claude_agent_sdk`` is an optional dep the dev extra does NOT install;
 ``SDKAdapter.__init__`` defers that import, so the module (and
@@ -31,9 +32,21 @@ M3_TOOL_NAMES = (
     "search_imports",
 )
 
+M4_TOOL_NAMES = (
+    "get_memory_status",
+    "get_memory_file_status",
+    "list_memory_files",
+    "get_memory_history_status",
+    "get_memory_history",
+)
+
 
 def test_m3_memory_tools_are_in_core_allowlist():
     assert set(M3_TOOL_NAMES) <= set(PUFFO_CORE_TOOL_NAMES)
+
+
+def test_m4_memory_tools_are_in_core_allowlist():
+    assert set(M4_TOOL_NAMES) <= set(PUFFO_CORE_TOOL_NAMES)
 
 
 def test_m3_memory_tool_fqns_pass_the_sdk_gate():
@@ -41,6 +54,16 @@ def test_m3_memory_tool_fqns_pass_the_sdk_gate():
     # (see SDKAdapter.__init__ / _gate). Reproduce the exact allow
     # check the gate performs for each M3 tool's FQN.
     for name in M3_TOOL_NAMES:
+        fqn = f"mcp__{MCP_SERVER_NAME}__{name}"
+        allowed = any(
+            _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS
+        )
+        assert allowed, f"{fqn} would be denied by the sdk gate"
+
+
+def test_m4_memory_tool_fqns_pass_the_sdk_gate():
+    # Same gate check for the five M4 read-only tools.
+    for name in M4_TOOL_NAMES:
         fqn = f"mcp__{MCP_SERVER_NAME}__{name}"
         allowed = any(
             _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS


### PR DESCRIPTION
5th PR in the PY memory stack (#124→#125→#126→#128→this), completing the memory design M1–M4. §M4 read-only recall + observability over the M2 store + M3 local-git audit: get_memory_status / get_memory_file_status, list_memory_files, bounded get_memory_history_status / get_memory_history (bounded entries + bounded diff, no raw git) — as MCP tools (callable via the #128 sdk-allowlist fix). No writes/rollback/message-DB recall. Verify: pytest --ignore=tests/test_host_credentials.py exit 0 + new test_memory_m4.py. **Held for review — do not merge (review the #124→…→this stack).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)