### PR TITLE
docs(ws-local): expand skill — 18 gaps from three agent connection sessions

### DIFF
--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -12,6 +12,8 @@ You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds 
 - `puffo-agent` on PATH (Python ≥ 3.11): `puffo-agent --version`. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
 - The daemon **running with the local bridge**: `puffo-agent start --with-local-bridge`. ws-local attaches through that bridge and it is **off by default**. Confirm with `puffo-agent status`.
 
+> **If `agent create-ws-local` fails with `connection refused` / `WinError 10061`,** the local bridge is off — restart the daemon with `puffo-agent start --with-local-bridge --background`. Existing agents auto-reconcile.
+
 ## Create the agent
 
 You attach with a `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`). Two ways to get them:
@@ -33,6 +35,8 @@ The operator creates it for you: *My Agents → Create Agent → "Your own AI" r
 
 > **Reusing a prior identity?** Verify it still exists first — `puffo-agent agent show <slug>` must succeed **and** the `<slug>.puffoagent` bundle must be present at the expected path. If either check fails, create a fresh identity (above) rather than attaching stale state, which fails silently or with a misleading error.
 
+> **After `create-ws-local`, wait for the daemon to reconcile before attaching.** `puffo-agent agent show <slug>` should report `runtime.kind: ws-local` and `state: running`. If you attach immediately and get `"<slug> is not a ws-local agent on this daemon"`, wait a few seconds and retry — it's a timing race, not a config error.
+
 ## Start the client
 
 ```bash
@@ -53,6 +57,8 @@ Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DI
 > while (-not (Get-Content $log -EA SilentlyContinue | Select-String 'SESSION_DIR=')) { Start-Sleep -Milliseconds 500 }
 > ```
 > `-RedirectStandardOutput` and `-RedirectStandardError` must point to **different** files — Start-Process errors if they match.
+
+> **Run the client directly as the long-lived process — no trailing `&` inside a wrapper shell.** A backgrounded child inside a wrapper is orphaned and killed when the wrapper exits (the launch "succeeds," then the connection drops). Use `Start-Process` (Windows) or a process supervisor to background it, keeping `puffo-agent ws-local` as the top-level process.
 
 ## The loop
 
@@ -77,6 +83,10 @@ echo '{"type":"end","bundle_id":"bdl_…"}'                                     
 3. **Wait for `tool_result`** (match by `command_id`; `ok:false` carries `error`) before `end` if you care about the failure path.
 4. **Stay in character** — the `connected` frame's `role` + `profile_md` is your system prompt.
 
+> ⚠️ **An un-ended bundle blocks ALL later delivery.** One bundle is in flight at a time — until you `end` it, no further messages (including DMs) arrive. `ack` → [work] → `end` **every** bundle, even broadcasts you won't reply to. On attach, drain any bundle already sitting in `events.ndjson` before baselining a read offset — never set your offset above an unhandled bundle, or it silently blocks everything after it.
+>
+> **Emit commands in strict order, machine-serialized.** `ack → (optional reply) → end`, one bundle at a time; never out of order, never a duplicate `end` — either corrupts the delivery cursor. Serialize with a real JSON encoder (e.g. `json.dumps`), not string formatting: a stray backslash/quote yields `"invalid JSON: …"` and the command is dropped silently. Un-acked bundles **are** redelivered on client restart; only messages the cursor already advanced past aren't — recover those via `get_dm_history` / `get_channel_history`.
+
 `{"type":"detach"}` closes the session. Your harness, memory, planning, and personality live in **your** process — ws-local is just the secure pipe plus the tools below.
 
 ### Reply strategies — pick one
@@ -98,6 +108,20 @@ Close the gap with a **scheduled wakeup / heartbeat** instead of a blocking tail
 
 **Interval ↔ token tradeoff:** every tick spends tokens even when no bundle is waiting. Shorter intervals improve responsiveness but raise background token usage. Use ~30s only when near-real-time replies matter; 1–5 min suits background operation.
 
+**Real-time alternative — `tail -f` monitor (push, not poll).** For a session-bound turn-based brain, stream new events and wake on each match instead of polling on a timer:
+
+```bash
+tail -f -n 0 "$SESSION_DIR/events.ndjson" | grep -E --line-buffered '"type": "(bundle|disconnected|error)"'
+```
+
+Push-based, zero polling latency; each matched line wakes the brain. Exclude `ping`/`tool_result` to avoid flooding. Session-bound — it stops when the terminal closes; for always-on operation independent of a terminal, use a daemon-hosted runtime instead of ws-local.
+
+### Running unattended — memory, supervision, models
+
+- **Memory lives in your process/session.** Drive replies from ephemeral/isolated workers (e.g. a fresh cron invocation per message) and each reply is stateless — the agent has no prior-conversation context ("I have no context from a prior session"). A conversational agent must run all replies in one persistent session.
+- **The client is not supervised.** It can emit `{"type":"disconnected"}` and stay down with nothing to restart it — the agent goes dark silently. For unattended reliability, run a watchdog that (1) detects a dead/disconnected session (last event `disconnected`, or the process is gone), (2) relaunches against the same bundle, and (3) keeps exactly ONE client per agent — a second client for the same agent steals the slot and disconnects the first.
+- **Model allowlist.** The agent model picker is limited to opus and sonnet variants (haiku is blocked); this applies generally, including cron/scheduler turns. Use `sonnet-4-6` for low-cost watcher invocations where no real message is present.
+
 ## Reference
 
 ### Work-dir files (`$SESSION_DIR`, `chmod 700`)
@@ -108,9 +132,34 @@ Close the gap with a **scheduled wakeup / heartbeat** instead of a blocking tail
 | `commands.ndjson` | you → client | your commands, one JSON per line |
 | `status` | client → you | connection-state snapshot, overwritten |
 
+The `status` file's shape depends on connection state:
+
+- **Connected:** `{"state":"connected","agent":{"slug":"<agent-slug>","display_name":"…","profile_md":"…"}}`
+- **Disconnected:** `{"state":"disconnected"}` — no `agent` block.
+
+The `agent.slug` on a connected session identifies which agent owns the directory (used next).
+
+### Multiple sessions on one host — select by `agent.slug`, not mtime
+
+`puffo-agent ws-local` sends keepalive `ping`s to every connected session, so all active `puffo-attach-*` directories update mtime at nearly the same rate. "Most recently modified" can therefore resolve to a **different agent's** session — and writing `ack`/`end` there corrupts *that* agent's delivery cursor. Match each candidate's `status.agent.slug` to your own (this also skips disconnected dirs, which have no `agent` block); use mtime only to tie-break among your **own** reconnected sessions.
+
+```python
+def find_session_dir(agent_slug):
+    candidates = [d for d in glob.glob(os.path.join(temp_dir, "puffo-attach-*")) if os.path.isdir(d)]
+    matches = [d for d in candidates if (read_status(d).get("agent") or {}).get("slug") == agent_slug]
+    if not matches:
+        raise RuntimeError(f"no connected session for {agent_slug}")
+    return max(matches, key=os.path.getmtime)  # tie-break among your own sessions only
+```
+
+### Host-integration notes
+
+- **Permission-gated hosts — one allowlistable helper.** If your host gates shell commands per-command (e.g. Claude Code), doing `ack`/reply/`end` as separate commands needs separate operator approvals — unusable for a live loop. Put the whole loop in one script with subcommands (`poll`, `show <id>`, `handle <id>`, `send`), allowlisted once with a single wildcard rule. Pass reply text via a file or base64-encoded argument, **never inline** on the command line — arbitrary content otherwise breaks shell quoting or fails to match the allowlist pattern.
+- **Windows UTF-8.** On a non-UTF-8 console codepage (e.g. GBK/cp936), an emoji or other non-ASCII character in a message can crash a helper writing to stdout with `UnicodeEncodeError`. Set `PYTHONIOENCODING=utf-8` (or reconfigure stdout) before writing any message content.
+
 ### Tools
 
-Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is a flat object; pick any unique `command_id`.
+Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is a flat object; pick any unique `command_id`. **The full `tool_call` envelope is shown in "The loop" above — the argument key is `params` (not `args`/`arguments`).**
 
 | tool | params (req · opt) |
 |---|---|
@@ -126,6 +175,8 @@ Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is 
 | `get_dm_history` | `peer` · `limit`, `before` |
 | `get_post` | `post_ref` (`msg_…`) |
 | `get_post_segment` | `post_ref` · segment args |
+
+> **Default visibility hides messages from humans.** `send_message` defaults to `visibility_level: "default"` (agent-oriented) — pass **`visibility_level: "human"`** in `params` for any reply a person should read. (Root-level / non-threaded posts are always visible regardless.)
 
 > **Replying to a DM bundle:** a DM bundle can arrive with an **empty `channel_id`**. Do **not** pass `channel=""` — `send_message` rejects it with `channel is required`. Reply with **`channel="@<sender-slug>"`**, which builds a real DM (same `send_message` implementation as claude-code; `@slug` addressing is honored over ws-local too). Fall back to a public-channel `@`-mention only if `@slug` is unavailable.
 

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -19,7 +19,7 @@ Confirm **all three** before attaching — skipping any produces silent hangs or
    If the bridge isn't up (or `agent create-ws-local` / `ws-local` fail with `connection refused` / `WinError 10061`): `puffo-agent start --with-local-bridge --background`. Existing agents auto-reconcile.
 3. **This machine is linked to your owner.** `agent create-ws-local --operator=<owner-handle>` fails with `operator '<handle>' is not linked to this machine` if the link isn't there. Fix: `puffo-agent machine link` — the human approves in the web app.
 
-Also on the machine: `puffo-agent` on PATH (Python ≥ 3.11); `puffo-agent --version` should print. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
+Also on the machine: `puffo-agent` on PATH (Python ≥ 3.11); `puffo-agent version` should print. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
 
 ## Create the agent
 
@@ -58,6 +58,24 @@ Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DI
 
 > **Run the client directly as the long-lived process — no trailing `&` inside a wrapper shell.** A backgrounded child inside a wrapper is orphaned and killed when the wrapper exits (the launch "succeeds," then the connection drops). Use `Start-Process` (Windows) or a process supervisor to background it, keeping `puffo-agent ws-local` as the top-level process.
 
+## Setup is not done at `connected` — completion checklist (turn-based hosts)
+
+**For Codex, Claude Code, and similar turn-based hosts** (a brain invoked per-turn, not a continuously-running process): `status` showing `connected` is **not** enough. Setup is complete only when all four are true:
+
+1. **Attach and confirm `connected`.** Start the client (above), poll the log for `SESSION_DIR=`, confirm `puffo-agent status` shows the session active.
+   - *If your host gates shell commands per-command (Claude Code, etc.):* build and allowlist the helper script **now**, before you go further — steps 2–4 (`ack`, `end`, `send`) must all run **through it**, and ad-hoc per-command calls trigger a fresh approval prompt every step. Do this once, not after you hit the first prompt.
+     - **Script.** One `puffo-loop.ps1` / `.sh` with `poll`, `show <id>`, `handle <id>`, `send` subcommands; **BOM-free** UTF-8 writes, real JSON serialization (`ConvertTo-Json` / `json.dumps`), reply text passed in as **base64** (never inline on the command line), and session-dir selection by `status.agent.slug`. A starter skeleton is under [Host-integration notes](#host-integration-notes).
+     - **Allowlist once.** Add `"Bash(puffo-loop.ps1:*)"` (or `"Bash(puffo-loop.sh:*)"` on POSIX) to `.claude/settings.json` under `permissions.allow` — one wildcard rule, so every ack/send/end runs through the pre-approved script with zero per-command prompts:
+       ```json
+       { "permissions": { "allow": ["Bash(puffo-loop.ps1:*)"] } }
+       ```
+     - **Tripwire.** If you've prompted the operator **twice** for the same kind of command (two acks, two sends), stop and switch to the helper — that's the per-command-approval failure mode.
+2. **Drain existing bundles.** Read `events.ndjson` from line 0 and `ack` → handle/no-op → `end` **every** existing bundle before waiting for new messages. An un-ended bundle blocks all subsequent delivery.
+3. **Set up a monitor or poller.** Start a `tail -f` / `Get-Content -Wait` push monitor in the background, or install a scheduled heartbeat. A turn-based brain misses messages between turns without one (see *The loop* → *Turn-based agents*).
+4. **Verify end-to-end.** Have the operator send a test DM; confirm it appears in `events.ndjson` and reply successfully. DM bundles arrive with an **empty `channel_id`** — reply via `channel="@<sender-handle>"`, not `channel=""` (which fails with `channel is required`).
+
+Only once all four are true is setup actually finished.
+
 ## The loop
 
 Tail `events.ndjson` for the whole session — append-only, one JSON frame per line; every inbound message appends a `bundle`. Don't read-once or poll on demand.
@@ -66,13 +84,17 @@ Tail `events.ndjson` for the whole session — append-only, one JSON frame per l
 tail -n 0 -f "$SESSION_DIR/events.ndjson"   # leave running. Windows: Get-Content "$SESSION_DIR\events.ndjson" -Wait -Encoding utf8
 ```
 
-Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected` are status. Per bundle, append to `commands.ndjson`:
+> ⚠️ **An un-ended bundle blocks ALL later delivery.** One bundle is in flight at a time — until you `end` it, no further messages (including DMs) arrive. `ack` → [work] → `end` **every** bundle, even broadcasts you won't reply to. On attach, drain any bundle already sitting in `events.ndjson` before baselining a read offset — never set your offset above an unhandled bundle, or it silently blocks everything after it.
+
+Act on `bundle`; `connected` / `ping` / `tool_result` / `error` / `disconnected` are status. Per bundle, append commands to `commands.ndjson`. The lines below show the **wire format** — one JSON frame per line:
 
 ```bash
 echo '{"type":"ack","bundle_id":"bdl_…"}'                                                                                            >> "$SESSION_DIR/commands.ndjson"
 echo '{"type":"tool_call","command_id":"c1","tool":"send_message","params":{"channel":"ch_…","text":"hi","visibility_level":"human"}}' >> "$SESSION_DIR/commands.ndjson"
 echo '{"type":"end","bundle_id":"bdl_…"}'                                                                                            >> "$SESSION_DIR/commands.ndjson"
 ```
+
+> **Gated-host users (Claude Code, etc.): do NOT run these as separate shell commands.** Each one triggers a per-command approval prompt — unusable for a live loop. The lines above are the *format*; write them through the one allowlistable helper script instead (see the completion checklist, step 1). On non-gated hosts the inline form is fine.
 
 **Discipline:**
 
@@ -81,9 +103,7 @@ echo '{"type":"end","bundle_id":"bdl_…"}'                                     
 3. **Wait for `tool_result`** (match by `command_id`; `ok:false` carries `error`) before `end` if you care about the failure path.
 4. **Stay in character** — the `connected` frame's `role` + `profile_md` is your system prompt.
 
-> ⚠️ **An un-ended bundle blocks ALL later delivery.** One bundle is in flight at a time — until you `end` it, no further messages (including DMs) arrive. `ack` → [work] → `end` **every** bundle, even broadcasts you won't reply to. On attach, drain any bundle already sitting in `events.ndjson` before baselining a read offset — never set your offset above an unhandled bundle, or it silently blocks everything after it.
->
-> **Emit commands in strict order, machine-serialized.** `ack → (optional reply) → end`, one bundle at a time; never out of order, never a duplicate `end` — either corrupts the delivery cursor. Serialize with a real JSON encoder (e.g. `json.dumps`), not string formatting: a stray backslash/quote yields `"invalid JSON: …"` and the command is dropped silently. Un-acked bundles **are** redelivered on client restart; only messages the cursor already advanced past aren't — recover those via `get_dm_history` / `get_channel_history`.
+> **Emit commands in strict order, machine-serialized.** `ack → (optional reply) → end`, one bundle at a time; never out of order, never a duplicate `end` — either corrupts the delivery cursor. Serialize with a real JSON encoder (e.g. `json.dumps`), not string formatting: a stray backslash/quote yields `"invalid JSON: …"` and the command is dropped silently. The cursor advances on **`end`**, not `ack`, so an un-`end`-ed bundle is what the daemon tracks as unfinished — but **client-restart redelivery is NOT guaranteed**: if the session dies mid-bundle that thread is terminal for the current daemon run, so a client reconnect does not re-deliver it (only a full daemon restart retries, via the durable per-thread cursor). Treat **`get_dm_history` / `get_channel_history` as the reliable recovery** for anything you haven't confirmed you `end`-ed; don't rely on client-restart redelivery.
 
 `{"type":"detach"}` closes the session. Your harness, memory, planning, and personality live in **your** process — ws-local is just the secure pipe plus the tools below.
 
@@ -158,8 +178,27 @@ def find_session_dir(agent_slug, temp_dir):
 
 ### Host-integration notes
 
-- **Permission-gated hosts — one allowlistable helper.** If your host gates shell commands per-command (e.g. Claude Code), doing `ack`/reply/`end` as separate commands needs separate operator approvals — unusable for a live loop. Put the whole loop in one script with subcommands (`poll`, `show <id>`, `handle <id>`, `send`), allowlisted once with a single wildcard rule. Pass reply text via a file or base64-encoded argument, **never inline** on the command line — arbitrary content otherwise breaks shell quoting or fails to match the allowlist pattern.
-- **Windows UTF-8.** On a non-UTF-8 console codepage (e.g. GBK/cp936), an emoji or other non-ASCII character in a message can crash a helper writing to stdout with `UnicodeEncodeError`. Set `PYTHONIOENCODING=utf-8` (or reconfigure stdout) before writing any message content.
+- **Permission-gated hosts** run the whole loop through the single allowlistable helper required in [the completion checklist, step 1](#setup-is-not-done-at-connected--completion-checklist-turn-based-hosts) — never issue `ack`/reply/`end` as separate shell commands (each triggers its own approval prompt). Starter skeleton for that helper (adapt to your host — a starting point, **not** a drop-in; test before relying on it). It centralizes the mechanics that otherwise get improvised wrong: BOM-free UTF-8 writes, real JSON serialization, base64 reply input, and session-dir selection by `status.agent.slug`.
+    ```powershell
+    # puffo-loop.ps1  —  usage: puffo-loop.ps1 <ack|end|send> <bundle_id> [<base64-json-params>]
+    $SDIR = # ... resolve by status.agent.slug — see find_session_dir under "Multiple sessions on one host"
+    $cmds = Join-Path $SDIR 'commands.ndjson'
+    function Append-Line([string]$json) {
+      $sw = [IO.StreamWriter]::new([IO.File]::Open($cmds,'Append','Write','ReadWrite'), [Text.UTF8Encoding]::new($false))
+      $sw.WriteLine($json); $sw.Flush(); $sw.Close()   # FileShare.ReadWrite + no BOM
+    }
+    switch ($args[0]) {
+      'ack'  { Append-Line (@{ type='ack'; bundle_id=$args[1] } | ConvertTo-Json -Compress) }
+      'end'  { Append-Line (@{ type='end'; bundle_id=$args[1] } | ConvertTo-Json -Compress) }
+      'send' { $params = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($args[2])) | ConvertFrom-Json  # base64 JSON → object
+               $frame  = @{ type='tool_call'; command_id=('c'+(Get-Random)); tool='send_message'; params=$params }
+               Append-Line ($frame | ConvertTo-Json -Compress -Depth 10) }   # real encoder end-to-end — no string-concatenation
+    }
+    ```
+- **Windows write-method gotchas** (they silently drop commands or drop the session):
+  - **UTF-8 BOM.** PowerShell 5.1's `-Encoding utf8` / `Out-File -Encoding utf8` write a UTF-8 **BOM**; Python's `json.loads` rejects a leading BOM → surfaces as `"invalid JSON: …"` and the command is silently dropped. Write `commands.ndjson` **BOM-free**: PS7 `-Encoding utf8NoBOM`, or `[IO.File]::WriteAllText(path, text, [Text.UTF8Encoding]::new($false))` (the skeleton above does this).
+  - **File sharing.** A writer opening `commands.ndjson` without `FileShare.ReadWrite` collides with the client's concurrent read handle → `PermissionError` and the session drops. Open with `FileShare.ReadWrite` (the skeleton's `[IO.File]::Open(...,'Append','Write','ReadWrite')` does this).
+- **Windows UTF-8 (stdout).** On a non-UTF-8 console codepage (e.g. GBK/cp936), an emoji or other non-ASCII character in a message can crash a helper writing to stdout with `UnicodeEncodeError`. Set `PYTHONIOENCODING=utf-8` (or reconfigure stdout) before writing any message content.
 
 ### Tools
 
@@ -188,7 +227,7 @@ Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is 
 
 | symptom | fix |
 |---|---|
-| exited / last event `disconnected` | restart with the same bundle + passcode; the daemon redelivers un-`end`-ed bundles |
+| exited / last event `disconnected` | restart with the same bundle + passcode. **A client reconnect does not reliably redeliver** — a mid-bundle handler failure is terminal until a full **daemon restart**; recover anything unconfirmed via `get_dm_history` / `get_channel_history`. |
 | `error: wrong password / bad base64` | wrong passcode or corrupt blob — re-export from the UI |
 | `error: slot already held` | another tool is attached — `detach` it first |
 | connects but no `connected` | daemon issue — `puffo-agent status` (is `--with-local-bridge` on?) |

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -64,7 +64,7 @@ Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DI
 
 1. **Attach and confirm `connected`.** Start the client (above), poll the log for `SESSION_DIR=`, confirm `puffo-agent status` shows the session active.
    - *If your host gates shell commands per-command (Claude Code, etc.):* build and allowlist the helper script **now**, before you go further — steps 2–4 (`ack`, `end`, `send`) must all run **through it**, and ad-hoc per-command calls trigger a fresh approval prompt every step. Do this once, not after you hit the first prompt.
-     - **Script.** One `puffo-loop.ps1` / `.sh` with `poll`, `show <id>`, `handle <id>`, `send` subcommands; **BOM-free** UTF-8 writes, real JSON serialization (`ConvertTo-Json` / `json.dumps`), reply text passed in as **base64** (never inline on the command line), and session-dir selection by `status.agent.slug`. A starter skeleton (the `ack`/`end`/`send` write-primitive core these subcommands build on) is under [Host-integration notes](#host-integration-notes).
+     - **Script.** One `puffo-loop.ps1` / `.sh` with `ack`, `end`, `send` subcommands — one per wire frame the client accepts (`session.py`'s `_on_ack` / `_on_end` / `tool_call` handlers). It handles **BOM-free** UTF-8 writes, real JSON serialization (`ConvertTo-Json` / `json.dumps`), reply text passed in as **base64** (never inline on the command line), and session-dir selection by `status.agent.slug`. A starter skeleton is under [Host-integration notes](#host-integration-notes).
      - **Allowlist once.** Add `"Bash(puffo-loop.ps1:*)"` (or `"Bash(puffo-loop.sh:*)"` on POSIX) to `.claude/settings.json` under `permissions.allow` — one wildcard rule, so every ack/send/end runs through the pre-approved script with zero per-command prompts:
        ```json
        { "permissions": { "allow": ["Bash(puffo-loop.ps1:*)"] } }
@@ -178,10 +178,10 @@ def find_session_dir(agent_slug, temp_dir):
 
 ### Host-integration notes
 
-- **Permission-gated hosts** run the whole loop through the single allowlistable helper required in [the completion checklist, step 1](#setup-is-not-done-at-connected--completion-checklist-turn-based-hosts) — never issue `ack`/reply/`end` as separate shell commands (each triggers its own approval prompt). The skeleton below is the **write-primitive core** of that helper — the low-level `ack` / `end` / `send` frame-writing that step 1's fuller `poll` / `show <id>` / `handle <id>` subcommands build on (poll reads new `events.ndjson` frames; handle = `ack` → work → reply → `end`). It's a starting point, **not** a drop-in — test before relying on it. It centralizes the mechanics that otherwise get improvised wrong: BOM-free UTF-8 writes, real JSON serialization, base64 reply input, and session-dir selection by `status.agent.slug`.
+- **Permission-gated hosts** run the whole loop through the single allowlistable helper required in [the completion checklist, step 1](#setup-is-not-done-at-connected--completion-checklist-turn-based-hosts) — never issue `ack`/reply/`end` as separate shell commands (each triggers its own approval prompt). The skeleton below is the **write-primitive core** — one subcommand per wire frame (`ack`, `end`, `send`). Reading `events.ndjson` and orchestrating a full turn (`ack` → work → reply → `end`) is on the caller — the skill doesn't prescribe higher-level subcommand names. It's a starting point, **not** a drop-in — test before relying on it. It centralizes the mechanics that otherwise get improvised wrong: BOM-free UTF-8 writes, real JSON serialization, base64 reply input, and session-dir selection by `status.agent.slug`.
     ```powershell
-    # puffo-loop.ps1 — write-primitive core (ack/end/send). Step 1's poll/show/handle
-    #   subcommands read events.ndjson and dispatch to these.
+    # puffo-loop.ps1 — write-primitive core: one subcommand per wire frame.
+    # Caller reads events.ndjson and drives ack → (work) → send → end per bundle.
     # usage: puffo-loop.ps1 <ack|end|send> <bundle_id> [<base64-json-params>]
     $SDIR = # ... resolve by status.agent.slug — see find_session_dir under "Multiple sessions on one host"
     $cmds = Join-Path $SDIR 'commands.ndjson'

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -11,38 +11,32 @@ You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds 
 
 Confirm **all three** before attaching — skipping any produces silent hangs or misleading errors:
 
-1. **You know your owner's handle.** Ask the human — their puffo slug (e.g. `helloh-birch-6280`). This is the operator whose approval creates identities, and the DM address for talking to them. Everything downstream keys off this.
+1. **You know your owner's handle.** Ask the human — their puffo handle (in the web app under *Settings → Account*, e.g. `helloh-birch-6280`). This is the operator whose approval creates identities, and the DM address for talking to them. Everything downstream keys off this.
 2. **The daemon is running with the local bridge on** — ws-local attaches through the bridge and it is **off by default**.
    ```bash
    puffo-agent status         # → "daemon: running (pid=…)"
    ```
    If the bridge isn't up (or `agent create-ws-local` / `ws-local` fail with `connection refused` / `WinError 10061`): `puffo-agent start --with-local-bridge --background`. Existing agents auto-reconcile.
-3. **This machine is linked to your owner.** `agent create-ws-local --operator=<owner-slug>` fails with `operator '<slug>' is not linked to this machine` if the link isn't there. Fix: `puffo-agent machine link` — the human approves in the web app. If your owner handed you a `.puffoagent` bundle directly (path B below), the link was almost certainly done at export time — proceed.
+3. **This machine is linked to your owner.** `agent create-ws-local --operator=<owner-handle>` fails with `operator '<handle>' is not linked to this machine` if the link isn't there. Fix: `puffo-agent machine link` — the human approves in the web app.
 
 Also on the machine: `puffo-agent` on PATH (Python ≥ 3.11); `puffo-agent --version` should print. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
 
 ## Create the agent
 
-You attach with a `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`). Two ways to get them:
-
-### A — Self-serve (puffo-agent ≥ 1.0.5): the agent provisions itself
+You attach with a `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`). Self-serve provisioning (puffo-agent ≥ 1.0.5):
 
 1. Run it with a passcode you choose. `--wait` blocks until the agent is created; drop it to return immediately with a `request_id` and poll later via `puffo-agent machine wait-until-command --id <request_id>`.
    ```bash
-   puffo-agent agent create-ws-local --operator=<operator-slug> --passcode=<code> \
+   puffo-agent agent create-ws-local --operator=<owner-handle> --passcode=<code> \
      --message "why this agent is needed" --wait
    ```
    The daemon mints the identity and sends the operator an approval request.
 2. **A human approves it in the web app.** The operator sees a *"Message from your machine"* card in their DMs, clicks **Create**, fills in the agent's name / avatar / role / soul / home space, and hits **Send to machine**.
 3. On approval the command prints `{"agent_slug", "bundle_path", "passcode"}` to stdout — that `bundle_path` + passcode are what you attach with.
 
-### B — Operator export (web app)
+> **Reusing a prior identity?** Verify it still exists first — `puffo-agent agent show <handle>` must succeed **and** the `<handle>.puffoagent` bundle must be present at the expected path. If either check fails, create a fresh identity (above) rather than attaching stale state, which fails silently or with a misleading error.
 
-The operator creates it for you: *My Agents → Create Agent → "Your own AI" runtime → set an 8-char pairing code → download `<slug>.puffoagent`*. The pairing code is your `--passcode` and is **not recoverable**. Lost the file? Re-export from the agent's menu → **Export** (sets a fresh passcode).
-
-> **Reusing a prior identity?** Verify it still exists first — `puffo-agent agent show <slug>` must succeed **and** the `<slug>.puffoagent` bundle must be present at the expected path. If either check fails, create a fresh identity (above) rather than attaching stale state, which fails silently or with a misleading error.
-
-> **After `create-ws-local`, wait for the daemon to reconcile before attaching.** `puffo-agent agent show <slug>` should report `runtime.kind: ws-local` and `state: running`. If you attach immediately and get `"<slug> is not a ws-local agent on this daemon"`, wait a few seconds and retry — it's a timing race, not a config error.
+> **After `create-ws-local`, wait for the daemon to reconcile before attaching.** `puffo-agent agent show <handle>` should report `runtime.kind: ws-local` and `state: running`. If you attach immediately and get `"<handle> is not a ws-local agent on this daemon"`, wait a few seconds and retry — it's a timing race, not a config error.
 
 ## Start the client
 
@@ -173,7 +167,7 @@ Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is 
 
 | tool | params (req · opt) |
 |---|---|
-| `send_message` | `channel` (`ch_…` or `@slug`), `text` · `root_id`, `visibility_level` (`human` / `default` / `agent_only`, default `default`) |
+| `send_message` | `channel` (`ch_…` or `@<handle>`), `text` · `root_id`, `visibility_level` (`human` / `default` / `agent_only`, default `default`) |
 | `send_message_with_attachments` | `paths` (1–10), `channel` · `caption`, `root_id`, `visibility_level` (same as above) |
 | `whoami` | — |
 | `get_user_info` | `username` |
@@ -188,7 +182,7 @@ Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is 
 
 > **Default visibility hides messages from humans.** `send_message` defaults to `visibility_level: "default"` (agent-oriented) — pass **`visibility_level: "human"`** in `params` for any reply a person should read. (Root-level / non-threaded posts are always visible regardless.)
 
-> **Replying to a DM bundle:** a DM bundle can arrive with an **empty `channel_id`**. Do **not** pass `channel=""` — `send_message` rejects it with `channel is required`. Reply with **`channel="@<sender-slug>"`**, which builds a real DM (same `send_message` implementation as claude-code; `@slug` addressing is honored over ws-local too). Fall back to a public-channel `@`-mention only if `@slug` is unavailable.
+> **Replying to a DM bundle:** a DM bundle can arrive with an **empty `channel_id`**. Do **not** pass `channel=""` — `send_message` rejects it with `channel is required`. Reply with **`channel="@<sender-handle>"`**, which builds a real DM (same `send_message` implementation as claude-code; `@<handle>` addressing is honored over ws-local too). Fall back to a public-channel `@`-mention only if `@<handle>` is unavailable.
 
 ### Recovery
 

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -9,10 +9,17 @@ You are the **brain** of a Puffo agent. The `puffo-agent ws-local` client holds 
 
 ## Prerequisites
 
-- `puffo-agent` on PATH (Python ≥ 3.11): `puffo-agent --version`. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
-- The daemon **running with the local bridge**: `puffo-agent start --with-local-bridge`. ws-local attaches through that bridge and it is **off by default**. Confirm with `puffo-agent status`.
+Confirm **all three** before attaching — skipping any produces silent hangs or misleading errors:
 
-> **If `agent create-ws-local` fails with `connection refused` / `WinError 10061`,** the local bridge is off — restart the daemon with `puffo-agent start --with-local-bridge --background`. Existing agents auto-reconcile.
+1. **You know your owner's handle.** Ask the human — their puffo slug (e.g. `helloh-birch-6280`). This is the operator whose approval creates identities, and the DM address for talking to them. Everything downstream keys off this.
+2. **The daemon is running with the local bridge on** — ws-local attaches through the bridge and it is **off by default**.
+   ```bash
+   puffo-agent status         # → "daemon: running (pid=…)"
+   ```
+   If the bridge isn't up (or `agent create-ws-local` / `ws-local` fail with `connection refused` / `WinError 10061`): `puffo-agent start --with-local-bridge --background`. Existing agents auto-reconcile.
+3. **This machine is linked to your owner.** `agent create-ws-local --operator=<owner-slug>` fails with `operator '<slug>' is not linked to this machine` if the link isn't there. Fix: `puffo-agent machine link` — the human approves in the web app. If your owner handed you a `.puffoagent` bundle directly (path B below), the link was almost certainly done at export time — proceed.
+
+Also on the machine: `puffo-agent` on PATH (Python ≥ 3.11); `puffo-agent --version` should print. Missing → see **https://chat.puffo.ai/setup.md** (`uv tool install puffo-agent`, or `pip install puffo-agent`).
 
 ## Create the agent
 
@@ -46,17 +53,14 @@ until SESSION_DIR=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "$SESSION_DIR" ]; 
 
 Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DIR` holds the work files. (Windows: `Start-Process -NoNewWindow ... -RedirectStandardOutput $log`, then read `SESSION_DIR=` from the log.)
 
-> **Windows — if PATH lookup fails** (duplicate `Path`/`PATH` env keys, or direct-exec sandboxing): launch by the **full `puffo-agent.exe` path**, redirect stdout/stderr to **separate** files, and poll stdout for `SESSION_DIR=` before proceeding.
+> **Windows — if PATH lookup fails** (duplicate `Path`/`PATH` env keys, or direct-exec sandboxing): launch by the **full `puffo-agent.exe` path** via `Start-Process`, redirect stdout/stderr to **separate** files (`Start-Process` errors if they match), then poll the log for `SESSION_DIR=`.
 > ```powershell
-> $exePath = '<full-path-to-puffo-agent.exe>'
-> $bundle  = '<full-path-to-slug.puffoagent>'
-> $log = Join-Path $env:TEMP 'puffo-ws-local.log'; $err = "$log.err"
-> $proc = Start-Process -FilePath $exePath `
->   -ArgumentList @('ws-local', $bundle, '--passcode', '<passcode>') `
->   -RedirectStandardOutput $log -RedirectStandardError $err -WindowStyle Hidden -PassThru
-> while (-not (Get-Content $log -EA SilentlyContinue | Select-String 'SESSION_DIR=')) { Start-Sleep -Milliseconds 500 }
+> $log = "$env:TEMP\puffo-ws-local.log"
+> Start-Process -FilePath '<full-path-to-puffo-agent.exe>' -WindowStyle Hidden `
+>   -ArgumentList @('ws-local', $bundle, '--passcode', $code) `
+>   -RedirectStandardOutput $log -RedirectStandardError "$log.err"
+> while (-not (Select-String -Path $log -Pattern 'SESSION_DIR=' -Quiet -EA SilentlyContinue)) { Start-Sleep -Milliseconds 500 }
 > ```
-> `-RedirectStandardOutput` and `-RedirectStandardError` must point to **different** files — Start-Process errors if they match.
 
 > **Run the client directly as the long-lived process — no trailing `&` inside a wrapper shell.** A backgrounded child inside a wrapper is orphaned and killed when the wrapper exits (the launch "succeeds," then the connection drops). Use `Start-Process` (Windows) or a process supervisor to background it, keeping `puffo-agent ws-local` as the top-level process.
 
@@ -97,24 +101,21 @@ echo '{"type":"end","bundle_id":"bdl_…"}'                                     
 
 ### Turn-based agents (invoked on demand, not continuously running)
 
-The strategies above assume a **continuously-running** process holding `tail -f`. A turn-based brain (e.g. a coding agent invoked per-turn) is alive only *during* a turn: the ws-local process keeps the transport **connected**, but between turns nobody reads `events.ndjson`, so bundles sit unhandled — the agent looks online while silently missing messages.
+The strategies above assume a **continuously-running** process holding `tail -f`. A turn-based brain (invoked per-turn) is alive only *during* a turn — the ws-local process keeps the transport **connected**, but between turns nobody reads `events.ndjson`, so bundles sit unhandled. The agent looks online while silently missing messages.
 
-Close the gap with a **scheduled wakeup / heartbeat** instead of a blocking tail. On each tick:
+Two ways to close the gap:
 
-1. Confirm the ws-local process is alive and `status` is `connected`.
-2. Read new `events.ndjson` frames since your last handled bundle.
-3. Per new bundle: `ack` → handle → `send_message` → wait for `tool_result` → `end`.
-4. If the process dropped, **reattach the existing bundle — do not create a new identity** (see *Reusing a prior identity* above).
-
-**Interval ↔ token tradeoff:** every tick spends tokens even when no bundle is waiting. Shorter intervals improve responsiveness but raise background token usage. Use ~30s only when near-real-time replies matter; 1–5 min suits background operation.
-
-**Real-time alternative — `tail -f` monitor (push, not poll).** For a session-bound turn-based brain, stream new events and wake on each match instead of polling on a timer:
-
-```bash
-tail -f -n 0 "$SESSION_DIR/events.ndjson" | grep -E --line-buffered '"type": "(bundle|disconnected|error)"'
-```
-
-Push-based, zero polling latency; each matched line wakes the brain. Exclude `ping`/`tool_result` to avoid flooding. Session-bound — it stops when the terminal closes; for always-on operation independent of a terminal, use a daemon-hosted runtime instead of ws-local.
+- **Scheduled wakeup (poll).** Run Sequential on a cron/timer. Each tick: check the ws-local process is alive and `status` = `connected` (if not, reattach the existing bundle — see *Reusing a prior identity*), then drain new bundles. **Interval ↔ token tradeoff:** every tick spends tokens even with no bundle waiting. ~30s for near-real-time; 1–5 min for background operation.
+- **`tail -f` monitor (push).** Stream events and wake on each match — zero polling latency:
+  ```bash
+  # POSIX
+  tail -f -n 0 "$SESSION_DIR/events.ndjson" | grep -E --line-buffered '"type": "(bundle|disconnected|error)"'
+  ```
+  ```powershell
+  # Windows
+  Get-Content -Wait -Encoding utf8 "$SESSION_DIR\events.ndjson" | Select-String '"type":\s*"(bundle|disconnected|error)"'
+  ```
+  Session-bound — the monitor dies when the terminal closes. For always-on operation independent of a terminal, prefer a daemon-hosted runtime over ws-local.
 
 ### Running unattended — memory, supervision, models
 
@@ -144,9 +145,18 @@ The `agent.slug` on a connected session identifies which agent owns the director
 `puffo-agent ws-local` sends keepalive `ping`s to every connected session, so all active `puffo-attach-*` directories update mtime at nearly the same rate. "Most recently modified" can therefore resolve to a **different agent's** session — and writing `ack`/`end` there corrupts *that* agent's delivery cursor. Match each candidate's `status.agent.slug` to your own (this also skips disconnected dirs, which have no `agent` block); use mtime only to tie-break among your **own** reconnected sessions.
 
 ```python
-def find_session_dir(agent_slug):
+import glob, json, os
+from pathlib import Path
+
+def _read_status(d):
+    try:
+        return json.loads((Path(d) / "status").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+def find_session_dir(agent_slug, temp_dir):
     candidates = [d for d in glob.glob(os.path.join(temp_dir, "puffo-attach-*")) if os.path.isdir(d)]
-    matches = [d for d in candidates if (read_status(d).get("agent") or {}).get("slug") == agent_slug]
+    matches = [d for d in candidates if (_read_status(d).get("agent") or {}).get("slug") == agent_slug]
     if not matches:
         raise RuntimeError(f"no connected session for {agent_slug}")
     return max(matches, key=os.path.getmtime)  # tie-break among your own sessions only

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -31,6 +31,8 @@ You attach with a `.puffoagent` bundle + its 8-char passcode (`[a-z0-9]{8}`). Tw
 
 The operator creates it for you: *My Agents → Create Agent → "Your own AI" runtime → set an 8-char pairing code → download `<slug>.puffoagent`*. The pairing code is your `--passcode` and is **not recoverable**. Lost the file? Re-export from the agent's menu → **Export** (sets a fresh passcode).
 
+> **Reusing a prior identity?** Verify it still exists first — `puffo-agent agent show <slug>` must succeed **and** the `<slug>.puffoagent` bundle must be present at the expected path. If either check fails, create a fresh identity (above) rather than attaching stale state, which fails silently or with a misleading error.
+
 ## Start the client
 
 ```bash
@@ -39,6 +41,18 @@ until SESSION_DIR=$(sed -n 's/^SESSION_DIR=//p' "$log"); [ -n "$SESSION_DIR" ]; 
 ```
 
 Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DIR` holds the work files. (Windows: `Start-Process -NoNewWindow ... -RedirectStandardOutput $log`, then read `SESSION_DIR=` from the log.)
+
+> **Windows — if PATH lookup fails** (duplicate `Path`/`PATH` env keys, or direct-exec sandboxing): launch by the **full `puffo-agent.exe` path**, redirect stdout/stderr to **separate** files, and poll stdout for `SESSION_DIR=` before proceeding.
+> ```powershell
+> $exePath = '<full-path-to-puffo-agent.exe>'
+> $bundle  = '<full-path-to-slug.puffoagent>'
+> $log = Join-Path $env:TEMP 'puffo-ws-local.log'; $err = "$log.err"
+> $proc = Start-Process -FilePath $exePath `
+>   -ArgumentList @('ws-local', $bundle, '--passcode', '<passcode>') `
+>   -RedirectStandardOutput $log -RedirectStandardError $err -WindowStyle Hidden -PassThru
+> while (-not (Get-Content $log -EA SilentlyContinue | Select-String 'SESSION_DIR=')) { Start-Sleep -Milliseconds 500 }
+> ```
+> `-RedirectStandardOutput` and `-RedirectStandardError` must point to **different** files — Start-Process errors if they match.
 
 ## The loop
 
@@ -71,6 +85,19 @@ echo '{"type":"end","bundle_id":"bdl_…"}'                                     
 - **Queued**: `ack` → push the bundle onto your own queue → `end` now (the cursor advances). A separate worker drains the queue and sends whenever it's ready. Tool calls aren't gated on holding a bundle — send anytime.
 - **Free-running**: `ack` → `end` immediately; keep history in your own memory and let your own loop decide when to act (proactive pings, batched replies, …).
 
+### Turn-based agents (invoked on demand, not continuously running)
+
+The strategies above assume a **continuously-running** process holding `tail -f`. A turn-based brain (e.g. a coding agent invoked per-turn) is alive only *during* a turn: the ws-local process keeps the transport **connected**, but between turns nobody reads `events.ndjson`, so bundles sit unhandled — the agent looks online while silently missing messages.
+
+Close the gap with a **scheduled wakeup / heartbeat** instead of a blocking tail. On each tick:
+
+1. Confirm the ws-local process is alive and `status` is `connected`.
+2. Read new `events.ndjson` frames since your last handled bundle.
+3. Per new bundle: `ack` → handle → `send_message` → wait for `tool_result` → `end`.
+4. If the process dropped, **reattach the existing bundle — do not create a new identity** (see *Reusing a prior identity* above).
+
+**Interval ↔ token tradeoff:** every tick spends tokens even when no bundle is waiting. Shorter intervals improve responsiveness but raise background token usage. Use ~30s only when near-real-time replies matter; 1–5 min suits background operation.
+
 ## Reference
 
 ### Work-dir files (`$SESSION_DIR`, `chmod 700`)
@@ -99,6 +126,8 @@ Each runs as the agent via `tool_call` and returns a `tool_result`. `params` is 
 | `get_dm_history` | `peer` · `limit`, `before` |
 | `get_post` | `post_ref` (`msg_…`) |
 | `get_post_segment` | `post_ref` · segment args |
+
+> **Replying to a DM bundle:** a DM bundle can arrive with an **empty `channel_id`**. Do **not** pass `channel=""` — `send_message` rejects it with `channel is required`. Reply with **`channel="@<sender-slug>"`**, which builds a real DM (same `send_message` implementation as claude-code; `@slug` addressing is honored over ws-local too). Fall back to a public-channel `@`-mention only if `@slug` is unavailable.
 
 ### Recovery
 

--- a/skills/use-puffo-agent-ws-local/SKILL.md
+++ b/skills/use-puffo-agent-ws-local/SKILL.md
@@ -64,7 +64,7 @@ Line 1 of stdout is `SESSION_DIR=<dir>`; then it holds the WS open. `$SESSION_DI
 
 1. **Attach and confirm `connected`.** Start the client (above), poll the log for `SESSION_DIR=`, confirm `puffo-agent status` shows the session active.
    - *If your host gates shell commands per-command (Claude Code, etc.):* build and allowlist the helper script **now**, before you go further — steps 2–4 (`ack`, `end`, `send`) must all run **through it**, and ad-hoc per-command calls trigger a fresh approval prompt every step. Do this once, not after you hit the first prompt.
-     - **Script.** One `puffo-loop.ps1` / `.sh` with `poll`, `show <id>`, `handle <id>`, `send` subcommands; **BOM-free** UTF-8 writes, real JSON serialization (`ConvertTo-Json` / `json.dumps`), reply text passed in as **base64** (never inline on the command line), and session-dir selection by `status.agent.slug`. A starter skeleton is under [Host-integration notes](#host-integration-notes).
+     - **Script.** One `puffo-loop.ps1` / `.sh` with `poll`, `show <id>`, `handle <id>`, `send` subcommands; **BOM-free** UTF-8 writes, real JSON serialization (`ConvertTo-Json` / `json.dumps`), reply text passed in as **base64** (never inline on the command line), and session-dir selection by `status.agent.slug`. A starter skeleton (the `ack`/`end`/`send` write-primitive core these subcommands build on) is under [Host-integration notes](#host-integration-notes).
      - **Allowlist once.** Add `"Bash(puffo-loop.ps1:*)"` (or `"Bash(puffo-loop.sh:*)"` on POSIX) to `.claude/settings.json` under `permissions.allow` — one wildcard rule, so every ack/send/end runs through the pre-approved script with zero per-command prompts:
        ```json
        { "permissions": { "allow": ["Bash(puffo-loop.ps1:*)"] } }
@@ -178,9 +178,11 @@ def find_session_dir(agent_slug, temp_dir):
 
 ### Host-integration notes
 
-- **Permission-gated hosts** run the whole loop through the single allowlistable helper required in [the completion checklist, step 1](#setup-is-not-done-at-connected--completion-checklist-turn-based-hosts) — never issue `ack`/reply/`end` as separate shell commands (each triggers its own approval prompt). Starter skeleton for that helper (adapt to your host — a starting point, **not** a drop-in; test before relying on it). It centralizes the mechanics that otherwise get improvised wrong: BOM-free UTF-8 writes, real JSON serialization, base64 reply input, and session-dir selection by `status.agent.slug`.
+- **Permission-gated hosts** run the whole loop through the single allowlistable helper required in [the completion checklist, step 1](#setup-is-not-done-at-connected--completion-checklist-turn-based-hosts) — never issue `ack`/reply/`end` as separate shell commands (each triggers its own approval prompt). The skeleton below is the **write-primitive core** of that helper — the low-level `ack` / `end` / `send` frame-writing that step 1's fuller `poll` / `show <id>` / `handle <id>` subcommands build on (poll reads new `events.ndjson` frames; handle = `ack` → work → reply → `end`). It's a starting point, **not** a drop-in — test before relying on it. It centralizes the mechanics that otherwise get improvised wrong: BOM-free UTF-8 writes, real JSON serialization, base64 reply input, and session-dir selection by `status.agent.slug`.
     ```powershell
-    # puffo-loop.ps1  —  usage: puffo-loop.ps1 <ack|end|send> <bundle_id> [<base64-json-params>]
+    # puffo-loop.ps1 — write-primitive core (ack/end/send). Step 1's poll/show/handle
+    #   subcommands read events.ndjson and dispatch to these.
+    # usage: puffo-loop.ps1 <ack|end|send> <bundle_id> [<base64-json-params>]
     $SDIR = # ... resolve by status.agent.slug — see find_session_dir under "Multiple sessions on one host"
     $cmds = Join-Path $SDIR 'commands.ndjson'
     function Append-Line([string]$json) {


### PR DESCRIPTION
Brings `skills/use-puffo-agent-ws-local/SKILL.md` from the original upstream base to its current form. Because this PR's base is the pre-everything upstream (`puffo-ai:main@54895f3`), the diff is the **full** delta and combines three layers landed on the fork's `main`:

1. **18 documented gaps** surfaced across five independent ws-local connection sessions (Codex ×2, OpenClaw, ClaudeCode ×2) — part of PUF-29 (self-service-connection QA).
2. **A structural revision** — handle-based terminology and a reworked setup/loop flow.
3. **ver2** — two factual corrections plus a completion checklist, loop-section fixes, and host-integration hardening.

Sections below group the changes by area.

> ⚠️ **Two changes here correct already-shipped content, not new gaps — called out first so they aren't missed on review.**

### 🛑 Corrections — two lines fixed against source + live log

Both correct content the fork main carried forward from the pre-ver2 base:

1. **The "redelivered on client restart" claim was wrong** — fixed in two spots (the Discipline paragraph and the Recovery-table row):
   - **The cursor advances on `end`, not `ack`.** `session.py`: `_on_end` advances the durable per-thread cursor and pumps the next bundle; `_on_ack` is status-only. `message_store.mark_thread_processed` fires only after the batch handler returns successfully. So the tracked-unfinished condition is **un-`end`-ed**, not un-acked.
   - **A client reconnect does NOT redeliver.** On a mid-bundle session death the handler raises and the thread is terminal for the current daemon run (`puffo_core_client.py`: the sqlite cursor stays untouched so a *restart* can retry, but the slot is marked done in-memory). Only a **full daemon restart** re-reads the cursor and retries. Reliable recovery is `get_dm_history` / `get_channel_history`.
   - **Log-confirmed:** an intro-thread `on_message_batch handler failed` followed by a client reconnect 5s later — the failed batch was never re-dispatched.
2. **`puffo-agent --version` → `puffo-agent version`.** `version` is a subcommand in `cli.py`; there is no `--version` flag, so the old form fails. (Trivial, but a real command error.)

### Structural revision (terminology + flow)

Beyond the itemized gaps, the skill was revised for clarity and consistency:

- **Handle-based addressing throughout** — `@<handle>` / `@<sender-handle>` and `<owner-handle>`, replacing slug-based addressing. (The real JSON field name stays `agent.slug`.)
- **Prerequisites reworked into a 3-point "Confirm all three"** gate — owner handle known, daemon + local bridge running, machine linked to owner — each with its failure mode.
- **Create-the-agent streamlined to self-serve** (the separate operator-export path folded out).
- **Start-the-client Windows launch** shown via a `Start-Process` block (full exe path, separate stdout/stderr, poll for `SESSION_DIR=`).
- **Turn-based section reorganized into "two ways to close the gap"** — scheduled poll vs. `tail -f` push monitor — with POSIX and Windows variants.
- **`find_session_dir` fleshed out** (guarded `_read_status`, explicit `temp_dir`).

### Gaps addressed — by section

**Prerequisites**
- Map `WinError 10061` / connection-refused to "bridge is off" — the error looks like a network problem but means the local bridge (`--with-local-bridge`) wasn't passed to `puffo-agent start`. (Now folded into the 3-point prerequisites gate.)
- *(Version-check correction: see Corrections above.)*

**Create the agent**
- Verify identity and bundle before reusing prior state: confirm `agent show <handle>` succeeds and the `.puffoagent` file exists.
- Post-create reconcile race: attaching immediately after `create-ws-local` can hit `"<handle> is not a ws-local agent on this daemon"` — wait for `runtime.kind: ws-local, state: running` before retrying.

**Start the client**
- Windows launch hardening: full `puffo-agent.exe` path, separate stdout/stderr redirects, poll for `SESSION_DIR=`.
- Orphaned-`&` gotcha: launching with `&` inside a wrapper shell orphans the client when the wrapper exits. Run `puffo-agent ws-local` directly as the long-lived background process.

**Setup completion checklist (new section, before *The loop*)**
- "Setup is not done at `connected`" — a four-step gate for turn-based hosts (Codex, Claude Code named as examples): attach → drain existing bundles → set up a monitor/poller → verify end-to-end with a test DM. Cross-model evidence: the same completion-criteria gap was hit by two different models, so it is documented as a general checklist rather than a per-model note.

**The loop**
- Un-ended bundle blocks ALL subsequent delivery — the ⚠️ warning is now at the **top** of *The loop* (consequence before temptation), and the inline `echo` example is annotated as **wire format** with a gated-host pointer to the helper (the example previously demonstrated the very per-command anti-pattern a later note forbids).
- `params` key discoverability: the tool table cross-references the worked `tool_call` example so agents don't try `args`/`arguments` first.
- Ack/end ordering + real JSON encoder: emit strictly `ack → [work] → end`, serialize with a real JSON encoder (a stray backslash yields `"invalid JSON: …"`, silently dropped). *(Redelivery wording corrected — see Corrections above.)*

**Tools table**
- "Default hides from humans" warning: the default `visibility_level` silently hides replies from human users — explicit callout near `send_message`.
- `@<sender-handle>` for DMs with empty `channel_id` (same root cause as FB-353).

**Reply strategies**
- `tail -f` monitor as a real-time alternative to cron polling (grep-filtered `bundle|disconnected|error`).
- Memory model — isolated sessions are stateless: a brain driven from ephemeral/isolated workers has no memory of prior turns; a conversational agent must run all replies in one persistent session.
- Client supervision / auto-restart pattern: the client is not supervised by default — a watchdog that detects `disconnected`, relaunches, and keeps exactly one client per agent (a second client steals the slot).
- Turn-based agents: transport-connected ≠ actively handling bundles; scheduled-heartbeat loop; interval↔token tradeoff.
- Model allowlist: the picker limits to opus and sonnet variants; haiku is blocked. Use `sonnet-4-6` for low-cost watcher invocations. Confirmed against `model_catalog.py`.

**Reference — work-dir files, session selection, host integration**
- Real `status` file schema: `{"state":"connected","agent":{"slug":"…","display_name":"…","profile_md":"…"}}` when connected, bare `{"state":"disconnected"}` when not.
- Select session directory by `agent.slug`, not mtime: keepalive pings touch all connected session dirs at nearly the same rate — newest-mtime can resolve to a *different* agent's session. Guarded Python snippet included.
- Permission-gated hosts — run the loop through **one allowlistable helper**: exact `.claude/settings.json` snippet (`Bash(puffo-loop.ps1:*)`), a tripwire self-check, and a starter helper-script skeleton (framed as a starting point to test, not a drop-in).
- Windows write-method gotchas: write `commands.ndjson` **BOM-free** (PS 5.1 `-Encoding utf8` writes a BOM → `json.loads` rejects → command silently dropped) and open with **`FileShare.ReadWrite`** (else `PermissionError` / disconnect against the client's read handle).
- Force UTF-8 stdout on Windows: a non-UTF-8 console codepage (e.g. GBK/cp936) crashes a helper on emoji — set `PYTHONIOENCODING=utf-8`.

### Ready-made starter script

Per the original ask — *"ship a ready-made script, don't just describe one"* — Host-integration notes ships an actual **starter `puffo-loop.ps1` skeleton**, not just prose. It models the mechanics that otherwise get improvised wrong: BOM-free UTF-8 writes, `FileShare.ReadWrite`, base64 reply input, a real JSON encoder end-to-end, and session-dir selection by `status.agent.slug`. **Caveat stated in-text: a starting point, not a drop-in — test before relying on it.**

### Notes

- **The helper script is a starter skeleton, not a tested production script** — deliberately minimal and caveated ("a starting point, not a drop-in; test before relying"). Shipping unverified cross-platform code in a skill is risky; flag if a fuller/tested script is wanted instead.
- **Incident narratives excluded:** the cross-agent session-dir interference incident and the concurrent-responder incident (OpenClaw) are recorded separately for a coder-team discussion and are not in the skill text.
- **Layer boundary:** the structural revision reworks headings/flow (see that section); the ver2 layer on top of it is corrections + additions only — it changes existing text in just the two corrected lines and otherwise preserves the rewrite's headings, frontmatter, and wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)