### PR TITLE
PUF-360: drain pre-turn stdout before writing the turn frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pre-turn stdout drain — no more cron chatter leaking into replies.**
+  Claude Code emits `assistant` events during its internal cron ticks
+  while a turn isn't in flight; those events sat in the subprocess
+  stdout stream until the next turn started and got folded into that
+  turn's reply — visible to the operator as messages like *"News
+  check complete. 3 new items…"* prepended to whatever the agent was
+  actually asked. `ClaudeSession._one_turn` now drains buffered
+  stdout events immediately before writing the turn frame; drained
+  events are audit-logged as `turn.pre_drain` so future cron-behavior
+  patterns are observable without a repro. Per-readline 0.1s timeout
+  (bounds the empty-buffer check) plus a 1.0s wall-time cap keep a
+  chatty pre-turn producer from stalling the turn.
+
 ## [1.0.7] — 2026-07-06
 
 ### Fixed

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -167,13 +167,11 @@ INIT_TIMEOUT_SECONDS = 10.0
 # every event size seen in practice.
 STREAM_READER_LIMIT_BYTES = 16 * 1024 * 1024
 
-# PUF-360: pre-turn stdout drain. Claude Code's internal cron / background
-# activity emits ``assistant`` events during quiet periods; those sit in the
-# stdout stream and, without draining, get read as the NEXT turn's reply
-# (the read loop has no turn-correlation — it collects text until ``result``).
-# Per-readline timeout only bounds the "buffer empty" check (already-buffered
-# lines return instantly); the wall-time budget caps a chatty pre-turn
-# producer so it can't stall the turn.
+# Read loop has no turn-correlation — collects until ``result`` — so any
+# pre-turn ``assistant`` chatter (Claude Code's internal cron ticks) leaks
+# into the next turn's reply. Drained before the frame write. Per-readline
+# timeout bounds the empty-buffer check; wall-time cap keeps a chatty
+# producer from stalling the turn.
 STALE_STDOUT_DRAIN_TIMEOUT = 0.1
 STALE_STDOUT_DRAIN_BUDGET = 1.0
 
@@ -660,14 +658,8 @@ class ClaudeSession:
     # ── One turn ──────────────────────────────────────────────────────────────
 
     async def _drain_stale_stdout(self) -> int:
-        """PUF-360: consume stdout events emitted before this turn's frame.
-
-        Called pre-frame-write, so anything buffered is pre-turn output
-        (Claude Code internal cron / background ``assistant`` chatter) that
-        the read loop would otherwise fold into this turn's reply. Drains
-        until the buffer is empty (per-readline timeout) or a wall-time
-        budget elapses; audit-logs any drained assistant text for
-        observability. Returns the number of events drained."""
+        """Consume stdout events buffered before this turn's frame is
+        written, so pre-turn chatter isn't folded into the reply."""
         assert self._proc is not None and self._proc.stdout is not None
         drained = 0
         deadline = time.monotonic() + STALE_STDOUT_DRAIN_BUDGET
@@ -678,15 +670,13 @@ class ClaudeSession:
                     timeout=STALE_STDOUT_DRAIN_TIMEOUT,
                 )
             except asyncio.TimeoutError:
-                break  # nothing more was already waiting — buffer drained
+                break
             except (asyncio.LimitOverrunError, ValueError,
                     ConnectionResetError, BrokenPipeError):
-                # Best-effort: any read problem here (oversized event,
-                # dead pipe) stops the drain and hands off to the main
-                # read loop, which has the full graceful-recovery path.
+                # Best-effort — main read loop handles recovery.
                 break
             if not line:
-                break  # EOF — subprocess died pre-turn; frame write surfaces it
+                break
             drained += 1
             event = _parse_event(line)
             if event is None or self.audit is None:
@@ -737,10 +727,6 @@ class ClaudeSession:
             "parent_tool_use_id": None,
             "session_id": self._session_id or "puffoagent-turn",
         }
-        # PUF-360: drain any stdout the subprocess emitted BEFORE this
-        # frame (internal cron / background chatter) so the read loop
-        # below only collects THIS turn's events. Pre-frame, so no
-        # turn-generated event can be in the buffer yet.
         await self._drain_stale_stdout()
         self._proc.stdin.write((json.dumps(frame) + "\n").encode("utf-8"))
         try:

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -167,6 +167,16 @@ INIT_TIMEOUT_SECONDS = 10.0
 # every event size seen in practice.
 STREAM_READER_LIMIT_BYTES = 16 * 1024 * 1024
 
+# PUF-360: pre-turn stdout drain. Claude Code's internal cron / background
+# activity emits ``assistant`` events during quiet periods; those sit in the
+# stdout stream and, without draining, get read as the NEXT turn's reply
+# (the read loop has no turn-correlation — it collects text until ``result``).
+# Per-readline timeout only bounds the "buffer empty" check (already-buffered
+# lines return instantly); the wall-time budget caps a chatty pre-turn
+# producer so it can't stall the turn.
+STALE_STDOUT_DRAIN_TIMEOUT = 0.1
+STALE_STDOUT_DRAIN_BUDGET = 1.0
+
 
 class _ResumeFailed(Exception):
     """The subprocess exited before emitting init — usually because
@@ -649,6 +659,52 @@ class ClaudeSession:
 
     # ── One turn ──────────────────────────────────────────────────────────────
 
+    async def _drain_stale_stdout(self) -> int:
+        """PUF-360: consume stdout events emitted before this turn's frame.
+
+        Called pre-frame-write, so anything buffered is pre-turn output
+        (Claude Code internal cron / background ``assistant`` chatter) that
+        the read loop would otherwise fold into this turn's reply. Drains
+        until the buffer is empty (per-readline timeout) or a wall-time
+        budget elapses; audit-logs any drained assistant text for
+        observability. Returns the number of events drained."""
+        assert self._proc is not None and self._proc.stdout is not None
+        drained = 0
+        deadline = time.monotonic() + STALE_STDOUT_DRAIN_BUDGET
+        while time.monotonic() < deadline:
+            try:
+                line = await asyncio.wait_for(
+                    self._proc.stdout.readline(),
+                    timeout=STALE_STDOUT_DRAIN_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                break  # nothing more was already waiting — buffer drained
+            except (asyncio.LimitOverrunError, ValueError,
+                    ConnectionResetError, BrokenPipeError):
+                # Best-effort: any read problem here (oversized event,
+                # dead pipe) stops the drain and hands off to the main
+                # read loop, which has the full graceful-recovery path.
+                break
+            if not line:
+                break  # EOF — subprocess died pre-turn; frame write surfaces it
+            drained += 1
+            event = _parse_event(line)
+            if event is None or self.audit is None:
+                continue
+            t = event.get("type")
+            text = ""
+            if t == "assistant":
+                for block in (event.get("message") or {}).get("content") or []:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text += block.get("text", "") or ""
+            self.audit.write("turn.pre_drain", event_type=t, text=text)
+        if drained:
+            logger.info(
+                "agent %s: drained %d stale pre-turn stdout event(s)",
+                self.agent_id, drained,
+            )
+        return drained
+
     async def _one_turn(self, user_message: str) -> TurnResult:
         assert self._proc is not None and self._proc.stdin is not None
         ums_bytes = len(user_message.encode("utf-8"))
@@ -681,6 +737,11 @@ class ClaudeSession:
             "parent_tool_use_id": None,
             "session_id": self._session_id or "puffoagent-turn",
         }
+        # PUF-360: drain any stdout the subprocess emitted BEFORE this
+        # frame (internal cron / background chatter) so the read loop
+        # below only collects THIS turn's events. Pre-frame, so no
+        # turn-generated event can be in the buffer yet.
+        await self._drain_stale_stdout()
         self._proc.stdin.write((json.dumps(frame) + "\n").encode("utf-8"))
         try:
             await self._proc.stdin.drain()

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -65,12 +65,9 @@ class _FakeProc:
     """Stand-in for ``asyncio.subprocess.Process``. Construct inside
     an async helper since StreamReader requires a running loop.
 
-    ``stdout_lines`` model the TURN response: they're fed on the first
-    ``stdin.write`` (the frame), mirroring that Claude Code only emits
-    after receiving the turn — so the PUF-360 pre-frame drain sees an
-    empty buffer, as in production. ``pre_turn_lines`` model stdout
-    already buffered BEFORE the turn (internal cron / background
-    chatter) and are fed at construction so the drain can consume them.
+    ``pre_turn_lines`` are fed at construction (buffered before the
+    turn frame); ``stdout_lines`` are fed on the first ``stdin.write``,
+    mirroring that Claude Code only emits after receiving the turn.
     """
     def __init__(
         self,
@@ -686,7 +683,7 @@ def test_run_turn_auth_error_takes_precedence_over_too_large_rewrite(
     assert out.metadata.get("request_too_large") is None
 
 
-# ── PUF-360: pre-turn stdout drain (cron / background chatter leak) ──────────
+# ── pre-turn stdout drain ────────────────────────────────────────────────────
 
 
 def _assistant_line(text: str) -> bytes:
@@ -722,12 +719,10 @@ def test_one_turn_drains_pre_turn_cron_stdout(tmp_path):
 
     out = asyncio.run(drive())
 
-    # The reply is the turn's text only — the cron line is gone.
     assert out.reply == "here is your answer"
     assert "News check complete" not in out.reply
     assert out.metadata["assistant_text_parts"] == ["here is your answer"]
 
-    # The drained cron text is audited for observability.
     events = _read_audit_events(tmp_path / "audit.log")
     pre = [e for e in events if e.get("event") == "turn.pre_drain"]
     assert len(pre) == 1
@@ -767,3 +762,39 @@ def test_no_pre_turn_stdout_is_a_clean_noop(tmp_path):
     assert out.reply == "all good"
     events = _read_audit_events(tmp_path / "audit.log")
     assert not [e for e in events if e.get("event") == "turn.pre_drain"]
+
+
+def test_drain_stops_on_eof_when_subprocess_died_pre_turn(tmp_path):
+    """Stdout EOF during the drain (subprocess exited pre-turn) exits
+    the drain cleanly; the main loop then reports eof_mid_turn."""
+    session = _make_session(tmp_path, audit=False)
+
+    async def drive():
+        reader = asyncio.StreamReader(limit=STREAM_READER_LIMIT_BYTES)
+        reader.feed_data(_assistant_line("last words"))
+        reader.feed_eof()
+        proc = _FakeProc(stdout_lines=[])
+        proc.stdout = reader
+        session._proc = proc
+        return await session._one_turn("hi")
+
+    out = asyncio.run(drive())
+    assert out.metadata.get("stream_error") == "eof_mid_turn"
+    assert out.reply == ""
+
+
+def test_drain_swallows_readline_error_and_hands_off_to_main_loop(tmp_path):
+    """Oversized event / dead pipe surfacing as LimitOverrunError during
+    the drain: the drain exits best-effort; the main read loop's own
+    handler then records the stream_error."""
+    session = _make_session(tmp_path, audit=False)
+
+    async def drive():
+        session._proc = _FakeProc(
+            stdout_raises=asyncio.LimitOverrunError("event too big", 0),
+        )
+        return await session._one_turn("hi")
+
+    out = asyncio.run(drive())
+    assert out.metadata.get("stream_error") == "readline_limit"
+    assert out.reply == ""

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -30,12 +30,15 @@ from puffo_agent.agent.adapters.base import TurnResult
 
 
 class _FakeStdin:
-    def __init__(self):
+    def __init__(self, on_write=None):
         self.buffer = bytearray()
         self._closed = False
+        self._on_write = on_write
 
     def write(self, data: bytes) -> None:
         self.buffer.extend(data)
+        if self._on_write is not None:
+            self._on_write()
 
     async def drain(self) -> None:
         return None
@@ -61,21 +64,40 @@ class _RaisingReader:
 class _FakeProc:
     """Stand-in for ``asyncio.subprocess.Process``. Construct inside
     an async helper since StreamReader requires a running loop.
+
+    ``stdout_lines`` model the TURN response: they're fed on the first
+    ``stdin.write`` (the frame), mirroring that Claude Code only emits
+    after receiving the turn — so the PUF-360 pre-frame drain sees an
+    empty buffer, as in production. ``pre_turn_lines`` model stdout
+    already buffered BEFORE the turn (internal cron / background
+    chatter) and are fed at construction so the drain can consume them.
     """
     def __init__(
         self,
         stdout_lines: list[bytes] | None = None,
         stdout_raises: BaseException | None = None,
         returncode: int = 0,
+        pre_turn_lines: list[bytes] | None = None,
     ):
-        self.stdin = _FakeStdin()
         if stdout_raises is not None:
+            self.stdin = _FakeStdin()
             self.stdout = _RaisingReader(stdout_raises)
         else:
             reader = asyncio.StreamReader(limit=STREAM_READER_LIMIT_BYTES)
-            for line in stdout_lines or []:
+            for line in pre_turn_lines or []:
                 reader.feed_data(line)
-            reader.feed_eof()
+            self._turn_lines = list(stdout_lines or [])
+            self._fed_turn = False
+
+            def _feed_turn() -> None:
+                if self._fed_turn:
+                    return
+                self._fed_turn = True
+                for line in self._turn_lines:
+                    reader.feed_data(line)
+                reader.feed_eof()
+
+            self.stdin = _FakeStdin(on_write=_feed_turn)
             self.stdout = reader
         empty = asyncio.StreamReader()
         empty.feed_eof()
@@ -662,3 +684,86 @@ def test_run_turn_auth_error_takes_precedence_over_too_large_rewrite(
     assert out.reply == ""
     assert out.metadata.get("auth_failed") is True
     assert out.metadata.get("request_too_large") is None
+
+
+# ── PUF-360: pre-turn stdout drain (cron / background chatter leak) ──────────
+
+
+def _assistant_line(text: str) -> bytes:
+    return (json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": text}]},
+    }) + "\n").encode("utf-8")
+
+
+def _result_line(session_id: str = "sess-1", result: str = "") -> bytes:
+    evt = {
+        "type": "result", "subtype": "success",
+        "session_id": session_id,
+        "usage": {"input_tokens": 3, "output_tokens": 4},
+    }
+    if result:
+        evt["result"] = result
+    return (json.dumps(evt) + "\n").encode("utf-8")
+
+
+def test_one_turn_drains_pre_turn_cron_stdout(tmp_path):
+    """Claude Code internal-cron ``assistant`` output buffered before the
+    turn must NOT be folded into this turn's reply — it's drained + audited,
+    and only turn-generated text is returned."""
+    session = _make_session(tmp_path, audit=True)
+
+    async def drive():
+        session._proc = _FakeProc(
+            pre_turn_lines=[_assistant_line("News check complete. 3 new items.")],
+            stdout_lines=[_assistant_line("here is your answer"), _result_line()],
+        )
+        return await session._one_turn("what's up")
+
+    out = asyncio.run(drive())
+
+    # The reply is the turn's text only — the cron line is gone.
+    assert out.reply == "here is your answer"
+    assert "News check complete" not in out.reply
+    assert out.metadata["assistant_text_parts"] == ["here is your answer"]
+
+    # The drained cron text is audited for observability.
+    events = _read_audit_events(tmp_path / "audit.log")
+    pre = [e for e in events if e.get("event") == "turn.pre_drain"]
+    assert len(pre) == 1
+    assert pre[0]["event_type"] == "assistant"
+    assert "News check complete" in pre[0]["text"]
+
+
+def test_drain_consumes_stale_result_so_next_turn_doesnt_break_early(tmp_path):
+    """A stale ``result`` event left in the buffer must be drained too —
+    otherwise the read loop would break on it immediately and return an
+    empty reply for the real turn."""
+    session = _make_session(tmp_path, audit=False)
+
+    async def drive():
+        session._proc = _FakeProc(
+            pre_turn_lines=[_result_line(session_id="sess-stale")],
+            stdout_lines=[_assistant_line("real answer"), _result_line("sess-live")],
+        )
+        return await session._one_turn("hi")
+
+    out = asyncio.run(drive())
+    assert out.reply == "real answer"
+
+
+def test_no_pre_turn_stdout_is_a_clean_noop(tmp_path):
+    """With nothing buffered pre-turn, the drain is a no-op and the turn
+    behaves exactly as before (regression guard)."""
+    session = _make_session(tmp_path, audit=True)
+
+    async def drive():
+        session._proc = _FakeProc(
+            stdout_lines=[_assistant_line("all good"), _result_line()],
+        )
+        return await session._one_turn("hello")
+
+    out = asyncio.run(drive())
+    assert out.reply == "all good"
+    events = _read_audit_events(tmp_path / "audit.log")
+    assert not [e for e in events if e.get("event") == "turn.pre_drain"]


### PR DESCRIPTION
## Summary

Fix for Claude Code internal-cron output leaking into next turn's reply. `ClaudeSession._one_turn`'s read loop collects `assistant.text` events until it sees `result` with no turn-correlation — so anything the subprocess emits into stdout *between* turns gets read as the next turn's reply (Han-observed channel spam: "News check complete. 3 new items…"). Han-approved 方案1: drain stdout before the stdin frame write.

**Fix**: new `_drain_stale_stdout()` runs immediately before `self._proc.stdin.write(frame)`. Reads buffered lines via `wait_for(readline, 0.1s)` — per-readline timeout only bounds the "buffer empty" check (already-buffered lines return instantly). Wall-time budget cap (1.0s) prevents a chatty pre-turn producer from stalling the turn. Handles all edges cleanly: `TimeoutError` (buffer drained → exit), `LimitOverrunError` / `ValueError` / `ConnectionResetError` / `BrokenPipeError` (dead pipe → best-effort exit, main read loop handles recovery), empty line (EOF → subprocess died pre-turn, frame write surfaces it).

**Observability** (Han's variant ii): audit-logs each drained event as `turn.pre_drain` (event_type + concatenated assistant text) — future cron-behavior patterns visible without needing repro.

**Realistic fake**: `_FakeProc` now feeds turn output on the first `stdin.write` (not upfront), mirroring that Claude only emits after receiving the turn. Pre-turn lines are fed at construction time, exactly modeling the leak. All existing stream tests pass unchanged.

## Test plan

- [x] `tests/test_cli_session_recovery.py` — **23/23 pass** (20 pre-existing + 3 new PUF-360):
  - **Sam-style repro**: pre-turn `assistant` event ("News check complete") + real turn "here is your answer" → reply is turn-only, cron text drained + `turn.pre_drain` audit-logged with the text.
  - **Stale-result edge**: leftover `result` event pre-turn → drained too, so real turn's `result` triggers loop exit properly (no empty-reply break-early).
  - **Clean no-op**: nothing buffered pre-turn → drain is silent, turn behaves exactly as before.
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1778 pass / 5 fail**. Failure set byte-identical to `origin/main` (`diff /tmp/puf360-main-fails.txt /tmp/puf360-pr-fails.txt` clean). **Zero regression.**
- [x] Adapter isolation confirmed — `_drain_stale_stdout` only referenced in `cli_session.py` (Claude Code adapter). Codex adapter has a separate turn model, out of scope per intake.
- [ ] **External-verify post-merge**: Han reproduces with scheduled cron on a Claude Code fleet-agent → real turn reply doesn't include cron text.

## Known limits

- **Microsecond race**: a cron firing between drain-end and frame-write can still leak — unavoidable without upstream per-turn correlation IDs. Strictly better than today. Called out in the source comment.
- **Wall-time budget (1.0s cap)**: if a producer emits many cron entries in the pre-turn window, the drain caps at 1s and logs the partial count. Non-blocker; log surfaces the case.
- **Claude Code adapter only** — codex path unchanged per intake.

Ticket: PUF-360 (Linear PUF-38)
Detail: `/home/hanchen/.puffo-agent/shared/PUF-360.md`