### PR TITLE
fat-cloud: thread wiring + keyless name-enrichment on the bridge message path

### DIFF
--- a/roadmap/cloud-agent/PHASE25-SERVER-ROUTE-GAPS.md
+++ b/roadmap/cloud-agent/PHASE25-SERVER-ROUTE-GAPS.md
@@ -1,0 +1,126 @@
+# Phase 2.5 (server) — keyless-path route & frame gaps
+
+This is the single spec for a future **puffo-server** run (working name:
+`fleet/cloud-agent-sandbox-token-auth`). It records every place the
+keyless (`transport: "bridge"`) `puffo-agent` path is already coded to
+*emit* or *read* a field/name but the server does not yet *carry* it or
+*authenticate* the request over the `x-sandbox-token` sandbox credential.
+
+Until these land the agent side **degrades gracefully**: threaded replies
+render top-level, names render as `@slug`. Nothing on the agent crashes —
+every reader uses `.get()` with a benign fallback and every enrichment
+helper returns empty/None offline. This doc is the checklist for closing
+those gaps on the server; no agent change is required when they land
+(the field names and query shapes below are already what the agent
+emits/reads).
+
+Scope note: the agent side of all of this is done. This run does **not**
+build a token-authed REST client — per the audit below there is currently
+**no** `x-sandbox-token`-authenticated REST route to call, so there is
+nothing to route through. The signed `crypto/http_client` stays retired
+on the bridge path; these routes are the server work that would give the
+agent something to call.
+
+---
+
+## 1. Inbound `Message` frame — missing thread + display fields
+
+**Frame:** `AgentServerMsg::Message` (`puffo-server` `.../bridge.rs`),
+emitted to the cloud-agent WS on inbound delivery. On every branch checked
+(`dev`, `cloud-agent-channel-frame`, `cloud-agent-send-threading`) it emits
+only:
+
+```
+envelope_id, sender_slug, space_id, channel_id,
+recipient_slug, sent_at, plaintext
+```
+
+**Add these fields to the frame:**
+
+| Field | Agent caller (already reads it) | Effect once present |
+| --- | --- | --- |
+| `thread_root_id` | `_payload_from_bridge_frame` (`puffo_core_client.py`) — maps `frame.get("thread_root_id")` onto `MessagePayload.thread_root_id` | inbound replies render/store as threaded instead of top-level |
+| `reply_to_id` | `_payload_from_bridge_frame` — maps `frame.get("reply_to_id")` onto `MessagePayload.reply_to_id` | reply linkage surfaces on the stored row |
+| `sender_display_name` (+ optional `avatar_url`) | `_preseed_frame_display_name` → `set_profile(...)` → `_handle_plaintext_payload`'s `_fetch_display_name` cache hit | sender renders by name with **no** HTTP lookup |
+
+Notes:
+
+- The agent reads `thread_root_id` / `reply_to_id` **today** and runs them
+  through the strict same-channel `_validate_incoming_parent_id` admit
+  check before storage, so a populated frame is honored the instant the
+  server adds the fields — forward-compatible, no agent change.
+- `sender_display_name` is read defensively (`sender_display_name` first,
+  then `display_name`); either key works. A non-empty value pre-seeds the
+  profile cache so the render path fires no `/identities/profiles` GET.
+- The **outbound** half of threading (`AgentClientMsg::Send` carrying
+  `reply_to_id` / `thread_root_id`) is a separate server branch
+  (`fleet/cloud-agent-send-threading`, `bridge.rs`). The agent already
+  emits both snake_case field names on the `send` frame; the server only
+  has to accept + persist them.
+
+---
+
+## 2. `GET /identities/profiles?slugs=<slug>` — needs an `x-sandbox-token` read variant
+
+**Agent caller:** `_fetch_user_profile` / `_fetch_display_name`
+(`puffo_core_client.py`), for `sender_display_name` on every inbound
+render, plus the MCP `whoami` / profile tools.
+
+**Today:** signed-auth only (`puffo-server` `.../lib.rs`). The sandbox token
+authenticates **only** the cloud-agent control WS
+(`/v2/cloud-agents/subscribe`, `v2/router.rs`), not this REST route. Over
+the bridge the agent's `http` has no signing key, so the call degrades to
+empty and the name renders as `@slug`.
+
+**Add:** an `x-sandbox-token`-authenticated read variant returning
+`{ profiles: [{ slug, display_name, avatar_url }] }` (same body shape the
+signed route returns). Until then, the frame-carried `sender_display_name`
+in §1 is the only name source on the keyless path.
+
+---
+
+## 3. `GET /spaces/{space_id}/channels` — needs an `x-sandbox-token` read variant
+
+**Agent caller:** `_resolve_channel_name` (`puffo_core_client.py`) — turns a
+`ch_<uuid>` into a human channel name for the `channel:` prompt line.
+
+**Today:** signed-auth only (`membership.rs` / `space_config.rs`). Keyless →
+the channel renders as its raw id.
+
+**Add:** an `x-sandbox-token` read variant returning the space's channel
+list (`{ channels: [{ id, name, ... }] }`). There is **no** frame-carried
+channel-name source, so this route is the only fix.
+
+---
+
+## 4. `GET /spaces/{space_id}/members` — needs an `x-sandbox-token` read variant
+
+**Agent caller:** `_get_space_members` (`puffo_core_client.py`) — scopes
+`@mention` resolution + the `is_bot` flag to real space members.
+Relatedly, `_resolve_space_name` needs a `GET /spaces` read variant to
+turn `space_id` into a space name.
+
+**Today:** signed-auth only (`membership.rs`). Keyless → mentions can't be
+scoped to members and the space renders as its raw id.
+
+**Add:** an `x-sandbox-token` read variant of `GET /spaces/{space_id}/members`
+(`{ members: [{ slug, role }] }`) and of `GET /spaces`
+(`{ spaces: [{ id, name }] }`). No frame-carried source exists for either.
+
+---
+
+## Summary — what closes each gap
+
+| Gap | Fix | Home |
+| --- | --- | --- |
+| inbound thread ids (`thread_root_id`, `reply_to_id`) | add to `Message` frame | `bridge.rs` (`fleet/cloud-agent-sandbox-token-auth`) |
+| inbound sender name (`sender_display_name`, `avatar_url`) | add to `Message` frame | `bridge.rs` |
+| outbound thread ids | accept `reply_to_id`/`thread_root_id` on `Send` | `fleet/cloud-agent-send-threading` (`bridge.rs`) |
+| sender display name (fallback) | token-read `/identities/profiles` | `lib.rs` |
+| channel name | token-read `/spaces/{space_id}/channels` | `membership.rs` / `space_config.rs` |
+| space members + names | token-read `/spaces/{space_id}/members`, `/spaces` | `membership.rs` |
+
+`fleet/cloud-agent-sandbox-token-auth` is the likely future home branch for
+the token-authed read routes; the frame additions may co-land there or with
+the threading branch. All of it is server-side — the agent already emits and
+reads the names above and degrades gracefully until they arrive.

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -212,10 +212,16 @@ class CloudBridgeClient:
         recipient_slug: Optional[str] = None,
         space_id: Optional[str] = None,
         channel_id: Optional[str] = None,
+        reply_to_id: Optional[str] = None,
+        thread_root_id: Optional[str] = None,
         timeout: float = 30.0,
     ) -> dict:
         # Pass EITHER recipient_slug (DM) OR space_id+channel_id
         # (channel); spec rejects mixed-shape frames as BAD_FRAME.
+        # ``reply_to_id`` / ``thread_root_id`` are route-agnostic thread
+        # linkage — the same snake_case field names a human/web message
+        # carries; added only when truthy so a top-level post stays
+        # shape-identical to the pre-threading frame.
         ws = await self._require_ws()
         client_ref = f"r_{uuid.uuid4().hex[:12]}"
         frame: dict[str, Any] = {
@@ -229,6 +235,10 @@ class CloudBridgeClient:
             frame["space_id"] = space_id
         if channel_id:
             frame["channel_id"] = channel_id
+        if reply_to_id:
+            frame["reply_to_id"] = reply_to_id
+        if thread_root_id:
+            frame["thread_root_id"] = thread_root_id
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._send_acks[client_ref] = fut
         await ws.send_json(frame)

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -810,6 +810,16 @@ class PuffoCoreMessageClient:
             try:
                 payload = self._payload_from_bridge_frame(frame)
                 if payload is not None:
+                    # Enrichment over the keyless path: the only sender
+                    # name achievable today is one the frame itself
+                    # carries. When present, pre-seed the profile cache so
+                    # the downstream ``_fetch_display_name`` is a cache hit
+                    # and fires NO HTTP (the signed /identities/profiles
+                    # route can't authenticate keyless — see the phase-2.5
+                    # gaps doc). Absent → the helper degrades to @slug as
+                    # before. Native frames never carry this, so their
+                    # path is untouched.
+                    self._preseed_frame_display_name(frame, payload)
                     await self._handle_plaintext_payload(payload)
             except Exception:
                 self._log.exception(
@@ -828,6 +838,45 @@ class PuffoCoreMessageClient:
             )
         else:
             self._log.debug("bridge frame ignored: type=%s", kind)
+
+    def _preseed_frame_display_name(
+        self, frame: dict, payload: MessagePayload,
+    ) -> None:
+        """If a bridge ``message`` frame carries the sender's display
+        name, prime the profile cache so the render path uses it with no
+        HTTP lookup.
+
+        This is the one enrichment the keyless wire permits today: the
+        Message frame has ``sender_slug`` but the signed profile route
+        (`/identities/profiles`) can't authenticate over the sandbox
+        token, so a name that isn't on the frame degrades to ``@slug``.
+        Reads defensively — ``sender_display_name`` first, then
+        ``display_name`` — and only seeds a non-empty name for a known
+        slug, so an absent/blank field leaves the cache untouched (never
+        pinning a false miss). ``avatar_url`` rides along when present.
+        Fail-soft: any error is swallowed so a malformed frame can't
+        break inbound delivery.
+        """
+        try:
+            slug = payload.sender_slug
+            if not slug:
+                return
+            name = (
+                frame.get("sender_display_name")
+                or frame.get("display_name")
+                or ""
+            )
+            name = name.strip() if isinstance(name, str) else ""
+            if not name:
+                return
+            avatar_url = frame.get("avatar_url") or ""
+            avatar_url = avatar_url.strip() if isinstance(avatar_url, str) else ""
+            self.set_profile(slug, name, avatar_url)
+        except Exception:
+            self._log.debug(
+                "bridge display-name pre-seed skipped (envelope_id=%s)",
+                frame.get("envelope_id"), exc_info=True,
+            )
 
     async def _handle_plaintext_payload(self, payload: MessagePayload) -> None:
         """Persist + surface a decoded message payload to the agent.
@@ -3819,8 +3868,11 @@ class PuffoCoreMessageClient:
             # crypto and fans out recipients. Empty channel_id ⇒ DM back
             # to the last DM sender; else a channel post (space resolved
             # from the same caches native uses). No encrypt_message /
-            # signed POST. Threaded ``root_id`` isn't wired on bridge yet
-            # (phase 3) — this replies top-level.
+            # signed POST. Threaded ``root_id`` rides the same snake_case
+            # ``thread_root_id`` / ``reply_to_id`` field names native
+            # stamps onto ``EncryptInput`` — passed unresolved (native's
+            # fallback path does too), so a reply threads under the id the
+            # daemon already validated on the inbound envelope.
             if channel_id:
                 target_space_id = self._channel_space.get(channel_id)
                 if not target_space_id:
@@ -3839,6 +3891,8 @@ class PuffoCoreMessageClient:
                     plaintext=text,
                     space_id=target_space_id,
                     channel_id=channel_id,
+                    thread_root_id=root_id or None,
+                    reply_to_id=root_id or None,
                 )
                 self._log.info(
                     "send_fallback_message[bridge] sent: kind=channel "
@@ -3854,7 +3908,10 @@ class PuffoCoreMessageClient:
                 )
                 return
             ack = await self._bridge.send_send(
-                plaintext=text, recipient_slug=recipient,
+                plaintext=text,
+                recipient_slug=recipient,
+                thread_root_id=root_id or None,
+                reply_to_id=root_id or None,
             )
             self._log.info(
                 "send_fallback_message[bridge] sent: kind=dm recipient=%s "

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -455,34 +455,52 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # T23 bridge transport: send plaintext; the server holds all
             # crypto and fans out recipients. DM ('@slug') vs channel
             # ('ch_') routing only — no device-key fetch, no encrypt, no
-            # signed POST. Threaded replies aren't wired on bridge yet
-            # (phase 3), so a non-empty root_id sends top-level with a note.
-            root_note = ""
-            if root_id:
-                root_note = (
-                    " (note: threaded replies aren't wired on bridge "
-                    "transport yet — sent as a top-level post)"
-                )
+            # signed POST. Threaded replies carry the same snake_case
+            # ``thread_root_id`` / ``reply_to_id`` field names a human/web
+            # message uses: ``thread_root_id`` is the resolved+validated
+            # true root (same resolvers the native branch runs, driven off
+            # the local store — no network), ``reply_to_id`` is the raw
+            # parent id the agent passed. Resolution is fail-soft — a miss
+            # falls through with a note and the send still completes.
             if channel_ref.startswith("@"):
                 bridge_recipient = channel_ref[1:]
                 if not bridge_recipient:
                     raise RuntimeError("DM recipient slug is required after '@'")
+                resolved_root, root_note = await _resolve_root_id(
+                    root_id, cfg.data_client,
+                )
+                resolved_root, validate_note = await _validate_root_same_channel(
+                    resolved_root, None, None, cfg.data_client,
+                )
                 ack = await cfg.bridge_client.send_send(
-                    plaintext=text, recipient_slug=bridge_recipient,
+                    plaintext=text,
+                    recipient_slug=bridge_recipient,
+                    thread_root_id=resolved_root or None,
+                    reply_to_id=root_id or None,
                 )
             else:
                 bridge_channel_id = channel_ref
                 bridge_space_id = await _resolve_channel_space(
                     cfg, bridge_channel_id,
                 )
+                resolved_root, root_note = await _resolve_root_id(
+                    root_id, cfg.data_client,
+                )
+                resolved_root, validate_note = await _validate_root_same_channel(
+                    resolved_root, bridge_channel_id, bridge_space_id,
+                    cfg.data_client,
+                )
                 ack = await cfg.bridge_client.send_send(
                     plaintext=text,
                     space_id=bridge_space_id,
                     channel_id=bridge_channel_id,
+                    thread_root_id=resolved_root or None,
+                    reply_to_id=root_id or None,
                 )
             return (
                 f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
                 f"{root_note}"
+                f"{validate_note}"
             )
 
         if channel_ref.startswith("@"):

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -80,13 +80,16 @@ class FakeBridge:
 
     async def send_send(
         self, *, plaintext, recipient_slug=None, space_id=None,
-        channel_id=None, timeout: float = 30.0,
+        channel_id=None, reply_to_id=None, thread_root_id=None,
+        timeout: float = 30.0,
     ) -> dict:
         self.sent.append({
             "plaintext": plaintext,
             "recipient_slug": recipient_slug,
             "space_id": space_id,
             "channel_id": channel_id,
+            "reply_to_id": reply_to_id,
+            "thread_root_id": thread_root_id,
         })
         return dict(self._ack)
 
@@ -425,19 +428,278 @@ async def test_b_send_message_channel_uses_bridge_no_encrypt(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_b_send_message_threaded_note_on_bridge(tmp_path):
-    """root_id isn't wired on bridge yet — send top-level with a note."""
+async def test_b_send_message_channel_threads_on_bridge(tmp_path):
+    """root_id now threads on bridge (replaces the old top-level-note
+    test). ``send_send`` carries ``thread_root_id`` = the resolved TRUE
+    root of ``root_id`` and ``reply_to_id`` = the raw id the agent
+    passed. Seed a root + a reply so resolution makes a real hop
+    (resolved root != passed id), proving the resolver ran."""
     ms = MessageStore(str(tmp_path / "b_thread.db"))
+    await ms.mark_channel_space("ch_xyz", "sp_1")
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_xyz",
+        "space_id": "sp_1", "content": "root",
+        "sent_at": 1_700_000_000_000,
+        "thread_root_id": None, "reply_to_id": None,
+    })
+    await ms.store({
+        "envelope_id": "msg_reply", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_xyz",
+        "space_id": "sp_1", "content": "a reply",
+        "sent_at": 1_700_000_000_001,
+        "thread_root_id": "msg_root", "reply_to_id": "msg_root",
+    })
     bridge = FakeBridge()
     cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
     tools = build_dispatch(cfg)
 
     result = await tools["send_message"](
-        channel="@alice-0001", text="reply", root_id="msg_parent",
+        channel="ch_xyz", text="reply", root_id="msg_reply",
     )
     assert len(bridge.sent) == 1
-    assert "top-level" in result.lower() or "phase 3" in result.lower() \
-        or "not wired" in result.lower()
+    sent = bridge.sent[0]
+    # Resolved to the true root, not the intermediate reply id.
+    assert sent["thread_root_id"] == "msg_root"
+    # Raw parent id the agent passed rides reply_to_id.
+    assert sent["reply_to_id"] == "msg_reply"
+    assert sent["space_id"] == "sp_1"
+    assert sent["channel_id"] == "ch_xyz"
+    # No stale "top-level" / "not wired" note — threading is live now.
+    assert "top-level" not in result.lower()
+    assert "not wired" not in result.lower()
+    assert "msg_bridgeack" in result
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_dm_threads_on_bridge(tmp_path):
+    """DM route of ``send_message`` also threads. With the DM root seeded
+    locally, resolution + same-channel validation keep it, so both
+    ``thread_root_id`` and ``reply_to_id`` carry it — proving the DM
+    branch is wired, not silently dropping the ids."""
+    ms = MessageStore(str(tmp_path / "b_dm_thread.db"))
+    # Seed a real DM root so thread_root_id survives validation.
+    await ms.store({
+        "envelope_id": "dm_root", "envelope_kind": "dm",
+        "sender_slug": "alice-0001", "channel_id": None,
+        "space_id": None, "recipient_slug": "bot-0001",
+        "content": "root dm", "sent_at": 1_700_000_000_002,
+        "thread_root_id": None, "reply_to_id": None,
+    })
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](
+        channel="@alice-0001", text="reply", root_id="dm_root",
+    )
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["recipient_slug"] == "alice-0001"
+    assert sent["thread_root_id"] == "dm_root"
+    assert sent["reply_to_id"] == "dm_root"
+    assert "msg_bridgeack" in result
+
+
+@pytest.mark.asyncio
+async def test_send_fallback_message_threads_on_bridge(tmp_path):
+    """``send_fallback_message`` passes ``root_id`` through as BOTH
+    ``thread_root_id`` and ``reply_to_id`` on the bridge, for the channel
+    route and the DM route (native's fallback path threads unresolved
+    too)."""
+    bridge = FakeBridge()
+    client = _bridge_client(tmp_path, bridge, db="fallback_thread.db")
+    await client.store.mark_channel_space("ch_a", "sp_1")
+
+    # channel route
+    await client.send_fallback_message("ch_a", "chan reply", root_id="msg_root")
+    # DM route: stash a DM sender so empty channel_id routes to them.
+    client._last_dm_sender = "carol-0001"
+    await client.send_fallback_message("", "dm reply", root_id="msg_root2")
+
+    assert len(bridge.sent) == 2
+    chan = bridge.sent[0]
+    assert chan["channel_id"] == "ch_a" and chan["space_id"] == "sp_1"
+    assert chan["thread_root_id"] == "msg_root"
+    assert chan["reply_to_id"] == "msg_root"
+    dm = bridge.sent[1]
+    assert dm["recipient_slug"] == "carol-0001"
+    assert dm["thread_root_id"] == "msg_root2"
+    assert dm["reply_to_id"] == "msg_root2"
+
+
+@pytest.mark.asyncio
+async def test_inbound_thread_ids_surface_on_stored_row(tmp_path):
+    """IN: an inbound ``message`` frame carrying
+    ``thread_root_id``/``reply_to_id`` yields a stored row with those ids
+    populated. The parent root arrives on the same connection (same
+    channel) so the strict admit-time ``_validate_incoming_parent_id``
+    check keeps them instead of wiping to None."""
+    scripted = [
+        {
+            "type": "message", "envelope_id": "env_root_in",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_100, "plaintext": "root",
+        },
+        {
+            "type": "message", "envelope_id": "env_reply_in",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_200, "plaintext": "threaded inbound",
+            "thread_root_id": "env_root_in", "reply_to_id": "env_root_in",
+        },
+    ]
+    bridge = FakeBridge(scripted=scripted)
+    client = _bridge_client(tmp_path, bridge, db="in_thread.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        if any(m.get("envelope_id") == "env_reply_in" for m in batch):
+            done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    row = await client.store.get_message_by_envelope("env_reply_in")
+    assert row is not None
+    assert row.thread_root_id == "env_root_in"
+    assert row.reply_to_id == "env_root_in"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_prefers_frame_display_name_no_http(tmp_path):
+    """c-1: when the inbound frame carries a sender display name, the
+    rendered ``sender_display_name`` uses it and NO
+    ``/identities/profiles`` GET is made (the pre-seed makes
+    ``_fetch_display_name`` a cache hit)."""
+    calls: list[str] = []
+
+    async def _recording_get(path, *a, **k):
+        calls.append(path)
+        return {}
+
+    bridge = FakeBridge(scripted=[{
+        "type": "message", "envelope_id": "env_named",
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_000_300, "plaintext": "hi",
+        "sender_display_name": "Alice Cooper",
+    }])
+    client = _bridge_client(tmp_path, bridge, db="enrich_named.db")
+    client.http.get = _recording_get  # type: ignore[method-assign]
+
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    named = [m for m in surfaced[0] if m["envelope_id"] == "env_named"][0]
+    assert named["sender_display_name"] == "Alice Cooper"
+    # No /identities/profiles GET at all — resolution came off the frame.
+    assert not any("identities/profiles" in p for p in calls), calls
+    # The pre-seed actually populated the profile cache.
+    assert client._profile_cache.get("alice-0001", (None,))[0] == "Alice Cooper"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_degrades_without_frame_name(tmp_path):
+    """c-2: without a frame-carried name the helpers degrade to an empty
+    display name (render falls back to @slug) and never raise."""
+    bridge = FakeBridge(scripted=[{
+        "type": "message", "envelope_id": "env_unnamed",
+        "sender_slug": "bob-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_000_400, "plaintext": "hi",
+        # no sender_display_name on the frame
+    }])
+    client = _bridge_client(tmp_path, bridge, db="enrich_unnamed.db")
+
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    named = [m for m in surfaced[0] if m["envelope_id"] == "env_unnamed"][0]
+    assert named["sender_display_name"] == ""  # degraded
+    assert named["sender_slug"] == "bob-0001"
+
+
+def test_preseed_frame_display_name_unit(tmp_path):
+    """Focused: the pre-seed helper seeds a non-empty frame name for a
+    known slug, and leaves the cache untouched when the name is
+    absent/blank or the slug is missing (never pins a false miss)."""
+    client = _bridge_client(tmp_path, FakeBridge(), db="preseed.db")
+
+    from puffo_agent.crypto.message import MessagePayload as _MP
+
+    def _payload(slug):
+        return _MP(
+            payload_type="message", version=1, envelope_id="e",
+            envelope_kind="channel", sender_slug=slug, sender_subkey_id="",
+            sent_at=1, message_nonce="", content_type="text/plain",
+            content="x", is_visible_to_human=True, space_id="sp_1",
+            channel_id="ch_a", recipient_slug=None,
+        )
+
+    # present → seeds
+    client._preseed_frame_display_name(
+        {"sender_display_name": "Alice Cooper", "avatar_url": "http://a/x.png"},
+        _payload("alice-0001"),
+    )
+    assert client._profile_cache["alice-0001"][0] == "Alice Cooper"
+    assert client._profile_cache["alice-0001"][1] == "http://a/x.png"
+
+    # blank name → cache untouched
+    client._preseed_frame_display_name(
+        {"sender_display_name": "   "}, _payload("bob-0001"),
+    )
+    assert "bob-0001" not in client._profile_cache
+
+    # absent name → cache untouched
+    client._preseed_frame_display_name({}, _payload("dave-0001"))
+    assert "dave-0001" not in client._profile_cache
+
+    # missing slug → no crash, nothing seeded
+    client._preseed_frame_display_name(
+        {"sender_display_name": "Nobody"}, _payload(""),
+    )
+    assert "" not in client._profile_cache
+
+    # fallback key `display_name` also works
+    client._preseed_frame_display_name(
+        {"display_name": "Eve X"}, _payload("eve-0001"),
+    )
+    assert client._profile_cache["eve-0001"][0] == "Eve X"
+
+
+def test_phase25_gap_doc_names_all_routes():
+    """c-2 (doc): the phase-2.5 server-gaps doc exists and names the
+    inbound Message frame (thread ids + display name) plus the three
+    token-read REST routes the keyless enrichment path needs."""
+    from pathlib import Path
+
+    doc = (
+        Path(__file__).resolve().parents[1]
+        / "roadmap" / "cloud-agent" / "PHASE25-SERVER-ROUTE-GAPS.md"
+    )
+    assert doc.is_file(), f"missing gap doc: {doc}"
+    text = doc.read_text(encoding="utf-8")
+    # Inbound Message frame + the fields the agent already reads/pre-seeds.
+    assert "Message" in text
+    assert "thread_root_id" in text and "reply_to_id" in text
+    assert "sender_display_name" in text
+    # The three token-auth REST read routes.
+    assert "identities/profiles" in text
+    assert "/spaces/{space_id}/channels" in text
+    assert "/spaces/{space_id}/members" in text
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What (stacks on #136)

Finishes the two metadata deferrals from phase-2, forward-compatibly. `native` transport unchanged; no crypto module deleted.

- **Threads**: bridge `send_message` + `send_fallback_message` emit `reply_to_id` + `thread_root_id` into the `Send` frame (via `CloudBridgeClient.send_send`), mirroring native's field name + root resolution (local `data_client`, no network). Inbound `_payload_from_bridge_frame` already reads them (phase-2). **Forward-compatible**: the server `Send`/`Message` thread fields live on `fleet/cloud-agent-send-threading` — agent emit is harmless until that lands.
- **Name enrichment over keyless**: prefer bridge-frame-carried sender data (no HTTP), else existing `x-sandbox-token` routes; every endpoint with no token route stays **fail-soft** (id fallback) and is recorded in `PHASE25-SERVER-ROUTE-GAPS.md` as the spec for a future puffo-server `phase-2.5-server` run.

## Verify
LLM-free + E2B-free pytest incl. **native-transport-unchanged** assertions. Full suite green.

**Stacked on `fleet/fatcloud-phase2-msgflow` (#136). HOLD — do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)