### PR TITLE
agent: reload config on profile.md/agent.yml mtime change (config-sync F)

### DIFF
--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -43,6 +43,7 @@ from .state import (
     agent_codex_user_dir,
     agent_dir,
     agent_home_dir,
+    agent_yml_path,
     cli_session_json_path,
     docker_shared_dir,
     shared_fs_dir,
@@ -1151,6 +1152,17 @@ class Worker:
         refresh_agent_flag_path = pa_dir / "refresh_agent.flag"
         refresh_host_sync_flag_path = pa_dir / "refresh_host_sync.flag"
         refresh_session_flag_path = pa_dir / "refresh_session.flag"
+        # Config-file mtime watcher (additive to the flag path above):
+        # baseline seeded at agent start from the bundle we just
+        # materialized, so the first between-turns check does not
+        # spuriously reload an untouched profile.md / agent.yml. Between
+        # turns, `_process_config_mtime_reload` re-stats these and
+        # rebuilds the prompt when either moves forward.
+        agent_yml_path_str = str(agent_yml_path(agent_id))
+        config_mtimes = {
+            "profile": _stat_mtime_or_none(profile_path),
+            "agent_yml": _stat_mtime_or_none(agent_yml_path_str),
+        }
         # Per-turn context for the cli-local permission hook. The hook
         # is a separate subprocess and reads this file to learn which
         # channel + root to reply to.
@@ -1195,6 +1207,22 @@ class Worker:
             first_post_id = batch[0].get("envelope_id", "")
             channel_id = channel_meta.get("channel_id", "")
 
+            # Config-file mtime watch runs first so a disk rewrite of
+            # profile.md / agent.yml is picked up before the flag path;
+            # both funnel into `adapter.reload`. Additive — the flag
+            # sentinels below are unchanged and still run after this.
+            await _process_config_mtime_reload(
+                agent_id=agent_id,
+                harness_name=(self.agent_cfg.runtime.harness or "").strip(),
+                shared_path=shared_path,
+                profile_path=profile_path,
+                memory_path=memory_path,
+                workspace_path=workspace_path,
+                agent_yml_path=agent_yml_path_str,
+                puffo=puffo,
+                adapter=self._adapter,
+                mtime_state=config_mtimes,
+            )
             await _process_refresh_flags(
                 agent_id=agent_id,
                 harness_name=(self.agent_cfg.runtime.harness or "").strip(),
@@ -1572,6 +1600,162 @@ class Worker:
                     pass
             self.runtime.status = "stopped"
             self.runtime.save(agent_id)
+
+
+def _stat_mtime_or_none(path: str | Path) -> float | None:
+    """``os.stat(path).st_mtime`` or ``None`` when the file is
+    missing / unreadable / mid-write. Never raises — callers use the
+    ``None`` sentinel to mean "couldn't observe; retry next turn"."""
+    try:
+        return os.stat(path).st_mtime
+    except OSError:
+        return None
+
+
+async def _reload_from_disk(
+    *,
+    harness_name: str,
+    agent_id: str,
+    shared_path: Path,
+    profile_path: str,
+    memory_path: str,
+    workspace_path: str,
+    puffo,
+    adapter,
+) -> bool:
+    """Rebuild the managed system prompt from disk and hand it to the
+    adapter — the same primitives ``_process_refresh_flags`` uses for
+    the ``refresh_agent`` flag, factored out so the mtime watcher can
+    reuse them.
+
+    Assembles the new prompt into a **local** first; only once
+    ``_rebuild_managed_system_prompt`` succeeds does it mutate
+    ``puffo.system_prompt`` and call ``adapter.reload``. So a partial /
+    mid-write ``profile.md`` (transiently missing → ``FileNotFoundError``,
+    or a truncated read) raises out of here **before** any state is
+    touched, and the caller's try/except keeps the prior config intact.
+
+    Uses ``adapter.reload(prompt)`` with the default ``with_session=False``
+    — profile/soul edits do not require a fresh session (matching the
+    ``agent_seen`` branch of ``_process_refresh_flags``). Returns ``True``
+    on success; propagates any exception so the caller can decline to
+    advance the mtime baseline.
+    """
+    new_prompt = _rebuild_managed_system_prompt(
+        harness_name=harness_name,
+        agent_id=agent_id,
+        shared_path=shared_path,
+        profile_path=profile_path,
+        memory_path=memory_path,
+        workspace_path=workspace_path,
+    )
+    puffo.system_prompt = new_prompt
+    await adapter.reload(new_prompt)
+    return True
+
+
+async def _process_config_mtime_reload(
+    *,
+    agent_id: str,
+    harness_name: str,
+    shared_path: Path,
+    profile_path: str,
+    memory_path: str,
+    workspace_path: str,
+    agent_yml_path: str,
+    puffo,
+    adapter,
+    mtime_state: dict,
+) -> None:
+    """Between-turns watcher: reload the agent's config when
+    ``profile.md`` or ``agent.yml`` is rewritten on disk (e.g. by AIM's
+    ``sandbox.files.write`` config-sync). An mtime poll on the existing
+    turn-start check — no filesystem watcher, no new thread, no deps.
+
+    ``mtime_state`` is a mutable ``{"profile": float|None, "agent_yml":
+    float|None}`` baseline seeded at agent start (so the first turn does
+    not spuriously reload). A file counts as "changed" only when its
+    current mtime is observable and strictly newer than the baseline;
+    backwards movement (truncate-then-rewrite landing an earlier mtime)
+    is ignored, only re-anchoring the baseline. If either file changed,
+    a **single** ``_reload_from_disk`` runs (both changes funnel into one
+    reload). On failure the triggering baselines are left unadvanced so
+    the same still-newer mtime re-fires next turn, and the prior config
+    is retained.
+
+    **Reload-vs-restart map:** only the safe prompt/soul subset is
+    hot-applied. ``agent.yml`` *runtime* fields (kind / harness /
+    provider / model) are baked into the adapter at construction and are
+    **not** hot-swapped here — they take effect on the next worker
+    restart (existing ``refresh`` tool + ``restart.flag``). An
+    ``agent.yml`` edit therefore re-applies the profile/system-prompt and
+    logs the restart requirement; it never rebuilds the adapter.
+    """
+    triggered: dict[str, float] = {}
+    for key, path in (
+        ("profile", profile_path),
+        ("agent_yml", agent_yml_path),
+    ):
+        current = _stat_mtime_or_none(path)
+        baseline = mtime_state.get(key)
+        if current is None:
+            # Missing / mid-write — leave the baseline; retry next turn.
+            logger.debug(
+                "agent %s: config watch could not stat %s (%s); "
+                "keeping prior baseline",
+                agent_id, key, path,
+            )
+            continue
+        if baseline is None or current > baseline:
+            triggered[key] = current
+        elif current < baseline:
+            # Backwards mtime (truncate-then-rewrite). Don't reload;
+            # just re-anchor so it can't loop on the same stale value.
+            mtime_state[key] = current
+
+    if not triggered:
+        return
+
+    if "agent_yml" in triggered:
+        logger.info(
+            "agent %s: agent.yml changed — runtime fields "
+            "(kind/harness/provider/model) take effect on the next worker "
+            "restart; hot reload re-applies profile/system-prompt only",
+            agent_id,
+        )
+
+    try:
+        await _reload_from_disk(
+            harness_name=harness_name,
+            agent_id=agent_id,
+            shared_path=shared_path,
+            profile_path=profile_path,
+            memory_path=memory_path,
+            workspace_path=workspace_path,
+            puffo=puffo,
+            adapter=adapter,
+        )
+    except Exception as exc:
+        # Partial/mid-write read or adapter failure: keep the prior
+        # config (Step 2 guarantees no partial mutation) and leave the
+        # triggering baselines unadvanced so we re-fire next turn.
+        logger.warning(
+            "agent %s: config mtime reload (%s) failed, keeping prior "
+            "config: %s",
+            agent_id, ",".join(triggered), exc,
+        )
+        return
+
+    # Success — advance the baseline of every file that triggered to the
+    # exact mtime observed in the trigger loop (not a re-stat, so a write
+    # that lands mid-reload stays strictly-newer and re-fires next turn
+    # rather than being silently absorbed).
+    for key, observed in triggered.items():
+        mtime_state[key] = observed
+    logger.info(
+        "agent %s: reloaded config from disk (%s)",
+        agent_id, ",".join(triggered),
+    )
 
 
 async def _process_refresh_flags(

--- a/tests/test_config_mtime_reload.py
+++ b/tests/test_config_mtime_reload.py
@@ -1,0 +1,255 @@
+"""Unit tests for the between-turns config-file mtime watcher
+(`_process_config_mtime_reload` / `_reload_from_disk` in
+`puffo_agent.portal.worker`).
+
+The watcher polls ``profile.md`` / ``agent.yml`` mtimes at turn start and
+funnels any forward movement into a single ``adapter.reload`` — reusing
+the flag-path reload primitives without touching them. These tests pin
+the six behaviours from the plan: changed→exactly-one-reload,
+unchanged→none, mid-write→no-crash-keeps-prior, seeded-baseline→no
+spurious first reload, backwards mtime→none, and agent.yml→one reload
+plus the documented restart-map log.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.portal import worker
+
+
+class FakeAdapter:
+    """Records every ``reload`` call so tests can assert the
+    exactly-one-reload contract."""
+
+    def __init__(self) -> None:
+        self.reload_calls: list[str] = []
+
+    async def reload(self, prompt, *, with_session: bool = False) -> None:
+        self.reload_calls.append(prompt)
+
+
+def _fake_rebuild(**kwargs) -> str:
+    """Stand-in for ``_rebuild_managed_system_prompt``: derives the
+    prompt from the profile file's contents so a rewrite produces a new
+    prompt, and raises ``FileNotFoundError`` if the profile is missing
+    (mimicking a mid-write read)."""
+    return "REBUILT:" + Path(kwargs["profile_path"]).read_text(encoding="utf-8")
+
+
+def _seed(profile_path: Path, agent_yml: Path) -> dict:
+    """Start-time baseline snapshot, mirroring what ``_run`` seeds."""
+    return {
+        "profile": worker._stat_mtime_or_none(profile_path),
+        "agent_yml": worker._stat_mtime_or_none(agent_yml),
+    }
+
+
+def _bump_mtime(path: Path, delta: float) -> None:
+    """Force ``path``'s mtime to move by ``delta`` seconds (deterministic
+    — no reliance on wall-clock resolution between writes)."""
+    base = os.stat(path).st_mtime
+    os.utime(path, (base + delta, base + delta))
+
+
+async def _watch(
+    *,
+    profile_path: Path,
+    agent_yml: Path,
+    puffo,
+    adapter,
+    mtime_state: dict,
+) -> None:
+    await worker._process_config_mtime_reload(
+        agent_id="agent-1",
+        harness_name="claude-code",
+        shared_path=Path("/nonexistent/shared"),
+        profile_path=str(profile_path),
+        memory_path="/nonexistent/mem",
+        workspace_path="/nonexistent/ws",
+        agent_yml_path=str(agent_yml),
+        puffo=puffo,
+        adapter=adapter,
+        mtime_state=mtime_state,
+    )
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """A profile.md + agent.yml on disk, a fake adapter/puffo, a seeded
+    baseline, and the rebuild function patched to the deterministic
+    stand-in."""
+    profile = tmp_path / "profile.md"
+    profile.write_text("you are helpful\n", encoding="utf-8")
+    agent_yml = tmp_path / "agent.yml"
+    agent_yml.write_text("runtime:\n  harness: claude-code\n", encoding="utf-8")
+
+    monkeypatch.setattr(worker, "_rebuild_managed_system_prompt", _fake_rebuild)
+
+    adapter = FakeAdapter()
+    puffo = SimpleNamespace(system_prompt="ORIGINAL")
+    mtime_state = _seed(profile, agent_yml)
+    return SimpleNamespace(
+        profile=profile,
+        agent_yml=agent_yml,
+        adapter=adapter,
+        puffo=puffo,
+        mtime_state=mtime_state,
+    )
+
+
+@pytest.mark.asyncio
+async def test_changed_profile_triggers_exactly_one_reload(env):
+    """(a) profile.md mtime moves forward → exactly one reload, prompt
+    rebuilt from disk, and a second unchanged check does not re-fire."""
+    env.profile.write_text("you are VERY helpful\n", encoding="utf-8")
+    _bump_mtime(env.profile, 10)
+
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+
+    assert len(env.adapter.reload_calls) == 1
+    assert env.puffo.system_prompt == "REBUILT:you are VERY helpful\n"
+    assert env.adapter.reload_calls[0] == env.puffo.system_prompt
+
+    # Baseline advanced → a follow-up check with no change is a no-op.
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert len(env.adapter.reload_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_unchanged_mtime_never_reloads(env):
+    """(b) No file change across two checks → zero reloads."""
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert env.adapter.reload_calls == []
+
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert env.adapter.reload_calls == []
+    assert env.puffo.system_prompt == "ORIGINAL"
+
+
+@pytest.mark.asyncio
+async def test_midwrite_failure_keeps_prior_and_reloads_after_recovery(env, monkeypatch):
+    """(c) A rebuild that raises (partial read) must not crash, must not
+    mutate the prompt, and must not advance the baseline — so once the
+    rebuild recovers the same still-newer mtime reloads."""
+    _bump_mtime(env.profile, 10)
+    baseline_before = env.mtime_state["profile"]
+
+    def _raise(**kwargs):
+        raise FileNotFoundError("profile.md vanished mid-write")
+
+    monkeypatch.setattr(worker, "_rebuild_managed_system_prompt", _raise)
+
+    # Must not raise out of the watcher.
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert env.adapter.reload_calls == []
+    assert env.puffo.system_prompt == "ORIGINAL"  # prior config kept
+    assert env.mtime_state["profile"] == baseline_before  # baseline NOT advanced
+
+    # Rebuild recovers; the still-newer mtime now reloads.
+    monkeypatch.setattr(worker, "_rebuild_managed_system_prompt", _fake_rebuild)
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert len(env.adapter.reload_calls) == 1
+    assert env.puffo.system_prompt.startswith("REBUILT:")
+
+
+@pytest.mark.asyncio
+async def test_seeded_baseline_no_spurious_first_reload(env):
+    """(d) Baseline seeded at start from the same snapshot → the first
+    between-turns check on untouched files does not reload."""
+    # env.mtime_state was seeded exactly as _run does; files untouched.
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert env.adapter.reload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_backwards_mtime_no_reload(env):
+    """(e) mtime moving backwards (truncate-then-rewrite landing an
+    earlier stamp) → no reload; baseline re-anchors to the earlier
+    value so it cannot loop."""
+    _bump_mtime(env.profile, -10)
+
+    await _watch(
+        profile_path=env.profile,
+        agent_yml=env.agent_yml,
+        puffo=env.puffo,
+        adapter=env.adapter,
+        mtime_state=env.mtime_state,
+    )
+    assert env.adapter.reload_calls == []
+    assert env.puffo.system_prompt == "ORIGINAL"
+    # Re-anchored to the earlier mtime.
+    assert env.mtime_state["profile"] == os.stat(env.profile).st_mtime
+
+
+@pytest.mark.asyncio
+async def test_agent_yml_change_reloads_and_logs_restart_map(env, caplog):
+    """(f) agent.yml mtime moves forward → exactly one reload plus the
+    documented restart-map log (runtime fields take effect on next
+    restart; only profile/system-prompt is hot-applied)."""
+    _bump_mtime(env.agent_yml, 10)
+
+    with caplog.at_level(logging.INFO, logger="puffo_agent.portal.worker"):
+        await _watch(
+            profile_path=env.profile,
+            agent_yml=env.agent_yml,
+            puffo=env.puffo,
+            adapter=env.adapter,
+            mtime_state=env.mtime_state,
+        )
+
+    assert len(env.adapter.reload_calls) == 1
+    restart_notes = [
+        r.getMessage()
+        for r in caplog.records
+        if "restart" in r.getMessage().lower()
+        and "runtime fields" in r.getMessage().lower()
+    ]
+    assert restart_notes, "expected a log noting runtime fields need a restart"


### PR DESCRIPTION
Agent side of the config-sync F decision (DECISION LOG 07-08): the between-turns reload check now watches `profile.md`/`agent.yml` mtime (additive to the existing `reload.flag` mechanism), reusing `_reload_from_disk`. This lets AIM propagate config by writing files into the E2B sandbox (`sandbox.files.write`); the agent self-reloads — transport-agnostic, no WS ConfigUpdate frame. Robust to partial/mid-write files; mtime initialized at start. Verify: pytest --ignore=tests/test_host_credentials.py exit 0 + new test_config_mtime_reload.py. **Held for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)