### PR TITLE
fat-cloud: slim cloud packaging (GUI→[gui] extra) + LiteLLM VK LLM plane

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,19 @@ dependencies = [
     "pyhpke>=0.6",
     "openai>=1.30",
     "psutil>=5.9",
-    "pyside6>=6.7",
     "python-socks>=2.4",
     "pyyaml>=6.0",
     "websockets>=12.0",
 ]
 
 [project.optional-dependencies]
+# pip install puffo-agent[gui]  — the PySide6 desktop UI (window + tray).
+# Kept out of the base install so `pip install puffo-agent` stays Qt-free
+# for headless/cloud daemons; `start`/`run_daemon` never import PySide6.
+# The `start --ui` / `start --tray` entry points fail with an actionable
+# "install puffo-agent[gui]" hint (see portal/cli.py cmd_start) when the
+# extra is absent.
+gui = ["pyside6>=6.7"]
 # pip install puffo-agent[sdk]  — needed for agents with runtime.kind=sdk
 sdk = ["claude-agent-sdk>=0.1.61"]
 # cli-local / cli-docker adapters don't need extra Python deps; they

--- a/roadmap/cloud-agent/FAT-E2B-INTEGRATION.md
+++ b/roadmap/cloud-agent/FAT-E2B-INTEGRATION.md
@@ -1,0 +1,115 @@
+# FAT `puffo-agent` → E2B cloud drop-in
+
+Notes for making the FAT `puffo-agent` a clean drop-in for the thin
+`puffo-agent-cloud` in the E2B/cloud image. Two independent changes
+landed here: **slim packaging** (so `pip install puffo-agent` is Qt-free)
+and a **config-driven LLM base URL** (so cloud agents' model calls route
+through Shan's LiteLLM virtual-key endpoint instead of the vendor
+default). Neither changes native/desktop behavior when the new config is
+absent.
+
+---
+
+## 1. Slim packaging — base install is Qt-free
+
+`pip install puffo-agent` no longer pulls **PySide6** (Qt). The only
+GUI-only dependency was `pyside6`; it moved out of `[project].dependencies`
+into a new `[project.optional-dependencies] gui` extra:
+
+```toml
+[project.optional-dependencies]
+gui = ["pyside6>=6.7"]
+```
+
+Consequences for the cloud image:
+
+- **Base install runs headless.** `puffo-agent start` (→ `run_daemon`),
+  `puffo-agent --help`, and `import puffo_agent.portal.daemon` all import
+  and run with PySide6 **absent**. Every `import PySide6` in the source
+  lives under `src/puffo_agent/portal/ui/`, and those modules are only
+  reached from the UI entry points — never from the daemon path.
+- **Restore the desktop UI** with `pip install 'puffo-agent[gui]'`. Then
+  `start --ui` (desktop window) and `start --tray` (menu-bar) work as
+  before.
+- **GUI commands without the extra fail loud, not ugly.** `start --ui` /
+  `start --tray-runner` invoked without `[gui]` print an actionable hint
+  (`pip install 'puffo-agent[gui]'`) and exit non-zero, instead of a raw
+  `ModuleNotFoundError` traceback. See `portal/cli.py cmd_start`.
+
+The cloud/E2B image should install the **base** package (no `[gui]`), which
+is what keeps the image slim and Qt-free. The `sdk` extra
+(`claude-agent-sdk`) is still required for `runtime.kind=sdk-local`.
+
+> `requirements.txt` is a stale partial list that never listed pyside6 —
+> `pyproject.toml` is the source of truth for dependencies.
+
+---
+
+## 2. LLM plane — route model calls through the LiteLLM VK
+
+Cloud agents should send their model calls to Shan's LiteLLM **virtual
+key (VK)** endpoint (an OpenAI/Anthropic-compatible base URL) rather than
+`api.anthropic.com` / `api.openai.com`. This is driven entirely from the
+`runtime` block of each agent's `agent.yml` — **no hard-coded URLs and no
+embedded key** in the package.
+
+### Fields Shan's cloud bundle sets (per agent `agent.yml`)
+
+```yaml
+runtime:
+  kind: chat-local            # or sdk-local / cli-local
+  llm_base_url: "<VK endpoint>"   # e.g. the LiteLLM proxy base URL
+  api_key: "<VK>"                 # the virtual key (reuses the existing api_key field)
+  # ...model / provider / etc. as usual
+```
+
+- **`llm_base_url`** — new field. OpenAI/Anthropic-compatible base URL.
+  Empty/absent → the vendor endpoint, i.e. **today's behavior, byte-for-
+  byte unchanged**.
+- **`api_key`** — the existing field, reused to carry the VK secret. No
+  new secret field was introduced.
+
+### What consumes them, per `runtime.kind`
+
+| `runtime.kind`            | `llm_base_url` routing                                                                 | VK secret (`api_key`)                          |
+| ------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `chat-local` (anthropic)  | `AnthropicProvider(base_url=…)` → `anthropic.Anthropic(base_url=…)`                    | `api_key` → client key                         |
+| `chat-local` (openai)     | `OpenAIProvider(base_url=…)` → `OpenAI(base_url=…)`                                    | `api_key` → client key                         |
+| `sdk-local`               | `SDKAdapter(base_url=…)` injects `ANTHROPIC_BASE_URL` into the SDK subprocess env      | `api_key` → `ANTHROPIC_API_KEY` (already wired) |
+| `cli-local` / claude-code | `LocalCLIAdapter(llm_base_url=…)` injects `ANTHROPIC_BASE_URL` into the claude spawn env | `api_key` → `ANTHROPIC_API_KEY` (VK), injected **only** when `llm_base_url` is also set |
+
+Notes:
+
+- **`cli-local` with an empty `llm_base_url` injects nothing** into the
+  spawn env — claude keeps its `claude login` / OAuth credential path
+  (`~/.claude/.credentials.json`). Only when `llm_base_url` is set do we
+  add `ANTHROPIC_BASE_URL`, and only then (and when `api_key` is
+  non-empty) do we add `ANTHROPIC_API_KEY=<VK>` so the CLI authenticates
+  against the VK.
+- The env mapping is a single shared pure helper,
+  `puffo_agent.agent.adapters.base.anthropic_base_url_env(base_url)`,
+  reused by the SDK and CLI adapters so the behavior is DRY and unit-tested.
+
+### Follow-ups (out of scope for this change)
+
+- **`cli-docker`** base-URL routing — threading `ANTHROPIC_BASE_URL` (and
+  the VK) into the per-agent container env is not wired yet.
+- **codex / OpenAI-CLI** — routing the VK into codex's `OPENAI_BASE_URL`
+  is not wired yet.
+- **Provisioning / rotating the VK** is Shan's; this change only threads
+  the config-driven fields. No key is embedded, defaulted, or fetched by
+  the package.
+
+---
+
+## Verification snapshot
+
+- `pip install .` in a fresh venv → `import PySide6` raises
+  `ModuleNotFoundError`, while `import puffo_agent.portal.daemon` and
+  `puffo-agent --help` succeed. `pip install '.[gui]'` →
+  `import puffo_agent.portal.ui.launcher` succeeds.
+- `tests/test_slim_packaging_headless.py` — headless import + GUI-hint guard.
+- `tests/test_llm_base_url_routing.py` — VK routing for chat-local
+  (Anthropic + OpenAI), cli-local spawn-env override, sdk-local wiring +
+  the shared env helper; and that an absent base URL leaves the vendor
+  endpoint unchanged.

--- a/src/puffo_agent/agent/adapters/base.py
+++ b/src/puffo_agent/agent/adapters/base.py
@@ -31,6 +31,22 @@ def is_silent(text: str) -> bool:
     return SILENT_MARKER in text
 
 
+def anthropic_base_url_env(base_url: str) -> dict[str, str]:
+    """Map an Anthropic-compatible LLM base URL to the subprocess/SDK
+    env override that routes model calls through it.
+
+    Returns ``{"ANTHROPIC_BASE_URL": base_url}`` when ``base_url`` is a
+    non-empty string, else ``{}`` — so an absent/empty base URL leaves
+    the spawn env untouched (vendor endpoint, today's behavior). Shared
+    by the SDK adapter (``run_turn`` env) and the cli-local adapter
+    (``_llm_env``) so the mapping stays DRY and unit-testable without
+    importing the optional ``claude-agent-sdk``.
+    """
+    if base_url:
+        return {"ANTHROPIC_BASE_URL": base_url}
+    return {}
+
+
 # Refresh when fewer than this many seconds remain on the access
 @dataclass
 class TurnContext:

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -42,7 +42,7 @@ from ...portal.state import (
     sync_host_skills,
 )
 from ..cli_bin import resolve_claude_bin, resolve_codex_bin, resolve_hermes_bin
-from .base import Adapter, TurnContext, TurnResult
+from .base import Adapter, TurnContext, TurnResult, anthropic_base_url_env
 from .cli_session import AuditLog, ClaudeSession
 from .codex_session import CodexSession
 from .desired_install import run_spawn_install
@@ -170,9 +170,18 @@ class LocalCLIAdapter(Adapter):
         puffo_core_server_url: str = "",
         puffo_core_slug: str = "",
         puffo_core_keys_dir: str = "",
+        llm_base_url: str = "",
+        llm_api_key: str = "",
     ):
         self.agent_id = agent_id
         self.model = model
+        # Anthropic-compatible base URL (e.g. LiteLLM VK) + its key.
+        # When ``llm_base_url`` is set, the claude-code spawn env gets
+        # ANTHROPIC_BASE_URL (and ANTHROPIC_API_KEY=VK when llm_api_key
+        # is non-empty). Empty base URL injects nothing, preserving the
+        # ``claude login`` / OAuth credential path. See ``_llm_env``.
+        self.llm_base_url = llm_base_url
+        self.llm_api_key = llm_api_key
         self.workspace_dir = workspace_dir
         self.claude_dir = claude_dir
         self.session_file = Path(session_file)
@@ -776,6 +785,7 @@ class LocalCLIAdapter(Adapter):
             "USERPROFILE": str(self.agent_home_dir),
             **self._permission_hook_env(),
             **self._macos_credential_env(),
+            **self._llm_env(),
         }
         self._session = ClaudeSession(
             agent_id=self.agent_id,
@@ -814,6 +824,22 @@ class LocalCLIAdapter(Adapter):
         return {
             "CLAUDE_CONFIG_DIR": str(Path(self.agent_home_dir) / ".claude"),
         }
+
+    def _llm_env(self) -> dict[str, str]:
+        """LLM-plane env overrides for the claude-code spawn.
+
+        Empty ``llm_base_url`` → ``{}`` (spawn env unchanged; claude
+        authenticates via ``~/.claude/.credentials.json`` / OAuth as
+        today). When set, inject ``ANTHROPIC_BASE_URL`` so the CLI's
+        model calls hit the proxy (LiteLLM VK), plus
+        ``ANTHROPIC_API_KEY=<VK>`` when ``llm_api_key`` is non-empty so
+        the CLI authenticates against the VK rather than the operator's
+        OAuth token.
+        """
+        env = anthropic_base_url_env(self.llm_base_url)
+        if env and self.llm_api_key:
+            env["ANTHROPIC_API_KEY"] = self.llm_api_key
+        return env
 
     def _permission_hook_env(self) -> dict[str, str]:
         """Env vars the PreToolUse hook script reads. Claude inherits

--- a/src/puffo_agent/agent/adapters/sdk.py
+++ b/src/puffo_agent/agent/adapters/sdk.py
@@ -19,7 +19,13 @@ from typing import Any
 from ...mcp.config import (
     PUFFO_CORE_TOOL_FQNS,
 )
-from .base import Adapter, TurnContext, TurnResult, format_history_as_prompt
+from .base import (
+    Adapter,
+    TurnContext,
+    TurnResult,
+    anthropic_base_url_env,
+    format_history_as_prompt,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +41,7 @@ class SDKAdapter(Adapter):
         workspace_dir: str = "",
         owner_username: str = "",
         max_turns: int = 10,
+        base_url: str = "",
     ):
         try:
             from claude_agent_sdk import (
@@ -61,6 +68,10 @@ class SDKAdapter(Adapter):
 
         self.api_key = api_key
         self.model = model
+        # Anthropic-compatible base URL (e.g. LiteLLM VK). Empty =
+        # vendor endpoint. Injected as ANTHROPIC_BASE_URL into the SDK
+        # subprocess env in run_turn.
+        self.base_url = base_url
         self.patterns = list(allowed_tools or [])
         # Puffo MCP tools auto-allow — users shouldn't need to thread
         # ``mcp__puffo__send_message`` through their allowed_tools.
@@ -77,6 +88,11 @@ class SDKAdapter(Adapter):
     async def run_turn(self, ctx: TurnContext) -> TurnResult:
         mcp_servers = self.mcp_servers_override or {}
 
+        # Vendor endpoint unless base_url is set; ANTHROPIC_BASE_URL then
+        # routes the SDK's model calls through the proxy (LiteLLM VK).
+        env = {"ANTHROPIC_API_KEY": self.api_key} if self.api_key else {}
+        env.update(anthropic_base_url_env(self.base_url))
+
         options = self._Options(
             system_prompt=ctx.system_prompt,
             cwd=ctx.workspace_dir or None,
@@ -88,7 +104,7 @@ class SDKAdapter(Adapter):
             can_use_tool=self._gate,
             permission_mode=self.permission_mode,
             model=self.model or None,
-            env={"ANTHROPIC_API_KEY": self.api_key} if self.api_key else {},
+            env=env,
             mcp_servers=mcp_servers,
             setting_sources=["project"],  # pick up .claude/CLAUDE.md under cwd
             max_turns=self.max_turns,

--- a/src/puffo_agent/agent/providers/anthropic_provider.py
+++ b/src/puffo_agent/agent/providers/anthropic_provider.py
@@ -2,8 +2,15 @@ import anthropic
 
 
 class AnthropicProvider:
-    def __init__(self, api_key: str, model: str):
-        self.client = anthropic.Anthropic(api_key=api_key)
+    def __init__(self, api_key: str, model: str, base_url: str | None = None):
+        # ``base_url`` routes completions through a proxy (e.g. a LiteLLM
+        # virtual-key endpoint) instead of api.anthropic.com. Passed to
+        # the client only when set so the default stays the vendor
+        # endpoint — byte-for-byte unchanged when no base_url is given.
+        if base_url:
+            self.client = anthropic.Anthropic(api_key=api_key, base_url=base_url)
+        else:
+            self.client = anthropic.Anthropic(api_key=api_key)
         self.model = model
 
     def complete(self, system_prompt: str, messages: list[dict]) -> tuple[str, int, int]:

--- a/src/puffo_agent/agent/providers/openai_provider.py
+++ b/src/puffo_agent/agent/providers/openai_provider.py
@@ -2,8 +2,15 @@ from openai import OpenAI
 
 
 class OpenAIProvider:
-    def __init__(self, api_key: str, model: str):
-        self.client = OpenAI(api_key=api_key)
+    def __init__(self, api_key: str, model: str, base_url: str | None = None):
+        # ``base_url`` routes completions through a proxy (e.g. a LiteLLM
+        # virtual-key endpoint) instead of api.openai.com. Passed to the
+        # client only when set so the default stays the vendor endpoint —
+        # byte-for-byte unchanged when no base_url is given.
+        if base_url:
+            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        else:
+            self.client = OpenAI(api_key=api_key)
         self.model = model
 
     def complete(self, system_prompt: str, messages: list[dict]) -> tuple[str, int, int]:

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -256,17 +256,41 @@ def cmd_config(args: argparse.Namespace) -> int:
 
 
 
+# Shown when a GUI entry point (``start --ui`` / ``start --tray``) is
+# invoked but the desktop UI's ``[gui]`` extra (PySide6) isn't installed.
+# The base ``pip install puffo-agent`` is deliberately Qt-free so headless
+# / cloud daemons don't pull Qt; PySide6 lives in the ``gui`` extra.
+_GUI_EXTRA_HINT = (
+    "the desktop UI requires the [gui] extra (PySide6), which is not "
+    "installed. install it with:\n\n    pip install 'puffo-agent[gui]'\n\n"
+    "(the headless daemon — `puffo-agent start` with no UI flag — runs "
+    "without it.)"
+)
+
+
 def cmd_start(args: argparse.Namespace) -> int:
     with_local_bridge = getattr(args, "with_local_bridge", False)
+    # The PySide6 import inside run_tray/launch is deferred to call time,
+    # so the ImportError surfaces from the call, not the ``from .ui...``
+    # line — wrap both so a missing [gui] extra yields the actionable hint
+    # instead of a raw ModuleNotFoundError traceback.
     if getattr(args, "tray_runner", False):
-        from .ui.tray import run_tray
-        return run_tray(with_local_bridge=with_local_bridge)
+        try:
+            from .ui.tray import run_tray
+            return run_tray(with_local_bridge=with_local_bridge)
+        except ImportError:
+            print(_GUI_EXTRA_HINT, file=sys.stderr)
+            return 1
     if getattr(args, "background", False):
         from .background import spawn_background
         return spawn_background(with_local_bridge=with_local_bridge)
     if getattr(args, "ui", False):
-        from .ui.launcher import launch
-        return launch(with_local_bridge=with_local_bridge)
+        try:
+            from .ui.launcher import launch
+            return launch(with_local_bridge=with_local_bridge)
+        except ImportError:
+            print(_GUI_EXTRA_HINT, file=sys.stderr)
+            return 1
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -987,6 +987,14 @@ class RuntimeConfig:
     provider: str = ""            # empty = default for kind
     model: str = ""
     api_key: str = ""
+    # OpenAI/Anthropic-compatible base URL for the LLM plane. Set this
+    # to route model calls through a proxy — e.g. Shan's LiteLLM virtual
+    # key endpoint for cloud agents — instead of the vendor default.
+    # Consumed by chat-local (Anthropic + OpenAI providers), sdk-local
+    # and cli-local/claude-code (as ANTHROPIC_BASE_URL). Empty = vendor
+    # endpoint (today's behavior, byte-for-byte unchanged). The matching
+    # secret rides on ``api_key`` (the VK), so no new field is needed.
+    llm_base_url: str = ""
     # Tool allowlist patterns (sdk | cli-local | cli-docker). Each
     # entry is a bare tool name ("Read") or tool-name-plus-arg glob
     # ("Bash(git *)", "Read(**/*.py)"). Empty = no tools allowed.
@@ -1122,6 +1130,7 @@ class AgentConfig:
                 provider=provider,
                 model=rt.get("model", ""),
                 api_key=rt.get("api_key", ""),
+                llm_base_url=rt.get("llm_base_url", ""),
                 allowed_tools=list(rt.get("allowed_tools") or []),
                 docker_image=rt.get("docker_image", ""),
                 docker_memory_limit=rt.get("docker_memory_limit", ""),

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -112,6 +112,9 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             agent_id=agent_cfg.id,
             workspace_dir=str(agent_cfg.resolve_workspace_dir()),
             max_turns=agent_cfg.runtime.max_turns,
+            # Empty = vendor endpoint (unchanged); set = route the SDK's
+            # model calls through the proxy via ANTHROPIC_BASE_URL.
+            base_url=agent_cfg.runtime.llm_base_url,
         )
         if agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_stdio_sdk_config, default_python_executable
@@ -239,6 +242,13 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             puffo_core_server_url=agent_cfg.puffo_core.server_url,
             puffo_core_slug=agent_cfg.puffo_core.slug,
             puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
+            # Empty base URL → no env override (claude keeps its OAuth /
+            # ~/.claude credential path). Set → ANTHROPIC_BASE_URL routes
+            # the CLI's model calls through the proxy; the VK rides on
+            # runtime.api_key (injected as ANTHROPIC_API_KEY only when
+            # the base URL is also set — see LocalCLIAdapter._llm_env).
+            llm_base_url=agent_cfg.runtime.llm_base_url,
+            llm_api_key=agent_cfg.runtime.api_key,
         )
         if agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_mcp_env
@@ -268,6 +278,9 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
     """Anthropic/OpenAI message-completion provider for the
     chat-local adapter. Per-agent fields override daemon defaults."""
     provider_name = runtime.provider or daemon_cfg.default_provider
+    # Empty base URL → None → vendor endpoint (today's behavior, byte-for-
+    # byte unchanged). Set → route completions through the proxy (VK).
+    base_url = runtime.llm_base_url or None
 
     if provider_name == "anthropic":
         from ..agent.providers.anthropic_provider import AnthropicProvider
@@ -277,7 +290,7 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
             raise RuntimeError(
                 "anthropic api_key is not set in daemon.yml or agent.yml"
             )
-        return AnthropicProvider(api_key=api_key, model=model)
+        return AnthropicProvider(api_key=api_key, model=model, base_url=base_url)
 
     if provider_name == "openai":
         from ..agent.providers.openai_provider import OpenAIProvider
@@ -287,7 +300,7 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
             raise RuntimeError(
                 "openai api_key is not set in daemon.yml or agent.yml"
             )
-        return OpenAIProvider(api_key=api_key, model=model)
+        return OpenAIProvider(api_key=api_key, model=model, base_url=base_url)
 
     raise RuntimeError(f"unknown provider {provider_name!r}")
 

--- a/tests/test_llm_base_url_routing.py
+++ b/tests/test_llm_base_url_routing.py
@@ -1,0 +1,197 @@
+"""LiteLLM VK LLM-plane routing (Item B): a config-driven
+``runtime.llm_base_url`` must thread into adapter/provider construction
+so cloud agents' model calls hit the virtual-key endpoint, while an
+absent/empty base URL leaves today's vendor-endpoint behavior unchanged.
+
+Covers the runtime kinds the cloud agent uses:
+  - chat-local: Anthropic + OpenAI provider ``client.base_url``
+  - cli-local:  the claude-code spawn-env override (``_llm_env``)
+  - sdk-local:  build_adapter threads ``base_url`` into SDKAdapter, and
+    the shared env helper maps it to ANTHROPIC_BASE_URL — asserted
+    without importing the optional ``claude-agent-sdk``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent.adapters.base import anthropic_base_url_env
+from puffo_agent.portal.state import AgentConfig, DaemonConfig, RuntimeConfig
+from puffo_agent.portal.worker import build_adapter
+
+VK = "https://vk.shan.example/litellm"
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(tmp_path, monkeypatch):
+    """Keep every adapter/config path under a throwaway home so building
+    adapters never touches the real ~/.puffo-agent."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+
+
+def _daemon_cfg() -> DaemonConfig:
+    return DaemonConfig()
+
+
+# ── chat-local: provider client.base_url ────────────────────────────────
+
+
+def test_chat_local_anthropic_routes_through_vk():
+    cfg = AgentConfig(
+        id="chat-anth-vk",
+        runtime=RuntimeConfig(
+            kind="chat-local", provider="anthropic",
+            api_key="k", llm_base_url=VK,
+        ),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    # httpx normalizes with a trailing slash; compare on the stem.
+    assert base.rstrip("/") == VK.rstrip("/")
+
+
+def test_chat_local_anthropic_default_when_unset():
+    cfg = AgentConfig(
+        id="chat-anth-default",
+        runtime=RuntimeConfig(kind="chat-local", provider="anthropic", api_key="k"),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    # Vendor default, byte-for-byte as before — and definitely not the VK.
+    assert "anthropic.com" in base
+    assert "vk.shan.example" not in base
+
+
+def test_chat_local_openai_routes_through_vk():
+    cfg = AgentConfig(
+        id="chat-oai-vk",
+        runtime=RuntimeConfig(
+            kind="chat-local", provider="openai",
+            api_key="k", llm_base_url=VK,
+        ),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    assert base.rstrip("/") == VK.rstrip("/")
+
+
+def test_chat_local_openai_default_when_unset():
+    cfg = AgentConfig(
+        id="chat-oai-default",
+        runtime=RuntimeConfig(kind="chat-local", provider="openai", api_key="k"),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    base = str(adapter._provider.client.base_url)
+    assert "openai.com" in base
+    assert "vk.shan.example" not in base
+
+
+# ── cli-local: the claude-code spawn-env override ───────────────────────
+
+
+def test_cli_local_env_override_carries_base_url_when_set():
+    cfg = AgentConfig(
+        id="cli-vk",
+        runtime=RuntimeConfig(
+            kind="cli-local", api_key="vk-secret", llm_base_url=VK,
+        ),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    assert adapter.llm_base_url == VK
+    env = adapter._llm_env()
+    assert env["ANTHROPIC_BASE_URL"] == VK
+    # The VK rides on runtime.api_key so the CLI authenticates to it.
+    assert env["ANTHROPIC_API_KEY"] == "vk-secret"
+
+
+def test_cli_local_env_override_empty_when_unset():
+    cfg = AgentConfig(id="cli-default", runtime=RuntimeConfig(kind="cli-local"))
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    # Empty base URL -> no env override at all, so the spawn env is
+    # unchanged and claude keeps its ~/.claude / OAuth credential path.
+    assert adapter._llm_env() == {}
+
+
+def test_cli_local_no_api_key_injection_without_base_url():
+    """A stray runtime.api_key alone (no base URL) must NOT leak an
+    ANTHROPIC_API_KEY into the spawn env — that would silently override
+    the operator's OAuth login."""
+    cfg = AgentConfig(
+        id="cli-key-only",
+        runtime=RuntimeConfig(kind="cli-local", api_key="stray"),
+    )
+    adapter = build_adapter(_daemon_cfg(), cfg)
+    assert adapter._llm_env() == {}
+
+
+# ── sdk-local: wiring + shared env mapping (no claude-agent-sdk needed) ──
+
+
+def test_sdk_local_build_adapter_threads_base_url(monkeypatch):
+    """build_adapter must pass ``base_url`` into SDKAdapter. Stub the
+    adapter so this holds whether or not the optional SDK is installed."""
+    from puffo_agent.agent.adapters import sdk as sdk_mod
+
+    captured: dict = {}
+
+    class _StubSDKAdapter:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(sdk_mod, "SDKAdapter", _StubSDKAdapter)
+
+    cfg = AgentConfig(
+        id="sdk-vk",
+        runtime=RuntimeConfig(kind="sdk-local", api_key="k", llm_base_url=VK),
+    )
+    build_adapter(_daemon_cfg(), cfg)
+    assert captured.get("base_url") == VK
+
+
+def test_sdk_local_build_adapter_base_url_empty_when_unset(monkeypatch):
+    from puffo_agent.agent.adapters import sdk as sdk_mod
+
+    captured: dict = {}
+
+    class _StubSDKAdapter:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(sdk_mod, "SDKAdapter", _StubSDKAdapter)
+
+    cfg = AgentConfig(
+        id="sdk-default",
+        runtime=RuntimeConfig(kind="sdk-local", api_key="k"),
+    )
+    build_adapter(_daemon_cfg(), cfg)
+    # Empty threads through as "" -> SDKAdapter.run_turn injects nothing.
+    assert captured.get("base_url") == ""
+
+
+def test_shared_env_helper_maps_base_url():
+    """The SDK adapter's run_turn env and the cli adapter's _llm_env both
+    build on this helper; it must map a set base URL to ANTHROPIC_BASE_URL
+    and an empty one to no override."""
+    assert anthropic_base_url_env(VK) == {"ANTHROPIC_BASE_URL": VK}
+    assert anthropic_base_url_env("") == {}
+    assert anthropic_base_url_env(None) == {}  # type: ignore[arg-type]
+
+
+# ── config round-trip (RuntimeConfig.llm_base_url) ──────────────────────
+
+
+def test_runtime_config_llm_base_url_round_trips():
+    """agent.yml save/load preserves llm_base_url (it serializes via
+    asdict(runtime), so this guards the load-side parse)."""
+    cfg = AgentConfig(
+        id="rt-agent",
+        runtime=RuntimeConfig(kind="chat-local", api_key="k", llm_base_url=VK),
+    )
+    cfg.save()
+    reloaded = AgentConfig.load("rt-agent")
+    assert reloaded.runtime.llm_base_url == VK

--- a/tests/test_slim_packaging_headless.py
+++ b/tests/test_slim_packaging_headless.py
@@ -1,0 +1,93 @@
+"""Slim-packaging guard (Item A): the daemon / CLI path must import and
+run with PySide6 absent, and a GUI command without the ``[gui]`` extra
+must fail with the actionable install hint — not a raw traceback.
+
+Deterministic in any environment: we block ``PySide6`` (and its
+submodules) via ``sys.modules[...] = None`` regardless of whether the
+extra happens to be installed, so this asserts the real headless
+contract rather than "the test box didn't have Qt".
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+
+import pytest
+
+
+# Every PySide6 entry point the UI modules reach for. Mapping a name to
+# ``None`` in sys.modules makes ``import <name>`` raise ImportError even
+# when the package is installed — the standard "pretend it's missing"
+# trick.
+_PYSIDE_NAMES = [
+    "PySide6",
+    "PySide6.QtCore",
+    "PySide6.QtGui",
+    "PySide6.QtWidgets",
+]
+
+
+@pytest.fixture
+def pyside6_blocked(monkeypatch):
+    """Block PySide6 and drop cached puffo_agent modules that could hold
+    a live reference, so imports re-run under the block."""
+    for name in _PYSIDE_NAMES:
+        monkeypatch.setitem(sys.modules, name, None)
+    # Drop cached daemon/cli/ui modules so the assertions below exercise
+    # a fresh import under the block rather than a warm module object.
+    for name in list(sys.modules):
+        if name == "puffo_agent.portal.daemon" or name == "puffo_agent.portal.cli":
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        elif name.startswith("puffo_agent.portal.ui"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    yield
+
+
+def test_pyside6_is_actually_blocked(pyside6_blocked):
+    """Sanity: the fixture makes ``import PySide6`` raise, so the two
+    assertions below mean what they say."""
+    with pytest.raises(ImportError):
+        import PySide6  # noqa: F401
+
+
+def test_daemon_and_cli_import_without_pyside6(pyside6_blocked):
+    """The headless daemon path (`puffo-agent start` -> run_daemon) and
+    the CLI module must import cleanly with Qt absent."""
+    daemon = importlib.import_module("puffo_agent.portal.daemon")
+    cli = importlib.import_module("puffo_agent.portal.cli")
+    # run_daemon is the headless entry point cmd_start dispatches to.
+    assert hasattr(daemon, "run_daemon")
+    assert hasattr(cli, "cmd_start")
+
+
+def test_gui_command_without_extra_yields_actionable_hint(
+    pyside6_blocked, capsys,
+):
+    """`start --ui` with PySide6 absent returns non-zero and prints the
+    `pip install 'puffo-agent[gui]'` hint instead of ModuleNotFoundError."""
+    cli = importlib.import_module("puffo_agent.portal.cli")
+    args = argparse.Namespace(
+        ui=True, tray_runner=False, background=False, with_local_bridge=False,
+    )
+    rc = cli.cmd_start(args)
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "puffo-agent[gui]" in combined
+
+
+def test_tray_command_without_extra_yields_actionable_hint(
+    pyside6_blocked, capsys,
+):
+    """Same guard for the `start --tray-runner` entry point."""
+    cli = importlib.import_module("puffo_agent.portal.cli")
+    args = argparse.Namespace(
+        ui=False, tray_runner=True, background=False, with_local_bridge=False,
+    )
+    rc = cli.cmd_start(args)
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "puffo-agent[gui]" in combined

--- a/tests/test_ui_mcp_scanner.py
+++ b/tests/test_ui_mcp_scanner.py
@@ -11,6 +11,11 @@ import textwrap
 
 import pytest
 
+# ``_scan_mcp_servers`` lives in ``widgets/agent_detail`` which imports
+# PySide6 at module level; PySide6 now ships only in the ``[gui]`` extra.
+# Skip this file when the extra isn't installed rather than failing.
+pytest.importorskip("PySide6")
+
 
 @pytest.fixture(autouse=True)
 def _qt_offscreen(monkeypatch):

--- a/tests/test_ui_views.py
+++ b/tests/test_ui_views.py
@@ -9,6 +9,11 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 
+# PySide6 now ships only in the ``[gui]`` extra (the base install is
+# Qt-free for headless/cloud daemons). Skip the Qt view tests when the
+# extra isn't installed rather than erroring out collection.
+pytest.importorskip("PySide6")
+
 from PySide6.QtWidgets import QApplication
 
 from puffo_agent.portal.ui.widgets.log_view import LogView


### PR DESCRIPTION
## What (stacks on #141)

Makes the fat `puffo-agent` a clean cloud drop-in replacement for the thin `puffo-agent-cloud`.

- **Slim packaging**: `pyside6` moved out of `[project].dependencies` → `[project.optional-dependencies] gui`. So `pip install puffo-agent` (cloud) is **Qt-free**; `pip install puffo-agent[gui]` (desktop) adds it. `run_daemon` imports clean without PySide6 (verified in a fresh venv — `pip show pyside6` → not found); a GUI command without the extra gives a clear "install puffo-agent[gui]" error. **This is what slims the fat E2B image (was 1.32GB with Qt baked).**
- **LLM plane**: thread an LLM `base_url` (`ANTHROPIC_BASE_URL` / OpenAI-compatible) from `agent.yml runtime` into the adapters/providers + spawned CLI env → cloud model calls route through Shan's **LiteLLM virtual key**. Absent → vendor default unchanged. No hard-coded URLs, no embedded key.
- `FAT-E2B-INTEGRATION.md`: the `agent.yml runtime` LLM fields the cloud bundle must set.

## Verify
Clean-venv slim proof (PySide6 absent from base + `[dev]`; present with `[gui]`) + LLM-free pytest (base_url routing, headless slim import). Native LLM behavior unchanged when no base_url set.

**Stacked on `fleet/cloud-agent-lifecycle-mcp` (#141). HOLD.** Part of making fat replace thin in the cloud (with #143 fixes + server #186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)