### PR TITLE
fat-cloud: address Codex review findings (P1 ack + P2s)

### DIFF
--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -81,37 +81,46 @@ class CloudBridgeClient:
             timeout=aiohttp.ClientTimeout(total=None),
         )
         headers = {"x-sandbox-token": self._token}
+        # F2: guard the whole handshake so EVERY failure path closes the
+        # half-open session/ws — the handshake error, a connector/OS error
+        # or TimeoutError from ws_connect/receive, and each bad-frame
+        # BridgeError. self.close() null-checks _ws/_session, so a pre-
+        # ws_connect failure (session only) still closes cleanly and
+        # leaves self._session is None.
         try:
-            self._ws = await self._session.ws_connect(
-                self._url, headers=headers, heartbeat=None,
-            )
-        except aiohttp.WSServerHandshakeError as exc:
-            await self._session.close()
-            self._session = None
-            raise BridgeError(
-                "HANDSHAKE",
-                f"WS upgrade failed (status={exc.status}): {exc.message}",
-            ) from exc
-        # Wait for the first frame — must be 'connected'.
-        first = await self._ws.receive(timeout=10.0)
-        if first.type != aiohttp.WSMsgType.TEXT:
+            try:
+                self._ws = await self._session.ws_connect(
+                    self._url, headers=headers, heartbeat=None,
+                )
+            except aiohttp.WSServerHandshakeError as exc:
+                raise BridgeError(
+                    "HANDSHAKE",
+                    f"WS upgrade failed (status={exc.status}): {exc.message}",
+                ) from exc
+            # Wait for the first frame — must be 'connected'.
+            first = await self._ws.receive(timeout=10.0)
+            if first.type != aiohttp.WSMsgType.TEXT:
+                raise BridgeError(
+                    "HANDSHAKE",
+                    f"expected text 'connected', got {first.type!r}",
+                )
+            try:
+                frame = json.loads(first.data)
+            except json.JSONDecodeError as exc:
+                raise BridgeError(
+                    "HANDSHAKE", f"bad first frame: {exc}",
+                ) from exc
+            if frame.get("type") != "connected":
+                raise BridgeError(
+                    "HANDSHAKE",
+                    f"expected 'connected', got {frame.get('type')!r}",
+                )
+        except BaseException:
             await self.close()
-            raise BridgeError(
-                "HANDSHAKE",
-                f"expected text 'connected', got {first.type!r}",
-            )
-        try:
-            frame = json.loads(first.data)
-        except json.JSONDecodeError as exc:
-            await self.close()
-            raise BridgeError("HANDSHAKE", f"bad first frame: {exc}") from exc
-        if frame.get("type") != "connected":
-            await self.close()
-            raise BridgeError(
-                "HANDSHAKE",
-                f"expected 'connected', got {frame.get('type')!r}",
-            )
+            raise
         logger.info("cloud bridge: WS connected (slug=%s)", self._slug)
+        # Start the heartbeat only after a clean handshake so no failure
+        # path leaves a live heartbeat task behind.
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
     async def frames(self) -> AsyncIterator[dict]:
@@ -490,6 +499,25 @@ class CloudBridgeClient:
             frame["limit"] = limit
         await ws.send_json(frame)
 
+    def _discard_waiter(
+        self, queue: "asyncio.Queue", fut: "asyncio.Future",
+    ) -> None:
+        """Remove ``fut`` from a FIFO waiter queue in place (F3).
+
+        Sync (no awaits) so it can't interleave with ``frames()`` popping
+        the same queue. Drains the queue, keeps every waiter that isn't
+        ``fut``, and re-enqueues them in order — so a timed-out waiter is
+        pulled out and the next real ``ack_result`` / ``spaces`` frame
+        isn't mis-delivered to a dead future.
+        """
+        remaining = []
+        while not queue.empty():
+            item = queue.get_nowait()
+            if item is not fut:
+                remaining.append(item)
+        for item in remaining:
+            queue.put_nowait(item)
+
     async def send_ack(
         self, envelope_ids: list[str], *, timeout: float = 30.0,
     ) -> dict:
@@ -497,14 +525,22 @@ class CloudBridgeClient:
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         await self._ack_result_waiters.put(fut)
         await ws.send_json({"type": "ack", "envelope_ids": envelope_ids})
-        return await asyncio.wait_for(fut, timeout=timeout)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._discard_waiter(self._ack_result_waiters, fut)
+            raise
 
     async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
         ws = await self._require_ws()
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         await self._spaces_waiters.put(fut)
         await ws.send_json({"type": "list_spaces"})
-        return await asyncio.wait_for(fut, timeout=timeout)
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._discard_waiter(self._spaces_waiters, fut)
+            raise
 
     async def close(self) -> None:
         if self._heartbeat_task is not None:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -494,6 +494,11 @@ class PuffoCoreMessageClient:
         # non-None, listen() runs the bridge lifecycle loop instead of
         # the signed WS client — no identity file is ever loaded.
         self._bridge = bridge_client
+        # In-flight ack tasks scheduled off the bridge dispatch loop
+        # (F1). Held so the tasks aren't GC'd mid-flight; each removes
+        # itself via a done-callback. Native transport never populates
+        # this — the ack lives only in the bridge dispatcher.
+        self._ack_tasks: set[asyncio.Task] = set()
         # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
         # "reply to whoever just DMed me". Single-slot is fine since
         # the worker handles one envelope at a time; concurrent DM
@@ -821,6 +826,17 @@ class PuffoCoreMessageClient:
                     # path is untouched.
                     self._preseed_frame_display_name(frame, payload)
                     await self._handle_plaintext_payload(payload)
+                    # F1: ack the delivered envelope now that it handled
+                    # cleanly. A handling exception above skips this (still
+                    # inside the try), so the server redelivers. Scheduled
+                    # async — awaiting send_ack inline would deadlock the
+                    # frames() loop, which must keep receiving to deliver the
+                    # server's ack_result that resolves send_ack's future.
+                    task = asyncio.create_task(
+                        self._ack_bridge_envelope([payload.envelope_id])
+                    )
+                    self._ack_tasks.add(task)
+                    task.add_done_callback(self._ack_tasks.discard)
             except Exception:
                 self._log.exception(
                     "bridge message frame handling failed (envelope_id=%s)",
@@ -838,6 +854,25 @@ class PuffoCoreMessageClient:
             )
         else:
             self._log.debug("bridge frame ignored: type=%s", kind)
+
+    async def _ack_bridge_envelope(self, envelope_ids: list[str]) -> None:
+        """Fail-soft ack of handled bridge envelopes (F1).
+
+        A failed ack must never crash the listen loop — the server
+        redelivers unacked envelopes, so a lost ack is at worst a
+        redelivery, not a dropped message. Native transport never calls
+        this (no ``_bridge``).
+        """
+        bridge = self._bridge
+        if bridge is None or not envelope_ids:
+            return
+        try:
+            await bridge.send_ack(envelope_ids)
+        except Exception:  # noqa: BLE001 — a failed ack must not crash the loop
+            self._log.warning(
+                "bridge ack failed (envelope_ids=%s)",
+                envelope_ids, exc_info=True,
+            )
 
     def _preseed_frame_display_name(
         self, frame: dict, payload: MessagePayload,
@@ -3840,8 +3875,15 @@ class PuffoCoreMessageClient:
                 # already logged; skip without failing the turn.
                 continue
             # Sanitise filename to block ``../`` / absolute-path
-            # write-outside-inbox via a malicious sender.
-            safe_name = Path(str(raw.get("filename") or "")).name or blob_id
+            # write-outside-inbox via a malicious sender. The blob_id
+            # fallback is basename-reduced too — a blob_id carrying path
+            # separators must not escape the inbox — and a final literal
+            # guarantees a non-empty name.
+            safe_name = (
+                Path(str(raw.get("filename") or "")).name
+                or Path(str(blob_id)).name
+                or "attachment"
+            )
             target = inbox / safe_name
             try:
                 target.write_bytes(data)

--- a/src/puffo_agent/mcp/lifecycle_tools.py
+++ b/src/puffo_agent/mcp/lifecycle_tools.py
@@ -54,7 +54,21 @@ def register_lifecycle_tools(mcp: FastMCP, cfg: Any) -> None:
         """
         if cfg.bridge_client is None:
             return "schedule_wake is only available to cloud (bridge) agents."
-        has_after = bool(after_seconds) and after_seconds > 0
+        # F7: a raw ws-local dispatch can hand us after_seconds as a string
+        # (e.g. {"after_seconds": "600"}). Coerce to int before the > 0
+        # compare — mirrors keep_alive — so a stringy value schedules
+        # cleanly instead of raising TypeError deeper in the compare.
+        if after_seconds in (None, "", 0, "0"):
+            after_val = 0
+        else:
+            try:
+                after_val = int(after_seconds)
+            except (TypeError, ValueError):
+                return (
+                    "schedule_wake: after_seconds must be an integer "
+                    "number of seconds."
+                )
+        has_after = after_val > 0
         has_at = bool(wake_at and wake_at.strip())
         if has_after and has_at:
             return (
@@ -68,7 +82,7 @@ def register_lifecycle_tools(mcp: FastMCP, cfg: Any) -> None:
             )
         try:
             result = await cfg.bridge_client.schedule_wake(
-                after_seconds=int(after_seconds) if has_after else None,
+                after_seconds=after_val if has_after else None,
                 wake_at=wake_at.strip() if has_at else None,
                 reason=reason,
             )

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -478,7 +478,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     plaintext=text,
                     recipient_slug=bridge_recipient,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    # F4: drop the raw parent ref when root validation wiped
+                    # the thread — no dangling reply_to for a root the send
+                    # no longer threads under.
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             else:
                 bridge_channel_id = channel_ref
@@ -497,7 +500,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     space_id=bridge_space_id,
                     channel_id=bridge_channel_id,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    # F4: drop the raw parent ref when root validation wiped
+                    # the thread (see the DM branch above).
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             return (
                 f"posted {(ack or {}).get('envelope_id', '?')} to {channel}"
@@ -1091,18 +1096,55 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # signed ``/messages`` POST — a bridge agent has no
             # signed-crypto seam. DM vs channel routing + fail-soft
             # thread resolution mirror ``send_message``'s bridge branch.
+            #
+            # F5: run EVERY precondition — destination resolve/validate,
+            # root resolve/validate, and all per-file size checks — BEFORE
+            # the first ``upload_blob``, so a rejected route or an oversized
+            # Nth file raises with no orphaned blobs left on the server.
             channel_ref = channel.strip()
             if channel_ref.startswith("#"):
                 raise RuntimeError(
                     "'#<name>' channel addressing isn't supported; pass "
                     "the channel id directly."
                 )
-            refs: list[dict] = []
+
+            # (1) Resolve + validate the destination first. A bare ``@`` or
+            # a stale ``ch_`` (``_resolve_channel_space`` raises) fails here,
+            # before any upload.
+            is_dm = channel_ref.startswith("@")
+            bridge_recipient = ""
+            bridge_channel_id = ""
+            bridge_space_id = None
+            if is_dm:
+                bridge_recipient = channel_ref[1:]
+                if not bridge_recipient:
+                    raise RuntimeError(
+                        "DM recipient slug is required after '@'"
+                    )
+            else:
+                bridge_channel_id = channel_ref
+                bridge_space_id = await _resolve_channel_space(
+                    cfg, bridge_channel_id,
+                )
+
+            # (2) Resolve + validate the thread root before uploads.
+            resolved_root, root_note = await _resolve_root_id(
+                root_id, cfg.data_client,
+            )
+            resolved_root, validate_note = await _validate_root_same_channel(
+                resolved_root,
+                None if is_dm else bridge_channel_id,
+                None if is_dm else bridge_space_id,
+                cfg.data_client,
+            )
+
+            # (3) Read every file + run the 8 MiB check for ALL files
+            # before uploading any — a later oversized file must not orphan
+            # earlier blobs.
+            prepared: list[tuple[Any, bytes, str]] = []
             total_bytes = 0
             for target in targets:
                 plaintext = target.read_bytes()
-                # Keep the native 8 MiB pre-check so an oversized file
-                # fails before we burn an upload round-trip.
                 if len(plaintext) > 8 * 1024 * 1024:
                     raise RuntimeError(
                         f"send_message_with_attachments: {target.name!r} is "
@@ -1110,6 +1152,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     )
                 mime_type, _ = mimetypes.guess_type(target.name)
                 mime_type = mime_type or "application/octet-stream"
+                prepared.append((target, plaintext, mime_type))
+                total_bytes += len(plaintext)
+
+            # (4) Only now upload each blob → build refs.
+            refs: list[dict] = []
+            for target, plaintext, mime_type in prepared:
                 up = await cfg.bridge_client.upload_blob(plaintext)
                 blob_id = up.get("blob_id") if isinstance(up, dict) else None
                 if not blob_id:
@@ -1123,46 +1171,25 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     "mime_type": mime_type,
                     "size_bytes": len(plaintext),
                 })
-                total_bytes += len(plaintext)
 
-            if channel_ref.startswith("@"):
-                bridge_recipient = channel_ref[1:]
-                if not bridge_recipient:
-                    raise RuntimeError(
-                        "DM recipient slug is required after '@'"
-                    )
-                resolved_root, root_note = await _resolve_root_id(
-                    root_id, cfg.data_client,
-                )
-                resolved_root, validate_note = await _validate_root_same_channel(
-                    resolved_root, None, None, cfg.data_client,
-                )
+            # (5) One send using the pre-resolved route + the F4 reply_to
+            # gate (drop the raw parent when root validation wiped it).
+            if is_dm:
                 ack = await cfg.bridge_client.send_send(
                     plaintext=caption,
                     recipient_slug=bridge_recipient,
                     attachments=refs,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             else:
-                bridge_channel_id = channel_ref
-                bridge_space_id = await _resolve_channel_space(
-                    cfg, bridge_channel_id,
-                )
-                resolved_root, root_note = await _resolve_root_id(
-                    root_id, cfg.data_client,
-                )
-                resolved_root, validate_note = await _validate_root_same_channel(
-                    resolved_root, bridge_channel_id, bridge_space_id,
-                    cfg.data_client,
-                )
                 ack = await cfg.bridge_client.send_send(
                     plaintext=caption,
                     space_id=bridge_space_id,
                     channel_id=bridge_channel_id,
                     attachments=refs,
                     thread_root_id=resolved_root or None,
-                    reply_to_id=root_id or None,
+                    reply_to_id=(root_id or None) if resolved_root else None,
                 )
             names = ", ".join(t.name for t in targets)
             thread_note = f" in thread {resolved_root}" if resolved_root else ""

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from types import SimpleNamespace
 
+import aiohttp
 import pytest
 from aiohttp import WSMsgType, web
 from aiohttp.test_utils import TestClient, TestServer
@@ -250,3 +252,183 @@ async def test_send_after_close_raises_bridge_closed():
         await c.close()
         with pytest.raises(BridgeClosed):
             await c.send_send(plaintext="hi", recipient_slug="alice")
+
+
+# --------------------------------------------------------------------------
+# F2: connect() closes the ClientSession on EVERY failed-connect path.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f2_connect_closes_session_when_ws_connect_raises(monkeypatch):
+    """A connector/OS error from ``ws_connect`` must not leak the session
+    — connect() closes it and leaves ``_session is None``."""
+    captured: dict = {}
+
+    async def _boom_ws_connect(self, *a, **k):
+        captured["session"] = self  # the bound ClientSession
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(aiohttp.ClientSession, "ws_connect", _boom_ws_connect)
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+
+    with pytest.raises(OSError):
+        await c.connect()
+
+    assert c._session is None, "failed connect leaked the ClientSession"
+    assert captured["session"].closed is True, "session was not closed"
+    assert c._ws is None
+    assert c._heartbeat_task is None, "no heartbeat should survive a failed connect"
+
+
+@pytest.mark.asyncio
+async def test_f2_connect_closes_session_when_first_receive_times_out(monkeypatch):
+    """A ``TimeoutError`` waiting for the first frame closes both the ws
+    and the session — no leak past the handshake."""
+    captured: dict = {}
+
+    class _BoomWs:
+        def __init__(self):
+            self.closed = False
+
+        async def receive(self, timeout=None):
+            raise asyncio.TimeoutError()
+
+        async def close(self):
+            self.closed = True
+
+    boom_ws = _BoomWs()
+
+    async def _ws_connect_then_timeout(self, *a, **k):
+        captured["session"] = self
+        return boom_ws
+
+    monkeypatch.setattr(
+        aiohttp.ClientSession, "ws_connect", _ws_connect_then_timeout,
+    )
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+
+    with pytest.raises(asyncio.TimeoutError):
+        await c.connect()
+
+    assert c._session is None
+    assert captured["session"].closed is True
+    assert boom_ws.closed is True, "the half-open ws was not closed"
+    assert c._ws is None
+
+
+@pytest.mark.asyncio
+async def test_f2_bad_handshake_frame_still_closes_session():
+    """The pre-existing bad-first-frame path also closes the session
+    (regression guard for the F2 rework)."""
+    bridge_app = _MockBridgeApp()
+    bridge_app.first_frame = {"type": "definitely-not-connected"}
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        with pytest.raises(BridgeError) as excinfo:
+            await c.connect()
+    assert excinfo.value.code == "HANDSHAKE"
+    assert c._session is None, "bad-handshake path leaked the session"
+    assert c._ws is None
+
+
+# --------------------------------------------------------------------------
+# F3: a timed-out send_ack / send_list_spaces waiter is pulled from its
+# FIFO so the next real ack_result / spaces frame resolves the next call.
+# --------------------------------------------------------------------------
+
+
+class _ScriptedWs:
+    """A minimal ws that ``frames()`` can iterate: fed TEXT frames arrive
+    via ``feed``; ``send_json`` records outbound frames. Blocks on an
+    empty inbox like a live socket."""
+
+    def __init__(self):
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def send_json(self, frame):
+        self.sent.append(frame)
+
+    def feed(self, frame: dict) -> None:
+        self._inbox.put_nowait(
+            SimpleNamespace(type=WSMsgType.TEXT, data=json.dumps(frame)),
+        )
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._inbox.get()
+
+    async def close(self):
+        self.closed = True
+
+
+async def _client_with_scripted_ws() -> tuple[CloudBridgeClient, _ScriptedWs]:
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+    ws = _ScriptedWs()
+    c._ws = ws  # _require_ws returns it (not None, not closed)
+    return c, ws
+
+
+@pytest.mark.asyncio
+async def test_f3_send_ack_timeout_discards_waiter_then_next_resolves():
+    c, ws = await _client_with_scripted_ws()
+    consumer = asyncio.create_task(_drain(c))  # routes ack_result → waiters
+    try:
+        # 1) No ack_result fed → this ack times out.
+        with pytest.raises(asyncio.TimeoutError):
+            await c.send_ack(["e1"], timeout=0.05)
+        # The dead waiter was pulled out of the FIFO.
+        assert c._ack_result_waiters.empty()
+
+        # 2) The NEXT ack must be resolved by the next ack_result — proving
+        # the dead waiter isn't eating it.
+        async def _deliver():
+            while c._ack_result_waiters.empty():
+                await asyncio.sleep(0)
+            ws.feed({"type": "ack_result", "acked": ["e2"]})
+
+        res, _ = await asyncio.gather(
+            c.send_ack(["e2"], timeout=2.0), _deliver(),
+        )
+        assert res["type"] == "ack_result"
+        assert res["acked"] == ["e2"]
+        assert c._ack_result_waiters.empty()
+    finally:
+        consumer.cancel()
+        try:
+            await consumer
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_f3_send_list_spaces_timeout_discards_waiter_then_next_resolves():
+    c, ws = await _client_with_scripted_ws()
+    consumer = asyncio.create_task(_drain(c))
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await c.send_list_spaces(timeout=0.05)
+        assert c._spaces_waiters.empty()
+
+        async def _deliver():
+            while c._spaces_waiters.empty():
+                await asyncio.sleep(0)
+            ws.feed({"type": "spaces", "spaces": [{"id": "sp_1"}]})
+
+        res, _ = await asyncio.gather(
+            c.send_list_spaces(timeout=2.0), _deliver(),
+        )
+        assert res["type"] == "spaces"
+        assert res["spaces"] == [{"id": "sp_1"}]
+        assert c._spaces_waiters.empty()
+    finally:
+        consumer.cancel()
+        try:
+            await consumer
+        except (asyncio.CancelledError, Exception):
+            pass

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -79,6 +79,9 @@ class FakeBridge:
             "client_ref": "r_test",
         }
         self.sent: list[dict] = []
+        # F1: every send_ack call records its envelope_ids, so a test can
+        # assert exactly one ack per handled bridge message.
+        self.acked: list[list[str]] = []
         self.connect_count = 0
         self.fetch_pending_count = 0
         self.close_count = 0
@@ -106,6 +109,12 @@ class FakeBridge:
     async def download_blob(self, blob_id: str):
         self.downloaded.append(blob_id)
         return self._blobs.get(blob_id)
+
+    async def send_ack(
+        self, envelope_ids, *, timeout: float = 30.0,
+    ) -> dict:
+        self.acked.append(list(envelope_ids))
+        return {"type": "ack_result", "acked": list(envelope_ids)}
 
     async def send_send(
         self, *, plaintext, recipient_slug=None, space_id=None,
@@ -1293,6 +1302,203 @@ async def test_e_native_attachments_still_encrypt_and_signed_http(
         m == "POST" and p == "/messages" for m, p, _ in http.calls
     ), f"native must POST the envelope; calls={http.calls}"
     assert "uploaded 1 file" in result
+
+
+# --------------------------------------------------------------------------
+# (F1) handled bridge messages are acked exactly once; the shared tail
+#      (native's whole inbound path) never acks.
+# --------------------------------------------------------------------------
+
+
+async def _open_dispatch_client(tmp_path, bridge, *, db):
+    """A bridge client with the minimal per-listen() state so
+    ``_dispatch_bridge_frame`` / ``_handle_plaintext_payload`` can run
+    without spinning up the full listen loop (mirrors the reference-path
+    setup in test (a))."""
+    client = _bridge_client(tmp_path, bridge, db=db)
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    await client.store.open()
+    return client
+
+
+def _bridge_message_frame(env_id: str) -> dict:
+    return {
+        "type": "message", "envelope_id": env_id,
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_004_000, "plaintext": "ack me",
+    }
+
+
+@pytest.mark.asyncio
+async def test_f1_handled_bridge_message_acked_exactly_once(tmp_path):
+    """A handled inbound ``message`` frame schedules exactly one
+    ``send_ack([envelope_id])`` off the dispatcher — the ack is async
+    (never awaited inline, which would deadlock ``frames()``)."""
+    ENV_ID = "env_ack_once"
+    bridge = FakeBridge()
+    client = await _open_dispatch_client(tmp_path, bridge, db="ack_once.db")
+
+    await client._dispatch_bridge_frame(_bridge_message_frame(ENV_ID))
+    # The ack is scheduled, not awaited inline: exactly one task is
+    # in-flight right after dispatch returns.
+    assert len(client._ack_tasks) == 1
+    # Let the scheduled ack task run to completion.
+    await asyncio.gather(*client._ack_tasks)
+
+    assert bridge.acked == [[ENV_ID]]
+    # The done-callback cleaned the task set up afterwards.
+    assert client._ack_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_f1_ack_over_full_listen_loop(tmp_path):
+    """End-to-end over ``_listen_bridge``: a live frame surfaces AND gets
+    acked exactly once (proves the ack fires on the real loop, not just a
+    direct dispatch call)."""
+    ENV_ID = "env_ack_live"
+    bridge = FakeBridge(scripted=[_bridge_message_frame(ENV_ID)])
+    client = _bridge_client(tmp_path, bridge, db="ack_live.db")
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+    # Drain any ack task still in flight after the loop was cancelled.
+    if client._ack_tasks:
+        await asyncio.gather(*client._ack_tasks, return_exceptions=True)
+
+    assert bridge.acked == [[ENV_ID]]
+
+
+@pytest.mark.asyncio
+async def test_f1_failing_message_handling_skips_ack(tmp_path):
+    """A frame whose handling raises is NOT acked — the ack sits inside
+    the handling ``try`` after a clean ``_handle_plaintext_payload``, so a
+    raise skips it and the server redelivers."""
+    ENV_ID = "env_ack_fail"
+    bridge = FakeBridge()
+    client = await _open_dispatch_client(tmp_path, bridge, db="ack_fail.db")
+
+    async def _boom(payload):
+        raise RuntimeError("handling blew up")
+
+    client._handle_plaintext_payload = _boom  # type: ignore[method-assign]
+
+    # _dispatch_bridge_frame swallows the handling exception (logs it).
+    await client._dispatch_bridge_frame(_bridge_message_frame(ENV_ID))
+    await asyncio.sleep(0)
+
+    assert client._ack_tasks == set()
+    assert bridge.acked == []
+
+
+@pytest.mark.asyncio
+async def test_f1_shared_tail_does_not_ack_native_untouched(tmp_path):
+    """The ack lives ONLY in ``_dispatch_bridge_frame``. The shared
+    ``_handle_plaintext_payload`` tail — the entirety of native's inbound
+    path — issues no ack. Proven with a bridge PRESENT: even then,
+    driving the tail directly acks nothing."""
+    bridge = FakeBridge()
+    client = await _open_dispatch_client(tmp_path, bridge, db="tail_noack.db")
+
+    payload = MessagePayload(
+        payload_type="puffo.message", version=1,
+        envelope_id="env_tail", envelope_kind="channel",
+        sender_slug="alice-0001", sender_subkey_id="", sent_at=1,
+        message_nonce="", content_type="text/plain", content="hi",
+        is_visible_to_human=True, space_id="sp_1", channel_id="ch_a",
+    )
+    await client._handle_plaintext_payload(payload)
+    await asyncio.sleep(0)
+
+    assert client._ack_tasks == set()
+    assert bridge.acked == []
+
+
+@pytest.mark.asyncio
+async def test_f1_native_config_client_never_acks(tmp_path):
+    """A genuinely native client (``bridge_client=None``) has no bridge to
+    ack against and never schedules an ack task when its inbound tail
+    runs."""
+    ks = _native_keystore(tmp_path)
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, "bot-0001")
+    store = MessageStore(str(tmp_path / "native_noack.db"))
+    client = PuffoCoreMessageClient(
+        slug="bot-0001", device_id="dev_test", space_id="sp_home",
+        keystore=ks, http_client=http, message_store=store,
+    )  # no bridge → native
+    assert client._bridge is None
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    await client.store.open()
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+
+    payload = MessagePayload(
+        payload_type="puffo.message", version=1,
+        envelope_id="env_native_tail", envelope_kind="channel",
+        sender_slug="alice-0001", sender_subkey_id="", sent_at=1,
+        message_nonce="", content_type="text/plain", content="hi",
+        is_visible_to_human=True, space_id="sp_1", channel_id="ch_a",
+    )
+    await client._handle_plaintext_payload(payload)
+    await asyncio.sleep(0)
+
+    assert client._ack_tasks == set()
+
+
+# --------------------------------------------------------------------------
+# (F6) the inbound bridge blob_id filename fallback is basename-sanitised
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f6_blob_id_fallback_sanitised_stays_in_inbox(tmp_path):
+    """A ref with NO filename and a ``blob_id`` carrying path separators
+    (``../escape``) is written by its basename INSIDE the inbox dir, never
+    a level above it."""
+    DATA = b"escape-attempt-bytes"
+    frame = {
+        "type": "message", "envelope_id": "env_f6",
+        "sender_slug": "alice-0001", "envelope_kind": "channel",
+        "space_id": "sp_1", "channel_id": "ch_a",
+        "sent_at": 1_700_000_005_000, "plaintext": "see attached",
+        # No filename → fallback to the (malicious) blob_id.
+        "attachments": [{"blob_id": "../escape"}],
+    }
+    bridge = FakeBridge(scripted=[frame], blobs={"../escape": DATA})
+    client = _bridge_client(
+        tmp_path, bridge, db="f6.db", workspace=str(tmp_path),
+    )
+    surfaced: list = []
+    done = asyncio.Event()
+
+    async def on_message(root_id, batch, channel_meta):
+        surfaced.append(batch)
+        done.set()
+
+    await _drive_listen_until(client, on_message=on_message, done=done)
+
+    inbox = (tmp_path / ".puffo" / "inbox" / "env_f6").resolve()
+    saved = inbox / "escape"
+    assert saved.is_file(), "sanitised file must land inside the inbox dir"
+    assert saved.read_bytes() == DATA
+    # The written path resolves inside the inbox — no ../ escape.
+    assert str(saved.resolve()).startswith(str(inbox))
+    # The pre-fix bug would have written one level up (a sibling of the
+    # envelope dir); assert that escaped location does NOT exist.
+    assert not (tmp_path / ".puffo" / "inbox" / "escape").exists()
+    # Surfaced attachment path points at the sanitised in-inbox file.
+    msg = [m for m in surfaced[0] if m["envelope_id"] == "env_f6"][0]
+    assert str(saved) in msg["attachments"]
 
 
 def test_message_payload_to_dict_omits_attachments():

--- a/tests/test_lifecycle_tools.py
+++ b/tests/test_lifecycle_tools.py
@@ -330,3 +330,60 @@ async def test_schedule_wake_rejects_neither():
     result = await dispatch["schedule_wake"]()
     assert "one of after_seconds" in result
     assert bridge.calls == []
+
+
+# --------------------------------------------------------------------------
+# F7: after_seconds is coerced to int before the > 0 compare, so a raw
+# ws-local string value schedules cleanly instead of raising TypeError.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_coerces_string_after_seconds():
+    """A raw ws-local ``{"after_seconds": "600"}`` schedules without a
+    TypeError and forwards the coerced INT to the bridge."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds="600")
+    # Confirmed-wake string, no crash.
+    assert "wake scheduled for" in result
+    # Exactly one schedule_wake call, forwarding the coerced int 600.
+    sched = [args for name, args in bridge.calls if name == "schedule_wake"]
+    assert len(sched) == 1
+    assert sched[0]["after_seconds"] == 600
+    assert isinstance(sched[0]["after_seconds"], int)
+    assert sched[0]["wake_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_int_after_seconds_still_works():
+    """Regression: the ordinary int path is unchanged by the coercion."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds=600)
+    assert "wake scheduled for" in result
+    sched = [args for name, args in bridge.calls if name == "schedule_wake"]
+    assert sched and sched[0]["after_seconds"] == 600
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_non_numeric_after_seconds_clean_error():
+    """A non-numeric ``after_seconds`` returns a clean coercion-error
+    string (fail-soft) and never reaches the bridge."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds="abc")
+    assert isinstance(result, str)
+    assert "must be an integer number of seconds" in result
+    assert bridge.calls == []
+
+
+@pytest.mark.asyncio
+async def test_f7_schedule_wake_string_zero_is_treated_as_unset():
+    """``"0"`` (and 0) coerce to the unset branch → the "pass one of"
+    guidance, not a spurious schedule."""
+    bridge = _FakeBridge()
+    dispatch = build_dispatch(_cfg(bridge))
+    result = await dispatch["schedule_wake"](after_seconds="0")
+    assert "one of after_seconds" in result
+    assert bridge.calls == []

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -1765,3 +1765,212 @@ async def test_resolve_rejects_unknown_level():
         await resolve_visibility("visible", "ch_x", "hi", "msg_root", http)
     with pytest.raises(RuntimeError):
         await resolve_visibility("", "ch_x", "hi", "msg_root", http)
+
+
+# ── F4 / F5: bridge-transport send preconditions ────────────────────
+#
+# F4: reply_to_id must be dropped when _validate_root_same_channel wipes
+#     the resolved root (no dangling parent ref).
+# F5: send_message_with_attachments must run EVERY precondition
+#     (destination resolve, root validate, all per-file size checks)
+#     before the first upload_blob, so a rejected route or an oversized
+#     later file raises with no orphaned blobs.
+
+
+class _RecordingBridge:
+    """Records ``send_send`` kwargs + blob uploads for the bridge-branch
+    tests. ``upload_blob`` mints a fresh blob_id per call and appends the
+    raw bytes to ``uploaded`` (empty ⇒ nothing was uploaded)."""
+
+    def __init__(self):
+        self.sent: list[dict] = []
+        self.uploaded: list[bytes] = []
+        self._seq = 0
+
+    async def upload_blob(self, data: bytes) -> dict:
+        self._seq += 1
+        self.uploaded.append(data)
+        return {"blob_id": f"blob_{self._seq:04d}", "size_bytes": len(data)}
+
+    async def send_send(self, *, plaintext, recipient_slug=None,
+                        space_id=None, channel_id=None, reply_to_id=None,
+                        thread_root_id=None, attachments=None,
+                        timeout: float = 30.0) -> dict:
+        self.sent.append({
+            "plaintext": plaintext, "recipient_slug": recipient_slug,
+            "space_id": space_id, "channel_id": channel_id,
+            "reply_to_id": reply_to_id, "thread_root_id": thread_root_id,
+            "attachments": attachments,
+        })
+        return {"type": "ack", "envelope_id": "msg_rec"}
+
+
+def _bridge_setup(bridge):
+    """A bridge-transport tools config reusing the native ``_setup``
+    keystore/http/store, plus ``bridge_client`` + a fresh ``workspace``
+    dir so the bridge branch of the send tools runs. Returns
+    ``(cfg, http, ms, workspace_dir)``."""
+    cfg, http, ms = _setup()
+    ws = tempfile.mkdtemp()
+    bcfg = PuffoCoreToolsConfig(
+        slug=cfg.slug,
+        device_id=cfg.device_id,
+        keystore=cfg.keystore,
+        http_client=http,
+        data_client=ms,
+        space_id=cfg.space_id,
+        workspace=ws,
+        bridge_client=bridge,
+    )
+    return bcfg, http, ms, ws
+
+
+def _write_ws_file(ws: str, name: str, data: bytes = b"x") -> str:
+    from pathlib import Path
+    (Path(ws) / name).write_bytes(data)
+    return name
+
+
+@pytest.mark.asyncio
+async def test_f4_bridge_reply_to_dropped_when_root_wiped():
+    """An unknown root_id gets wiped by _validate_root_same_channel; the
+    outbound send must carry NEITHER thread_root_id NOR reply_to_id (F4:
+    no dangling parent ref)."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, _ = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    mcp = _build_tools(cfg)
+
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "reply", "root_id": "msg_never_seen",
+    })
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["thread_root_id"] is None
+    assert sent["reply_to_id"] is None  # F4: dropped alongside the wiped root
+    assert "posted" in result
+
+
+@pytest.mark.asyncio
+async def test_f4_bridge_reply_to_kept_when_root_valid():
+    """A valid same-channel root is preserved: both thread_root_id and
+    reply_to_id ride the send."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, _ = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    await ms.store({
+        "envelope_id": "msg_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root post", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+    mcp = _build_tools(cfg)
+
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc", "text": "reply", "root_id": "msg_root",
+    })
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["thread_root_id"] == "msg_root"
+    assert sent["reply_to_id"] == "msg_root"
+    assert "posted" in result
+
+
+@pytest.mark.asyncio
+async def test_f4_bridge_attachments_reply_to_dropped_when_root_wiped():
+    """The same F4 gate applies to the attachments send path."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+
+    await _call(mcp, "send_message_with_attachments", {
+        "paths": ["a.txt"], "channel": "ch_abc", "caption": "cap",
+        "root_id": "msg_never_seen",
+    })
+
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["thread_root_id"] is None
+    assert sent["reply_to_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_bare_at_dm_raises_before_upload():
+    """A bare ``@`` destination is rejected before any blob is uploaded."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+
+    with pytest.raises(Exception) as exc:
+        await _call(mcp, "send_message_with_attachments", {
+            "paths": ["a.txt"], "channel": "@", "caption": "x",
+        })
+    assert "DM recipient" in str(exc.value)
+    assert bridge.uploaded == []  # F5: no orphaned blobs
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_stale_channel_raises_before_upload():
+    """A stale/unknown ``ch_`` id (not in the cache) raises via
+    _resolve_channel_space before any upload."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    _write_ws_file(ws, "a.txt", b"aaa")
+    mcp = _build_tools(cfg)
+
+    with pytest.raises(Exception) as exc:
+        await _call(mcp, "send_message_with_attachments", {
+            "paths": ["a.txt"], "channel": "ch_stale", "caption": "x",
+        })
+    assert "no record of channel" in str(exc.value)
+    assert bridge.uploaded == []
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_oversized_later_file_orphans_nothing():
+    """An oversized SECOND file makes the whole send raise before ANY
+    upload — the earlier valid file must not be orphaned on the server."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "small.txt", b"small")
+    _write_ws_file(ws, "big.bin", b"x" * (8 * 1024 * 1024 + 1))
+    mcp = _build_tools(cfg)
+
+    with pytest.raises(Exception) as exc:
+        await _call(mcp, "send_message_with_attachments", {
+            "paths": ["small.txt", "big.bin"], "channel": "ch_abc",
+            "caption": "x",
+        })
+    assert "8 MiB" in str(exc.value)
+    assert bridge.uploaded == []  # F5: the earlier small file wasn't uploaded
+
+
+@pytest.mark.asyncio
+async def test_f5_attachments_happy_path_uploads_all_and_sends_once():
+    """The valid multi-file path uploads every file and issues exactly
+    one send carrying all refs."""
+    bridge = _RecordingBridge()
+    cfg, http, ms, ws = _bridge_setup(bridge)
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    _write_ws_file(ws, "a.txt", b"aaa")
+    _write_ws_file(ws, "b.txt", b"bbbb")
+    mcp = _build_tools(cfg)
+
+    result = await _call(mcp, "send_message_with_attachments", {
+        "paths": ["a.txt", "b.txt"], "channel": "ch_abc", "caption": "hi",
+    })
+
+    assert bridge.uploaded == [b"aaa", b"bbbb"]
+    assert len(bridge.sent) == 1
+    sent = bridge.sent[0]
+    assert sent["space_id"] == "sp_test"
+    assert sent["channel_id"] == "ch_abc"
+    assert [r["filename"] for r in sent["attachments"]] == ["a.txt", "b.txt"]
+    assert "uploaded 2 file" in result


### PR DESCRIPTION
## What (stacks on #141)

Addresses the automated **Codex** review findings across the fat-cloud agent stack. `native` transport unchanged; each fix has a test.

- **[P1] Ack bridge messages** — a handled inbound bridge `message` (live + `FetchPending` backfill) now sends `CloudBridgeClient.send_ack(envelope_ids)` async → the server's pending queue drains, reconnects don't redeliver.
- **[P2]** close `ClientSession` on all failed bridge connects (no leak) · drop timed-out FIFO ack waiters (no mis-delivery) · clear `reply_to_id` when root validation wipes `thread_root_id` · validate all bridge send inputs **before** uploading blobs (no orphaned plaintext blobs) · sanitize the `blob_id` filename fallback (no path escape) · coerce `after_seconds` before comparing (ws-local raw-JSON string param safe).

## Verify
LLM-free + E2B-free pytest; each finding has a test; native transport asserted unchanged.

**Stacked on `fleet/cloud-agent-lifecycle-mcp` (#141). HOLD.** The consolidated agent PR **#142** will be re-pointed to include these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)