### PR TITLE
Fat cloud agent — complete stack (keyless transport swap + messaging + attachments + self-lifecycle)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,19 @@ dependencies = [
     "pyhpke>=0.6",
     "openai>=1.30",
     "psutil>=5.9",
-    "pyside6>=6.7",
     "python-socks>=2.4",
     "pyyaml>=6.0",
     "websockets>=12.0",
 ]
 
 [project.optional-dependencies]
+# pip install puffo-agent[gui]  — the PySide6 desktop UI (window + tray).
+# Kept out of the base install so `pip install puffo-agent` stays Qt-free
+# for headless/cloud daemons; `start`/`run_daemon` never import PySide6.
+# The `start --ui` / `start --tray` entry points fail with an actionable
+# "install puffo-agent[gui]" hint (see portal/cli.py cmd_start) when the
+# extra is absent.
+gui = ["pyside6>=6.7"]
 # pip install puffo-agent[sdk]  — needed for agents with runtime.kind=sdk
 sdk = ["claude-agent-sdk>=0.1.61"]
 # cli-local / cli-docker adapters don't need extra Python deps; they

--- a/roadmap/cloud-agent/FAT-E2B-INTEGRATION.md
+++ b/roadmap/cloud-agent/FAT-E2B-INTEGRATION.md
@@ -8,6 +8,12 @@ through Shan's LiteLLM virtual-key endpoint instead of the vendor
 default). Neither changes native/desktop behavior when the new config is
 absent.
 
+> **Keyless outbound dispatch (T23 phase 1):** how a keyless cloud agent
+> does all outbound tool work over unsigned `/v2/cloud-agents/*` HTTP
+> (egress-injected `x-sandbox-token`) instead of the bridge WS — and which
+> GAP rows flip to PASS — is written up in
+> [`KEYLESS-DISPATCH-PHASE1.md`](./KEYLESS-DISPATCH-PHASE1.md).
+
 ---
 
 ## 1. Slim packaging — base install is Qt-free

--- a/roadmap/cloud-agent/FAT-E2B-INTEGRATION.md
+++ b/roadmap/cloud-agent/FAT-E2B-INTEGRATION.md
@@ -1,0 +1,115 @@
+# FAT `puffo-agent` → E2B cloud drop-in
+
+Notes for making the FAT `puffo-agent` a clean drop-in for the thin
+`puffo-agent-cloud` in the E2B/cloud image. Two independent changes
+landed here: **slim packaging** (so `pip install puffo-agent` is Qt-free)
+and a **config-driven LLM base URL** (so cloud agents' model calls route
+through Shan's LiteLLM virtual-key endpoint instead of the vendor
+default). Neither changes native/desktop behavior when the new config is
+absent.
+
+---
+
+## 1. Slim packaging — base install is Qt-free
+
+`pip install puffo-agent` no longer pulls **PySide6** (Qt). The only
+GUI-only dependency was `pyside6`; it moved out of `[project].dependencies`
+into a new `[project.optional-dependencies] gui` extra:
+
+```toml
+[project.optional-dependencies]
+gui = ["pyside6>=6.7"]
+```
+
+Consequences for the cloud image:
+
+- **Base install runs headless.** `puffo-agent start` (→ `run_daemon`),
+  `puffo-agent --help`, and `import puffo_agent.portal.daemon` all import
+  and run with PySide6 **absent**. Every `import PySide6` in the source
+  lives under `src/puffo_agent/portal/ui/`, and those modules are only
+  reached from the UI entry points — never from the daemon path.
+- **Restore the desktop UI** with `pip install 'puffo-agent[gui]'`. Then
+  `start --ui` (desktop window) and `start --tray` (menu-bar) work as
+  before.
+- **GUI commands without the extra fail loud, not ugly.** `start --ui` /
+  `start --tray-runner` invoked without `[gui]` print an actionable hint
+  (`pip install 'puffo-agent[gui]'`) and exit non-zero, instead of a raw
+  `ModuleNotFoundError` traceback. See `portal/cli.py cmd_start`.
+
+The cloud/E2B image should install the **base** package (no `[gui]`), which
+is what keeps the image slim and Qt-free. The `sdk` extra
+(`claude-agent-sdk`) is still required for `runtime.kind=sdk-local`.
+
+> `requirements.txt` is a stale partial list that never listed pyside6 —
+> `pyproject.toml` is the source of truth for dependencies.
+
+---
+
+## 2. LLM plane — route model calls through the LiteLLM VK
+
+Cloud agents should send their model calls to Shan's LiteLLM **virtual
+key (VK)** endpoint (an OpenAI/Anthropic-compatible base URL) rather than
+`api.anthropic.com` / `api.openai.com`. This is driven entirely from the
+`runtime` block of each agent's `agent.yml` — **no hard-coded URLs and no
+embedded key** in the package.
+
+### Fields Shan's cloud bundle sets (per agent `agent.yml`)
+
+```yaml
+runtime:
+  kind: chat-local            # or sdk-local / cli-local
+  llm_base_url: "<VK endpoint>"   # e.g. the LiteLLM proxy base URL
+  api_key: "<VK>"                 # the virtual key (reuses the existing api_key field)
+  # ...model / provider / etc. as usual
+```
+
+- **`llm_base_url`** — new field. OpenAI/Anthropic-compatible base URL.
+  Empty/absent → the vendor endpoint, i.e. **today's behavior, byte-for-
+  byte unchanged**.
+- **`api_key`** — the existing field, reused to carry the VK secret. No
+  new secret field was introduced.
+
+### What consumes them, per `runtime.kind`
+
+| `runtime.kind`            | `llm_base_url` routing                                                                 | VK secret (`api_key`)                          |
+| ------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `chat-local` (anthropic)  | `AnthropicProvider(base_url=…)` → `anthropic.Anthropic(base_url=…)`                    | `api_key` → client key                         |
+| `chat-local` (openai)     | `OpenAIProvider(base_url=…)` → `OpenAI(base_url=…)`                                    | `api_key` → client key                         |
+| `sdk-local`               | `SDKAdapter(base_url=…)` injects `ANTHROPIC_BASE_URL` into the SDK subprocess env      | `api_key` → `ANTHROPIC_API_KEY` (already wired) |
+| `cli-local` / claude-code | `LocalCLIAdapter(llm_base_url=…)` injects `ANTHROPIC_BASE_URL` into the claude spawn env | `api_key` → `ANTHROPIC_API_KEY` (VK), injected **only** when `llm_base_url` is also set |
+
+Notes:
+
+- **`cli-local` with an empty `llm_base_url` injects nothing** into the
+  spawn env — claude keeps its `claude login` / OAuth credential path
+  (`~/.claude/.credentials.json`). Only when `llm_base_url` is set do we
+  add `ANTHROPIC_BASE_URL`, and only then (and when `api_key` is
+  non-empty) do we add `ANTHROPIC_API_KEY=<VK>` so the CLI authenticates
+  against the VK.
+- The env mapping is a single shared pure helper,
+  `puffo_agent.agent.adapters.base.anthropic_base_url_env(base_url)`,
+  reused by the SDK and CLI adapters so the behavior is DRY and unit-tested.
+
+### Follow-ups (out of scope for this change)
+
+- **`cli-docker`** base-URL routing — threading `ANTHROPIC_BASE_URL` (and
+  the VK) into the per-agent container env is not wired yet.
+- **codex / OpenAI-CLI** — routing the VK into codex's `OPENAI_BASE_URL`
+  is not wired yet.
+- **Provisioning / rotating the VK** is Shan's; this change only threads
+  the config-driven fields. No key is embedded, defaulted, or fetched by
+  the package.
+
+---
+
+## Verification snapshot
+
+- `pip install .` in a fresh venv → `import PySide6` raises
+  `ModuleNotFoundError`, while `import puffo_agent.portal.daemon` and
+  `puffo-agent --help` succeed. `pip install '.[gui]'` →
+  `import puffo_agent.portal.ui.launcher` succeeds.
+- `tests/test_slim_packaging_headless.py` — headless import + GUI-hint guard.
+- `tests/test_llm_base_url_routing.py` — VK routing for chat-local
+  (Anthropic + OpenAI), cli-local spawn-env override, sdk-local wiring +
+  the shared env helper; and that an absent base URL leaves the vendor
+  endpoint unchanged.

--- a/roadmap/cloud-agent/KEYLESS-DISPATCH-PHASE1.md
+++ b/roadmap/cloud-agent/KEYLESS-DISPATCH-PHASE1.md
@@ -1,0 +1,88 @@
+# Keyless outbound dispatch (T23 phase 1)
+
+How a **keyless cloud agent** (`puffo_core.transport == "bridge"`, no
+signing key on disk) does all outbound tool work — and why native
+(keystore-backed) agents are untouched.
+
+## The transport picture
+
+| Direction | Keyless (bridge) agent | Native agent |
+|-----------|------------------------|--------------|
+| Outbound reads (`list_spaces`, channels, members, profiles) | **unsigned HTTP** `GET /v2/cloud-agents/*` | signed `GET /spaces …` |
+| Outbound sends (`send_message`, attachments) | **unsigned HTTP** `POST /v2/cloud-agents/messages` + `POST /v2/cloud-agents/blobs/upload` | encrypt + signed `POST /messages` / `/blobs/upload` |
+| Auth on outbound | E2B **egress proxy injects `x-sandbox-token`** on outbound HTTPS — no key in the sandbox | Ed25519 subkey signature (keystore) |
+| Inbound (receive push, `fetch_pending` / `ack`) | bridge **WS** (unchanged) | n/a |
+| Sandbox lifecycle (`schedule_wake`, `keep_alive`, …) | bridge WS / token-authed (unchanged) | not registered |
+
+**Key change vs. the earlier bridge draft:** outbound sends no longer go
+over the bridge WS (`send_send` / `upload_blob`). They are plain unsigned
+HTTP POSTs, so they work from **any process** — the daemon's in-process
+ws-local dispatch *and* the cli-local subprocess MCP — because the egress
+proxy, not the process, supplies auth. The bridge WS is retained for
+**inbound only**.
+
+Native agents keep the signed keystore path **byte-for-byte**. The whole
+keyless behaviour is gated on a single flag, `PuffoCoreHttpClient.keyless`
+(True iff `transport == "bridge"`), surfaced to the tools as
+`PuffoCoreToolsConfig.keyless`.
+
+## Where the seam lives
+
+`puffo_core_tools.py` has one helper per wire read/write, each branching
+on `cfg.keyless`:
+
+- `_read_spaces` → `GET /v2/cloud-agents/spaces`
+- `_read_space_channels` → `GET /v2/cloud-agents/spaces/{sp}/channels`
+- `_read_channel_members` → `GET /v2/cloud-agents/spaces/{sp}/members`
+- `_read_profiles` → `GET /v2/cloud-agents/identities/profiles?slugs=…`
+- `_send_keyless` → `POST /v2/cloud-agents/messages`
+- `_upload_blob_keyless` → `POST /v2/cloud-agents/blobs/upload`
+
+The egress token injection is `PuffoCoreHttpClient._egress_headers`,
+called only from `get_unsigned` / `post_unsigned` / `post_bytes_unsigned`.
+
+## `list_channel_members` → space roster (documented caveat)
+
+The server exposes **four** keyless read routes (`reads.rs`): `spaces`,
+`spaces/{id}/channels`, `spaces/{id}/members` (the **space roster**), and
+`identities/profiles`. There is **no keyless *channel*-members route**. So
+under keyless, `list_channel_members` resolves channel→space (the existing
+`_resolve_channel_space` cache) and reads the space roster
+`GET /v2/cloud-agents/spaces/{space_id}/members`. Native keeps its
+channel-scoped `/spaces/{sp}/channels/{ch}/members`. This is a deliberate,
+documented behaviour difference — not a route we add here.
+
+## GAP rows that flip to PASS
+
+These six tools were GAP under the keyless bridge (they still hit the
+signed keystore path with no keys) and now PASS over `/v2/cloud-agents/*`:
+
+- `list_spaces`
+- `list_channels_in_space`
+- `list_channels_in_all_spaces`
+- `list_channel_members` (→ space roster, per the caveat above)
+- `get_user_info`
+- `whoami` (builds identity from config + resolves `display_name` over the
+  unsigned profiles route; the subkey is *managed server-side*, so it
+  never loads the keystore)
+
+And the **cli-local LLM subprocess** `send_message` / `list_spaces` now
+authenticate **keyless** with no bridge and no daemon-RPC — the subprocess
+is self-sufficient because `build_server(transport="bridge")` builds its
+`PuffoCoreHttpClient` with `keyless=True` and the egress proxy supplies the
+token.
+
+## Test-only egress shim
+
+Production leaves `PUFFO_LOCAL_SANDBOX_TOKEN` unset — the real E2B egress
+proxy injects `x-sandbox-token`, and nothing is written to any config
+file. For local end-to-end runs the shim reads that env var and adds the
+header itself; `config.py` forwards the var into the MCP subprocess env
+**only when it is present** in the daemon environment.
+
+## Out of scope
+
+Native/signed behaviour, the bridge WS inbound path, the lifecycle tools,
+and any puffo-server change (the keyless routes already exist in
+`reads.rs` / `send.rs`). See `FAT-E2B-INTEGRATION.md` for the surrounding
+cloud drop-in work.

--- a/roadmap/cloud-agent/PHASE25-SERVER-ROUTE-GAPS.md
+++ b/roadmap/cloud-agent/PHASE25-SERVER-ROUTE-GAPS.md
@@ -1,0 +1,126 @@
+# Phase 2.5 (server) — keyless-path route & frame gaps
+
+This is the single spec for a future **puffo-server** run (working name:
+`fleet/cloud-agent-sandbox-token-auth`). It records every place the
+keyless (`transport: "bridge"`) `puffo-agent` path is already coded to
+*emit* or *read* a field/name but the server does not yet *carry* it or
+*authenticate* the request over the `x-sandbox-token` sandbox credential.
+
+Until these land the agent side **degrades gracefully**: threaded replies
+render top-level, names render as `@slug`. Nothing on the agent crashes —
+every reader uses `.get()` with a benign fallback and every enrichment
+helper returns empty/None offline. This doc is the checklist for closing
+those gaps on the server; no agent change is required when they land
+(the field names and query shapes below are already what the agent
+emits/reads).
+
+Scope note: the agent side of all of this is done. This run does **not**
+build a token-authed REST client — per the audit below there is currently
+**no** `x-sandbox-token`-authenticated REST route to call, so there is
+nothing to route through. The signed `crypto/http_client` stays retired
+on the bridge path; these routes are the server work that would give the
+agent something to call.
+
+---
+
+## 1. Inbound `Message` frame — missing thread + display fields
+
+**Frame:** `AgentServerMsg::Message` (`puffo-server` `.../bridge.rs`),
+emitted to the cloud-agent WS on inbound delivery. On every branch checked
+(`dev`, `cloud-agent-channel-frame`, `cloud-agent-send-threading`) it emits
+only:
+
+```
+envelope_id, sender_slug, space_id, channel_id,
+recipient_slug, sent_at, plaintext
+```
+
+**Add these fields to the frame:**
+
+| Field | Agent caller (already reads it) | Effect once present |
+| --- | --- | --- |
+| `thread_root_id` | `_payload_from_bridge_frame` (`puffo_core_client.py`) — maps `frame.get("thread_root_id")` onto `MessagePayload.thread_root_id` | inbound replies render/store as threaded instead of top-level |
+| `reply_to_id` | `_payload_from_bridge_frame` — maps `frame.get("reply_to_id")` onto `MessagePayload.reply_to_id` | reply linkage surfaces on the stored row |
+| `sender_display_name` (+ optional `avatar_url`) | `_preseed_frame_display_name` → `set_profile(...)` → `_handle_plaintext_payload`'s `_fetch_display_name` cache hit | sender renders by name with **no** HTTP lookup |
+
+Notes:
+
+- The agent reads `thread_root_id` / `reply_to_id` **today** and runs them
+  through the strict same-channel `_validate_incoming_parent_id` admit
+  check before storage, so a populated frame is honored the instant the
+  server adds the fields — forward-compatible, no agent change.
+- `sender_display_name` is read defensively (`sender_display_name` first,
+  then `display_name`); either key works. A non-empty value pre-seeds the
+  profile cache so the render path fires no `/identities/profiles` GET.
+- The **outbound** half of threading (`AgentClientMsg::Send` carrying
+  `reply_to_id` / `thread_root_id`) is a separate server branch
+  (`fleet/cloud-agent-send-threading`, `bridge.rs`). The agent already
+  emits both snake_case field names on the `send` frame; the server only
+  has to accept + persist them.
+
+---
+
+## 2. `GET /identities/profiles?slugs=<slug>` — needs an `x-sandbox-token` read variant
+
+**Agent caller:** `_fetch_user_profile` / `_fetch_display_name`
+(`puffo_core_client.py`), for `sender_display_name` on every inbound
+render, plus the MCP `whoami` / profile tools.
+
+**Today:** signed-auth only (`puffo-server` `.../lib.rs`). The sandbox token
+authenticates **only** the cloud-agent control WS
+(`/v2/cloud-agents/subscribe`, `v2/router.rs`), not this REST route. Over
+the bridge the agent's `http` has no signing key, so the call degrades to
+empty and the name renders as `@slug`.
+
+**Add:** an `x-sandbox-token`-authenticated read variant returning
+`{ profiles: [{ slug, display_name, avatar_url }] }` (same body shape the
+signed route returns). Until then, the frame-carried `sender_display_name`
+in §1 is the only name source on the keyless path.
+
+---
+
+## 3. `GET /spaces/{space_id}/channels` — needs an `x-sandbox-token` read variant
+
+**Agent caller:** `_resolve_channel_name` (`puffo_core_client.py`) — turns a
+`ch_<uuid>` into a human channel name for the `channel:` prompt line.
+
+**Today:** signed-auth only (`membership.rs` / `space_config.rs`). Keyless →
+the channel renders as its raw id.
+
+**Add:** an `x-sandbox-token` read variant returning the space's channel
+list (`{ channels: [{ id, name, ... }] }`). There is **no** frame-carried
+channel-name source, so this route is the only fix.
+
+---
+
+## 4. `GET /spaces/{space_id}/members` — needs an `x-sandbox-token` read variant
+
+**Agent caller:** `_get_space_members` (`puffo_core_client.py`) — scopes
+`@mention` resolution + the `is_bot` flag to real space members.
+Relatedly, `_resolve_space_name` needs a `GET /spaces` read variant to
+turn `space_id` into a space name.
+
+**Today:** signed-auth only (`membership.rs`). Keyless → mentions can't be
+scoped to members and the space renders as its raw id.
+
+**Add:** an `x-sandbox-token` read variant of `GET /spaces/{space_id}/members`
+(`{ members: [{ slug, role }] }`) and of `GET /spaces`
+(`{ spaces: [{ id, name }] }`). No frame-carried source exists for either.
+
+---
+
+## Summary — what closes each gap
+
+| Gap | Fix | Home |
+| --- | --- | --- |
+| inbound thread ids (`thread_root_id`, `reply_to_id`) | add to `Message` frame | `bridge.rs` (`fleet/cloud-agent-sandbox-token-auth`) |
+| inbound sender name (`sender_display_name`, `avatar_url`) | add to `Message` frame | `bridge.rs` |
+| outbound thread ids | accept `reply_to_id`/`thread_root_id` on `Send` | `fleet/cloud-agent-send-threading` (`bridge.rs`) |
+| sender display name (fallback) | token-read `/identities/profiles` | `lib.rs` |
+| channel name | token-read `/spaces/{space_id}/channels` | `membership.rs` / `space_config.rs` |
+| space members + names | token-read `/spaces/{space_id}/members`, `/spaces` | `membership.rs` |
+
+`fleet/cloud-agent-sandbox-token-auth` is the likely future home branch for
+the token-authed read routes; the frame additions may co-land there or with
+the threading branch. All of it is server-side — the agent already emits and
+reads the names above and degrades gracefully until they arrive.

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -31,6 +31,22 @@ def is_silent(text: str) -> bool:
     return SILENT_MARKER in text
 
 
+def anthropic_base_url_env(base_url: str) -> dict[str, str]:
+    """Map an Anthropic-compatible LLM base URL to the subprocess/SDK
+    env override that routes model calls through it.
+
+    Returns ``{"ANTHROPIC_BASE_URL": base_url}`` when ``base_url`` is a
+    non-empty string, else ``{}`` — so an absent/empty base URL leaves
+    the spawn env untouched (vendor endpoint, today's behavior). Shared
+    by the SDK adapter (``run_turn`` env) and the cli-local adapter
+    (``_llm_env``) so the mapping stays DRY and unit-testable without
+    importing the optional ``claude-agent-sdk``.
+    """
+    if base_url:
+        return {"ANTHROPIC_BASE_URL": base_url}
+    return {}
+
+
 # Refresh when fewer than this many seconds remain on the access
 @dataclass
 class TurnContext:

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -42,7 +42,7 @@ from ...portal.state import (
     sync_host_skills,
 )
 from ..cli_bin import resolve_claude_bin, resolve_codex_bin, resolve_hermes_bin
-from .base import Adapter, TurnContext, TurnResult
+from .base import Adapter, TurnContext, TurnResult, anthropic_base_url_env
 from .cli_session import AuditLog, ClaudeSession
 from .codex_session import CodexSession
 from .desired_install import run_spawn_install
@@ -170,9 +170,18 @@ class LocalCLIAdapter(Adapter):
         puffo_core_server_url: str = "",
         puffo_core_slug: str = "",
         puffo_core_keys_dir: str = "",
+        llm_base_url: str = "",
+        llm_api_key: str = "",
     ):
         self.agent_id = agent_id
         self.model = model
+        # Anthropic-compatible base URL (e.g. LiteLLM VK) + its key.
+        # When ``llm_base_url`` is set, the claude-code spawn env gets
+        # ANTHROPIC_BASE_URL (and ANTHROPIC_API_KEY=VK when llm_api_key
+        # is non-empty). Empty base URL injects nothing, preserving the
+        # ``claude login`` / OAuth credential path. See ``_llm_env``.
+        self.llm_base_url = llm_base_url
+        self.llm_api_key = llm_api_key
         self.workspace_dir = workspace_dir
         self.claude_dir = claude_dir
         self.session_file = Path(session_file)
@@ -776,6 +785,7 @@ class LocalCLIAdapter(Adapter):
             "USERPROFILE": str(self.agent_home_dir),
             **self._permission_hook_env(),
             **self._macos_credential_env(),
+            **self._llm_env(),
         }
         self._session = ClaudeSession(
             agent_id=self.agent_id,
@@ -814,6 +824,22 @@ class LocalCLIAdapter(Adapter):
         return {
             "CLAUDE_CONFIG_DIR": str(Path(self.agent_home_dir) / ".claude"),
         }
+
+    def _llm_env(self) -> dict[str, str]:
+        """LLM-plane env overrides for the claude-code spawn.
+
+        Empty ``llm_base_url`` → ``{}`` (spawn env unchanged; claude
+        authenticates via ``~/.claude/.credentials.json`` / OAuth as
+        today). When set, inject ``ANTHROPIC_BASE_URL`` so the CLI's
+        model calls hit the proxy (LiteLLM VK), plus
+        ``ANTHROPIC_API_KEY=<VK>`` when ``llm_api_key`` is non-empty so
+        the CLI authenticates against the VK rather than the operator's
+        OAuth token.
+        """
+        env = anthropic_base_url_env(self.llm_base_url)
+        if env and self.llm_api_key:
+            env["ANTHROPIC_API_KEY"] = self.llm_api_key
+        return env
 
     def _permission_hook_env(self) -> dict[str, str]:
         """Env vars the PreToolUse hook script reads. Claude inherits

--- a/src/puffo_agent/agent/adapters/sdk.py
+++ b/src/puffo_agent/agent/adapters/sdk.py
@@ -19,7 +19,13 @@ from typing import Any
 from ...mcp.config import (
     PUFFO_CORE_TOOL_FQNS,
 )
-from .base import Adapter, TurnContext, TurnResult, format_history_as_prompt
+from .base import (
+    Adapter,
+    TurnContext,
+    TurnResult,
+    anthropic_base_url_env,
+    format_history_as_prompt,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +41,7 @@ class SDKAdapter(Adapter):
         workspace_dir: str = "",
         owner_username: str = "",
         max_turns: int = 10,
+        base_url: str = "",
     ):
         try:
             from claude_agent_sdk import (
@@ -61,6 +68,10 @@ class SDKAdapter(Adapter):
 
         self.api_key = api_key
         self.model = model
+        # Anthropic-compatible base URL (e.g. LiteLLM VK). Empty =
+        # vendor endpoint. Injected as ANTHROPIC_BASE_URL into the SDK
+        # subprocess env in run_turn.
+        self.base_url = base_url
         self.patterns = list(allowed_tools or [])
         # Puffo MCP tools auto-allow — users shouldn't need to thread
         # ``mcp__puffo__send_message`` through their allowed_tools.
@@ -77,6 +88,11 @@ class SDKAdapter(Adapter):
     async def run_turn(self, ctx: TurnContext) -> TurnResult:
         mcp_servers = self.mcp_servers_override or {}
 
+        # Vendor endpoint unless base_url is set; ANTHROPIC_BASE_URL then
+        # routes the SDK's model calls through the proxy (LiteLLM VK).
+        env = {"ANTHROPIC_API_KEY": self.api_key} if self.api_key else {}
+        env.update(anthropic_base_url_env(self.base_url))
+
         options = self._Options(
             system_prompt=ctx.system_prompt,
             cwd=ctx.workspace_dir or None,
@@ -88,7 +104,7 @@ class SDKAdapter(Adapter):
             can_use_tool=self._gate,
             permission_mode=self.permission_mode,
             model=self.model or None,
-            env={"ANTHROPIC_API_KEY": self.api_key} if self.api_key else {},
+            env=env,
             mcp_servers=mcp_servers,
             setting_sources=["project"],  # pick up .claude/CLAUDE.md under cwd
             max_turns=self.max_turns,

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -212,10 +212,16 @@ class CloudBridgeClient:
         recipient_slug: Optional[str] = None,
         space_id: Optional[str] = None,
         channel_id: Optional[str] = None,
+        reply_to_id: Optional[str] = None,
+        thread_root_id: Optional[str] = None,
         timeout: float = 30.0,
     ) -> dict:
         # Pass EITHER recipient_slug (DM) OR space_id+channel_id
         # (channel); spec rejects mixed-shape frames as BAD_FRAME.
+        # ``reply_to_id`` / ``thread_root_id`` are route-agnostic thread
+        # linkage — the same snake_case field names a human/web message
+        # carries; added only when truthy so a top-level post stays
+        # shape-identical to the pre-threading frame.
         ws = await self._require_ws()
         client_ref = f"r_{uuid.uuid4().hex[:12]}"
         frame: dict[str, Any] = {
@@ -229,6 +235,10 @@ class CloudBridgeClient:
             frame["space_id"] = space_id
         if channel_id:
             frame["channel_id"] = channel_id
+        if reply_to_id:
+            frame["reply_to_id"] = reply_to_id
+        if thread_root_id:
+            frame["thread_root_id"] = thread_root_id
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._send_acks[client_ref] = fut
         await ws.send_json(frame)

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -60,6 +60,10 @@ class CloudBridgeClient:
     ) -> None:
         ws_base = cloud_url.replace("http", "ws", 1)
         self._url = f"{ws_base.rstrip('/')}/v2/cloud-agents/subscribe"
+        # Keep the original http(s):// base for the keyless blob REST
+        # routes (``upload_blob`` / ``download_blob``) — same
+        # ``x-sandbox-token`` auth as the WS, no signed-crypto seam.
+        self._http_base = cloud_url.rstrip("/")
         self._token = sandbox_token
         self._slug = agent_slug
         self._session: aiohttp.ClientSession | None = None
@@ -205,6 +209,78 @@ class CloudBridgeClient:
             raise BridgeClosed("WS is not connected")
         return self._ws
 
+    async def upload_blob(self, data: bytes) -> dict:
+        """Keyless blob upload: POST the raw plaintext bytes to the
+        sandbox blob route, authenticated by ``x-sandbox-token`` (no
+        signed crypto — the server holds the at-rest store). Returns the
+        server ack JSON ``{ blob_id, size_bytes, uploaded_at }``.
+
+        Raises ``BridgeError`` on any non-2xx / transport / bad-body
+        failure so the caller (an outbound attachment send) surfaces a
+        clear tool error rather than silently dropping the file. Opens a
+        short-lived session per call so blob HTTP is independent of the
+        WS lifecycle.
+        """
+        url = f"{self._http_base}/v2/cloud-agents/blobs/upload"
+        headers = {
+            "x-sandbox-token": self._token,
+            "content-type": "application/octet-stream",
+        }
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as session:
+                async with session.post(
+                    url, data=data, headers=headers,
+                ) as resp:
+                    body = await resp.read()
+                    if resp.status // 100 != 2:
+                        raise BridgeError(
+                            "BLOB_UPLOAD",
+                            f"upload failed (status={resp.status}): "
+                            f"{body[:200]!r}",
+                        )
+                    try:
+                        return json.loads(body)
+                    except json.JSONDecodeError as exc:
+                        raise BridgeError(
+                            "BLOB_UPLOAD",
+                            f"upload returned non-JSON body: {exc}",
+                        ) from exc
+        except aiohttp.ClientError as exc:
+            raise BridgeError(
+                "BLOB_UPLOAD", f"upload transport error: {exc}",
+            ) from exc
+
+    async def download_blob(self, blob_id: str) -> bytes | None:
+        """Keyless blob download by id: GET the raw bytes from the
+        sandbox blob route, authenticated by ``x-sandbox-token`` (no
+        decrypt). Fail-soft — returns ``None`` on any non-200 (404
+        BLOB_NOT_FOUND, 413 FILE_TOO_LARGE, 401 UNAUTHORIZED) or
+        transport error, logging at WARNING; a missing / oversized /
+        unfetchable blob must never crash the inbound turn or the listen
+        loop.
+        """
+        url = f"{self._http_base}/v2/cloud-agents/blobs/{blob_id}"
+        headers = {"x-sandbox-token": self._token}
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as session:
+                async with session.get(url, headers=headers) as resp:
+                    if resp.status != 200:
+                        logger.warning(
+                            "cloud bridge: blob download failed "
+                            "(%s, status=%s)", blob_id, resp.status,
+                        )
+                        return None
+                    return await resp.read()
+        except Exception as exc:  # noqa: BLE001 — fail-soft download
+            logger.warning(
+                "cloud bridge: blob download error (%s): %s", blob_id, exc,
+            )
+            return None
+
     async def send_send(
         self,
         *,
@@ -214,6 +290,7 @@ class CloudBridgeClient:
         channel_id: Optional[str] = None,
         reply_to_id: Optional[str] = None,
         thread_root_id: Optional[str] = None,
+        attachments: Optional[list[dict]] = None,
         timeout: float = 30.0,
     ) -> dict:
         # Pass EITHER recipient_slug (DM) OR space_id+channel_id
@@ -222,6 +299,11 @@ class CloudBridgeClient:
         # linkage — the same snake_case field names a human/web message
         # carries; added only when truthy so a top-level post stays
         # shape-identical to the pre-threading frame.
+        # ``attachments`` is the canonical top-level list of
+        # ``AttachmentRef`` dicts ({ blob_id, filename?, mime_type?,
+        # size_bytes? }); blobs were already uploaded keyless via
+        # ``upload_blob``. Added only when non-empty so a plain send
+        # stays byte-shape-identical to the pre-attachment frame.
         ws = await self._require_ws()
         client_ref = f"r_{uuid.uuid4().hex[:12]}"
         frame: dict[str, Any] = {
@@ -239,6 +321,8 @@ class CloudBridgeClient:
             frame["reply_to_id"] = reply_to_id
         if thread_root_id:
             frame["thread_root_id"] = thread_root_id
+        if attachments:
+            frame["attachments"] = attachments
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._send_acks[client_ref] = fut
         await ws.send_json(frame)

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -81,37 +81,46 @@ class CloudBridgeClient:
             timeout=aiohttp.ClientTimeout(total=None),
         )
         headers = {"x-sandbox-token": self._token}
+        # F2: guard the whole handshake so EVERY failure path closes the
+        # half-open session/ws — the handshake error, a connector/OS error
+        # or TimeoutError from ws_connect/receive, and each bad-frame
+        # BridgeError. self.close() null-checks _ws/_session, so a pre-
+        # ws_connect failure (session only) still closes cleanly and
+        # leaves self._session is None.
         try:
-            self._ws = await self._session.ws_connect(
-                self._url, headers=headers, heartbeat=None,
-            )
-        except aiohttp.WSServerHandshakeError as exc:
-            await self._session.close()
-            self._session = None
-            raise BridgeError(
-                "HANDSHAKE",
-                f"WS upgrade failed (status={exc.status}): {exc.message}",
-            ) from exc
-        # Wait for the first frame — must be 'connected'.
-        first = await self._ws.receive(timeout=10.0)
-        if first.type != aiohttp.WSMsgType.TEXT:
+            try:
+                self._ws = await self._session.ws_connect(
+                    self._url, headers=headers, heartbeat=None,
+                )
+            except aiohttp.WSServerHandshakeError as exc:
+                raise BridgeError(
+                    "HANDSHAKE",
+                    f"WS upgrade failed (status={exc.status}): {exc.message}",
+                ) from exc
+            # Wait for the first frame — must be 'connected'.
+            first = await self._ws.receive(timeout=10.0)
+            if first.type != aiohttp.WSMsgType.TEXT:
+                raise BridgeError(
+                    "HANDSHAKE",
+                    f"expected text 'connected', got {first.type!r}",
+                )
+            try:
+                frame = json.loads(first.data)
+            except json.JSONDecodeError as exc:
+                raise BridgeError(
+                    "HANDSHAKE", f"bad first frame: {exc}",
+                ) from exc
+            if frame.get("type") != "connected":
+                raise BridgeError(
+                    "HANDSHAKE",
+                    f"expected 'connected', got {frame.get('type')!r}",
+                )
+        except BaseException:
             await self.close()
-            raise BridgeError(
-                "HANDSHAKE",
-                f"expected text 'connected', got {first.type!r}",
-            )
-        try:
-            frame = json.loads(first.data)
-        except json.JSONDecodeError as exc:
-            await self.close()
-            raise BridgeError("HANDSHAKE", f"bad first frame: {exc}") from exc
-        if frame.get("type") != "connected":
-            await self.close()
-            raise BridgeError(
-                "HANDSHAKE",
-                f"expected 'connected', got {frame.get('type')!r}",
-            )
+            raise
         logger.info("cloud bridge: WS connected (slug=%s)", self._slug)
+        # Start the heartbeat only after a clean handshake so no failure
+        # path leaves a live heartbeat task behind.
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
     async def frames(self) -> AsyncIterator[dict]:
@@ -490,6 +499,25 @@ class CloudBridgeClient:
             frame["limit"] = limit
         await ws.send_json(frame)
 
+    def _discard_waiter(
+        self, queue: "asyncio.Queue", fut: "asyncio.Future",
+    ) -> None:
+        """Remove ``fut`` from a FIFO waiter queue in place (F3).
+
+        Sync (no awaits) so it can't interleave with ``frames()`` popping
+        the same queue. Drains the queue, keeps every waiter that isn't
+        ``fut``, and re-enqueues them in order — so a timed-out waiter is
+        pulled out and the next real ``ack_result`` / ``spaces`` frame
+        isn't mis-delivered to a dead future.
+        """
+        remaining = []
+        while not queue.empty():
+            item = queue.get_nowait()
+            if item is not fut:
+                remaining.append(item)
+        for item in remaining:
+            queue.put_nowait(item)
+
     async def send_ack(
         self, envelope_ids: list[str], *, timeout: float = 30.0,
     ) -> dict:
@@ -497,14 +525,22 @@ class CloudBridgeClient:
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         await self._ack_result_waiters.put(fut)
         await ws.send_json({"type": "ack", "envelope_ids": envelope_ids})
-        return await asyncio.wait_for(fut, timeout=timeout)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._discard_waiter(self._ack_result_waiters, fut)
+            raise
 
     async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
         ws = await self._require_ws()
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         await self._spaces_waiters.put(fut)
         await ws.send_json({"type": "list_spaces"})
-        return await asyncio.wait_for(fut, timeout=timeout)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._discard_waiter(self._spaces_waiters, fut)
+            raise
 
     async def close(self) -> None:
         if self._heartbeat_task is not None:

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -281,6 +281,157 @@ class CloudBridgeClient:
             )
             return None
 
+    async def _token_request(
+        self, method: str, path: str, *, json_body: Any = None,
+    ) -> tuple[int, Any]:
+        """Keyless REST call on the sandbox HTTP surface: send ``method``
+        to ``{http_base}{path}`` authenticated by ``x-sandbox-token``
+        (the same seam ``upload_blob`` / ``download_blob`` use — no
+        signed crypto). ``json_body`` is sent as a JSON request body when
+        given. Returns ``(status, parsed_json_or_None)``; an empty or
+        non-JSON body (e.g. a 204) parses to ``None``. Wraps transport
+        failures in ``BridgeError`` so lifecycle callers surface a clean
+        error instead of a raw aiohttp exception.
+
+        Opens a short-lived session per call so lifecycle HTTP stays
+        independent of the WS lifecycle (mirrors the blob routes).
+        """
+        url = f"{self._http_base}{path}"
+        headers = {"x-sandbox-token": self._token}
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as session:
+                async with session.request(
+                    method, url, headers=headers, json=json_body,
+                ) as resp:
+                    body = await resp.read()
+                    if not body:
+                        return resp.status, None
+                    try:
+                        return resp.status, json.loads(body)
+                    except json.JSONDecodeError:
+                        return resp.status, None
+        except aiohttp.ClientError as exc:
+            raise BridgeError(
+                "LIFECYCLE", f"{method} {path} transport error: {exc}",
+            ) from exc
+
+    async def schedule_wake(
+        self,
+        *,
+        after_seconds: int | None = None,
+        wake_at: str | None = None,
+        reason: str = "",
+    ) -> dict:
+        """Schedule a server-side wake for this sandbox: POST
+        ``/v2/cloud-agents/schedule-wake`` keyless. Pass exactly one of
+        ``after_seconds`` (relative) or ``wake_at`` (absolute ISO ts) —
+        the caller enforces that; ``reason`` rides along when non-empty.
+        Returns the server's confirmed ``{wake_at, reason}``. Non-2xx /
+        transport → ``BridgeError``."""
+        body: dict[str, Any] = {}
+        if after_seconds is not None:
+            body["after_seconds"] = after_seconds
+        if wake_at is not None:
+            body["wake_at"] = wake_at
+        if reason:
+            body["reason"] = reason
+        status, parsed = await self._token_request(
+            "POST", "/v2/cloud-agents/schedule-wake", json_body=body,
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "SCHEDULE_WAKE",
+                f"schedule-wake failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def get_scheduled_wake(self) -> dict:
+        """Read the current scheduled wake: GET
+        ``/v2/cloud-agents/scheduled-wake`` keyless. Returns the server
+        body — ``{wake_at, reason}`` when one is set, or ``{wake_at:
+        None}`` when none is scheduled. Non-2xx / transport →
+        ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "GET", "/v2/cloud-agents/scheduled-wake",
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "SCHEDULED_WAKE",
+                f"scheduled-wake read failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {"wake_at": None}
+
+    async def cancel_wake(self) -> dict:
+        """Cancel the scheduled wake: DELETE
+        ``/v2/cloud-agents/scheduled-wake`` keyless. Returns the parsed
+        body, or ``{}`` on an empty 204. Non-2xx / transport →
+        ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "DELETE", "/v2/cloud-agents/scheduled-wake",
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "CANCEL_WAKE",
+                f"cancel-wake failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def runtime_status(self) -> dict:
+        """Read this sandbox's runtime status: GET
+        ``/v2/cloud-agents/runtime-status`` keyless. Returns the server
+        body (``{state, timeout_at, seconds_until_sleep?, sandbox_id}``);
+        ``seconds_until_sleep`` may be ``None`` when the server can't
+        compute it — surfaced verbatim, never fabricated. Non-2xx /
+        transport → ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "GET", "/v2/cloud-agents/runtime-status",
+        )
+        if status // 100 != 2:
+            raise BridgeError(
+                "RUNTIME_STATUS",
+                f"runtime-status read failed (status={status}): {parsed!r}",
+            )
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def keepalive(self, seconds: int) -> dict:
+        """Push back this sandbox's auto-sleep deadline: POST
+        ``/v2/cloud-agents/keepalive`` ``{seconds}`` keyless.
+
+        Normalizes the "deadline-refresh not landed upstream" signal to
+        a first-class result so the caller branches without catching:
+          - 2xx → ``{"available": True, **body}`` (body carries
+            ``timeout_at`` / ``seconds_until_sleep``).
+          - 501 / 503, or a 2xx body with ``available`` false →
+            ``{"available": False, "detail": <msg>}``.
+        Any other non-2xx / transport failure → ``BridgeError``."""
+        status, parsed = await self._token_request(
+            "POST", "/v2/cloud-agents/keepalive",
+            json_body={"seconds": seconds},
+        )
+        parsed = parsed if isinstance(parsed, dict) else {}
+        if status in (501, 503):
+            detail = (
+                parsed.get("error")
+                or parsed.get("detail")
+                or f"keepalive unavailable (status={status})"
+            )
+            return {"available": False, "detail": detail}
+        if status // 100 == 2:
+            if parsed.get("available") is False:
+                detail = (
+                    parsed.get("error")
+                    or parsed.get("detail")
+                    or "keepalive reported unavailable"
+                )
+                return {"available": False, "detail": detail}
+            return {"available": True, **parsed}
+        raise BridgeError(
+            "KEEPALIVE",
+            f"keepalive failed (status={status}): {parsed!r}",
+        )
+
     async def send_send(
         self,
         *,

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -1,0 +1,290 @@
+"""Keyless cloud-bridge WS client (T23 phase 1, experimental).
+
+Ported from the thin runtime's
+``packages/puffo-agent-cloud/src/puffo_agent_cloud/cloud_client.py``
+(proven in E2B, PR #157) with frame semantics unchanged. The server
+holds all crypto — frames are plaintext JSON, authenticated by the
+``x-sandbox-token`` header. Wire spec:
+``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``.
+
+Selected per agent via ``puffo_core.transport: "bridge"`` in agent.yml;
+the default ``"native"`` transport keeps today's signed-crypto path and
+never imports this module. Deliberately does NOT import anything from
+``crypto/`` (slated for deletion once the bridge is the only transport).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import uuid
+from typing import Any, AsyncIterator, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+# Module constant (not class attribute) so tests can monkeypatch a
+# short interval. Server recv-timeout is 90s.
+_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+class BridgeError(Exception):
+    """Server-emitted ``error`` frame (code + message). Categories:
+    ``NO_SUBKEY``, ``NOT_AUTHORIZED``, ``DECRYPT_FAILED``,
+    ``BAD_FRAME``, ``INTERNAL``."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class BridgeClosed(Exception):
+    """Raised when ``send_*`` is called after the WS closed and
+    before reconnect."""
+
+
+class CloudBridgeClient:
+    """One-WS-per-agent plaintext bridge. ``send_*`` methods are
+    request/response (correlated by ``client_ref`` or FIFO);
+    ``frames()`` yields the inbound stream (``message`` /
+    ``pending_delivered`` / uncorrelated ``error``). A background
+    task pumps a heartbeat every 30s (server recv-timeout = 90s)."""
+
+    def __init__(
+        self, cloud_url: str, sandbox_token: str, agent_slug: str,
+    ) -> None:
+        ws_base = cloud_url.replace("http", "ws", 1)
+        self._url = f"{ws_base.rstrip('/')}/v2/cloud-agents/subscribe"
+        self._token = sandbox_token
+        self._slug = agent_slug
+        self._session: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+        # client_ref → Future for ack correlation (one ack per send).
+        self._send_acks: dict[str, asyncio.Future] = {}
+        # FIFO of futures awaiting ack_result / spaces (no client_ref
+        # in the spec — only one in-flight at a time).
+        self._ack_result_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+        self._spaces_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+
+    async def connect(self) -> None:
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=None),
+        )
+        headers = {"x-sandbox-token": self._token}
+        try:
+            self._ws = await self._session.ws_connect(
+                self._url, headers=headers, heartbeat=None,
+            )
+        except aiohttp.WSServerHandshakeError as exc:
+            await self._session.close()
+            self._session = None
+            raise BridgeError(
+                "HANDSHAKE",
+                f"WS upgrade failed (status={exc.status}): {exc.message}",
+            ) from exc
+        # Wait for the first frame — must be 'connected'.
+        first = await self._ws.receive(timeout=10.0)
+        if first.type != aiohttp.WSMsgType.TEXT:
+            await self.close()
+            raise BridgeError(
+                "HANDSHAKE",
+                f"expected text 'connected', got {first.type!r}",
+            )
+        try:
+            frame = json.loads(first.data)
+        except json.JSONDecodeError as exc:
+            await self.close()
+            raise BridgeError("HANDSHAKE", f"bad first frame: {exc}") from exc
+        if frame.get("type") != "connected":
+            await self.close()
+            raise BridgeError(
+                "HANDSHAKE",
+                f"expected 'connected', got {frame.get('type')!r}",
+            )
+        logger.info("cloud bridge: WS connected (slug=%s)", self._slug)
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def frames(self) -> AsyncIterator[dict]:
+        # Yields message / pending_delivered / uncorrelated error.
+        # ping swallowed (no reply per spec §5.1); ack / ack_result /
+        # spaces routed to send_*() futures.
+        if self._ws is None:
+            return
+        async for msg in self._ws:
+            if msg.type != aiohttp.WSMsgType.TEXT:
+                if msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.ERROR,
+                ):
+                    logger.info(
+                        "cloud bridge: WS closing (%s)", msg.type,
+                    )
+                    break
+                continue
+            try:
+                frame = json.loads(msg.data)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "cloud bridge: dropped non-JSON WS frame",
+                )
+                continue
+            kind = frame.get("type", "")
+            if kind == "ping":
+                # Server keepalive — no reply per spec §5.1.
+                continue
+            if kind == "ack":
+                client_ref = frame.get("client_ref")
+                if client_ref and client_ref in self._send_acks:
+                    fut = self._send_acks.pop(client_ref)
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                # Unsolicited ack (e.g. server-side resend / lost
+                # correlation) — surface it for diagnostics.
+                logger.debug(
+                    "cloud bridge: ack with unknown client_ref=%r",
+                    client_ref,
+                )
+                continue
+            if kind == "ack_result":
+                if not self._ack_result_waiters.empty():
+                    fut = self._ack_result_waiters.get_nowait()
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                logger.debug("cloud bridge: ack_result with no waiter")
+                continue
+            if kind == "spaces":
+                if not self._spaces_waiters.empty():
+                    fut = self._spaces_waiters.get_nowait()
+                    if not fut.done():
+                        fut.set_result(frame)
+                    continue
+                logger.debug("cloud bridge: spaces with no waiter")
+                continue
+            if kind == "error" and frame.get("client_ref"):
+                # An error correlated to a send — route to that future
+                # as an exception.
+                client_ref = frame["client_ref"]
+                if client_ref in self._send_acks:
+                    fut = self._send_acks.pop(client_ref)
+                    if not fut.done():
+                        fut.set_exception(BridgeError(
+                            frame.get("code", "ERROR"),
+                            frame.get("message", ""),
+                        ))
+                    continue
+            yield frame
+
+    async def _heartbeat_loop(self) -> None:
+        while self._ws is not None and not self._ws.closed:
+            try:
+                await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                return
+            if self._ws is None or self._ws.closed:
+                return
+            try:
+                await self._ws.send_json({"type": "heartbeat"})
+            except (aiohttp.ClientError, ConnectionError) as exc:
+                logger.warning(
+                    "cloud bridge: heartbeat send failed: %s", exc,
+                )
+                return
+
+    async def _require_ws(self) -> aiohttp.ClientWebSocketResponse:
+        if self._ws is None or self._ws.closed:
+            raise BridgeClosed("WS is not connected")
+        return self._ws
+
+    async def send_send(
+        self,
+        *,
+        plaintext: str,
+        recipient_slug: Optional[str] = None,
+        space_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        # Pass EITHER recipient_slug (DM) OR space_id+channel_id
+        # (channel); spec rejects mixed-shape frames as BAD_FRAME.
+        ws = await self._require_ws()
+        client_ref = f"r_{uuid.uuid4().hex[:12]}"
+        frame: dict[str, Any] = {
+            "type": "send",
+            "plaintext": plaintext,
+            "client_ref": client_ref,
+        }
+        if recipient_slug:
+            frame["recipient_slug"] = recipient_slug
+        if space_id:
+            frame["space_id"] = space_id
+        if channel_id:
+            frame["channel_id"] = channel_id
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._send_acks[client_ref] = fut
+        await ws.send_json(frame)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        finally:
+            self._send_acks.pop(client_ref, None)
+
+    async def send_fetch_pending(self, *, limit: Optional[int] = None) -> None:
+        # Resulting message + pending_delivered surface via frames().
+        ws = await self._require_ws()
+        frame: dict[str, Any] = {"type": "fetch_pending"}
+        if limit is not None:
+            frame["limit"] = limit
+        await ws.send_json(frame)
+
+    async def send_ack(
+        self, envelope_ids: list[str], *, timeout: float = 30.0,
+    ) -> dict:
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        await self._ack_result_waiters.put(fut)
+        await ws.send_json({"type": "ack", "envelope_ids": envelope_ids})
+        return await asyncio.wait_for(fut, timeout=timeout)
+
+    async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        await self._spaces_waiters.put(fut)
+        await ws.send_json({"type": "list_spaces"})
+        return await asyncio.wait_for(fut, timeout=timeout)
+
+    async def close(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._heartbeat_task
+            self._heartbeat_task = None
+        if self._ws is not None and not self._ws.closed:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+        self._ws = None
+        if self._session is not None and not self._session.closed:
+            with contextlib.suppress(Exception):
+                await self._session.close()
+        self._session = None
+        # Cancel pending waiters with a clean BridgeClosed.
+        for fut in list(self._send_acks.values()):
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        self._send_acks.clear()
+        while not self._ack_result_waiters.empty():
+            fut = self._ack_result_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        while not self._spaces_waiters.empty():
+            fut = self._spaces_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))

--- a/src/puffo_agent/agent/providers/anthropic_provider.py
+++ b/src/puffo_agent/agent/providers/anthropic_provider.py
@@ -2,8 +2,15 @@ import anthropic
 
 
 class AnthropicProvider:
-    def __init__(self, api_key: str, model: str):
-        self.client = anthropic.Anthropic(api_key=api_key)
+    def __init__(self, api_key: str, model: str, base_url: str | None = None):
+        # ``base_url`` routes completions through a proxy (e.g. a LiteLLM
+        # virtual-key endpoint) instead of api.anthropic.com. Passed to
+        # the client only when set so the default stays the vendor
+        # endpoint — byte-for-byte unchanged when no base_url is given.
+        if base_url:
+            self.client = anthropic.Anthropic(api_key=api_key, base_url=base_url)
+        else:
+            self.client = anthropic.Anthropic(api_key=api_key)
         self.model = model
 
     def complete(self, system_prompt: str, messages: list[dict]) -> tuple[str, int, int]:

--- a/src/puffo_agent/agent/providers/openai_provider.py
+++ b/src/puffo_agent/agent/providers/openai_provider.py
@@ -2,8 +2,15 @@ from openai import OpenAI
 
 
 class OpenAIProvider:
-    def __init__(self, api_key: str, model: str):
-        self.client = OpenAI(api_key=api_key)
+    def __init__(self, api_key: str, model: str, base_url: str | None = None):
+        # ``base_url`` routes completions through a proxy (e.g. a LiteLLM
+        # virtual-key endpoint) instead of api.openai.com. Passed to the
+        # client only when set so the default stays the vendor endpoint —
+        # byte-for-byte unchanged when no base_url is given.
+        if base_url:
+            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        else:
+            self.client = OpenAI(api_key=api_key)
         self.model = model
 
     def complete(self, system_prompt: str, messages: list[dict]) -> tuple[str, int, int]:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -12,7 +12,7 @@ import random
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Coroutine, Optional
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional
 
 from ..crypto.encoding import base64url_decode
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
@@ -24,7 +24,10 @@ from ..crypto.message import (
     encrypt_message,
 )
 from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
-from ..crypto.ws_client import PuffoCoreWsClient
+from ..crypto.ws_client import INITIAL_BACKOFF, MAX_BACKOFF, PuffoCoreWsClient
+
+if TYPE_CHECKING:
+    from .bridge_client import CloudBridgeClient
 from . import disk_cache
 from ._invite_strings import format_invite_error, format_leave_error
 from .core import AgentAPIError
@@ -456,6 +459,8 @@ class PuffoCoreMessageClient:
         segment_chars: int = 2000,
         agent_created_at: int = 0,
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
+        *,
+        bridge_client: "CloudBridgeClient | None" = None,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -484,6 +489,10 @@ class PuffoCoreMessageClient:
         self.store = message_store
         self._key_cache = DeviceKeyCache(http_client)
         self._ws: Optional[PuffoCoreWsClient] = None
+        # T23: injected keyless bridge transport (experimental). When
+        # non-None, listen() runs the bridge lifecycle loop instead of
+        # the signed WS client — no identity file is ever loaded.
+        self._bridge = bridge_client
         # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
         # "reply to whoever just DMed me". Single-slot is fine since
         # the worker handles one envelope at a time; concurrent DM
@@ -587,6 +596,14 @@ class PuffoCoreMessageClient:
         turn exit (fresh dispatch AND kick-retry recovery).
         Invoked as ``on_turn_success(root_id, batch, channel_meta)``.
         """
+        if self._bridge is not None:
+            # T23 phase 1: keyless bridge transport. No identity file
+            # to load, and the consumer / invite-poll / warm tasks are
+            # skipped — they drive signed HTTP endpoints that can't
+            # work keyless until phase 2 rewires envelope flow.
+            await self._listen_bridge()
+            return
+
         identity = self.keystore.load_identity(self.slug)
         kem_kp = KemKeyPair.from_secret_bytes(
             decode_secret(identity.kem_secret_key)
@@ -938,6 +955,39 @@ class PuffoCoreMessageClient:
                     await task
                 except (asyncio.CancelledError, Exception):
                     pass
+
+    async def _listen_bridge(self) -> None:
+        """Bridge-transport lifecycle loop: connect → drain frames →
+        reconnect, with the same backoff schedule as the native
+        ``PuffoCoreWsClient.run()`` (start at INITIAL_BACKOFF, double
+        on failure, cap at MAX_BACKOFF, reset on successful connect).
+        """
+        bridge = self._bridge
+        assert bridge is not None  # guarded by listen()
+        backoff = INITIAL_BACKOFF
+        while True:
+            try:
+                try:
+                    await bridge.connect()
+                    backoff = INITIAL_BACKOFF
+                    async for frame in bridge.frames():
+                        # Phase 2 maps these into the message store +
+                        # thread queue; phase 1 logs and drops.
+                        self._log.info(
+                            "bridge frame dropped (phase 1): type=%s",
+                            frame.get("type", ""),
+                        )
+                finally:
+                    await bridge.close()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._log.warning(
+                    "bridge WS disconnected (%s: %s), reconnecting in %ds",
+                    type(exc).__name__, exc, backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, MAX_BACKOFF)
 
     async def _admit_thread_message(
         self,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -810,6 +810,16 @@ class PuffoCoreMessageClient:
             try:
                 payload = self._payload_from_bridge_frame(frame)
                 if payload is not None:
+                    # Enrichment over the keyless path: the only sender
+                    # name achievable today is one the frame itself
+                    # carries. When present, pre-seed the profile cache so
+                    # the downstream ``_fetch_display_name`` is a cache hit
+                    # and fires NO HTTP (the signed /identities/profiles
+                    # route can't authenticate keyless — see the phase-2.5
+                    # gaps doc). Absent → the helper degrades to @slug as
+                    # before. Native frames never carry this, so their
+                    # path is untouched.
+                    self._preseed_frame_display_name(frame, payload)
                     await self._handle_plaintext_payload(payload)
             except Exception:
                 self._log.exception(
@@ -828,6 +838,45 @@ class PuffoCoreMessageClient:
             )
         else:
             self._log.debug("bridge frame ignored: type=%s", kind)
+
+    def _preseed_frame_display_name(
+        self, frame: dict, payload: MessagePayload,
+    ) -> None:
+        """If a bridge ``message`` frame carries the sender's display
+        name, prime the profile cache so the render path uses it with no
+        HTTP lookup.
+
+        This is the one enrichment the keyless wire permits today: the
+        Message frame has ``sender_slug`` but the signed profile route
+        (`/identities/profiles`) can't authenticate over the sandbox
+        token, so a name that isn't on the frame degrades to ``@slug``.
+        Reads defensively — ``sender_display_name`` first, then
+        ``display_name`` — and only seeds a non-empty name for a known
+        slug, so an absent/blank field leaves the cache untouched (never
+        pinning a false miss). ``avatar_url`` rides along when present.
+        Fail-soft: any error is swallowed so a malformed frame can't
+        break inbound delivery.
+        """
+        try:
+            slug = payload.sender_slug
+            if not slug:
+                return
+            name = (
+                frame.get("sender_display_name")
+                or frame.get("display_name")
+                or ""
+            )
+            name = name.strip() if isinstance(name, str) else ""
+            if not name:
+                return
+            avatar_url = frame.get("avatar_url") or ""
+            avatar_url = avatar_url.strip() if isinstance(avatar_url, str) else ""
+            self.set_profile(slug, name, avatar_url)
+        except Exception:
+            self._log.debug(
+                "bridge display-name pre-seed skipped (envelope_id=%s)",
+                frame.get("envelope_id"), exc_info=True,
+            )
 
     async def _handle_plaintext_payload(self, payload: MessagePayload) -> None:
         """Persist + surface a decoded message payload to the agent.
@@ -3819,8 +3868,11 @@ class PuffoCoreMessageClient:
             # crypto and fans out recipients. Empty channel_id ⇒ DM back
             # to the last DM sender; else a channel post (space resolved
             # from the same caches native uses). No encrypt_message /
-            # signed POST. Threaded ``root_id`` isn't wired on bridge yet
-            # (phase 3) — this replies top-level.
+            # signed POST. Threaded ``root_id`` rides the same snake_case
+            # ``thread_root_id`` / ``reply_to_id`` field names native
+            # stamps onto ``EncryptInput`` — passed unresolved (native's
+            # fallback path does too), so a reply threads under the id the
+            # daemon already validated on the inbound envelope.
             if channel_id:
                 target_space_id = self._channel_space.get(channel_id)
                 if not target_space_id:
@@ -3839,6 +3891,8 @@ class PuffoCoreMessageClient:
                     plaintext=text,
                     space_id=target_space_id,
                     channel_id=channel_id,
+                    thread_root_id=root_id or None,
+                    reply_to_id=root_id or None,
                 )
                 self._log.info(
                     "send_fallback_message[bridge] sent: kind=channel "
@@ -3854,7 +3908,10 @@ class PuffoCoreMessageClient:
                 )
                 return
             ack = await self._bridge.send_send(
-                plaintext=text, recipient_slug=recipient,
+                plaintext=text,
+                recipient_slug=recipient,
+                thread_root_id=root_id or None,
+                reply_to_id=root_id or None,
             )
             self._log.info(
                 "send_fallback_message[bridge] sent: kind=dm recipient=%s "

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -494,6 +494,11 @@ class PuffoCoreMessageClient:
         # non-None, listen() runs the bridge lifecycle loop instead of
         # the signed WS client — no identity file is ever loaded.
         self._bridge = bridge_client
+        # In-flight ack tasks scheduled off the bridge dispatch loop
+        # (F1). Held so the tasks aren't GC'd mid-flight; each removes
+        # itself via a done-callback. Native transport never populates
+        # this — the ack lives only in the bridge dispatcher.
+        self._ack_tasks: set[asyncio.Task] = set()
         # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
         # "reply to whoever just DMed me". Single-slot is fine since
         # the worker handles one envelope at a time; concurrent DM
@@ -821,6 +826,17 @@ class PuffoCoreMessageClient:
                     # path is untouched.
                     self._preseed_frame_display_name(frame, payload)
                     await self._handle_plaintext_payload(payload)
+                    # F1: ack the delivered envelope now that it handled
+                    # cleanly. A handling exception above skips this (still
+                    # inside the try), so the server redelivers. Scheduled
+                    # async — awaiting send_ack inline would deadlock the
+                    # frames() loop, which must keep receiving to deliver the
+                    # server's ack_result that resolves send_ack's future.
+                    task = asyncio.create_task(
+                        self._ack_bridge_envelope([payload.envelope_id])
+                    )
+                    self._ack_tasks.add(task)
+                    task.add_done_callback(self._ack_tasks.discard)
             except Exception:
                 self._log.exception(
                     "bridge message frame handling failed (envelope_id=%s)",
@@ -838,6 +854,25 @@ class PuffoCoreMessageClient:
             )
         else:
             self._log.debug("bridge frame ignored: type=%s", kind)
+
+    async def _ack_bridge_envelope(self, envelope_ids: list[str]) -> None:
+        """Fail-soft ack of handled bridge envelopes (F1).
+
+        A failed ack must never crash the listen loop — the server
+        redelivers unacked envelopes, so a lost ack is at worst a
+        redelivery, not a dropped message. Native transport never calls
+        this (no ``_bridge``).
+        """
+        bridge = self._bridge
+        if bridge is None or not envelope_ids:
+            return
+        try:
+            await bridge.send_ack(envelope_ids)
+        except Exception:  # noqa: BLE001 — a failed ack must not crash the loop
+            self._log.warning(
+                "bridge ack failed (envelope_ids=%s)",
+                envelope_ids, exc_info=True,
+            )
 
     def _preseed_frame_display_name(
         self, frame: dict, payload: MessagePayload,
@@ -3840,8 +3875,15 @@ class PuffoCoreMessageClient:
                 # already logged; skip without failing the turn.
                 continue
             # Sanitise filename to block ``../`` / absolute-path
-            # write-outside-inbox via a malicious sender.
-            safe_name = Path(str(raw.get("filename") or "")).name or blob_id
+            # write-outside-inbox via a malicious sender. The blob_id
+            # fallback is basename-reduced too — a blob_id carrying path
+            # separators must not escape the inbox — and a final literal
+            # guarantees a non-empty name.
+            safe_name = (
+                Path(str(raw.get("filename") or "")).name
+                or Path(str(blob_id)).name
+                or "attachment"
+            )
             target = inbox / safe_name
             try:
                 target.write_bytes(data)

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -19,6 +19,7 @@ from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import (
     EncryptInput,
+    MessagePayload,
     RecipientDevice,
     decrypt_message,
     encrypt_message,
@@ -597,11 +598,17 @@ class PuffoCoreMessageClient:
         Invoked as ``on_turn_success(root_id, batch, channel_meta)``.
         """
         if self._bridge is not None:
-            # T23 phase 1: keyless bridge transport. No identity file
-            # to load, and the consumer / invite-poll / warm tasks are
-            # skipped — they drive signed HTTP endpoints that can't
-            # work keyless until phase 2 rewires envelope flow.
-            await self._listen_bridge()
+            # T23 phase 2: keyless bridge transport. No identity file to
+            # load; inbound plaintext frames flow through the same store
+            # + thread-queue tail native uses (the consumer runs). The
+            # invite-poll / member-warm tasks stay skipped — they drive
+            # signed HTTP endpoints that can't work keyless.
+            await self._listen_bridge(
+                on_message,
+                on_api_error_retry,
+                on_api_error_abandon,
+                on_turn_success,
+            )
             return
 
         identity = self.keystore.load_identity(self.slug)
@@ -673,250 +680,7 @@ class PuffoCoreMessageClient:
                 )
                 return
 
-            # PUF-227-A: strict cache-validation invariant for incoming
-            # ids. Any thread_root_id / reply_to_id that doesn't point
-            # to a same-channel parent in our local message_store gets
-            # wiped to None before storage — the agent's local view
-            # never honors a thread linkage that can't be resolved here.
-            # Catches the Scout-class symptom: a server / UI / sender
-            # that stamps a cross-channel id can't poison the recipient
-            # daemon's thread state.
-            validated_thread_root_id = await self._validate_incoming_parent_id(
-                payload.thread_root_id, payload.channel_id, payload.space_id,
-            )
-            validated_reply_to_id = await self._validate_incoming_parent_id(
-                payload.reply_to_id, payload.channel_id, payload.space_id,
-            )
-            await self.store.store({
-                "envelope_id": payload.envelope_id,
-                "envelope_kind": payload.envelope_kind,
-                "sender_slug": payload.sender_slug,
-                "channel_id": payload.channel_id,
-                "space_id": payload.space_id,
-                "recipient_slug": payload.recipient_slug,
-                "content_type": payload.content_type,
-                "content": payload.content,
-                "sent_at": payload.sent_at,
-                "thread_root_id": validated_thread_root_id,
-                "reply_to_id": validated_reply_to_id,
-            })
-            # Rebind for downstream code (root_id resolution at the
-            # batch-coalesce step, channel_meta construction, etc.) so
-            # admit-time wipes propagate through the agent prompt.
-            payload_thread_root_id = validated_thread_root_id
-            payload_reply_to_id = validated_reply_to_id
-
-            # Self-echo lands here too now (see ``handle_envelope``'s
-            # opening comment). Persist it — so ``get_channel_history``
-            # / ``get_thread_history`` show the agent's own posts —
-            # then stop before any of the LLM-facing pipeline below
-            # runs. The agent already produced this message; queueing
-            # it again would feed the agent its own words and trip a
-            # turn-by-turn echo loop.
-            if payload.sender_slug == self.slug:
-                return
-
-            # Daemon-side intercept: ``y``/``n`` from the operator on an
-            # outstanding invite-DM accepts/rejects without waking the
-            # LLM. A threaded reply answers just that invite; a direct
-            # (top-level) reply answers all pending invites at once.
-            if (
-                payload.envelope_kind == "dm"
-                and payload.sender_slug == self.operator_slug
-            ):
-                text_raw = str(payload.content) if payload.content else ""
-                targets, is_direct = self._resolve_invite_targets(
-                    payload_thread_root_id, text_raw,
-                )
-                handled_labels = (
-                    await self._apply_invite_replies(targets, text_raw)
-                    if targets else []
-                )
-                if handled_labels:
-                    # Handled inline — don't queue for the LLM.
-                    self._last_dm_sender = payload.sender_slug
-                    if is_direct:
-                        await self._send_invite_bulk_summary(
-                            handled_labels, text_raw, payload_thread_root_id or "",
-                        )
-                    return
-                # Same gate for agent-initiated leave requests, but
-                # threaded-only — each leave is confirmed in its own
-                # thread (no direct/bulk path).
-                if await self._maybe_handle_leave_reply(
-                    thread_root_id=payload_thread_root_id or "", text=text_raw,
-                ):
-                    self._last_dm_sender = payload.sender_slug
-                    return
-
-            channel_id = payload.channel_id or ""
-            is_dm = payload.envelope_kind == "dm"
-            # ``puffo/message+attachments/v1`` carries
-            # ``{ text, attachments: [...] }``; other content types
-            # use the plain-string path.
-            attachment_paths: list[str] = []
-            if payload.content_type == "puffo/message+attachments/v1" and isinstance(
-                payload.content, dict,
-            ):
-                raw_text = str(payload.content.get("text") or "")
-                metas_raw = payload.content.get("attachments") or []
-                if isinstance(metas_raw, list):
-                    attachment_paths = await self._save_inbound_attachments(
-                        envelope_id=payload.envelope_id, metas_raw=metas_raw,
-                    )
-            else:
-                raw_text = str(payload.content) if payload.content else ""
-
-            # Stash the sender so `send_fallback_message("")` can route replies.
-            # Always overwrite — first-write would pin replies to a
-            # stale peer when a different person DMs us.
-            if is_dm:
-                self._last_dm_sender = payload.sender_slug
-            elif payload.channel_id and payload.space_id:
-                # Remember which space owns this channel so replies
-                # resolve members in the right space (cross-space
-                # invites would otherwise fail).
-                self._channel_space[payload.channel_id] = payload.space_id
-
-            # Parse all ``@<slug>`` and scope to space members
-            # (matches the web client). Self is always kept.
-            self_slug_lower = self.slug.lower()
-            seen: set[str] = set()
-            parsed: list[str] = []
-            for m in _MENTION_RE.finditer(raw_text):
-                slug = m.group(1).lower()
-                if slug in seen:
-                    continue
-                seen.add(slug)
-                parsed.append(slug)
-            is_mention = self_slug_lower in seen
-            space_members = (
-                await self._get_space_members(payload.space_id)
-                if payload.space_id
-                else {}
-            )
-            mentions: list[dict] = []
-            for slug in parsed:
-                if slug == self_slug_lower:
-                    mentions.append({"username": self.slug, "is_bot": True, "is_self": True})
-                    continue
-                if space_members and slug not in space_members:
-                    continue
-                is_bot = space_members.get(slug) == "agent"
-                mentions.append({"username": slug, "is_bot": is_bot, "is_self": False})
-
-            # Self-mention rewrite: `@<our-slug>` → `@you(<our-slug>)`
-            # (the documented "addressed to you" signal).
-            clean_text = raw_text.replace(
-                f"@{self.slug}", f"@you({self.slug})",
-            ).strip() if is_mention else raw_text
-
-            # Resolve human-readable names so the LLM sees ``space:``/
-            # ``channel:`` instead of bare ids. Cached per session. DMs
-            # render an explicit "Direct message" label.
-            space_id = payload.space_id or ""
-            space_name = (
-                await self._resolve_space_name(space_id) if space_id else ""
-            )
-            if is_dm:
-                channel_name = "Direct message"
-            elif channel_id:
-                channel_name = await self._resolve_channel_name(
-                    space_id, channel_id,
-                )
-            else:
-                channel_name = channel_id
-
-            direct = is_dm or is_mention
-            sender_is_bot = False  # puffo-core has no is_bot flag yet
-            priority = _compute_priority(direct, sender_is_bot)
-
-            # Thread-batched queue: every message coalesces under
-            # its ``root_id`` (the envelope's ``thread_root_id``, or
-            # the message itself when it's a top-level post). The
-            # PriorityQueue holds one slot per root; new arrivals on
-            # the same thread either join the existing batch
-            # (priority same or lower) or bump the slot to the new
-            # higher priority. The agent processes one whole thread
-            # at a time in ``on_message_batch``.
-            # PUF-227-A: route on the VALIDATED thread_root_id. If
-            # admit-time validation wiped it (parent not in cache or
-            # cross-channel), the message gets a fresh per-envelope
-            # root_id and lands in its own batch — never inheriting a
-            # stale channel_meta from an unrelated thread.
-            root_id = payload_thread_root_id or payload.envelope_id
-
-            # Cross-restart dedup: after a daemon restart the server
-            # redelivers anything in /messages/pending. If we already
-            # dispatched a batch that covers ``payload.sent_at``,
-            # skip — the agent has seen this.
-            last_processed = await self.store.get_last_processed_sent_at(root_id)
-            if payload.sent_at <= last_processed:
-                self._log.info(
-                    "handle_envelope: cursor-rejected duplicate envelope=%s "
-                    "(sent_at=%d <= last_processed=%d, root=%s)",
-                    payload.envelope_id, payload.sent_at,
-                    last_processed, root_id,
-                )
-                return
-
-            # Per-session display-name cache turns this into ~1 HTTP
-            # call per distinct sender per session; same helper the
-            # invite-DM flow already uses. Empty string on miss.
-            sender_display_name = await self._fetch_display_name(
-                payload.sender_slug,
-            )
-
-            # Long-message redaction. Operators paste big chunks of
-            # code or transcripts that, combined with the agent's
-            # system prompt + thread history, can blow past the LLM
-            # context window — historically observable as the agent
-            # getting stuck in a "Prompt is too long" retry loop the
-            # restart path didn't recover from. The full envelope
-            # stays in messages.db; only the in-prompt view collapses
-            # to a placeholder pointing at ``get_post_segment``.
-            llm_text = _maybe_redact_long_text(
-                clean_text,
-                envelope_id=payload.envelope_id,
-                sender_slug=payload.sender_slug,
-                sender_display_name=sender_display_name,
-                max_inline_chars=self._max_inline_chars,
-                segment_chars=self._segment_chars,
-                agent_slug=self.slug,
-            )
-
-            msg_dict = {
-                "channel_id": channel_id,
-                "channel_name": channel_name,
-                "space_id": space_id,
-                "space_name": space_name,
-                "sender_slug": payload.sender_slug,
-                "sender_display_name": sender_display_name,
-                "sender_email": "",
-                "text": llm_text,
-                "root_id": payload_thread_root_id or "",
-                "is_dm": is_dm,
-                "attachments": attachment_paths,
-                "sender_is_bot": sender_is_bot,
-                "mentions": mentions,
-                "envelope_id": payload.envelope_id,
-                "sent_at": payload.sent_at,
-                "is_visible_to_human": payload.is_visible_to_human,
-            }
-            channel_meta = {
-                "channel_id": channel_id,
-                "channel_name": channel_name,
-                "space_id": space_id,
-                "space_name": space_name,
-                "is_dm": is_dm,
-            }
-
-            await self._admit_thread_message(
-                root_id=root_id,
-                priority=priority,
-                msg_dict=msg_dict,
-                channel_meta=channel_meta,
-            )
+            await self._handle_plaintext_payload(payload)
 
         # Per-listen() queue. A reconnect drops any envelopes not yet
         # drained; the server redelivers via /messages/pending on the
@@ -956,38 +720,421 @@ class PuffoCoreMessageClient:
                 except (asyncio.CancelledError, Exception):
                     pass
 
-    async def _listen_bridge(self) -> None:
-        """Bridge-transport lifecycle loop: connect → drain frames →
-        reconnect, with the same backoff schedule as the native
-        ``PuffoCoreWsClient.run()`` (start at INITIAL_BACKOFF, double
-        on failure, cap at MAX_BACKOFF, reset on successful connect).
+    async def _listen_bridge(
+        self,
+        on_message: Callable[..., Coroutine[Any, Any, Any]],
+        on_api_error_retry: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        on_api_error_abandon: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        on_turn_success: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+    ) -> None:
+        """Bridge-transport lifecycle loop: connect → fetch_pending →
+        drain frames → reconnect, with the same backoff schedule as the
+        native ``PuffoCoreWsClient.run()`` (start at INITIAL_BACKOFF,
+        double on failure, cap at MAX_BACKOFF, reset on successful
+        connect).
+
+        Inbound plaintext ``message`` frames map to a ``MessagePayload``
+        and flow through the same ``_handle_plaintext_payload`` tail the
+        native decrypt path uses — so a bridge-transport agent stores +
+        surfaces DMs / channel posts exactly like native, minus the
+        crypto. A fresh ``connect()`` drives ``send_fetch_pending()``
+        once so a cold sandbox drains its server-side queue;
+        ``pending_delivered`` marks that backfill complete (the loop
+        keeps running for live delivery).
+
+        Deliberately does NOT start ``_invite_poll_loop`` /
+        ``_warm_member_caches`` — they drive signed HTTP endpoints that
+        can't work keyless; names render as ids until those are rewired.
         """
         bridge = self._bridge
         assert bridge is not None  # guarded by listen()
+
+        # Per-listen() queue + thread state, mirrored from native
+        # listen(): a reconnect drops any envelopes not yet drained;
+        # the server redelivers them on the next fetch_pending, and the
+        # sqlite cursor keeps the agent from re-running handled threads.
+        self._queue = asyncio.PriorityQueue()
+        self._queue_seq = 0
+        self._thread_state = {}
+        await self.store.open()
+        consumer_task = asyncio.ensure_future(
+            self._consume_queue(
+                on_message, on_api_error_retry,
+                on_api_error_abandon, on_turn_success,
+            ),
+        )
         backoff = INITIAL_BACKOFF
-        while True:
-            try:
+        try:
+            while True:
                 try:
-                    await bridge.connect()
-                    backoff = INITIAL_BACKOFF
-                    async for frame in bridge.frames():
-                        # Phase 2 maps these into the message store +
-                        # thread queue; phase 1 logs and drops.
-                        self._log.info(
-                            "bridge frame dropped (phase 1): type=%s",
-                            frame.get("type", ""),
-                        )
-                finally:
-                    await bridge.close()
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                self._log.warning(
-                    "bridge WS disconnected (%s: %s), reconnecting in %ds",
-                    type(exc).__name__, exc, backoff,
+                    try:
+                        await bridge.connect()
+                        backoff = INITIAL_BACKOFF
+                        # Cold-start IN backfill: one fetch_pending per
+                        # successful connect drains the server queue.
+                        # Idempotent (server redelivers on redelivery),
+                        # so a reconnect re-fetches for free.
+                        await bridge.send_fetch_pending()
+                        async for frame in bridge.frames():
+                            await self._dispatch_bridge_frame(frame)
+                    finally:
+                        await bridge.close()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    self._log.warning(
+                        "bridge WS disconnected (%s: %s), reconnecting in %ds",
+                        type(exc).__name__, exc, backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, MAX_BACKOFF)
+        finally:
+            consumer_task.cancel()
+            try:
+                await consumer_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _dispatch_bridge_frame(self, frame: dict) -> None:
+        """Route one inbound bridge frame off ``frames()``.
+
+        ``message`` handling is wrapped so one poison frame logs and is
+        skipped rather than killing the listen loop (which would drop
+        every subsequent live message until the next reconnect).
+        Correlated ``error`` frames are already routed to the send
+        futures inside ``frames()``; anything surfacing here is
+        uncorrelated, so it only warns.
+        """
+        kind = frame.get("type", "")
+        if kind == "message":
+            try:
+                payload = self._payload_from_bridge_frame(frame)
+                if payload is not None:
+                    await self._handle_plaintext_payload(payload)
+            except Exception:
+                self._log.exception(
+                    "bridge message frame handling failed (envelope_id=%s)",
+                    frame.get("envelope_id"),
                 )
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, MAX_BACKOFF)
+        elif kind == "pending_delivered":
+            self._log.info(
+                "bridge backfill complete: pending_delivered (count=%s)",
+                frame.get("count"),
+            )
+        elif kind == "error":
+            self._log.warning(
+                "bridge error frame: code=%s message=%s",
+                frame.get("code"), frame.get("message"),
+            )
+        else:
+            self._log.debug("bridge frame ignored: type=%s", kind)
+
+    async def _handle_plaintext_payload(self, payload: MessagePayload) -> None:
+        """Persist + surface a decoded message payload to the agent.
+
+        Shared tail of the inbound path: native ``handle_envelope``
+        calls this after ``decrypt_message`` produces ``payload``, and
+        the T23 bridge listener calls it with a payload built straight
+        from a plaintext ``message`` frame (no decrypt). Everything from
+        here down is crypto-agnostic — it only touches ``payload`` +
+        ``self`` (store, caches, thread queue), and every HTTP-backed
+        enrichment helper it calls degrades to empty/None offline, so
+        the keyless bridge path renders ids-for-names rather than
+        crashing.
+        """
+        # PUF-227-A: strict cache-validation invariant for incoming
+        # ids. Any thread_root_id / reply_to_id that doesn't point
+        # to a same-channel parent in our local message_store gets
+        # wiped to None before storage — the agent's local view
+        # never honors a thread linkage that can't be resolved here.
+        # Catches the Scout-class symptom: a server / UI / sender
+        # that stamps a cross-channel id can't poison the recipient
+        # daemon's thread state.
+        validated_thread_root_id = await self._validate_incoming_parent_id(
+            payload.thread_root_id, payload.channel_id, payload.space_id,
+        )
+        validated_reply_to_id = await self._validate_incoming_parent_id(
+            payload.reply_to_id, payload.channel_id, payload.space_id,
+        )
+        await self.store.store({
+            "envelope_id": payload.envelope_id,
+            "envelope_kind": payload.envelope_kind,
+            "sender_slug": payload.sender_slug,
+            "channel_id": payload.channel_id,
+            "space_id": payload.space_id,
+            "recipient_slug": payload.recipient_slug,
+            "content_type": payload.content_type,
+            "content": payload.content,
+            "sent_at": payload.sent_at,
+            "thread_root_id": validated_thread_root_id,
+            "reply_to_id": validated_reply_to_id,
+        })
+        # Rebind for downstream code (root_id resolution at the
+        # batch-coalesce step, channel_meta construction, etc.) so
+        # admit-time wipes propagate through the agent prompt.
+        payload_thread_root_id = validated_thread_root_id
+        payload_reply_to_id = validated_reply_to_id
+
+        # Self-echo lands here too now (see ``handle_envelope``'s
+        # opening comment). Persist it — so ``get_channel_history``
+        # / ``get_thread_history`` show the agent's own posts —
+        # then stop before any of the LLM-facing pipeline below
+        # runs. The agent already produced this message; queueing
+        # it again would feed the agent its own words and trip a
+        # turn-by-turn echo loop.
+        if payload.sender_slug == self.slug:
+            return
+
+        # Daemon-side intercept: ``y``/``n`` from the operator on an
+        # outstanding invite-DM accepts/rejects without waking the
+        # LLM. A threaded reply answers just that invite; a direct
+        # (top-level) reply answers all pending invites at once.
+        if (
+            payload.envelope_kind == "dm"
+            and payload.sender_slug == self.operator_slug
+        ):
+            text_raw = str(payload.content) if payload.content else ""
+            targets, is_direct = self._resolve_invite_targets(
+                payload_thread_root_id, text_raw,
+            )
+            handled_labels = (
+                await self._apply_invite_replies(targets, text_raw)
+                if targets else []
+            )
+            if handled_labels:
+                # Handled inline — don't queue for the LLM.
+                self._last_dm_sender = payload.sender_slug
+                if is_direct:
+                    await self._send_invite_bulk_summary(
+                        handled_labels, text_raw, payload_thread_root_id or "",
+                    )
+                return
+            # Same gate for agent-initiated leave requests, but
+            # threaded-only — each leave is confirmed in its own
+            # thread (no direct/bulk path).
+            if await self._maybe_handle_leave_reply(
+                thread_root_id=payload_thread_root_id or "", text=text_raw,
+            ):
+                self._last_dm_sender = payload.sender_slug
+                return
+
+        channel_id = payload.channel_id or ""
+        is_dm = payload.envelope_kind == "dm"
+        # ``puffo/message+attachments/v1`` carries
+        # ``{ text, attachments: [...] }``; other content types
+        # use the plain-string path.
+        attachment_paths: list[str] = []
+        if payload.content_type == "puffo/message+attachments/v1" and isinstance(
+            payload.content, dict,
+        ):
+            raw_text = str(payload.content.get("text") or "")
+            metas_raw = payload.content.get("attachments") or []
+            if isinstance(metas_raw, list):
+                attachment_paths = await self._save_inbound_attachments(
+                    envelope_id=payload.envelope_id, metas_raw=metas_raw,
+                )
+        else:
+            raw_text = str(payload.content) if payload.content else ""
+
+        # Stash the sender so `send_fallback_message("")` can route replies.
+        # Always overwrite — first-write would pin replies to a
+        # stale peer when a different person DMs us.
+        if is_dm:
+            self._last_dm_sender = payload.sender_slug
+        elif payload.channel_id and payload.space_id:
+            # Remember which space owns this channel so replies
+            # resolve members in the right space (cross-space
+            # invites would otherwise fail).
+            self._channel_space[payload.channel_id] = payload.space_id
+
+        # Parse all ``@<slug>`` and scope to space members
+        # (matches the web client). Self is always kept.
+        self_slug_lower = self.slug.lower()
+        seen: set[str] = set()
+        parsed: list[str] = []
+        for m in _MENTION_RE.finditer(raw_text):
+            slug = m.group(1).lower()
+            if slug in seen:
+                continue
+            seen.add(slug)
+            parsed.append(slug)
+        is_mention = self_slug_lower in seen
+        space_members = (
+            await self._get_space_members(payload.space_id)
+            if payload.space_id
+            else {}
+        )
+        mentions: list[dict] = []
+        for slug in parsed:
+            if slug == self_slug_lower:
+                mentions.append({"username": self.slug, "is_bot": True, "is_self": True})
+                continue
+            if space_members and slug not in space_members:
+                continue
+            is_bot = space_members.get(slug) == "agent"
+            mentions.append({"username": slug, "is_bot": is_bot, "is_self": False})
+
+        # Self-mention rewrite: `@<our-slug>` → `@you(<our-slug>)`
+        # (the documented "addressed to you" signal).
+        clean_text = raw_text.replace(
+            f"@{self.slug}", f"@you({self.slug})",
+        ).strip() if is_mention else raw_text
+
+        # Resolve human-readable names so the LLM sees ``space:``/
+        # ``channel:`` instead of bare ids. Cached per session. DMs
+        # render an explicit "Direct message" label.
+        space_id = payload.space_id or ""
+        space_name = (
+            await self._resolve_space_name(space_id) if space_id else ""
+        )
+        if is_dm:
+            channel_name = "Direct message"
+        elif channel_id:
+            channel_name = await self._resolve_channel_name(
+                space_id, channel_id,
+            )
+        else:
+            channel_name = channel_id
+
+        direct = is_dm or is_mention
+        sender_is_bot = False  # puffo-core has no is_bot flag yet
+        priority = _compute_priority(direct, sender_is_bot)
+
+        # Thread-batched queue: every message coalesces under
+        # its ``root_id`` (the envelope's ``thread_root_id``, or
+        # the message itself when it's a top-level post). The
+        # PriorityQueue holds one slot per root; new arrivals on
+        # the same thread either join the existing batch
+        # (priority same or lower) or bump the slot to the new
+        # higher priority. The agent processes one whole thread
+        # at a time in ``on_message_batch``.
+        # PUF-227-A: route on the VALIDATED thread_root_id. If
+        # admit-time validation wiped it (parent not in cache or
+        # cross-channel), the message gets a fresh per-envelope
+        # root_id and lands in its own batch — never inheriting a
+        # stale channel_meta from an unrelated thread.
+        root_id = payload_thread_root_id or payload.envelope_id
+
+        # Cross-restart dedup: after a daemon restart the server
+        # redelivers anything in /messages/pending. If we already
+        # dispatched a batch that covers ``payload.sent_at``,
+        # skip — the agent has seen this.
+        last_processed = await self.store.get_last_processed_sent_at(root_id)
+        if payload.sent_at <= last_processed:
+            self._log.info(
+                "handle_envelope: cursor-rejected duplicate envelope=%s "
+                "(sent_at=%d <= last_processed=%d, root=%s)",
+                payload.envelope_id, payload.sent_at,
+                last_processed, root_id,
+            )
+            return
+
+        # Per-session display-name cache turns this into ~1 HTTP
+        # call per distinct sender per session; same helper the
+        # invite-DM flow already uses. Empty string on miss.
+        sender_display_name = await self._fetch_display_name(
+            payload.sender_slug,
+        )
+
+        # Long-message redaction. Operators paste big chunks of
+        # code or transcripts that, combined with the agent's
+        # system prompt + thread history, can blow past the LLM
+        # context window — historically observable as the agent
+        # getting stuck in a "Prompt is too long" retry loop the
+        # restart path didn't recover from. The full envelope
+        # stays in messages.db; only the in-prompt view collapses
+        # to a placeholder pointing at ``get_post_segment``.
+        llm_text = _maybe_redact_long_text(
+            clean_text,
+            envelope_id=payload.envelope_id,
+            sender_slug=payload.sender_slug,
+            sender_display_name=sender_display_name,
+            max_inline_chars=self._max_inline_chars,
+            segment_chars=self._segment_chars,
+            agent_slug=self.slug,
+        )
+
+        msg_dict = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "sender_slug": payload.sender_slug,
+            "sender_display_name": sender_display_name,
+            "sender_email": "",
+            "text": llm_text,
+            "root_id": payload_thread_root_id or "",
+            "is_dm": is_dm,
+            "attachments": attachment_paths,
+            "sender_is_bot": sender_is_bot,
+            "mentions": mentions,
+            "envelope_id": payload.envelope_id,
+            "sent_at": payload.sent_at,
+            "is_visible_to_human": payload.is_visible_to_human,
+        }
+        channel_meta = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "is_dm": is_dm,
+        }
+
+        await self._admit_thread_message(
+            root_id=root_id,
+            priority=priority,
+            msg_dict=msg_dict,
+            channel_meta=channel_meta,
+        )
+
+    def _payload_from_bridge_frame(self, frame: dict) -> MessagePayload | None:
+        """Map a plaintext bridge ``message`` frame onto a
+        ``MessagePayload`` so it can flow through the same
+        ``_handle_plaintext_payload`` tail the native decrypt path uses.
+
+        The server holds all crypto on the bridge transport, so the
+        frame body is already plaintext — there is no decrypt step.
+        Every routing field is read with ``.get()`` and a benign
+        fallback so a wire-field rename or a sparse frame degrades to a
+        skip (bad ``envelope_id``) rather than a ``KeyError`` mid-loop.
+        The exact wire field names live in
+        ``puffo-server/roadmap/cloud-agent/BRIDGE-WIRE-PROTOCOL.md``;
+        only ``envelope_id`` / ``sender_slug`` / ``plaintext`` are
+        anchored by tests, so a rename is a one-line change confined
+        here.
+        """
+        envelope_id = frame.get("envelope_id")
+        if not envelope_id:
+            self._log.warning(
+                "bridge message frame missing envelope_id — skipping "
+                "(keys=%s)", sorted(frame.keys()),
+            )
+            return None
+        recipient_slug = frame.get("recipient_slug")
+        envelope_kind = frame.get("envelope_kind") or (
+            "dm" if recipient_slug else "channel"
+        )
+        content = frame.get("plaintext")
+        if content is None:
+            content = frame.get("content", "")
+        return MessagePayload(
+            payload_type=frame.get("payload_type", "message"),
+            version=frame.get("version", 1),
+            envelope_id=envelope_id,
+            envelope_kind=envelope_kind,
+            sender_slug=frame.get("sender_slug", ""),
+            sender_subkey_id=frame.get("sender_subkey_id", ""),
+            sent_at=frame.get("sent_at") or int(time.time() * 1000),
+            message_nonce=frame.get("message_nonce", ""),
+            content_type=frame.get("content_type", "text/plain"),
+            content=content,
+            is_visible_to_human=frame.get("is_visible_to_human", True),
+            space_id=frame.get("space_id"),
+            channel_id=frame.get("channel_id"),
+            recipient_slug=recipient_slug,
+            thread_root_id=frame.get("thread_root_id"),
+            reply_to_id=frame.get("reply_to_id"),
+        )
 
     async def _admit_thread_message(
         self,
@@ -3667,6 +3814,55 @@ class PuffoCoreMessageClient:
         Empty ``channel_id``: DM reply; recipients are me and the peer
         so the agent's other devices see the fan-out.
         """
+        if self._bridge is not None:
+            # T23 bridge transport: send plaintext; the server holds all
+            # crypto and fans out recipients. Empty channel_id ⇒ DM back
+            # to the last DM sender; else a channel post (space resolved
+            # from the same caches native uses). No encrypt_message /
+            # signed POST. Threaded ``root_id`` isn't wired on bridge yet
+            # (phase 3) — this replies top-level.
+            if channel_id:
+                target_space_id = self._channel_space.get(channel_id)
+                if not target_space_id:
+                    target_space_id = (
+                        await self.store.lookup_channel_space(channel_id) or ""
+                    )
+                    if target_space_id:
+                        self._channel_space[channel_id] = target_space_id
+                if not target_space_id:
+                    self._log.warning(
+                        "send_fallback_message[bridge]: no known space for "
+                        "channel %s — dropping reply", channel_id,
+                    )
+                    return
+                ack = await self._bridge.send_send(
+                    plaintext=text,
+                    space_id=target_space_id,
+                    channel_id=channel_id,
+                )
+                self._log.info(
+                    "send_fallback_message[bridge] sent: kind=channel "
+                    "channel=%s envelope_id=%s",
+                    channel_id, (ack or {}).get("envelope_id"),
+                )
+                return
+            recipient = self._last_dm_sender
+            if not recipient:
+                self._log.warning(
+                    "send_fallback_message[bridge] called with empty "
+                    "channel_id but no DM context — dropping reply",
+                )
+                return
+            ack = await self._bridge.send_send(
+                plaintext=text, recipient_slug=recipient,
+            )
+            self._log.info(
+                "send_fallback_message[bridge] sent: kind=dm recipient=%s "
+                "envelope_id=%s",
+                recipient, (ack or {}).get("envelope_id"),
+            )
+            return
+
         sess = self.keystore.load_session(self.slug)
         signing_key = Ed25519KeyPair.from_secret_bytes(
             decode_secret(sess.subkey_secret_key)

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -985,6 +985,30 @@ class PuffoCoreMessageClient:
         else:
             raw_text = str(payload.content) if payload.content else ""
 
+        # Keyless-bridge attachments: the server holds the blob store, so
+        # an inbound bridge ``message`` frame carries top-level
+        # ``attachments`` = [{ blob_id, filename, mime_type, size_bytes }]
+        # (surfaced onto ``payload.attachments`` by
+        # ``_payload_from_bridge_frame``). Download each by ``blob_id``
+        # via the keyless GET — no decrypt — and save into the same
+        # inbox the native content-type block fills, so the agent's
+        # ``attachments`` message field is populated identically. Native
+        # payloads never set ``payload.attachments`` (it's excluded from
+        # ``to_payload_dict`` and only the bridge mapper sets it) and
+        # ``self._bridge`` is None on native, so this branch is
+        # bridge-only. Per-ref failures log + skip inside the helper.
+        if (
+            self._bridge is not None
+            and isinstance(payload.attachments, list)
+            and payload.attachments
+        ):
+            attachment_paths.extend(
+                await self._save_inbound_bridge_attachments(
+                    envelope_id=payload.envelope_id,
+                    refs=payload.attachments,
+                )
+            )
+
         # Stash the sender so `send_fallback_message("")` can route replies.
         # Always overwrite — first-write would pin replies to a
         # stale peer when a different person DMs us.
@@ -1183,6 +1207,11 @@ class PuffoCoreMessageClient:
             recipient_slug=recipient_slug,
             thread_root_id=frame.get("thread_root_id"),
             reply_to_id=frame.get("reply_to_id"),
+            # Keyless-bridge attachments ride the frame top level as
+            # ``[{ blob_id, filename, mime_type, size_bytes }]``; the
+            # shared inbound tail downloads each blob by id (no decrypt).
+            # Native frames never carry this key, so it stays None there.
+            attachments=frame.get("attachments"),
         )
 
     async def _admit_thread_message(
@@ -3762,6 +3791,81 @@ class PuffoCoreMessageClient:
                 except OSError as exc:
                     self._log.warning(
                         "could not rename compressed image %s: %s", target, exc,
+                    )
+                    paths.append(str(target))
+            else:
+                paths.append(str(target))
+        return paths
+
+    async def _save_inbound_bridge_attachments(
+        self, *, envelope_id: str, refs: list,
+    ) -> list[str]:
+        """Keyless-bridge sibling of ``_save_inbound_attachments``:
+        download each blob by ``blob_id`` (no decrypt — the server holds
+        the blob store) and save it to ``<workspace>/.puffo/inbox/
+        <envelope_id>/<filename>``, returning absolute paths. Per-ref
+        failures (bad shape, missing/oversized/unfetchable blob, save
+        error) are logged and skipped so one bad ref never crashes the
+        turn or the listen loop.
+
+        Mirrors the native saver's filename sanitisation + oversized-
+        image downscale so a bridge-delivered image is treated
+        identically to a native one.
+        """
+        if not self.workspace or not refs or self._bridge is None:
+            return []
+        from pathlib import Path
+        inbox = Path(self.workspace) / ".puffo" / "inbox" / envelope_id
+        inbox.mkdir(parents=True, exist_ok=True)
+        paths: list[str] = []
+        for raw in refs:
+            if not isinstance(raw, dict):
+                continue
+            blob_id = raw.get("blob_id")
+            if not blob_id:
+                self._log.warning(
+                    "bridge attachment ref missing blob_id: %r", raw,
+                )
+                continue
+            try:
+                data = await self._bridge.download_blob(blob_id)
+            except Exception as exc:  # noqa: BLE001 — one bad ref never fatal
+                self._log.warning(
+                    "bridge attachment download raised (%s): %s",
+                    blob_id, exc,
+                )
+                continue
+            if data is None:
+                # Missing / oversized / unfetchable — download_blob
+                # already logged; skip without failing the turn.
+                continue
+            # Sanitise filename to block ``../`` / absolute-path
+            # write-outside-inbox via a malicious sender.
+            safe_name = Path(str(raw.get("filename") or "")).name or blob_id
+            target = inbox / safe_name
+            try:
+                target.write_bytes(data)
+            except OSError as exc:
+                self._log.warning(
+                    "bridge attachment save failed (%s): %s", target, exc,
+                )
+                continue
+            # Shrink oversized images off-loop, same as the native saver.
+            origin = target.with_name(f"{target.stem}.origin{target.suffix}")
+            resized = await asyncio.to_thread(
+                _downscale_oversized_image, target, origin, self._image_edge_px,
+            )
+            if resized:
+                compressed = target.with_name(
+                    f"{target.stem}.compressed{target.suffix}"
+                )
+                try:
+                    target.rename(compressed)
+                    paths.append(str(compressed))
+                except OSError as exc:
+                    self._log.warning(
+                        "could not rename compressed image %s: %s",
+                        target, exc,
                     )
                     paths.append(str(target))
             else:

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any
 
 import aiohttp
@@ -24,10 +25,22 @@ class HttpError(Exception):
 
 
 class PuffoCoreHttpClient:
-    def __init__(self, server_url: str, keystore: KeyStore, slug: str):
+    def __init__(
+        self,
+        server_url: str,
+        keystore: KeyStore,
+        slug: str,
+        keyless: bool = False,
+    ):
         self.server_url = server_url.rstrip("/")
         self.keystore = keystore
         self.slug = slug
+        # T23 keyless bridge transport: outbound tool work goes over the
+        # unsigned ``/v2/cloud-agents/*`` routes and the E2B egress proxy
+        # injects ``x-sandbox-token`` on the way out. Tools branch on this
+        # to pick the keyless vs native (signed) path; native agents leave
+        # it False and are byte-for-byte unchanged.
+        self.keyless = keyless
         self._session: aiohttp.ClientSession | None = None
 
     async def _get_session(self) -> aiohttp.ClientSession:
@@ -181,13 +194,52 @@ class PuffoCoreHttpClient:
         _, data = await self._request("DELETE", path)
         return data
 
+    def _egress_headers(self, base: dict[str, str] | None = None) -> dict[str, str]:
+        """Merge the test-only egress ``x-sandbox-token`` shim into the
+        request headers.
+
+        In production the E2B egress proxy injects the sandbox token on
+        outbound HTTPS, so ``PUFFO_LOCAL_SANDBOX_TOKEN`` is unset and this
+        returns ``base`` untouched — no header is written into any config
+        file or request. Set the env var locally to simulate that
+        injection against a plaintext test server. Called ONLY from the
+        unsigned keyless methods below; native signed requests never hit
+        this path.
+        """
+        headers = dict(base or {})
+        token = os.environ.get("PUFFO_LOCAL_SANDBOX_TOKEN")
+        if token:
+            headers["x-sandbox-token"] = token
+        return headers
+
     async def post_unsigned(self, path: str, body: dict | None = None) -> Any:
         raw = json.dumps(body).encode() if body else b""
         http = await self._get_session()
         async with http.post(
             f"{self.server_url}{path}",
             data=raw,
-            headers={"content-type": "application/json"},
+            headers=self._egress_headers({"content-type": "application/json"}),
+        ) as resp:
+            text = await resp.text()
+            if resp.status >= 400:
+                raise HttpError(resp.status, text)
+            try:
+                return json.loads(text)
+            except (json.JSONDecodeError, ValueError):
+                return text
+
+    async def post_bytes_unsigned(self, path: str, body: bytes) -> Any:
+        """POST raw bytes unsigned (keyless blob upload). Mirrors
+        ``post_unsigned`` but carries an ``application/octet-stream`` body
+        and no signature — the egress proxy supplies auth via
+        ``x-sandbox-token``."""
+        http = await self._get_session()
+        async with http.post(
+            f"{self.server_url}{path}",
+            data=body,
+            headers=self._egress_headers(
+                {"content-type": "application/octet-stream"}
+            ),
         ) as resp:
             text = await resp.text()
             if resp.status >= 400:
@@ -199,7 +251,10 @@ class PuffoCoreHttpClient:
 
     async def get_unsigned(self, path: str) -> Any:
         http = await self._get_session()
-        async with http.get(f"{self.server_url}{path}") as resp:
+        async with http.get(
+            f"{self.server_url}{path}",
+            headers=self._egress_headers(),
+        ) as resp:
             text = await resp.text()
             if resp.status >= 400:
                 raise HttpError(resp.status, text)

--- a/src/puffo_agent/crypto/message.py
+++ b/src/puffo_agent/crypto/message.py
@@ -72,6 +72,14 @@ class MessagePayload:
     recipient_slug: Optional[str] = None
     thread_root_id: Optional[str] = None
     reply_to_id: Optional[str] = None
+    # Keyless-bridge only: top-level ``AttachmentRef`` list carried on
+    # inbound plaintext ``message`` frames. NOT part of the native
+    # signed/AEAD payload — deliberately excluded from
+    # ``to_payload_dict()`` so every native seal/open produces the
+    # identical canonical bytes the Rust server expects. Native inbound
+    # keys off ``content_type`` and never reads this field, so it stays
+    # ``None`` on that path.
+    attachments: Optional[list] = None
 
     def to_payload_dict(self) -> dict:
         """JSON shape matching the server's ``MessagePayload``.
@@ -80,6 +88,10 @@ class MessagePayload:
         omitted): the server's verified-payload validator calls
         ``expect_null`` on the inactive route fields per envelope
         kind, so omitting them returns InvalidInput.
+
+        ``attachments`` is intentionally NOT emitted here — it's a
+        bridge-transport-only surface field, and adding it would
+        diverge the canonical signing bytes from the server's.
         """
         return {
             "type": self.payload_type,

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -271,6 +271,15 @@ def puffo_core_mcp_env(
     # wiring lands with phase 2.
     if transport:
         env["PUFFO_CORE_TRANSPORT"] = transport
+    # Test-only egress shim: forward PUFFO_LOCAL_SANDBOX_TOKEN into the
+    # subprocess so its keyless http client can simulate the E2B egress
+    # token injection against a local server. Guarded on presence in the
+    # daemon environment — production leaves it unset, so nothing is
+    # written to any config file.
+    import os as _os
+    local_sandbox_token = _os.environ.get("PUFFO_LOCAL_SANDBOX_TOKEN")
+    if local_sandbox_token:
+        env["PUFFO_LOCAL_SANDBOX_TOKEN"] = local_sandbox_token
     # codex only forwards [mcp_servers.puffo.env] to the subprocess,
     # so CODEX_HOME must be pinned explicitly or list_mcp_servers
     # would read the operator's host config instead of the agent's.

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -243,6 +243,7 @@ def puffo_core_mcp_env(
     rpc_url: str = "http://127.0.0.1:63385",
     runtime_kind: str = "",
     harness: str = "",
+    transport: str = "",
 ) -> dict[str, str]:
     """Env dict for the puffo-core MCP subprocess. The MCP never
     touches ``messages.db`` or ``~/.claude.json`` directly — the
@@ -266,6 +267,10 @@ def puffo_core_mcp_env(
         env["PUFFO_RUNTIME_KIND"] = runtime_kind
     if harness:
         env["PUFFO_HARNESS"] = harness
+    # T23 bridge transport — no caller passes this yet; adapter env
+    # wiring lands with phase 2.
+    if transport:
+        env["PUFFO_CORE_TRANSPORT"] = transport
     # codex only forwards [mcp_servers.puffo.env] to the subprocess,
     # so CODEX_HOME must be pinned explicitly or list_mcp_servers
     # would read the operator's host config instead of the agent's.

--- a/src/puffo_agent/mcp/lifecycle_tools.py
+++ b/src/puffo_agent/mcp/lifecycle_tools.py
@@ -1,0 +1,214 @@
+"""Bridge-only sandbox-lifecycle MCP tools (T23).
+
+Registered *only* for cloud (bridge-transport) agents — gated on
+``cfg.bridge_client is not None`` at the ``register_core_tools`` call
+site — and exposed over the ws-local dispatch allowlist
+(``WS_LOCAL_ALLOWED_TOOLS``). A native/desktop agent (signed-crypto
+transport, ``bridge_client is None``) never registers them, so this
+whole surface is invisible to native agents.
+
+Every tool is a thin, fail-soft wrapper over the ``CloudBridgeClient``
+keyless ``x-sandbox-token`` lifecycle methods: a failing lifecycle call
+returns a plain error string the model can reason about, never an
+exception that would crash the turn. The server owns all wake / sleep
+state — these tools are stateless request/response calls, no
+persistence or background scheduling on the agent side.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from ..agent.bridge_client import BridgeClosed, BridgeError
+
+logger = logging.getLogger(__name__)
+
+
+def register_lifecycle_tools(mcp: FastMCP, cfg: Any) -> None:
+    """Register the five cloud-lifecycle tools on ``mcp``. Call only
+    when ``cfg.bridge_client is not None`` — each tool also defends the
+    gate itself so a stray registration can't act on a native agent."""
+
+    @mcp.tool()
+    async def schedule_wake(
+        after_seconds: int = 0,
+        wake_at: str = "",
+        reason: str = "",
+    ) -> str:
+        """Schedule a server-side wake so a long task self-resumes after
+        your cloud sandbox auto-sleeps. Cloud (bridge) agents only.
+
+        Your sandbox is put to sleep after an idle timeout; a scheduled
+        wake tells the server to bring it back so an in-flight task keeps
+        going instead of stalling until the next inbound message.
+
+        Pass EXACTLY ONE of:
+          - ``after_seconds`` — wake this many seconds from now (relative).
+          - ``wake_at`` — an absolute ISO-8601 timestamp to wake at.
+        ``reason`` is an optional short note stored with the wake.
+
+        Returns the confirmed wake time.
+        """
+        if cfg.bridge_client is None:
+            return "schedule_wake is only available to cloud (bridge) agents."
+        has_after = bool(after_seconds) and after_seconds > 0
+        has_at = bool(wake_at and wake_at.strip())
+        if has_after and has_at:
+            return (
+                "schedule_wake: pass exactly one of after_seconds or "
+                "wake_at, not both."
+            )
+        if not has_after and not has_at:
+            return (
+                "schedule_wake: pass one of after_seconds (>0) or wake_at "
+                "(an ISO-8601 timestamp)."
+            )
+        try:
+            result = await cfg.bridge_client.schedule_wake(
+                after_seconds=int(after_seconds) if has_after else None,
+                wake_at=wake_at.strip() if has_at else None,
+                reason=reason,
+            )
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "schedule_wake failed (x-sandbox-token POST "
+                f"/v2/cloud-agents/schedule-wake): {exc}"
+            )
+        result = result or {}
+        confirmed = result.get("wake_at") or "?"
+        note = result.get("reason") or reason
+        tail = f" (reason: {note})" if note else ""
+        return f"wake scheduled for {confirmed}{tail}"
+
+    @mcp.tool()
+    async def cancel_wake() -> str:
+        """Cancel a previously scheduled wake for this cloud sandbox.
+        Cloud (bridge) agents only. Safe to call when nothing is
+        scheduled — the server treats that as a no-op."""
+        if cfg.bridge_client is None:
+            return "cancel_wake is only available to cloud (bridge) agents."
+        try:
+            await cfg.bridge_client.cancel_wake()
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "cancel_wake failed (x-sandbox-token DELETE "
+                f"/v2/cloud-agents/scheduled-wake): {exc}"
+            )
+        return "scheduled wake cancelled."
+
+    @mcp.tool()
+    async def get_scheduled_wake() -> str:
+        """Show the wake currently scheduled for this cloud sandbox, if
+        any. Cloud (bridge) agents only."""
+        if cfg.bridge_client is None:
+            return (
+                "get_scheduled_wake is only available to cloud (bridge) "
+                "agents."
+            )
+        try:
+            result = await cfg.bridge_client.get_scheduled_wake()
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "get_scheduled_wake failed (x-sandbox-token GET "
+                f"/v2/cloud-agents/scheduled-wake): {exc}"
+            )
+        result = result or {}
+        wake_at = result.get("wake_at")
+        if not wake_at:
+            return "no wake is currently scheduled."
+        reason = result.get("reason") or ""
+        tail = f" (reason: {reason})" if reason else ""
+        return f"wake scheduled for {wake_at}{tail}"
+
+    @mcp.tool()
+    async def get_runtime_status() -> str:
+        """Report this cloud sandbox's runtime state and how long until
+        it auto-sleeps. Cloud (bridge) agents only.
+
+        ``seconds_until_sleep`` is shown as ``unknown`` when the server
+        can't compute it — never a fabricated number. Use ``keep_alive``
+        to push the deadline back, or ``schedule_wake`` to self-resume
+        after a sleep."""
+        if cfg.bridge_client is None:
+            return (
+                "get_runtime_status is only available to cloud (bridge) "
+                "agents."
+            )
+        try:
+            result = await cfg.bridge_client.runtime_status()
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "get_runtime_status failed (x-sandbox-token GET "
+                f"/v2/cloud-agents/runtime-status): {exc}"
+            )
+        result = result or {}
+        state = result.get("state") or "unknown"
+        sandbox_id = result.get("sandbox_id") or "?"
+        timeout_at = result.get("timeout_at") or "unknown"
+        secs = result.get("seconds_until_sleep")
+        # ``null``/absent → the literal word "unknown"; a real number
+        # (including 0) renders as itself. Never guess a value.
+        secs_str = "unknown" if secs is None else str(secs)
+        return (
+            f"sandbox {sandbox_id}: state={state}, "
+            f"seconds_until_sleep={secs_str}, timeout_at={timeout_at}"
+        )
+
+    @mcp.tool()
+    async def keep_alive(seconds: int = 600) -> str:
+        """Push back this cloud sandbox's auto-sleep deadline by roughly
+        ``seconds``. Cloud (bridge) agents only.
+
+        Use this to hold the sandbox awake while a long task runs. If the
+        upstream deadline-refresh isn't available yet, this automatically
+        falls back to scheduling a wake ~``seconds`` out, so the task
+        still self-resumes even if the sandbox sleeps. Returns what
+        happened either way."""
+        if cfg.bridge_client is None:
+            return "keep_alive is only available to cloud (bridge) agents."
+        try:
+            secs = int(seconds)
+        except (TypeError, ValueError):
+            return "keep_alive: seconds must be an integer number of seconds."
+        if secs <= 0:
+            return "keep_alive: seconds must be > 0."
+        try:
+            result = await cfg.bridge_client.keepalive(secs)
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                "keep_alive failed (x-sandbox-token POST "
+                f"/v2/cloud-agents/keepalive): {exc}"
+            )
+        result = result or {}
+        if result.get("available"):
+            timeout_at = result.get("timeout_at") or "?"
+            secs_left = result.get("seconds_until_sleep")
+            secs_str = "unknown" if secs_left is None else str(secs_left)
+            return (
+                f"keepalive ok — auto-sleep pushed to {timeout_at} "
+                f"(seconds_until_sleep={secs_str})."
+            )
+        # Upstream deadline-refresh not landed yet — fall back to a
+        # scheduled wake so a long task still self-resumes if the sandbox
+        # sleeps before it finishes.
+        detail = result.get("detail") or "keepalive unavailable upstream"
+        try:
+            wake = await cfg.bridge_client.schedule_wake(
+                after_seconds=secs, reason="keepalive fallback",
+            )
+        except (BridgeError, BridgeClosed, Exception) as exc:  # noqa: BLE001
+            return (
+                f"keep_alive: upstream keepalive is unavailable ({detail}) "
+                f"and the schedule_wake fallback also failed: {exc}. The "
+                "sandbox may sleep without resuming — retry keep_alive or "
+                "schedule_wake."
+            )
+        wake_at = (wake or {}).get("wake_at") or f"~{secs}s from now"
+        return (
+            f"keepalive is not available upstream yet ({detail}); scheduled "
+            f"a wake at {wake_at} (~{secs}s) as a fallback so this task "
+            "self-resumes if the sandbox sleeps."
+        )

--- a/src/puffo_agent/mcp/lifecycle_tools.py
+++ b/src/puffo_agent/mcp/lifecycle_tools.py
@@ -54,7 +54,21 @@ def register_lifecycle_tools(mcp: FastMCP, cfg: Any) -> None:
         """
         if cfg.bridge_client is None:
             return "schedule_wake is only available to cloud (bridge) agents."
-        has_after = bool(after_seconds) and after_seconds > 0
+        # F7: a raw ws-local dispatch can hand us after_seconds as a string
+        # (e.g. {"after_seconds": "600"}). Coerce to int before the > 0
+        # compare — mirrors keep_alive — so a stringy value schedules
+        # cleanly instead of raising TypeError deeper in the compare.
+        if after_seconds in (None, "", 0, "0"):
+            after_val = 0
+        else:
+            try:
+                after_val = int(after_seconds)
+            except (TypeError, ValueError):
+                return (
+                    "schedule_wake: after_seconds must be an integer "
+                    "number of seconds."
+                )
+        has_after = after_val > 0
         has_at = bool(wake_at and wake_at.strip())
         if has_after and has_at:
             return (
@@ -68,7 +82,7 @@ def register_lifecycle_tools(mcp: FastMCP, cfg: Any) -> None:
             )
         try:
             result = await cfg.bridge_client.schedule_wake(
-                after_seconds=int(after_seconds) if has_after else None,
+                after_seconds=after_val if has_after else None,
                 wake_at=wake_at.strip() if has_at else None,
                 reason=reason,
             )

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -250,7 +250,14 @@ def build_server(
         _BridgeNoKeysStore(keystore_dir) if transport == "bridge"
         else KeyStore(keystore_dir)
     )
-    http = PuffoCoreHttpClient(server_url, ks, slug)
+    # Keyless (T23 bridge) tools do all outbound work over the unsigned
+    # ``/v2/cloud-agents/*`` routes (egress-injected ``x-sandbox-token``),
+    # so the subprocess is self-sufficient with no local keystore. The
+    # ``_BridgeNoKeysStore`` guard above stays as a defensive dead-end for
+    # any residual signed call.
+    http = PuffoCoreHttpClient(
+        server_url, ks, slug, keyless=(transport == "bridge"),
+    )
     data = DataClient(data_service_url, agent_id)
 
     # None when PUFFO_RPC_URL is unset; tools surface a clear error

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -221,6 +221,18 @@ def _register_local_tools(
         return "\n".join(lines)
 
 
+class _BridgeNoKeysStore(KeyStore):
+    """Bridge transport (T23): the agent holds no local keys. Tools
+    that still hit a signed path get a clear error instead of a
+    FileNotFoundError, until phase 2 rewires them keyless."""
+
+    def load_identity(self, slug: str):
+        raise RuntimeError("bridge transport: agent holds no local keys")
+
+    def load_session(self, slug: str):
+        raise RuntimeError("bridge transport: agent holds no local keys")
+
+
 def build_server(
     slug: str,
     device_id: str,
@@ -232,8 +244,12 @@ def build_server(
     data_service_url: str,
     runtime_kind: str = "",
     harness: str = "",
+    transport: str = "",
 ) -> FastMCP:
-    ks = KeyStore(keystore_dir)
+    ks = (
+        _BridgeNoKeysStore(keystore_dir) if transport == "bridge"
+        else KeyStore(keystore_dir)
+    )
     http = PuffoCoreHttpClient(server_url, ks, slug)
     data = DataClient(data_service_url, agent_id)
 
@@ -295,6 +311,7 @@ def _cfg_from_env() -> dict[str, str]:
         "data_service_url": data_service_url,
         "runtime_kind": os.environ.get("PUFFO_RUNTIME_KIND", ""),
         "harness": os.environ.get("PUFFO_HARNESS", ""),
+        "transport": os.environ.get("PUFFO_CORE_TRANSPORT", ""),
     }
 
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -1438,3 +1438,13 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             reason=reason,
         )
 
+    # Bridge-only sandbox-lifecycle tools (schedule_wake / cancel_wake /
+    # get_scheduled_wake / get_runtime_status / keep_alive). Gated on
+    # ``bridge_client`` — set ONLY at the in-process ws-local site — so a
+    # native/subprocess agent never registers them (and never exposes the
+    # keyless ``x-sandbox-token`` lifecycle surface). Imported lazily so
+    # the native path doesn't pay for a module it will never use.
+    if cfg.bridge_client is not None:
+        from .lifecycle_tools import register_lifecycle_tools
+        register_lifecycle_tools(mcp, cfg)
+

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -455,34 +455,52 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # T23 bridge transport: send plaintext; the server holds all
             # crypto and fans out recipients. DM ('@slug') vs channel
             # ('ch_') routing only — no device-key fetch, no encrypt, no
-            # signed POST. Threaded replies aren't wired on bridge yet
-            # (phase 3), so a non-empty root_id sends top-level with a note.
-            root_note = ""
-            if root_id:
-                root_note = (
-                    " (note: threaded replies aren't wired on bridge "
-                    "transport yet — sent as a top-level post)"
-                )
+            # signed POST. Threaded replies carry the same snake_case
+            # ``thread_root_id`` / ``reply_to_id`` field names a human/web
+            # message uses: ``thread_root_id`` is the resolved+validated
+            # true root (same resolvers the native branch runs, driven off
+            # the local store — no network), ``reply_to_id`` is the raw
+            # parent id the agent passed. Resolution is fail-soft — a miss
+            # falls through with a note and the send still completes.
             if channel_ref.startswith("@"):
                 bridge_recipient = channel_ref[1:]
                 if not bridge_recipient:
                     raise RuntimeError("DM recipient slug is required after '@'")
+                resolved_root, root_note = await _resolve_root_id(
+                    root_id, cfg.data_client,
+                )
+                resolved_root, validate_note = await _validate_root_same_channel(
+                    resolved_root, None, None, cfg.data_client,
+                )
                 ack = await cfg.bridge_client.send_send(
-                    plaintext=text, recipient_slug=bridge_recipient,
+                    plaintext=text,
+                    recipient_slug=bridge_recipient,
+                    thread_root_id=resolved_root or None,
+                    reply_to_id=root_id or None,
                 )
             else:
                 bridge_channel_id = channel_ref
                 bridge_space_id = await _resolve_channel_space(
                     cfg, bridge_channel_id,
                 )
+                resolved_root, root_note = await _resolve_root_id(
+                    root_id, cfg.data_client,
+                )
+                resolved_root, validate_note = await _validate_root_same_channel(
+                    resolved_root, bridge_channel_id, bridge_space_id,
+                    cfg.data_client,
+                )
                 ack = await cfg.bridge_client.send_send(
                     plaintext=text,
                     space_id=bridge_space_id,
                     channel_id=bridge_channel_id,
+                    thread_root_id=resolved_root or None,
+                    reply_to_id=root_id or None,
                 )
             return (
                 f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
                 f"{root_note}"
+                f"{validate_note}"
             )
 
         if channel_ref.startswith("@"):

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -109,8 +109,10 @@ class PuffoCoreToolsConfig:
     # T23 keyless bridge transport (``CloudBridgeClient``). Populated only
     # at the in-process ws-local site (from ``client._bridge``); the
     # subprocess/RPC MCP path leaves it None → native encrypt+signed POST.
-    # When set, ``send_message`` sends plaintext via the bridge and
-    # ``send_message_with_attachments`` refuses (phase 3).
+    # When set, both ``send_message`` and ``send_message_with_attachments``
+    # send plaintext via the bridge: attachment bytes are uploaded keyless
+    # (``bridge_client.upload_blob``) and referenced by ``blob_id`` in the
+    # frame's top-level ``attachments`` — no encrypt, no signed POST.
     bridge_client: Any = None
 
 
@@ -1038,13 +1040,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "send_message_with_attachments: agent has no configured "
                 "workspace dir"
             )
-        if cfg.bridge_client is not None:
-            # T23 phase 3: attachments over the keyless bridge aren't
-            # wired yet. Fail loud rather than silently encrypt (native
-            # path) or crash — a bridge agent has no signed-crypto seam.
-            raise RuntimeError(
-                "attachments are not supported on bridge transport yet"
-            )
         if not paths or not isinstance(paths, list):
             raise RuntimeError(
                 "send_message_with_attachments: paths is required "
@@ -1085,6 +1080,99 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     f"send_message_with_attachments: {rel!r} is not a file"
                 )
             targets.append(target)
+
+        if cfg.bridge_client is not None:
+            # T23 bridge transport: the server holds the at-rest blob
+            # store, so we upload each file's PLAINTEXT bytes keyless
+            # (``upload_blob`` → ``x-sandbox-token``, raw body) and pass
+            # the returned ``blob_id``s as top-level ``AttachmentRef``s
+            # into the same plaintext ``send`` frame ``send_message``
+            # uses. No ``encrypt_attachment``, no device-key fetch, no
+            # signed ``/messages`` POST — a bridge agent has no
+            # signed-crypto seam. DM vs channel routing + fail-soft
+            # thread resolution mirror ``send_message``'s bridge branch.
+            channel_ref = channel.strip()
+            if channel_ref.startswith("#"):
+                raise RuntimeError(
+                    "'#<name>' channel addressing isn't supported; pass "
+                    "the channel id directly."
+                )
+            refs: list[dict] = []
+            total_bytes = 0
+            for target in targets:
+                plaintext = target.read_bytes()
+                # Keep the native 8 MiB pre-check so an oversized file
+                # fails before we burn an upload round-trip.
+                if len(plaintext) > 8 * 1024 * 1024:
+                    raise RuntimeError(
+                        f"send_message_with_attachments: {target.name!r} is "
+                        f"{len(plaintext)} bytes (server caps at 8 MiB)"
+                    )
+                mime_type, _ = mimetypes.guess_type(target.name)
+                mime_type = mime_type or "application/octet-stream"
+                up = await cfg.bridge_client.upload_blob(plaintext)
+                blob_id = up.get("blob_id") if isinstance(up, dict) else None
+                if not blob_id:
+                    raise RuntimeError(
+                        f"send_message_with_attachments: bridge returned no "
+                        f"blob_id for {target.name!r} ({up!r})"
+                    )
+                refs.append({
+                    "blob_id": blob_id,
+                    "filename": target.name,
+                    "mime_type": mime_type,
+                    "size_bytes": len(plaintext),
+                })
+                total_bytes += len(plaintext)
+
+            if channel_ref.startswith("@"):
+                bridge_recipient = channel_ref[1:]
+                if not bridge_recipient:
+                    raise RuntimeError(
+                        "DM recipient slug is required after '@'"
+                    )
+                resolved_root, root_note = await _resolve_root_id(
+                    root_id, cfg.data_client,
+                )
+                resolved_root, validate_note = await _validate_root_same_channel(
+                    resolved_root, None, None, cfg.data_client,
+                )
+                ack = await cfg.bridge_client.send_send(
+                    plaintext=caption,
+                    recipient_slug=bridge_recipient,
+                    attachments=refs,
+                    thread_root_id=resolved_root or None,
+                    reply_to_id=root_id or None,
+                )
+            else:
+                bridge_channel_id = channel_ref
+                bridge_space_id = await _resolve_channel_space(
+                    cfg, bridge_channel_id,
+                )
+                resolved_root, root_note = await _resolve_root_id(
+                    root_id, cfg.data_client,
+                )
+                resolved_root, validate_note = await _validate_root_same_channel(
+                    resolved_root, bridge_channel_id, bridge_space_id,
+                    cfg.data_client,
+                )
+                ack = await cfg.bridge_client.send_send(
+                    plaintext=caption,
+                    space_id=bridge_space_id,
+                    channel_id=bridge_channel_id,
+                    attachments=refs,
+                    thread_root_id=resolved_root or None,
+                    reply_to_id=root_id or None,
+                )
+            names = ", ".join(t.name for t in targets)
+            thread_note = f" in thread {resolved_root}" if resolved_root else ""
+            return (
+                f"uploaded {len(targets)} file(s) [{names}] ({total_bytes} "
+                f"bytes total) to {channel}{thread_note} "
+                f"(envelope_id {(ack or {}).get('envelope_id', '?')})"
+                f"{root_note}"
+                f"{validate_note}"
+            )
 
         # Encrypt + upload each file. ``blob_id`` is patched in
         # after /blobs/upload returns — AAD doesn't depend on it.

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -106,6 +106,12 @@ class PuffoCoreToolsConfig:
     # Set only on the in-process (ws-local) path, where tools run inside
     # the daemon and drive the message client directly instead of via RPC.
     message_client: Any = None
+    # T23 keyless bridge transport (``CloudBridgeClient``). Populated only
+    # at the in-process ws-local site (from ``client._bridge``); the
+    # subprocess/RPC MCP path leaves it None → native encrypt+signed POST.
+    # When set, ``send_message`` sends plaintext via the bridge and
+    # ``send_message_with_attachments`` refuses (phase 3).
+    bridge_client: Any = None
 
 
 async def _fetch_device_keys(
@@ -443,6 +449,40 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "'#<name>' channel addressing isn't supported; "
                 "use the channel id (e.g. 'ch_<uuid>') or call "
                 "list_channels_in_all_spaces to look one up."
+            )
+
+        if cfg.bridge_client is not None:
+            # T23 bridge transport: send plaintext; the server holds all
+            # crypto and fans out recipients. DM ('@slug') vs channel
+            # ('ch_') routing only — no device-key fetch, no encrypt, no
+            # signed POST. Threaded replies aren't wired on bridge yet
+            # (phase 3), so a non-empty root_id sends top-level with a note.
+            root_note = ""
+            if root_id:
+                root_note = (
+                    " (note: threaded replies aren't wired on bridge "
+                    "transport yet — sent as a top-level post)"
+                )
+            if channel_ref.startswith("@"):
+                bridge_recipient = channel_ref[1:]
+                if not bridge_recipient:
+                    raise RuntimeError("DM recipient slug is required after '@'")
+                ack = await cfg.bridge_client.send_send(
+                    plaintext=text, recipient_slug=bridge_recipient,
+                )
+            else:
+                bridge_channel_id = channel_ref
+                bridge_space_id = await _resolve_channel_space(
+                    cfg, bridge_channel_id,
+                )
+                ack = await cfg.bridge_client.send_send(
+                    plaintext=text,
+                    space_id=bridge_space_id,
+                    channel_id=bridge_channel_id,
+                )
+            return (
+                f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
+                f"{root_note}"
             )
 
         if channel_ref.startswith("@"):
@@ -979,6 +1019,13 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             raise RuntimeError(
                 "send_message_with_attachments: agent has no configured "
                 "workspace dir"
+            )
+        if cfg.bridge_client is not None:
+            # T23 phase 3: attachments over the keyless bridge aren't
+            # wired yet. Fail loud rather than silently encrypt (native
+            # path) or crash — a bridge agent has no signed-crypto seam.
+            raise RuntimeError(
+                "attachments are not supported on bridge transport yet"
             )
         if not paths or not isinstance(paths, list):
             raise RuntimeError(

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -88,6 +88,70 @@ def _ts_to_iso(ms: int) -> str:
     return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat(timespec="seconds")
 
 
+# ── transport seam ─────────────────────────────────────────────────
+#
+# One helper per wire read/write. Each branches on ``cfg.keyless``: the
+# keyless (T23 bridge) transport hits the unsigned, token-authed
+# ``/v2/cloud-agents/*`` routes (the E2B egress proxy injects
+# ``x-sandbox-token``); the native transport keeps the signed keystore
+# path byte-for-byte. Kept as module-level ``_read_*``/``_send_*``
+# functions to match the existing ``_resolve_channel_space`` /
+# ``_fetch_device_keys`` idiom.
+
+
+async def _read_spaces(cfg: Any) -> Any:
+    if cfg.keyless:
+        return await cfg.http_client.get_unsigned("/v2/cloud-agents/spaces")
+    return await cfg.http_client.get("/spaces")
+
+
+async def _read_space_channels(cfg: Any, space_id: str) -> Any:
+    if cfg.keyless:
+        return await cfg.http_client.get_unsigned(
+            f"/v2/cloud-agents/spaces/{space_id}/channels"
+        )
+    return await cfg.http_client.get(f"/spaces/{space_id}/channels")
+
+
+async def _read_channel_members(
+    cfg: Any, space_id: str, channel_id: str,
+) -> Any:
+    """Keyless degrades to the space roster: the server exposes no
+    keyless *channel*-members route, only ``/spaces/{id}/members``, so
+    the keyless branch reads that (``channel_id`` is unused). Native
+    keeps its channel-scoped route."""
+    if cfg.keyless:
+        return await cfg.http_client.get_unsigned(
+            f"/v2/cloud-agents/spaces/{space_id}/members"
+        )
+    return await cfg.http_client.get(
+        f"/spaces/{space_id}/channels/{channel_id}/members"
+    )
+
+
+async def _read_profiles(cfg: Any, slugs_csv: str) -> Any:
+    quoted = urllib.parse.quote(slugs_csv, safe=",")
+    if cfg.keyless:
+        return await cfg.http_client.get_unsigned(
+            f"/v2/cloud-agents/identities/profiles?slugs={quoted}"
+        )
+    return await cfg.http_client.get(
+        f"/identities/profiles?slugs={quoted}"
+    )
+
+
+async def _send_keyless(cfg: Any, body: dict) -> dict:
+    return await cfg.http_client.post_unsigned(
+        "/v2/cloud-agents/messages", body,
+    ) or {}
+
+
+async def _upload_blob_keyless(cfg: Any, data: bytes) -> dict:
+    return await cfg.http_client.post_bytes_unsigned(
+        "/v2/cloud-agents/blobs/upload", data,
+    ) or {}
+
+
 @dataclass
 class PuffoCoreToolsConfig:
     slug: str
@@ -114,6 +178,15 @@ class PuffoCoreToolsConfig:
     # (``bridge_client.upload_blob``) and referenced by ``blob_id`` in the
     # frame's top-level ``attachments`` — no encrypt, no signed POST.
     bridge_client: Any = None
+
+    @property
+    def keyless(self) -> bool:
+        """True on the T23 bridge transport: outbound reads/sends go over
+        the unsigned ``/v2/cloud-agents/*`` routes (egress-injected
+        ``x-sandbox-token``) instead of the signed keystore path. Reads
+        ``http_client.keyless``; test fakes without the attribute default
+        to native, so existing native tests keep passing untouched."""
+        return getattr(self.http_client, "keyless", False)
 
 
 async def _fetch_device_keys(
@@ -379,6 +452,36 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     async def whoami() -> str:
         """Return your own identity: display name, slug, device_id, and
         subkey info."""
+        if cfg.keyless:
+            # T23 keyless bridge transport: the sandbox holds no local
+            # keystore, so build identity from the config instead of
+            # ``load_identity``/``load_session``. display_name resolves
+            # over the unsigned profiles route; the signing subkey is
+            # managed server-side.
+            lines = []
+            try:
+                data = await _read_profiles(cfg, cfg.slug)
+                profiles = (
+                    data.get("profiles", []) if isinstance(data, dict) else []
+                )
+                display_name = (
+                    (profiles[0].get("display_name") or "").strip()
+                    if profiles else ""
+                )
+                if display_name:
+                    lines.append(f"display_name: {display_name}")
+            except Exception as exc:
+                logger.warning(
+                    "whoami: failed to fetch own display_name: %s", exc,
+                )
+            lines += [
+                f"slug:      {cfg.slug}",
+                f"device_id: {cfg.device_id}",
+                f"server:    {cfg.http_client.server_url}",
+                "subkey:    (managed server-side; keyless transport)",
+            ]
+            return "\n".join(lines)
+
         identity = cfg.keystore.load_identity(cfg.slug)
         lines = []
         # display_name lives on the server (the local keystore only has
@@ -453,11 +556,13 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 "list_channels_in_all_spaces to look one up."
             )
 
-        if cfg.bridge_client is not None:
-            # T23 bridge transport: send plaintext; the server holds all
-            # crypto and fans out recipients. DM ('@slug') vs channel
-            # ('ch_') routing only — no device-key fetch, no encrypt, no
-            # signed POST. Threaded replies carry the same snake_case
+        if cfg.keyless:
+            # T23 keyless bridge transport: POST plaintext to the unsigned
+            # ``/v2/cloud-agents/messages`` route (the E2B egress proxy
+            # injects ``x-sandbox-token``); the server holds all crypto and
+            # fans out recipients. DM ('@slug') vs channel ('ch_') routing
+            # only — no device-key fetch, no encrypt, no signed POST, no
+            # bridge WS. Threaded replies carry the same snake_case
             # ``thread_root_id`` / ``reply_to_id`` field names a human/web
             # message uses: ``thread_root_id`` is the resolved+validated
             # true root (same resolvers the native branch runs, driven off
@@ -465,8 +570,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # parent id the agent passed. Resolution is fail-soft — a miss
             # falls through with a note and the send still completes.
             if channel_ref.startswith("@"):
-                bridge_recipient = channel_ref[1:]
-                if not bridge_recipient:
+                keyless_recipient = channel_ref[1:]
+                if not keyless_recipient:
                     raise RuntimeError("DM recipient slug is required after '@'")
                 resolved_root, root_note = await _resolve_root_id(
                     root_id, cfg.data_client,
@@ -474,36 +579,35 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 resolved_root, validate_note = await _validate_root_same_channel(
                     resolved_root, None, None, cfg.data_client,
                 )
-                ack = await cfg.bridge_client.send_send(
-                    plaintext=text,
-                    recipient_slug=bridge_recipient,
-                    thread_root_id=resolved_root or None,
-                    # F4: drop the raw parent ref when root validation wiped
-                    # the thread — no dangling reply_to for a root the send
-                    # no longer threads under.
-                    reply_to_id=(root_id or None) if resolved_root else None,
-                )
+                body: dict[str, Any] = {
+                    "plaintext": text,
+                    "recipient_slug": keyless_recipient,
+                }
             else:
-                bridge_channel_id = channel_ref
-                bridge_space_id = await _resolve_channel_space(
-                    cfg, bridge_channel_id,
+                keyless_channel_id = channel_ref
+                keyless_space_id = await _resolve_channel_space(
+                    cfg, keyless_channel_id,
                 )
                 resolved_root, root_note = await _resolve_root_id(
                     root_id, cfg.data_client,
                 )
                 resolved_root, validate_note = await _validate_root_same_channel(
-                    resolved_root, bridge_channel_id, bridge_space_id,
+                    resolved_root, keyless_channel_id, keyless_space_id,
                     cfg.data_client,
                 )
-                ack = await cfg.bridge_client.send_send(
-                    plaintext=text,
-                    space_id=bridge_space_id,
-                    channel_id=bridge_channel_id,
-                    thread_root_id=resolved_root or None,
-                    # F4: drop the raw parent ref when root validation wiped
-                    # the thread (see the DM branch above).
-                    reply_to_id=(root_id or None) if resolved_root else None,
-                )
+                body = {
+                    "plaintext": text,
+                    "space_id": keyless_space_id,
+                    "channel_id": keyless_channel_id,
+                }
+            # Only truthy thread keys ride the body. F4: drop the raw parent
+            # ref when root validation wiped the thread — no dangling
+            # reply_to for a root the send no longer threads under.
+            if resolved_root:
+                body["thread_root_id"] = resolved_root
+                if root_id:
+                    body["reply_to_id"] = root_id
+            ack = await _send_keyless(cfg, body)
             return (
                 f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
                 f"{root_note}"
@@ -744,7 +848,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         agent actually has, so the result reflects authoritative
         permissions — channels can be enumerated for any space
         listed here via ``list_channels_in_space``."""
-        data = await cfg.http_client.get("/spaces")
+        data = await _read_spaces(cfg)
         spaces_entries = (data or {}).get("spaces", []) or []
         if not spaces_entries:
             return "(not a member of any space)"
@@ -774,7 +878,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         sid = (space_id or "").strip()
         if not sid:
             raise RuntimeError("space_id is required")
-        data = await cfg.http_client.get(f"/spaces/{sid}/channels")
+        data = await _read_space_channels(cfg, sid)
         channels = (
             data.get("channels", []) if isinstance(data, dict) else []
         ) or []
@@ -804,7 +908,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         for the case where the LLM wants the full membership picture
         in one tool call. Walks one ``GET /spaces`` plus one
         ``GET /spaces/<sp>/channels`` per space."""
-        spaces_data = await cfg.http_client.get("/spaces")
+        spaces_data = await _read_spaces(cfg)
         spaces_entries = (spaces_data or {}).get("spaces", []) or []
         if not spaces_entries:
             return "(not a member of any space)"
@@ -814,9 +918,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             space_name = sp.get("name", "") or space_id
             if not space_id:
                 continue
-            ch_data = await cfg.http_client.get(
-                f"/spaces/{space_id}/channels"
-            )
+            ch_data = await _read_space_channels(cfg, space_id)
             channels = (
                 ch_data.get("channels", []) if isinstance(ch_data, dict) else []
             )
@@ -849,9 +951,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         # for any channel not in the agent's home space.
         space_id = await _resolve_channel_space(cfg, channel_id)
 
-        data = await cfg.http_client.get(
-            f"/spaces/{space_id}/channels/{channel_id}/members"
-        )
+        # Keyless degrades to the space roster (no keyless channel-members
+        # route exists); native reads the channel-scoped members. See
+        # ``_read_channel_members``.
+        data = await _read_channel_members(cfg, space_id, channel_id)
         rows = []
         for m in data.get("members", []):
             slug = m.get("slug", "?")
@@ -875,9 +978,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         # ``/identities/profiles?slugs=`` accepts a comma-separated
         # list; we read back the first entry. Empty list means the
         # slug isn't registered.
-        data = await cfg.http_client.get(
-            f"/identities/profiles?slugs={urllib.parse.quote(slug, safe='')}"
-        )
+        data = await _read_profiles(cfg, slug)
         profiles = data.get("profiles", []) if isinstance(data, dict) else []
         if not profiles:
             return f"(no profile for {slug})"
@@ -1086,21 +1187,22 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 )
             targets.append(target)
 
-        if cfg.bridge_client is not None:
-            # T23 bridge transport: the server holds the at-rest blob
-            # store, so we upload each file's PLAINTEXT bytes keyless
-            # (``upload_blob`` → ``x-sandbox-token``, raw body) and pass
-            # the returned ``blob_id``s as top-level ``AttachmentRef``s
-            # into the same plaintext ``send`` frame ``send_message``
-            # uses. No ``encrypt_attachment``, no device-key fetch, no
-            # signed ``/messages`` POST — a bridge agent has no
-            # signed-crypto seam. DM vs channel routing + fail-soft
-            # thread resolution mirror ``send_message``'s bridge branch.
+        if cfg.keyless:
+            # T23 keyless bridge transport: the server holds the at-rest
+            # blob store, so we upload each file's PLAINTEXT bytes unsigned
+            # (``post_bytes_unsigned`` → egress-injected ``x-sandbox-token``,
+            # raw body) and pass the returned ``blob_id``s as top-level
+            # ``AttachmentRef``s into the same plaintext ``/v2/cloud-agents/
+            # messages`` POST ``send_message`` uses. No ``encrypt_attachment``,
+            # no device-key fetch, no signed ``/messages`` POST — a keyless
+            # agent has no signed-crypto seam. DM vs channel routing +
+            # fail-soft thread resolution mirror ``send_message``'s keyless
+            # branch.
             #
             # F5: run EVERY precondition — destination resolve/validate,
             # root resolve/validate, and all per-file size checks — BEFORE
-            # the first ``upload_blob``, so a rejected route or an oversized
-            # Nth file raises with no orphaned blobs left on the server.
+            # the first upload, so a rejected route or an oversized Nth file
+            # raises with no orphaned blobs left on the server.
             channel_ref = channel.strip()
             if channel_ref.startswith("#"):
                 raise RuntimeError(
@@ -1112,19 +1214,19 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # a stale ``ch_`` (``_resolve_channel_space`` raises) fails here,
             # before any upload.
             is_dm = channel_ref.startswith("@")
-            bridge_recipient = ""
-            bridge_channel_id = ""
-            bridge_space_id = None
+            keyless_recipient = ""
+            keyless_channel_id = ""
+            keyless_space_id = None
             if is_dm:
-                bridge_recipient = channel_ref[1:]
-                if not bridge_recipient:
+                keyless_recipient = channel_ref[1:]
+                if not keyless_recipient:
                     raise RuntimeError(
                         "DM recipient slug is required after '@'"
                     )
             else:
-                bridge_channel_id = channel_ref
-                bridge_space_id = await _resolve_channel_space(
-                    cfg, bridge_channel_id,
+                keyless_channel_id = channel_ref
+                keyless_space_id = await _resolve_channel_space(
+                    cfg, keyless_channel_id,
                 )
 
             # (2) Resolve + validate the thread root before uploads.
@@ -1133,8 +1235,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             )
             resolved_root, validate_note = await _validate_root_same_channel(
                 resolved_root,
-                None if is_dm else bridge_channel_id,
-                None if is_dm else bridge_space_id,
+                None if is_dm else keyless_channel_id,
+                None if is_dm else keyless_space_id,
                 cfg.data_client,
             )
 
@@ -1158,12 +1260,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # (4) Only now upload each blob → build refs.
             refs: list[dict] = []
             for target, plaintext, mime_type in prepared:
-                up = await cfg.bridge_client.upload_blob(plaintext)
+                up = await _upload_blob_keyless(cfg, plaintext)
                 blob_id = up.get("blob_id") if isinstance(up, dict) else None
                 if not blob_id:
                     raise RuntimeError(
-                        f"send_message_with_attachments: bridge returned no "
-                        f"blob_id for {target.name!r} ({up!r})"
+                        f"send_message_with_attachments: keyless upload "
+                        f"returned no blob_id for {target.name!r} ({up!r})"
                     )
                 refs.append({
                     "blob_id": blob_id,
@@ -1175,22 +1277,23 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # (5) One send using the pre-resolved route + the F4 reply_to
             # gate (drop the raw parent when root validation wiped it).
             if is_dm:
-                ack = await cfg.bridge_client.send_send(
-                    plaintext=caption,
-                    recipient_slug=bridge_recipient,
-                    attachments=refs,
-                    thread_root_id=resolved_root or None,
-                    reply_to_id=(root_id or None) if resolved_root else None,
-                )
+                body: dict[str, Any] = {
+                    "plaintext": caption,
+                    "recipient_slug": keyless_recipient,
+                    "attachments": refs,
+                }
             else:
-                ack = await cfg.bridge_client.send_send(
-                    plaintext=caption,
-                    space_id=bridge_space_id,
-                    channel_id=bridge_channel_id,
-                    attachments=refs,
-                    thread_root_id=resolved_root or None,
-                    reply_to_id=(root_id or None) if resolved_root else None,
-                )
+                body = {
+                    "plaintext": caption,
+                    "space_id": keyless_space_id,
+                    "channel_id": keyless_channel_id,
+                    "attachments": refs,
+                }
+            if resolved_root:
+                body["thread_root_id"] = resolved_root
+                if root_id:
+                    body["reply_to_id"] = root_id
+            ack = await _send_keyless(cfg, body)
             names = ", ".join(t.name for t in targets)
             thread_note = f" in thread {resolved_root}" if resolved_root else ""
             return (

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -478,7 +478,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     plaintext=text,
                     recipient_slug=bridge_recipient,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    # F4: drop the raw parent ref when root validation wiped
+                    # the thread — no dangling reply_to for a root the send
+                    # no longer threads under.
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             else:
                 bridge_channel_id = channel_ref
@@ -497,7 +500,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     space_id=bridge_space_id,
                     channel_id=bridge_channel_id,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    # F4: drop the raw parent ref when root validation wiped
+                    # the thread (see the DM branch above).
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             return (
                 f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
@@ -1091,18 +1096,55 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # signed ``/messages`` POST — a bridge agent has no
             # signed-crypto seam. DM vs channel routing + fail-soft
             # thread resolution mirror ``send_message``'s bridge branch.
+            #
+            # F5: run EVERY precondition — destination resolve/validate,
+            # root resolve/validate, and all per-file size checks — BEFORE
+            # the first ``upload_blob``, so a rejected route or an oversized
+            # Nth file raises with no orphaned blobs left on the server.
             channel_ref = channel.strip()
             if channel_ref.startswith("#"):
                 raise RuntimeError(
                     "'#<name>' channel addressing isn't supported; pass "
                     "the channel id directly."
                 )
-            refs: list[dict] = []
+
+            # (1) Resolve + validate the destination first. A bare ``@`` or
+            # a stale ``ch_`` (``_resolve_channel_space`` raises) fails here,
+            # before any upload.
+            is_dm = channel_ref.startswith("@")
+            bridge_recipient = ""
+            bridge_channel_id = ""
+            bridge_space_id = None
+            if is_dm:
+                bridge_recipient = channel_ref[1:]
+                if not bridge_recipient:
+                    raise RuntimeError(
+                        "DM recipient slug is required after '@'"
+                    )
+            else:
+                bridge_channel_id = channel_ref
+                bridge_space_id = await _resolve_channel_space(
+                    cfg, bridge_channel_id,
+                )
+
+            # (2) Resolve + validate the thread root before uploads.
+            resolved_root, root_note = await _resolve_root_id(
+                root_id, cfg.data_client,
+            )
+            resolved_root, validate_note = await _validate_root_same_channel(
+                resolved_root,
+                None if is_dm else bridge_channel_id,
+                None if is_dm else bridge_space_id,
+                cfg.data_client,
+            )
+
+            # (3) Read every file + run the 8 MiB check for ALL files
+            # before uploading any — a later oversized file must not orphan
+            # earlier blobs.
+            prepared: list[tuple[Any, bytes, str]] = []
             total_bytes = 0
             for target in targets:
                 plaintext = target.read_bytes()
-                # Keep the native 8 MiB pre-check so an oversized file
-                # fails before we burn an upload round-trip.
                 if len(plaintext) > 8 * 1024 * 1024:
                     raise RuntimeError(
                         f"send_message_with_attachments: {target.name!r} is "
@@ -1110,6 +1152,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     )
                 mime_type, _ = mimetypes.guess_type(target.name)
                 mime_type = mime_type or "application/octet-stream"
+                prepared.append((target, plaintext, mime_type))
+                total_bytes += len(plaintext)
+
+            # (4) Only now upload each blob → build refs.
+            refs: list[dict] = []
+            for target, plaintext, mime_type in prepared:
                 up = await cfg.bridge_client.upload_blob(plaintext)
                 blob_id = up.get("blob_id") if isinstance(up, dict) else None
                 if not blob_id:
@@ -1123,46 +1171,25 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     "mime_type": mime_type,
                     "size_bytes": len(plaintext),
                 })
-                total_bytes += len(plaintext)
 
-            if channel_ref.startswith("@"):
-                bridge_recipient = channel_ref[1:]
-                if not bridge_recipient:
-                    raise RuntimeError(
-                        "DM recipient slug is required after '@'"
-                    )
-                resolved_root, root_note = await _resolve_root_id(
-                    root_id, cfg.data_client,
-                )
-                resolved_root, validate_note = await _validate_root_same_channel(
-                    resolved_root, None, None, cfg.data_client,
-                )
+            # (5) One send using the pre-resolved route + the F4 reply_to
+            # gate (drop the raw parent when root validation wiped it).
+            if is_dm:
                 ack = await cfg.bridge_client.send_send(
                     plaintext=caption,
                     recipient_slug=bridge_recipient,
                     attachments=refs,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             else:
-                bridge_channel_id = channel_ref
-                bridge_space_id = await _resolve_channel_space(
-                    cfg, bridge_channel_id,
-                )
-                resolved_root, root_note = await _resolve_root_id(
-                    root_id, cfg.data_client,
-                )
-                resolved_root, validate_note = await _validate_root_same_channel(
-                    resolved_root, bridge_channel_id, bridge_space_id,
-                    cfg.data_client,
-                )
                 ack = await cfg.bridge_client.send_send(
                     plaintext=caption,
                     space_id=bridge_space_id,
                     channel_id=bridge_channel_id,
                     attachments=refs,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             names = ", ".join(t.name for t in targets)
             thread_note = f" in thread {resolved_root}" if resolved_root else ""

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -256,17 +256,41 @@ def cmd_config(args: argparse.Namespace) -> int:
 
 
 
+# Shown when a GUI entry point (``start --ui`` / ``start --tray``) is
+# invoked but the desktop UI's ``[gui]`` extra (PySide6) isn't installed.
+# The base ``pip install puffo-agent`` is deliberately Qt-free so headless
+# / cloud daemons don't pull Qt; PySide6 lives in the ``gui`` extra.
+_GUI_EXTRA_HINT = (
+    "the desktop UI requires the [gui] extra (PySide6), which is not "
+    "installed. install it with:\n\n    pip install 'puffo-agent[gui]'\n\n"
+    "(the headless daemon — `puffo-agent start` with no UI flag — runs "
+    "without it.)"
+)
+
+
 def cmd_start(args: argparse.Namespace) -> int:
     with_local_bridge = getattr(args, "with_local_bridge", False)
+    # The PySide6 import inside run_tray/launch is deferred to call time,
+    # so the ImportError surfaces from the call, not the ``from .ui...``
+    # line — wrap both so a missing [gui] extra yields the actionable hint
+    # instead of a raw ModuleNotFoundError traceback.
     if getattr(args, "tray_runner", False):
-        from .ui.tray import run_tray
-        return run_tray(with_local_bridge=with_local_bridge)
+        try:
+            from .ui.tray import run_tray
+            return run_tray(with_local_bridge=with_local_bridge)
+        except ImportError:
+            print(_GUI_EXTRA_HINT, file=sys.stderr)
+            return 1
     if getattr(args, "background", False):
         from .background import spawn_background
         return spawn_background(with_local_bridge=with_local_bridge)
     if getattr(args, "ui", False):
-        from .ui.launcher import launch
-        return launch(with_local_bridge=with_local_bridge)
+        try:
+            from .ui.launcher import launch
+            return launch(with_local_bridge=with_local_bridge)
+        except ImportError:
+            print(_GUI_EXTRA_HINT, file=sys.stderr)
+            return 1
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -987,6 +987,14 @@ class RuntimeConfig:
     provider: str = ""            # empty = default for kind
     model: str = ""
     api_key: str = ""
+    # OpenAI/Anthropic-compatible base URL for the LLM plane. Set this
+    # to route model calls through a proxy — e.g. Shan's LiteLLM virtual
+    # key endpoint for cloud agents — instead of the vendor default.
+    # Consumed by chat-local (Anthropic + OpenAI providers), sdk-local
+    # and cli-local/claude-code (as ANTHROPIC_BASE_URL). Empty = vendor
+    # endpoint (today's behavior, byte-for-byte unchanged). The matching
+    # secret rides on ``api_key`` (the VK), so no new field is needed.
+    llm_base_url: str = ""
     # Tool allowlist patterns (sdk | cli-local | cli-docker). Each
     # entry is a bare tool name ("Read") or tool-name-plus-arg glob
     # ("Bash(git *)", "Read(**/*.py)"). Empty = no tools allowed.
@@ -1122,6 +1130,7 @@ class AgentConfig:
                 provider=provider,
                 model=rt.get("model", ""),
                 api_key=rt.get("api_key", ""),
+                llm_base_url=rt.get("llm_base_url", ""),
                 allowed_tools=list(rt.get("allowed_tools") or []),
                 docker_image=rt.get("docker_image", ""),
                 docker_memory_limit=rt.get("docker_memory_limit", ""),

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -941,6 +941,13 @@ class TriggerRules:
 DEFAULT_PUFFO_SERVER_URL = "https://chat.puffo.ai/relay"
 
 
+## Transports for the puffo-core backend (T23). ``native`` is today's
+## signed-crypto path; ``bridge`` is the experimental keyless WS bridge
+## (server holds all crypto, auth via sandbox_token). agent.yml only —
+## no UI knob while bridge is experimental.
+VALID_TRANSPORTS = ("native", "bridge")
+
+
 @dataclass
 class PuffoCoreConfig:
     """puffo-core signed API config — the agent's only chat backend."""
@@ -955,6 +962,13 @@ class PuffoCoreConfig:
     # Hidden knob (no UI, agent.yml only): when true, space invites from
     # non-operators are auto-accepted, then the operator is DM'd a report.
     auto_accept_space_invitations: bool = False
+    # One of VALID_TRANSPORTS. ``bridge`` (experimental) talks plaintext
+    # WS to ``server_url``'s /v2/cloud-agents/subscribe endpoint using
+    # ``sandbox_token`` instead of local key files. Absent from saved
+    # agent.yml unless set to bridge.
+    transport: str = "native"
+    # Bridge only — the keyless auth credential minted at provision time.
+    sandbox_token: str = ""
 
     def is_configured(self) -> bool:
         return bool(self.server_url and self.slug and self.device_id and self.space_id)
@@ -1068,6 +1082,22 @@ class AgentConfig:
                 f"agent {agent_id!r}: invalid runtime config — {result.error}"
             )
 
+        # Transport validation (T23). Absent key ⇒ native ⇒ identical
+        # to pre-transport configs; bridge requires its credential pair.
+        transport = pc.get("transport", "native")
+        sandbox_token = pc.get("sandbox_token", "")
+        server_url = pc.get("server_url") or DEFAULT_PUFFO_SERVER_URL
+        if transport not in VALID_TRANSPORTS:
+            raise RuntimeError(
+                f"agent {agent_id!r}: invalid puffo_core.transport "
+                f"{transport!r} — valid transports: {list(VALID_TRANSPORTS)}"
+            )
+        if transport == "bridge" and not (sandbox_token and server_url):
+            raise RuntimeError(
+                f"agent {agent_id!r}: puffo_core.transport 'bridge' "
+                "requires both server_url and sandbox_token"
+            )
+
         return cls(
             id=raw.get("id", agent_id),
             state=raw.get("state", "running"),
@@ -1076,7 +1106,7 @@ class AgentConfig:
             role=raw.get("role", ""),
             role_short=raw.get("role_short", ""),
             puffo_core=PuffoCoreConfig(
-                server_url=pc.get("server_url") or DEFAULT_PUFFO_SERVER_URL,
+                server_url=server_url,
                 slug=pc.get("slug", ""),
                 device_id=pc.get("device_id", ""),
                 space_id=pc.get("space_id", ""),
@@ -1084,6 +1114,8 @@ class AgentConfig:
                 auto_accept_space_invitations=bool(
                     pc.get("auto_accept_space_invitations", False)
                 ),
+                transport=transport,
+                sandbox_token=sandbox_token,
             ),
             runtime=RuntimeConfig(
                 kind=kind,
@@ -1114,6 +1146,12 @@ class AgentConfig:
     def save(self) -> None:
         path = agent_yml_path(self.id)
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Native agents (the default) keep a byte-identical agent.yml:
+        # the transport keys are only written for bridge agents.
+        pc_dict = asdict(self.puffo_core)
+        if self.puffo_core.transport == "native":
+            pc_dict.pop("transport", None)
+            pc_dict.pop("sandbox_token", None)
         data = {
             "id": self.id,
             "state": self.state,
@@ -1122,7 +1160,7 @@ class AgentConfig:
             "role": self.role,
             "role_short": self.role_short,
             "created_at": self.created_at,
-            "puffo_core": asdict(self.puffo_core),
+            "puffo_core": pc_dict,
             "runtime": asdict(self.runtime),
             "profile": self.profile,
             "memory_dir": self.memory_dir,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -359,7 +359,18 @@ def _build_puffo_core_client(
     from ..crypto.keystore import KeyStore
 
     pc = agent_cfg.puffo_core
-    _ensure_agent_identity_imported(agent_id, pc.slug)
+    bridge = None
+    if pc.transport == "bridge":
+        # T23 keyless transport: no identity file exists to import;
+        # the bridge authenticates with the sandbox token instead.
+        # Keystore/http below are still constructed (both lazy — they
+        # never touch disk/network in __init__); phase 2 replaces
+        # their call sites.
+        from ..agent.bridge_client import CloudBridgeClient
+
+        bridge = CloudBridgeClient(pc.server_url, pc.sandbox_token, pc.slug)
+    else:
+        _ensure_agent_identity_imported(agent_id, pc.slug)
     ks_dir = str(agent_dir(agent_id) / "keys")
     ks = KeyStore(ks_dir)
     http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
@@ -393,6 +404,7 @@ def _build_puffo_core_client(
         segment_chars=segment_chars,
         agent_created_at=agent_cfg.created_at,
         image_edge_px=max_image_edge_px(model),
+        bridge_client=bridge,
     )
 
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -386,7 +386,12 @@ def _build_puffo_core_client(
         _ensure_agent_identity_imported(agent_id, pc.slug)
     ks_dir = str(agent_dir(agent_id) / "keys")
     ks = KeyStore(ks_dir)
-    http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
+    # Bridge agents dispatch outbound tool work keyless over the unsigned
+    # ``/v2/cloud-agents/*`` routes; ``route.py`` reuses ``client.http``, so
+    # the in-process ws-local cfg's ``keyless`` accessor reads True here.
+    http = PuffoCoreHttpClient(
+        pc.server_url, ks, pc.slug, keyless=(pc.transport == "bridge"),
+    )
     ms = MessageStore(str(agent_dir(agent_id) / "messages.db"))
 
     max_inline = (

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -112,6 +112,9 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             agent_id=agent_cfg.id,
             workspace_dir=str(agent_cfg.resolve_workspace_dir()),
             max_turns=agent_cfg.runtime.max_turns,
+            # Empty = vendor endpoint (unchanged); set = route the SDK's
+            # model calls through the proxy via ANTHROPIC_BASE_URL.
+            base_url=agent_cfg.runtime.llm_base_url,
         )
         if agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_stdio_sdk_config, default_python_executable
@@ -239,6 +242,13 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             puffo_core_server_url=agent_cfg.puffo_core.server_url,
             puffo_core_slug=agent_cfg.puffo_core.slug,
             puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
+            # Empty base URL → no env override (claude keeps its OAuth /
+            # ~/.claude credential path). Set → ANTHROPIC_BASE_URL routes
+            # the CLI's model calls through the proxy; the VK rides on
+            # runtime.api_key (injected as ANTHROPIC_API_KEY only when
+            # the base URL is also set — see LocalCLIAdapter._llm_env).
+            llm_base_url=agent_cfg.runtime.llm_base_url,
+            llm_api_key=agent_cfg.runtime.api_key,
         )
         if agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_mcp_env
@@ -268,6 +278,9 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
     """Anthropic/OpenAI message-completion provider for the
     chat-local adapter. Per-agent fields override daemon defaults."""
     provider_name = runtime.provider or daemon_cfg.default_provider
+    # Empty base URL → None → vendor endpoint (today's behavior, byte-for-
+    # byte unchanged). Set → route completions through the proxy (VK).
+    base_url = runtime.llm_base_url or None
 
     if provider_name == "anthropic":
         from ..agent.providers.anthropic_provider import AnthropicProvider
@@ -277,7 +290,7 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
             raise RuntimeError(
                 "anthropic api_key is not set in daemon.yml or agent.yml"
             )
-        return AnthropicProvider(api_key=api_key, model=model)
+        return AnthropicProvider(api_key=api_key, model=model, base_url=base_url)
 
     if provider_name == "openai":
         from ..agent.providers.openai_provider import OpenAIProvider
@@ -287,7 +300,7 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
             raise RuntimeError(
                 "openai api_key is not set in daemon.yml or agent.yml"
             )
-        return OpenAIProvider(api_key=api_key, model=model)
+        return OpenAIProvider(api_key=api_key, model=model, base_url=base_url)
 
     raise RuntimeError(f"unknown provider {provider_name!r}")
 

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -44,6 +44,11 @@ def _build_tool_dispatch(point: AttachPoint):
         space_id=getattr(client, "space_id", None),
         workspace=getattr(client, "workspace", None),
         message_client=client,
+        # T23: the daemon owns the single per-agent bridge WS, so only
+        # the in-process ws-local tools can drive it. None on native
+        # agents → send_message keeps the signed-crypto path. The
+        # subprocess/RPC MCP site can't own this WS, so it stays None.
+        bridge_client=getattr(client, "_bridge", None),
     )
     return _build_dispatch(cfg)
 

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -37,6 +37,13 @@ WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
     # membership
     "leave_space",
     "leave_channel",
+    # bridge-only sandbox lifecycle (registered only when
+    # cfg.bridge_client is set — native agents never see these)
+    "schedule_wake",
+    "cancel_wake",
+    "get_scheduled_wake",
+    "get_runtime_status",
+    "keep_alive",
 })
 
 

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from types import SimpleNamespace
 
+import aiohttp
 import pytest
 from aiohttp import WSMsgType, web
 from aiohttp.test_utils import TestClient, TestServer
@@ -250,3 +252,183 @@ async def test_send_after_close_raises_bridge_closed():
         await c.close()
         with pytest.raises(BridgeClosed):
             await c.send_send(plaintext="hi", recipient_slug="alice")
+
+
+# --------------------------------------------------------------------------
+# F2: connect() closes the ClientSession on EVERY failed-connect path.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f2_connect_closes_session_when_ws_connect_raises(monkeypatch):
+    """A connector/OS error from ``ws_connect`` must not leak the session
+    — connect() closes it and leaves ``_session is None``."""
+    captured: dict = {}
+
+    async def _boom_ws_connect(self, *a, **k):
+        captured["session"] = self  # the bound ClientSession
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(aiohttp.ClientSession, "ws_connect", _boom_ws_connect)
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+
+    with pytest.raises(OSError):
+        await c.connect()
+
+    assert c._session is None, "failed connect leaked the ClientSession"
+    assert captured["session"].closed is True, "session was not closed"
+    assert c._ws is None
+    assert c._heartbeat_task is None, "no heartbeat should survive a failed connect"
+
+
+@pytest.mark.asyncio
+async def test_f2_connect_closes_session_when_first_receive_times_out(monkeypatch):
+    """A ``TimeoutError`` waiting for the first frame closes both the ws
+    and the session — no leak past the handshake."""
+    captured: dict = {}
+
+    class _BoomWs:
+        def __init__(self):
+            self.closed = False
+
+        async def receive(self, timeout=None):
+            raise asyncio.TimeoutError()
+
+        async def close(self):
+            self.closed = True
+
+    boom_ws = _BoomWs()
+
+    async def _ws_connect_then_timeout(self, *a, **k):
+        captured["session"] = self
+        return boom_ws
+
+    monkeypatch.setattr(
+        aiohttp.ClientSession, "ws_connect", _ws_connect_then_timeout,
+    )
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+
+    with pytest.raises(asyncio.TimeoutError):
+        await c.connect()
+
+    assert c._session is None
+    assert captured["session"].closed is True
+    assert boom_ws.closed is True, "the half-open ws was not closed"
+    assert c._ws is None
+
+
+@pytest.mark.asyncio
+async def test_f2_bad_handshake_frame_still_closes_session():
+    """The pre-existing bad-first-frame path also closes the session
+    (regression guard for the F2 rework)."""
+    bridge_app = _MockBridgeApp()
+    bridge_app.first_frame = {"type": "definitely-not-connected"}
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.connect()
+    assert excinfo.value.code == "HANDSHAKE"
+    assert c._session is None, "bad-handshake path leaked the session"
+    assert c._ws is None
+
+
+# --------------------------------------------------------------------------
+# F3: a timed-out send_ack / send_list_spaces waiter is pulled from its
+# FIFO so the next real ack_result / spaces frame resolves the next call.
+# --------------------------------------------------------------------------
+
+
+class _ScriptedWs:
+    """A minimal ws that ``frames()`` can iterate: fed TEXT frames arrive
+    via ``feed``; ``send_json`` records outbound frames. Blocks on an
+    empty inbox like a live socket."""
+
+    def __init__(self):
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def send_json(self, frame):
+        self.sent.append(frame)
+
+    def feed(self, frame: dict) -> None:
+        self._inbox.put_nowait(
+            SimpleNamespace(type=WSMsgType.TEXT, data=json.dumps(frame)),
+        )
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._inbox.get()
+
+    async def close(self):
+        self.closed = True
+
+
+async def _client_with_scripted_ws() -> tuple[CloudBridgeClient, _ScriptedWs]:
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+    ws = _ScriptedWs()
+    c._ws = ws  # _require_ws returns it (not None, not closed)
+    return c, ws
+
+
+@pytest.mark.asyncio
+async def test_f3_send_ack_timeout_discards_waiter_then_next_resolves():
+    c, ws = await _client_with_scripted_ws()
+    consumer = asyncio.create_task(_drain(c))  # routes ack_result → waiters
+    try:
+        # 1) No ack_result fed → this ack times out.
+        with pytest.raises(asyncio.TimeoutError):
+            await c.send_ack(["e1"], timeout=0.05)
+        # The dead waiter was pulled out of the FIFO.
+        assert c._ack_result_waiters.empty()
+
+        # 2) The NEXT ack must be resolved by the next ack_result — proving
+        # the dead waiter isn't eating it.
+        async def _deliver():
+            while c._ack_result_waiters.empty():
+                await asyncio.sleep(0)
+            ws.feed({"type": "ack_result", "acked": ["e2"]})
+
+        res, _ = await asyncio.gather(
+            c.send_ack(["e2"], timeout=2.0), _deliver(),
+        )
+        assert res["type"] == "ack_result"
+        assert res["acked"] == ["e2"]
+        assert c._ack_result_waiters.empty()
+    finally:
+        consumer.cancel()
+        try:
+            await consumer
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_f3_send_list_spaces_timeout_discards_waiter_then_next_resolves():
+    c, ws = await _client_with_scripted_ws()
+    consumer = asyncio.create_task(_drain(c))
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await c.send_list_spaces(timeout=0.05)
+        assert c._spaces_waiters.empty()
+
+        async def _deliver():
+            while c._spaces_waiters.empty():
+                await asyncio.sleep(0)
+            ws.feed({"type": "spaces", "spaces": [{"id": "sp_1"}]})
+
+        res, _ = await asyncio.gather(
+            c.send_list_spaces(timeout=2.0), _deliver(),
+        )
+        assert res["type"] == "spaces"
+        assert res["spaces"] == [{"id": "sp_1"}]
+        assert c._spaces_waiters.empty()
+    finally:
+        consumer.cancel()
+        try:
+            await consumer
+        except (asyncio.CancelledError, Exception):
+            pass

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -1,0 +1,252 @@
+"""T23 phase 1: ``CloudBridgeClient`` vs. a local aiohttp WS server
+that speaks the bridge wire protocol (BRIDGE-WIRE-PROTOCOL.md) —
+``connected`` first frame, heartbeat-tolerant, ``send`` /
+``fetch_pending`` handlers. Loopback only, no real network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+from aiohttp import WSMsgType, web
+from aiohttp.test_utils import TestClient, TestServer
+
+import puffo_agent.agent.bridge_client as bridge_client_mod
+from puffo_agent.agent.bridge_client import (
+    BridgeClosed,
+    BridgeError,
+    CloudBridgeClient,
+)
+
+
+class _MockBridgeApp:
+    """Minimal bridge speaking just enough of the wire protocol to
+    drive the client. Records what the client sent."""
+
+    def __init__(self) -> None:
+        # Frames the server pushes in response to fetch_pending.
+        self.pending_messages: list[dict] = []
+        # Extra frames pushed right after 'connected' (e.g. an
+        # uncorrelated error for the frames() surfacing test).
+        self.push_after_connect: list[dict] = []
+        # First frame override — None means the normal 'connected'.
+        self.first_frame: dict | None = None
+        # When set, 'send' frames get an error reply (echoing
+        # client_ref) instead of an ack.
+        self.error_on_send: dict | None = None
+        self.recv_send: list[dict] = []
+        self.recv_heartbeats: list[dict] = []
+        self.token_seen: str | None = None
+        self.heartbeat_received = asyncio.Event()
+
+    async def ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        self.token_seen = request.headers.get("x-sandbox-token")
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.send_json(self.first_frame or {"type": "connected"})
+        for frame in self.push_after_connect:
+            await ws.send_json(frame)
+        async for msg in ws:
+            if msg.type != WSMsgType.TEXT:
+                break
+            frame = json.loads(msg.data)
+            kind = frame.get("type", "")
+            if kind == "heartbeat":
+                self.recv_heartbeats.append(frame)
+                self.heartbeat_received.set()
+            elif kind == "send":
+                self.recv_send.append(frame)
+                if self.error_on_send is not None:
+                    await ws.send_json({
+                        **self.error_on_send,
+                        "client_ref": frame.get("client_ref"),
+                    })
+                else:
+                    await ws.send_json({
+                        "type": "ack",
+                        "client_ref": frame.get("client_ref"),
+                        "envelope_id": f"msg_{uuid.uuid4().hex[:8]}",
+                        "devices_queued": 2,
+                    })
+            elif kind == "fetch_pending":
+                count = 0
+                while self.pending_messages:
+                    await ws.send_json(self.pending_messages.pop(0))
+                    count += 1
+                await ws.send_json({
+                    "type": "pending_delivered",
+                    "count": count,
+                    "more": False,
+                })
+        return ws
+
+
+def _build_app(bridge: _MockBridgeApp) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/v2/cloud-agents/subscribe", bridge.ws_handler)
+    return app
+
+
+async def _drain(c: CloudBridgeClient) -> None:
+    try:
+        async for _ in c.frames():
+            pass
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_handshake_connected_sends_x_sandbox_token_header():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_test_abc", "agent-slug")
+        try:
+            await c.connect()
+        finally:
+            await c.close()
+    assert bridge_app.token_seen == "sbx_test_abc"
+
+
+@pytest.mark.asyncio
+async def test_bad_handshake_first_frame_raises_bridge_error():
+    bridge_app = _MockBridgeApp()
+    bridge_app.first_frame = {"type": "definitely-not-connected"}
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.connect()
+        await c.close()
+    assert excinfo.value.code == "HANDSHAKE"
+
+
+@pytest.mark.asyncio
+async def test_send_send_correlates_ack_via_client_ref():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        # Ack correlation happens inside frames() — run the consumer
+        # in the background while send_send awaits its future.
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            ack = await c.send_send(
+                plaintext="hi alice", recipient_slug="alice",
+            )
+        finally:
+            await c.close()
+            consumer.cancel()
+    assert ack["type"] == "ack"
+    assert ack["envelope_id"].startswith("msg_")
+    assert len(bridge_app.recv_send) == 1
+    sent = bridge_app.recv_send[0]
+    assert sent["type"] == "send"
+    assert sent["plaintext"] == "hi alice"
+    assert sent["client_ref"] == ack["client_ref"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_yields_message_then_pending_delivered():
+    bridge_app = _MockBridgeApp()
+    bridge_app.pending_messages = [{
+        "type": "message",
+        "envelope_id": "env_1",
+        "sender_slug": "alice-0001",
+        "plaintext": "hello",
+    }]
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            await c.send_fetch_pending()
+            seen: list[dict] = []
+            async for frame in c.frames():
+                seen.append(frame)
+                if frame.get("type") == "pending_delivered":
+                    break
+        finally:
+            await c.close()
+    assert [f["type"] for f in seen] == ["message", "pending_delivered"]
+    assert seen[0]["envelope_id"] == "env_1"
+    assert seen[1]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_frame_reaches_server(monkeypatch):
+    monkeypatch.setattr(
+        bridge_client_mod, "_HEARTBEAT_INTERVAL_SECONDS", 0.05,
+    )
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            await asyncio.wait_for(
+                bridge_app.heartbeat_received.wait(), timeout=5.0,
+            )
+        finally:
+            await c.close()
+    assert bridge_app.recv_heartbeats[0] == {"type": "heartbeat"}
+
+
+@pytest.mark.asyncio
+async def test_correlated_error_frame_rejects_send_as_bridge_error():
+    bridge_app = _MockBridgeApp()
+    bridge_app.error_on_send = {
+        "type": "error",
+        "code": "NOT_AUTHORIZED",
+        "message": "token revoked",
+    }
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        consumer = asyncio.create_task(_drain(c))
+        try:
+            with pytest.raises(BridgeError) as excinfo:
+                await c.send_send(plaintext="hi", recipient_slug="alice")
+        finally:
+            await c.close()
+            consumer.cancel()
+    assert excinfo.value.code == "NOT_AUTHORIZED"
+    assert "token revoked" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_uncorrelated_error_frame_surfaces_via_frames():
+    bridge_app = _MockBridgeApp()
+    bridge_app.push_after_connect = [{
+        "type": "error",
+        "code": "INTERNAL",
+        "message": "hiccup",
+    }]
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            frame = await asyncio.wait_for(
+                c.frames().__anext__(), timeout=5.0,
+            )
+        finally:
+            await c.close()
+    assert frame == {"type": "error", "code": "INTERNAL", "message": "hiccup"}
+
+
+@pytest.mark.asyncio
+async def test_send_after_close_raises_bridge_closed():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        await c.close()
+        with pytest.raises(BridgeClosed):
+            await c.send_send(plaintext="hi", recipient_slug="alice")

--- a/tests/test_cloud_bridge_lifecycle_client.py
+++ b/tests/test_cloud_bridge_lifecycle_client.py
@@ -1,0 +1,266 @@
+"""``CloudBridgeClient`` keyless lifecycle REST methods vs. a loopback
+aiohttp mock app (mirrors ``test_cloud_bridge_client.py``). Exercises the
+``x-sandbox-token`` HTTP surface — POST/GET/DELETE on
+``/v2/cloud-agents/{schedule-wake,scheduled-wake,runtime-status,keepalive}``
+— asserting the client sends the right route/body/header and maps the
+response. Loopback only, no real network / E2B / server.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from puffo_agent.agent.bridge_client import BridgeError, CloudBridgeClient
+
+
+class _MockLifecycleApp:
+    """Records requests to the lifecycle routes and returns canned
+    bodies/status the test configures."""
+
+    def __init__(self) -> None:
+        self.token_seen: str | None = None
+        self.requests: list[dict] = []
+        # Per-route canned responses: (status, json_body). Defaults
+        # exercise the happy path; tests override to drive edge cases.
+        self.schedule_wake_response: tuple[int, dict] = (
+            200, {"wake_at": "2026-07-07T12:00:00Z", "reason": "ok"},
+        )
+        self.scheduled_wake_response: tuple[int, dict | None] = (
+            200, {"wake_at": None},
+        )
+        self.cancel_wake_status = 204
+        self.runtime_status_response: tuple[int, dict] = (
+            200, {
+                "state": "running",
+                "timeout_at": "2026-07-07T13:00:00Z",
+                "seconds_until_sleep": 900,
+                "sandbox_id": "sbx_1",
+            },
+        )
+        self.keepalive_response: tuple[int, dict] = (
+            200, {
+                "timeout_at": "2026-07-07T14:00:00Z",
+                "seconds_until_sleep": 3600,
+            },
+        )
+
+    async def _record(self, request: web.Request) -> None:
+        self.token_seen = request.headers.get("x-sandbox-token")
+        body = None
+        if request.can_read_body:
+            try:
+                body = await request.json()
+            except Exception:
+                body = None
+        self.requests.append({
+            "method": request.method,
+            "path": request.path,
+            "token": request.headers.get("x-sandbox-token"),
+            "body": body,
+        })
+
+    async def schedule_wake(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.schedule_wake_response
+        return web.json_response(body, status=status)
+
+    async def scheduled_wake_get(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.scheduled_wake_response
+        return web.json_response(body, status=status)
+
+    async def scheduled_wake_delete(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        if self.cancel_wake_status == 204:
+            return web.Response(status=204)
+        return web.json_response({"cancelled": True}, status=self.cancel_wake_status)
+
+    async def runtime_status(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.runtime_status_response
+        return web.json_response(body, status=status)
+
+    async def keepalive(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        status, body = self.keepalive_response
+        return web.json_response(body, status=status)
+
+
+def _build_app(app: _MockLifecycleApp) -> web.Application:
+    a = web.Application()
+    a.router.add_post("/v2/cloud-agents/schedule-wake", app.schedule_wake)
+    a.router.add_get("/v2/cloud-agents/scheduled-wake", app.scheduled_wake_get)
+    a.router.add_delete(
+        "/v2/cloud-agents/scheduled-wake", app.scheduled_wake_delete,
+    )
+    a.router.add_get("/v2/cloud-agents/runtime-status", app.runtime_status)
+    a.router.add_post("/v2/cloud-agents/keepalive", app.keepalive)
+    return a
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_after_seconds_posts_body_and_token():
+    mock = _MockLifecycleApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.schedule_wake(after_seconds=1800, reason="long task")
+    assert result == {"wake_at": "2026-07-07T12:00:00Z", "reason": "ok"}
+    req = mock.requests[-1]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v2/cloud-agents/schedule-wake"
+    assert req["token"] == "sbx_tok"
+    assert req["body"] == {"after_seconds": 1800, "reason": "long task"}
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_wake_at_posts_body():
+    mock = _MockLifecycleApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        await c.schedule_wake(wake_at="2026-07-07T15:30:00Z")
+    req = mock.requests[-1]
+    assert req["body"] == {"wake_at": "2026-07-07T15:30:00Z"}
+    assert "after_seconds" not in req["body"]
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_non_2xx_raises_bridge_error():
+    mock = _MockLifecycleApp()
+    mock.schedule_wake_response = (409, {"error": "already scheduled"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.schedule_wake(after_seconds=60)
+    assert excinfo.value.code == "SCHEDULE_WAKE"
+
+
+@pytest.mark.asyncio
+async def test_get_scheduled_wake_null_when_none():
+    mock = _MockLifecycleApp()
+    mock.scheduled_wake_response = (200, {"wake_at": None})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.get_scheduled_wake()
+    assert result == {"wake_at": None}
+    req = mock.requests[-1]
+    assert req["method"] == "GET"
+    assert req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_get_scheduled_wake_returns_fields_when_set():
+    mock = _MockLifecycleApp()
+    mock.scheduled_wake_response = (
+        200, {"wake_at": "2026-07-07T12:00:00Z", "reason": "batch"},
+    )
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.get_scheduled_wake()
+    assert result["wake_at"] == "2026-07-07T12:00:00Z"
+    assert result["reason"] == "batch"
+
+
+@pytest.mark.asyncio
+async def test_cancel_wake_issues_delete():
+    mock = _MockLifecycleApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.cancel_wake()
+    # 204 empty body → {}
+    assert result == {}
+    req = mock.requests[-1]
+    assert req["method"] == "DELETE"
+    assert req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_returns_fields_incl_null_seconds():
+    mock = _MockLifecycleApp()
+    mock.runtime_status_response = (
+        200, {
+            "state": "running",
+            "timeout_at": "2026-07-07T13:00:00Z",
+            "seconds_until_sleep": None,
+            "sandbox_id": "sbx_9",
+        },
+    )
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.runtime_status()
+    assert result["state"] == "running"
+    assert result["sandbox_id"] == "sbx_9"
+    # null seconds_until_sleep is preserved verbatim (not fabricated).
+    assert result["seconds_until_sleep"] is None
+    req = mock.requests[-1]
+    assert req["method"] == "GET"
+    assert req["path"] == "/v2/cloud-agents/runtime-status"
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_keepalive_available_returns_deadline():
+    mock = _MockLifecycleApp()
+    mock.keepalive_response = (
+        200, {"timeout_at": "2026-07-07T14:00:00Z", "seconds_until_sleep": 3600},
+    )
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.keepalive(600)
+    assert result["available"] is True
+    assert result["timeout_at"] == "2026-07-07T14:00:00Z"
+    assert result["seconds_until_sleep"] == 3600
+    req = mock.requests[-1]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v2/cloud-agents/keepalive"
+    assert req["body"] == {"seconds": 600}
+    assert req["token"] == "sbx_tok"
+
+
+@pytest.mark.asyncio
+async def test_keepalive_unavailable_flags_available_false():
+    mock = _MockLifecycleApp()
+    # Server signals the AIM deadline-refresh isn't landed yet.
+    mock.keepalive_response = (501, {"error": "keepalive not implemented yet"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.keepalive(600)
+    assert result["available"] is False
+    assert "keepalive not implemented yet" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_unavailable_via_200_available_false():
+    mock = _MockLifecycleApp()
+    # Alternate contract: 200 with an explicit available:false body.
+    mock.keepalive_response = (200, {"available": False, "detail": "not ready"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        result = await c.keepalive(600)
+    assert result["available"] is False
+    assert "not ready" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_other_non_2xx_raises_bridge_error():
+    mock = _MockLifecycleApp()
+    mock.keepalive_response = (500, {"error": "boom"})
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx_tok", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.keepalive(600)
+    assert excinfo.value.code == "KEEPALIVE"

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -79,6 +79,9 @@ class FakeBridge:
             "client_ref": "r_test",
         }
         self.sent: list[dict] = []
+        # F1: every send_ack call records its envelope_ids, so a test can
+        # assert exactly one ack per handled bridge message.
+        self.acked: list[list[str]] = []
         self.connect_count = 0
         self.fetch_pending_count = 0
         self.close_count = 0
@@ -106,6 +109,12 @@ class FakeBridge:
     async def download_blob(self, blob_id: str):
         self.downloaded.append(blob_id)
         return self._blobs.get(blob_id)
+
+    async def send_ack(
+        self, envelope_ids, *, timeout: float = 30.0,
+    ) -> dict:
+        self.acked.append(list(envelope_ids))
+        return {"type": "ack_result", "acked": list(envelope_ids)}
 
     async def send_send(
         self, *, plaintext, recipient_slug=None, space_id=None,
@@ -1293,6 +1302,203 @@ async def test_e_native_attachments_still_encrypt_and_signed_http(
         m == "POST" and p == "/messages" for m, p, _ in http.calls
     ), f"native must POST the envelope; calls={http.calls}"
     assert "uploaded 1 file" in result
+
+
+# --------------------------------------------------------------------------
+# (F1) handled bridge messages are acked exactly once; the shared tail
+#      (native's whole inbound path) never acks.
+# --------------------------------------------------------------------------
+
+
+async def _open_dispatch_client(tmp_path, bridge, *, db):
+    """A bridge client with the minimal per-listen() state so
+    ``_dispatch_bridge_frame`` / ``_handle_plaintext_payload`` can run
+    without spinning up the full listen loop (mirrors the reference-path
+    setup in test (a))."""
+    client = _bridge_client(tmp_path, bridge, db=db)
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    await client.store.open()
+    return client
+
+
+def _bridge_message_frame(env_id: str) -> dict:
+    return {
+        "type": "message", "envelope_id": env_id,
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_004_000, "plaintext": "ack me",
+    }
+
+
+@pytest.mark.asyncio
+async def test_f1_handled_bridge_message_acked_exactly_once(tmp_path):
+    """A handled inbound ``message`` frame schedules exactly one
+    ``send_ack([envelope_id])`` off the dispatcher — the ack is async
+    (never awaited inline, which would deadlock ``frames()``)."""
+    ENV_ID = "env_ack_once"
+    bridge = FakeBridge()
+    client = await _open_dispatch_client(tmp_path, bridge, db="ack_once.db")
+
+    await client._dispatch_bridge_frame(_bridge_message_frame(ENV_ID))
+    # The ack is scheduled, not awaited inline: exactly one task is
+    # in-flight right after dispatch returns.
+    assert len(client._ack_tasks) == 1
+    # Let the scheduled ack task run to completion.
+    await asyncio.gather(*client._ack_tasks)
+
+    assert bridge.acked == [[ENV_ID]]
+    # The done-callback cleaned the task set up afterwards.
+    assert client._ack_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_f1_ack_over_full_listen_loop(tmp_path):
+    """End-to-end over ``_listen_bridge``: a live frame surfaces AND gets
+    acked exactly once (proves the ack fires on the real loop, not just a
+    direct dispatch call)."""
+    ENV_ID = "env_ack_live"
+    bridge = FakeBridge(scripted=[_bridge_message_frame(ENV_ID)])
+    client = _bridge_client(tmp_path, bridge, db="ack_live.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+    # Drain any ack task still in flight after the loop was cancelled.
+    if client._ack_tasks:
+        await asyncio.gather(*client._ack_tasks, return_exceptions=True)
+
+    assert bridge.acked == [[ENV_ID]]
+
+
+@pytest.mark.asyncio
+async def test_f1_failing_message_handling_skips_ack(tmp_path):
+    """A frame whose handling raises is NOT acked — the ack sits inside
+    the handling ``try`` after a clean ``_handle_plaintext_payload``, so a
+    raise skips it and the server redelivers."""
+    ENV_ID = "env_ack_fail"
+    bridge = FakeBridge()
+    client = await _open_dispatch_client(tmp_path, bridge, db="ack_fail.db")
+
+    async def _boom(payload):
+        raise RuntimeError("handling blew up")
+
+    client._handle_plaintext_payload = _boom  # type: ignore[method-assign]
+
+    # _dispatch_bridge_frame swallows the handling exception (logs it).
+    await client._dispatch_bridge_frame(_bridge_message_frame(ENV_ID))
+    await asyncio.sleep(0)
+
+    assert client._ack_tasks == set()
+    assert bridge.acked == []
+
+
+@pytest.mark.asyncio
+async def test_f1_shared_tail_does_not_ack_native_untouched(tmp_path):
+    """The ack lives ONLY in ``_dispatch_bridge_frame``. The shared
+    ``_handle_plaintext_payload`` tail — the entirety of native's inbound
+    path — issues no ack. Proven with a bridge PRESENT: even then,
+    driving the tail directly acks nothing."""
+    bridge = FakeBridge()
+    client = await _open_dispatch_client(tmp_path, bridge, db="tail_noack.db")
+
+    payload = MessagePayload(
+        payload_type="puffo.message", version=1,
+        envelope_id="env_tail", envelope_kind="channel",
+        sender_slug="alice-0001", sender_subkey_id="", sent_at=1,
+        message_nonce="", content_type="text/plain", content="hi",
+        is_visible_to_human=True, space_id="sp_1", channel_id="ch_a",
+    )
+    await client._handle_plaintext_payload(payload)
+    await asyncio.sleep(0)
+
+    assert client._ack_tasks == set()
+    assert bridge.acked == []
+
+
+@pytest.mark.asyncio
+async def test_f1_native_config_client_never_acks(tmp_path):
+    """A genuinely native client (``bridge_client=None``) has no bridge to
+    ack against and never schedules an ack task when its inbound tail
+    runs."""
+    ks = _native_keystore(tmp_path)
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, "bot-0001")
+    store = MessageStore(str(tmp_path / "native_noack.db"))
+    client = PuffoCoreMessageClient(
+        slug="bot-0001", device_id="dev_test", space_id="sp_home",
+        keystore=ks, http_client=http, message_store=store,
+    )  # no bridge → native
+    assert client._bridge is None
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    await client.store.open()
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+
+    payload = MessagePayload(
+        payload_type="puffo.message", version=1,
+        envelope_id="env_native_tail", envelope_kind="channel",
+        sender_slug="alice-0001", sender_subkey_id="", sent_at=1,
+        message_nonce="", content_type="text/plain", content="hi",
+        is_visible_to_human=True, space_id="sp_1", channel_id="ch_a",
+    )
+    await client._handle_plaintext_payload(payload)
+    await asyncio.sleep(0)
+
+    assert client._ack_tasks == set()
+
+
+# --------------------------------------------------------------------------
+# (F6) the inbound bridge blob_id filename fallback is basename-sanitised
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f6_blob_id_fallback_sanitised_stays_in_inbox(tmp_path):
+    """A ref with NO filename and a ``blob_id`` carrying path separators
+    (``../escape``) is written by its basename INSIDE the inbox dir, never
+    a level above it."""
+    DATA = b"escape-attempt-bytes"
+    frame = {
+        "type": "message", "envelope_id": "env_f6",
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_005_000, "plaintext": "see attached",
+        # No filename → fallback to the (malicious) blob_id.
+        "attachments": [{"blob_id": "../escape"}],
+    }
+    bridge = FakeBridge(scripted=[frame], blobs={"../escape": DATA})
+    client = _bridge_client(
+        tmp_path, bridge, db="f6.db", workspace=str(tmp_path),
+    )
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    inbox = (tmp_path / ".puffo" / "inbox" / "env_f6").resolve()
+    saved = inbox / "escape"
+    assert saved.is_file(), "sanitised file must land inside the inbox dir"
+    assert saved.read_bytes() == DATA
+    # The written path resolves inside the inbox — no ../ escape.
+    assert str(saved.resolve()).startswith(str(inbox))
+    # The pre-fix bug would have written one level up (a sibling of the
+    # envelope dir); assert that escaped location does NOT exist.
+    assert not (tmp_path / ".puffo" / "inbox" / "escape").exists()
+    # Surfaced attachment path points at the sanitised in-inbox file.
+    msg = [m for m in surfaced[0] if m["envelope_id"] == "env_f6"][0]
+    assert str(saved) in msg["attachments"]
 
 
 def test_message_payload_to_dict_omits_attachments():

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -13,7 +13,11 @@ suite pins the phase-2 seam swap:
       loop keeps running for live frames);
   (d) native (``bridge_client=None``) still encrypts on send and
       decrypts on receive — the extraction is behaviour-preserving;
-  (e) attachments over the bridge fail loud (phase 3).
+  (e) attachments over the bridge upload PLAINTEXT bytes keyless
+      (``upload_blob``) + ref them by ``blob_id`` in the ``send`` frame
+      on the way out, and download by ``blob_id`` (``download_blob``,
+      no decrypt) into the inbox on the way in — with native attachment
+      send still encrypting + using signed HTTP.
 
 Every fake is offline: no real WS, HTTP, E2B, or LLM.
 """
@@ -54,11 +58,20 @@ class FakeBridge:
     ``frames()`` replays a scripted list then suspends (mimicking a live
     WS awaiting its next frame) so ``_listen_bridge`` stays connected
     instead of reconnect-storming — the test cancels the task when done.
-    ``send_send`` records its kwargs and returns a canned ack;
-    ``send_fetch_pending`` / ``connect`` / ``close`` count calls.
+    ``send_send`` records its kwargs (including ``attachments``) and
+    returns a canned ack; ``send_fetch_pending`` / ``connect`` / ``close``
+    count calls. ``upload_blob`` mints a fresh ``blob_id`` per call and
+    records the raw bytes; ``download_blob`` serves from a ``blob_id`` →
+    bytes map (``None`` for an unknown id, mimicking a missing/oversized
+    blob) and records every id requested.
     """
 
-    def __init__(self, scripted: list[dict] | None = None, ack: dict | None = None):
+    def __init__(
+        self,
+        scripted: list[dict] | None = None,
+        ack: dict | None = None,
+        blobs: dict[str, bytes] | None = None,
+    ):
         self._scripted = list(scripted or [])
         self._ack = ack or {
             "type": "ack",
@@ -69,6 +82,11 @@ class FakeBridge:
         self.connect_count = 0
         self.fetch_pending_count = 0
         self.close_count = 0
+        # Keyless blob surface.
+        self.uploaded: list[bytes] = []
+        self.downloaded: list[str] = []
+        self._blobs: dict[str, bytes] = dict(blobs or {})
+        self._upload_seq = 0
         # Never set → frames() suspends after the script drains.
         self._blocked = asyncio.Event()
 
@@ -78,10 +96,21 @@ class FakeBridge:
     async def send_fetch_pending(self, *, limit=None) -> None:
         self.fetch_pending_count += 1
 
+    async def upload_blob(self, data: bytes) -> dict:
+        self._upload_seq += 1
+        blob_id = f"blob_{self._upload_seq:04d}"
+        self.uploaded.append(data)
+        self._blobs[blob_id] = data
+        return {"blob_id": blob_id, "size_bytes": len(data), "uploaded_at": 0}
+
+    async def download_blob(self, blob_id: str):
+        self.downloaded.append(blob_id)
+        return self._blobs.get(blob_id)
+
     async def send_send(
         self, *, plaintext, recipient_slug=None, space_id=None,
         channel_id=None, reply_to_id=None, thread_root_id=None,
-        timeout: float = 30.0,
+        attachments=None, timeout: float = 30.0,
     ) -> dict:
         self.sent.append({
             "plaintext": plaintext,
@@ -90,6 +119,7 @@ class FakeBridge:
             "channel_id": channel_id,
             "reply_to_id": reply_to_id,
             "thread_root_id": thread_root_id,
+            "attachments": attachments,
         })
         return dict(self._ack)
 
@@ -145,6 +175,12 @@ class FakeHttp:
         self.calls.append(("POST", path, body))
         return self.responses.get(path, {"ok": True})
 
+    async def post_bytes(self, path, body=None):
+        # Native attachment path uploads ciphertext here; return a
+        # canned blob_id unless a test registers its own response.
+        self.calls.append(("POST_BYTES", path, body))
+        return self.responses.get(path, {"blob_id": "blob_native_1"})
+
 
 # --------------------------------------------------------------------------
 # Builders
@@ -152,10 +188,12 @@ class FakeHttp:
 
 
 def _bridge_client(
-    tmp_path, bridge, *, slug="bot-0001", db="messages.db",
+    tmp_path, bridge, *, slug="bot-0001", db="messages.db", workspace=None,
 ) -> PuffoCoreMessageClient:
     """A bridge-transport message client with a stubbed (offline) http
-    so inbound enrichment helpers degrade to ids-for-names."""
+    so inbound enrichment helpers degrade to ids-for-names. Pass
+    ``workspace`` when the test exercises inbound attachment saving
+    (the saver no-ops on an empty workspace)."""
     ks = KeyStore(str(tmp_path / f"keys-{db}"))
     http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, slug)
     store = MessageStore(str(tmp_path / db))
@@ -166,6 +204,7 @@ def _bridge_client(
         keystore=ks,
         http_client=http,
         message_store=store,
+        workspace=workspace or "",
         bridge_client=bridge,
     )
 
@@ -919,29 +958,352 @@ async def test_d_native_inbound_still_decrypts_before_storing(tmp_path, monkeypa
 
 
 # --------------------------------------------------------------------------
-# (e) attachment guard
+# (e) attachments over the bridge: keyless blob upload/download, native
+#     unchanged
 # --------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_e_attachments_refused_on_bridge_no_encrypt(tmp_path, monkeypatch):
+async def test_e_attachments_uploaded_keyless_and_reffed_on_bridge(
+    tmp_path, monkeypatch,
+):
+    """OUT: a bridge DM attachment send uploads each file's PLAINTEXT
+    bytes via ``upload_blob`` and rides the returned ``blob_id``(s) into
+    the ``send`` frame's top-level ``attachments`` (with filename /
+    mime_type / size_bytes) — no ``encrypt_*`` and no signed HTTP."""
     enc_calls: list[int] = []
     monkeypatch.setattr(
         pct_mod, "encrypt_message_with_content_key",
         lambda *a, **k: enc_calls.append(1),
     )
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message", lambda *a, **k: enc_calls.append(1),
+    )
+    monkeypatch.setattr(
+        pct_mod, "encrypt_attachment", lambda *a, **k: enc_calls.append(1),
+    )
 
-    ms = MessageStore(str(tmp_path / "e.db"))
+    ms = MessageStore(str(tmp_path / "e_out.db"))
+    bridge = FakeBridge()
+    http = FakeHttp()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms, http=http)
+    tools = build_dispatch(cfg)
+
+    body = b"hello attachment bytes"
+    (tmp_path / "note.txt").write_bytes(body)
+    result = await tools["send_message_with_attachments"](
+        paths=["note.txt"], channel="@alice-0001", caption="see file",
+    )
+
+    # Uploaded exactly once, with the raw plaintext bytes.
+    assert bridge.uploaded == [body]
+    # One send frame carrying the ref by blob_id.
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["plaintext"] == "see file"
+    assert sent["recipient_slug"] == "alice-0001"
+    assert sent["space_id"] is None and sent["channel_id"] is None
+    refs = sent["attachments"]
+    assert isinstance(refs, list) and len(refs) == 1
+    ref = refs[0]
+    assert ref["blob_id"] == "blob_0001"
+    assert ref["filename"] == "note.txt"
+    assert ref["mime_type"] == "text/plain"
+    assert ref["size_bytes"] == len(body)
+    # No signed-crypto: no encrypt, no /blobs/upload or /messages POST.
+    assert enc_calls == []
+    assert not any(
+        p in ("/blobs/upload", "/messages") for _, p, _ in http.calls
+    ), http.calls
+    assert "msg_bridgeack" in result
+
+
+@pytest.mark.asyncio
+async def test_e_attachments_channel_route_on_bridge(tmp_path):
+    """OUT (channel route): a channel attachment send resolves the
+    space from the local cache and threads the ``send`` frame with the
+    space/channel ids, carrying the blob ref."""
+    ms = MessageStore(str(tmp_path / "e_out_ch.db"))
+    await ms.mark_channel_space("ch_xyz", "sp_1")
     bridge = FakeBridge()
     cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
     tools = build_dispatch(cfg)
 
-    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
-    with pytest.raises(RuntimeError) as excinfo:
-        await tools["send_message_with_attachments"](
-            paths=["note.txt"], channel="@alice-0001", caption="see file",
-        )
-    msg = str(excinfo.value).lower()
-    assert "bridge" in msg and "not supported" in msg
-    assert enc_calls == []
-    assert bridge.sent == []
+    (tmp_path / "doc.txt").write_bytes(b"team doc")
+    await tools["send_message_with_attachments"](
+        paths=["doc.txt"], channel="ch_xyz", caption="team file",
+    )
+    assert len(bridge.uploaded) == 1
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["space_id"] == "sp_1"
+    assert sent["channel_id"] == "ch_xyz"
+    assert sent["recipient_slug"] is None
+    assert sent["attachments"][0]["blob_id"] == "blob_0001"
+
+
+@pytest.mark.asyncio
+async def test_send_send_puts_attachments_top_level():
+    """Frame-shape unit on the real ``CloudBridgeClient.send_send``:
+    ``attachments`` lands at the frame top level when non-empty and is
+    omitted entirely when ``None`` (a plain send stays shape-identical to
+    the pre-attachment frame)."""
+    from puffo_agent.agent.bridge_client import CloudBridgeClient
+
+    client = CloudBridgeClient("http://127.0.0.1:1", "tok", "bot-0001")
+
+    class _CapturingWs:
+        def __init__(self, owner):
+            self.owner = owner
+            self.sent_frames: list[dict] = []
+
+        async def send_json(self, frame):
+            self.sent_frames.append(frame)
+            # send_send set the ack future before calling send_json;
+            # resolve it so the awaited call returns immediately.
+            cref = frame.get("client_ref")
+            fut = self.owner._send_acks.get(cref)
+            if fut is not None and not fut.done():
+                fut.set_result({"type": "ack", "envelope_id": "msg_cap"})
+
+    ws = _CapturingWs(client)
+
+    async def _require_ws():
+        return ws
+
+    client._require_ws = _require_ws  # type: ignore[method-assign]
+
+    refs = [{"blob_id": "b1", "filename": "a.txt", "mime_type": "text/plain"}]
+    await client.send_send(
+        plaintext="cap", recipient_slug="alice-0001", attachments=refs,
+    )
+    frame_with = ws.sent_frames[-1]
+    assert frame_with["attachments"] == refs
+    assert frame_with["plaintext"] == "cap"
+    assert frame_with["recipient_slug"] == "alice-0001"
+
+    # No attachments → key absent entirely.
+    await client.send_send(plaintext="hi", recipient_slug="alice-0001")
+    frame_without = ws.sent_frames[-1]
+    assert "attachments" not in frame_without
+
+
+@pytest.mark.asyncio
+async def test_inbound_attachments_surface_and_download_by_blob_id(tmp_path):
+    """IN: an inbound ``message`` frame with top-level ``attachments``
+    drives ``download_blob(blob_id)`` and writes the bytes into
+    ``.puffo/inbox/<envelope_id>/<filename>``; the surfaced message
+    event's ``attachments`` lists that path."""
+    BLOB = "blob_in1"
+    DATA = b"inbound report bytes"
+    frame = {
+        "type": "message", "envelope_id": "env_att_in",
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_001_000, "plaintext": "see attached",
+        "attachments": [{
+            "blob_id": BLOB, "filename": "report.txt",
+            "mime_type": "text/plain", "size_bytes": len(DATA),
+        }],
+    }
+    bridge = FakeBridge(scripted=[frame], blobs={BLOB: DATA})
+    client = _bridge_client(
+        tmp_path, bridge, db="att_in.db", workspace=str(tmp_path),
+    )
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # Fetched by blob_id, no decrypt.
+    assert bridge.downloaded == [BLOB]
+    saved = tmp_path / ".puffo" / "inbox" / "env_att_in" / "report.txt"
+    assert saved.is_file()
+    assert saved.read_bytes() == DATA
+    msg = [m for m in surfaced[0] if m["envelope_id"] == "env_att_in"][0]
+    assert str(saved) in msg["attachments"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_backfill_carries_attachments(tmp_path):
+    """IN (backfill): a message frame drained via the cold-start
+    ``fetch_pending`` path (same ``frames()``/handle_inbound tail)
+    surfaces + downloads attachments identically to a live frame."""
+    BLOB = "blob_bf1"
+    DATA = b"backfilled file"
+    scripted = [
+        {
+            "type": "message", "envelope_id": "env_att_bf",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_001_500, "plaintext": "backfilled attach",
+            "attachments": [{
+                "blob_id": BLOB, "filename": "bf.txt",
+                "mime_type": "text/plain", "size_bytes": len(DATA),
+            }],
+        },
+        {"type": "pending_delivered", "count": 1},
+    ]
+    bridge = FakeBridge(scripted=scripted, blobs={BLOB: DATA})
+    client = _bridge_client(
+        tmp_path, bridge, db="att_bf.db", workspace=str(tmp_path),
+    )
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # The backfill drive fired exactly one fetch_pending.
+    assert bridge.fetch_pending_count == 1
+    assert bridge.downloaded == [BLOB]
+    saved = tmp_path / ".puffo" / "inbox" / "env_att_bf" / "bf.txt"
+    assert saved.is_file() and saved.read_bytes() == DATA
+    msg = [m for m in surfaced[0] if m["envelope_id"] == "env_att_bf"][0]
+    assert str(saved) in msg["attachments"]
+
+
+@pytest.mark.asyncio
+async def test_inbound_missing_blob_skipped_loop_survives(tmp_path):
+    """Fail-soft: a ref whose blob ``download_blob`` returns ``None`` for
+    (missing / oversized) is skipped — no exception, the message still
+    delivers with empty ``attachments``, and the listen loop keeps
+    running so a following frame is still processed."""
+    scripted = [
+        {
+            "type": "message", "envelope_id": "env_missing_blob",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_002_000, "plaintext": "attached but gone",
+            "attachments": [{"blob_id": "blob_missing", "filename": "x.bin"}],
+        },
+        {
+            "type": "message", "envelope_id": "env_after_missing",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_002_100, "plaintext": "still flowing",
+        },
+    ]
+    # Empty blob map → download_blob returns None for blob_missing.
+    bridge = FakeBridge(scripted=scripted, blobs={})
+    client = _bridge_client(
+        tmp_path, bridge, db="missing_blob.db", workspace=str(tmp_path),
+    )
+    surfaced: dict[str, dict] = {}
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        for m in batch:
+            surfaced[m["envelope_id"]] = m
+        if "env_after_missing" in surfaced:
+            done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # Download was attempted then skipped.
+    assert bridge.downloaded == ["blob_missing"]
+    # Both messages delivered — the loop survived the missing blob.
+    assert await client.store.get_message_by_envelope("env_missing_blob") is not None
+    assert await client.store.get_message_by_envelope("env_after_missing") is not None
+    assert "env_missing_blob" in surfaced and "env_after_missing" in surfaced
+    # The message with the missing blob carries no attachment path.
+    assert surfaced["env_missing_blob"]["attachments"] == []
+    # No blob dir/file was written for the skipped ref.
+    assert not (tmp_path / ".puffo" / "inbox" / "env_missing_blob" / "x.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_e_native_attachments_still_encrypt_and_signed_http(
+    tmp_path, monkeypatch,
+):
+    """Native (``bridge_client=None``) attachment send still encrypts the
+    file (``encrypt_attachment``) + the envelope
+    (``encrypt_message_with_content_key``) and uploads the ciphertext via
+    signed ``http_client.post_bytes('/blobs/upload', ...)``, then POSTs
+    ``/messages`` — the bridge blob surface is never touched."""
+    enc_att_calls: list[int] = []
+    enc_msg_calls: list[int] = []
+
+    class _FakeMeta:
+        def __init__(self):
+            self.blob_id = ""
+
+        def to_dict(self):
+            return {"blob_id": self.blob_id, "filename": "note.txt"}
+
+    def _enc_att_spy(*, plaintext, filename, mime_type, blob_id):
+        enc_att_calls.append(1)
+        return (b"CIPHERTEXT", _FakeMeta())
+
+    def _enc_msg_spy(inp, signing_key, *, now_ms=None):
+        enc_msg_calls.append(1)
+        return ({"envelope_id": "msg_native_att", "type": "message_envelope"}, b"ck")
+
+    monkeypatch.setattr(pct_mod, "encrypt_attachment", _enc_att_spy)
+    monkeypatch.setattr(pct_mod, "encrypt_message_with_content_key", _enc_msg_spy)
+
+    ks = _native_keystore(tmp_path)
+    http = FakeHttp()
+    http.responses["/blobs/upload"] = {"blob_id": "blob_native_att"}
+    http.responses["/certs/sync?slugs=bot-0001,alice-0001"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_a",
+                "kem_public_key": base64url_encode(
+                    KemKeyPair.generate().public_key_bytes()
+                ),
+            },
+        }],
+        "has_more": False,
+    }
+    ms = MessageStore(str(tmp_path / "e_native.db"))
+    cfg = PuffoCoreToolsConfig(
+        slug="bot-0001",
+        device_id="dev_test",
+        keystore=ks,
+        http_client=http,
+        data_client=ms,
+        space_id="sp_home",
+        workspace=str(tmp_path),
+        bridge_client=None,  # native
+    )
+    tools = build_dispatch(cfg)
+
+    (tmp_path / "note.txt").write_bytes(b"native file bytes")
+    result = await tools["send_message_with_attachments"](
+        paths=["note.txt"], channel="@alice-0001", caption="native attach",
+    )
+
+    assert enc_att_calls, "native attachment send must encrypt the file"
+    assert enc_msg_calls, "native attachment send must encrypt the envelope"
+    assert any(
+        m == "POST_BYTES" and p == "/blobs/upload" for m, p, _ in http.calls
+    ), f"native must upload ciphertext via signed post_bytes; calls={http.calls}"
+    assert any(
+        m == "POST" and p == "/messages" for m, p, _ in http.calls
+    ), f"native must POST the envelope; calls={http.calls}"
+    assert "uploaded 1 file" in result
+
+
+def test_message_payload_to_dict_omits_attachments():
+    """Guard: the additive ``attachments`` field is NOT serialized by
+    ``to_payload_dict()`` — native seal canonical bytes stay unchanged."""
+    p = MessagePayload(
+        payload_type="message_payload", version=1, envelope_id="msg_x",
+        envelope_kind="dm", sender_slug="bot-0001", sender_subkey_id="sk",
+        sent_at=1, message_nonce="n", content_type="text/plain",
+        content="hi", is_visible_to_human=True,
+        attachments=[{"blob_id": "b1"}],
+    )
+    d = p.to_payload_dict()
+    assert "attachments" not in d

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -80,13 +80,16 @@ class FakeBridge:
 
     async def send_send(
         self, *, plaintext, recipient_slug=None, space_id=None,
-        channel_id=None, timeout: float = 30.0,
+        channel_id=None, reply_to_id=None, thread_root_id=None,
+        timeout: float = 30.0,
     ) -> dict:
         self.sent.append({
             "plaintext": plaintext,
             "recipient_slug": recipient_slug,
             "space_id": space_id,
             "channel_id": channel_id,
+            "reply_to_id": reply_to_id,
+            "thread_root_id": thread_root_id,
         })
         return dict(self._ack)
 
@@ -425,19 +428,278 @@ async def test_b_send_message_channel_uses_bridge_no_encrypt(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_b_send_message_threaded_note_on_bridge(tmp_path):
-    """root_id isn't wired on bridge yet — send top-level with a note."""
+async def test_b_send_message_channel_threads_on_bridge(tmp_path):
+    """root_id now threads on bridge (replaces the old top-level-note
+    test). ``send_send`` carries ``thread_root_id`` = the resolved TRUE
+    root of ``root_id`` and ``reply_to_id`` = the raw id the agent
+    passed. Seed a root + a reply so resolution makes a real hop
+    (resolved root != passed id), proving the resolver ran."""
     ms = MessageStore(str(tmp_path / "b_thread.db"))
+    await ms.mark_channel_space("ch_xyz", "sp_1")
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_xyz",
+        "space_id": "sp_1", "content": "root",
+        "sent_at": 1_700_000_000_000,
+        "thread_root_id": None, "reply_to_id": None,
+    })
+    await ms.store({
+        "envelope_id": "msg_reply", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_xyz",
+        "space_id": "sp_1", "content": "a reply",
+        "sent_at": 1_700_000_000_001,
+        "thread_root_id": "msg_root", "reply_to_id": "msg_root",
+    })
     bridge = FakeBridge()
     cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
     tools = build_dispatch(cfg)
 
     result = await tools["send_message"](
-        channel="@alice-0001", text="reply", root_id="msg_parent",
+        channel="ch_xyz", text="reply", root_id="msg_reply",
     )
     assert len(bridge.sent) == 1
-    assert "top-level" in result.lower() or "phase 3" in result.lower() \
-        or "not wired" in result.lower()
+    sent = bridge.sent[0]
+    # Resolved to the true root, not the intermediate reply id.
+    assert sent["thread_root_id"] == "msg_root"
+    # Raw parent id the agent passed rides reply_to_id.
+    assert sent["reply_to_id"] == "msg_reply"
+    assert sent["space_id"] == "sp_1"
+    assert sent["channel_id"] == "ch_xyz"
+    # No stale "top-level" / "not wired" note — threading is live now.
+    assert "top-level" not in result.lower()
+    assert "not wired" not in result.lower()
+    assert "msg_bridgeack" in result
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_dm_threads_on_bridge(tmp_path):
+    """DM route of ``send_message`` also threads. With the DM root seeded
+    locally, resolution + same-channel validation keep it, so both
+    ``thread_root_id`` and ``reply_to_id`` carry it — proving the DM
+    branch is wired, not silently dropping the ids."""
+    ms = MessageStore(str(tmp_path / "b_dm_thread.db"))
+    # Seed a real DM root so thread_root_id survives validation.
+    await ms.store({
+        "envelope_id": "dm_root", "envelope_kind": "dm",
+        "sender_slug": "alice-0001", "channel_id": None,
+        "space_id": None, "recipient_slug": "bot-0001",
+        "content": "root dm", "sent_at": 1_700_000_000_002,
+        "thread_root_id": None, "reply_to_id": None,
+    })
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](
+        channel="@alice-0001", text="reply", root_id="dm_root",
+    )
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["recipient_slug"] == "alice-0001"
+    assert sent["thread_root_id"] == "dm_root"
+    assert sent["reply_to_id"] == "dm_root"
+    assert "msg_bridgeack" in result
+
+
+@pytest.mark.asyncio
+async def test_send_fallback_message_threads_on_bridge(tmp_path):
+    """``send_fallback_message`` passes ``root_id`` through as BOTH
+    ``thread_root_id`` and ``reply_to_id`` on the bridge, for the channel
+    route and the DM route (native's fallback path threads unresolved
+    too)."""
+    bridge = FakeBridge()
+    client = _bridge_client(tmp_path, bridge, db="fallback_thread.db")
+    await client.store.mark_channel_space("ch_a", "sp_1")
+
+    # channel route
+    await client.send_fallback_message("ch_a", "chan reply", root_id="msg_root")
+    # DM route: stash a DM sender so empty channel_id routes to them.
+    client._last_dm_sender = "carol-0001"
+    await client.send_fallback_message("", "dm reply", root_id="msg_root2")
+
+    assert len(bridge.sent) == 2
+    chan = bridge.sent[0]
+    assert chan["channel_id"] == "ch_a" and chan["space_id"] == "sp_1"
+    assert chan["thread_root_id"] == "msg_root"
+    assert chan["reply_to_id"] == "msg_root"
+    dm = bridge.sent[1]
+    assert dm["recipient_slug"] == "carol-0001"
+    assert dm["thread_root_id"] == "msg_root2"
+    assert dm["reply_to_id"] == "msg_root2"
+
+
+@pytest.mark.asyncio
+async def test_inbound_thread_ids_surface_on_stored_row(tmp_path):
+    """IN: an inbound ``message`` frame carrying
+    ``thread_root_id``/``reply_to_id`` yields a stored row with those ids
+    populated. The parent root arrives on the same connection (same
+    channel) so the strict admit-time ``_validate_incoming_parent_id``
+    check keeps them instead of wiping to None."""
+    scripted = [
+        {
+            "type": "message", "envelope_id": "env_root_in",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_100, "plaintext": "root",
+        },
+        {
+            "type": "message", "envelope_id": "env_reply_in",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_200, "plaintext": "threaded inbound",
+            "thread_root_id": "env_root_in", "reply_to_id": "env_root_in",
+        },
+    ]
+    bridge = FakeBridge(scripted=scripted)
+    client = _bridge_client(tmp_path, bridge, db="in_thread.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        if any(m.get("envelope_id") == "env_reply_in" for m in batch):
+            done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    row = await client.store.get_message_by_envelope("env_reply_in")
+    assert row is not None
+    assert row.thread_root_id == "env_root_in"
+    assert row.reply_to_id == "env_root_in"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_prefers_frame_display_name_no_http(tmp_path):
+    """c-1: when the inbound frame carries a sender display name, the
+    rendered ``sender_display_name`` uses it and NO
+    ``/identities/profiles`` GET is made (the pre-seed makes
+    ``_fetch_display_name`` a cache hit)."""
+    calls: list[str] = []
+
+    async def _recording_get(path, *a, **k):
+        calls.append(path)
+        return {}
+
+    bridge = FakeBridge(scripted=[{
+        "type": "message", "envelope_id": "env_named",
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_000_300, "plaintext": "hi",
+        "sender_display_name": "Alice Cooper",
+    }])
+    client = _bridge_client(tmp_path, bridge, db="enrich_named.db")
+    client.http.get = _recording_get  # type: ignore[method-assign]
+
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    named = [m for m in surfaced[0] if m["envelope_id"] == "env_named"][0]
+    assert named["sender_display_name"] == "Alice Cooper"
+    # No /identities/profiles GET at all — resolution came off the frame.
+    assert not any("identities/profiles" in p for p in calls), calls
+    # The pre-seed actually populated the profile cache.
+    assert client._profile_cache.get("alice-0001", (None,))[0] == "Alice Cooper"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_degrades_without_frame_name(tmp_path):
+    """c-2: without a frame-carried name the helpers degrade to an empty
+    display name (render falls back to @slug) and never raise."""
+    bridge = FakeBridge(scripted=[{
+        "type": "message", "envelope_id": "env_unnamed",
+        "sender_slug": "bob-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_000_400, "plaintext": "hi",
+        # no sender_display_name on the frame
+    }])
+    client = _bridge_client(tmp_path, bridge, db="enrich_unnamed.db")
+
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    named = [m for m in surfaced[0] if m["envelope_id"] == "env_unnamed"][0]
+    assert named["sender_display_name"] == ""  # degraded
+    assert named["sender_slug"] == "bob-0001"
+
+
+def test_preseed_frame_display_name_unit(tmp_path):
+    """Focused: the pre-seed helper seeds a non-empty frame name for a
+    known slug, and leaves the cache untouched when the name is
+    absent/blank or the slug is missing (never pins a false miss)."""
+    client = _bridge_client(tmp_path, FakeBridge(), db="preseed.db")
+
+    from puffo_agent.crypto.message import MessagePayload as _MP
+
+    def _payload(slug):
+        return _MP(
+            payload_type="message", version=1, envelope_id="e",
+            envelope_kind="channel", sender_slug=slug, sender_subkey_id="",
+            sent_at=1, message_nonce="", content_type="text/plain",
+            content="x", is_visible_to_human=True, space_id="sp_1",
+            channel_id="ch_a", recipient_slug=None,
+        )
+
+    # present → seeds
+    client._preseed_frame_display_name(
+        {"sender_display_name": "Alice Cooper", "avatar_url": "http://a/x.png"},
+        _payload("alice-0001"),
+    )
+    assert client._profile_cache["alice-0001"][0] == "Alice Cooper"
+    assert client._profile_cache["alice-0001"][1] == "http://a/x.png"
+
+    # blank name → cache untouched
+    client._preseed_frame_display_name(
+        {"sender_display_name": "   "}, _payload("bob-0001"),
+    )
+    assert "bob-0001" not in client._profile_cache
+
+    # absent name → cache untouched
+    client._preseed_frame_display_name({}, _payload("dave-0001"))
+    assert "dave-0001" not in client._profile_cache
+
+    # missing slug → no crash, nothing seeded
+    client._preseed_frame_display_name(
+        {"sender_display_name": "Nobody"}, _payload(""),
+    )
+    assert "" not in client._profile_cache
+
+    # fallback key `display_name` also works
+    client._preseed_frame_display_name(
+        {"display_name": "Eve X"}, _payload("eve-0001"),
+    )
+    assert client._profile_cache["eve-0001"][0] == "Eve X"
+
+
+def test_phase25_gap_doc_names_all_routes():
+    """c-2 (doc): the phase-2.5 server-gaps doc exists and names the
+    inbound Message frame (thread ids + display name) plus the three
+    token-read REST routes the keyless enrichment path needs."""
+    from pathlib import Path
+
+    doc = (
+        Path(__file__).resolve().parents[1]
+        / "roadmap" / "cloud-agent" / "PHASE25-SERVER-ROUTE-GAPS.md"
+    )
+    assert doc.is_file(), f"missing gap doc: {doc}"
+    text = doc.read_text(encoding="utf-8")
+    # Inbound Message frame + the fields the agent already reads/pre-seeds.
+    assert "Message" in text
+    assert "thread_root_id" in text and "reply_to_id" in text
+    assert "sender_display_name" in text
+    # The three token-auth REST read routes.
+    assert "identities/profiles" in text
+    assert "/spaces/{space_id}/channels" in text
+    assert "/spaces/{space_id}/members" in text
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -1,0 +1,685 @@
+"""T23 phase 2: keyless bridge message flow.
+
+Under ``puffo_core.transport: "bridge"`` the message path runs over the
+plaintext ``CloudBridgeClient`` — the server holds all crypto. This
+suite pins the phase-2 seam swap:
+
+  (a) inbound plaintext ``message`` frames persist + surface exactly
+      like a native decrypted envelope, but WITHOUT ``decrypt_message``;
+  (b) outbound ``send_message`` sends plaintext via ``bridge.send_send``
+      WITHOUT ``encrypt_message*``;
+  (c) a fresh connect drives ``send_fetch_pending`` exactly once and
+      ``pending_delivered`` is recognised as backfill completion (the
+      loop keeps running for live frames);
+  (d) native (``bridge_client=None``) still encrypts on send and
+      decrypts on receive — the extraction is behaviour-preserving;
+  (e) attachments over the bridge fail loud (phase 3).
+
+Every fake is offline: no real WS, HTTP, E2B, or LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+import puffo_agent.agent.puffo_core_client as pcc_mod
+import puffo_agent.mcp.puffo_core_tools as pct_mod
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import (
+    KeyStore,
+    Session,
+    StoredIdentity,
+    encode_secret,
+)
+from puffo_agent.crypto.message import MessagePayload
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+from puffo_agent.mcp.puffo_core_tools import PuffoCoreToolsConfig
+from puffo_agent.portal.ws_local.tool_dispatch import build_dispatch
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class FakeBridge:
+    """Offline ``CloudBridgeClient`` stand-in for the phase-2 flow.
+
+    ``frames()`` replays a scripted list then suspends (mimicking a live
+    WS awaiting its next frame) so ``_listen_bridge`` stays connected
+    instead of reconnect-storming — the test cancels the task when done.
+    ``send_send`` records its kwargs and returns a canned ack;
+    ``send_fetch_pending`` / ``connect`` / ``close`` count calls.
+    """
+
+    def __init__(self, scripted: list[dict] | None = None, ack: dict | None = None):
+        self._scripted = list(scripted or [])
+        self._ack = ack or {
+            "type": "ack",
+            "envelope_id": "msg_bridgeack",
+            "client_ref": "r_test",
+        }
+        self.sent: list[dict] = []
+        self.connect_count = 0
+        self.fetch_pending_count = 0
+        self.close_count = 0
+        # Never set → frames() suspends after the script drains.
+        self._blocked = asyncio.Event()
+
+    async def connect(self) -> None:
+        self.connect_count += 1
+
+    async def send_fetch_pending(self, *, limit=None) -> None:
+        self.fetch_pending_count += 1
+
+    async def send_send(
+        self, *, plaintext, recipient_slug=None, space_id=None,
+        channel_id=None, timeout: float = 30.0,
+    ) -> dict:
+        self.sent.append({
+            "plaintext": plaintext,
+            "recipient_slug": recipient_slug,
+            "space_id": space_id,
+            "channel_id": channel_id,
+        })
+        return dict(self._ack)
+
+    async def frames(self):
+        for frame in self._scripted:
+            yield frame
+        await self._blocked.wait()  # suspend like a live WS
+        yield {}  # pragma: no cover — keeps this an async generator
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+class FakeHttp:
+    """Async HTTP stub. ``get`` matches on exact path, path-without-
+    query, then query-modulo-``since`` (the ``/certs/sync`` cursor), so a
+    test registers one canonical key. Everything else returns ``{}`` so
+    the inbound enrichment helpers degrade offline rather than crash.
+    """
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, object]] = []
+        self.responses: dict[str, dict] = {}
+
+    def _match(self, path: str) -> dict:
+        if path in self.responses:
+            return self.responses[path]
+        base = path.split("?", 1)[0]
+        if base in self.responses:
+            return self.responses[base]
+        if "?" in path:
+            from urllib.parse import parse_qsl
+            actual = sorted(
+                (k, v)
+                for k, v in parse_qsl(path.split("?", 1)[1], keep_blank_values=True)
+                if k != "since"
+            )
+            for key in self.responses:
+                if "?" not in key:
+                    continue
+                key_base, key_qs = key.split("?", 1)
+                if key_base != base:
+                    continue
+                if sorted(parse_qsl(key_qs, keep_blank_values=True)) == actual:
+                    return self.responses[key]
+        return {}
+
+    async def get(self, path):
+        self.calls.append(("GET", path, None))
+        return self._match(path)
+
+    async def post(self, path, body=None):
+        self.calls.append(("POST", path, body))
+        return self.responses.get(path, {"ok": True})
+
+
+# --------------------------------------------------------------------------
+# Builders
+# --------------------------------------------------------------------------
+
+
+def _bridge_client(
+    tmp_path, bridge, *, slug="bot-0001", db="messages.db",
+) -> PuffoCoreMessageClient:
+    """A bridge-transport message client with a stubbed (offline) http
+    so inbound enrichment helpers degrade to ids-for-names."""
+    ks = KeyStore(str(tmp_path / f"keys-{db}"))
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, slug)
+    store = MessageStore(str(tmp_path / db))
+    client = PuffoCoreMessageClient(
+        slug=slug,
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=store,
+        bridge_client=bridge,
+    )
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+    return client
+
+
+def _native_keystore(tmp_path, slug="bot-0001") -> KeyStore:
+    ks = KeyStore(str(tmp_path / "native-keys"))
+    ks.save_identity(StoredIdentity(
+        slug=slug,
+        device_id="dev_test",
+        root_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        device_signing_secret_key=encode_secret(
+            Ed25519KeyPair.generate().secret_bytes()
+        ),
+        kem_secret_key=encode_secret(KemKeyPair.generate().secret_bytes()),
+        server_url="http://127.0.0.1:1",
+    ))
+    ks.save_session(Session(
+        slug=slug,
+        subkey_id="sk_test",
+        subkey_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        expires_at=32_503_680_000_000,
+    ))
+    return ks
+
+
+def _tools_cfg(tmp_path, *, bridge, data_client, http=None, slug="bot-0001"):
+    ks = KeyStore(str(tmp_path / "cfg-keys"))
+    return PuffoCoreToolsConfig(
+        slug=slug,
+        device_id="dev_test",
+        keystore=ks,
+        http_client=http or FakeHttp(),
+        data_client=data_client,
+        space_id="sp_home",
+        workspace=str(tmp_path),
+        bridge_client=bridge,
+    )
+
+
+async def _drive_listen_until(client, *, on_message, done: asyncio.Event, timeout=5.0):
+    """Run ``_listen_bridge`` as a task until ``done`` fires, then cancel
+    it cleanly. Returns nothing — assertions read the store / bridge."""
+    task = asyncio.ensure_future(client._listen_bridge(on_message))
+    try:
+        await asyncio.wait_for(done.wait(), timeout=timeout)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _no_jitter(monkeypatch):
+    # The consumer sleeps random.uniform(0, 1.5) before dispatch; zero it
+    # so batch-callback tests don't wait seconds.
+    monkeypatch.setattr(pcc_mod.random, "uniform", lambda a, b: 0.0)
+
+
+# --------------------------------------------------------------------------
+# (a) inbound plaintext stores like native, no decrypt
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_inbound_stores_like_native_without_decrypt(tmp_path, monkeypatch):
+    ENV_ID = "env_bridge_1"
+    SENDER = "alice-0001"
+    CHANNEL = "ch_xyz"
+    SPACE = "sp_1"
+    CONTENT = "hello from the bridge"
+    SENT_AT = 1_700_000_000_000
+
+    decrypt_calls: list[int] = []
+
+    def _decrypt_spy(*a, **k):  # pragma: no cover — must never run here
+        decrypt_calls.append(1)
+        raise AssertionError("decrypt_message must not run on the bridge path")
+
+    monkeypatch.setattr(pcc_mod, "decrypt_message", _decrypt_spy)
+
+    frame = {
+        "type": "message",
+        "envelope_id": ENV_ID,
+        "sender_slug": SENDER,
+        "envelope_kind": "channel",
+        "space_id": SPACE,
+        "channel_id": CHANNEL,
+        "sent_at": SENT_AT,
+        "plaintext": CONTENT,
+    }
+    # The decrypted-equivalent of the same logical message — what the
+    # native decrypt_message would yield. Feeding this straight through
+    # the shared tail gives the reference store row to compare against.
+    ref_payload = MessagePayload(
+        payload_type="puffo.message",
+        version=1,
+        envelope_id=ENV_ID,
+        envelope_kind="channel",
+        sender_slug=SENDER,
+        sender_subkey_id="",
+        sent_at=SENT_AT,
+        message_nonce="",
+        content_type="text/plain",
+        content=CONTENT,
+        is_visible_to_human=True,
+        space_id=SPACE,
+        channel_id=CHANNEL,
+    )
+
+    # --- bridge path ---
+    bridge = FakeBridge(scripted=[frame])
+    client = _bridge_client(tmp_path, bridge, db="bridge.db")
+    surfaced: list[tuple] = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append((root_id, batch, channel_meta))
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # --- native reference path (post-decrypt shared tail) ---
+    ref = _bridge_client(tmp_path, FakeBridge(), db="native_ref.db")
+    ref._queue = asyncio.PriorityQueue()
+    ref._queue_seq = 0
+    ref._thread_state = {}
+    await ref.store.open()
+    await ref._handle_plaintext_payload(ref_payload)
+
+    bridge_row = await client.store.get_message_by_envelope(ENV_ID)
+    ref_row = await ref.store.get_message_by_envelope(ENV_ID)
+    assert bridge_row is not None, "bridge inbound frame was not persisted"
+    assert ref_row is not None
+
+    persisted_fields = (
+        "envelope_id", "sender_slug", "channel_id", "space_id",
+        "recipient_slug", "content_type", "content", "sent_at",
+        "envelope_kind",
+    )
+    for f in persisted_fields:
+        assert getattr(bridge_row, f) == getattr(ref_row, f), (
+            f"bridge/native persisted field {f!r} diverged: "
+            f"{getattr(bridge_row, f)!r} != {getattr(ref_row, f)!r}"
+        )
+    # Concrete spot-checks so the equivalence isn't vacuously true.
+    assert bridge_row.content == CONTENT
+    assert bridge_row.sender_slug == SENDER
+    assert bridge_row.envelope_kind == "channel"
+    assert bridge_row.content_type == "text/plain"
+
+    # decrypt never ran, and the message surfaced to the agent.
+    assert decrypt_calls == []
+    assert len(surfaced) == 1
+    root_id, batch, channel_meta = surfaced[0]
+    assert any(m["envelope_id"] == ENV_ID for m in batch)
+    assert channel_meta["channel_id"] == CHANNEL
+
+
+@pytest.mark.asyncio
+async def test_a_inbound_dm_frame_routes_as_dm(tmp_path):
+    """A frame with ``recipient_slug`` and no explicit ``envelope_kind``
+    is inferred as a DM (mapper fallback) and stashed for reply routing.
+    """
+    bridge = FakeBridge(scripted=[{
+        "type": "message",
+        "envelope_id": "env_dm_1",
+        "sender_slug": "carol-0001",
+        "recipient_slug": "bot-0001",
+        "sent_at": 1_700_000_000_001,
+        "plaintext": "ping",
+    }])
+    client = _bridge_client(tmp_path, bridge, db="dm.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    row = await client.store.get_message_by_envelope("env_dm_1")
+    assert row is not None
+    assert row.envelope_kind == "dm"
+    assert row.recipient_slug == "bot-0001"
+    # DM sender stashed so send_fallback_message("") can reply to them.
+    assert client._last_dm_sender == "carol-0001"
+
+
+def test_payload_from_bridge_frame_skips_missing_envelope_id(tmp_path):
+    client = _bridge_client(tmp_path, FakeBridge(), db="skip.db")
+    assert client._payload_from_bridge_frame({"plaintext": "x"}) is None
+
+
+# --------------------------------------------------------------------------
+# (b) bridge send, no encrypt
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_dm_uses_bridge_no_encrypt(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message_with_content_key",
+        lambda *a, **k: enc_calls.append(1),
+    )
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message", lambda *a, **k: enc_calls.append(1),
+    )
+
+    ms = MessageStore(str(tmp_path / "b_dm.db"))
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](channel="@alice-0001", text="hi alice")
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["plaintext"] == "hi alice"
+    assert sent["recipient_slug"] == "alice-0001"
+    assert sent["space_id"] is None and sent["channel_id"] is None
+    assert "msg_bridgeack" in result
+    assert enc_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_channel_uses_bridge_no_encrypt(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message_with_content_key",
+        lambda *a, **k: enc_calls.append(1),
+    )
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message", lambda *a, **k: enc_calls.append(1),
+    )
+
+    ms = MessageStore(str(tmp_path / "b_ch.db"))
+    await ms.mark_channel_space("ch_xyz", "sp_1")
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](channel="ch_xyz", text="team update")
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["plaintext"] == "team update"
+    assert sent["space_id"] == "sp_1"
+    assert sent["channel_id"] == "ch_xyz"
+    assert sent["recipient_slug"] is None
+    assert "msg_bridgeack" in result
+    assert enc_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b_send_message_threaded_note_on_bridge(tmp_path):
+    """root_id isn't wired on bridge yet — send top-level with a note."""
+    ms = MessageStore(str(tmp_path / "b_thread.db"))
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](
+        channel="@alice-0001", text="reply", root_id="msg_parent",
+    )
+    assert len(bridge.sent) == 1
+    assert "top-level" in result.lower() or "phase 3" in result.lower() \
+        or "not wired" in result.lower()
+
+
+# --------------------------------------------------------------------------
+# (c) connect drives exactly one fetch_pending; pending_delivered ends backfill
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_c_connect_drives_one_fetch_pending_and_survives_pending_delivered(
+    tmp_path, caplog,
+):
+    # backfill message, the terminator, then a live message — proving the
+    # loop kept running for live delivery after pending_delivered.
+    scripted = [
+        {
+            "type": "message", "envelope_id": "env_backfill",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_010, "plaintext": "backfilled",
+        },
+        {"type": "pending_delivered", "count": 1},
+        {
+            "type": "message", "envelope_id": "env_live",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_020, "plaintext": "live one",
+        },
+    ]
+    bridge = FakeBridge(scripted=scripted)
+    client = _bridge_client(tmp_path, bridge, db="c.db")
+
+    seen_roots: list[str] = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        seen_roots.append(root_id)
+        if len(seen_roots) >= 2:
+            done.set()
+
+    with caplog.at_level(logging.INFO, logger="puffo_agent.agent.puffo_core_client"):
+        await _drive_listen_until(client, on_message=on_message, done=done)
+
+    # Exactly one connect + one fetch_pending drove the cold-start drain.
+    assert bridge.connect_count == 1
+    assert bridge.fetch_pending_count == 1
+    # pending_delivered was recognised as backfill completion.
+    assert "backfill complete" in caplog.text
+    # Both the backfill and the post-terminator live message landed.
+    assert await client.store.get_message_by_envelope("env_backfill") is not None
+    assert await client.store.get_message_by_envelope("env_live") is not None
+
+
+@pytest.mark.asyncio
+async def test_c_uncorrelated_error_frame_does_not_crash_loop(tmp_path, caplog):
+    scripted = [
+        {"type": "error", "code": "INTERNAL", "message": "transient blip"},
+        {
+            "type": "message", "envelope_id": "env_after_err",
+            "sender_slug": "alice-0001", "envelope_kind": "channel",
+            "space_id": "sp_1", "channel_id": "ch_a",
+            "sent_at": 1_700_000_000_030, "plaintext": "still alive",
+        },
+    ]
+    bridge = FakeBridge(scripted=scripted)
+    client = _bridge_client(tmp_path, bridge, db="c_err.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        done.set()
+
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.agent.puffo_core_client"):
+        await _drive_listen_until(client, on_message=on_message, done=done)
+
+    assert "bridge error frame" in caplog.text
+    # The loop survived the error frame and delivered the next message.
+    assert await client.store.get_message_by_envelope("env_after_err") is not None
+
+
+# --------------------------------------------------------------------------
+# (d) native untouched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_d_native_send_message_still_encrypts_and_posts(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+
+    def _enc_spy(inp, signing_key, *, now_ms=None):
+        enc_calls.append(1)
+        return ({"envelope_id": "msg_native", "type": "message_envelope"}, b"ck")
+
+    monkeypatch.setattr(pct_mod, "encrypt_message_with_content_key", _enc_spy)
+
+    ks = _native_keystore(tmp_path)
+    http = FakeHttp()
+    http.responses["/certs/sync?slugs=bot-0001,alice-0001"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_a",
+                "kem_public_key": base64url_encode(
+                    KemKeyPair.generate().public_key_bytes()
+                ),
+            },
+        }],
+        "has_more": False,
+    }
+    ms = MessageStore(str(tmp_path / "d_send.db"))
+    cfg = PuffoCoreToolsConfig(
+        slug="bot-0001",
+        device_id="dev_test",
+        keystore=ks,
+        http_client=http,
+        data_client=ms,
+        space_id="sp_home",
+        bridge_client=None,  # native
+    )
+    tools = build_dispatch(cfg)
+
+    result = await tools["send_message"](channel="@alice-0001", text="hi native")
+
+    assert enc_calls, "native send_message must still encrypt"
+    assert any(p == "/messages" for m, p, _ in http.calls if m == "POST"), (
+        f"native send must POST via http_client; calls={http.calls}"
+    )
+    assert "posted" in result
+
+
+class _RecordingWs:
+    """PuffoCoreWsClient stand-in: captures ``on_message`` (the native
+    ``handle_envelope`` closure) and no-ops ``run()`` so ``listen()``
+    returns instead of blocking."""
+
+    instances: list["_RecordingWs"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.on_message = None
+        self.on_event = None
+        _RecordingWs.instances.append(self)
+
+    async def run(self) -> None:
+        return
+
+
+@pytest.mark.asyncio
+async def test_d_native_inbound_still_decrypts_before_storing(tmp_path, monkeypatch):
+    monkeypatch.setattr(_RecordingWs, "instances", [])
+    monkeypatch.setattr(pcc_mod, "PuffoCoreWsClient", _RecordingWs)
+
+    decrypt_calls: list[int] = []
+    canned = MessagePayload(
+        payload_type="puffo.message",
+        version=1,
+        envelope_id="env_native_in",
+        envelope_kind="channel",
+        sender_slug="alice-0001",
+        sender_subkey_id="",
+        sent_at=1_700_000_000_050,
+        message_nonce="",
+        content_type="text/plain",
+        content="decrypted body",
+        is_visible_to_human=True,
+        space_id="sp_1",
+        channel_id="ch_a",
+    )
+
+    def _decrypt_spy(*a, **k):
+        decrypt_calls.append(1)
+        return canned
+
+    monkeypatch.setattr(pcc_mod, "decrypt_message", _decrypt_spy)
+
+    ks = _native_keystore(tmp_path)
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, "bot-0001")
+    store = MessageStore(str(tmp_path / "d_in.db"))
+    client = PuffoCoreMessageClient(
+        slug="bot-0001",
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=store,
+    )  # no bridge → native
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+
+    async def _fake_signing_keys(slug):
+        return [object()]  # one non-empty pubkey so the decrypt loop runs
+
+    client._key_cache.get_signing_keys = _fake_signing_keys  # type: ignore[method-assign]
+
+    async def on_message(*a):
+        return
+
+    # Native listen() wires handle_envelope onto the (recording) WS and
+    # returns because run() is a no-op.
+    await client.listen(on_message)
+    assert len(_RecordingWs.instances) == 1
+    handle_envelope = _RecordingWs.instances[0].on_message
+    assert handle_envelope is not None
+
+    await handle_envelope({
+        "envelope_id": "env_native_in",
+        "sender_slug": "alice-0001",
+    })
+
+    assert decrypt_calls, "native inbound must call decrypt_message"
+    row = await client.store.get_message_by_envelope("env_native_in")
+    assert row is not None
+    assert row.content == "decrypted body"
+
+
+# --------------------------------------------------------------------------
+# (e) attachment guard
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e_attachments_refused_on_bridge_no_encrypt(tmp_path, monkeypatch):
+    enc_calls: list[int] = []
+    monkeypatch.setattr(
+        pct_mod, "encrypt_message_with_content_key",
+        lambda *a, **k: enc_calls.append(1),
+    )
+
+    ms = MessageStore(str(tmp_path / "e.db"))
+    bridge = FakeBridge()
+    cfg = _tools_cfg(tmp_path, bridge=bridge, data_client=ms)
+    tools = build_dispatch(cfg)
+
+    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
+    with pytest.raises(RuntimeError) as excinfo:
+        await tools["send_message_with_attachments"](
+            paths=["note.txt"], channel="@alice-0001", caption="see file",
+        )
+    msg = str(excinfo.value).lower()
+    assert "bridge" in msg and "not supported" in msg
+    assert enc_calls == []
+    assert bridge.sent == []

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -152,6 +152,13 @@ class FakeHttp:
     def __init__(self):
         self.calls: list[tuple[str, str, object]] = []
         self.responses: dict[str, dict] = {}
+        # T23 keyless surface. Off by default (native/inbound tests keep
+        # the signed path); ``_tools_cfg`` flips it on for the send-tool
+        # tests so they exercise the unsigned ``/v2/cloud-agents/*`` seam.
+        self.keyless = False
+        self.server_url = "http://sandbox.local"
+        self.uploaded: list[bytes] = []
+        self._blob_seq = 0
 
     def _match(self, path: str) -> dict:
         if path in self.responses:
@@ -189,6 +196,29 @@ class FakeHttp:
         # canned blob_id unless a test registers its own response.
         self.calls.append(("POST_BYTES", path, body))
         return self.responses.get(path, {"blob_id": "blob_native_1"})
+
+    # ── keyless (T23) unsigned methods ──────────────────────────────
+
+    async def get_unsigned(self, path):
+        self.calls.append(("GET_UNSIGNED", path, None))
+        return self._match(path)
+
+    async def post_unsigned(self, path, body=None):
+        self.calls.append(("POST_UNSIGNED", path, body))
+        if path in self.responses:
+            return self.responses[path]
+        return {"envelope_id": "msg_bridgeack"}
+
+    async def post_bytes_unsigned(self, path, body):
+        self._blob_seq += 1
+        self.uploaded.append(body)
+        self.calls.append(
+            ("POST_BYTES_UNSIGNED", path, len(body) if body else 0)
+        )
+        return {
+            "blob_id": f"blob_{self._blob_seq:04d}",
+            "size_bytes": len(body) if body else 0,
+        }
 
 
 # --------------------------------------------------------------------------
@@ -247,16 +277,26 @@ def _native_keystore(tmp_path, slug="bot-0001") -> KeyStore:
 
 def _tools_cfg(tmp_path, *, bridge, data_client, http=None, slug="bot-0001"):
     ks = KeyStore(str(tmp_path / "cfg-keys"))
+    http = http or FakeHttp()
+    # T23: outbound send tools run keyless over ``/v2/cloud-agents/*``.
+    # The ``bridge`` stays on the cfg (inbound + lifecycle) but must NOT
+    # be touched by send — the tests assert ``bridge.sent == []``.
+    http.keyless = True
     return PuffoCoreToolsConfig(
         slug=slug,
         device_id="dev_test",
         keystore=ks,
-        http_client=http or FakeHttp(),
+        http_client=http,
         data_client=data_client,
         space_id="sp_home",
         workspace=str(tmp_path),
         bridge_client=bridge,
     )
+
+
+def _http_sends(http):
+    """Bodies of every keyless ``POST /v2/cloud-agents/messages``."""
+    return [b for m, p, b in http.calls if m == "POST_UNSIGNED"]
 
 
 async def _drive_listen_until(client, *, on_message, done: asyncio.Event, timeout=5.0):
@@ -437,11 +477,17 @@ async def test_b_send_message_dm_uses_bridge_no_encrypt(tmp_path, monkeypatch):
 
     result = await tools["send_message"](channel="@alice-0001", text="hi alice")
 
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["plaintext"] == "hi alice"
-    assert sent["recipient_slug"] == "alice-0001"
-    assert sent["space_id"] is None and sent["channel_id"] is None
+    # Keyless: one unsigned POST /v2/cloud-agents/messages, no bridge send.
+    sends = _http_sends(cfg.http_client)
+    assert [p for m, p, _ in cfg.http_client.calls if m == "POST_UNSIGNED"] == [
+        "/v2/cloud-agents/messages",
+    ]
+    assert len(sends) == 1
+    body = sends[0]
+    assert body["plaintext"] == "hi alice"
+    assert body["recipient_slug"] == "alice-0001"
+    assert "space_id" not in body and "channel_id" not in body
+    assert bridge.sent == []
     assert "msg_bridgeack" in result
     assert enc_calls == []
 
@@ -465,12 +511,14 @@ async def test_b_send_message_channel_uses_bridge_no_encrypt(tmp_path, monkeypat
 
     result = await tools["send_message"](channel="ch_xyz", text="team update")
 
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["plaintext"] == "team update"
-    assert sent["space_id"] == "sp_1"
-    assert sent["channel_id"] == "ch_xyz"
-    assert sent["recipient_slug"] is None
+    sends = _http_sends(cfg.http_client)
+    assert len(sends) == 1
+    body = sends[0]
+    assert body["plaintext"] == "team update"
+    assert body["space_id"] == "sp_1"
+    assert body["channel_id"] == "ch_xyz"
+    assert "recipient_slug" not in body
+    assert bridge.sent == []
     assert "msg_bridgeack" in result
     assert enc_calls == []
 
@@ -505,14 +553,16 @@ async def test_b_send_message_channel_threads_on_bridge(tmp_path):
     result = await tools["send_message"](
         channel="ch_xyz", text="reply", root_id="msg_reply",
     )
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
+    sends = _http_sends(cfg.http_client)
+    assert len(sends) == 1
+    body = sends[0]
     # Resolved to the true root, not the intermediate reply id.
-    assert sent["thread_root_id"] == "msg_root"
+    assert body["thread_root_id"] == "msg_root"
     # Raw parent id the agent passed rides reply_to_id.
-    assert sent["reply_to_id"] == "msg_reply"
-    assert sent["space_id"] == "sp_1"
-    assert sent["channel_id"] == "ch_xyz"
+    assert body["reply_to_id"] == "msg_reply"
+    assert body["space_id"] == "sp_1"
+    assert body["channel_id"] == "ch_xyz"
+    assert bridge.sent == []
     # No stale "top-level" / "not wired" note — threading is live now.
     assert "top-level" not in result.lower()
     assert "not wired" not in result.lower()
@@ -541,11 +591,13 @@ async def test_b_send_message_dm_threads_on_bridge(tmp_path):
     result = await tools["send_message"](
         channel="@alice-0001", text="reply", root_id="dm_root",
     )
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["recipient_slug"] == "alice-0001"
-    assert sent["thread_root_id"] == "dm_root"
-    assert sent["reply_to_id"] == "dm_root"
+    sends = _http_sends(cfg.http_client)
+    assert len(sends) == 1
+    body = sends[0]
+    assert body["recipient_slug"] == "alice-0001"
+    assert body["thread_root_id"] == "dm_root"
+    assert body["reply_to_id"] == "dm_root"
+    assert bridge.sent == []
     assert "msg_bridgeack" in result
 
 
@@ -1004,14 +1056,19 @@ async def test_e_attachments_uploaded_keyless_and_reffed_on_bridge(
         paths=["note.txt"], channel="@alice-0001", caption="see file",
     )
 
-    # Uploaded exactly once, with the raw plaintext bytes.
-    assert bridge.uploaded == [body]
-    # One send frame carrying the ref by blob_id.
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
+    # Uploaded exactly once, keyless, with the raw plaintext bytes.
+    assert http.uploaded == [body]
+    assert [p for m, p, _ in http.calls if m == "POST_BYTES_UNSIGNED"] == [
+        "/v2/cloud-agents/blobs/upload",
+    ]
+    # One keyless send carrying the ref by blob_id; bridge untouched.
+    assert bridge.uploaded == [] and bridge.sent == []
+    sends = _http_sends(http)
+    assert len(sends) == 1
+    sent = sends[0]
     assert sent["plaintext"] == "see file"
     assert sent["recipient_slug"] == "alice-0001"
-    assert sent["space_id"] is None and sent["channel_id"] is None
+    assert "space_id" not in sent and "channel_id" not in sent
     refs = sent["attachments"]
     assert isinstance(refs, list) and len(refs) == 1
     ref = refs[0]
@@ -1019,7 +1076,7 @@ async def test_e_attachments_uploaded_keyless_and_reffed_on_bridge(
     assert ref["filename"] == "note.txt"
     assert ref["mime_type"] == "text/plain"
     assert ref["size_bytes"] == len(body)
-    # No signed-crypto: no encrypt, no /blobs/upload or /messages POST.
+    # No signed-crypto: no encrypt, no signed /blobs/upload or /messages POST.
     assert enc_calls == []
     assert not any(
         p in ("/blobs/upload", "/messages") for _, p, _ in http.calls
@@ -1042,12 +1099,14 @@ async def test_e_attachments_channel_route_on_bridge(tmp_path):
     await tools["send_message_with_attachments"](
         paths=["doc.txt"], channel="ch_xyz", caption="team file",
     )
-    assert len(bridge.uploaded) == 1
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
+    assert len(cfg.http_client.uploaded) == 1
+    assert bridge.uploaded == [] and bridge.sent == []
+    sends = _http_sends(cfg.http_client)
+    assert len(sends) == 1
+    sent = sends[0]
     assert sent["space_id"] == "sp_1"
     assert sent["channel_id"] == "ch_xyz"
-    assert sent["recipient_slug"] is None
+    assert "recipient_slug" not in sent
     assert sent["attachments"][0]["blob_id"] == "blob_0001"
 
 

--- a/tests/test_cloud_bridge_seam.py
+++ b/tests/test_cloud_bridge_seam.py
@@ -1,0 +1,212 @@
+"""T23 phase 1: transport seam. An injected ``bridge_client`` flips
+``PuffoCoreMessageClient.listen()`` to the keyless bridge lifecycle
+(no ``PuffoCoreWsClient``, no ``keystore.load_identity``); default
+construction keeps the native signed path. ``build_server`` under
+``transport="bridge"`` builds with zero key files on disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+import puffo_agent.agent.puffo_core_client as pcc_mod
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import (
+    KeyStore,
+    Session,
+    StoredIdentity,
+    encode_secret,
+)
+from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
+
+
+class _SpyKeyStore(KeyStore):
+    """Records load_identity calls; bridge mode must never make one."""
+
+    def __init__(self) -> None:
+        super().__init__(tempfile.mkdtemp(prefix="spy-keys-"))
+        self.load_identity_calls: list[str] = []
+
+    def load_identity(self, slug: str) -> StoredIdentity:
+        self.load_identity_calls.append(slug)
+        return super().load_identity(slug)
+
+
+class _StubBridge:
+    """Bridge stub: records the lifecycle calls listen() makes."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.connected = asyncio.Event()
+
+    async def connect(self) -> None:
+        self.calls.append("connect")
+        self.connected.set()
+
+    async def frames(self):
+        self.calls.append("frames")
+        await asyncio.Event().wait()  # block until the test cancels
+        yield {}  # pragma: no cover — makes this an async generator
+
+    async def close(self) -> None:
+        self.calls.append("close")
+
+
+class _RecordingWs:
+    """PuffoCoreWsClient stand-in — records construction, run() is a
+    no-op so listen() returns instead of blocking."""
+
+    instances: list["_RecordingWs"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.on_message = None
+        self.on_event = None
+        _RecordingWs.instances.append(self)
+
+    async def run(self) -> None:
+        return
+
+
+def _make_client(keystore: KeyStore, tmp_path, **kwargs) -> PuffoCoreMessageClient:
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", keystore, "bot-0001")
+    store = MessageStore(str(tmp_path / "messages.db"))
+    return PuffoCoreMessageClient(
+        slug="bot-0001",
+        device_id="dev_test",
+        space_id="sp_test",
+        keystore=keystore,
+        http_client=http,
+        message_store=store,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_injected_bridge_skips_ws_client_and_identity_load(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setattr(_RecordingWs, "instances", [])
+    monkeypatch.setattr(pcc_mod, "PuffoCoreWsClient", _RecordingWs)
+    spy_ks = _SpyKeyStore()
+    stub = _StubBridge()
+    client = _make_client(spy_ks, tmp_path, bridge_client=stub)
+
+    async def on_message(*args) -> None:
+        return
+
+    task = asyncio.create_task(client.listen(on_message))
+    await asyncio.wait_for(stub.connected.wait(), timeout=5.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stub.calls[:2] == ["connect", "frames"]
+    assert "close" in stub.calls
+    assert _RecordingWs.instances == []
+    assert spy_ks.load_identity_calls == []
+
+
+def test_default_construction_has_no_bridge(tmp_path):
+    client = _make_client(KeyStore(str(tmp_path / "keys")), tmp_path)
+    assert client._bridge is None
+
+
+@pytest.mark.asyncio
+async def test_native_path_reaches_ws_client_construction(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setattr(_RecordingWs, "instances", [])
+    monkeypatch.setattr(pcc_mod, "PuffoCoreWsClient", _RecordingWs)
+    ks = KeyStore(str(tmp_path / "keys"))
+    ks.save_identity(StoredIdentity(
+        slug="bot-0001",
+        device_id="dev_test",
+        root_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        device_signing_secret_key=encode_secret(
+            Ed25519KeyPair.generate().secret_bytes()
+        ),
+        kem_secret_key=encode_secret(KemKeyPair.generate().secret_bytes()),
+        server_url="http://127.0.0.1:1",
+    ))
+    ks.save_session(Session(
+        slug="bot-0001",
+        subkey_id="sk_test",
+        subkey_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+        expires_at=32_503_680_000_000,
+    ))
+    client = _make_client(ks, tmp_path)
+
+    async def on_message(*args) -> None:
+        return
+
+    await client.listen(on_message)
+    assert len(_RecordingWs.instances) == 1
+    assert _RecordingWs.instances[0].kwargs["slug"] == "bot-0001"
+
+
+def test_build_server_bridge_transport_needs_no_key_files(tmp_path):
+    from mcp.server.fastmcp import FastMCP
+    from puffo_agent.mcp.puffo_core_server import build_server
+
+    server = build_server(
+        slug="bot-0001",
+        device_id="dev_test",
+        server_url="http://127.0.0.1:1",
+        space_id="",
+        keystore_dir="",  # zero key files anywhere
+        workspace=str(tmp_path),
+        agent_id="bot-0001",
+        data_service_url="http://127.0.0.1:1",
+        transport="bridge",
+    )
+    assert isinstance(server, FastMCP)
+
+
+def test_bridge_inert_keystore_raises_clear_error():
+    from puffo_agent.mcp.puffo_core_server import _BridgeNoKeysStore
+
+    ks = _BridgeNoKeysStore("")
+    with pytest.raises(RuntimeError, match="no local keys"):
+        ks.load_identity("bot-0001")
+    with pytest.raises(RuntimeError, match="no local keys"):
+        ks.load_session("bot-0001")
+
+
+def test_cfg_from_env_picks_up_transport(monkeypatch):
+    from puffo_agent.mcp.puffo_core_server import _cfg_from_env
+
+    monkeypatch.setenv("PUFFO_CORE_SLUG", "bot-0001")
+    monkeypatch.setenv("PUFFO_CORE_DEVICE_ID", "dev_test")
+    monkeypatch.setenv("PUFFO_CORE_SERVER_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("PUFFO_CORE_TRANSPORT", "bridge")
+    cfg = _cfg_from_env()
+    assert cfg["transport"] == "bridge"
+
+    monkeypatch.delenv("PUFFO_CORE_TRANSPORT")
+    assert _cfg_from_env()["transport"] == ""
+
+
+def test_puffo_core_mcp_env_transport_is_additive():
+    from puffo_agent.mcp.config import puffo_core_mcp_env
+
+    base = dict(
+        slug="bot-0001",
+        device_id="dev_test",
+        server_url="http://127.0.0.1:1",
+        keystore_dir="/keys",
+        workspace="/ws",
+    )
+    default_env = puffo_core_mcp_env(**base)
+    assert "PUFFO_CORE_TRANSPORT" not in default_env
+    bridge_env = puffo_core_mcp_env(**base, transport="bridge")
+    assert bridge_env["PUFFO_CORE_TRANSPORT"] == "bridge"
+    # Only the transport var differs — default output stays identical.
+    bridge_env.pop("PUFFO_CORE_TRANSPORT")
+    assert bridge_env == default_env

--- a/tests/test_cloud_bridge_seam.py
+++ b/tests/test_cloud_bridge_seam.py
@@ -39,7 +39,12 @@ class _SpyKeyStore(KeyStore):
 
 
 class _StubBridge:
-    """Bridge stub: records the lifecycle calls listen() makes."""
+    """Bridge stub: records the lifecycle calls listen() makes.
+
+    Phase 2 drives ``send_fetch_pending`` once per successful connect
+    (cold-start backfill) before iterating frames, so the recorded
+    order is connect → fetch_pending → frames.
+    """
 
     def __init__(self) -> None:
         self.calls: list[str] = []
@@ -48,6 +53,9 @@ class _StubBridge:
     async def connect(self) -> None:
         self.calls.append("connect")
         self.connected.set()
+
+    async def send_fetch_pending(self, *, limit=None) -> None:
+        self.calls.append("fetch_pending")
 
     async def frames(self):
         self.calls.append("frames")
@@ -107,7 +115,7 @@ async def test_injected_bridge_skips_ws_client_and_identity_load(
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert stub.calls[:2] == ["connect", "frames"]
+    assert stub.calls[:3] == ["connect", "fetch_pending", "frames"]
     assert "close" in stub.calls
     assert _RecordingWs.instances == []
     assert spy_ks.load_identity_calls == []

--- a/tests/test_cloud_bridge_transport_config.py
+++ b/tests/test_cloud_bridge_transport_config.py
@@ -1,0 +1,132 @@
+"""T23 phase 1: ``puffo_core.transport`` config parse / validate /
+round-trip. The flag-off (native) path must stay byte-identical:
+no new keys in saved agent.yml, every parsed field unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_agent_yml(agent_id: str, puffo_core_extra: str = "") -> Path:
+    from puffo_agent.portal.state import agent_yml_path
+    yml = agent_yml_path(agent_id)
+    yml.parent.mkdir(parents=True, exist_ok=True)
+    yml.write_text(
+        f"id: {agent_id}\n"
+        "state: running\n"
+        f"display_name: {agent_id}\n"
+        "created_at: 0\n"
+        "puffo_core:\n"
+        "  server_url: 'https://relay.example'\n"
+        "  slug: 'bot-1234'\n"
+        "  device_id: 'dev-1'\n"
+        "  space_id: 'sp-1'\n"
+        "  operator_slug: 'op-5678'\n"
+        f"{puffo_core_extra}"
+        "runtime: {kind: chat-local}\n"
+        "triggers: {on_mention: true, on_dm: true}\n",
+        encoding="utf-8",
+    )
+    return yml
+
+
+def test_absent_transport_key_defaults_to_native(home):
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml("agent-no-transport")
+    cfg = AgentConfig.load("agent-no-transport")
+    assert cfg.puffo_core.transport == "native"
+    assert cfg.puffo_core.sandbox_token == ""
+
+
+def test_absent_transport_key_leaves_every_other_field_unchanged(home):
+    # Control: an identical agent.yml under a different id. Loading
+    # the transport-less file must parse every non-transport field
+    # exactly as the control does.
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml("agent-a")
+    _write_agent_yml("agent-b")
+    a = asdict(AgentConfig.load("agent-a").puffo_core)
+    b = asdict(AgentConfig.load("agent-b").puffo_core)
+    assert a == b
+    assert a["server_url"] == "https://relay.example"
+    assert a["slug"] == "bot-1234"
+    assert a["device_id"] == "dev-1"
+    assert a["space_id"] == "sp-1"
+    assert a["operator_slug"] == "op-5678"
+    assert a["auto_accept_space_invitations"] is False
+
+
+def test_native_save_emits_no_transport_keys(home):
+    # Flag-off byte-identity: the saved puffo_core block carries the
+    # exact pre-T23 key-set — transport/sandbox_token never leak in.
+    from puffo_agent.portal.state import AgentConfig, agent_yml_path
+    cfg = AgentConfig(id="agent-native-save", display_name="n")
+    cfg.puffo_core.slug = "bot-1234"
+    cfg.save()
+    raw = yaml.safe_load(
+        agent_yml_path("agent-native-save").read_text(encoding="utf-8")
+    )
+    assert set(raw["puffo_core"].keys()) == {
+        "server_url",
+        "slug",
+        "device_id",
+        "space_id",
+        "operator_slug",
+        "auto_accept_space_invitations",
+    }
+
+
+def test_bridge_fields_parse_and_round_trip(home):
+    from puffo_agent.portal.state import AgentConfig, agent_yml_path
+    _write_agent_yml(
+        "agent-bridge",
+        puffo_core_extra=(
+            "  transport: bridge\n"
+            "  sandbox_token: 'sbx_secret_1'\n"
+        ),
+    )
+    cfg = AgentConfig.load("agent-bridge")
+    assert cfg.puffo_core.transport == "bridge"
+    assert cfg.puffo_core.sandbox_token == "sbx_secret_1"
+    assert cfg.puffo_core.server_url == "https://relay.example"
+    # Bridge agents DO persist the transport keys.
+    cfg.save()
+    raw = yaml.safe_load(
+        agent_yml_path("agent-bridge").read_text(encoding="utf-8")
+    )
+    assert raw["puffo_core"]["transport"] == "bridge"
+    assert raw["puffo_core"]["sandbox_token"] == "sbx_secret_1"
+    reloaded = AgentConfig.load("agent-bridge")
+    assert reloaded.puffo_core.transport == "bridge"
+    assert reloaded.puffo_core.sandbox_token == "sbx_secret_1"
+
+
+def test_bridge_without_sandbox_token_fails_fast(home):
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml(
+        "agent-bridge-no-token",
+        puffo_core_extra="  transport: bridge\n",
+    )
+    with pytest.raises(RuntimeError, match="sandbox_token"):
+        AgentConfig.load("agent-bridge-no-token")
+
+
+def test_unknown_transport_fails_fast_naming_valid_transports(home):
+    from puffo_agent.portal.state import AgentConfig
+    _write_agent_yml(
+        "agent-bad-transport",
+        puffo_core_extra="  transport: carrier-pigeon\n",
+    )
+    with pytest.raises(RuntimeError, match="native.*bridge"):
+        AgentConfig.load("agent-bad-transport")

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -4,6 +4,7 @@ import os
 import sys
 import tempfile
 import time
+from unittest.mock import patch
 
 import aiohttp
 from aiohttp import web
@@ -418,5 +419,111 @@ class TestHttpClientUnsigned(AioHTTPTestCase):
         try:
             result = await client.get_unsigned("/invites/ABC/check")
             assert result["available"] is True
+        finally:
+            await client.close()
+
+
+class TestHttpClientKeylessEgress(AioHTTPTestCase):
+    """T23 keyless transport: ``post_bytes_unsigned`` + the test-only
+    egress ``x-sandbox-token`` shim on the three unsigned methods. An
+    echo handler captures the headers + body the server received."""
+
+    def setUp(self):
+        self.ks, _ = _make_keystore_with_identity()
+        self.subkey = Ed25519KeyPair.generate()
+        _make_keystore_with_session(self.ks, self.subkey)
+        self.captured_headers = {}
+        self.captured_body = b""
+        super().setUp()
+
+    async def get_application(self):
+        app = web.Application()
+        app.router.add_route("POST", "/v2/cloud-agents/blobs/upload", self._echo)
+        app.router.add_route("POST", "/v2/cloud-agents/messages", self._echo)
+        app.router.add_route("GET", "/v2/cloud-agents/spaces", self._echo)
+        # Signed routes — used to prove the shim never touches them.
+        app.router.add_route("GET", "/health", self._echo)
+        app.router.add_route("POST", "/messages", self._echo)
+        return app
+
+    async def _echo(self, request: web.Request):
+        self.captured_headers = {k.lower(): v for k, v in request.headers.items()}
+        self.captured_body = await request.read()
+        return web.json_response({"ok": True, "blob_id": "b1"})
+
+    @unittest_run_loop
+    async def test_post_bytes_unsigned_sends_raw_bytes_no_signature(self):
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001", keyless=True)
+        try:
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PUFFO_LOCAL_SANDBOX_TOKEN", None)
+                result = await client.post_bytes_unsigned(
+                    "/v2/cloud-agents/blobs/upload", b"\x00\x01raw-bytes",
+                )
+            assert result["blob_id"] == "b1"
+            # Raw body posted verbatim; octet-stream content type; unsigned.
+            assert self.captured_body == b"\x00\x01raw-bytes"
+            assert self.captured_headers.get("content-type", "").startswith(
+                "application/octet-stream"
+            )
+            assert "x-puffo-signature" not in self.captured_headers
+            assert "x-sandbox-token" not in self.captured_headers
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_egress_shim_adds_token_when_env_set(self):
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001", keyless=True)
+        try:
+            with patch.dict(os.environ, {"PUFFO_LOCAL_SANDBOX_TOKEN": "tok-abc"}):
+                await client.get_unsigned("/v2/cloud-agents/spaces")
+                assert self.captured_headers.get("x-sandbox-token") == "tok-abc"
+                await client.post_unsigned(
+                    "/v2/cloud-agents/messages", {"plaintext": "hi"},
+                )
+                assert self.captured_headers.get("x-sandbox-token") == "tok-abc"
+                await client.post_bytes_unsigned(
+                    "/v2/cloud-agents/blobs/upload", b"blobbytes",
+                )
+                assert self.captured_headers.get("x-sandbox-token") == "tok-abc"
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_egress_shim_absent_when_env_unset(self):
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001", keyless=True)
+        try:
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PUFFO_LOCAL_SANDBOX_TOKEN", None)
+                await client.get_unsigned("/v2/cloud-agents/spaces")
+                assert "x-sandbox-token" not in self.captured_headers
+                await client.post_unsigned(
+                    "/v2/cloud-agents/messages", {"plaintext": "hi"},
+                )
+                assert "x-sandbox-token" not in self.captured_headers
+                await client.post_bytes_unsigned(
+                    "/v2/cloud-agents/blobs/upload", b"x",
+                )
+                assert "x-sandbox-token" not in self.captured_headers
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_signed_methods_never_carry_sandbox_token(self):
+        # Even with the env var set, the signed get/post must stay
+        # untouched — the shim lives only on the unsigned methods.
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001")
+        try:
+            with patch.dict(os.environ, {"PUFFO_LOCAL_SANDBOX_TOKEN": "tok-abc"}):
+                await client.get("/health")
+                assert "x-sandbox-token" not in self.captured_headers
+                assert "x-puffo-signature" in self.captured_headers
+                await client.post("/messages", {"x": 1})
+                assert "x-sandbox-token" not in self.captured_headers
+                assert "x-puffo-signature" in self.captured_headers
         finally:
             await client.close()

--- a/tests/test_lifecycle_tools.py
+++ b/tests/test_lifecycle_tools.py
@@ -1,0 +1,332 @@
+"""Bridge-only lifecycle MCP tools: mapping / fallback / gating logic.
+
+Handlers are obtained through
+``portal.ws_local.tool_dispatch.build_dispatch`` — that both proves the
+allowlist wiring and exercises the ``register_core_tools`` gate on
+``cfg.bridge_client``. Most cases use a fake ``bridge_client`` for the
+mapping/fallback/gating logic; the two ``*_posts_right_body_*`` /
+``*_hit_right_routes`` cases drive a **real** ``CloudBridgeClient``
+against a loopback mock so we pin the actual ``x-sandbox-token`` HTTP.
+LLM-free, E2B-free, server-free.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from puffo_agent.agent.bridge_client import BridgeError, CloudBridgeClient
+from puffo_agent.mcp.puffo_core_tools import PuffoCoreToolsConfig
+from puffo_agent.portal.ws_local.tool_dispatch import build_dispatch
+
+
+LIFECYCLE_TOOLS = frozenset({
+    "schedule_wake",
+    "cancel_wake",
+    "get_scheduled_wake",
+    "get_runtime_status",
+    "keep_alive",
+})
+
+
+def _cfg(bridge) -> PuffoCoreToolsConfig:
+    """Minimal tools config; only ``bridge_client`` matters here — the
+    lifecycle tools never touch keystore/http/data."""
+    return PuffoCoreToolsConfig(
+        slug="agent-1",
+        device_id="dev-1",
+        keystore=MagicMock(),
+        http_client=MagicMock(),
+        data_client=MagicMock(),
+        bridge_client=bridge,
+    )
+
+
+class _FakeBridge:
+    """Records lifecycle-method calls and returns canned results.
+    Set ``raise_on`` to a method name to make it raise ``BridgeError``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.raise_on: str | None = None
+        self.schedule_wake_result: dict = {"wake_at": "2026-07-07T12:00:00Z"}
+        self.get_scheduled_wake_result: dict = {"wake_at": None}
+        self.cancel_wake_result: dict = {}
+        self.runtime_status_result: dict = {
+            "state": "running",
+            "timeout_at": "2026-07-07T13:00:00Z",
+            "seconds_until_sleep": 900,
+            "sandbox_id": "sbx_1",
+        }
+        self.keepalive_result: dict = {
+            "available": True,
+            "timeout_at": "2026-07-07T14:00:00Z",
+            "seconds_until_sleep": 3600,
+        }
+
+    def _maybe_raise(self, name: str) -> None:
+        if self.raise_on == name:
+            raise BridgeError("KEEPALIVE", "simulated transport failure")
+
+    async def schedule_wake(self, *, after_seconds=None, wake_at=None, reason=""):
+        self.calls.append((
+            "schedule_wake",
+            {"after_seconds": after_seconds, "wake_at": wake_at, "reason": reason},
+        ))
+        self._maybe_raise("schedule_wake")
+        return self.schedule_wake_result
+
+    async def get_scheduled_wake(self):
+        self.calls.append(("get_scheduled_wake", {}))
+        self._maybe_raise("get_scheduled_wake")
+        return self.get_scheduled_wake_result
+
+    async def cancel_wake(self):
+        self.calls.append(("cancel_wake", {}))
+        self._maybe_raise("cancel_wake")
+        return self.cancel_wake_result
+
+    async def runtime_status(self):
+        self.calls.append(("runtime_status", {}))
+        self._maybe_raise("runtime_status")
+        return self.runtime_status_result
+
+    async def keepalive(self, seconds):
+        self.calls.append(("keepalive", {"seconds": seconds}))
+        self._maybe_raise("keepalive")
+        return self.keepalive_result
+
+
+# --------------------------------------------------------------------------
+# Loopback mock app for the real-CloudBridgeClient end-to-end cases
+# --------------------------------------------------------------------------
+
+
+class _MockApp:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def _record(self, request: web.Request) -> None:
+        body = None
+        if request.can_read_body:
+            try:
+                body = await request.json()
+            except Exception:
+                body = None
+        self.requests.append({
+            "method": request.method,
+            "path": request.path,
+            "token": request.headers.get("x-sandbox-token"),
+            "body": body,
+        })
+
+    async def schedule_wake(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        return web.json_response(
+            {"wake_at": "2026-07-07T12:00:00Z", "reason": "batch job"},
+        )
+
+    async def scheduled_wake_get(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        return web.json_response({"wake_at": None})
+
+    async def scheduled_wake_delete(self, request: web.Request) -> web.Response:
+        await self._record(request)
+        return web.Response(status=204)
+
+
+def _build_app(mock: _MockApp) -> web.Application:
+    a = web.Application()
+    a.router.add_post("/v2/cloud-agents/schedule-wake", mock.schedule_wake)
+    a.router.add_get("/v2/cloud-agents/scheduled-wake", mock.scheduled_wake_get)
+    a.router.add_delete(
+        "/v2/cloud-agents/scheduled-wake", mock.scheduled_wake_delete,
+    )
+    return a
+
+
+# --------------------------------------------------------------------------
+# (verify a) real-client end-to-end: right route/body/token
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_tool_posts_right_body_with_token():
+    mock = _MockApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        bridge = CloudBridgeClient(url, "sbx_e2e", "slug")
+        dispatch = build_dispatch(_cfg(bridge))
+        assert "schedule_wake" in dispatch
+        result = await dispatch["schedule_wake"](
+            after_seconds=1800, reason="batch job",
+        )
+    req = mock.requests[-1]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v2/cloud-agents/schedule-wake"
+    assert req["token"] == "sbx_e2e"
+    assert req["body"] == {"after_seconds": 1800, "reason": "batch job"}
+    # Tool surfaces the confirmed wake_at from the server.
+    assert "2026-07-07T12:00:00Z" in result
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_get_scheduled_wake_hit_right_routes():
+    mock = _MockApp()
+    async with TestClient(TestServer(_build_app(mock))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        bridge = CloudBridgeClient(url, "sbx_e2e", "slug")
+        dispatch = build_dispatch(_cfg(bridge))
+        await dispatch["cancel_wake"]()
+        delete_req = mock.requests[-1]
+        result = await dispatch["get_scheduled_wake"]()
+        get_req = mock.requests[-1]
+    assert delete_req["method"] == "DELETE"
+    assert delete_req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert get_req["method"] == "GET"
+    assert get_req["path"] == "/v2/cloud-agents/scheduled-wake"
+    assert get_req["token"] == "sbx_e2e"
+    # No wake scheduled → readable "none" summary.
+    assert "no wake" in result.lower()
+
+
+# --------------------------------------------------------------------------
+# (verify b) runtime-status null → "unknown"
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_status_maps_null_seconds_to_unknown():
+    bridge = _FakeBridge()
+    bridge.runtime_status_result = {
+        "state": "running",
+        "timeout_at": "2026-07-07T13:00:00Z",
+        "seconds_until_sleep": None,
+        "sandbox_id": "sbx_1",
+    }
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["get_runtime_status"]()
+    assert "unknown" in result
+    # Never fabricate a number for an unknown deadline.
+    assert "seconds_until_sleep=unknown" in result
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_status_renders_real_seconds():
+    bridge = _FakeBridge()  # default seconds_until_sleep=900
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["get_runtime_status"]()
+    assert "900" in result
+    assert "unknown" not in result
+
+
+# --------------------------------------------------------------------------
+# (verify c) keep_alive available vs. fallback
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_returns_refreshed_deadline():
+    bridge = _FakeBridge()
+    bridge.keepalive_result = {
+        "available": True,
+        "timeout_at": "2026-07-07T14:00:00Z",
+        "seconds_until_sleep": 3600,
+    }
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["keep_alive"](600)
+    assert "2026-07-07T14:00:00Z" in result
+    assert ("keepalive", {"seconds": 600}) in bridge.calls
+    # No fallback schedule_wake when keepalive succeeded.
+    assert all(name != "schedule_wake" for name, _ in bridge.calls)
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_falls_back_to_schedule_wake_when_unavailable():
+    bridge = _FakeBridge()
+    bridge.keepalive_result = {"available": False, "detail": "not landed yet"}
+    bridge.schedule_wake_result = {"wake_at": "2026-07-07T12:10:00Z"}
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["keep_alive"](600)
+    # keepalive was tried, then schedule_wake fallback fired with ~600s.
+    sched = [args for name, args in bridge.calls if name == "schedule_wake"]
+    assert len(sched) == 1
+    assert sched[0]["after_seconds"] == 600
+    # Message explains the fallback and self-resume.
+    lowered = result.lower()
+    assert "wake" in lowered
+    assert "fallback" in lowered or "not available" in lowered
+    assert "2026-07-07T12:10:00Z" in result
+
+
+# --------------------------------------------------------------------------
+# (verify d) registration gating on bridge transport
+# --------------------------------------------------------------------------
+
+
+def test_lifecycle_tools_not_registered_under_native_transport():
+    dispatch = build_dispatch(_cfg(None))  # native: bridge_client is None
+    for name in LIFECYCLE_TOOLS:
+        assert name not in dispatch
+
+
+def test_lifecycle_tools_registered_under_bridge_transport():
+    dispatch = build_dispatch(_cfg(_FakeBridge()))
+    for name in LIFECYCLE_TOOLS:
+        assert name in dispatch
+
+
+# --------------------------------------------------------------------------
+# (verify e) transport error is a fail-soft string, not a crash
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_error_returned_as_tool_error_not_crash():
+    bridge = _FakeBridge()
+    bridge.raise_on = "schedule_wake"
+    dispatch = build_dispatch(_cfg(bridge))
+    # Must NOT propagate — the tool returns a string the model can read.
+    result = await dispatch["schedule_wake"](after_seconds=60)
+    assert isinstance(result, str)
+    assert "schedule_wake failed" in result
+    assert "simulated transport failure" in result
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_transport_error_is_fail_soft():
+    bridge = _FakeBridge()
+    bridge.raise_on = "keepalive"
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["keep_alive"](600)
+    assert isinstance(result, str)
+    assert "keep_alive failed" in result
+
+
+# --------------------------------------------------------------------------
+# input validation (fail-soft strings, no exceptions)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_rejects_both_after_and_wake_at():
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](
+        after_seconds=60, wake_at="2026-07-07T12:00:00Z",
+    )
+    assert "exactly one" in result
+    # Nothing was sent to the bridge.
+    assert bridge.calls == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_wake_rejects_neither():
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"]()
+    assert "one of after_seconds" in result
+    assert bridge.calls == []

--- a/tests/test_lifecycle_tools.py
+++ b/tests/test_lifecycle_tools.py
@@ -330,3 +330,60 @@ async def test_schedule_wake_rejects_neither():
     result = await dispatch["schedule_wake"]()
     assert "one of after_seconds" in result
     assert bridge.calls == []
+
+
+# --------------------------------------------------------------------------
+# F7: after_seconds is coerced to int before the > 0 compare, so a raw
+# ws-local string value schedules cleanly instead of raising TypeError.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_coerces_string_after_seconds():
+    """A raw ws-local ``{"after_seconds": "600"}`` schedules without a
+    TypeError and forwards the coerced INT to the bridge."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds="600")
+    # Confirmed-wake string, no crash.
+    assert "wake scheduled for" in result
+    # Exactly one schedule_wake call, forwarding the coerced int 600.
+    sched = [args for name, args in bridge.calls if name == "schedule_wake"]
+    assert len(sched) == 1
+    assert sched[0]["after_seconds"] == 600
+    assert isinstance(sched[0]["after_seconds"], int)
+    assert sched[0]["wake_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_int_after_seconds_still_works():
+    """Regression: the ordinary int path is unchanged by the coercion."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds=600)
+    assert "wake scheduled for" in result
+    sched = [args for name, args in bridge.calls if name == "schedule_wake"]
+    assert sched and sched[0]["after_seconds"] == 600
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_non_numeric_after_seconds_clean_error():
+    """A non-numeric ``after_seconds`` returns a clean coercion-error
+    string (fail-soft) and never reaches the bridge."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds="abc")
+    assert isinstance(result, str)
+    assert "must be an integer number of seconds" in result
+    assert bridge.calls == []
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_string_zero_is_treated_as_unset():
+    """``"0"`` (and 0) coerce to the unset branch → the "pass one of"
+    guidance, not a spurious schedule."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds="0")
+    assert "one of after_seconds" in result
+    assert bridge.calls == []

--- a/tests/test_llm_base_url_routing.py
+++ b/tests/test_llm_base_url_routing.py
@@ -1,0 +1,197 @@
+"""LiteLLM VK LLM-plane routing (Item B): a config-driven
+``runtime.llm_base_url`` must thread into adapter/provider construction
+so cloud agents' model calls hit the virtual-key endpoint, while an
+absent/empty base URL leaves today's vendor-endpoint behavior unchanged.
+
+Covers the runtime kinds the cloud agent uses:
+  - chat-local: Anthropic + OpenAI provider ``client.base_url``
+  - cli-local:  the claude-code spawn-env override (``_llm_env``)
+  - sdk-local:  build_adapter threads ``base_url`` into SDKAdapter, and
+    the shared env helper maps it to ANTHROPIC_BASE_URL — asserted
+    without importing the optional ``claude-agent-sdk``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.base import anthropic_base_url_env
+from puffo_agent.portal.state import AgentConfig, DaemonConfig, RuntimeConfig
+from puffo_agent.portal.worker import build_adapter
+
+VK = "https://vk.shan.example/litellm"
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(tmp_path, monkeypatch):
+    """Keep every adapter/config path under a throwaway home so building
+    adapters never touches the real ~/.puffo-agent."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+
+
+def _daemon_cfg() -> DaemonConfig:
+    return DaemonConfig()
+
+
+# ── chat-local: provider client.base_url ────────────────────────────────
+
+
+def test_chat_local_anthropic_routes_through_vk():
+    cfg = AgentConfig(
+        id="chat-anth-vk",
+        runtime=RuntimeConfig(
+            kind="chat-local", provider="anthropic",
+            api_key="k", llm_base_url=VK,
+        ),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    # httpx normalizes with a trailing slash; compare on the stem.
+    assert base.rstrip("/") == VK.rstrip("/")
+
+
+def test_chat_local_anthropic_default_when_unset():
+    cfg = AgentConfig(
+        id="chat-anth-default",
+        runtime=RuntimeConfig(kind="chat-local", provider="anthropic", api_key="k"),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    # Vendor default, byte-for-byte as before — and definitely not the VK.
+    assert "anthropic.com" in base
+    assert "vk.shan.example" not in base
+
+
+def test_chat_local_openai_routes_through_vk():
+    cfg = AgentConfig(
+        id="chat-oai-vk",
+        runtime=RuntimeConfig(
+            kind="chat-local", provider="openai",
+            api_key="k", llm_base_url=VK,
+        ),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    assert base.rstrip("/") == VK.rstrip("/")
+
+
+def test_chat_local_openai_default_when_unset():
+    cfg = AgentConfig(
+        id="chat-oai-default",
+        runtime=RuntimeConfig(kind="chat-local", provider="openai", api_key="k"),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    assert "openai.com" in base
+    assert "vk.shan.example" not in base
+
+
+# ── cli-local: the claude-code spawn-env override ───────────────────────
+
+
+def test_cli_local_env_override_carries_base_url_when_set():
+    cfg = AgentConfig(
+        id="cli-vk",
+        runtime=RuntimeConfig(
+            kind="cli-local", api_key="vk-secret", llm_base_url=VK,
+        ),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    assert adapter.llm_base_url == VK
+    env = adapter._llm_env()
+    assert env["ANTHROPIC_BASE_URL"] == VK
+    # The VK rides on runtime.api_key so the CLI authenticates to it.
+    assert env["ANTHROPIC_API_KEY"] == "vk-secret"
+
+
+def test_cli_local_env_override_empty_when_unset():
+    cfg = AgentConfig(id="cli-default", runtime=RuntimeConfig(kind="cli-local"))
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    # Empty base URL -> no env override at all, so the spawn env is
+    # unchanged and claude keeps its ~/.claude / OAuth credential path.
+    assert adapter._llm_env() == {}
+
+
+def test_cli_local_no_api_key_injection_without_base_url():
+    """A stray runtime.api_key alone (no base URL) must NOT leak an
+    ANTHROPIC_API_KEY into the spawn env — that would silently override
+    the operator's OAuth login."""
+    cfg = AgentConfig(
+        id="cli-key-only",
+        runtime=RuntimeConfig(kind="cli-local", api_key="stray"),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    assert adapter._llm_env() == {}
+
+
+# ── sdk-local: wiring + shared env mapping (no claude-agent-sdk needed) ──
+
+
+def test_sdk_local_build_adapter_threads_base_url(monkeypatch):
+    """build_adapter must pass ``base_url`` into SDKAdapter. Stub the
+    adapter so this holds whether or not the optional SDK is installed."""
+    from puffo_agent.agent.adapters import sdk as sdk_mod
+
+    captured: dict = {}
+
+    class _StubSDKAdapter:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(sdk_mod, "SDKAdapter", _StubSDKAdapter)
+
+    cfg = AgentConfig(
+        id="sdk-vk",
+        runtime=RuntimeConfig(kind="sdk-local", api_key="k", llm_base_url=VK),
+    )
+    build_adapter(_daemon_cfg(), cfg)
+    assert captured.get("base_url") == VK
+
+
+def test_sdk_local_build_adapter_base_url_empty_when_unset(monkeypatch):
+    from puffo_agent.agent.adapters import sdk as sdk_mod
+
+    captured: dict = {}
+
+    class _StubSDKAdapter:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(sdk_mod, "SDKAdapter", _StubSDKAdapter)
+
+    cfg = AgentConfig(
+        id="sdk-default",
+        runtime=RuntimeConfig(kind="sdk-local", api_key="k"),
+    )
+    build_adapter(_daemon_cfg(), cfg)
+    # Empty threads through as "" -> SDKAdapter.run_turn injects nothing.
+    assert captured.get("base_url") == ""
+
+
+def test_shared_env_helper_maps_base_url():
+    """The SDK adapter's run_turn env and the cli adapter's _llm_env both
+    build on this helper; it must map a set base URL to ANTHROPIC_BASE_URL
+    and an empty one to no override."""
+    assert anthropic_base_url_env(VK) == {"ANTHROPIC_BASE_URL": VK}
+    assert anthropic_base_url_env("") == {}
+    assert anthropic_base_url_env(None) == {}  # type: ignore[arg-type]
+
+
+# ── config round-trip (RuntimeConfig.llm_base_url) ──────────────────────
+
+
+def test_runtime_config_llm_base_url_round_trips():
+    """agent.yml save/load preserves llm_base_url (it serializes via
+    asdict(runtime), so this guards the load-side parse)."""
+    cfg = AgentConfig(
+        id="rt-agent",
+        runtime=RuntimeConfig(kind="chat-local", api_key="k", llm_base_url=VK),
+    )
+    cfg.save()
+    reloaded = AgentConfig.load("rt-agent")
+    assert reloaded.runtime.llm_base_url == VK

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -1765,3 +1765,212 @@ async def test_resolve_rejects_unknown_level():
         await resolve_visibility("visible", "ch_x", "hi", "msg_root", http)
     with pytest.raises(RuntimeError):
         await resolve_visibility("", "ch_x", "hi", "msg_root", http)
+
+
+# ── F4 / F5: bridge-transport send preconditions ────────────────────
+#
+# F4: reply_to_id must be dropped when _validate_root_same_channel wipes
+#     the resolved root (no dangling parent ref).
+# F5: send_message_with_attachments must run EVERY precondition
+#     (destination resolve, root validate, all per-file size checks)
+#     before the first upload_blob, so a rejected route or an oversized
+#     later file raises with no orphaned blobs.
+
+
+class _RecordingBridge:
+    """Records ``send_send`` kwargs + blob uploads for the bridge-branch
+    tests. ``upload_blob`` mints a fresh blob_id per call and appends the
+    raw bytes to ``uploaded`` (empty ⇒ nothing was uploaded)."""
+
+    def __init__(self):
+        self.sent: list[dict] = []
+        self.uploaded: list[bytes] = []
+        self._seq = 0
+
+    async def upload_blob(self, data: bytes) -> dict:
+        self._seq += 1
+        self.uploaded.append(data)
+        return {"blob_id": f"blob_{self._seq:04d}", "size_bytes": len(data)}
+
+    async def send_send(self, *, plaintext, recipient_slug=None,
+                        space_id=None, channel_id=None, reply_to_id=None,
+                        thread_root_id=None, attachments=None,
+                        timeout: float = 30.0) -> dict:
+        self.sent.append({
+            "plaintext": plaintext, "recipient_slug": recipient_slug,
+            "space_id": space_id, "channel_id": channel_id,
+            "reply_to_id": reply_to_id, "thread_root_id": thread_root_id,
+            "attachments": attachments,
+        })
+        return {"type": "ack", "envelope_id": "msg_rec"}
+
+
+def _bridge_setup(bridge):
+    """A bridge-transport tools config reusing the native ``_setup``
+    keystore/http/store, plus ``bridge_client`` + a fresh ``workspace``
+    dir so the bridge branch of the send tools runs. Returns
+    ``(cfg, http, ms, workspace_dir)``."""
+    cfg, http, ms = _setup()
+    ws = tempfile.mkdtemp()
+    bcfg = PuffoCoreToolsConfig(
+        slug=cfg.slug,
+        device_id=cfg.device_id,
+        keystore=cfg.keystore,
+        http_client=http,
+        data_client=ms,
+        space_id=cfg.space_id,
+        workspace=ws,
+        bridge_client=bridge,
+    )
+    return bcfg, http, ms, ws
+
+
+def _write_ws_file(ws: str, name: str, data: bytes = b"x") -> str:
+    from pathlib import Path
+    (Path(ws) / name).write_bytes(data)
+    return name
+
+
+@pytest.mark.asyncio
+async def test_f4_bridge_reply_to_dropped_when_root_wiped():
+    """An unknown root_id gets wiped by _validate_root_same_channel; the
+    outbound send must carry NEITHER thread_root_id NOR reply_to_id (F4:
+    no dangling parent ref)."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, _ = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    mcp = _build_tools(cfg)
+
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "reply", "root_id": "msg_never_seen",
+    })
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["thread_root_id"] is None
+    assert sent["reply_to_id"] is None  # F4: dropped alongside the wiped root
+    assert "posted" in result
+
+
+@pytest.mark.asyncio
+async def test_f4_bridge_reply_to_kept_when_root_valid():
+    """A valid same-channel root is preserved: both thread_root_id and
+    reply_to_id ride the send."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, _ = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root post", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+    mcp = _build_tools(cfg)
+
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "reply", "root_id": "msg_root",
+    })
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["thread_root_id"] == "msg_root"
+    assert sent["reply_to_id"] == "msg_root"
+    assert "posted" in result
+
+
+@pytest.mark.asyncio
+async def test_f4_bridge_attachments_reply_to_dropped_when_root_wiped():
+    """The same F4 gate applies to the attachments send path."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+
+    await _call(mcp, "send_message_with_attachments", {
+        "paths": ["a.txt"], "channel": "ch_abc", "caption": "cap",
+        "root_id": "msg_never_seen",
+    })
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["thread_root_id"] is None
+    assert sent["reply_to_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_bare_at_dm_raises_before_upload():
+    """A bare ``@`` destination is rejected before any blob is uploaded."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+
+    with pytest.raises(Exception) as exc:
+        await _call(mcp, "send_message_with_attachments", {
+            "paths": ["a.txt"], "channel": "@", "caption": "x",
+        })
+    assert "DM recipient" in str(exc.value)
+    assert bridge.uploaded == []  # F5: no orphaned blobs
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_stale_channel_raises_before_upload():
+    """A stale/unknown ``ch_`` id (not in the cache) raises via
+    _resolve_channel_space before any upload."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+
+    with pytest.raises(Exception) as exc:
+        await _call(mcp, "send_message_with_attachments", {
+            "paths": ["a.txt"], "channel": "ch_stale", "caption": "x",
+        })
+    assert "no record of channel" in str(exc.value)
+    assert bridge.uploaded == []
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_oversized_later_file_orphans_nothing():
+    """An oversized SECOND file makes the whole send raise before ANY
+    upload — the earlier valid file must not be orphaned on the server."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "small.txt", b"small")
+    _write_ws_file(ws, "big.bin", b"x" * (8 * 1024 * 1024 + 1))
+    mcp = _build_tools(cfg)
+
+    with pytest.raises(Exception) as exc:
+        await _call(mcp, "send_message_with_attachments", {
+            "paths": ["small.txt", "big.bin"], "channel": "ch_abc",
+            "caption": "x",
+        })
+    assert "8 MiB" in str(exc.value)
+    assert bridge.uploaded == []  # F5: the earlier small file wasn't uploaded
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_happy_path_uploads_all_and_sends_once():
+    """The valid multi-file path uploads every file and issues exactly
+    one send carrying all refs."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "a.txt", b"aaa")
+    _write_ws_file(ws, "b.txt", b"bbbb")
+    mcp = _build_tools(cfg)
+
+    result = await _call(mcp, "send_message_with_attachments", {
+        "paths": ["a.txt", "b.txt"], "channel": "ch_abc", "caption": "hi",
+    })
+
+    assert bridge.uploaded == [b"aaa", b"bbbb"]
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["space_id"] == "sp_test"
+    assert sent["channel_id"] == "ch_abc"
+    assert [r["filename"] for r in sent["attachments"]] == ["a.txt", "b.txt"]
+    assert "uploaded 2 file" in result

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -121,6 +121,91 @@ def _setup():
     return cfg, http, ms
 
 
+class KeylessFakeHttpClient:
+    """Recording stub for the T23 keyless transport. ``keyless=True``
+    flips ``PuffoCoreToolsConfig.keyless`` so the tools take the unsigned
+    ``/v2/cloud-agents/*`` seam. Records every unsigned call and mints a
+    fresh blob_id per upload. The signed ``get``/``post``/``post_bytes``
+    methods are deliberately ABSENT so any accidental signed call fails
+    loud (proving keyless tools never hit the signed path)."""
+
+    def __init__(self, server_url: str = "http://sandbox.local"):
+        self.keyless = True
+        self.server_url = server_url
+        self.calls: list[tuple[str, str, object]] = []
+        self.responses: dict[str, dict] = {}
+        self.uploaded: list[bytes] = []
+        self._blob_seq = 0
+
+    def _match(self, path: str) -> dict:
+        if path in self.responses:
+            return self.responses[path]
+        base = path.split("?", 1)[0]
+        return self.responses.get(base, {})
+
+    async def get_unsigned(self, path):
+        self.calls.append(("GET_UNSIGNED", path, None))
+        return self._match(path)
+
+    async def post_unsigned(self, path, body=None):
+        self.calls.append(("POST_UNSIGNED", path, body))
+        if path in self.responses:
+            return self.responses[path]
+        return {"envelope_id": "msg_keyless"}
+
+    async def post_bytes_unsigned(self, path, body):
+        self._blob_seq += 1
+        self.uploaded.append(body)
+        self.calls.append(
+            ("POST_BYTES_UNSIGNED", path, len(body) if body else 0)
+        )
+        return {
+            "blob_id": f"blob_{self._blob_seq:04d}",
+            "size_bytes": len(body) if body else 0,
+        }
+
+
+class _SpyKeyStore:
+    """Records any keystore load so a keyless tool that accidentally
+    reaches the keystore is caught. Both loads raise, mirroring the
+    ``_BridgeNoKeysStore`` dead-end."""
+
+    def __init__(self):
+        self.loads: list[tuple[str, str]] = []
+
+    def load_identity(self, slug):
+        self.loads.append(("identity", slug))
+        raise AssertionError("keyless tool must not load identity")
+
+    def load_session(self, slug):
+        self.loads.append(("session", slug))
+        raise AssertionError("keyless tool must not load session")
+
+
+def _setup_keyless():
+    """Keyless tools config: recording keyless http client + a real
+    MessageStore, and NO keystore identity/session written to disk —
+    proving the keyless tools never touch the keystore."""
+    d = tempfile.mkdtemp()
+    ks = KeyStore(os.path.join(d, "keys"))
+    ms = MessageStore(os.path.join(d, "messages.db"))
+    http = KeylessFakeHttpClient()
+    cfg = PuffoCoreToolsConfig(
+        slug="agent-0001",
+        device_id="dev_test",
+        keystore=ks,
+        http_client=http,
+        data_client=ms,
+        space_id="sp_test",
+    )
+    return cfg, http, ms
+
+
+def _keyless_sends(http):
+    """The bodies of every keyless ``POST /v2/cloud-agents/messages``."""
+    return [b for m, p, b in http.calls if m == "POST_UNSIGNED"]
+
+
 def _build_tools(cfg):
     from mcp.server.fastmcp import FastMCP
     mcp = FastMCP("test")
@@ -1767,20 +1852,25 @@ async def test_resolve_rejects_unknown_level():
         await resolve_visibility("", "ch_x", "hi", "msg_root", http)
 
 
-# ── F4 / F5: bridge-transport send preconditions ────────────────────
+# ── F4 / F5: keyless-transport send preconditions ───────────────────
+#
+# Under the T23 keyless transport the two send tools POST plaintext to
+# ``/v2/cloud-agents/messages`` (blobs to ``/v2/cloud-agents/blobs/
+# upload``) instead of driving the bridge WS. F4/F5 semantics are
+# preserved on that HTTP seam:
 #
 # F4: reply_to_id must be dropped when _validate_root_same_channel wipes
 #     the resolved root (no dangling parent ref).
 # F5: send_message_with_attachments must run EVERY precondition
 #     (destination resolve, root validate, all per-file size checks)
-#     before the first upload_blob, so a rejected route or an oversized
+#     before the first blob upload, so a rejected route or an oversized
 #     later file raises with no orphaned blobs.
 
 
 class _RecordingBridge:
-    """Records ``send_send`` kwargs + blob uploads for the bridge-branch
-    tests. ``upload_blob`` mints a fresh blob_id per call and appends the
-    raw bytes to ``uploaded`` (empty ⇒ nothing was uploaded)."""
+    """A bridge stub used only to PROVE the keyless send path bypasses
+    the WS: if it's ever touched (``sent``/``uploaded`` non-empty) the
+    keyless branch wrongly fell back to the bridge."""
 
     def __init__(self):
         self.sent: list[dict] = []
@@ -1805,24 +1895,17 @@ class _RecordingBridge:
         return {"type": "ack", "envelope_id": "msg_rec"}
 
 
-def _bridge_setup(bridge):
-    """A bridge-transport tools config reusing the native ``_setup``
-    keystore/http/store, plus ``bridge_client`` + a fresh ``workspace``
-    dir so the bridge branch of the send tools runs. Returns
+def _keyless_ws_setup(bridge=None):
+    """A keyless tools config with a workspace dir so the send tools'
+    attachments path runs. An optional ``bridge`` is attached only to
+    prove the keyless branch never touches it. Returns
     ``(cfg, http, ms, workspace_dir)``."""
-    cfg, http, ms = _setup()
+    cfg, http, ms = _setup_keyless()
     ws = tempfile.mkdtemp()
-    bcfg = PuffoCoreToolsConfig(
-        slug=cfg.slug,
-        device_id=cfg.device_id,
-        keystore=cfg.keystore,
-        http_client=http,
-        data_client=ms,
-        space_id=cfg.space_id,
-        workspace=ws,
-        bridge_client=bridge,
-    )
-    return bcfg, http, ms, ws
+    cfg.workspace = ws
+    if bridge is not None:
+        cfg.bridge_client = bridge
+    return cfg, http, ms, ws
 
 
 def _write_ws_file(ws: str, name: str, data: bytes = b"x") -> str:
@@ -1832,12 +1915,11 @@ def _write_ws_file(ws: str, name: str, data: bytes = b"x") -> str:
 
 
 @pytest.mark.asyncio
-async def test_f4_bridge_reply_to_dropped_when_root_wiped():
+async def test_f4_keyless_reply_to_dropped_when_root_wiped():
     """An unknown root_id gets wiped by _validate_root_same_channel; the
-    outbound send must carry NEITHER thread_root_id NOR reply_to_id (F4:
-    no dangling parent ref)."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, _ = _bridge_setup(bridge)
+    keyless send body must carry NEITHER thread_root_id NOR reply_to_id
+    (F4: no dangling parent ref)."""
+    cfg, http, ms, _ = _keyless_ws_setup()
     await ms.mark_channel_space("ch_abc", "sp_test")
     mcp = _build_tools(cfg)
 
@@ -1845,19 +1927,19 @@ async def test_f4_bridge_reply_to_dropped_when_root_wiped():
         "channel": "ch_abc", "text": "reply", "root_id": "msg_never_seen",
     })
 
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["thread_root_id"] is None
-    assert sent["reply_to_id"] is None  # F4: dropped alongside the wiped root
+    sends = _keyless_sends(http)
+    assert len(sends) == 1
+    body = sends[0]
+    assert "thread_root_id" not in body
+    assert "reply_to_id" not in body  # F4: dropped alongside the wiped root
     assert "posted" in result
 
 
 @pytest.mark.asyncio
-async def test_f4_bridge_reply_to_kept_when_root_valid():
+async def test_f4_keyless_reply_to_kept_when_root_valid():
     """A valid same-channel root is preserved: both thread_root_id and
-    reply_to_id ride the send."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, _ = _bridge_setup(bridge)
+    reply_to_id ride the keyless send body."""
+    cfg, http, ms, _ = _keyless_ws_setup()
     await ms.mark_channel_space("ch_abc", "sp_test")
     await ms.store({
         "envelope_id": "msg_root", "envelope_kind": "channel",
@@ -1872,18 +1954,16 @@ async def test_f4_bridge_reply_to_kept_when_root_valid():
         "channel": "ch_abc", "text": "reply", "root_id": "msg_root",
     })
 
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["thread_root_id"] == "msg_root"
-    assert sent["reply_to_id"] == "msg_root"
+    body = _keyless_sends(http)[0]
+    assert body["thread_root_id"] == "msg_root"
+    assert body["reply_to_id"] == "msg_root"
     assert "posted" in result
 
 
 @pytest.mark.asyncio
-async def test_f4_bridge_attachments_reply_to_dropped_when_root_wiped():
-    """The same F4 gate applies to the attachments send path."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, ws = _bridge_setup(bridge)
+async def test_f4_keyless_attachments_reply_to_dropped_when_root_wiped():
+    """The same F4 gate applies to the keyless attachments send path."""
+    cfg, http, ms, ws = _keyless_ws_setup()
     await ms.mark_channel_space("ch_abc", "sp_test")
     _write_ws_file(ws, "a.txt", b"aaa")
     mcp = _build_tools(cfg)
@@ -1893,17 +1973,15 @@ async def test_f4_bridge_attachments_reply_to_dropped_when_root_wiped():
         "root_id": "msg_never_seen",
     })
 
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["thread_root_id"] is None
-    assert sent["reply_to_id"] is None
+    body = _keyless_sends(http)[0]
+    assert "thread_root_id" not in body
+    assert "reply_to_id" not in body
 
 
 @pytest.mark.asyncio
-async def test_f5_attachments_bare_at_dm_raises_before_upload():
+async def test_f5_keyless_attachments_bare_at_dm_raises_before_upload():
     """A bare ``@`` destination is rejected before any blob is uploaded."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, ws = _bridge_setup(bridge)
+    cfg, http, ms, ws = _keyless_ws_setup()
     _write_ws_file(ws, "a.txt", b"aaa")
     mcp = _build_tools(cfg)
 
@@ -1912,15 +1990,14 @@ async def test_f5_attachments_bare_at_dm_raises_before_upload():
             "paths": ["a.txt"], "channel": "@", "caption": "x",
         })
     assert "DM recipient" in str(exc.value)
-    assert bridge.uploaded == []  # F5: no orphaned blobs
+    assert http.uploaded == []  # F5: no orphaned blobs
 
 
 @pytest.mark.asyncio
-async def test_f5_attachments_stale_channel_raises_before_upload():
+async def test_f5_keyless_attachments_stale_channel_raises_before_upload():
     """A stale/unknown ``ch_`` id (not in the cache) raises via
     _resolve_channel_space before any upload."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, ws = _bridge_setup(bridge)
+    cfg, http, ms, ws = _keyless_ws_setup()
     _write_ws_file(ws, "a.txt", b"aaa")
     mcp = _build_tools(cfg)
 
@@ -1929,15 +2006,15 @@ async def test_f5_attachments_stale_channel_raises_before_upload():
             "paths": ["a.txt"], "channel": "ch_stale", "caption": "x",
         })
     assert "no record of channel" in str(exc.value)
-    assert bridge.uploaded == []
+    assert http.uploaded == []
+    await ms.close()
 
 
 @pytest.mark.asyncio
-async def test_f5_attachments_oversized_later_file_orphans_nothing():
+async def test_f5_keyless_attachments_oversized_later_file_orphans_nothing():
     """An oversized SECOND file makes the whole send raise before ANY
     upload — the earlier valid file must not be orphaned on the server."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, ws = _bridge_setup(bridge)
+    cfg, http, ms, ws = _keyless_ws_setup()
     await ms.mark_channel_space("ch_abc", "sp_test")
     _write_ws_file(ws, "small.txt", b"small")
     _write_ws_file(ws, "big.bin", b"x" * (8 * 1024 * 1024 + 1))
@@ -1949,15 +2026,16 @@ async def test_f5_attachments_oversized_later_file_orphans_nothing():
             "caption": "x",
         })
     assert "8 MiB" in str(exc.value)
-    assert bridge.uploaded == []  # F5: the earlier small file wasn't uploaded
+    assert http.uploaded == []  # F5: the earlier small file wasn't uploaded
+    await ms.close()
 
 
 @pytest.mark.asyncio
-async def test_f5_attachments_happy_path_uploads_all_and_sends_once():
-    """The valid multi-file path uploads every file and issues exactly
-    one send carrying all refs."""
-    bridge = _RecordingBridge()
-    cfg, http, ms, ws = _bridge_setup(bridge)
+async def test_f5_keyless_attachments_happy_path_uploads_all_and_sends_once():
+    """The valid multi-file keyless path uploads every file via
+    ``post_bytes_unsigned`` then issues exactly one
+    ``post_unsigned`` carrying all blob refs."""
+    cfg, http, ms, ws = _keyless_ws_setup()
     await ms.mark_channel_space("ch_abc", "sp_test")
     _write_ws_file(ws, "a.txt", b"aaa")
     _write_ws_file(ws, "b.txt", b"bbbb")
@@ -1967,10 +2045,285 @@ async def test_f5_attachments_happy_path_uploads_all_and_sends_once():
         "paths": ["a.txt", "b.txt"], "channel": "ch_abc", "caption": "hi",
     })
 
-    assert bridge.uploaded == [b"aaa", b"bbbb"]
-    assert len(bridge.sent) == 1
-    sent = bridge.sent[0]
-    assert sent["space_id"] == "sp_test"
-    assert sent["channel_id"] == "ch_abc"
-    assert [r["filename"] for r in sent["attachments"]] == ["a.txt", "b.txt"]
+    # Two unsigned blob uploads, in order, then one unsigned message send.
+    upload_paths = [p for m, p, _ in http.calls if m == "POST_BYTES_UNSIGNED"]
+    assert upload_paths == [
+        "/v2/cloud-agents/blobs/upload", "/v2/cloud-agents/blobs/upload",
+    ]
+    assert http.uploaded == [b"aaa", b"bbbb"]
+    sends = _keyless_sends(http)
+    assert len(sends) == 1
+    body = sends[0]
+    assert body["space_id"] == "sp_test"
+    assert body["channel_id"] == "ch_abc"
+    assert body["plaintext"] == "hi"
+    assert [r["filename"] for r in body["attachments"]] == ["a.txt", "b.txt"]
+    assert [r["blob_id"] for r in body["attachments"]] == ["blob_0001", "blob_0002"]
     assert "uploaded 2 file" in result
+
+
+# ── keyless reads → /v2/cloud-agents/* (unsigned) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_keyless_list_spaces_hits_cloud_agents_route():
+    cfg, http, ms = _setup_keyless()
+    http.responses["/v2/cloud-agents/spaces"] = {
+        "spaces": [{"space_id": "sp_team", "name": "Team"}],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_spaces")
+    assert "sp_team" in result and "Team" in result
+    assert ("GET_UNSIGNED", "/v2/cloud-agents/spaces", None) in http.calls
+
+
+@pytest.mark.asyncio
+async def test_keyless_list_channels_in_space_hits_cloud_agents_route():
+    cfg, http, ms = _setup_keyless()
+    http.responses["/v2/cloud-agents/spaces/sp_target/channels"] = {
+        "channels": [{"channel_id": "ch_g", "name": "general"}],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels_in_space", {"space_id": "sp_target"})
+    assert "ch_g" in result and "general" in result
+    assert (
+        "GET_UNSIGNED", "/v2/cloud-agents/spaces/sp_target/channels", None,
+    ) in http.calls
+
+
+@pytest.mark.asyncio
+async def test_keyless_list_channels_in_all_spaces_hits_cloud_agents_routes():
+    cfg, http, ms = _setup_keyless()
+    http.responses["/v2/cloud-agents/spaces"] = {
+        "spaces": [{"space_id": "sp_a", "name": "A"}],
+    }
+    http.responses["/v2/cloud-agents/spaces/sp_a/channels"] = {
+        "channels": [{"channel_id": "ch_x", "name": "general"}],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channels_in_all_spaces")
+    assert "sp_a" in result and "ch_x" in result
+    assert ("GET_UNSIGNED", "/v2/cloud-agents/spaces", None) in http.calls
+    assert (
+        "GET_UNSIGNED", "/v2/cloud-agents/spaces/sp_a/channels", None,
+    ) in http.calls
+
+
+@pytest.mark.asyncio
+async def test_keyless_list_channel_members_degrades_to_space_roster():
+    """No keyless channel-members route exists; the keyless tool reads
+    the space roster ``/v2/cloud-agents/spaces/<sp>/members`` after
+    resolving channel→space from the cache."""
+    cfg, http, ms = _setup_keyless()
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    http.responses["/v2/cloud-agents/spaces/sp_test/members"] = {
+        "members": [
+            {"slug": "alice-0001", "role": "owner"},
+            {"slug": "agent-0001", "role": "member"},
+        ],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "list_channel_members", {"channel": "ch_abc"})
+    assert "alice-0001" in result and "(owner)" in result
+    assert "agent-0001" in result and "(member)" in result
+    assert (
+        "GET_UNSIGNED", "/v2/cloud-agents/spaces/sp_test/members", None,
+    ) in http.calls
+    # NEVER the native channel-scoped route.
+    assert not any("channels/ch_abc/members" in p for _, p, _ in http.calls)
+
+
+@pytest.mark.asyncio
+async def test_keyless_get_user_info_hits_cloud_agents_route():
+    cfg, http, ms = _setup_keyless()
+    http.responses["/v2/cloud-agents/identities/profiles?slugs=alice-0001"] = {
+        "profiles": [{
+            "slug": "alice-0001", "display_name": "Alice", "bio": "A user",
+        }],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "get_user_info", {"username": "@alice-0001"})
+    assert "alice-0001" in result and "Alice" in result and "A user" in result
+    assert (
+        "GET_UNSIGNED",
+        "/v2/cloud-agents/identities/profiles?slugs=alice-0001",
+        None,
+    ) in http.calls
+
+
+# ── keyless whoami: no keystore ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_keyless_whoami_needs_no_keystore():
+    """Keyless whoami builds identity from cfg + resolves display_name
+    over the unsigned profiles route, never loading the keystore."""
+    cfg, http, ms = _setup_keyless()
+    spy = _SpyKeyStore()
+    cfg.keystore = spy
+    http.responses["/v2/cloud-agents/identities/profiles?slugs=agent-0001"] = {
+        "profiles": [{"slug": "agent-0001", "display_name": "Cloud Bot"}],
+    }
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "whoami")
+    assert "Cloud Bot" in result
+    assert "agent-0001" in result
+    assert "dev_test" in result
+    assert "sandbox.local" in result          # from http_client.server_url
+    assert "managed server-side" in result    # keyless subkey line
+    assert spy.loads == []                     # keystore never touched
+
+
+# ── keyless send_message: unsigned POST, no bridge ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_message_dm_posts_unsigned():
+    cfg, http, ms = _setup_keyless()
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "@alice-0001", "text": "hi there",
+    })
+    assert "posted" in result
+    sends = [(p, b) for m, p, b in http.calls if m == "POST_UNSIGNED"]
+    assert len(sends) == 1
+    path, body = sends[0]
+    assert path == "/v2/cloud-agents/messages"
+    assert body == {"plaintext": "hi there", "recipient_slug": "alice-0001"}
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_message_channel_posts_unsigned():
+    cfg, http, ms = _setup_keyless()
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "hello channel",
+    })
+    assert "posted" in result
+    sends = [(p, b) for m, p, b in http.calls if m == "POST_UNSIGNED"]
+    assert len(sends) == 1
+    path, body = sends[0]
+    assert path == "/v2/cloud-agents/messages"
+    assert body == {
+        "plaintext": "hello channel",
+        "space_id": "sp_test",
+        "channel_id": "ch_abc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_message_channel_threaded_carries_ids():
+    cfg, http, ms = _setup_keyless()
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root", "sent_at": _now_ms(), "thread_root_id": None,
+    })
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "reply", "root_id": "msg_root",
+    })
+    assert "posted" in result
+    body = _keyless_sends(http)[0]
+    assert body["space_id"] == "sp_test"
+    assert body["channel_id"] == "ch_abc"
+    assert body["thread_root_id"] == "msg_root"
+    assert body["reply_to_id"] == "msg_root"
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_message_returns_ack_envelope_id():
+    cfg, http, ms = _setup_keyless()
+    http.responses["/v2/cloud-agents/messages"] = {"envelope_id": "msg_ack99"}
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "@alice-0001", "text": "hi",
+    })
+    assert "msg_ack99" in result
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_message_bypasses_bridge():
+    """A bridge is present but the keyless branch must POST over HTTP and
+    make ZERO bridge send_send calls."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, _ = _keyless_ws_setup(bridge)
+    mcp = _build_tools(cfg)
+    await _call(mcp, "send_message", {"channel": "@bob-0001", "text": "yo"})
+    assert bridge.sent == []
+    assert bridge.uploaded == []
+    assert _keyless_sends(http) == [
+        {"plaintext": "yo", "recipient_slug": "bob-0001"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_keyless_attachments_bypasses_bridge():
+    """Keyless attachments upload via post_bytes_unsigned and never touch
+    the bridge's upload_blob/send_send."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _keyless_ws_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+    await _call(mcp, "send_message_with_attachments", {
+        "paths": ["a.txt"], "channel": "ch_abc", "caption": "cap",
+    })
+    assert bridge.sent == []
+    assert bridge.uploaded == []
+    assert http.uploaded == [b"aaa"]
+    assert len(_keyless_sends(http)) == 1
+
+
+# ── build_server(transport="bridge") is keyless-self-sufficient ─────
+
+
+def test_build_server_bridge_transport_is_keyless(tmp_path, monkeypatch):
+    """The subprocess server built with ``transport="bridge"`` gives its
+    ``PuffoCoreHttpClient`` ``keyless=True`` and keeps ``bridge_client``
+    None (outbound is HTTP, not WS)."""
+    import puffo_agent.mcp.puffo_core_server as pcs
+
+    captured = {}
+    real = pcs.PuffoCoreHttpClient
+
+    def spy(server_url, ks, slug, keyless=False):
+        client = real(server_url, ks, slug, keyless=keyless)
+        captured["client"] = client
+        return client
+
+    monkeypatch.setattr(pcs, "PuffoCoreHttpClient", spy)
+    server = pcs.build_server(
+        slug="bot-0001", device_id="dev_test", server_url="http://127.0.0.1:1",
+        space_id="", keystore_dir="", workspace=str(tmp_path),
+        agent_id="bot-0001", data_service_url="http://127.0.0.1:1",
+        transport="bridge",
+    )
+    from mcp.server.fastmcp import FastMCP
+    assert isinstance(server, FastMCP)
+    assert captured["client"].keyless is True
+
+
+def test_build_server_native_transport_is_not_keyless(tmp_path, monkeypatch):
+    """A non-bridge build keeps the signed path — ``keyless`` is False."""
+    import puffo_agent.mcp.puffo_core_server as pcs
+
+    captured = {}
+    real = pcs.PuffoCoreHttpClient
+
+    def spy(server_url, ks, slug, keyless=False):
+        client = real(server_url, ks, slug, keyless=keyless)
+        captured["client"] = client
+        return client
+
+    monkeypatch.setattr(pcs, "PuffoCoreHttpClient", spy)
+    pcs.build_server(
+        slug="bot-0001", device_id="dev_test", server_url="http://127.0.0.1:1",
+        space_id="", keystore_dir=str(tmp_path / "keys"),
+        workspace=str(tmp_path), agent_id="bot-0001",
+        data_service_url="http://127.0.0.1:1",
+    )
+    assert captured["client"].keyless is False

--- a/tests/test_slim_packaging_headless.py
+++ b/tests/test_slim_packaging_headless.py
@@ -1,0 +1,93 @@
+"""Slim-packaging guard (Item A): the daemon / CLI path must import and
+run with PySide6 absent, and a GUI command without the ``[gui]`` extra
+must fail with the actionable install hint — not a raw traceback.
+
+Deterministic in any environment: we block ``PySide6`` (and its
+submodules) via ``sys.modules[...] = None`` regardless of whether the
+extra happens to be installed, so this asserts the real headless
+contract rather than "the test box didn't have Qt".
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+
+import pytest
+
+
+# Every PySide6 entry point the UI modules reach for. Mapping a name to
+# ``None`` in sys.modules makes ``import <name>`` raise ImportError even
+# when the package is installed — the standard "pretend it's missing"
+# trick.
+_PYSIDE_NAMES = [
+    "PySide6",
+    "PySide6.QtCore",
+    "PySide6.QtGui",
+    "PySide6.QtWidgets",
+]
+
+
+@pytest.fixture
+def pyside6_blocked(monkeypatch):
+    """Block PySide6 and drop cached puffo_agent modules that could hold
+    a live reference, so imports re-run under the block."""
+    for name in _PYSIDE_NAMES:
+        monkeypatch.setitem(sys.modules, name, None)
+    # Drop cached daemon/cli/ui modules so the assertions below exercise
+    # a fresh import under the block rather than a warm module object.
+    for name in list(sys.modules):
+        if name == "puffo_agent.portal.daemon" or name == "puffo_agent.portal.cli":
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        elif name.startswith("puffo_agent.portal.ui"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    yield
+
+
+def test_pyside6_is_actually_blocked(pyside6_blocked):
+    """Sanity: the fixture makes ``import PySide6`` raise, so the two
+    assertions below mean what they say."""
+    with pytest.raises(ImportError):
+        import PySide6  # noqa: F401
+
+
+def test_daemon_and_cli_import_without_pyside6(pyside6_blocked):
+    """The headless daemon path (`puffo-agent start` -> run_daemon) and
+    the CLI module must import cleanly with Qt absent."""
+    daemon = importlib.import_module("puffo_agent.portal.daemon")
+    cli = importlib.import_module("puffo_agent.portal.cli")
+    # run_daemon is the headless entry point cmd_start dispatches to.
+    assert hasattr(daemon, "run_daemon")
+    assert hasattr(cli, "cmd_start")
+
+
+def test_gui_command_without_extra_yields_actionable_hint(
+    pyside6_blocked, capsys,
+):
+    """`start --ui` with PySide6 absent returns non-zero and prints the
+    `pip install 'puffo-agent[gui]'` hint instead of ModuleNotFoundError."""
+    cli = importlib.import_module("puffo_agent.portal.cli")
+    args = argparse.Namespace(
+        ui=True, tray_runner=False, background=False, with_local_bridge=False,
+    )
+    rc = cli.cmd_start(args)
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "puffo-agent[gui]" in combined
+
+
+def test_tray_command_without_extra_yields_actionable_hint(
+    pyside6_blocked, capsys,
+):
+    """Same guard for the `start --tray-runner` entry point."""
+    cli = importlib.import_module("puffo_agent.portal.cli")
+    args = argparse.Namespace(
+        ui=False, tray_runner=True, background=False, with_local_bridge=False,
+    )
+    rc = cli.cmd_start(args)
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "puffo-agent[gui]" in combined

--- a/tests/test_ui_mcp_scanner.py
+++ b/tests/test_ui_mcp_scanner.py
@@ -11,6 +11,11 @@ import textwrap
 
 import pytest
 
+# ``_scan_mcp_servers`` lives in ``widgets/agent_detail`` which imports
+# PySide6 at module level; PySide6 now ships only in the ``[gui]`` extra.
+# Skip this file when the extra isn't installed rather than failing.
+pytest.importorskip("PySide6")
+
 
 @pytest.fixture(autouse=True)
 def _qt_offscreen(monkeypatch):

--- a/tests/test_ui_views.py
+++ b/tests/test_ui_views.py
@@ -9,6 +9,11 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 
+# PySide6 now ships only in the ``[gui]`` extra (the base install is
+# Qt-free for headless/cloud daemons). Skip the Qt view tests when the
+# extra isn't installed rather than erroring out collection.
+pytest.importorskip("PySide6")
+
 from PySide6.QtWidgets import QApplication
 
 from puffo_agent.portal.ui.widgets.log_view import LogView

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -39,6 +39,12 @@ def test_allowed_tools_are_the_send_read_and_membership_tools():
         # membership
         "leave_space",
         "leave_channel",
+        # bridge-only sandbox lifecycle
+        "schedule_wake",
+        "cancel_wake",
+        "get_scheduled_wake",
+        "get_runtime_status",
+        "keep_alive",
     })
 
 


### PR DESCRIPTION
## One PR to review the whole fat cloud agent

This is the **consolidated** agent-side view of the fat-cloud pivot — the fat `puffo-agent` runs as the cloud agent with its transport swapped from client-held-key crypto to the **keyless `x-sandbox-token` bridge** (server holds all crypto). `native` (desktop) transport is untouched throughout. All 5 commits in order:

| Commit | What | Granular PR |
|---|---|---|
| `030a196` | **T23 phase-1** — opt-in keyless bridge transport foundation (`CloudBridgeClient`, `puffo_core.transport: "bridge"`) | #127 |
| `2f39084` | **phase-2** — message flow over the bridge: drop `encrypt/decrypt` at the 2 seam points, plaintext send/recv + backfill | #136 |
| `df73bee` | **threads + name-enrich** — thread-id wiring (forward-compat) + keyless name enrichment (degrade + `PHASE25-SERVER-ROUTE-GAPS.md`) | #137 |
| `327c7ea` | **attachments** — agent-side send/receive over the keyless blob routes | #139 |
| `e271187` | **self-lifecycle MCP** — `schedule_wake` / `get_runtime_status` / `keep_alive` tools (bridge-gated; `keep_alive`→`schedule_wake` fallback) | #141 |

**Diff:** +4308 / −250 across 19 files. LLM-free + E2B-free pytest throughout (each phase asserts **native transport unchanged**). Also locally proven end-to-end: the fat image `docker run` connected the keyless bridge against a local server (**GREEN**, puffo-server #181).

### Companion server-side PRs (puffo-server — the bridge/routes this agent talks to)
- #182 keyless **attachment** bridge frame + storage → #183 keyless **enrichment** (inbound Message display/thread fields + 4 `x-sandbox-token` read routes)
- #184 keyless **schedule-wake** (self-timer) · #185 **runtime-status + keepalive** proxy (AIM-stubbed; `LIFECYCLE-AIM-CONTRACT.md` = Shan's part)
- #181 fat local-docker keyless-bridge **E2E** (GREEN)

### Notes
- Supersedes the granular chain #127→#136→#137→#139→#141 for **review convenience** — those remain open (close them or this one after review, your call).
- `sense-sleep` + `keep_alive` actually affect the E2B sandbox only once Shan lands the AIM contract (keepalive RPC + `timeout_at`); until then they degrade gracefully (schedule-wake fallback / "unknown" deadline).

**HOLD — do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)