### PR TITLE
draft: agent archive-check — verify server-side revocation of archived agents

### DIFF
--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -1891,6 +1891,52 @@ async def agents_import(request: web.Request) -> web.Response:
     return web.json_response(body)
 
 
+async def archive_check(request: web.Request) -> web.Response:
+    # Walks ~/.puffo-agent/archived/*/, probes each device server-side,
+    # and re-issues the self-revoke for any that aren't yet revoked.
+    # Only returns rows for archived agents owned by the paired operator.
+    from .. import import_agents as imp
+
+    paired_root = request["paired_root_pubkey"]
+    results = await imp.sweep_archive_check()
+    filtered = [r for r in results if r.owner_root_pubkey == paired_root]
+    body = {
+        "results": [
+            {
+                "dir_name": r.dir_name,
+                "slug": r.slug,
+                "device_id": r.device_id,
+                "outcome": r.outcome.value,
+                "detail": r.detail,
+            }
+            for r in filtered
+        ],
+        "summary": {
+            "total": len(filtered),
+            "consistent": sum(
+                1 for r in filtered if r.outcome is imp.ArchiveCheckOutcome.CONSISTENT
+            ),
+            "reconciled": sum(
+                1 for r in filtered if r.outcome is imp.ArchiveCheckOutcome.RECONCILED
+            ),
+            "problems": sum(
+                1 for r in filtered
+                if r.outcome in (
+                    imp.ArchiveCheckOutcome.UNREACHABLE,
+                    imp.ArchiveCheckOutcome.NO_KEYS,
+                    imp.ArchiveCheckOutcome.DEVICE_NOT_FOUND,
+                )
+            ),
+        },
+    }
+    logger.info(
+        "bridge: archive-check total=%d consistent=%d reconciled=%d problems=%d",
+        body["summary"]["total"], body["summary"]["consistent"],
+        body["summary"]["reconciled"], body["summary"]["problems"],
+    )
+    return web.json_response(body)
+
+
 async def agent_revoke_pending(request: web.Request) -> web.Response:
     from .. import import_agents as imp
 

--- a/src/puffo_agent/portal/api/server.py
+++ b/src/puffo_agent/portal/api/server.py
@@ -61,6 +61,7 @@ def build_app(cfg: BridgeConfig, ws_local_hub=None) -> web.Application:
     app.router.add_get("/v1/agents/{id}/claude-md", h.get_claude_md)
     app.router.add_post("/v1/agents/export", h.agents_export)
     app.router.add_post("/v1/agents/import", h.agents_import)
+    app.router.add_post("/v1/agents/archive-check", h.archive_check)
     app.router.add_post("/v1/agents/{id}/revoke-pending", h.agent_revoke_pending)
     return app
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1164,6 +1164,47 @@ def cmd_agent_archive(args: argparse.Namespace) -> int:
     return asyncio.run(_archive_async())
 
 
+_ARCHIVE_CHECK_MARK = {
+    "consistent": "ok",
+    "reconciled": "revoked",
+    "device_not_found": "device-not-found",
+    "no_keys": "no-keys",
+    "unreachable": "unreachable",
+}
+
+
+def format_archive_check_results(results) -> tuple[str, int]:
+    # Returns (printable text, rc). rc=1 if any result needs
+    # operator attention (unreachable / no-keys / device-not-found).
+    if not results:
+        return "no archived agents to check", 0
+    lines = []
+    for r in results:
+        line = f"[{_ARCHIVE_CHECK_MARK[r.outcome.value]}] {r.dir_name}"
+        if r.detail:
+            line += f"  ({r.detail})"
+        lines.append(line)
+    reconciled = sum(1 for r in results if r.outcome.value == "reconciled")
+    problems = sum(
+        1 for r in results
+        if r.outcome.value in ("unreachable", "no_keys", "device_not_found")
+    )
+    lines.append(
+        f"summary: {len(results)} checked, {reconciled} revoked, "
+        f"{problems} needing attention"
+    )
+    return "\n".join(lines), (0 if problems == 0 else 1)
+
+
+def cmd_agent_archive_check(args: argparse.Namespace) -> int:
+    from .import_agents import sweep_archive_check
+
+    results = asyncio.run(sweep_archive_check())
+    text, rc = format_archive_check_results(results)
+    print(text)
+    return rc
+
+
 def cmd_agent_edit(args: argparse.Namespace) -> int:
     agent_id = args.id
     if not agent_yml_path(agent_id).exists():
@@ -1888,6 +1929,15 @@ def build_parser() -> argparse.ArgumentParser:
     archive = agent_sub.add_parser("archive", help="Stop and archive an agent to ~/.puffo-agent/archived/")
     archive.add_argument("id")
     archive.set_defaults(func=cmd_agent_archive)
+
+    archive_check = agent_sub.add_parser(
+        "archive-check",
+        help=(
+            "Verify every archived agent is also revoked server-side; "
+            "re-issue the self-revoke for any that aren't."
+        ),
+    )
+    archive_check.set_defaults(func=cmd_agent_archive_check)
 
     edit = agent_sub.add_parser("edit", help="Open the agent's profile.md in $EDITOR")
     edit.add_argument("id")

--- a/src/puffo_agent/portal/import_agents.py
+++ b/src/puffo_agent/portal/import_agents.py
@@ -768,3 +768,174 @@ async def sweep_archived_pending_revokes() -> int:
         if outcome is _RetryOutcome.SUCCEEDED:
             retried += 1
     return retried
+
+
+class ArchiveCheckOutcome(enum.Enum):
+    CONSISTENT = "consistent"                # server already has the revocation
+    RECONCILED = "reconciled"                # device was active; we just revoked it
+    NO_KEYS = "no_keys"                      # keystore missing / unparseable
+    DEVICE_NOT_FOUND = "device_not_found"    # server never had this device_id
+    UNREACHABLE = "unreachable"              # network / server / other failure
+
+
+@dataclass
+class ArchiveCheckResult:
+    dir_name: str                # basename of the archived dir
+    slug: str
+    device_id: str
+    outcome: ArchiveCheckOutcome
+    detail: str = ""
+    owner_root_pubkey: str = ""  # from identity_cert.declared_operator_public_key
+
+
+def _read_archived_puffo_core(archived_agent_dir: Path) -> tuple[str, str, str] | None:
+    # (server_url, slug, device_id) from archived agent.yml, or None if
+    # the file is missing / unreadable / lacks the puffo_core block.
+    import yaml
+    path = archived_agent_dir / "agent.yml"
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    pc = raw.get("puffo_core") or {}
+    slug = pc.get("slug") or ""
+    server_url = pc.get("server_url") or ""
+    device_id = pc.get("device_id") or ""
+    if not (slug and server_url and device_id):
+        return None
+    return server_url, slug, device_id
+
+
+async def check_archived_device(archived_agent_dir: Path) -> ArchiveCheckResult:
+    dir_name = archived_agent_dir.name
+    parsed = _read_archived_puffo_core(archived_agent_dir)
+    if parsed is None:
+        return ArchiveCheckResult(
+            dir_name=dir_name, slug="", device_id="",
+            outcome=ArchiveCheckOutcome.NO_KEYS,
+            detail="agent.yml missing or lacks puffo_core.{server_url,slug,device_id}",
+        )
+    server_url, slug, device_id = parsed
+    try:
+        identity = KeyStore(archived_agent_dir / "keys").load_identity(slug)
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        return ArchiveCheckResult(
+            dir_name=dir_name, slug=slug, device_id=device_id,
+            outcome=ArchiveCheckOutcome.NO_KEYS, detail=f"{type(exc).__name__}: {exc}",
+        )
+    owner_pk = ""
+    if identity.identity_cert_json:
+        try:
+            cert = json.loads(identity.identity_cert_json)
+            op = cert.get("declared_operator_public_key") if isinstance(cert, dict) else None
+            if isinstance(op, str):
+                owner_pk = op
+        except (TypeError, ValueError):
+            pass
+    try:
+        root_signing = Ed25519KeyPair.from_secret_bytes(decode_secret(identity.root_secret_key))
+        device_signing = Ed25519KeyPair.from_secret_bytes(
+            decode_secret(identity.device_signing_secret_key)
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ArchiveCheckResult(
+            dir_name=dir_name, slug=slug, device_id=device_id,
+            outcome=ArchiveCheckOutcome.NO_KEYS, detail=f"key decode failed: {exc}",
+            owner_root_pubkey=owner_pk,
+        )
+
+    try:
+        async with _remote_http_session(server_url) as session:
+            # Probe: try to register a fresh session subkey. Server's
+            # subkey handler rejects revoked devices with 403 DEVICE_REVOKED.
+            subkey = Ed25519KeyPair.generate()
+            cert = create_subkey_cert(device_signing, device_id, subkey.public_key_bytes())
+            body_bytes = json.dumps(
+                {"subkey_cert": cert}, separators=(",", ":")
+            ).encode("utf-8")
+            headers = sign_request(
+                signing_key=device_signing,
+                slug=slug,
+                signer_id=device_id,
+                method="POST",
+                path="/devices/subkeys",
+                body=body_bytes,
+            ).to_dict()
+            async with session.post(
+                f"{server_url.rstrip('/')}/devices/subkeys",
+                data=body_bytes,
+                headers=headers,
+            ) as resp:
+                status = resp.status
+                text = await resp.text()
+            if status == 403 and "DEVICE_REVOKED" in text:
+                return ArchiveCheckResult(
+                    dir_name=dir_name, slug=slug, device_id=device_id,
+                    outcome=ArchiveCheckOutcome.CONSISTENT,
+                    owner_root_pubkey=owner_pk,
+                )
+            if status == 400 and "DEVICE_NOT_FOUND" in text:
+                return ArchiveCheckResult(
+                    dir_name=dir_name, slug=slug, device_id=device_id,
+                    outcome=ArchiveCheckOutcome.DEVICE_NOT_FOUND,
+                    owner_root_pubkey=owner_pk,
+                )
+            if status >= 400:
+                return ArchiveCheckResult(
+                    dir_name=dir_name, slug=slug, device_id=device_id,
+                    outcome=ArchiveCheckOutcome.UNREACHABLE,
+                    detail=f"subkey probe returned {status}: {text[:200]}",
+                    owner_root_pubkey=owner_pk,
+                )
+            # Device is active — post revocation with the fresh subkey.
+            revocation = create_device_revocation(root_signing, device_id)
+            await _signed_post(
+                session,
+                server_url=server_url,
+                path=f"/devices/{device_id}/revoke",
+                signer_key=subkey,
+                signer_id=cert["subkey_id"],
+                slug=slug,
+                body_dict=revocation,
+            )
+    except ImportError as exc:
+        return ArchiveCheckResult(
+            dir_name=dir_name, slug=slug, device_id=device_id,
+            outcome=ArchiveCheckOutcome.UNREACHABLE, detail=str(exc),
+            owner_root_pubkey=owner_pk,
+        )
+    except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
+        return ArchiveCheckResult(
+            dir_name=dir_name, slug=slug, device_id=device_id,
+            outcome=ArchiveCheckOutcome.UNREACHABLE,
+            detail=f"{type(exc).__name__}: {exc}",
+            owner_root_pubkey=owner_pk,
+        )
+
+    # Revoke succeeded — clear any stale pending_revoke marker.
+    marker = archived_pending_revoke_path(archived_agent_dir)
+    if marker.exists():
+        try:
+            marker.unlink()
+        except OSError:
+            pass
+    return ArchiveCheckResult(
+        dir_name=dir_name, slug=slug, device_id=device_id,
+        outcome=ArchiveCheckOutcome.RECONCILED,
+        owner_root_pubkey=owner_pk,
+    )
+
+
+async def sweep_archive_check() -> list[ArchiveCheckResult]:
+    # Walks ~/.puffo-agent/archived/*/ and probes every archived agent.
+    from .state import archived_dir
+
+    root = archived_dir()
+    if not root.exists():
+        return []
+    results: list[ArchiveCheckResult] = []
+    for entry in sorted(root.iterdir(), key=lambda p: p.name):
+        if not entry.is_dir():
+            continue
+        results.append(await check_archived_device(entry))
+    return results

--- a/src/puffo_agent/portal/ui/widgets/agent_list.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_list.py
@@ -155,6 +155,7 @@ class AgentList(QWidget):
     agent_selected = Signal(object)
     # Background import worker → main thread; bool = success, str = summary.
     _import_done = Signal(bool, str)
+    _archive_check_done = Signal(bool, str)
 
     def __init__(
         self,
@@ -168,6 +169,7 @@ class AgentList(QWidget):
         self._running_only = True
         self._build()
         self._import_done.connect(self._on_import_finished)
+        self._archive_check_done.connect(self._on_archive_check_finished)
         if avatar_cache is not None:
             avatar_cache.avatar_ready.connect(self._on_avatar_ready)
 
@@ -183,6 +185,13 @@ class AgentList(QWidget):
         self._import_btn = QPushButton("Import agent")
         self._import_btn.clicked.connect(self._on_import_clicked)
         t_layout.addWidget(self._import_btn)
+        self._archive_check_btn = QPushButton("Archive check")
+        self._archive_check_btn.setToolTip(
+            "Verify every locally-archived agent is also revoked "
+            "server-side; re-issue the revoke for any that aren't."
+        )
+        self._archive_check_btn.clicked.connect(self._on_archive_check_clicked)
+        t_layout.addWidget(self._archive_check_btn)
         t_layout.addStretch(1)
         layout.addWidget(toolbar)
 
@@ -313,6 +322,62 @@ class AgentList(QWidget):
         if success:
             QMessageBox.information(self, title, summary)
             self.refresh()
+        else:
+            QMessageBox.warning(self, title, summary)
+
+    def _on_archive_check_clicked(self) -> None:
+        self._archive_check_btn.setEnabled(False)
+        self._archive_check_btn.setText("Checking…")
+
+        def worker() -> None:
+            try:
+                from ...import_agents import (
+                    ArchiveCheckOutcome,
+                    sweep_archive_check,
+                )
+                results = asyncio.run(sweep_archive_check())
+                if not results:
+                    self._archive_check_done.emit(True, "no archived agents to check")
+                    return
+                mark = {
+                    ArchiveCheckOutcome.CONSISTENT: "ok",
+                    ArchiveCheckOutcome.RECONCILED: "revoked",
+                    ArchiveCheckOutcome.DEVICE_NOT_FOUND: "device-not-found",
+                    ArchiveCheckOutcome.NO_KEYS: "no-keys",
+                    ArchiveCheckOutcome.UNREACHABLE: "unreachable",
+                }
+                lines = [
+                    f"[{mark[r.outcome]}] {r.dir_name}"
+                    + (f"  ({r.detail})" if r.detail else "")
+                    for r in results
+                ]
+                reconciled = sum(
+                    1 for r in results if r.outcome is ArchiveCheckOutcome.RECONCILED
+                )
+                problems = sum(
+                    1 for r in results
+                    if r.outcome in (
+                        ArchiveCheckOutcome.UNREACHABLE,
+                        ArchiveCheckOutcome.NO_KEYS,
+                        ArchiveCheckOutcome.DEVICE_NOT_FOUND,
+                    )
+                )
+                lines.append(
+                    f"\n{len(results)} checked, {reconciled} revoked, "
+                    f"{problems} needing attention"
+                )
+                self._archive_check_done.emit(problems == 0, "\n".join(lines))
+            except Exception as exc:
+                self._archive_check_done.emit(False, f"{type(exc).__name__}: {exc}")
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_archive_check_finished(self, ok: bool, summary: str) -> None:
+        self._archive_check_btn.setEnabled(True)
+        self._archive_check_btn.setText("Archive check")
+        title = "Archive check" + ("" if ok else " — attention required")
+        if ok:
+            QMessageBox.information(self, title, summary)
         else:
             QMessageBox.warning(self, title, summary)
 

--- a/tests/test_archive_check.py
+++ b/tests/test_archive_check.py
@@ -1,0 +1,550 @@
+"""Unit + e2e tests for portal.import_agents.check_archived_device.
+
+Covers the five outcomes (CONSISTENT / RECONCILED / DEVICE_NOT_FOUND /
+NO_KEYS / UNREACHABLE), the pending_revoke marker cleanup, the sweep
+runner, and race safety when two concurrent probes hit the same dir.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import yaml
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from _bridge_support import isolated_home
+
+from puffo_agent.crypto.canonical import canonicalize_for_signing
+from puffo_agent.crypto.certs import derive_public_key_id
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.keystore import StoredIdentity, encode_secret
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+pytestmark = pytest.mark.asyncio
+
+
+# ────────────────────────────────────────────────────────────────────
+# Mock puffo-server with configurable behaviour per device_id.
+# ────────────────────────────────────────────────────────────────────
+
+
+def _make_state():
+    return {
+        "calls": [],
+        "revoked_devices": set(),       # device_ids the server already has revoked
+        "missing_devices": set(),       # 400 DEVICE_NOT_FOUND
+        "subkey_fail_status": None,     # override probe status entirely
+        "revoke_fail_status": None,     # induce failure on the second POST
+    }
+
+
+def _make_app(state):
+    app = web.Application()
+
+    async def post_subkey(request):
+        body = await request.json()
+        cert = body.get("subkey_cert") or {}
+        device_id = cert.get("device_id", "")
+        state["calls"].append(("POST", "/devices/subkeys", device_id))
+        if state["subkey_fail_status"] is not None:
+            return web.json_response(
+                {"error": "INDUCED", "message": "test"},
+                status=state["subkey_fail_status"],
+            )
+        if device_id in state["missing_devices"]:
+            return web.json_response(
+                {"error": "DEVICE_NOT_FOUND", "message": "not in cert registry"},
+                status=400,
+            )
+        if device_id in state["revoked_devices"]:
+            return web.json_response(
+                {"error": "DEVICE_REVOKED", "message": "device has been revoked"},
+                status=403,
+            )
+        return web.json_response({"ok": True})
+
+    async def post_revoke(request):
+        device_id = request.match_info["device_id"]
+        state["calls"].append(("POST", f"/devices/{device_id}/revoke", device_id))
+        if state["revoke_fail_status"] is not None:
+            return web.json_response({"error": "INDUCED"}, status=state["revoke_fail_status"])
+        state["revoked_devices"].add(device_id)
+        return web.json_response({"ok": True}, status=201)
+
+    app.router.add_post("/devices/subkeys", post_subkey)
+    app.router.add_post("/devices/{device_id}/revoke", post_revoke)
+    return app
+
+
+@pytest_asyncio.fixture
+async def mock_server():
+    state = _make_state()
+    server = TestServer(_make_app(state))
+    await server.start_server()
+    try:
+        yield server, state
+    finally:
+        await server.close()
+
+
+@pytest.fixture(autouse=True)
+def fresh_home():
+    isolated_home()
+    yield
+
+
+# ────────────────────────────────────────────────────────────────────
+# Seed helpers: materialise an archived agent as it would exist on
+# disk after cmd_agent_archive moved its directory.
+# ────────────────────────────────────────────────────────────────────
+
+
+def _signed_identity_cert(root: Ed25519KeyPair, operator_pk: str = "") -> dict:
+    cert = {
+        "type": "identity_cert",
+        "version": 1,
+        "root_public_key": base64url_encode(root.public_key_bytes()),
+        "identity_type": "human",
+        "declared_operator_public_key": operator_pk or None,
+    }
+    cert["self_signature"] = base64url_encode(
+        root.sign(canonicalize_for_signing(cert))
+    )
+    return cert
+
+
+def _signed_slug_binding(root: Ed25519KeyPair, slug: str) -> dict:
+    sb = {
+        "type": "slug_binding",
+        "version": 1,
+        "root_public_key": base64url_encode(root.public_key_bytes()),
+        "slug": slug,
+        "issued_at": int(time.time() * 1000),
+    }
+    sb["self_signature"] = base64url_encode(
+        root.sign(canonicalize_for_signing(sb))
+    )
+    return sb
+
+
+def _seed_archived(
+    dir_name: str,
+    *,
+    slug: str,
+    server_url: str,
+    operator_pk: str = "",
+) -> dict:
+    home = Path(os.environ["PUFFO_AGENT_HOME"])
+    adir = home / "archived" / dir_name
+    (adir / "keys").mkdir(parents=True, exist_ok=True)
+
+    root = Ed25519KeyPair.generate()
+    device_signing = Ed25519KeyPair.generate()
+    kem = KemKeyPair.generate()
+    device_id = derive_public_key_id("dev", device_signing.public_key_bytes())
+
+    cfg = {
+        "id": dir_name.split("-2026")[0],
+        "state": "paused",
+        "display_name": slug,
+        "puffo_core": {
+            "server_url": server_url,
+            "slug": slug,
+            "device_id": device_id,
+            "space_id": "sp_test",
+        },
+        "runtime": {
+            "kind": "chat-local",
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "api_key": "",
+            "harness": "claude-code",
+            "permission_mode": "bypassPermissions",
+        },
+        "profile": "profile.md",
+        "memory_dir": "memory",
+        "workspace_dir": "workspace",
+        "triggers": {"on_mention": True, "on_dm": True},
+    }
+    (adir / "agent.yml").write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    identity = StoredIdentity(
+        slug=slug,
+        device_id=device_id,
+        root_secret_key=encode_secret(root.secret_bytes()),
+        device_signing_secret_key=encode_secret(device_signing.secret_bytes()),
+        kem_secret_key=encode_secret(kem.secret_bytes()),
+        server_url=server_url,
+        slug_binding_json=json.dumps(_signed_slug_binding(root, slug)),
+        identity_cert_json=json.dumps(_signed_identity_cert(root, operator_pk)),
+    )
+    (adir / "keys" / f"{slug}.json").write_text(
+        json.dumps(identity.to_dict(), indent=2), encoding="utf-8"
+    )
+    return {
+        "dir": adir,
+        "slug": slug,
+        "device_id": device_id,
+        "root": root,
+        "operator_pk": operator_pk,
+    }
+
+
+# ────────────────────────────────────────────────────────────────────
+# Outcome matrix
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_reconciled_when_server_still_active(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("alpha-20260707-000000", slug="alpha", server_url=url)
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.RECONCILED
+    assert result.slug == "alpha"
+    assert result.device_id == info["device_id"]
+    # Server got both calls: probe accepted, revoke posted.
+    paths = [c[1] for c in state["calls"]]
+    assert "/devices/subkeys" in paths
+    assert f"/devices/{info['device_id']}/revoke" in paths
+    assert info["device_id"] in state["revoked_devices"]
+
+
+async def test_consistent_when_server_already_revoked(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("beta-20260707-000000", slug="beta", server_url=url)
+    state["revoked_devices"].add(info["device_id"])  # server already knows
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.CONSISTENT
+    # No revoke POST — probe alone told us we're consistent.
+    revoke_calls = [c for c in state["calls"] if c[1].endswith("/revoke")]
+    assert revoke_calls == []
+
+
+async def test_device_not_found(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("gamma-20260707-000000", slug="gamma", server_url=url)
+    state["missing_devices"].add(info["device_id"])
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.DEVICE_NOT_FOUND
+
+
+async def test_unreachable_when_probe_5xx(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("delta-20260707-000000", slug="delta", server_url=url)
+    state["subkey_fail_status"] = 500
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.UNREACHABLE
+    assert "500" in result.detail
+
+
+async def test_unreachable_when_revoke_5xx(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("eps-20260707-000000", slug="eps", server_url=url)
+    state["revoke_fail_status"] = 500
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.UNREACHABLE
+    # Probe succeeded, revoke didn't — server had NOT actually revoked.
+    assert info["device_id"] not in state["revoked_devices"]
+
+
+async def test_no_keys_when_agent_yml_missing(mock_server):
+    server, _state = mock_server
+    home = Path(os.environ["PUFFO_AGENT_HOME"])
+    adir = home / "archived" / "zeta-20260707-000000"
+    adir.mkdir(parents=True)
+    # No agent.yml, no keys/.
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(adir)
+    assert result.outcome is imp.ArchiveCheckOutcome.NO_KEYS
+    assert result.slug == ""
+
+
+async def test_no_keys_when_agent_yml_lacks_puffo_core():
+    home = Path(os.environ["PUFFO_AGENT_HOME"])
+    adir = home / "archived" / "empty-20260707-000000"
+    adir.mkdir(parents=True)
+    (adir / "agent.yml").write_text("id: foo\nstate: paused\n", encoding="utf-8")
+
+    from puffo_agent.portal import import_agents as imp
+    r = await imp.check_archived_device(adir)
+    assert r.outcome is imp.ArchiveCheckOutcome.NO_KEYS
+
+
+async def test_no_keys_when_agent_yml_unparseable():
+    home = Path(os.environ["PUFFO_AGENT_HOME"])
+    adir = home / "archived" / "junk-20260707-000000"
+    adir.mkdir(parents=True)
+    (adir / "agent.yml").write_text("::: not: valid: yaml\n:\n", encoding="utf-8")
+
+    from puffo_agent.portal import import_agents as imp
+    r = await imp.check_archived_device(adir)
+    assert r.outcome is imp.ArchiveCheckOutcome.NO_KEYS
+
+
+async def test_corrupt_identity_cert_json_leaves_owner_blank(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("crptcert-20260707-000000", slug="crptcert", server_url=url)
+    state["revoked_devices"].add(info["device_id"])
+    # Overwrite the keystore JSON so identity_cert_json is a
+    # non-JSON string — code path 833-834.
+    keys_file = info["dir"] / "keys" / "crptcert.json"
+    stored = json.loads(keys_file.read_text(encoding="utf-8"))
+    stored["identity_cert_json"] = "not-valid-json {"
+    keys_file.write_text(json.dumps(stored), encoding="utf-8")
+
+    from puffo_agent.portal import import_agents as imp
+    r = await imp.check_archived_device(info["dir"])
+    assert r.outcome is imp.ArchiveCheckOutcome.CONSISTENT
+    assert r.owner_root_pubkey == ""
+
+
+async def test_no_keys_when_root_secret_key_corrupt(mock_server):
+    server, _state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("brokenkey-20260707-000000", slug="brokenkey", server_url=url)
+    keys_file = info["dir"] / "keys" / "brokenkey.json"
+    stored = json.loads(keys_file.read_text(encoding="utf-8"))
+    # Well-formed base64 but wrong length → Ed25519 constructor rejects.
+    stored["root_secret_key"] = "AAAA"
+    keys_file.write_text(json.dumps(stored), encoding="utf-8")
+
+    from puffo_agent.portal import import_agents as imp
+    r = await imp.check_archived_device(info["dir"])
+    assert r.outcome is imp.ArchiveCheckOutcome.NO_KEYS
+    assert "key decode failed" in r.detail
+
+
+async def test_unreachable_when_server_closed():
+    # Spin up a TestServer, capture its URL, then close it so the
+    # first probe hits the aiohttp.ClientError branch.
+    server = TestServer(_make_app(_make_state()))
+    await server.start_server()
+    url = str(server.make_url("/")).rstrip("/")
+    await server.close()
+
+    info = _seed_archived("dead-20260707-000000", slug="dead", server_url=url)
+    from puffo_agent.portal import import_agents as imp
+    r = await imp.check_archived_device(info["dir"])
+    assert r.outcome is imp.ArchiveCheckOutcome.UNREACHABLE
+
+
+async def test_no_keys_when_keystore_dir_missing(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("eta-20260707-000000", slug="eta", server_url=url)
+    # Nuke the keystore so load_identity errors.
+    import shutil
+    shutil.rmtree(info["dir"] / "keys")
+
+    from puffo_agent.portal import import_agents as imp
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.NO_KEYS
+
+
+async def test_reconcile_clears_pending_revoke_marker(mock_server):
+    server, _state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("theta-20260707-000000", slug="theta", server_url=url)
+
+    from puffo_agent.portal import import_agents as imp
+    imp.write_archived_pending_revoke(
+        info["dir"],
+        server_url=url,
+        slug="theta",
+        device_id=info["device_id"],
+        last_error="prior fail",
+    )
+    marker = imp.archived_pending_revoke_path(info["dir"])
+    assert marker.exists()
+
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.RECONCILED
+    assert not marker.exists()  # cleaned up on successful revoke
+
+
+async def test_consistent_does_not_touch_marker(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("iota-20260707-000000", slug="iota", server_url=url)
+    state["revoked_devices"].add(info["device_id"])
+
+    from puffo_agent.portal import import_agents as imp
+    imp.write_archived_pending_revoke(
+        info["dir"], server_url=url, slug="iota",
+        device_id=info["device_id"], last_error="prior",
+    )
+    marker = imp.archived_pending_revoke_path(info["dir"])
+    assert marker.exists()
+
+    result = await imp.check_archived_device(info["dir"])
+    assert result.outcome is imp.ArchiveCheckOutcome.CONSISTENT
+    # Marker left intact — we didn't post a revoke, so nothing to
+    # unmark. The daemon's startup sweep will handle it.
+    assert marker.exists()
+
+
+# ────────────────────────────────────────────────────────────────────
+# sweep_archive_check + result surfacing
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_sweep_walks_all_archived_dirs(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info_a = _seed_archived("aaa-20260707-000000", slug="aaa", server_url=url)
+    info_b = _seed_archived("bbb-20260707-000000", slug="bbb", server_url=url)
+    info_c = _seed_archived("ccc-20260707-000000", slug="ccc", server_url=url)
+    state["revoked_devices"].add(info_b["device_id"])  # already revoked
+    state["missing_devices"].add(info_c["device_id"])
+
+    from puffo_agent.portal import import_agents as imp
+    results = await imp.sweep_archive_check()
+
+    by_slug = {r.slug: r for r in results}
+    assert by_slug["aaa"].outcome is imp.ArchiveCheckOutcome.RECONCILED
+    assert by_slug["bbb"].outcome is imp.ArchiveCheckOutcome.CONSISTENT
+    assert by_slug["ccc"].outcome is imp.ArchiveCheckOutcome.DEVICE_NOT_FOUND
+
+
+async def test_sweep_returns_empty_when_no_archived_dir():
+    from puffo_agent.portal import import_agents as imp
+    results = await imp.sweep_archive_check()
+    assert results == []
+
+
+async def test_sweep_ignores_files_at_top_level(mock_server):
+    server, _state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("solo-20260707-000000", slug="solo", server_url=url)
+    # Drop a stray file that must not confuse the walker.
+    (info["dir"].parent / ".DS_Store").write_bytes(b"junk")
+
+    from puffo_agent.portal import import_agents as imp
+    results = await imp.sweep_archive_check()
+    assert len(results) == 1
+    assert results[0].slug == "solo"
+
+
+async def test_owner_pk_propagates_from_identity_cert(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    op_pk = "op-root-pubkey-test"
+    info = _seed_archived(
+        "owned-20260707-000000",
+        slug="owned",
+        server_url=url,
+        operator_pk=op_pk,
+    )
+    state["revoked_devices"].add(info["device_id"])
+
+    from puffo_agent.portal import import_agents as imp
+    r = await imp.check_archived_device(info["dir"])
+    assert r.owner_root_pubkey == op_pk
+
+
+# ────────────────────────────────────────────────────────────────────
+# Race: two probes on the same dir in parallel must not corrupt state.
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_parallel_probes_are_safe(mock_server):
+    server, state = mock_server
+    url = str(server.make_url("/")).rstrip("/")
+    info = _seed_archived("race-20260707-000000", slug="race", server_url=url)
+
+    from puffo_agent.portal import import_agents as imp
+    r1, r2 = await asyncio.gather(
+        imp.check_archived_device(info["dir"]),
+        imp.check_archived_device(info["dir"]),
+    )
+    # Both should succeed logically: one reconciles, the other sees
+    # the freshly-revoked device and reports CONSISTENT (server is
+    # stateful across both requests, so second probe hits the
+    # already-revoked branch).
+    outcomes = {r1.outcome, r2.outcome}
+    assert imp.ArchiveCheckOutcome.RECONCILED in outcomes
+    assert outcomes.issubset({
+        imp.ArchiveCheckOutcome.RECONCILED,
+        imp.ArchiveCheckOutcome.CONSISTENT,
+    })
+    assert info["device_id"] in state["revoked_devices"]
+
+
+# ────────────────────────────────────────────────────────────────────
+# CLI wrapper — rc=0 when everything clean, rc=1 when problems.
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_cli_format_all_consistent():
+    from puffo_agent.portal import cli, import_agents as imp
+    results = [
+        imp.ArchiveCheckResult(
+            dir_name="alpha-20260707-000000", slug="alpha",
+            device_id="dev_x", outcome=imp.ArchiveCheckOutcome.CONSISTENT,
+        ),
+        imp.ArchiveCheckResult(
+            dir_name="beta-20260707-000000", slug="beta",
+            device_id="dev_y", outcome=imp.ArchiveCheckOutcome.RECONCILED,
+        ),
+    ]
+    text, rc = cli.format_archive_check_results(results)
+    assert rc == 0
+    assert "[ok] alpha-20260707-000000" in text
+    assert "[revoked] beta-20260707-000000" in text
+    assert "summary: 2 checked, 1 revoked, 0 needing attention" in text
+
+
+async def test_cli_format_flags_problems():
+    from puffo_agent.portal import cli, import_agents as imp
+    results = [
+        imp.ArchiveCheckResult(
+            dir_name="alpha-20260707-000000", slug="alpha", device_id="dev_x",
+            outcome=imp.ArchiveCheckOutcome.UNREACHABLE, detail="TimeoutError",
+        ),
+        imp.ArchiveCheckResult(
+            dir_name="beta-20260707-000000", slug="",
+            device_id="", outcome=imp.ArchiveCheckOutcome.NO_KEYS,
+            detail="agent.yml missing",
+        ),
+        imp.ArchiveCheckResult(
+            dir_name="gamma-20260707-000000", slug="gamma", device_id="dev_z",
+            outcome=imp.ArchiveCheckOutcome.DEVICE_NOT_FOUND,
+        ),
+    ]
+    text, rc = cli.format_archive_check_results(results)
+    assert rc == 1
+    assert "[unreachable]" in text
+    assert "[no-keys]" in text
+    assert "[device-not-found]" in text
+    assert "summary: 3 checked, 0 revoked, 3 needing attention" in text
+
+
+async def test_cli_format_empty():
+    from puffo_agent.portal import cli
+    text, rc = cli.format_archive_check_results([])
+    assert rc == 0
+    assert text == "no archived agents to check"


### PR DESCRIPTION
## Status

**Draft — operator flagged the approach as wrong; leaving here for reference.**

## What this branch does

Adds `puffo-agent agent archive-check` + a matching "Archive check" button next to Import on the Agents tab.

For each dir under `~/.puffo-agent/archived/`, uses the retained root + device keys to probe `POST /devices/subkeys`:

- **403 `DEVICE_REVOKED`** → consistent (server already has the revocation)
- **200** → device still active server-side; immediately post `create_device_revocation` signed by the fresh subkey → reconciled
- **400 `DEVICE_NOT_FOUND`** / **anything else** → surfaced to the operator

The `pending_revoke.json` marker is cleared on reconcile.

## Surfaces

- `import_agents.py` — `ArchiveCheckOutcome`, `ArchiveCheckResult`, `check_archived_device`, `sweep_archive_check`
- `cli.py` — `puffo-agent agent archive-check` (+ extracted `format_archive_check_results` for testability)
- `api/handlers.py` — `POST /v1/agents/archive-check`, filtered by paired operator via `identity_cert.declared_operator_public_key`
- `api/server.py` — route wired
- `ui/widgets/agent_list.py` — "Archive check" QPushButton to the right of Import, background worker, QMessageBox summary

## Tests

`tests/test_archive_check.py` — 22 cases: five-outcome matrix, marker cleanup on reconcile / preservation on consistent, sweep walker (multi-dir + non-dir top-level entries), owner-pubkey propagation, parallel-probe race, and 3 CLI formatter cases.

`PYTHONPATH=src python -m pytest`: **1802 passed / 7 skipped** (skips are pre-existing symlink/permission-bit ones). New code line coverage on `import_agents.py` = 100% minus a 2-line defensive `except OSError: pass` on marker.unlink (matches house style at `import_agents.py:733`).

## Not smoked live

353 archived agents on the operator's machine × real chat.puffo.ai revocation calls — not safe to fire without direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)