### PR TITLE
PUF-361: sender-identity metadata — owner_slug, from-operator marker, sender_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   daemon reads `owner_slug` off the same `/identities/profiles` fetch
   that resolves the sender's display name, caches it under the profile
   TTL so re-ownership propagates without a daemon restart. Primer
-  documents both.
+  documents both. `sender_type` now reads `agent` (was always
+  `human` — the upstream is-bot flag is unset pending a server-side
+  signal, but `owner_slug`'s presence is already a reliable agent
+  marker); the display value is renamed `bot` → `agent` to match the
+  `(agent)` mention suffix. Priority banding is unchanged.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Sender-identity metadata on inbound messages.** Two new fields land
+  in the structured user-block agents see: `sender_owner_slug` names
+  the operator behind an agent sender (present only for agents, sourced
+  from the attestation chain via `/identities/profiles`), and
+  `is_from_operator: true` marks a message from THIS agent's own
+  operator. Both emit conditionally so older agents don't see keys
+  their primer doesn't document. Zero extra HTTP round-trips: the
+  daemon reads `owner_slug` off the same `/identities/profiles` fetch
+  that resolves the sender's display name, caches it under the profile
+  TTL so re-ownership propagates without a daemon restart. Primer
+  documents both.
+
+### Changed
+
+- **Dead `followup_messages_since` removed from the primer + code.**
+  No code path has emitted the field since thread batching replaced
+  single-message dispatch, but the primer still documented it —
+  agents went looking for it and misreported batched messages as
+  message loss. The primer now documents the real shape (one turn
+  may carry several metadata blocks) and points agents at
+  `get_thread_history` / `get_channel_history` when mid-turn
+  freshness matters.
+
 ### Fixed
 
 - **Multi-message batches reached CLI agents with only the last
@@ -18,17 +43,6 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   subprocess, in DMs and channels alike. The whole batch now lands as
   one user entry (per-message metadata blocks, blank-line separated),
   fixing all CLI-family runtimes at the shell layer.
-
-### Changed
-
-- **Dead `followup_messages_since` removed from the primer + code.**
-  No code path has emitted the field since thread batching replaced
-  single-message dispatch, but the primer still documented it —
-  agents went looking for it and misreported batched messages as
-  message loss. The primer now documents the real shape (one turn
-  may carry several metadata blocks) and points agents at
-  `get_thread_history` / `get_channel_history` when mid-turn
-  freshness matters.
 
 ## [1.0.8] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-07-08
+
 ### Added
 
 - **Sender-identity metadata on inbound messages.** Two new fields land

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.0.8"
+version = "1.1.0"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -486,7 +486,11 @@ class PuffoAgent:
         display = sender_display_name or sender
         lines.append(f"- sender: {display}")
         lines.append(f"- sender_slug: {sender}")
-        lines.append(f"- sender_type: {'bot' if sender_is_bot else 'human'}")
+        # ``owner_slug`` exists only for agents, so it doubles as the
+        # agent signal here. Display-only — priority banding still
+        # runs on the upstream ``sender_is_bot`` flag.
+        sender_type = "agent" if (sender_is_bot or sender_owner_slug) else "human"
+        lines.append(f"- sender_type: {sender_type}")
         # ``sender_owner_slug`` fires only for agent senders (their
         # operator); ``is_from_operator`` only when the sender IS the
         # agent's own operator. Emit conditionally so older agents

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -116,6 +116,8 @@ class PuffoAgent:
         create_at: int = 0,
         space_id: str = "",
         space_name: str = "",
+        sender_owner_slug: str = "",
+        is_from_operator: bool = False,
     ) -> str | None:
         self._append_user(
             channel_name, sender, sender_email, text,
@@ -128,6 +130,8 @@ class PuffoAgent:
             create_at=create_at,
             space_id=space_id,
             space_name=space_name,
+            sender_owner_slug=sender_owner_slug,
+            is_from_operator=is_from_operator,
         )
         return await self._run_turn_and_route(
             channel_name=channel_name,
@@ -177,6 +181,8 @@ class PuffoAgent:
                 space_name=channel_meta.get("space_name", ""),
                 sender_display_name=msg.get("sender_display_name", ""),
                 is_visible_to_human=msg.get("is_visible_to_human", True),
+                sender_owner_slug=msg.get("sender_owner_slug", ""),
+                is_from_operator=msg.get("is_from_operator", False),
             )
             for msg in batch
         ]
@@ -237,6 +243,8 @@ class PuffoAgent:
                 space_id=channel_meta.get("space_id", ""),
                 space_name=channel_meta.get("space_name", ""),
                 sender_display_name=msg.get("sender_display_name", ""),
+                sender_owner_slug=msg.get("sender_owner_slug", ""),
+                is_from_operator=msg.get("is_from_operator", False),
             ))
         fallback_text = "\n\n".join(fallback_chunks)
 
@@ -400,6 +408,8 @@ class PuffoAgent:
         space_name: str = "",
         sender_display_name: str = "",
         is_visible_to_human: bool = True,
+        sender_owner_slug: str = "",
+        is_from_operator: bool = False,
     ):
         content = self._format_user_block(
             channel_name=channel_name,
@@ -417,6 +427,8 @@ class PuffoAgent:
             space_name=space_name,
             sender_display_name=sender_display_name,
             is_visible_to_human=is_visible_to_human,
+            sender_owner_slug=sender_owner_slug,
+            is_from_operator=is_from_operator,
         )
         self.log.append({"role": "user", "content": content})
         self._truncate_log()
@@ -439,6 +451,8 @@ class PuffoAgent:
         space_name: str = "",
         sender_display_name: str = "",
         is_visible_to_human: bool = True,
+        sender_owner_slug: str = "",
+        is_from_operator: bool = False,
     ) -> str:
         # Structured markdown block keeps context metadata distinct
         # from message content, preventing the LLM from echoing
@@ -473,6 +487,14 @@ class PuffoAgent:
         lines.append(f"- sender: {display}")
         lines.append(f"- sender_slug: {sender}")
         lines.append(f"- sender_type: {'bot' if sender_is_bot else 'human'}")
+        # PUF-361: sender-identity enrichment. ``sender_owner_slug`` is
+        # present only when the sender is an agent (the operator behind
+        # it, from the attestation chain); ``is_from_operator`` marks a
+        # message from THIS agent's own operator.
+        if sender_owner_slug:
+            lines.append(f"- sender_owner_slug: {sender_owner_slug}")
+        if is_from_operator:
+            lines.append("- is_from_operator: true")
         lines.append(
             f"- is_visible_to_human: {'true' if is_visible_to_human else 'false'}"
         )

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -487,10 +487,10 @@ class PuffoAgent:
         lines.append(f"- sender: {display}")
         lines.append(f"- sender_slug: {sender}")
         lines.append(f"- sender_type: {'bot' if sender_is_bot else 'human'}")
-        # PUF-361: sender-identity enrichment. ``sender_owner_slug`` is
-        # present only when the sender is an agent (the operator behind
-        # it, from the attestation chain); ``is_from_operator`` marks a
-        # message from THIS agent's own operator.
+        # ``sender_owner_slug`` fires only for agent senders (their
+        # operator); ``is_from_operator`` only when the sender IS the
+        # agent's own operator. Emit conditionally so older agents
+        # don't see keys their primer doesn't document.
         if sender_owner_slug:
             lines.append(f"- sender_owner_slug: {sender_owner_slug}")
         if is_from_operator:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -505,6 +505,12 @@ class PuffoCoreMessageClient:
         # under the same TTL — transient lookup failures self-heal at
         # the next tick instead of pinning a permanent "" miss.
         self._profile_cache: dict[str, tuple[str, str, float]] = {}
+        # PUF-361: slug → (owner_slug, fetched_at_monotonic). Filled from
+        # the same /identities/profiles response as the profile cache;
+        # ``owner_slug`` is non-empty only for agents (their operator, per
+        # the attestation chain). Same TTL so re-ownership propagates
+        # without a daemon restart.
+        self._owner_slug_cache: dict[str, tuple[str, float]] = {}
         # Invitation event_ids the worker has already processed.
         # Lifetime-scoped — the operator-DM branch isn't idempotent
         # against server-side state, so resetting on reconnect would
@@ -849,6 +855,16 @@ class PuffoCoreMessageClient:
             sender_display_name = await self._fetch_display_name(
                 payload.sender_slug,
             )
+            # PUF-361: sender-identity enrichment. owner_slug is a
+            # cache hit off the display-name fetch above; the operator
+            # marker is a local equality.
+            sender_owner_slug = await self._fetch_owner_slug(
+                payload.sender_slug,
+            )
+            is_from_operator = bool(
+                self.operator_slug
+                and payload.sender_slug == self.operator_slug
+            )
 
             # Long-message redaction. Operators paste big chunks of
             # code or transcripts that, combined with the agent's
@@ -875,6 +891,8 @@ class PuffoCoreMessageClient:
                 "space_name": space_name,
                 "sender_slug": payload.sender_slug,
                 "sender_display_name": sender_display_name,
+                "sender_owner_slug": sender_owner_slug,
+                "is_from_operator": is_from_operator,
                 "sender_email": "",
                 "text": llm_text,
                 "root_id": payload_thread_root_id or "",
@@ -2085,6 +2103,22 @@ class PuffoCoreMessageClient:
         name, _ = await self._fetch_user_profile(slug)
         return name
 
+    async def _fetch_owner_slug(self, slug: str) -> str:
+        """PUF-361: the sender's operator slug (agents only; ``""`` for
+        humans / revoked attestation), from the same /identities/profiles
+        response the display-name fetch uses. The inbound path resolves
+        the sender's display_name just before this, so the TTL'd cache is
+        warm — no extra round-trip."""
+        if not slug:
+            return ""
+        now = time.monotonic()
+        cached = self._owner_slug_cache.get(slug)
+        if cached is not None and now - cached[1] < _PROFILE_CACHE_TTL_SECONDS:
+            return cached[0]
+        await self._fetch_user_profile(slug, force_refresh=True)
+        fresh = self._owner_slug_cache.get(slug)
+        return fresh[0] if fresh else ""
+
     def set_profile(self, slug: str, display_name: str, avatar_url: str) -> None:
         """Inject fresh values into the profile cache, bypassing TTL.
         Used by the MCP ``get_user_info`` tool to share its just-
@@ -2116,6 +2150,7 @@ class PuffoCoreMessageClient:
                 return (cached[0], cached[1])
         name = ""
         avatar_url = ""
+        owner_slug = ""
         try:
             data = await self.http.get(
                 f"/identities/profiles?slugs={slug}",
@@ -2124,6 +2159,8 @@ class PuffoCoreMessageClient:
                 if entry.get("slug") == slug:
                     name = (entry.get("display_name") or "").strip()
                     avatar_url = (entry.get("avatar_url") or "").strip()
+                    # PUF-361: present only for agents (the operator).
+                    owner_slug = (entry.get("owner_slug") or "").strip()
                     break
         except Exception as exc:
             self._log.debug(
@@ -2131,6 +2168,7 @@ class PuffoCoreMessageClient:
                 slug, exc,
             )
         self._profile_cache[slug] = (name, avatar_url, now)
+        self._owner_slug_cache[slug] = (owner_slug, now)
         disk_cache.persist_profile(slug, name, avatar_url)
         if avatar_url:
             asyncio.create_task(self._fetch_and_cache_avatar(avatar_url))

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -505,11 +505,10 @@ class PuffoCoreMessageClient:
         # under the same TTL — transient lookup failures self-heal at
         # the next tick instead of pinning a permanent "" miss.
         self._profile_cache: dict[str, tuple[str, str, float]] = {}
-        # PUF-361: slug → (owner_slug, fetched_at_monotonic). Filled from
-        # the same /identities/profiles response as the profile cache;
-        # ``owner_slug`` is non-empty only for agents (their operator, per
-        # the attestation chain). Same TTL so re-ownership propagates
-        # without a daemon restart.
+        # slug → (owner_slug, fetched_at_monotonic). Populated by the
+        # same ``/identities/profiles`` call as ``_profile_cache``; empty
+        # for humans, the operator for agents. Same TTL so re-ownership
+        # propagates without a daemon restart.
         self._owner_slug_cache: dict[str, tuple[str, float]] = {}
         # Invitation event_ids the worker has already processed.
         # Lifetime-scoped — the operator-DM branch isn't idempotent
@@ -855,9 +854,7 @@ class PuffoCoreMessageClient:
             sender_display_name = await self._fetch_display_name(
                 payload.sender_slug,
             )
-            # PUF-361: sender-identity enrichment. owner_slug is a
-            # cache hit off the display-name fetch above; the operator
-            # marker is a local equality.
+            # Cache-hit off ``_fetch_display_name`` above — no extra HTTP.
             sender_owner_slug = await self._fetch_owner_slug(
                 payload.sender_slug,
             )
@@ -2104,11 +2101,9 @@ class PuffoCoreMessageClient:
         return name
 
     async def _fetch_owner_slug(self, slug: str) -> str:
-        """PUF-361: the sender's operator slug (agents only; ``""`` for
-        humans / revoked attestation), from the same /identities/profiles
-        response the display-name fetch uses. The inbound path resolves
-        the sender's display_name just before this, so the TTL'd cache is
-        warm — no extra round-trip."""
+        """Sender's operator slug (agents only; ``""`` for humans /
+        revoked attestation). Inbound path resolves the display_name
+        just before this so the TTL'd cache is warm — no extra HTTP."""
         if not slug:
             return ""
         now = time.monotonic()
@@ -2159,7 +2154,7 @@ class PuffoCoreMessageClient:
                 if entry.get("slug") == slug:
                     name = (entry.get("display_name") or "").strip()
                     avatar_url = (entry.get("avatar_url") or "").strip()
-                    # PUF-361: present only for agents (the operator).
+                    # Non-empty only for agents (their operator).
                     owner_slug = (entry.get("owner_slug") or "").strip()
                     break
         except Exception as exc:

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -49,7 +49,7 @@ Every user message carries a metadata block:
 - timestamp: <ISO-8601>
 - sender: <display_name>         # human-readable name for prose
 - sender_slug: <slug>            # structural id — @-mentions + DM routing
-- sender_type: human | bot
+- sender_type: human | agent
 - sender_owner_slug: <slug>      # only when sender is an agent — the
                                  # operator who owns it
 - is_from_operator: true         # only when the sender is YOUR operator
@@ -132,7 +132,7 @@ but don't echo `@you(...)` literally — it's incoming-only syntax.
 Other users' @-mentions appear unchanged.
 
 **Deciding whether to reply** — check `sender_type` and `mentions`:
-- `sender_type: bot` → may be bot-loop; stay `[SILENT]` unless a
+- `sender_type: agent` → may be agent-loop; stay `[SILENT]` unless a
   human is clearly in the loop.
 - `mentions` includes `(you)` or message has `@you(...)` → reply.
 - `mentions` names others but not you → often `[SILENT]`.

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -50,6 +50,9 @@ Every user message carries a metadata block:
 - sender: <display_name>         # human-readable name for prose
 - sender_slug: <slug>            # structural id — @-mentions + DM routing
 - sender_type: human | bot
+- sender_owner_slug: <slug>      # only when sender is an agent — the
+                                 # operator who owns it
+- is_from_operator: true         # only when the sender is YOUR operator
 - is_visible_to_human: true | false
 - mentions:                      # only when @-mentions present
   - puffotest-19b1 (you)

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -1,0 +1,66 @@
+"""PUF-361: inbound-metadata sender-identity enrichment — ``sender_owner_slug``
+when the sender is an agent, ``is_from_operator`` when the sender is this
+agent's own operator. ``_format_user_block`` uses only its args, so an unbound
+call renders the block in isolation.
+"""
+
+from __future__ import annotations
+
+from puffo_agent.agent.core import PuffoAgent
+
+
+def _block(**over) -> str:
+    args = dict(
+        channel_name="general",
+        sender="Nova",
+        sender_email="",
+        text="hi",
+        attachments=None,
+        sender_slug="nova-agent-1234",
+    )
+    args.update(over)
+    # sender_slug isn't a _format_user_block param; the block uses ``sender``
+    # for the slug line. Pass it through ``sender`` for the assertions.
+    args.pop("sender_slug", None)
+    return PuffoAgent._format_user_block(object(), **args)
+
+
+def test_agent_sender_gets_owner_slug():
+    block = _block(sender="nova-agent-1234", sender_owner_slug="nova-op-9999")
+    assert "- sender_owner_slug: nova-op-9999" in block
+    assert "- is_from_operator:" not in block
+
+
+def test_message_from_own_operator_is_flagged():
+    block = _block(sender="mingvase-8795", is_from_operator=True)
+    assert "- is_from_operator: true" in block
+    # A human operator has no owner_slug of their own.
+    assert "- sender_owner_slug:" not in block
+
+
+def test_human_non_operator_gets_neither_field():
+    block = _block(sender="random-human-0001")
+    assert "- sender_owner_slug:" not in block
+    assert "- is_from_operator:" not in block
+
+
+def test_agent_owned_by_current_operator_gets_both():
+    # An agent whose sender IS also somehow the operator is unusual, but the
+    # two annotations are independent — both fire when both conditions hold.
+    block = _block(
+        sender="agt-of-op-0001",
+        sender_owner_slug="mingvase-8795",
+        is_from_operator=True,
+    )
+    assert "- sender_owner_slug: mingvase-8795" in block
+    assert "- is_from_operator: true" in block
+
+
+def test_fields_sit_between_sender_type_and_visibility():
+    # Ordering guard so the block stays stable for readers/tests.
+    block = _block(sender="nova-agent-1234", sender_owner_slug="nova-op-9999")
+    lines = block.splitlines()
+    st = next(i for i, ln in enumerate(lines) if ln.startswith("- sender_type:"))
+    ow = next(i for i, ln in enumerate(lines) if ln.startswith("- sender_owner_slug:"))
+    vis = next(i for i, ln in enumerate(lines) if ln.startswith("- is_visible_to_human:"))
+    assert st < ow < vis

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -1,6 +1,6 @@
-"""PUF-361: inbound-metadata sender-identity enrichment — ``sender_owner_slug``
-when the sender is an agent, ``is_from_operator`` when the sender is this
-agent's own operator. ``_format_user_block`` uses only its args, so an unbound
+"""Inbound-metadata sender-identity enrichment: ``sender_owner_slug``
+fires for agent senders, ``is_from_operator`` for the agent's own
+operator. ``_format_user_block`` uses only its args, so an unbound
 call renders the block in isolation.
 """
 

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -29,6 +29,9 @@ def test_agent_sender_gets_owner_slug():
     block = _block(sender="nova-agent-1234", sender_owner_slug="nova-op-9999")
     assert "- sender_owner_slug: nova-op-9999" in block
     assert "- is_from_operator:" not in block
+    # owner_slug is agent-only, so it flips the displayed type even
+    # while the upstream sender_is_bot flag is still hardcoded False.
+    assert "- sender_type: agent" in block
 
 
 def test_message_from_own_operator_is_flagged():
@@ -36,12 +39,14 @@ def test_message_from_own_operator_is_flagged():
     assert "- is_from_operator: true" in block
     # A human operator has no owner_slug of their own.
     assert "- sender_owner_slug:" not in block
+    assert "- sender_type: human" in block
 
 
 def test_human_non_operator_gets_neither_field():
     block = _block(sender="random-human-0001")
     assert "- sender_owner_slug:" not in block
     assert "- is_from_operator:" not in block
+    assert "- sender_type: human" in block
 
 
 def test_agent_owned_by_current_operator_gets_both():

--- a/tests/test_sender_owner_slug_fetch.py
+++ b/tests/test_sender_owner_slug_fetch.py
@@ -1,6 +1,7 @@
-"""PUF-361: the daemon reads ``owner_slug`` off the same /identities/profiles
-response it already fetches for display names, caches it under the profile TTL,
-and serves it via ``_fetch_owner_slug`` (agents only; empty for humans)."""
+"""Daemon reads ``owner_slug`` off the same ``/identities/profiles``
+response it already fetches for display names, caches it under the
+profile TTL, and serves it via ``_fetch_owner_slug`` (agents only;
+empty for humans)."""
 
 from __future__ import annotations
 

--- a/tests/test_sender_owner_slug_fetch.py
+++ b/tests/test_sender_owner_slug_fetch.py
@@ -1,0 +1,106 @@
+"""PUF-361: the daemon reads ``owner_slug`` off the same /identities/profiles
+response it already fetches for display names, caches it under the profile TTL,
+and serves it via ``_fetch_owner_slug`` (agents only; empty for humans)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+
+def _bare_client() -> PuffoCoreMessageClient:
+    c = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    c.slug = "agent-1"
+    c._profile_cache = {}
+    c._owner_slug_cache = {}
+    return c
+
+
+class _StubHttp:
+    def __init__(self, profiles: dict[str, dict]):
+        self.profiles = profiles
+        self.calls: list[str] = []
+
+    async def get(self, path: str):
+        self.calls.append(path)
+        slug = path.split("slugs=", 1)[1]
+        entry = self.profiles.get(slug)
+        return {"profiles": [entry] if entry else []}
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_profile_caches_owner_slug_for_agent(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "puffo_agent.agent.disk_cache.persist_profile", lambda *a, **k: None,
+    )
+    c = _bare_client()
+    c.http = _StubHttp({
+        "nova-bot-1234": {
+            "slug": "nova-bot-1234",
+            "display_name": "Nova",
+            "avatar_url": "",
+            "owner_slug": "nova-op-9999",
+        },
+    })
+    owner = await c._fetch_owner_slug("nova-bot-1234")
+    assert owner == "nova-op-9999"
+    assert c._owner_slug_cache["nova-bot-1234"][0] == "nova-op-9999"
+
+
+@pytest.mark.asyncio
+async def test_human_sender_has_empty_owner_slug(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.agent.disk_cache.persist_profile", lambda *a, **k: None,
+    )
+    c = _bare_client()
+    c.http = _StubHttp({
+        "alice-1234": {
+            "slug": "alice-1234",
+            "display_name": "Alice",
+            "avatar_url": "",
+            # humans have no owner_slug field
+        },
+    })
+    assert await c._fetch_owner_slug("alice-1234") == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_owner_slug_serves_from_cache_without_refetch():
+    c = _bare_client()
+
+    calls: list[str] = []
+
+    async def fake_profile(slug: str, *, force_refresh: bool = False):
+        calls.append(slug)
+        c._owner_slug_cache[slug] = ("nova-op", time.monotonic())
+        return ("Nova", "")
+
+    c._fetch_user_profile = fake_profile  # type: ignore[assignment]
+
+    assert await c._fetch_owner_slug("nova-bot") == "nova-op"  # cold → fetch
+    assert await c._fetch_owner_slug("nova-bot") == "nova-op"  # warm → cache
+    assert calls == ["nova-bot"]
+    assert await c._fetch_owner_slug("") == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_owner_slug_refetches_when_stale():
+    c = _bare_client()
+    # A stale entry (fetched "long ago") forces a refresh → re-ownership
+    # propagates without a daemon restart.
+    c._owner_slug_cache["nova-bot"] = ("old-op", time.monotonic() - 10_000)
+
+    calls: list[str] = []
+
+    async def fake_profile(slug: str, *, force_refresh: bool = False):
+        calls.append(slug)
+        c._owner_slug_cache[slug] = ("new-op", time.monotonic())
+        return ("Nova", "")
+
+    c._fetch_user_profile = fake_profile  # type: ignore[assignment]
+
+    assert await c._fetch_owner_slug("nova-bot") == "new-op"
+    assert calls == ["nova-bot"]

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -254,6 +254,9 @@ def test_primer_metadata_example_matches_builder():
     # full peer blocks in one turn instead.
     assert "followup_messages_since" not in DEFAULT_SHARED_CLAUDE_MD
     assert "SEVERAL of these blocks" in DEFAULT_SHARED_CLAUDE_MD
+    # Sender-identity enrichment fields documented.
+    assert "- sender_owner_slug: <slug>" in DEFAULT_SHARED_CLAUDE_MD
+    assert "- is_from_operator: true" in DEFAULT_SHARED_CLAUDE_MD
     assert ".puffo/inbox/<envelope_id>/<filename>" in DEFAULT_SHARED_CLAUDE_MD
     # The old, wrong relative form must be gone.
     assert "- attachments/<envelope_id>" not in DEFAULT_SHARED_CLAUDE_MD


### PR DESCRIPTION
## Summary

Enrich inbound message metadata so agents can tell (a) whether a sender is an agent and who operates it, and (b) when a message is from their own operator. Per Vase's spec (msg_3a2bf128), plus the sender_type follow-through surfaced in live testing.

**No server change needed**: `/identities/profiles` already returns `owner_slug` (agents only, from the attestation chain); the daemon just discarded it.

### `sender_owner_slug`

Read off the same `/identities/profiles` fetch the daemon already does for display names. Cached in `_owner_slug_cache` under the same TTL as the profile cache, so re-ownership propagates without a daemon restart. **Zero extra HTTP round-trips** — the display-name fetch just before it populates both caches; `_fetch_owner_slug` is a cache hit.

### `is_from_operator`

Local equality `payload.sender_slug == self.operator_slug`. Works uniformly in channels + DMs.

Both fields emit conditionally (only when set) — older agents never see keys their primer doesn't document.

### `sender_type` now honest for agents (live-testing follow-up)

Operator testing caught agent senders rendering `sender_type: human` right next to their `sender_owner_slug` — the upstream `sender_is_bot` flag is hardcoded `False` (puffo-core exposes no is-bot signal yet) and deliberately left alone because it feeds `_compute_priority`. But `owner_slug`'s presence IS a reliable agent marker, so the display layer now derives the type from either signal:

```python
sender_type = "agent" if (sender_is_bot or sender_owner_slug) else "human"
```

**Priority banding is unchanged** — `_compute_priority` still runs on the untouched upstream flag; wiring a real is-agent signal into priority stays a separate follow-up.

Display vocabulary renamed `bot` → `agent` (block value, primer example, reply-decision guidance) to match the existing `(agent)` mention suffix.

**Field placement**: `sender_type` → `sender_owner_slug` → `is_from_operator` → `is_visible_to_human`, pinned by test.

## Test plan

- [x] Touched suite — **22/22 pass**:
  - Agent sender → `sender_owner_slug` present + `sender_type: agent`; no operator flag.
  - Message from own operator → `is_from_operator: true`, `sender_type: human`, no owner_slug.
  - Human non-operator → neither field, `sender_type: human`.
  - Agent owned by MY operator → both fields.
  - Field ordering pinned.
  - `_fetch_user_profile` caches owner_slug for agents; human sender caches `""`.
  - `_fetch_owner_slug` serves from cache without refetch (pins the no-extra-HTTP contract); refetches when stale.
  - Primer invariant test pins both field lines.
- [x] Full pytest: **1823 passed / 7 skipped** (zero regressions).
- [x] **Live-tested by operator** on the local daemon: agent sender renders `sender_type: agent` + `sender_owner_slug: <operator>`; operator DM renders `is_from_operator: true`.

## Note

Shares `handle_message_batch` surface with #152 (batch-delivery fix) — whichever merges second gets a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)