### PR TITLE
T23 phase 2: fat-cloud message flow over the keyless bridge (drop encrypt/decrypt at seam)

### DIFF
--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -19,6 +19,7 @@ from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import (
     EncryptInput,
+    MessagePayload,
     RecipientDevice,
     decrypt_message,
     encrypt_message,
@@ -597,11 +598,17 @@ class PuffoCoreMessageClient:
         Invoked as ``on_turn_success(root_id, batch, channel_meta)``.
         """
         if self._bridge is not None:
-            # T23 phase 1: keyless bridge transport. No identity file
-            # to load, and the consumer / invite-poll / warm tasks are
-            # skipped — they drive signed HTTP endpoints that can't
-            # work keyless until phase 2 rewires envelope flow.
-            await self._listen_bridge()
+            # T23 phase 2: keyless bridge transport. No identity file to
+            # load; inbound plaintext frames flow through the same store
+            # + thread-queue tail native uses (the consumer runs). The
+            # invite-poll / member-warm tasks stay skipped — they drive
+            # signed HTTP endpoints that can't work keyless.
+            await self._listen_bridge(
+                on_message,
+                on_api_error_retry,
+                on_api_error_abandon,
+                on_turn_success,
+            )
             return
 
         identity = self.keystore.load_identity(self.slug)
@@ -673,250 +680,7 @@ class PuffoCoreMessageClient:
                 )
                 return
 
-            # PUF-227-A: strict cache-validation invariant for incoming
-            # ids. Any thread_root_id / reply_to_id that doesn't point
-            # to a same-channel parent in our local message_store gets
-            # wiped to None before storage — the agent's local view
-            # never honors a thread linkage that can't be resolved here.
-            # Catches the Scout-class symptom: a server / UI / sender
-            # that stamps a cross-channel id can't poison the recipient
-            # daemon's thread state.
-            validated_thread_root_id = await self._validate_incoming_parent_id(
-                payload.thread_root_id, payload.channel_id, payload.space_id,
-            )
-            validated_reply_to_id = await self._validate_incoming_parent_id(
-                payload.reply_to_id, payload.channel_id, payload.space_id,
-            )
-            await self.store.store({
-                "envelope_id": payload.envelope_id,
-                "envelope_kind": payload.envelope_kind,
-                "sender_slug": payload.sender_slug,
-                "channel_id": payload.channel_id,
-                "space_id": payload.space_id,
-                "recipient_slug": payload.recipient_slug,
-                "content_type": payload.content_type,
-                "content": payload.content,
-                "sent_at": payload.sent_at,
-                "thread_root_id": validated_thread_root_id,
-                "reply_to_id": validated_reply_to_id,
-            })
-            # Rebind for downstream code (root_id resolution at the
-            # batch-coalesce step, channel_meta construction, etc.) so
-            # admit-time wipes propagate through the agent prompt.
-            payload_thread_root_id = validated_thread_root_id
-            payload_reply_to_id = validated_reply_to_id
-
-            # Self-echo lands here too now (see ``handle_envelope``'s
-            # opening comment). Persist it — so ``get_channel_history``
-            # / ``get_thread_history`` show the agent's own posts —
-            # then stop before any of the LLM-facing pipeline below
-            # runs. The agent already produced this message; queueing
-            # it again would feed the agent its own words and trip a
-            # turn-by-turn echo loop.
-            if payload.sender_slug == self.slug:
-                return
-
-            # Daemon-side intercept: ``y``/``n`` from the operator on an
-            # outstanding invite-DM accepts/rejects without waking the
-            # LLM. A threaded reply answers just that invite; a direct
-            # (top-level) reply answers all pending invites at once.
-            if (
-                payload.envelope_kind == "dm"
-                and payload.sender_slug == self.operator_slug
-            ):
-                text_raw = str(payload.content) if payload.content else ""
-                targets, is_direct = self._resolve_invite_targets(
-                    payload_thread_root_id, text_raw,
-                )
-                handled_labels = (
-                    await self._apply_invite_replies(targets, text_raw)
-                    if targets else []
-                )
-                if handled_labels:
-                    # Handled inline — don't queue for the LLM.
-                    self._last_dm_sender = payload.sender_slug
-                    if is_direct:
-                        await self._send_invite_bulk_summary(
-                            handled_labels, text_raw, payload_thread_root_id or "",
-                        )
-                    return
-                # Same gate for agent-initiated leave requests, but
-                # threaded-only — each leave is confirmed in its own
-                # thread (no direct/bulk path).
-                if await self._maybe_handle_leave_reply(
-                    thread_root_id=payload_thread_root_id or "", text=text_raw,
-                ):
-                    self._last_dm_sender = payload.sender_slug
-                    return
-
-            channel_id = payload.channel_id or ""
-            is_dm = payload.envelope_kind == "dm"
-            # ``puffo/message+attachments/v1`` carries
-            # ``{ text, attachments: [...] }``; other content types
-            # use the plain-string path.
-            attachment_paths: list[str] = []
-            if payload.content_type == "puffo/message+attachments/v1" and isinstance(
-                payload.content, dict,
-            ):
-                raw_text = str(payload.content.get("text") or "")
-                metas_raw = payload.content.get("attachments") or []
-                if isinstance(metas_raw, list):
-                    attachment_paths = await self._save_inbound_attachments(
-                        envelope_id=payload.envelope_id, metas_raw=metas_raw,
-                    )
-            else:
-                raw_text = str(payload.content) if payload.content else ""
-
-            # Stash the sender so `send_fallback_message("")` can route replies.
-            # Always overwrite — first-write would pin replies to a
-            # stale peer when a different person DMs us.
-            if is_dm:
-                self._last_dm_sender = payload.sender_slug
-            elif payload.channel_id and payload.space_id:
-                # Remember which space owns this channel so replies
-                # resolve members in the right space (cross-space
-                # invites would otherwise fail).
-                self._channel_space[payload.channel_id] = payload.space_id
-
-            # Parse all ``@<slug>`` and scope to space members
-            # (matches the web client). Self is always kept.
-            self_slug_lower = self.slug.lower()
-            seen: set[str] = set()
-            parsed: list[str] = []
-            for m in _MENTION_RE.finditer(raw_text):
-                slug = m.group(1).lower()
-                if slug in seen:
-                    continue
-                seen.add(slug)
-                parsed.append(slug)
-            is_mention = self_slug_lower in seen
-            space_members = (
-                await self._get_space_members(payload.space_id)
-                if payload.space_id
-                else {}
-            )
-            mentions: list[dict] = []
-            for slug in parsed:
-                if slug == self_slug_lower:
-                    mentions.append({"username": self.slug, "is_bot": True, "is_self": True})
-                    continue
-                if space_members and slug not in space_members:
-                    continue
-                is_bot = space_members.get(slug) == "agent"
-                mentions.append({"username": slug, "is_bot": is_bot, "is_self": False})
-
-            # Self-mention rewrite: `@<our-slug>` → `@you(<our-slug>)`
-            # (the documented "addressed to you" signal).
-            clean_text = raw_text.replace(
-                f"@{self.slug}", f"@you({self.slug})",
-            ).strip() if is_mention else raw_text
-
-            # Resolve human-readable names so the LLM sees ``space:``/
-            # ``channel:`` instead of bare ids. Cached per session. DMs
-            # render an explicit "Direct message" label.
-            space_id = payload.space_id or ""
-            space_name = (
-                await self._resolve_space_name(space_id) if space_id else ""
-            )
-            if is_dm:
-                channel_name = "Direct message"
-            elif channel_id:
-                channel_name = await self._resolve_channel_name(
-                    space_id, channel_id,
-                )
-            else:
-                channel_name = channel_id
-
-            direct = is_dm or is_mention
-            sender_is_bot = False  # puffo-core has no is_bot flag yet
-            priority = _compute_priority(direct, sender_is_bot)
-
-            # Thread-batched queue: every message coalesces under
-            # its ``root_id`` (the envelope's ``thread_root_id``, or
-            # the message itself when it's a top-level post). The
-            # PriorityQueue holds one slot per root; new arrivals on
-            # the same thread either join the existing batch
-            # (priority same or lower) or bump the slot to the new
-            # higher priority. The agent processes one whole thread
-            # at a time in ``on_message_batch``.
-            # PUF-227-A: route on the VALIDATED thread_root_id. If
-            # admit-time validation wiped it (parent not in cache or
-            # cross-channel), the message gets a fresh per-envelope
-            # root_id and lands in its own batch — never inheriting a
-            # stale channel_meta from an unrelated thread.
-            root_id = payload_thread_root_id or payload.envelope_id
-
-            # Cross-restart dedup: after a daemon restart the server
-            # redelivers anything in /messages/pending. If we already
-            # dispatched a batch that covers ``payload.sent_at``,
-            # skip — the agent has seen this.
-            last_processed = await self.store.get_last_processed_sent_at(root_id)
-            if payload.sent_at <= last_processed:
-                self._log.info(
-                    "handle_envelope: cursor-rejected duplicate envelope=%s "
-                    "(sent_at=%d <= last_processed=%d, root=%s)",
-                    payload.envelope_id, payload.sent_at,
-                    last_processed, root_id,
-                )
-                return
-
-            # Per-session display-name cache turns this into ~1 HTTP
-            # call per distinct sender per session; same helper the
-            # invite-DM flow already uses. Empty string on miss.
-            sender_display_name = await self._fetch_display_name(
-                payload.sender_slug,
-            )
-
-            # Long-message redaction. Operators paste big chunks of
-            # code or transcripts that, combined with the agent's
-            # system prompt + thread history, can blow past the LLM
-            # context window — historically observable as the agent
-            # getting stuck in a "Prompt is too long" retry loop the
-            # restart path didn't recover from. The full envelope
-            # stays in messages.db; only the in-prompt view collapses
-            # to a placeholder pointing at ``get_post_segment``.
-            llm_text = _maybe_redact_long_text(
-                clean_text,
-                envelope_id=payload.envelope_id,
-                sender_slug=payload.sender_slug,
-                sender_display_name=sender_display_name,
-                max_inline_chars=self._max_inline_chars,
-                segment_chars=self._segment_chars,
-                agent_slug=self.slug,
-            )
-
-            msg_dict = {
-                "channel_id": channel_id,
-                "channel_name": channel_name,
-                "space_id": space_id,
-                "space_name": space_name,
-                "sender_slug": payload.sender_slug,
-                "sender_display_name": sender_display_name,
-                "sender_email": "",
-                "text": llm_text,
-                "root_id": payload_thread_root_id or "",
-                "is_dm": is_dm,
-                "attachments": attachment_paths,
-                "sender_is_bot": sender_is_bot,
-                "mentions": mentions,
-                "envelope_id": payload.envelope_id,
-                "sent_at": payload.sent_at,
-                "is_visible_to_human": payload.is_visible_to_human,
-            }
-            channel_meta = {
-                "channel_id": channel_id,
-                "channel_name": channel_name,
-                "space_id": space_id,
-                "space_name": space_name,
-                "is_dm": is_dm,
-            }
-
-            await self._admit_thread_message(
-                root_id=root_id,
-                priority=priority,
-                msg_dict=msg_dict,
-                channel_meta=channel_meta,
-            )
+            await self._handle_plaintext_payload(payload)
 
         # Per-listen() queue. A reconnect drops any envelopes not yet
         # drained; the server redelivers via /messages/pending on the
@@ -956,38 +720,421 @@ class PuffoCoreMessageClient:
                 except (asyncio.CancelledError, Exception):
                     pass
 
-    async def _listen_bridge(self) -> None:
-        """Bridge-transport lifecycle loop: connect → drain frames →
-        reconnect, with the same backoff schedule as the native
-        ``PuffoCoreWsClient.run()`` (start at INITIAL_BACKOFF, double
-        on failure, cap at MAX_BACKOFF, reset on successful connect).
+    async def _listen_bridge(
+        self,
+        on_message: Callable[..., Coroutine[Any, Any, Any]],
+        on_api_error_retry: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        on_api_error_abandon: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        on_turn_success: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+    ) -> None:
+        """Bridge-transport lifecycle loop: connect → fetch_pending →
+        drain frames → reconnect, with the same backoff schedule as the
+        native ``PuffoCoreWsClient.run()`` (start at INITIAL_BACKOFF,
+        double on failure, cap at MAX_BACKOFF, reset on successful
+        connect).
+
+        Inbound plaintext ``message`` frames map to a ``MessagePayload``
+        and flow through the same ``_handle_plaintext_payload`` tail the
+        native decrypt path uses — so a bridge-transport agent stores +
+        surfaces DMs / channel posts exactly like native, minus the
+        crypto. A fresh ``connect()`` drives ``send_fetch_pending()``
+        once so a cold sandbox drains its server-side queue;
+        ``pending_delivered`` marks that backfill complete (the loop
+        keeps running for live delivery).
+
+        Deliberately does NOT start ``_invite_poll_loop`` /
+        ``_warm_member_caches`` — they drive signed HTTP endpoints that
+        can't work keyless; names render as ids until those are rewired.
         """
         bridge = self._bridge
         assert bridge is not None  # guarded by listen()
+
+        # Per-listen() queue + thread state, mirrored from native
+        # listen(): a reconnect drops any envelopes not yet drained;
+        # the server redelivers them on the next fetch_pending, and the
+        # sqlite cursor keeps the agent from re-running handled threads.
+        self._queue = asyncio.PriorityQueue()
+        self._queue_seq = 0
+        self._thread_state = {}
+        await self.store.open()
+        consumer_task = asyncio.ensure_future(
+            self._consume_queue(
+                on_message, on_api_error_retry,
+                on_api_error_abandon, on_turn_success,
+            ),
+        )
         backoff = INITIAL_BACKOFF
-        while True:
-            try:
+        try:
+            while True:
                 try:
-                    await bridge.connect()
-                    backoff = INITIAL_BACKOFF
-                    async for frame in bridge.frames():
-                        # Phase 2 maps these into the message store +
-                        # thread queue; phase 1 logs and drops.
-                        self._log.info(
-                            "bridge frame dropped (phase 1): type=%s",
-                            frame.get("type", ""),
-                        )
-                finally:
-                    await bridge.close()
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                self._log.warning(
-                    "bridge WS disconnected (%s: %s), reconnecting in %ds",
-                    type(exc).__name__, exc, backoff,
+                    try:
+                        await bridge.connect()
+                        backoff = INITIAL_BACKOFF
+                        # Cold-start IN backfill: one fetch_pending per
+                        # successful connect drains the server queue.
+                        # Idempotent (server redelivers on redelivery),
+                        # so a reconnect re-fetches for free.
+                        await bridge.send_fetch_pending()
+                        async for frame in bridge.frames():
+                            await self._dispatch_bridge_frame(frame)
+                    finally:
+                        await bridge.close()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    self._log.warning(
+                        "bridge WS disconnected (%s: %s), reconnecting in %ds",
+                        type(exc).__name__, exc, backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, MAX_BACKOFF)
+        finally:
+            consumer_task.cancel()
+            try:
+                await consumer_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _dispatch_bridge_frame(self, frame: dict) -> None:
+        """Route one inbound bridge frame off ``frames()``.
+
+        ``message`` handling is wrapped so one poison frame logs and is
+        skipped rather than killing the listen loop (which would drop
+        every subsequent live message until the next reconnect).
+        Correlated ``error`` frames are already routed to the send
+        futures inside ``frames()``; anything surfacing here is
+        uncorrelated, so it only warns.
+        """
+        kind = frame.get("type", "")
+        if kind == "message":
+            try:
+                payload = self._payload_from_bridge_frame(frame)
+                if payload is not None:
+                    await self._handle_plaintext_payload(payload)
+            except Exception:
+                self._log.exception(
+                    "bridge message frame handling failed (envelope_id=%s)",
+                    frame.get("envelope_id"),
                 )
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, MAX_BACKOFF)
+        elif kind == "pending_delivered":
+            self._log.info(
+                "bridge backfill complete: pending_delivered (count=%s)",
+                frame.get("count"),
+            )
+        elif kind == "error":
+            self._log.warning(
+                "bridge error frame: code=%s message=%s",
+                frame.get("code"), frame.get("message"),
+            )
+        else:
+            self._log.debug("bridge frame ignored: type=%s", kind)
+
+    async def _handle_plaintext_payload(self, payload: MessagePayload) -> None:
+        """Persist + surface a decoded message payload to the agent.
+
+        Shared tail of the inbound path: native ``handle_envelope``
+        calls this after ``decrypt_message`` produces ``payload``, and
+        the T23 bridge listener calls it with a payload built straight
+        from a plaintext ``message`` frame (no decrypt). Everything from
+        here down is crypto-agnostic — it only touches ``payload`` +
+        ``self`` (store, caches, thread queue), and every HTTP-backed
+        enrichment helper it calls degrades to empty/None offline, so
+        the keyless bridge path renders ids-for-names rather than
+        crashing.
+        """
+        # PUF-227-A: strict cache-validation invariant for incoming
+        # ids. Any thread_root_id / reply_to_id that doesn't point
+        # to a same-channel parent in our local message_store gets
+        # wiped to None before storage — the agent's local view
+        # never honors a thread linkage that can't be resolved here.
+        # Catches the Scout-class symptom: a server / UI / sender
+        # that stamps a cross-channel id can't poison the recipient
+        # daemon's thread state.
+        validated_thread_root_id = await self._validate_incoming_parent_id(
+            payload.thread_root_id, payload.channel_id, payload.space_id,
+        )
+        validated_reply_to_id = await self._validate_incoming_parent_id(
+            payload.reply_to_id, payload.channel_id, payload.space_id,
+        )
+        await self.store.store({
+            "envelope_id": payload.envelope_id,
+            "envelope_kind": payload.envelope_kind,
+            "sender_slug": payload.sender_slug,
+            "channel_id": payload.channel_id,
+            "space_id": payload.space_id,
+            "recipient_slug": payload.recipient_slug,
+            "content_type": payload.content_type,
+            "content": payload.content,
+            "sent_at": payload.sent_at,
+            "thread_root_id": validated_thread_root_id,
+            "reply_to_id": validated_reply_to_id,
+        })
+        # Rebind for downstream code (root_id resolution at the
+        # batch-coalesce step, channel_meta construction, etc.) so
+        # admit-time wipes propagate through the agent prompt.
+        payload_thread_root_id = validated_thread_root_id
+        payload_reply_to_id = validated_reply_to_id
+
+        # Self-echo lands here too now (see ``handle_envelope``'s
+        # opening comment). Persist it — so ``get_channel_history``
+        # / ``get_thread_history`` show the agent's own posts —
+        # then stop before any of the LLM-facing pipeline below
+        # runs. The agent already produced this message; queueing
+        # it again would feed the agent its own words and trip a
+        # turn-by-turn echo loop.
+        if payload.sender_slug == self.slug:
+            return
+
+        # Daemon-side intercept: ``y``/``n`` from the operator on an
+        # outstanding invite-DM accepts/rejects without waking the
+        # LLM. A threaded reply answers just that invite; a direct
+        # (top-level) reply answers all pending invites at once.
+        if (
+            payload.envelope_kind == "dm"
+            and payload.sender_slug == self.operator_slug
+        ):
+            text_raw = str(payload.content) if payload.content else ""
+            targets, is_direct = self._resolve_invite_targets(
+                payload_thread_root_id, text_raw,
+            )
+            handled_labels = (
+                await self._apply_invite_replies(targets, text_raw)
+                if targets else []
+            )
+            if handled_labels:
+                # Handled inline — don't queue for the LLM.
+                self._last_dm_sender = payload.sender_slug
+                if is_direct:
+                    await self._send_invite_bulk_summary(
+                        handled_labels, text_raw, payload_thread_root_id or "",
+                    )
+                return
+            # Same gate for agent-initiated leave requests, but
+            # threaded-only — each leave is confirmed in its own
+            # thread (no direct/bulk path).
+            if await self._maybe_handle_leave_reply(
+                thread_root_id=payload_thread_root_id or "", text=text_raw,
+            ):
+                self._last_dm_sender = payload.sender_slug
+                return
+
+        channel_id = payload.channel_id or ""
+        is_dm = payload.envelope_kind == "dm"
+        # ``puffo/message+attachments/v1`` carries
+        # ``{ text, attachments: [...] }``; other content types
+        # use the plain-string path.
+        attachment_paths: list[str] = []
+        if payload.content_type == "puffo/message+attachments/v1" and isinstance(
+            payload.content, dict,
+        ):
+            raw_text = str(payload.content.get("text") or "")
+            metas_raw = payload.content.get("attachments") or []
+            if isinstance(metas_raw, list):
+                attachment_paths = await self._save_inbound_attachments(
+                    envelope_id=payload.envelope_id, metas_raw=metas_raw,
+                )
+        else:
+            raw_text = str(payload.content) if payload.content else ""
+
+        # Stash the sender so `send_fallback_message("")` can route replies.
+        # Always overwrite — first-write would pin replies to a
+        # stale peer when a different person DMs us.
+        if is_dm:
+            self._last_dm_sender = payload.sender_slug
+        elif payload.channel_id and payload.space_id:
+            # Remember which space owns this channel so replies
+            # resolve members in the right space (cross-space
+            # invites would otherwise fail).
+            self._channel_space[payload.channel_id] = payload.space_id
+
+        # Parse all ``@<slug>`` and scope to space members
+        # (matches the web client). Self is always kept.
+        self_slug_lower = self.slug.lower()
+        seen: set[str] = set()
+        parsed: list[str] = []
+        for m in _MENTION_RE.finditer(raw_text):
+            slug = m.group(1).lower()
+            if slug in seen:
+                continue
+            seen.add(slug)
+            parsed.append(slug)
+        is_mention = self_slug_lower in seen
+        space_members = (
+            await self._get_space_members(payload.space_id)
+            if payload.space_id
+            else {}
+        )
+        mentions: list[dict] = []
+        for slug in parsed:
+            if slug == self_slug_lower:
+                mentions.append({"username": self.slug, "is_bot": True, "is_self": True})
+                continue
+            if space_members and slug not in space_members:
+                continue
+            is_bot = space_members.get(slug) == "agent"
+            mentions.append({"username": slug, "is_bot": is_bot, "is_self": False})
+
+        # Self-mention rewrite: `@<our-slug>` → `@you(<our-slug>)`
+        # (the documented "addressed to you" signal).
+        clean_text = raw_text.replace(
+            f"@{self.slug}", f"@you({self.slug})",
+        ).strip() if is_mention else raw_text
+
+        # Resolve human-readable names so the LLM sees ``space:``/
+        # ``channel:`` instead of bare ids. Cached per session. DMs
+        # render an explicit "Direct message" label.
+        space_id = payload.space_id or ""
+        space_name = (
+            await self._resolve_space_name(space_id) if space_id else ""
+        )
+        if is_dm:
+            channel_name = "Direct message"
+        elif channel_id:
+            channel_name = await self._resolve_channel_name(
+                space_id, channel_id,
+            )
+        else:
+            channel_name = channel_id
+
+        direct = is_dm or is_mention
+        sender_is_bot = False  # puffo-core has no is_bot flag yet
+        priority = _compute_priority(direct, sender_is_bot)
+
+        # Thread-batched queue: every message coalesces under
+        # its ``root_id`` (the envelope's ``thread_root_id``, or
+        # the message itself when it's a top-level post). The
+        # PriorityQueue holds one slot per root; new arrivals on
+        # the same thread either join the existing batch
+        # (priority same or lower) or bump the slot to the new
+        # higher priority. The agent processes one whole thread
+        # at a time in ``on_message_batch``.
+        # PUF-227-A: route on the VALIDATED thread_root_id. If
+        # admit-time validation wiped it (parent not in cache or
+        # cross-channel), the message gets a fresh per-envelope
+        # root_id and lands in its own batch — never inheriting a
+        # stale channel_meta from an unrelated thread.
+        root_id = payload_thread_root_id or payload.envelope_id
+
+        # Cross-restart dedup: after a daemon restart the server
+        # redelivers anything in /messages/pending. If we already
+        # dispatched a batch that covers ``payload.sent_at``,
+        # skip — the agent has seen this.
+        last_processed = await self.store.get_last_processed_sent_at(root_id)
+        if payload.sent_at <= last_processed:
+            self._log.info(
+                "handle_envelope: cursor-rejected duplicate envelope=%s "
+                "(sent_at=%d <= last_processed=%d, root=%s)",
+                payload.envelope_id, payload.sent_at,
+                last_processed, root_id,
+            )
+            return
+
+        # Per-session display-name cache turns this into ~1 HTTP
+        # call per distinct sender per session; same helper the
+        # invite-DM flow already uses. Empty string on miss.
+        sender_display_name = await self._fetch_display_name(
+            payload.sender_slug,
+        )
+
+        # Long-message redaction. Operators paste big chunks of
+        # code or transcripts that, combined with the agent's
+        # system prompt + thread history, can blow past the LLM
+        # context window — historically observable as the agent
+        # getting stuck in a "Prompt is too long" retry loop the
+        # restart path didn't recover from. The full envelope
+        # stays in messages.db; only the in-prompt view collapses
+        # to a placeholder pointing at ``get_post_segment``.
+        llm_text = _maybe_redact_long_text(
+            clean_text,
+            envelope_id=payload.envelope_id,
+            sender_slug=payload.sender_slug,
+            sender_display_name=sender_display_name,
+            max_inline_chars=self._max_inline_chars,
+            segment_chars=self._segment_chars,
+            agent_slug=self.slug,
+        )
+
+        msg_dict = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "sender_slug": payload.sender_slug,
+            "sender_display_name": sender_display_name,
+            "sender_email": "",
+            "text": llm_text,
+            "root_id": payload_thread_root_id or "",
+            "is_dm": is_dm,
+            "attachments": attachment_paths,
+            "sender_is_bot": sender_is_bot,
+            "mentions": mentions,
+            "envelope_id": payload.envelope_id,
+            "sent_at": payload.sent_at,
+            "is_visible_to_human": payload.is_visible_to_human,
+        }
+        channel_meta = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "is_dm": is_dm,
+        }
+
+        await self._admit_thread_message(
+            root_id=root_id,
+            priority=priority,
+            msg_dict=msg_dict,
+            channel_meta=channel_meta,
+        )
+
+    def _payload_from_bridge_frame(self, frame: dict) -> MessagePayload | None:
+        """Map a plaintext bridge ``message`` frame onto a
+        ``MessagePayload`` so it can flow through the same
+        ``_handle_plaintext_payload`` tail the native decrypt path uses.
+
+        The server holds all crypto on the bridge transport, so the
+        frame body is already plaintext — there is no decrypt step.
+        Every routing field is read with ``.get()`` and a benign
+        fallback so a wire-field rename or a sparse frame degrades to a
+        skip (bad ``envelope_id``) rather than a ``KeyError`` mid-loop.
+        The exact wire field names live in
+        ``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``;
+        only ``envelope_id`` / ``sender_slug`` / ``plaintext`` are
+        anchored by tests, so a rename is a one-line change confined
+        here.
+        """
+        envelope_id = frame.get("envelope_id")
+        if not envelope_id:
+            self._log.warning(
+                "bridge message frame missing envelope_id — skipping "
+                "(keys=%s)", sorted(frame.keys()),
+            )
+            return None
+        recipient_slug = frame.get("recipient_slug")
+        envelope_kind = frame.get("envelope_kind") or (
+            "dm" if recipient_slug else "channel"
+        )
+        content = frame.get("plaintext")
+        if content is None:
+            content = frame.get("content", "")
+        return MessagePayload(
+            payload_type=frame.get("payload_type", "message"),
+            version=frame.get("version", 1),
+            envelope_id=envelope_id,
+            envelope_kind=envelope_kind,
+            sender_slug=frame.get("sender_slug", ""),
+            sender_subkey_id=frame.get("sender_subkey_id", ""),
+            sent_at=frame.get("sent_at") or int(time.time() * 1000),
+            message_nonce=frame.get("message_nonce", ""),
+            content_type=frame.get("content_type", "text/plain"),
+            content=content,
+            is_visible_to_human=frame.get("is_visible_to_human", True),
+            space_id=frame.get("space_id"),
+            channel_id=frame.get("channel_id"),
+            recipient_slug=recipient_slug,
+            thread_root_id=frame.get("thread_root_id"),
+            reply_to_id=frame.get("reply_to_id"),
+        )
 
     async def _admit_thread_message(
         self,
@@ -3667,6 +3814,55 @@ class PuffoCoreMessageClient:
         Empty ``channel_id``: DM reply; recipients are me and the peer
         so the agent's other devices see the fan-out.
         """
+        if self._bridge is not None:
+            # T23 bridge transport: send plaintext; the server holds all
+            # crypto and fans out recipients. Empty channel_id ⇒ DM back
+            # to the last DM sender; else a channel post (space resolved
+            # from the same caches native uses). No encrypt_message /
+            # signed POST. Threaded ``root_id`` isn't wired on bridge yet
+            # (phase 3) — this replies top-level.
+            if channel_id:
+                target_space_id = self._channel_space.get(channel_id)
+                if not target_space_id:
+                    target_space_id = (
+                        await self.store.lookup_channel_space(channel_id) or ""
+                    )
+                    if target_space_id:
+                        self._channel_space[channel_id] = target_space_id
+                if not target_space_id:
+                    self._log.warning(
+                        "send_fallback_message[bridge]: no known space for "
+                        "channel %s — dropping reply", channel_id,
+                    )
+                    return
+                ack = await self._bridge.send_send(
+                    plaintext=text,
+                    space_id=target_space_id,
+                    channel_id=channel_id,
+                )
+                self._log.info(
+                    "send_fallback_message[bridge] sent: kind=channel "
+                    "channel=%s envelope_id=%s",
+                    channel_id, (ack or {}).get("envelope_id"),
+                )
+                return
+            recipient = self._last_dm_sender
+            if not recipient:
+                self._log.warning(
+                    "send_fallback_message[bridge] called with empty "
+                    "channel_id but no DM context — dropping reply",
+                )
+                return
+            ack = await self._bridge.send_send(
+                plaintext=text, recipient_slug=recipient,
+            )
+            self._log.info(
+                "send_fallback_message[bridge] sent: kind=dm recipient=%s "
+                "envelope_id=%s",
+                recipient, (ack or {}).get("envelope_id"),
+            )
+            return
+
         sess = self.keystore.load_session(self.slug)
         signing_key = Ed25519KeyPair.from_secret_bytes(
             decode_secret(sess.subkey_secret_key)

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -106,6 +106,12 @@ class PuffoCoreToolsConfig:
     # Set only on the in-process (ws-local) path, where tools run inside
     # the daemon and drive the message client directly instead of via RPC.
     message_client: Any = None
+    # T23 keyless bridge transport (``CloudBridgeClient``). Populated only
+    # at the in-process ws-local site (from ``client._bridge``); the
+    # subprocess/RPC MCP path leaves it None → native encrypt+signed POST.
+    # When set, ``send_message`` sends plaintext via the bridge and
+    # ``send_message_with_attachments`` refuses (phase 3).
+    bridge_client: Any = None
 
 
 async def _fetch_device_keys(
@@ -443,6 +449,40 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "'#<name>' channel addressing isn't supported; "
                 "use the channel id (e.g. 'ch_<uuid>') or call "
                 "list_channels_in_all_spaces to look one up."
+            )
+
+        if cfg.bridge_client is not None:
+            # T23 bridge transport: send plaintext; the server holds all
+            # crypto and fans out recipients. DM ('@slug') vs channel
+            # ('ch_') routing only — no device-key fetch, no encrypt, no
+            # signed POST. Threaded replies aren't wired on bridge yet
+            # (phase 3), so a non-empty root_id sends top-level with a note.
+            root_note = ""
+            if root_id:
+                root_note = (
+                    " (note: threaded replies aren't wired on bridge "
+                    "transport yet — sent as a top-level post)"
+                )
+            if channel_ref.startswith("@"):
+                bridge_recipient = channel_ref[1:]
+                if not bridge_recipient:
+                    raise RuntimeError("DM recipient slug is required after '@'")
+                ack = await cfg.bridge_client.send_send(
+                    plaintext=text, recipient_slug=bridge_recipient,
+                )
+            else:
+                bridge_channel_id = channel_ref
+                bridge_space_id = await _resolve_channel_space(
+                    cfg, bridge_channel_id,
+                )
+                ack = await cfg.bridge_client.send_send(
+                    plaintext=text,
+                    space_id=bridge_space_id,
+                    channel_id=bridge_channel_id,
+                )
+            return (
+                f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
+                f"{root_note}"
             )
 
         if channel_ref.startswith("@"):
@@ -979,6 +1019,13 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             raise RuntimeError(
                 "send_message_with_attachments: agent has no configured "
                 "workspace dir"
+            )
+        if cfg.bridge_client is not None:
+            # T23 phase 3: attachments over the keyless bridge aren't
+            # wired yet. Fail loud rather than silently encrypt (native
+            # path) or crash — a bridge agent has no signed-crypto seam.
+            raise RuntimeError(
+                "attachments are not supported on bridge transport yet"
             )
         if not paths or not isinstance(paths, list):
             raise RuntimeError(

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -44,6 +44,11 @@ def _build_tool_dispatch(point: AttachPoint):
         space_id=getattr(client, "space_id", None),
         workspace=getattr(client, "workspace", None),
         message_client=client,
+        # T23: the daemon owns the single per-agent bridge WS, so only
+        # the in-process ws-local tools can drive it. None on native
+        # agents → send_message keeps the signed-crypto path. The
+        # subprocess/RPC MCP site can't own this WS, so it stays None.
+        bridge_client=getattr(client, "_bridge", None),
     )
     return _build_dispatch(cfg)
 

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -1,0 +1,685 @@
+"""T23 phase 2: keyless bridge message flow.
+
+Under ``puffo_core.transport: "bridge"`` the message path runs over the
+plaintext ``CloudBridgeClient`` — the server holds all crypto. This
+suite pins the phase-2 seam swap:
+
+  (a) inbound plaintext ``message`` frames persist + surface exactly
+      like a native decrypted envelope, but WITHOUT ``decrypt_message``;
+  (b) outbound ``send_message`` sends plaintext via ``bridge.send_send``
+      WITHOUT ``encrypt_message*``;
+  (c) a fresh connect drives ``send_fetch_pending`` exactly once and
+      ``pending_delivered`` is recognised as backfill completion (the
+      loop keeps running for live frames);
+  (d) native (``bridge_client=None``) still encrypts on send and
+      decrypts on receive — the extraction is behaviour-preserving;
+  (e) attachments over the bridge fail loud (phase 3).
+
+Every fake is offline: no real WS, HTTP, E2B, or LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+import puffo_agent.agent.puffo_core_client as pcc_mod
+import puffo_agent.mcp.puffo_core_tools as pct_mod
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import (
+    KeyStore,
+    Session,
+    StoredIdentity,
+    encode_secret,
+)
+from puffo_agent.crypto.message import MessagePayload
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+from puffo_agent.mcp.puffo_core_tools import PuffoCoreToolsConfig
+from puffo_agent.portal.ws_local.tool_dispatch import build_dispatch
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class FakeBridge:
+    """Offline ``CloudBridgeClient`` stand-in for the phase-2 flow.
+
+    ``frames()`` replays a scripted list then suspends (mimicking a live
+    WS awaiting its next frame) so ``_listen_bridge`` stays connected
+    instead of reconnect-storming — the test cancels the task when done.
+    ``send_send`` records its kwargs and returns a canned ack;
+    ``send_fetch_pending`` / ``connect`` / ``close`` count calls.
+    """
+
+    def __init__(self, scripted: list[dict] | None = None, ack: dict | None = None):
+        self._scripted = list(scripted or [])
+        self._ack = ack or {
+            "type": "ack",
+            "envelope_id": "msg_bridgeack",
+            "client_ref": "r_test",
+        }
+        self.sent: list[dict] = []
+        self.connect_count = 0
+        self.fetch_pending_count = 0
+        self.close_count = 0
+        # Never set → frames() suspends after the script drains.
+        self._blocked = asyncio.Event()
+
+    async def connect(self) -> None:
+        self.connect_count += 1
+
+    async def send_fetch_pending(self, *, limit=None) -> None:
+        self.fetch_pending_count += 1
+
+    async def send_send(
+        self, *, plaintext, recipient_slug=None, space_id=None,
+        channel_id=None, timeout: float = 30.0,
+    ) -> dict:
+        self.sent.append({
+            "plaintext": plaintext,
+            "recipient_slug": recipient_slug,
+            "space_id": space_id,
+            "channel_id": channel_id,
+        })
+        return dict(self._ack)
+
+    async def frames(self):
+        for frame in self._scripted:
+            yield frame
+        await self._blocked.wait()  # suspend like a live WS
+        yield {}  # pragma: no cover — keeps this an async generator
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+class FakeHttp:
+    """Async HTTP stub. ``get`` matches on exact path, path-without-
+    query, then query-modulo-``since`` (the ``/certs/sync`` cursor), so a
+    test registers one canonical key. Everything else returns ``{}`` so
+    the inbound enrichment helpers degrade offline rather than crash.
+    """
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, object]] = []
+        self.responses: dict[str, dict] = {}
+
+    def _match(self, path: str) -> dict:
+        if path in self.responses:
+            return self.responses[path]
+        base = path.split("?", 1)[0]
+        if base in self.responses:
+            return self.responses[base]
+        if "?" in path:
+            from urllib.parse import parse_qsl
+            actual = sorted(
+                (k, v)
+                for k, v in parse_qsl(path.split("?", 1)[1], keep_blank_values=True)
+                if k != "since"
+            )
+            for key in self.responses:
+                if "?" not in key:
+                    continue
+                key_base, key_qs = key.split("?", 1)
+                if key_base != base:
+                    continue
+                if sorted(parse_qsl(key_qs, keep_blank_values=True)) == actual:
+                    return self.responses[key]
+        return {}
+
+    async def get(self, path):
+        self.calls.append(("GET", path, None))
+        return self._match(path)
+
+    async def post(self, path, body=None):
+        self.calls.append(("POST", path, body))
+        return self.responses.get(path, {"ok": True})
+
+
+# --------------------------------------------------------------------------
+# Builders
+# --------------------------------------------------------------------------
+
+
+def _bridge_client(
+    tmp_path, bridge, *, slug="bot-0001", db="messages.db",
+) -> PuffoCoreMessageClient:
+    """A bridge-transport message client with a stubbed (offline) http
+    so inbound enrichment helpers degrade to ids-for-names."""
+    ks = KeyStore(str(tmp_path / f"keys-{db}"))
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, slug)
+    store = MessageStore(str(tmp_path / db))
+    client = PuffoCoreMessageClient(
+        slug=slug,
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=store,
+        bridge_client=bridge,
+    )
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+    return client
+
+
+def _native_keystore(tmp_path, slug="bot-0001") -> KeyStore:
+    ks = KeyStore(str(tmp_path / "native-keys"))
+    ks.save_identity(StoredIdentity(
+        slug=slug,
+        device_id="dev_test",
+        root_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        device_signing_secret_key=encode_secret(
+            Ed25519KeyPair.generate().secret_bytes()
+        ),
+        kem_secret_key=encode_secret(KemKeyPair.generate().secret_bytes()),
+        server_url="http://127.0.0.1:1",
+    ))
+    ks.save_session(Session(
+        slug=slug,
+        subkey_id="sk_test",
+        subkey_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        expires_at=32_503_680_000_000,
+    ))
+    return ks
+
+
+def _tools_cfg(tmp_path, *, bridge, data_client, http=None, slug="bot-0001"):
+    ks = KeyStore(str(tmp_path / "cfg-keys"))
+    return PuffoCoreToolsConfig(
+        slug=slug,
+        device_id="dev_test",
+        keystore=ks,
+        http_client=http or FakeHttp(),
+        data_client=data_client,
+        space_id="sp_home",
+        workspace=str(tmp_path),
+        bridge_client=bridge,
+    )
+
+
+async def _drive_listen_until(client, *, on_message, done: asyncio.Event, timeout=5.0):
+    """Run ``_listen_bridge`` as a task until ``done`` fires, then cancel
+    it cleanly. Returns nothing — assertions read the store / bridge."""
+    task = asyncio.ensure_future(client._listen_bridge(on_message))
+    try:
+        await asyncio.wait_for(done.wait(), timeout=timeout)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _no_jitter(monkeypatch):
+    # The consumer sleeps random.uniform(0, 1.5) before dispatch; zero it
+    # so batch-callback tests don't wait seconds.
+    monkeypatch.setattr(pcc_mod.random, "uniform", lambda a, b: 0.0)
+
+
+# --------------------------------------------------------------------------
+# (a) inbound plaintext stores like native, no decrypt
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_inbound_stores_like_native_without_decrypt(tmp_path, monkeypatch):
+    ENV_ID = "env_bridge_1"
+    SENDER = "alice-0001"
+    CHANNEL = "ch_xyz"
+    SPACE = "sp_1"
+    CONTENT = "hello from the bridge"
+    SENT_AT = 1_700_000_000_000
+
+    decrypt_calls: list[int] = []
+
+    def _decrypt_spy(*a, **k):  # pragma: no cover — must never run here
+        decrypt_calls.append(1)
+        raise AssertionError("decrypt_message must not run on the bridge path")
+
+    monkeypatch.setattr(pcc_mod, "decrypt_message", _decrypt_spy)
+
+    frame = {
+        "type": "message",
+        "envelope_id": ENV_ID,
+        "sender_slug": SENDER,
+        "envelope_kind": "channel",
+        "space_id": SPACE,
+        "channel_id": CHANNEL,
+        "sent_at": SENT_AT,
+        "plaintext": CONTENT,
+    }
+    # The decrypted-equivalent of the same logical message — what the
+    # native decrypt_message would yield. Feeding this straight through
+    # the shared tail gives the reference store row to compare against.
+    ref_payload = MessagePayload(
+        payload_type="puffo.message",
+        version=1,
+        envelope_id=ENV_ID,
+        envelope_kind="channel",
+        sender_slug=SENDER,
+        sender_subkey_id="",
+        sent_at=SENT_AT,
+        message_nonce="",
+        content_type="text/plain",
+        content=CONTENT,
+        is_visible_to_human=True,
+        space_id=SPACE,
+        channel_id=CHANNEL,
+    )
+
+    # --- bridge path ---
+    bridge = FakeBridge(scripted=[frame])
+    client = _bridge_client(tmp_path, bridge, db="bridge.db")
+    surfaced: list[tuple] = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append((root_id, batch, channel_meta))
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # --- native reference path (post-decrypt shared tail) ---
+    ref = _bridge_client(tmp_path, FakeBridge(), db="native_ref.db")
+    ref._queue = asyncio.PriorityQueue()
+    ref._queue_seq = 0
+    ref._thread_state = {}
+    await ref.store.open()
+    await ref._handle_plaintext_payload(ref_payload)
+
+    bridge_row = await client.store.get_message_by_envelope(ENV_ID)
+    ref_row = await ref.store.get_message_by_envelope(ENV_ID)
+    assert bridge_row is not None, "bridge inbound frame was not persisted"
+    assert ref_row is not None
+
+    persisted_fields = (
+        "envelope_id", "sender_slug", "channel_id", "space_id",
+        "recipient_slug", "content_type", "content", "sent_at",
+        "envelope_kind",
+    )
+    for f in persisted_fields:
+        assert getattr(bridge_row, f) == getattr(ref_row, f), (
+            f"bridge/native persisted field {f!r} diverged: "
+            f"{getattr(bridge_row, f)!r} != {getattr(ref_row, f)!r}"
+        )
+    # Concrete spot-checks so the equivalence isn't vacuously true.
+    assert bridge_row.content == CONTENT
+    assert bridge_row.sender_slug == SENDER
+    assert bridge_row.envelope_kind == "channel"
+    assert bridge_row.content_type == "text/plain"
+
+    # decrypt never ran, and the message surfaced to the agent.
+    assert decrypt_calls == []
+    assert len(surfaced) == 1
+    root_id, batch, channel_meta = surfaced[0]
+    assert any(m["envelope_id"] == ENV_ID for m in batch)
+    assert channel_meta["channel_id"] == CHANNEL
+
+
+@pytest.mark.asyncio
+async def test_a_inbound_dm_frame_routes_as_dm(tmp_path):
+    """A frame with ``recipient_slug`` and no explicit ``envelope_kind``
+    is inferred as a DM (mapper fallback) and stashed for reply routing.
+    """
+    bridge = FakeBridge(scripted=[{
+        "type": "message",
+        "envelope_id": "env_dm_1",
+        "sender_slug": "carol-0001",
+        "recipient_slug": "bot-0001",
+        "sent_at": 1_700_000_000_001,
+        "plaintext": "ping",
+    }])
+    client = _bridge_client(tmp_path, bridge, db="dm.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    row = await client.store.get_message_by_envelope("env_dm_1")
+    assert row is not None
+    assert row.envelope_kind == "dm"
+    assert row.recipient_slug == "bot-0001"
+    # DM sender stashed so send_fallback_message("") can reply to them.
+    assert client._last_dm_sender == "carol-0001"
+
+
+def test_payload_from_bridge_frame_skips_missing_envelope_id(tmp_path):
+    client = _bridge_client(tmp_path, FakeBridge(), db="skip.db")
+    assert client._payload_from_bridge_frame({"plaintext": "x"}) is None
+
+
+# --------------------------------------------------------------------------
+# (b) bridge send, no encrypt
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_dm_uses_bridge_no_encrypt(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message_with_content_key",
+        lambda *a, **k: enc_calls.append(1),
+    )
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message", lambda *a, **k: enc_calls.append(1),
+    )
+
+    ms = MessageStore(str(tmp_path / "b_dm.db"))
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](channel="@alice-0001", text="hi alice")
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["plaintext"] == "hi alice"
+    assert sent["recipient_slug"] == "alice-0001"
+    assert sent["space_id"] is None and sent["channel_id"] is None
+    assert "msg_bridgeack" in result
+    assert enc_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_channel_uses_bridge_no_encrypt(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message_with_content_key",
+        lambda *a, **k: enc_calls.append(1),
+    )
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message", lambda *a, **k: enc_calls.append(1),
+    )
+
+    ms = MessageStore(str(tmp_path / "b_ch.db"))
+    await ms.mark_channel_space("ch_xyz", "sp_1")
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](channel="ch_xyz", text="team update")
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["plaintext"] == "team update"
+    assert sent["space_id"] == "sp_1"
+    assert sent["channel_id"] == "ch_xyz"
+    assert sent["recipient_slug"] is None
+    assert "msg_bridgeack" in result
+    assert enc_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_threaded_note_on_bridge(tmp_path):
+    """root_id isn't wired on bridge yet — send top-level with a note."""
+    ms = MessageStore(str(tmp_path / "b_thread.db"))
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](
+        channel="@alice-0001", text="reply", root_id="msg_parent",
+    )
+    assert len(bridge.sent) == 1
+    assert "top-level" in result.lower() or "phase 3" in result.lower() \
+        or "not wired" in result.lower()
+
+
+# --------------------------------------------------------------------------
+# (c) connect drives exactly one fetch_pending; pending_delivered ends backfill
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_c_connect_drives_one_fetch_pending_and_survives_pending_delivered(
+    tmp_path, caplog,
+):
+    # backfill message, the terminator, then a live message — proving the
+    # loop kept running for live delivery after pending_delivered.
+    scripted = [
+        {
+            "type": "message", "envelope_id": "env_backfill",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_010, "plaintext": "backfilled",
+        },
+        {"type": "pending_delivered", "count": 1},
+        {
+            "type": "message", "envelope_id": "env_live",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_020, "plaintext": "live one",
+        },
+    ]
+    bridge = FakeBridge(scripted=scripted)
+    client = _bridge_client(tmp_path, bridge, db="c.db")
+
+    seen_roots: list[str] = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        seen_roots.append(root_id)
+        if len(seen_roots) >= 2:
+            done.set()
+
+    with caplog.at_level(logging.INFO, logger="puffo_agent.agent.puffo_core_client"):
+        await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # Exactly one connect + one fetch_pending drove the cold-start drain.
+    assert bridge.connect_count == 1
+    assert bridge.fetch_pending_count == 1
+    # pending_delivered was recognised as backfill completion.
+    assert "backfill complete" in caplog.text
+    # Both the backfill and the post-terminator live message landed.
+    assert await client.store.get_message_by_envelope("env_backfill") is not None
+    assert await client.store.get_message_by_envelope("env_live") is not None
+
+
+@pytest.mark.asyncio
+async def test_c_uncorrelated_error_frame_does_not_crash_loop(tmp_path, caplog):
+    scripted = [
+        {"type": "error", "code": "INTERNAL", "message": "transient blip"},
+        {
+            "type": "message", "envelope_id": "env_after_err",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_030, "plaintext": "still alive",
+        },
+    ]
+    bridge = FakeBridge(scripted=scripted)
+    client = _bridge_client(tmp_path, bridge, db="c_err.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        done.set()
+
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.agent.puffo_core_client"):
+        await _drive_listen_until(client, on_message=on_message, done=done)
+
+    assert "bridge error frame" in caplog.text
+    # The loop survived the error frame and delivered the next message.
+    assert await client.store.get_message_by_envelope("env_after_err") is not None
+
+
+# --------------------------------------------------------------------------
+# (d) native untouched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_d_native_send_message_still_encrypts_and_posts(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+
+    def _enc_spy(inp, signing_key, *, now_ms=None):
+        enc_calls.append(1)
+        return ({"envelope_id": "msg_native", "type": "message_envelope"}, b"ck")
+
+    monkeypatch.setattr(pct_mod, "encrypt_message_with_content_key", _enc_spy)
+
+    ks = _native_keystore(tmp_path)
+    http = FakeHttp()
+    http.responses["/certs/sync?slugs=bot-0001,alice-0001"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_a",
+                "kem_public_key": base64url_encode(
+                    KemKeyPair.generate().public_key_bytes()
+                ),
+            },
+        }],
+        "has_more": False,
+    }
+    ms = MessageStore(str(tmp_path / "d_send.db"))
+    cfg = PuffoCoreToolsConfig(
+        slug="bot-0001",
+        device_id="dev_test",
+        keystore=ks,
+        http_client=http,
+        data_client=ms,
+        space_id="sp_home",
+        bridge_client=None,  # native
+    )
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](channel="@alice-0001", text="hi native")
+
+    assert enc_calls, "native send_message must still encrypt"
+    assert any(p == "/messages" for m, p, _ in http.calls if m == "POST"), (
+        f"native send must POST via http_client; calls={http.calls}"
+    )
+    assert "posted" in result
+
+
+class _RecordingWs:
+    """PuffoCoreWsClient stand-in: captures ``on_message`` (the native
+    ``handle_envelope`` closure) and no-ops ``run()`` so ``listen()``
+    returns instead of blocking."""
+
+    instances: list["_RecordingWs"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.on_message = None
+        self.on_event = None
+        _RecordingWs.instances.append(self)
+
+    async def run(self) -> None:
+        return
+
+
+@pytest.mark.asyncio
+async def test_d_native_inbound_still_decrypts_before_storing(tmp_path, monkeypatch):
+    monkeypatch.setattr(_RecordingWs, "instances", [])
+    monkeypatch.setattr(pcc_mod, "PuffoCoreWsClient", _RecordingWs)
+
+    decrypt_calls: list[int] = []
+    canned = MessagePayload(
+        payload_type="puffo.message",
+        version=1,
+        envelope_id="env_native_in",
+        envelope_kind="channel",
+        sender_slug="alice-0001",
+        sender_subkey_id="",
+        sent_at=1_700_000_000_050,
+        message_nonce="",
+        content_type="text/plain",
+        content="decrypted body",
+        is_visible_to_human=True,
+        space_id="sp_1",
+        channel_id="ch_a",
+    )
+
+    def _decrypt_spy(*a, **k):
+        decrypt_calls.append(1)
+        return canned
+
+    monkeypatch.setattr(pcc_mod, "decrypt_message", _decrypt_spy)
+
+    ks = _native_keystore(tmp_path)
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, "bot-0001")
+    store = MessageStore(str(tmp_path / "d_in.db"))
+    client = PuffoCoreMessageClient(
+        slug="bot-0001",
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=store,
+    )  # no bridge → native
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+
+    async def _fake_signing_keys(slug):
+        return [object()]  # one non-empty pubkey so the decrypt loop runs
+
+    client._key_cache.get_signing_keys = _fake_signing_keys  # type: ignore[method-assign]
+
+    async def on_message(*a):
+        return
+
+    # Native listen() wires handle_envelope onto the (recording) WS and
+    # returns because run() is a no-op.
+    await client.listen(on_message)
+    assert len(_RecordingWs.instances) == 1
+    handle_envelope = _RecordingWs.instances[0].on_message
+    assert handle_envelope is not None
+
+    await handle_envelope({
+        "envelope_id": "env_native_in",
+        "sender_slug": "alice-0001",
+    })
+
+    assert decrypt_calls, "native inbound must call decrypt_message"
+    row = await client.store.get_message_by_envelope("env_native_in")
+    assert row is not None
+    assert row.content == "decrypted body"
+
+
+# --------------------------------------------------------------------------
+# (e) attachment guard
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e_attachments_refused_on_bridge_no_encrypt(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message_with_content_key",
+        lambda *a, **k: enc_calls.append(1),
+    )
+
+    ms = MessageStore(str(tmp_path / "e.db"))
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
+    with pytest.raises(RuntimeError) as excinfo:
+        await tools["send_message_with_attachments"](
+            paths=["note.txt"], channel="@alice-0001", caption="see file",
+        )
+    msg = str(excinfo.value).lower()
+    assert "bridge" in msg and "not supported" in msg
+    assert enc_calls == []
+    assert bridge.sent == []

--- a/tests/test_cloud_bridge_seam.py
+++ b/tests/test_cloud_bridge_seam.py
@@ -39,7 +39,12 @@ class _SpyKeyStore(KeyStore):
 
 
 class _StubBridge:
-    """Bridge stub: records the lifecycle calls listen() makes."""
+    """Bridge stub: records the lifecycle calls listen() makes.
+
+    Phase 2 drives ``send_fetch_pending`` once per successful connect
+    (cold-start backfill) before iterating frames, so the recorded
+    order is connect → fetch_pending → frames.
+    """
 
     def __init__(self) -> None:
         self.calls: list[str] = []
@@ -48,6 +53,9 @@ class _StubBridge:
     async def connect(self) -> None:
         self.calls.append("connect")
         self.connected.set()
+
+    async def send_fetch_pending(self, *, limit=None) -> None:
+        self.calls.append("fetch_pending")
 
     async def frames(self):
         self.calls.append("frames")
@@ -107,7 +115,7 @@ async def test_injected_bridge_skips_ws_client_and_identity_load(
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert stub.calls[:2] == ["connect", "frames"]
+    assert stub.calls[:3] == ["connect", "fetch_pending", "frames"]
     assert "close" in stub.calls
     assert _RecordingWs.instances == []
     assert spy_ks.load_identity_calls == []


### PR DESCRIPTION
## What (stacks on #127)

**Phase 2** of the fat-cloud transport swap. Under `puffo_core.transport: "bridge"`, the message path now carries **plaintext** (server holds all crypto). The `native` (signed-crypto, client-held keys) transport is **byte-for-byte unchanged** — this is transport dispatch, not a rewrite. Crypto module deletion is phase 4.

## The two seam points

- **IN** (`agent/puffo_core_client.py`): `_listen_bridge` drives **one** `send_fetch_pending()` per connect (cold-sandbox backfill), and routes inbound plaintext `message` frames via a new `_payload_from_bridge_frame` → `_handle_plaintext_payload` — the latter **extracted behavior-preservingly** from the native post-`decrypt_message` body, so native still decrypts and calls the same handler. `pending_delivered` terminates backfill.
- **OUT** (`mcp/puffo_core_tools.py` + `send_fallback_message`): send plaintext via `CloudBridgeClient.send_send` instead of `encrypt_message*`, mapping the ack to the existing return shape. Dispatch threaded **only** at the in-process ws-local site (`portal/ws_local/route.py`); the subprocess/RPC MCP path stays native (`bridge_client=None`) — a subprocess can't own the daemon's single per-agent bridge WS.

## Scope (design §2 = DM + channel text)
Threads (`root_id`) sent top-level, attachments **hard-refused** on bridge, name-enrichment degrades offline (helpers return empty rather than crash) — all **phase 3**. No `crypto/` module deleted (**phase 4**).

## Verify
LLM-free + E2B-free pytest (`tests/test_cloud_bridge_msgflow.py`): inbound plaintext lands in `message_store` identically to native (no `decrypt_message`); `send_message` uses bridge plaintext + no `encrypt_message*`; connect drives exactly one `send_fetch_pending`; **native transport still encrypts/decrypts** (asserted). Full suite green.

**Stacked on `fleet/fat-cloud-phase1` (#127). HOLD — do not self-merge.** Rebases onto the merged result when #127 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)