### PR TITLE
feat(cloud-agent): agent-side lifecycle MCP tools (schedule_wake / runtime-status / keep_alive)

### DIFF
--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -281,6 +281,157 @@ class CloudBridgeClient:
             )
             return None
 
+    async def _token_request(
+        self, method: str, path: str, *, json_body: Any = None,
+    ) -> tuple[int, Any]:
+        """Keyless REST call on the sandbox HTTP surface: send ``method``
+        to ``{http_base}{path}`` authenticated by ``x-sandbox-token``
+        (the same seam ``upload_blob`` / ``download_blob`` use — no
+        signed crypto). ``json_body`` is sent as a JSON request body when
+        given. Returns ``(status, parsed_json_or_None)``; an empty or
+        non-JSON body (e.g. a 204) parses to ``None``. Wraps transport
+        failures in ``BridgeError`` so lifecycle callers surface a clean
+        error instead of a raw aiohttp exception.
+
+        Opens a short-lived session per call so lifecycle HTTP stays
+        independent of the WS lifecycle (mirrors the blob routes).
+        """
+        url = f"{self._http_base}{path}"
+        headers = {"x-sandbox-token": self._token}
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as session:
+                async with session.request(
+                    method, url, headers=headers, json=json_body,
+                ) as resp:
+                    body = await resp.read()
+                    if not body:
+                        return resp.status, None
+                    try:
+                        return resp.status, json.loads(body)
+                    except json.JSONDecodeError:
+                        return resp.status, None
+        except aiohttp.ClientError as exc:
+            raise BridgeError(
+                "LIFECYCLE", f"{method} {path} transport error: {exc}",
+            ) from exc
+
+    async def schedule_wake(
+        self,
+        *,
+        after_seconds: int | None = None,
+        wake_at: str | None = None,
+        reason: str = "",
+    ) -> dict:
+        """Schedule a server-side wake for this sandbox: POST
+        ``/v2/cloud-agents/schedule-wake`` keyless. Pass exactly one of
+        ``after_seconds`` (relative) or ``wake_at`` (absolute ISO ts) —
+        the caller enforces that; ``reason`` rides along when non-empty.
+        Returns the server's confirmed ``{wake_at, reason}``. Non-2xx /
+        transport → ``BridgeError``."""
+        body: dict[str, Any] = {}
+        if after_seconds is not None:
+            body["after_seconds"] = after_seconds
+        if wake_at is not None:
+            body["wake_at"] = wake_at
+        if reason:
+            body["reason"] = reason
+        status, parsed = await self._token_request(
+            "POST", "/v2/cloud-agents/schedule-wake", json_body=body,
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "SCHEDULE_WAKE",
+                f"schedule-wake failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def get_scheduled_wake(self) -> dict:
+        """Read the current scheduled wake: GET
+        ``/v2/cloud-agents/scheduled-wake`` keyless. Returns the server
+        body — ``{wake_at, reason}`` when one is set, or ``{wake_at:
+        None}`` when none is scheduled. Non-2xx / transport →
+        ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "GET", "/v2/cloud-agents/scheduled-wake",
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "SCHEDULED_WAKE",
+                f"scheduled-wake read failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {"wake_at": None}
+
+    async def cancel_wake(self) -> dict:
+        """Cancel the scheduled wake: DELETE
+        ``/v2/cloud-agents/scheduled-wake`` keyless. Returns the parsed
+        body, or ``{}`` on an empty 204. Non-2xx / transport →
+        ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "DELETE", "/v2/cloud-agents/scheduled-wake",
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "CANCEL_WAKE",
+                f"cancel-wake failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def runtime_status(self) -> dict:
+        """Read this sandbox's runtime status: GET
+        ``/v2/cloud-agents/runtime-status`` keyless. Returns the server
+        body (``{state, timeout_at, seconds_until_sleep?, sandbox_id}``);
+        ``seconds_until_sleep`` may be ``None`` when the server can't
+        compute it — surfaced verbatim, never fabricated. Non-2xx /
+        transport → ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "GET", "/v2/cloud-agents/runtime-status",
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "RUNTIME_STATUS",
+                f"runtime-status read failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def keepalive(self, seconds: int) -> dict:
+        """Push back this sandbox's auto-sleep deadline: POST
+        ``/v2/cloud-agents/keepalive`` ``{seconds}`` keyless.
+
+        Normalizes the "deadline-refresh not landed upstream" signal to
+        a first-class result so the caller branches without catching:
+          - 2xx → ``{"available": True, **body}`` (body carries
+            ``timeout_at`` / ``seconds_until_sleep``).
+          - 501 / 503, or a 2xx body with ``available`` false →
+            ``{"available": False, "detail": <msg>}``.
+        Any other non-2xx / transport failure → ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "POST", "/v2/cloud-agents/keepalive",
+            json_body={"seconds": seconds},
+        )
+        parsed = parsed if isinstance(parsed, dict) else {}
+        if status in (501, 503):
+            detail = (
+                parsed.get("error")
+                or parsed.get("detail")
+                or f"keepalive unavailable (status={status})"
+            )
+            return {"available": False, "detail": detail}
+        if status // 100 == 2:
+            if parsed.get("available") is False:
+                detail = (
+                    parsed.get("error")
+                    or parsed.get("detail")
+                    or "keepalive reported unavailable"
+                )
+                return {"available": False, "detail": detail}
+            return {"available": True, **parsed}
+        raise BridgeError(
+            "KEEPALIVE",
+            f"keepalive failed (status={status}): {parsed!r}",
+        )
+
     async def send_send(
         self,
         *,

--- a/src/puffo_agent/mcp/lifecycle_tools.py
+++ b/src/puffo_agent/mcp/lifecycle_tools.py
@@ -1,0 +1,214 @@
+"""Bridge-only sandbox-lifecycle MCP tools (T23).
+
+Registered *only* for cloud (bridge-transport) agents — gated on
+``cfg.bridge_client is not None`` at the ``register_core_tools`` call
+site — and exposed over the ws-local dispatch allowlist
+(``WS_LOCAL_ALLOWED_TOOLS``). A native/desktop agent (signed-crypto
+transport, ``bridge_client is None``) never registers them, so this
+whole surface is invisible to native agents.
+
+Every tool is a thin, fail-soft wrapper over the ``CloudBridgeClient``
+keyless ``x-sandbox-token`` lifecycle methods: a failing lifecycle call
+returns a plain error string the model can reason about, never an
+exception that would crash the turn. The server owns all wake / sleep
+state — these tools are stateless request/response calls, no
+persistence or background scheduling on the agent side.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from ..agent.bridge_client import BridgeClosed, BridgeError
+
+logger = logging.getLogger(__name__)
+
+
+def register_lifecycle_tools(mcp: FastMCP, cfg: Any) -> None:
+    """Register the five cloud-lifecycle tools on ``mcp``. Call only
+    when ``cfg.bridge_client is not None`` — each tool also defends the
+    gate itself so a stray registration can't act on a native agent."""
+
+    @mcp.tool()
+    async def schedule_wake(
+        after_seconds: int = 0,
+        wake_at: str = "",
+        reason: str = "",
+    ) -> str:
+        """Schedule a server-side wake so a long task self-resumes after
+        your cloud sandbox auto-sleeps. Cloud (bridge) agents only.
+
+        Your sandbox is put to sleep after an idle timeout; a scheduled
+        wake tells the server to bring it back so an in-flight task keeps
+        going instead of stalling until the next inbound message.
+
+        Pass EXACTLY ONE of:
+          - ``after_seconds`` — wake this many seconds from now (relative).
+          - ``wake_at`` — an absolute ISO-8601 timestamp to wake at.
+        ``reason`` is an optional short note stored with the wake.
+
+        Returns the confirmed wake time.
+        """
+        if cfg.bridge_client is None:
+            return "schedule_wake is only available to cloud (bridge) agents."
+        has_after = bool(after_seconds) and after_seconds > 0
+        has_at = bool(wake_at and wake_at.strip())
+        if has_after and has_at:
+            return (
+                "schedule_wake: pass exactly one of after_seconds or "
+                "wake_at, not both."
+            )
+        if not has_after and not has_at:
+            return (
+                "schedule_wake: pass one of after_seconds (>0) or wake_at "
+                "(an ISO-8601 timestamp)."
+            )
+        try:
+            result = await cfg.bridge_client.schedule_wake(
+                after_seconds=int(after_seconds) if has_after else None,
+                wake_at=wake_at.strip() if has_at else None,
+                reason=reason,
+            )
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "schedule_wake failed (x-sandbox-token POST "
+                f"/v2/cloud-agents/schedule-wake): {exc}"
+            )
+        result = result or {}
+        confirmed = result.get("wake_at") or "?"
+        note = result.get("reason") or reason
+        tail = f" (reason: {note})" if note else ""
+        return f"wake scheduled for {confirmed}{tail}"
+
+    @mcp.tool()
+    async def cancel_wake() -> str:
+        """Cancel a previously scheduled wake for this cloud sandbox.
+        Cloud (bridge) agents only. Safe to call when nothing is
+        scheduled — the server treats that as a no-op."""
+        if cfg.bridge_client is None:
+            return "cancel_wake is only available to cloud (bridge) agents."
+        try:
+            await cfg.bridge_client.cancel_wake()
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "cancel_wake failed (x-sandbox-token DELETE "
+                f"/v2/cloud-agents/scheduled-wake): {exc}"
+            )
+        return "scheduled wake cancelled."
+
+    @mcp.tool()
+    async def get_scheduled_wake() -> str:
+        """Show the wake currently scheduled for this cloud sandbox, if
+        any. Cloud (bridge) agents only."""
+        if cfg.bridge_client is None:
+            return (
+                "get_scheduled_wake is only available to cloud (bridge) "
+                "agents."
+            )
+        try:
+            result = await cfg.bridge_client.get_scheduled_wake()
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "get_scheduled_wake failed (x-sandbox-token GET "
+                f"/v2/cloud-agents/scheduled-wake): {exc}"
+            )
+        result = result or {}
+        wake_at = result.get("wake_at")
+        if not wake_at:
+            return "no wake is currently scheduled."
+        reason = result.get("reason") or ""
+        tail = f" (reason: {reason})" if reason else ""
+        return f"wake scheduled for {wake_at}{tail}"
+
+    @mcp.tool()
+    async def get_runtime_status() -> str:
+        """Report this cloud sandbox's runtime state and how long until
+        it auto-sleeps. Cloud (bridge) agents only.
+
+        ``seconds_until_sleep`` is shown as ``unknown`` when the server
+        can't compute it — never a fabricated number. Use ``keep_alive``
+        to push the deadline back, or ``schedule_wake`` to self-resume
+        after a sleep."""
+        if cfg.bridge_client is None:
+            return (
+                "get_runtime_status is only available to cloud (bridge) "
+                "agents."
+            )
+        try:
+            result = await cfg.bridge_client.runtime_status()
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "get_runtime_status failed (x-sandbox-token GET "
+                f"/v2/cloud-agents/runtime-status): {exc}"
+            )
+        result = result or {}
+        state = result.get("state") or "unknown"
+        sandbox_id = result.get("sandbox_id") or "?"
+        timeout_at = result.get("timeout_at") or "unknown"
+        secs = result.get("seconds_until_sleep")
+        # ``null``/absent → the literal word "unknown"; a real number
+        # (including 0) renders as itself. Never guess a value.
+        secs_str = "unknown" if secs is None else str(secs)
+        return (
+            f"sandbox {sandbox_id}: state={state}, "
+            f"seconds_until_sleep={secs_str}, timeout_at={timeout_at}"
+        )
+
+    @mcp.tool()
+    async def keep_alive(seconds: int = 600) -> str:
+        """Push back this cloud sandbox's auto-sleep deadline by roughly
+        ``seconds``. Cloud (bridge) agents only.
+
+        Use this to hold the sandbox awake while a long task runs. If the
+        upstream deadline-refresh isn't available yet, this automatically
+        falls back to scheduling a wake ~``seconds`` out, so the task
+        still self-resumes even if the sandbox sleeps. Returns what
+        happened either way."""
+        if cfg.bridge_client is None:
+            return "keep_alive is only available to cloud (bridge) agents."
+        try:
+            secs = int(seconds)
+        except (TypeError, ValueError):
+            return "keep_alive: seconds must be an integer number of seconds."
+        if secs <= 0:
+            return "keep_alive: seconds must be > 0."
+        try:
+            result = await cfg.bridge_client.keepalive(secs)
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "keep_alive failed (x-sandbox-token POST "
+                f"/v2/cloud-agents/keepalive): {exc}"
+            )
+        result = result or {}
+        if result.get("available"):
+            timeout_at = result.get("timeout_at") or "?"
+            secs_left = result.get("seconds_until_sleep")
+            secs_str = "unknown" if secs_left is None else str(secs_left)
+            return (
+                f"keepalive ok — auto-sleep pushed to {timeout_at} "
+                f"(seconds_until_sleep={secs_str})."
+            )
+        # Upstream deadline-refresh not landed yet — fall back to a
+        # scheduled wake so a long task still self-resumes if the sandbox
+        # sleeps before it finishes.
+        detail = result.get("detail") or "keepalive unavailable upstream"
+        try:
+            wake = await cfg.bridge_client.schedule_wake(
+                after_seconds=secs, reason="keepalive fallback",
+            )
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                f"keep_alive: upstream keepalive is unavailable ({detail}) "
+                f"and the schedule_wake fallback also failed: {exc}. The "
+                "sandbox may sleep without resuming — retry keep_alive or "
+                "schedule_wake."
+            )
+        wake_at = (wake or {}).get("wake_at") or f"~{secs}s from now"
+        return (
+            f"keepalive is not available upstream yet ({detail}); scheduled "
+            f"a wake at {wake_at} (~{secs}s) as a fallback so this task "
+            "self-resumes if the sandbox sleeps."
+        )

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -1438,3 +1438,13 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             reason=reason,
         )
 
+    # Bridge-only sandbox-lifecycle tools (schedule_wake / cancel_wake /
+    # get_scheduled_wake / get_runtime_status / keep_alive). Gated on
+    # ``bridge_client`` — set ONLY at the in-process ws-local site — so a
+    # native/subprocess agent never registers them (and never exposes the
+    # keyless ``x-sandbox-token`` lifecycle surface). Imported lazily so
+    # the native path doesn't pay for a module it will never use.
+    if cfg.bridge_client is not None:
+        from .lifecycle_tools import register_lifecycle_tools
+        register_lifecycle_tools(mcp, cfg)
+

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -37,6 +37,13 @@ WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
     # membership
     "leave_space",
     "leave_channel",
+    # bridge-only sandbox lifecycle (registered only when
+    # cfg.bridge_client is set — native agents never see these)
+    "schedule_wake",
+    "cancel_wake",
+    "get_scheduled_wake",
+    "get_runtime_status",
+    "keep_alive",
 })
 
 

--- a/tests/test_cloud_bridge_lifecycle_client.py
+++ b/tests/test_cloud_bridge_lifecycle_client.py
@@ -1,0 +1,266 @@
+"""``CloudBridgeClient`` keyless lifecycle REST methods vs. a loopback
+aiohttp mock app (mirrors ``test_cloud_bridge_client.py``). Exercises the
+``x-sandbox-token`` HTTP surface — POST/GET/DELETE on
+``/v2/cloud-agents/{schedule-wake,scheduled-wake,runtime-status,keepalive}``
+— asserting the client sends the right route/body/header and maps the
+response. Loopback only, no real network / E2B / server.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from puffo_agent.agent.bridge_client import BridgeError, CloudBridgeClient
+
+
+class _MockLifecycleApp:
+    """Records requests to the lifecycle routes and returns canned
+    bodies/status the test configures."""
+
+    def __init__(self) -> None:
+        self.token_seen: str | None = None
+        self.requests: list[dict] = []
+        # Per-route canned responses: (status, json_body). Defaults
+        # exercise the happy path; tests override to drive edge cases.
+        self.schedule_wake_response: tuple[int, dict] = (
+            200, {"wake_at": "2026-07-07T12:00:00Z", "reason": "ok"},
+        )
+        self.scheduled_wake_response: tuple[int, dict | None] = (
+            200, {"wake_at": None},
+        )
+        self.cancel_wake_status = 204
+        self.runtime_status_response: tuple[int, dict] = (
+            200, {
+                "state": "running",
+                "timeout_at": "2026-07-07T13:00:00Z",
+                "seconds_until_sleep": 900,
+                "sandbox_id": "sbx_1",
+            },
+        )
+        self.keepalive_response: tuple[int, dict] = (
+            200, {
+                "timeout_at": "2026-07-07T14:00:00Z",
+                "seconds_until_sleep": 3600,
+            },
+        )
+
+    async def _record(self, request: web.Request) -> None:
+        self.token_seen = request.headers.get("x-sandbox-token")
+        body = None
+        if request.can_read_body:
+            try:
+                body = await request.json()
+            except Exception:
+                body = None
+        self.requests.append({
+            "method": request.method,
+            "path": request.path,
+            "token": request.headers.get("x-sandbox-token"),
+            "body": body,
+        })
+
+    async def schedule_wake(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.schedule_wake_response
+        return web.json_response(body, status=status)
+
+    async def scheduled_wake_get(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.scheduled_wake_response
+        return web.json_response(body, status=status)
+
+    async def scheduled_wake_delete(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        if self.cancel_wake_status == 204:
+            return web.Response(status=204)
+        return web.json_response({"cancelled": True}, status=self.cancel_wake_status)
+
+    async def runtime_status(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.runtime_status_response
+        return web.json_response(body, status=status)
+
+    async def keepalive(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.keepalive_response
+        return web.json_response(body, status=status)
+
+
+def _build_app(app: _MockLifecycleApp) -> web.Application:
+    a = web.Application()
+    a.router.add_post("/v2/cloud-agents/schedule-wake", app.schedule_wake)
+    a.router.add_get("/v2/cloud-agents/scheduled-wake", app.scheduled_wake_get)
+    a.router.add_delete(
+        "/v2/cloud-agents/scheduled-wake", app.scheduled_wake_delete,
+    )
+    a.router.add_get("/v2/cloud-agents/runtime-status", app.runtime_status)
+    a.router.add_post("/v2/cloud-agents/keepalive", app.keepalive)
+    return a
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_after_seconds_posts_body_and_token():
+    mock = _MockLifecycleApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.schedule_wake(after_seconds=1800, reason="long task")
+    assert result == {"wake_at": "2026-07-07T12:00:00Z", "reason": "ok"}
+    req = mock.requests[-1]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v2/cloud-agents/schedule-wake"
+    assert req["token"] == "sbx_tok"
+    assert req["body"] == {"after_seconds": 1800, "reason": "long task"}
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_wake_at_posts_body():
+    mock = _MockLifecycleApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        await c.schedule_wake(wake_at="2026-07-07T15:30:00Z")
+    req = mock.requests[-1]
+    assert req["body"] == {"wake_at": "2026-07-07T15:30:00Z"}
+    assert "after_seconds" not in req["body"]
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_non_2xx_raises_bridge_error():
+    mock = _MockLifecycleApp()
+    mock.schedule_wake_response = (409, {"error": "already scheduled"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.schedule_wake(after_seconds=60)
+    assert excinfo.value.code == "SCHEDULE_WAKE"
+
+
+@pytest.mark.asyncio
+async def test_get_scheduled_wake_null_when_none():
+    mock = _MockLifecycleApp()
+    mock.scheduled_wake_response = (200, {"wake_at": None})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.get_scheduled_wake()
+    assert result == {"wake_at": None}
+    req = mock.requests[-1]
+    assert req["method"] == "GET"
+    assert req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_get_scheduled_wake_returns_fields_when_set():
+    mock = _MockLifecycleApp()
+    mock.scheduled_wake_response = (
+        200, {"wake_at": "2026-07-07T12:00:00Z", "reason": "batch"},
+    )
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.get_scheduled_wake()
+    assert result["wake_at"] == "2026-07-07T12:00:00Z"
+    assert result["reason"] == "batch"
+
+
+@pytest.mark.asyncio
+async def test_cancel_wake_issues_delete():
+    mock = _MockLifecycleApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.cancel_wake()
+    # 204 empty body → {}
+    assert result == {}
+    req = mock.requests[-1]
+    assert req["method"] == "DELETE"
+    assert req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_returns_fields_incl_null_seconds():
+    mock = _MockLifecycleApp()
+    mock.runtime_status_response = (
+        200, {
+            "state": "running",
+            "timeout_at": "2026-07-07T13:00:00Z",
+            "seconds_until_sleep": None,
+            "sandbox_id": "sbx_9",
+        },
+    )
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.runtime_status()
+    assert result["state"] == "running"
+    assert result["sandbox_id"] == "sbx_9"
+    # null seconds_until_sleep is preserved verbatim (not fabricated).
+    assert result["seconds_until_sleep"] is None
+    req = mock.requests[-1]
+    assert req["method"] == "GET"
+    assert req["path"] == "/v2/cloud-agents/runtime-status"
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_keepalive_available_returns_deadline():
+    mock = _MockLifecycleApp()
+    mock.keepalive_response = (
+        200, {"timeout_at": "2026-07-07T14:00:00Z", "seconds_until_sleep": 3600},
+    )
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.keepalive(600)
+    assert result["available"] is True
+    assert result["timeout_at"] == "2026-07-07T14:00:00Z"
+    assert result["seconds_until_sleep"] == 3600
+    req = mock.requests[-1]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v2/cloud-agents/keepalive"
+    assert req["body"] == {"seconds": 600}
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_keepalive_unavailable_flags_available_false():
+    mock = _MockLifecycleApp()
+    # Server signals the AIM deadline-refresh isn't landed yet.
+    mock.keepalive_response = (501, {"error": "keepalive not implemented yet"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.keepalive(600)
+    assert result["available"] is False
+    assert "keepalive not implemented yet" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_unavailable_via_200_available_false():
+    mock = _MockLifecycleApp()
+    # Alternate contract: 200 with an explicit available:false body.
+    mock.keepalive_response = (200, {"available": False, "detail": "not ready"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.keepalive(600)
+    assert result["available"] is False
+    assert "not ready" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_other_non_2xx_raises_bridge_error():
+    mock = _MockLifecycleApp()
+    mock.keepalive_response = (500, {"error": "boom"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.keepalive(600)
+    assert excinfo.value.code == "KEEPALIVE"

--- a/tests/test_lifecycle_tools.py
+++ b/tests/test_lifecycle_tools.py
@@ -1,0 +1,332 @@
+"""Bridge-only lifecycle MCP tools: mapping / fallback / gating logic.
+
+Handlers are obtained through
+``portal.ws_local.tool_dispatch.build_dispatch`` — that both proves the
+allowlist wiring and exercises the ``register_core_tools`` gate on
+``cfg.bridge_client``. Most cases use a fake ``bridge_client`` for the
+mapping/fallback/gating logic; the two ``*_posts_right_body_*`` /
+``*_hit_right_routes`` cases drive a **real** ``CloudBridgeClient``
+against a loopback mock so we pin the actual ``x-sandbox-token`` HTTP.
+LLM-free, E2B-free, server-free.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from puffo_agent.agent.bridge_client import BridgeError, CloudBridgeClient
+from puffo_agent.mcp.puffo_core_tools import PuffoCoreToolsConfig
+from puffo_agent.portal.ws_local.tool_dispatch import build_dispatch
+
+
+LIFECYCLE_TOOLS = frozenset({
+    "schedule_wake",
+    "cancel_wake",
+    "get_scheduled_wake",
+    "get_runtime_status",
+    "keep_alive",
+})
+
+
+def _cfg(bridge) -> PuffoCoreToolsConfig:
+    """Minimal tools config; only ``bridge_client`` matters here — the
+    lifecycle tools never touch keystore/http/data."""
+    return PuffoCoreToolsConfig(
+        slug="agent-1",
+        device_id="dev-1",
+        keystore=MagicMock(),
+        http_client=MagicMock(),
+        data_client=MagicMock(),
+        bridge_client=bridge,
+    )
+
+
+class _FakeBridge:
+    """Records lifecycle-method calls and returns canned results.
+    Set ``raise_on`` to a method name to make it raise ``BridgeError``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.raise_on: str | None = None
+        self.schedule_wake_result: dict = {"wake_at": "2026-07-07T12:00:00Z"}
+        self.get_scheduled_wake_result: dict = {"wake_at": None}
+        self.cancel_wake_result: dict = {}
+        self.runtime_status_result: dict = {
+            "state": "running",
+            "timeout_at": "2026-07-07T13:00:00Z",
+            "seconds_until_sleep": 900,
+            "sandbox_id": "sbx_1",
+        }
+        self.keepalive_result: dict = {
+            "available": True,
+            "timeout_at": "2026-07-07T14:00:00Z",
+            "seconds_until_sleep": 3600,
+        }
+
+    def _maybe_raise(self, name: str) -> None:
+        if self.raise_on == name:
+            raise BridgeError("KEEPALIVE", "simulated transport failure")
+
+    async def schedule_wake(self, *, after_seconds=None, wake_at=None, reason=""):
+        self.calls.append((
+            "schedule_wake",
+            {"after_seconds": after_seconds, "wake_at": wake_at, "reason": reason},
+        ))
+        self._maybe_raise("schedule_wake")
+        return self.schedule_wake_result
+
+    async def get_scheduled_wake(self):
+        self.calls.append(("get_scheduled_wake", {}))
+        self._maybe_raise("get_scheduled_wake")
+        return self.get_scheduled_wake_result
+
+    async def cancel_wake(self):
+        self.calls.append(("cancel_wake", {}))
+        self._maybe_raise("cancel_wake")
+        return self.cancel_wake_result
+
+    async def runtime_status(self):
+        self.calls.append(("runtime_status", {}))
+        self._maybe_raise("runtime_status")
+        return self.runtime_status_result
+
+    async def keepalive(self, seconds):
+        self.calls.append(("keepalive", {"seconds": seconds}))
+        self._maybe_raise("keepalive")
+        return self.keepalive_result
+
+
+# --------------------------------------------------------------------------
+# Loopback mock app for the real-CloudBridgeClient end-to-end cases
+# --------------------------------------------------------------------------
+
+
+class _MockApp:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def _record(self, request: web.Request) -> None:
+        body = None
+        if request.can_read_body:
+            try:
+                body = await request.json()
+            except Exception:
+                body = None
+        self.requests.append({
+            "method": request.method,
+            "path": request.path,
+            "token": request.headers.get("x-sandbox-token"),
+            "body": body,
+        })
+
+    async def schedule_wake(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        return web.json_response(
+            {"wake_at": "2026-07-07T12:00:00Z", "reason": "batch job"},
+        )
+
+    async def scheduled_wake_get(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        return web.json_response({"wake_at": None})
+
+    async def scheduled_wake_delete(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        return web.Response(status=204)
+
+
+def _build_app(mock: _MockApp) -> web.Application:
+    a = web.Application()
+    a.router.add_post("/v2/cloud-agents/schedule-wake", mock.schedule_wake)
+    a.router.add_get("/v2/cloud-agents/scheduled-wake", mock.scheduled_wake_get)
+    a.router.add_delete(
+        "/v2/cloud-agents/scheduled-wake", mock.scheduled_wake_delete,
+    )
+    return a
+
+
+# --------------------------------------------------------------------------
+# (verify a) real-client end-to-end: right route/body/token
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_tool_posts_right_body_with_token():
+    mock = _MockApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        bridge = CloudBridgeClient(url, "sbx_e2e", "slug")
+        dispatch = build_dispatch(_cfg(bridge))
+        assert "schedule_wake" in dispatch
+        result = await dispatch["schedule_wake"](
+            after_seconds=1800, reason="batch job",
+        )
+    req = mock.requests[-1]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v2/cloud-agents/schedule-wake"
+    assert req["token"] == "sbx_e2e"
+    assert req["body"] == {"after_seconds": 1800, "reason": "batch job"}
+    # Tool surfaces the confirmed wake_at from the server.
+    assert "2026-07-07T12:00:00Z" in result
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_get_scheduled_wake_hit_right_routes():
+    mock = _MockApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        bridge = CloudBridgeClient(url, "sbx_e2e", "slug")
+        dispatch = build_dispatch(_cfg(bridge))
+        await dispatch["cancel_wake"]()
+        delete_req = mock.requests[-1]
+        result = await dispatch["get_scheduled_wake"]()
+        get_req = mock.requests[-1]
+    assert delete_req["method"] == "DELETE"
+    assert delete_req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert get_req["method"] == "GET"
+    assert get_req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert get_req["token"] == "sbx_e2e"
+    # No wake scheduled → readable "none" summary.
+    assert "no wake" in result.lower()
+
+
+# --------------------------------------------------------------------------
+# (verify b) runtime-status null → "unknown"
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_status_maps_null_seconds_to_unknown():
+    bridge = _FakeBridge()
+    bridge.runtime_status_result = {
+        "state": "running",
+        "timeout_at": "2026-07-07T13:00:00Z",
+        "seconds_until_sleep": None,
+        "sandbox_id": "sbx_1",
+    }
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["get_runtime_status"]()
+    assert "unknown" in result
+    # Never fabricate a number for an unknown deadline.
+    assert "seconds_until_sleep=unknown" in result
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_status_renders_real_seconds():
+    bridge = _FakeBridge()  # default seconds_until_sleep=900
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["get_runtime_status"]()
+    assert "900" in result
+    assert "unknown" not in result
+
+
+# --------------------------------------------------------------------------
+# (verify c) keep_alive available vs. fallback
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_returns_refreshed_deadline():
+    bridge = _FakeBridge()
+    bridge.keepalive_result = {
+        "available": True,
+        "timeout_at": "2026-07-07T14:00:00Z",
+        "seconds_until_sleep": 3600,
+    }
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["keep_alive"](600)
+    assert "2026-07-07T14:00:00Z" in result
+    assert ("keepalive", {"seconds": 600}) in bridge.calls
+    # No fallback schedule_wake when keepalive succeeded.
+    assert all(name != "schedule_wake" for name, _ in bridge.calls)
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_falls_back_to_schedule_wake_when_unavailable():
+    bridge = _FakeBridge()
+    bridge.keepalive_result = {"available": False, "detail": "not landed yet"}
+    bridge.schedule_wake_result = {"wake_at": "2026-07-07T12:10:00Z"}
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["keep_alive"](600)
+    # keepalive was tried, then schedule_wake fallback fired with ~600s.
+    sched = [args for name, args in bridge.calls if name == "schedule_wake"]
+    assert len(sched) == 1
+    assert sched[0]["after_seconds"] == 600
+    # Message explains the fallback and self-resume.
+    lowered = result.lower()
+    assert "wake" in lowered
+    assert "fallback" in lowered or "not available" in lowered
+    assert "2026-07-07T12:10:00Z" in result
+
+
+# --------------------------------------------------------------------------
+# (verify d) registration gating on bridge transport
+# --------------------------------------------------------------------------
+
+
+def test_lifecycle_tools_not_registered_under_native_transport():
+    dispatch = build_dispatch(_cfg(None))  # native: bridge_client is None
+    for name in LIFECYCLE_TOOLS:
+        assert name not in dispatch
+
+
+def test_lifecycle_tools_registered_under_bridge_transport():
+    dispatch = build_dispatch(_cfg(_FakeBridge()))
+    for name in LIFECYCLE_TOOLS:
+        assert name in dispatch
+
+
+# --------------------------------------------------------------------------
+# (verify e) transport error is a fail-soft string, not a crash
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_error_returned_as_tool_error_not_crash():
+    bridge = _FakeBridge()
+    bridge.raise_on = "schedule_wake"
+    dispatch = build_dispatch(_cfg(bridge))
+    # Must NOT propagate — the tool returns a string the model can read.
+    result = await dispatch["schedule_wake"](after_seconds=60)
+    assert isinstance(result, str)
+    assert "schedule_wake failed" in result
+    assert "simulated transport failure" in result
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_transport_error_is_fail_soft():
+    bridge = _FakeBridge()
+    bridge.raise_on = "keepalive"
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["keep_alive"](600)
+    assert isinstance(result, str)
+    assert "keep_alive failed" in result
+
+
+# --------------------------------------------------------------------------
+# input validation (fail-soft strings, no exceptions)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_rejects_both_after_and_wake_at():
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](
+        after_seconds=60, wake_at="2026-07-07T12:00:00Z",
+    )
+    assert "exactly one" in result
+    # Nothing was sent to the bridge.
+    assert bridge.calls == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_rejects_neither():
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"]()
+    assert "one of after_seconds" in result
+    assert bridge.calls == []

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -39,6 +39,12 @@ def test_allowed_tools_are_the_send_read_and_membership_tools():
         # membership
         "leave_space",
         "leave_channel",
+        # bridge-only sandbox lifecycle
+        "schedule_wake",
+        "cancel_wake",
+        "get_scheduled_wake",
+        "get_runtime_status",
+        "keep_alive",
     })
 
 


### PR DESCRIPTION
## What (stacks on #139)

Agent half of cloud-agent self-lifecycle control. **Bridge-transport-gated** (native/desktop agents don't expose these); calls the keyless `x-sandbox-token` routes (#184 schedule-wake, #185 runtime-status/keepalive).

- **`mcp/lifecycle_tools.py`**: `schedule_wake` / `cancel_wake` / `get_scheduled_wake` / `get_runtime_status` / `keep_alive` over the keyless token-HTTP helper
- **`keep_alive` belt-and-suspenders**: on "upstream keepalive unavailable" (AIM not landed yet) it falls back to `schedule_wake(after≈seconds)` so a long task self-resumes if E2B sleeps it
- `get_runtime_status` surfaces a null `seconds_until_sleep` plainly as "unknown" — never fabricates
- fail-soft: a lifecycle error returns a tool error string, not a crash

## Verify
LLM-free + E2B-free pytest (mock keyless HTTP): routes/bodies/`x-sandbox-token`, keepalive fallback, bridge-gating, error-as-tool-error. Full suite green.

**Stacked on `fleet/fatcloud-agent-attach-consume` (#139). HOLD — do not self-merge.** (Route contracts land via #184/#185.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)