### PR TITLE
Memory M1–M4 (consolidated) — tree + briefing + MemoryStore + semantic MCP tools + recall APIs

### DIFF
--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -292,6 +292,7 @@ class DockerCLIAdapter(Adapter):
         # No PUFFO_CORE_DB_PATH — MCP routes data reads through the
         # daemon's data service at PUFFO_DATA_SERVICE_URL.
         env["PUFFO_WORKSPACE"] = "/workspace"
+        env["PUFFO_MEMORY_DIR"] = "/home/agent/.puffo-agent-state/memory"
         env["PUFFO_RUNTIME_KIND"] = "cli-docker"
         env["PUFFO_HARNESS"] = "hermes"
         env["PYTHONPATH"] = "/opt/puffoagent-pkg"
@@ -731,6 +732,7 @@ class DockerCLIAdapter(Adapter):
             # No PUFFO_CORE_DB_PATH — SQLite reads route via the
             # daemon's data service.
             env["PUFFO_WORKSPACE"] = "/workspace"
+            env["PUFFO_MEMORY_DIR"] = "/home/agent/.puffo-agent-state/memory"
             env["PUFFO_RUNTIME_KIND"] = "cli-docker"
             env["PUFFO_HARNESS"] = self.harness.name()
             env["PYTHONPATH"] = "/opt/puffoagent-pkg"
@@ -1166,6 +1168,7 @@ def _puffo_gemini_mcp_entry(
     env["PUFFO_CORE_KEYSTORE_DIR"] = "/home/agent/.puffo-agent-state/keys"
     # No PUFFO_CORE_DB_PATH — see mcp/data_client.py.
     env["PUFFO_WORKSPACE"] = "/workspace"
+    env["PUFFO_MEMORY_DIR"] = "/home/agent/.puffo-agent-state/memory"
     env["PUFFO_RUNTIME_KIND"] = "cli-docker"
     env["PUFFO_HARNESS"] = "gemini-cli"
     env["PYTHONPATH"] = "/opt/puffoagent-pkg"

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -94,7 +94,7 @@ class PuffoAgent:
         self.agent_id = agent_id
         self.logger = agent_logger(__name__, agent_id)
 
-        self.memory = MemoryManager(memory_dir)
+        self.memory = MemoryManager(memory_dir, workspace_dir=workspace_dir)
         self.memory_dir = memory_dir
 
         # Conversation log shared across all channels.

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -55,7 +55,46 @@ _MANAGED_BLOCK_RE = re.compile(
 )
 
 
-class BriefingCompileError(Exception):
+class MemoryStoreError(Exception):
+    """Structured memory-store error: the M1 ``{path, size, limit,
+    suggestion}`` shape extended with ``code`` (M3-aligned names such
+    as ``memory_invalid_path`` / ``memory_scope_readonly``).
+    ``size``/``limit`` only apply to size violations; errors without
+    them omit the keys from ``to_dict()``."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        suggestion: str,
+        size: int | None = None,
+        limit: int | None = None,
+    ):
+        self.code = code
+        self.path = path
+        self.size = size
+        self.limit = limit
+        self.suggestion = suggestion
+        if size is not None and limit is not None:
+            message = (
+                f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+            )
+        else:
+            message = f"{code}: {path}. {suggestion}"
+        super().__init__(message)
+
+    def to_dict(self) -> dict:
+        out: dict = {"code": self.code, "path": self.path}
+        if self.size is not None:
+            out["size"] = self.size
+        if self.limit is not None:
+            out["limit"] = self.limit
+        out["suggestion"] = self.suggestion
+        return out
+
+
+class BriefingCompileError(MemoryStoreError):
     """A briefing violates the compile budget. Fail closed — callers
     get no truncated/partial output. ``code`` is one of
     ``memory_file_too_large`` / ``memory_briefing_too_large``
@@ -70,23 +109,35 @@ class BriefingCompileError(Exception):
         limit: int,
         suggestion: str,
     ):
-        self.code = code
-        self.path = path
-        self.size = size
-        self.limit = limit
-        self.suggestion = suggestion
         super().__init__(
-            f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+            code, path=path, size=size, limit=limit, suggestion=suggestion,
         )
 
-    def to_dict(self) -> dict:
-        return {
-            "code": self.code,
-            "path": self.path,
-            "size": self.size,
-            "limit": self.limit,
-            "suggestion": self.suggestion,
-        }
+
+def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> None:
+    """Drop ``refresh_agent.flag`` so the worker rebuilds the prompt
+    artifacts on the next batch. Best-effort; same payload shape as
+    ``profile_sync.write_refresh_agent_flag``. No-op without a
+    workspace dir."""
+    if not workspace_dir:
+        return
+    from ..portal.state import refresh_agent_flag_path
+
+    flag_path = refresh_agent_flag_path(Path(workspace_dir))
+    try:
+        flag_path.parent.mkdir(parents=True, exist_ok=True)
+        flag_path.write_text(
+            json.dumps({
+                "version": 1,
+                "requested_at": int(time.time()),
+                "reason": reason,
+            }) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning(
+            "refresh_agent.flag write failed (%s): %s", reason, exc,
+        )
 
 
 def ensure_memory_tree(memory_root: Path) -> None:
@@ -333,9 +384,13 @@ def sync_profile_briefing(
             # Pre-existing user file without markers: identity framing
             # leads, user content follows untouched.
             new_text = block + "\n" + text
-        path.write_text(new_text, encoding="utf-8")
     else:
-        path.write_text(block, encoding="utf-8")
+        new_text = block
+    from .memory_store import MemoryStore
+
+    MemoryStore(memory_root)._put_memory_file(
+        f"{BRIEFING_DIR}/{PROFILE_BRIEFING_NAME}", new_text,
+    )
     return path
 
 
@@ -354,72 +409,22 @@ class MemoryManager:
         return compile_briefing(Path(self.memory_dir))
 
     def save(self, topic: str, content: str):
+        from .memory_store import MemoryStore
+
         safe_topic = topic.replace(" ", "_").replace("/", "-")
-        path = Path(self.memory_dir) / BRIEFING_DIR / f"{safe_topic}.md"
         # Aware-UTC with ``Z`` suffix (``datetime.utcnow`` is
         # deprecated in 3.12+).
         updated = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
         body = f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n"
-        size = _byte_size(body)
-        if size > PER_FILE_LIMIT:
-            raise BriefingCompileError(
-                "memory_file_too_large",
-                path=str(path),
-                size=size,
-                limit=PER_FILE_LIMIT,
-                suggestion=(
-                    "Save a shorter briefing topic; put the detail in "
-                    f"memory/{NOTES_DIR}/ instead."
-                ),
-            )
-        # Pre-validate the would-be compiled total so an oversized
-        # save never leaves partial state behind.
-        profile_body, entries = _read_briefing_entries(
-            Path(self.memory_dir), enforce_per_file=False,
+        # The store validates sizes (per-file + would-be compiled
+        # total, raising BriefingCompileError) before any write, so an
+        # oversized save never leaves partial state behind. The
+        # refresh flag stays owned by save() — the store gets no
+        # workspace_dir — so its reason keeps the M1 shape.
+        MemoryStore(self.memory_dir)._put_memory_file(
+            f"{BRIEFING_DIR}/{safe_topic}.md", body,
         )
-        entry_map = dict(entries)
-        if safe_topic == "profile":
-            profile_body = body.strip()
-        else:
-            entry_map[safe_topic] = body.strip()
-        total = _byte_size(
-            _compose_briefing(profile_body, sorted(entry_map.items()))
-        )
-        if total > TOTAL_LIMIT:
-            raise BriefingCompileError(
-                "memory_briefing_too_large",
-                path=str(path),
-                size=total,
-                limit=TOTAL_LIMIT,
-                suggestion=(
-                    "This save would push the compiled briefing over "
-                    f"budget; move topics to memory/{NOTES_DIR}/ first."
-                ),
-            )
-        path.write_text(body, encoding="utf-8")
         self._request_refresh(topic)
 
     def _request_refresh(self, topic: str) -> None:
-        """Drop ``refresh_agent.flag`` so the worker rebuilds the
-        prompt artifacts on the next batch. Best-effort; same payload
-        shape as ``profile_sync.write_refresh_agent_flag``."""
-        if not self.workspace_dir:
-            return
-        from ..portal.state import refresh_agent_flag_path
-
-        flag_path = refresh_agent_flag_path(Path(self.workspace_dir))
-        try:
-            flag_path.parent.mkdir(parents=True, exist_ok=True)
-            flag_path.write_text(
-                json.dumps({
-                    "version": 1,
-                    "requested_at": int(time.time()),
-                    "reason": f"memory.save:{topic}",
-                }) + "\n",
-                encoding="utf-8",
-            )
-        except OSError as exc:
-            logger.warning(
-                "refresh_agent.flag write failed after memory save (%s): %s",
-                topic, exc,
-            )
+        request_prompt_refresh(self.workspace_dir, f"memory.save:{topic}")

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -24,7 +24,14 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .memory_errors import BriefingCompileError, MemoryStoreError
+
 logger = logging.getLogger(__name__)
+
+# Re-exported so ``from .memory import MemoryStoreError`` /
+# ``BriefingCompileError`` keeps working now that the classes live in
+# the leaf ``memory_errors`` module.
+__all__ = ["BriefingCompileError", "MemoryStoreError"]
 
 BRIEFING_DIR = "briefing"
 NOTES_DIR = "notes"
@@ -53,65 +60,6 @@ _MANAGED_BLOCK_RE = re.compile(
     re.escape(PROFILE_MANAGED_BEGIN) + r".*?" + re.escape(PROFILE_MANAGED_END),
     re.DOTALL,
 )
-
-
-class MemoryStoreError(Exception):
-    """Structured memory-store error: the M1 ``{path, size, limit,
-    suggestion}`` shape extended with ``code`` (M3-aligned names such
-    as ``memory_invalid_path`` / ``memory_scope_readonly``).
-    ``size``/``limit`` only apply to size violations; errors without
-    them omit the keys from ``to_dict()``."""
-
-    def __init__(
-        self,
-        code: str,
-        *,
-        path: str,
-        suggestion: str,
-        size: int | None = None,
-        limit: int | None = None,
-    ):
-        self.code = code
-        self.path = path
-        self.size = size
-        self.limit = limit
-        self.suggestion = suggestion
-        if size is not None and limit is not None:
-            message = (
-                f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
-            )
-        else:
-            message = f"{code}: {path}. {suggestion}"
-        super().__init__(message)
-
-    def to_dict(self) -> dict:
-        out: dict = {"code": self.code, "path": self.path}
-        if self.size is not None:
-            out["size"] = self.size
-        if self.limit is not None:
-            out["limit"] = self.limit
-        out["suggestion"] = self.suggestion
-        return out
-
-
-class BriefingCompileError(MemoryStoreError):
-    """A briefing violates the compile budget. Fail closed — callers
-    get no truncated/partial output. ``code`` is one of
-    ``memory_file_too_large`` / ``memory_briefing_too_large``
-    (M3-aligned names)."""
-
-    def __init__(
-        self,
-        code: str,
-        *,
-        path: str,
-        size: int,
-        limit: int,
-        suggestion: str,
-    ):
-        super().__init__(
-            code, path=path, size=size, limit=limit, suggestion=suggestion,
-        )
 
 
 def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> bool:
@@ -159,9 +107,26 @@ def _byte_size(text: str) -> int:
     return len(text.encode("utf-8"))
 
 
+def _resolves_within_root(path: Path, memory_root: Path) -> bool:
+    """True iff ``path`` resolves to a location inside ``memory_root``.
+
+    The host-side compile / migration paths read the filesystem
+    directly (not through the M2 store), so a symlink under the memory
+    tree could otherwise pull in content from outside it. Resolving
+    both sides collapses symlinks in either the leaf or an ancestor
+    dir; a resolution failure is treated as "not contained"."""
+    try:
+        return path.resolve().is_relative_to(memory_root.resolve())
+    except OSError:
+        return False
+
+
 def _is_briefing_topic(path: Path) -> bool:
     return (
         path.is_file()
+        # ``is_file()`` follows symlinks; a symlinked briefing/<t>.md
+        # would inject its target's bytes, so exclude symlinks outright.
+        and not path.is_symlink()
         and path.suffix == ".md"
         and not path.name.startswith(".")
     )
@@ -174,7 +139,8 @@ def _read_briefing_entries(
     profile first, remaining topics by sorted filename. Empty bodies
     are dropped. Raises ``BriefingCompileError`` on a per-file limit
     violation unless ``enforce_per_file`` is off."""
-    briefing = Path(memory_root) / BRIEFING_DIR
+    memory_root = Path(memory_root)
+    briefing = memory_root / BRIEFING_DIR
     profile_body = ""
     entries: list[tuple[str, str]] = []
     if not briefing.is_dir():
@@ -185,6 +151,15 @@ def _read_briefing_entries(
         paths.remove(profile_path)
         paths.insert(0, profile_path)
     for path in paths:
+        # ``_is_briefing_topic`` already dropped leaf symlinks; this
+        # catches a topic that resolves outside the root through a
+        # symlinked ancestor dir (e.g. a symlinked briefing/).
+        if not _resolves_within_root(path, memory_root):
+            logger.warning(
+                "memory briefing: skipping %s — resolves outside the "
+                "memory root", path,
+            )
+            continue
         body = path.read_text(encoding="utf-8")
         if enforce_per_file and _byte_size(body) > PER_FILE_LIMIT:
             raise BriefingCompileError(
@@ -260,16 +235,30 @@ def migrate_flat_memory(memory_root: Path) -> list[str]:
     if not memory_root.is_dir():
         return []
     ensure_memory_tree(memory_root)
-    flat = [
-        p for p in sorted(memory_root.glob("*.md"))
-        if p.is_file() and p.name != "README.md" and not p.name.startswith(".")
-    ]
+    flat = []
+    for p in sorted(memory_root.glob("*.md")):
+        if not p.is_file() or p.name == "README.md" or p.name.startswith("."):
+            continue
+        # A symlinked flat file (or one resolving outside the root)
+        # must never be read or moved into the tree — that would fold
+        # arbitrary host content into the agent's memory.
+        if p.is_symlink() or not _resolves_within_root(p, memory_root):
+            logger.warning(
+                "memory migrate: skipping %s — symlink or resolves "
+                "outside the memory root", p,
+            )
+            continue
+        flat.append(p)
     if not flat:
         return []
 
     briefing_dir = memory_root / BRIEFING_DIR
     notes_dir = memory_root / NOTES_DIR
     pointer_path = briefing_dir / f"{MIGRATED_NOTES_TOPIC}.md"
+
+    from .memory_store import MemoryStore
+
+    store = MemoryStore(memory_root)
 
     # Live simulation state: recomposing from these on every candidate
     # keeps the fit check exact (section headers + join separators
@@ -310,6 +299,7 @@ def migrate_flat_memory(memory_root: Path) -> list[str]:
                 dest = notes_dir / f"{path.stem}-migrated-{n}.md"
                 n += 1
         path.rename(dest)
+        moved.append(f"{NOTES_DIR}/{dest.name}")
         pointer_line = (
             f"- {NOTES_DIR}/{dest.name} — migrated from flat memory\n"
         )
@@ -318,9 +308,25 @@ def migrate_flat_memory(memory_root: Path) -> list[str]:
             existing = pointer_path.read_text(encoding="utf-8")
         elif not entry_map.get(MIGRATED_NOTES_TOPIC):
             existing = "# Migrated notes\n\n"
-        pointer_path.write_text(existing + pointer_line, encoding="utf-8")
-        entry_map[MIGRATED_NOTES_TOPIC] = (existing + pointer_line).strip()
-        moved.append(f"{NOTES_DIR}/{dest.name}")
+        new_body = existing + pointer_line
+        try:
+            # Route the pointer through the store: same atomic write and
+            # per-file/total budget validation as any briefing topic, so
+            # a migration can never leave a briefing that fails the next
+            # compile.
+            store.put_memory_file(
+                f"{BRIEFING_DIR}/{MIGRATED_NOTES_TOPIC}.md", new_body,
+            )
+        except BriefingCompileError as exc:
+            # The note itself already migrated to notes/; only its
+            # pointer line is dropped so the briefing stays compilable.
+            logger.warning(
+                "memory migrate: pointer to %s skipped (%s) — the note "
+                "migrated but the briefing budget is full",
+                dest.name, exc.code,
+            )
+            continue
+        entry_map[MIGRATED_NOTES_TOPIC] = new_body.strip()
     return moved
 
 
@@ -391,7 +397,7 @@ def sync_profile_briefing(
         new_text = block
     from .memory_store import MemoryStore
 
-    MemoryStore(memory_root)._put_memory_file(
+    MemoryStore(memory_root).put_memory_file(
         f"{BRIEFING_DIR}/{PROFILE_BRIEFING_NAME}", new_text,
     )
     return path
@@ -424,7 +430,7 @@ class MemoryManager:
         # oversized save never leaves partial state behind. The
         # refresh flag stays owned by save() — the store gets no
         # workspace_dir — so its reason keeps the M1 shape.
-        MemoryStore(self.memory_dir)._put_memory_file(
+        MemoryStore(self.memory_dir).put_memory_file(
             f"{BRIEFING_DIR}/{safe_topic}.md", body,
         )
         self._request_refresh(topic)

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -1,37 +1,425 @@
-import os
-import glob
+"""Agent memory tree (M1): bounded briefing compile + notes.
+
+Layout under an agent's memory root::
+
+    memory/
+      briefing/           # always-loaded; compiled (bounded) into the
+        profile.md        #   provider prompt artifacts. profile.md is
+        <topic>.md        #   identity framing, synced from agent.yml.
+      notes/              # durable detail; searchable, never injected
+      recollection/       # reserved (M4)
+      imports/index.md    # reserved; provenance of imported content
+
+The compile is deterministic (profile first, then sorted filenames)
+and fails closed: an over-limit briefing raises
+``BriefingCompileError`` rather than truncating.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
 from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+BRIEFING_DIR = "briefing"
+NOTES_DIR = "notes"
+RECOLLECTION_DIR = "recollection"
+IMPORTS_DIR = "imports"
+
+# Bounded-briefing budget (M1 ships the top of the design's ranges;
+# M2 may tighten). Byte sizes of the UTF-8 encoded content.
+PER_FILE_LIMIT = 16 * 1024
+TOTAL_LIMIT = 64 * 1024
+
+PROFILE_BRIEFING_NAME = "profile.md"
+MIGRATED_NOTES_TOPIC = "migrated-notes"
+
+_IMPORTS_INDEX_SEED = """\
+# Imports index
+
+Provenance of content imported into this agent's memory. Reserved —
+maintained by the platform; one entry per import.
+"""
+
+PROFILE_MANAGED_BEGIN = "<!-- puffo:managed-profile -->"
+PROFILE_MANAGED_END = "<!-- /puffo:managed-profile -->"
+
+_MANAGED_BLOCK_RE = re.compile(
+    re.escape(PROFILE_MANAGED_BEGIN) + r".*?" + re.escape(PROFILE_MANAGED_END),
+    re.DOTALL,
+)
+
+
+class BriefingCompileError(Exception):
+    """A briefing violates the compile budget. Fail closed — callers
+    get no truncated/partial output. ``code`` is one of
+    ``memory_file_too_large`` / ``memory_briefing_too_large``
+    (M3-aligned names)."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        size: int,
+        limit: int,
+        suggestion: str,
+    ):
+        self.code = code
+        self.path = path
+        self.size = size
+        self.limit = limit
+        self.suggestion = suggestion
+        super().__init__(
+            f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "path": self.path,
+            "size": self.size,
+            "limit": self.limit,
+            "suggestion": self.suggestion,
+        }
+
+
+def ensure_memory_tree(memory_root: Path) -> None:
+    """Create the M1 memory tree under ``memory_root``. Idempotent;
+    never touches existing content. All paths are built by joining
+    fixed names under the root — nothing is written outside it."""
+    memory_root = Path(memory_root)
+    for sub in (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR, IMPORTS_DIR):
+        (memory_root / sub).mkdir(parents=True, exist_ok=True)
+    index = memory_root / IMPORTS_DIR / "index.md"
+    if not index.exists():
+        index.write_text(_IMPORTS_INDEX_SEED, encoding="utf-8")
+
+
+def _byte_size(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def _is_briefing_topic(path: Path) -> bool:
+    return (
+        path.is_file()
+        and path.suffix == ".md"
+        and not path.name.startswith(".")
+    )
+
+
+def _read_briefing_entries(
+    memory_root: Path, *, enforce_per_file: bool = True,
+) -> tuple[str, list[tuple[str, str]]]:
+    """``(profile_body, [(stem, body), ...])`` in compile order:
+    profile first, remaining topics by sorted filename. Empty bodies
+    are dropped. Raises ``BriefingCompileError`` on a per-file limit
+    violation unless ``enforce_per_file`` is off."""
+    briefing = Path(memory_root) / BRIEFING_DIR
+    profile_body = ""
+    entries: list[tuple[str, str]] = []
+    if not briefing.is_dir():
+        return profile_body, entries
+    profile_path = briefing / PROFILE_BRIEFING_NAME
+    paths = [p for p in sorted(briefing.glob("*.md")) if _is_briefing_topic(p)]
+    if profile_path in paths:
+        paths.remove(profile_path)
+        paths.insert(0, profile_path)
+    for path in paths:
+        body = path.read_text(encoding="utf-8")
+        if enforce_per_file and _byte_size(body) > PER_FILE_LIMIT:
+            raise BriefingCompileError(
+                "memory_file_too_large",
+                path=str(path),
+                size=_byte_size(body),
+                limit=PER_FILE_LIMIT,
+                suggestion=(
+                    "Trim this briefing topic; move detail to "
+                    f"memory/{NOTES_DIR}/ (searchable, not injected)."
+                ),
+            )
+        body = body.strip()
+        if not body:
+            continue
+        if path == profile_path:
+            profile_body = body
+        else:
+            entries.append((path.stem, body))
+    return profile_body, entries
+
+
+def _compose_briefing(profile_body: str, entries: list[tuple[str, str]]) -> str:
+    parts: list[str] = []
+    if profile_body:
+        parts.append(profile_body)
+    for stem, body in entries:
+        parts.append(f"### {stem}\n\n{body}")
+    return "\n\n".join(parts)
+
+
+def compile_briefing(memory_root: Path) -> str:
+    """Deterministically compile ``briefing/`` into one prompt block:
+    profile.md body first (verbatim), then every other ``*.md`` as a
+    ``### <stem>`` section in sorted filename order. Enforces
+    ``PER_FILE_LIMIT`` per file and ``TOTAL_LIMIT`` on the joined
+    output; raises ``BriefingCompileError`` instead of truncating.
+    Returns ``""`` for an empty/missing briefing."""
+    memory_root = Path(memory_root)
+    profile_body, entries = _read_briefing_entries(memory_root)
+    compiled = _compose_briefing(profile_body, entries)
+    total = _byte_size(compiled)
+    if total > TOTAL_LIMIT:
+        raise BriefingCompileError(
+            "memory_briefing_too_large",
+            path=str(memory_root / BRIEFING_DIR),
+            size=total,
+            limit=TOTAL_LIMIT,
+            suggestion=(
+                "The compiled briefing exceeds the total budget; move "
+                f"topics to memory/{NOTES_DIR}/ or trim them."
+            ),
+        )
+    return compiled
+
+
+def migrate_flat_memory(memory_root: Path) -> list[str]:
+    """Migrate legacy flat ``memory/*.md`` files into the tree.
+
+    Deterministic rule: files are processed in sorted filename order
+    (``README.md`` and dotfiles excluded). A file moves to
+    ``briefing/<name>`` iff it is ≤ ``PER_FILE_LIMIT`` bytes, the
+    briefing slot is free, and the would-be compiled briefing
+    (current briefing + already-migrated files + this file) stays
+    ≤ ``TOTAL_LIMIT``; otherwise it moves to ``notes/<name>`` (or
+    ``notes/<stem>-migrated.md`` on collision) and a pointer line is
+    appended to ``briefing/migrated-notes.md``. Idempotent: a pass
+    leaves no flat ``*.md`` behind, so re-runs are no-ops.
+
+    Returns the migrated files' new memory-root-relative paths.
+    """
+    memory_root = Path(memory_root)
+    if not memory_root.is_dir():
+        return []
+    ensure_memory_tree(memory_root)
+    flat = [
+        p for p in sorted(memory_root.glob("*.md"))
+        if p.is_file() and p.name != "README.md" and not p.name.startswith(".")
+    ]
+    if not flat:
+        return []
+
+    briefing_dir = memory_root / BRIEFING_DIR
+    notes_dir = memory_root / NOTES_DIR
+    pointer_path = briefing_dir / f"{MIGRATED_NOTES_TOPIC}.md"
+
+    # Live simulation state: recomposing from these on every candidate
+    # keeps the fit check exact (section headers + join separators
+    # count toward the total, and so do appended pointer lines).
+    profile_body, entries = _read_briefing_entries(
+        memory_root, enforce_per_file=False,
+    )
+    entry_map: dict[str, str] = dict(entries)
+
+    def compiled_size_with(stem: str, body: str) -> int:
+        candidate = dict(entry_map)
+        candidate[stem] = body.strip()
+        composed = _compose_briefing(
+            profile_body, sorted(candidate.items()),
+        )
+        return _byte_size(composed)
+
+    moved: list[str] = []
+    for path in flat:
+        body = path.read_text(encoding="utf-8")
+        fits_briefing = (
+            _byte_size(body) <= PER_FILE_LIMIT
+            and path.name != PROFILE_BRIEFING_NAME
+            and not (briefing_dir / path.name).exists()
+            and compiled_size_with(path.stem, body) <= TOTAL_LIMIT
+        )
+        if fits_briefing:
+            dest = briefing_dir / path.name
+            path.rename(dest)
+            entry_map[path.stem] = body.strip()
+            moved.append(f"{BRIEFING_DIR}/{dest.name}")
+            continue
+        dest = notes_dir / path.name
+        if dest.exists():
+            dest = notes_dir / f"{path.stem}-migrated.md"
+            n = 2
+            while dest.exists():
+                dest = notes_dir / f"{path.stem}-migrated-{n}.md"
+                n += 1
+        path.rename(dest)
+        pointer_line = (
+            f"- {NOTES_DIR}/{dest.name} — migrated from flat memory\n"
+        )
+        existing = ""
+        if pointer_path.exists():
+            existing = pointer_path.read_text(encoding="utf-8")
+        elif not entry_map.get(MIGRATED_NOTES_TOPIC):
+            existing = "# Migrated notes\n\n"
+        pointer_path.write_text(existing + pointer_line, encoding="utf-8")
+        entry_map[MIGRATED_NOTES_TOPIC] = (existing + pointer_line).strip()
+        moved.append(f"{NOTES_DIR}/{dest.name}")
+    return moved
+
+
+def render_profile_briefing(
+    *,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+    soul: str = "",
+) -> str:
+    """Identity framing for ``briefing/profile.md``: display name,
+    role lines, soul body. Deliberately NO ``## Instructions`` and no
+    runtime-behavior sections — those live in the agent-root
+    profile.md / primer. Missing fields degrade to a minimal identity
+    line derived from agent id + display name."""
+    name = display_name or agent_id or "agent"
+    identity = f"You are {name}"
+    if agent_id:
+        identity += f" (agent `{agent_id}`)"
+    identity += "."
+    lines = [f"# {name}", "", identity]
+    if role:
+        lines += ["", f"Role: {role}"]
+    if role_short:
+        lines.append(f"Role (short): {role_short}")
+    if soul.strip():
+        lines += ["", "## Soul", "", soul.strip()]
+    return "\n".join(lines) + "\n"
+
+
+def sync_profile_briefing(
+    memory_root: Path,
+    *,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+    soul: str = "",
+) -> Path:
+    """(Re)write the managed block of ``briefing/profile.md`` from the
+    native profile surfaces (agent.yml identity fields + the ``# Soul``
+    body of agent-root profile.md). Content between the
+    ``puffo:managed-profile`` markers is regenerated on every managed
+    rebuild; user-authored text outside the markers is preserved."""
+    memory_root = Path(memory_root)
+    ensure_memory_tree(memory_root)
+    path = memory_root / BRIEFING_DIR / PROFILE_BRIEFING_NAME
+    rendered = render_profile_briefing(
+        agent_id=agent_id,
+        display_name=display_name,
+        role=role,
+        role_short=role_short,
+        soul=soul,
+    )
+    block = f"{PROFILE_MANAGED_BEGIN}\n{rendered}{PROFILE_MANAGED_END}\n"
+    if path.exists():
+        text = path.read_text(encoding="utf-8")
+        if _MANAGED_BLOCK_RE.search(text):
+            new_text = _MANAGED_BLOCK_RE.sub(
+                lambda _m: block.rstrip("\n"), text, count=1,
+            )
+        else:
+            # Pre-existing user file without markers: identity framing
+            # leads, user content follows untouched.
+            new_text = block + "\n" + text
+        path.write_text(new_text, encoding="utf-8")
+    else:
+        path.write_text(block, encoding="utf-8")
+    return path
 
 
 class MemoryManager:
-    def __init__(self, memory_dir: str):
-        self.memory_dir = memory_dir
-        self.memories: dict[str, str] = {}
-        self._load()
+    """Compat shim over the memory tree. ``save()`` keeps its historic
+    name/signature but writes a briefing topic (bounded, fail closed)
+    and marks the prompt artifacts for rebuild; ``get_context()``
+    returns the compiled briefing instead of a full join."""
 
-    def _load(self):
-        for path in glob.glob(os.path.join(self.memory_dir, "*.md")):
-            if os.path.basename(path) == "README.md":
-                continue
-            with open(path, "r", encoding="utf-8") as f:
-                content = f.read()
-            topic = os.path.splitext(os.path.basename(path))[0]
-            self.memories[topic] = content
+    def __init__(self, memory_dir: str, workspace_dir: str = ""):
+        self.memory_dir = memory_dir
+        self.workspace_dir = workspace_dir
+        ensure_memory_tree(Path(memory_dir))
 
     def get_context(self) -> str:
-        if not self.memories:
-            return ""
-        parts = ["## Memory\n"]
-        for topic, content in self.memories.items():
-            parts.append(f"### {topic}\n{content}\n")
-        return "\n".join(parts)
+        return compile_briefing(Path(self.memory_dir))
 
     def save(self, topic: str, content: str):
-        self.memories[topic] = content
         safe_topic = topic.replace(" ", "_").replace("/", "-")
-        path = os.path.join(self.memory_dir, f"{safe_topic}.md")
+        path = Path(self.memory_dir) / BRIEFING_DIR / f"{safe_topic}.md"
         # Aware-UTC with ``Z`` suffix (``datetime.utcnow`` is
         # deprecated in 3.12+).
         updated = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n")
+        body = f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n"
+        size = _byte_size(body)
+        if size > PER_FILE_LIMIT:
+            raise BriefingCompileError(
+                "memory_file_too_large",
+                path=str(path),
+                size=size,
+                limit=PER_FILE_LIMIT,
+                suggestion=(
+                    "Save a shorter briefing topic; put the detail in "
+                    f"memory/{NOTES_DIR}/ instead."
+                ),
+            )
+        # Pre-validate the would-be compiled total so an oversized
+        # save never leaves partial state behind.
+        profile_body, entries = _read_briefing_entries(
+            Path(self.memory_dir), enforce_per_file=False,
+        )
+        entry_map = dict(entries)
+        if safe_topic == "profile":
+            profile_body = body.strip()
+        else:
+            entry_map[safe_topic] = body.strip()
+        total = _byte_size(
+            _compose_briefing(profile_body, sorted(entry_map.items()))
+        )
+        if total > TOTAL_LIMIT:
+            raise BriefingCompileError(
+                "memory_briefing_too_large",
+                path=str(path),
+                size=total,
+                limit=TOTAL_LIMIT,
+                suggestion=(
+                    "This save would push the compiled briefing over "
+                    f"budget; move topics to memory/{NOTES_DIR}/ first."
+                ),
+            )
+        path.write_text(body, encoding="utf-8")
+        self._request_refresh(topic)
+
+    def _request_refresh(self, topic: str) -> None:
+        """Drop ``refresh_agent.flag`` so the worker rebuilds the
+        prompt artifacts on the next batch. Best-effort; same payload
+        shape as ``profile_sync.write_refresh_agent_flag``."""
+        if not self.workspace_dir:
+            return
+        from ..portal.state import refresh_agent_flag_path
+
+        flag_path = refresh_agent_flag_path(Path(self.workspace_dir))
+        try:
+            flag_path.parent.mkdir(parents=True, exist_ok=True)
+            flag_path.write_text(
+                json.dumps({
+                    "version": 1,
+                    "requested_at": int(time.time()),
+                    "reason": f"memory.save:{topic}",
+                }) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "refresh_agent.flag write failed after memory save (%s): %s",
+                topic, exc,
+            )

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -114,13 +114,14 @@ class BriefingCompileError(MemoryStoreError):
         )
 
 
-def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> None:
+def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> bool:
     """Drop ``refresh_agent.flag`` so the worker rebuilds the prompt
     artifacts on the next batch. Best-effort; same payload shape as
     ``profile_sync.write_refresh_agent_flag``. No-op without a
-    workspace dir."""
+    workspace dir. Returns True iff the flag was written (the M3
+    tools layer maps this to the ``provider_reload`` post-effect)."""
     if not workspace_dir:
-        return
+        return False
     from ..portal.state import refresh_agent_flag_path
 
     flag_path = refresh_agent_flag_path(Path(workspace_dir))
@@ -138,6 +139,8 @@ def request_prompt_refresh(workspace_dir: str | Path, reason: str) -> None:
         logger.warning(
             "refresh_agent.flag write failed (%s): %s", reason, exc,
         )
+        return False
+    return True
 
 
 def ensure_memory_tree(memory_root: Path) -> None:

--- a/src/puffo_agent/agent/memory_errors.py
+++ b/src/puffo_agent/agent/memory_errors.py
@@ -1,0 +1,69 @@
+"""Structured memory errors, hoisted out of ``memory.py``.
+
+These live in their own leaf module so every layer of the memory stack
+(``memory`` M1, ``memory_store`` M2, ``memory_tools`` M3, and the
+``portal`` callers) can import the error types without pulling in — or
+being pulled in by — the higher layers. ``memory`` re-exports both
+names, so ``from .memory import MemoryStoreError`` keeps working.
+"""
+
+from __future__ import annotations
+
+
+class MemoryStoreError(Exception):
+    """Structured memory-store error: the M1 ``{path, size, limit,
+    suggestion}`` shape extended with ``code`` (M3-aligned names such
+    as ``memory_invalid_path`` / ``memory_scope_readonly``).
+    ``size``/``limit`` only apply to size violations; errors without
+    them omit the keys from ``to_dict()``."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        suggestion: str,
+        size: int | None = None,
+        limit: int | None = None,
+    ):
+        self.code = code
+        self.path = path
+        self.size = size
+        self.limit = limit
+        self.suggestion = suggestion
+        if size is not None and limit is not None:
+            message = (
+                f"{code}: {path} is {size} bytes (limit {limit}). {suggestion}"
+            )
+        else:
+            message = f"{code}: {path}. {suggestion}"
+        super().__init__(message)
+
+    def to_dict(self) -> dict:
+        out: dict = {"code": self.code, "path": self.path}
+        if self.size is not None:
+            out["size"] = self.size
+        if self.limit is not None:
+            out["limit"] = self.limit
+        out["suggestion"] = self.suggestion
+        return out
+
+
+class BriefingCompileError(MemoryStoreError):
+    """A briefing violates the compile budget. Fail closed — callers
+    get no truncated/partial output. ``code`` is one of
+    ``memory_file_too_large`` / ``memory_briefing_too_large``
+    (M3-aligned names)."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        path: str,
+        size: int,
+        limit: int,
+        suggestion: str,
+    ):
+        super().__init__(
+            code, path=path, size=size, limit=limit, suggestion=suggestion,
+        )

--- a/src/puffo_agent/agent/memory_errors.py
+++ b/src/puffo_agent/agent/memory_errors.py
@@ -67,3 +67,29 @@ class BriefingCompileError(MemoryStoreError):
         super().__init__(
             code, path=path, size=size, limit=limit, suggestion=suggestion,
         )
+
+
+class MemoryHistoryError(Exception):
+    """Structured memory-history error: the M4 read-only audit query
+    analogue of ``MemoryStoreError``. Carries ``code`` (one of the M4
+    history codes such as ``memory_history_unavailable`` /
+    ``memory_history_not_initialized`` / ``memory_invalid_history_query``
+    / ``memory_history_query_too_large`` / ``memory_history_read_failed``),
+    plus a human ``message`` and a ``suggestion``. Unlike
+    ``MemoryStoreError`` it carries no ``path``/``size``/``limit`` — a
+    history query is over the audit log, not a single file — so the
+    tools layer maps it to the ``{code, message, suggestion}`` envelope
+    with a ``memory_git`` cause layer."""
+
+    def __init__(self, code: str, *, message: str, suggestion: str):
+        self.code = code
+        self.message = message
+        self.suggestion = suggestion
+        super().__init__(f"{code}: {message} {suggestion}".rstrip())
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "suggestion": self.suggestion,
+        }

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -17,9 +17,18 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
+
+from .memory import (
+    BRIEFING_DIR,
+    IMPORTS_DIR,
+    NOTES_DIR,
+    RECOLLECTION_DIR,
+)
+from .memory_errors import MemoryHistoryError
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +40,33 @@ _GIT_TIMEOUT = 30
 # in the daemon's environment could otherwise redirect an audit commit
 # into an attacker-chosen repo, so they are scrubbed from every run.
 _GIT_LOCATION_ENV = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+
+# ── M4 read-only history query bounds ────────────────────────────────
+HISTORY_DEFAULT_LIMIT = 20
+HISTORY_MAX_LIMIT = 100
+# include_diff attaches a diff per returned commit, so its limit is
+# tighter than a metadata-only query.
+HISTORY_DIFF_MAX_LIMIT = 20
+HISTORY_DIFF_BYTE_CAP = 4000
+# Unified-context lines for include_diff excerpts. Small on purpose —
+# the diff is a bounded audit excerpt, not a full patch.
+_HISTORY_DIFF_CONTEXT = 3
+
+# The four memory areas a history query may be scoped to.
+_HISTORY_SCOPES = (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR, IMPORTS_DIR)
+
+# git log field/record separators (ASCII US / RS): control chars that
+# never occur in a memory path or commit subject, so record parsing is
+# unambiguous and no user-supplied filter value can be mistaken for a
+# delimiter. The %b body is the LAST field, so the trailing --numstat
+# block is peeled off it in Python (see _split_body_numstat).
+_HISTORY_REC_SEP = "\x1e"
+_HISTORY_FIELD_SEP = "\x1f"
+_HISTORY_LOG_FORMAT = "%x1e%H%x1f%h%x1f%cI%x1f%an%x1f%s%x1f%b"
+
+# A --numstat line: "<added>\t<deleted>\t<path>" where added/deleted are
+# digits or "-" (binary files).
+_NUMSTAT_RE = re.compile(r"^(\d+|-)\t(\d+|-)\t(.+)$")
 
 
 def git_available() -> bool:
@@ -168,3 +204,406 @@ def commit_memory_change(
     if head is None or head.returncode != 0:
         return None
     return head.stdout.strip() or None
+
+
+# ── M4 read-only audit history queries ───────────────────────────────
+#
+# These NEVER init the tree or the repo (unlike the M3 read tools' lazy
+# ensure): a status/history read on an uninitialised root reports the
+# truth (unavailable / not initialised) rather than materialising it.
+# Only whitelisted, glued/``--``-guarded git args are ever built — no
+# arbitrary flags, refs, revision ranges, or rollback are exposed.
+
+
+def _history_unavailable() -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_unavailable",
+        message="git is not installed, so the memory audit history is unavailable.",
+        suggestion=(
+            "Install git to enable memory history; memory reads and writes "
+            "still work without it."
+        ),
+    )
+
+
+def _history_not_initialized(root: Path) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_not_initialized",
+        message=f"No local memory audit repo exists yet at {root}.",
+        suggestion="History appears once the first memory write is audit-committed.",
+    )
+
+
+def _history_read_failed(detail: str) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_read_failed",
+        message=f"Reading the memory audit history failed: {detail}.",
+        suggestion="Retry; if it persists, check the memory git repo.",
+    )
+
+
+def _history_invalid_query(detail: str, suggestion: str) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_invalid_history_query", message=detail, suggestion=suggestion,
+    )
+
+
+def _history_too_large(detail: str, suggestion: str) -> MemoryHistoryError:
+    return MemoryHistoryError(
+        "memory_history_query_too_large", message=detail, suggestion=suggestion,
+    )
+
+
+def _history_env_ok(memory_root: str | Path) -> Path:
+    """Guard every history entry point: a git binary AND a local audit
+    repo must both exist. Returns the root; raises the matching
+    MemoryHistoryError otherwise. Never creates anything."""
+    root = Path(memory_root)
+    if not git_available():
+        raise _history_unavailable()
+    if not (root / ".git").is_dir():
+        raise _history_not_initialized(root)
+    return root
+
+
+def _porcelain_paths(text: str) -> list[str]:
+    """Work-tree/index paths from ``git status --porcelain`` output.
+    Rename/copy entries (``old -> new``) report the new path."""
+    out: list[str] = []
+    for line in text.splitlines():
+        if len(line) < 4:
+            continue
+        entry = line[3:]
+        if " -> " in entry:
+            entry = entry.split(" -> ", 1)[1]
+        out.append(entry)
+    return out
+
+
+def history_status(
+    memory_root: str | Path, path: str | None = None,
+) -> dict:
+    """Read-only health of the local audit repo: HEAD id, clean/dirty
+    work tree, and — when ``path`` is given (a logical memory path,
+    pre-validated by the caller) — whether that path is tracked and
+    when it last changed. Operates on committed history and tolerates a
+    dirty work tree (dirtiness is reported via ``clean`` /
+    ``uncommitted_paths``, never raised)."""
+    root = _history_env_ok(memory_root)
+    # HEAD short id — None (not an error) on an unborn/empty repo, where
+    # ``--verify --quiet`` exits nonzero with empty output.
+    head = _run_git(
+        root, ["rev-parse", "--verify", "--quiet", "--short", "HEAD"],
+    )
+    if head is None:
+        raise _history_read_failed("git rev-parse failed to run")
+    if head.returncode == 0:
+        head_id = head.stdout.strip() or None
+    elif not head.stdout.strip():
+        head_id = None
+    else:
+        raise _history_read_failed(
+            (head.stderr or head.stdout).strip() or "git rev-parse failed"
+        )
+
+    status = _run_git(root, ["status", "--porcelain"])
+    if status is None or status.returncode != 0:
+        detail = (
+            (status.stderr or status.stdout).strip()
+            if status else "git status failed to run"
+        )
+        raise _history_read_failed(detail or "git status failed")
+    uncommitted = _porcelain_paths(status.stdout)
+
+    result: dict = {
+        "git_enabled": True,
+        "repo_initialized": True,
+        "head_commit_id": head_id,
+        "clean": not uncommitted,
+        "uncommitted_paths": uncommitted,
+    }
+    if path is not None:
+        result["path"] = path
+        if head_id is None:
+            # No commits yet: nothing is tracked (a bare `git log` on an
+            # unborn HEAD would exit nonzero — treat as not-tracked).
+            result.update({
+                "path_tracked": False,
+                "last_changed_commit_id": None,
+                "last_changed_at": None,
+            })
+        else:
+            log = _run_git(
+                root, ["log", "-1", "--format=%h%x1f%cI", "--", path],
+            )
+            if log is None or log.returncode != 0:
+                detail = (
+                    (log.stderr or log.stdout).strip()
+                    if log else "git log failed to run"
+                )
+                raise _history_read_failed(detail or "git log failed")
+            out = log.stdout.strip()
+            if out:
+                short, _, iso = out.partition(_HISTORY_FIELD_SEP)
+                result.update({
+                    "path_tracked": True,
+                    "last_changed_commit_id": short or None,
+                    "last_changed_at": iso or None,
+                })
+            else:
+                result.update({
+                    "path_tracked": False,
+                    "last_changed_commit_id": None,
+                    "last_changed_at": None,
+                })
+    return result
+
+
+def _parse_commit_body(body: str) -> tuple[str | None, str | None]:
+    """Pull ``operation`` (from the ``tool:`` line) and ``reason`` (from
+    the ``reason:`` line) out of a commit body written by
+    ``format_commit_message``. Either may be absent."""
+    operation: str | None = None
+    reason: str | None = None
+    for line in body.splitlines():
+        stripped = line.strip()
+        if operation is None and stripped.startswith("tool:"):
+            operation = stripped[len("tool:"):].strip() or None
+        elif reason is None and stripped.startswith("reason:"):
+            reason = stripped[len("reason:"):].strip() or None
+    return operation, reason
+
+
+def _split_body_numstat(rest: str) -> tuple[str, list[str], int, int]:
+    """Peel the trailing ``--numstat`` block off the last (%b) field of
+    a log record. Returns ``(body, changed_paths, insertions,
+    deletions)``. The numstat lines are contiguous at the tail, so we
+    walk backward collecting rows that match ``_NUMSTAT_RE`` until the
+    first non-numstat line — everything above (minus trailing blanks) is
+    the commit body."""
+    lines = rest.split("\n")
+    while lines and lines[-1] == "":
+        lines.pop()
+    insertions = 0
+    deletions = 0
+    changed: list[str] = []
+    i = len(lines)
+    while i > 0:
+        m = _NUMSTAT_RE.match(lines[i - 1])
+        if not m:
+            break
+        i -= 1
+        added, removed, pth = m.group(1), m.group(2), m.group(3)
+        changed.append(pth)
+        if added != "-":
+            insertions += int(added)
+        if removed != "-":
+            deletions += int(removed)
+    changed.reverse()
+    body_lines = lines[:i]
+    while body_lines and body_lines[-1] == "":
+        body_lines.pop()
+    return "\n".join(body_lines), changed, insertions, deletions
+
+
+def _parse_history_records(output: str) -> list[dict]:
+    """Parse ``git log`` record-separated output into commit dicts.
+    ``_full`` (the full %H hash) is kept for a follow-up diff and popped
+    before the result is returned to the caller."""
+    commits: list[dict] = []
+    for raw in output.split(_HISTORY_REC_SEP):
+        if not raw.strip():
+            continue
+        fields = raw.split(_HISTORY_FIELD_SEP, 5)
+        if len(fields) < 6:
+            continue
+        full, short, iso, actor, subject, rest = fields
+        body, changed, insertions, deletions = _split_body_numstat(rest)
+        operation, reason = _parse_commit_body(body)
+        commits.append({
+            "_full": full,
+            "commit_id": short,
+            "time": iso,
+            "actor": actor,
+            "operation": operation,
+            "reason": reason,
+            "message": subject,
+            "changed_paths": changed,
+            "summary": {
+                "files_changed": len(changed),
+                "insertions": insertions,
+                "deletions": deletions,
+            },
+        })
+    return commits
+
+
+def _history_diff(
+    root: Path, full_hash: str, pathspec: list[str],
+) -> tuple[str, bool]:
+    """Bounded diff excerpt for one commit, scoped to the same
+    pathspec. ``full_hash`` is git-generated (%H), never user input.
+    Byte-capped at ``HISTORY_DIFF_BYTE_CAP``; returns ``(diff,
+    truncated)``. A diff we can't read degrades to an empty excerpt
+    rather than failing the whole query."""
+    args = [
+        "show", "--format=", f"--unified={_HISTORY_DIFF_CONTEXT}",
+        full_hash, "--", *pathspec,
+    ]
+    proc = _run_git(root, args)
+    if proc is None or proc.returncode != 0:
+        return "", False
+    data = proc.stdout.encode("utf-8")
+    if len(data) > HISTORY_DIFF_BYTE_CAP:
+        return data[:HISTORY_DIFF_BYTE_CAP].decode("utf-8", errors="ignore"), True
+    return proc.stdout, False
+
+
+def _normalize_history_filter(value: object, name: str) -> str | None:
+    """Empty/absent → None (no filter); a non-empty string passes
+    through; anything else is an invalid query."""
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise _history_invalid_query(
+            f"{name} must be a string.",
+            f"Pass {name} as a string, or omit it.",
+        )
+    return value
+
+
+def query_history(
+    memory_root: str | Path,
+    *,
+    path: str | None = None,
+    scopes: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    actor: str | None = None,
+    operation: str | None = None,
+    query: str | None = None,
+    limit: int = HISTORY_DEFAULT_LIMIT,
+    include_diff: bool = False,
+) -> dict:
+    """Bounded read-only audit query over the local git history — NOT a
+    ``git log`` passthrough. Only the whitelisted filters are honoured,
+    each built as a glued option (``--since=…``) or a ``--``-guarded
+    pathspec, so no value can be reinterpreted as a git flag, ref, or
+    revision range. ``operation`` (substring of the recorded ``tool:``)
+    and ``query`` (case-insensitive substring over subject + reason +
+    changed paths — never a diff grep) are applied as Python
+    post-filters. Returns ``{entries, truncated}``; ``include_diff``
+    attaches a byte-capped ``diff`` excerpt per entry."""
+    root = _history_env_ok(memory_root)
+
+    # -- arg validation (memory_invalid_history_query) -----------------
+    since = _normalize_history_filter(since, "since")
+    until = _normalize_history_filter(until, "until")
+    actor = _normalize_history_filter(actor, "actor")
+    operation = _normalize_history_filter(operation, "operation")
+    query = _normalize_history_filter(query, "query")
+    if path is not None and not isinstance(path, str):
+        raise _history_invalid_query(
+            "path must be a string.",
+            "Pass a logical memory path, or omit it.",
+        )
+    path = path or None
+    if scopes is not None:
+        if not isinstance(scopes, (list, tuple)):
+            raise _history_invalid_query(
+                "scopes must be a list of memory areas.",
+                "Pass scopes like ['briefing','notes'], or omit it.",
+            )
+        for sc in scopes:
+            if sc not in _HISTORY_SCOPES:
+                raise _history_invalid_query(
+                    f"unknown scope {sc!r}.",
+                    "Pick scopes from: briefing, notes, recollection, imports.",
+                )
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        raise _history_invalid_query(
+            f"limit must be a positive integer, got {limit!r}.",
+            f"Use 1 <= limit <= {HISTORY_MAX_LIMIT}.",
+        )
+
+    # -- size bounds (memory_history_query_too_large) ------------------
+    if limit > HISTORY_MAX_LIMIT:
+        raise _history_too_large(
+            f"limit {limit} exceeds the maximum {HISTORY_MAX_LIMIT}.",
+            f"Use limit <= {HISTORY_MAX_LIMIT}.",
+        )
+    if include_diff and limit > HISTORY_DIFF_MAX_LIMIT:
+        raise _history_too_large(
+            f"include_diff caps limit at {HISTORY_DIFF_MAX_LIMIT}; got {limit}.",
+            f"Use limit <= {HISTORY_DIFF_MAX_LIMIT} with include_diff, or "
+            "drop include_diff.",
+        )
+
+    # -- pathspec: always after `--`, one entry per scope or the path --
+    if path is not None:
+        pathspec = [path]
+    elif scopes:
+        pathspec = [f"{sc}/" for sc in scopes]
+    else:
+        pathspec = []
+
+    # -- git log: glued options only; no ref/revision-range ever built.
+    # Over-fetch a bounded window so the Python post-filters can drop
+    # commits and still fill `limit` / detect truncation.
+    fetch = HISTORY_MAX_LIMIT + 1
+    args = [
+        "log", f"--max-count={fetch}", f"--format={_HISTORY_LOG_FORMAT}",
+        "--numstat",
+    ]
+    if since is not None:
+        args.append(f"--since={since}")
+    if until is not None:
+        args.append(f"--until={until}")
+    if actor is not None:
+        args.append(f"--author={actor}")
+    args.append("--")
+    args.extend(pathspec)
+
+    proc = _run_git(root, args)
+    if proc is None or proc.returncode != 0:
+        # An unborn/empty repo makes `git log` exit nonzero with a
+        # "does not have any commits yet" message — that's simply no
+        # history, not a read failure.
+        stderr = (proc.stderr if proc else "") or ""
+        if proc is not None and "does not have any commits" in stderr:
+            return {"entries": [], "truncated": False}
+        detail = (
+            (proc.stderr or proc.stdout).strip()
+            if proc else "git log failed to run"
+        )
+        raise _history_read_failed(detail or "git log failed")
+
+    commits = _parse_history_records(proc.stdout)
+
+    def _passes(c: dict) -> bool:
+        if operation is not None:
+            if operation.lower() not in (c["operation"] or "").lower():
+                return False
+        if query is not None:
+            haystack = " ".join([
+                c["message"] or "",
+                c["reason"] or "",
+                " ".join(c["changed_paths"]),
+            ]).lower()
+            if query.lower() not in haystack:
+                return False
+        return True
+
+    filtered = [c for c in commits if _passes(c)]
+    truncated = len(filtered) > limit
+    entries = filtered[:limit]
+
+    if include_diff:
+        for entry in entries:
+            entry["diff"], entry["diff_truncated"] = _history_diff(
+                root, entry["_full"], pathspec,
+            )
+    for entry in entries:
+        entry.pop("_full", None)
+
+    return {"entries": entries, "truncated": truncated}

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -16,6 +16,7 @@ or a failed commit is logged and reported to the caller (``False`` /
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -26,24 +27,54 @@ logger = logging.getLogger(__name__)
 # guards against a wedged git process.
 _GIT_TIMEOUT = 30
 
+# Env vars that relocate git's repo/work-tree/index. A poisoned value
+# in the daemon's environment could otherwise redirect an audit commit
+# into an attacker-chosen repo, so they are scrubbed from every run.
+_GIT_LOCATION_ENV = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+
 
 def git_available() -> bool:
     """True when a ``git`` binary is on PATH."""
     return shutil.which("git") is not None
 
 
+def _scrubbed_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for var in _GIT_LOCATION_ENV:
+        env.pop(var, None)
+    return env
+
+
 def _run_git(
-    memory_root: Path, args: list[str],
+    memory_root: Path, args: list[str], *, pin_repo: bool = True,
 ) -> subprocess.CompletedProcess | None:
-    """Run one git command inside the memory root. ``None`` on any
-    launch/timeout failure; callers also check ``returncode``."""
+    """Run one git command against the audit repo at ``memory_root``.
+
+    The environment is scrubbed of git location overrides
+    (``GIT_DIR``/``GIT_WORK_TREE``/``GIT_INDEX_FILE``), and — when
+    ``pin_repo`` — ``--git-dir``/``--work-tree`` are passed explicitly
+    so the command can only ever touch ``<root>/.git``: never an
+    enclosing repo, never a repo an env var points at.
+    ``pin_repo=False`` is used only for ``git init``, which must run
+    before ``.git`` exists. ``None`` on any launch/timeout failure;
+    callers also check ``returncode``."""
+    root = Path(memory_root)
+    cmd = ["git"]
+    if pin_repo:
+        cmd += [
+            f"--git-dir={root / '.git'}",
+            f"--work-tree={root}",
+            "-c", f"safe.directory={root}",
+        ]
+    cmd += args
     try:
         return subprocess.run(
-            ["git", *args],
-            cwd=str(memory_root),
+            cmd,
+            cwd=str(root),
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            env=_scrubbed_env(),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         logger.warning("memory git %s failed to run: %s", args[:1], exc)
@@ -66,14 +97,16 @@ def ensure_memory_git(memory_root: str | Path) -> bool:
             "audit-committed", memory_root,
         )
         return False
+    # ``init`` runs before ``.git`` exists, so it can't pin --git-dir;
+    # the config steps that follow do (the repo is present by then).
     steps = [
-        ["init", "--quiet"],
-        ["config", "user.name", "puffo-agent"],
-        ["config", "user.email", "memory@puffo.local"],
-        ["config", "commit.gpgsign", "false"],
+        (["init", "--quiet"], False),
+        (["config", "user.name", "puffo-agent"], True),
+        (["config", "user.email", "memory@puffo.local"], True),
+        (["config", "commit.gpgsign", "false"], True),
     ]
-    for step in steps:
-        proc = _run_git(memory_root, step)
+    for step, pin_repo in steps:
+        proc = _run_git(memory_root, step, pin_repo=pin_repo)
         if proc is None or proc.returncode != 0:
             detail = (proc.stderr or proc.stdout).strip() if proc else "launch failed"
             logger.warning(
@@ -105,6 +138,15 @@ def commit_memory_change(
     that warrants a warning)."""
     memory_root = Path(memory_root)
     if not paths:
+        return None
+    # Only ever commit into our OWN audit repo. If the memory root sits
+    # inside an enclosing git repo but has no ``.git`` of its own, an
+    # unguarded add/commit would land in that outer repo — refuse.
+    if not (memory_root / ".git").is_dir():
+        logger.warning(
+            "memory git commit skipped at %s: no local .git audit repo",
+            memory_root,
+        )
         return None
     add = _run_git(memory_root, ["add", "--", *paths])
     if add is None or add.returncode != 0:

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -1,0 +1,128 @@
+"""Local git audit layer for the agent memory tree (M3).
+
+Every successful semantic memory write is recorded as one commit in a
+git repository living at the memory root. The repo is strictly
+machine-local: this module only ever runs ``init`` / ``config`` /
+``add`` / ``commit`` / ``rev-parse`` inside the memory root, and the
+init step sets repo-local identity (``user.name`` / ``user.email``)
+plus ``commit.gpgsign=false`` so commits are hermetic regardless of
+the operator's global git configuration.
+
+Everything degrades gracefully: a missing git binary, a failed init,
+or a failed commit is logged and reported to the caller (``False`` /
+``None``) — memory writes never fail because the audit layer did.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Local plumbing commands finish in milliseconds; the bound only
+# guards against a wedged git process.
+_GIT_TIMEOUT = 30
+
+
+def git_available() -> bool:
+    """True when a ``git`` binary is on PATH."""
+    return shutil.which("git") is not None
+
+
+def _run_git(
+    memory_root: Path, args: list[str],
+) -> subprocess.CompletedProcess | None:
+    """Run one git command inside the memory root. ``None`` on any
+    launch/timeout failure; callers also check ``returncode``."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(memory_root),
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("memory git %s failed to run: %s", args[:1], exc)
+        return None
+
+
+def ensure_memory_git(memory_root: str | Path) -> bool:
+    """Initialise the local audit repo at ``memory_root`` (idempotent).
+
+    Existing ``.git/`` → no-op True. Otherwise ``git init`` plus
+    repo-local config. Returns False (degrade, logged) when git is
+    unavailable or any init step fails.
+    """
+    memory_root = Path(memory_root)
+    if (memory_root / ".git").exists():
+        return True
+    if not git_available():
+        logger.warning(
+            "git is not installed; memory changes at %s will not be "
+            "audit-committed", memory_root,
+        )
+        return False
+    steps = [
+        ["init", "--quiet"],
+        ["config", "user.name", "puffo-agent"],
+        ["config", "user.email", "memory@puffo.local"],
+        ["config", "commit.gpgsign", "false"],
+    ]
+    for step in steps:
+        proc = _run_git(memory_root, step)
+        if proc is None or proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout).strip() if proc else "launch failed"
+            logger.warning(
+                "memory git init failed at %s (%s): %s",
+                memory_root, " ".join(step), detail,
+            )
+            return False
+    return True
+
+
+def format_commit_message(tool: str, paths: list[str], reason: str = "") -> str:
+    """Audit commit message: subject ``memory: <tool> <logical path>``,
+    body ``tool:`` line plus a ``reason:`` line only when the semantic
+    caller supplied one."""
+    first = paths[0] if paths else ""
+    subject = f"memory: {tool} {first}".rstrip()
+    body = [f"tool: {tool}"]
+    if reason:
+        body.append(f"reason: {reason}")
+    return subject + "\n\n" + "\n".join(body) + "\n"
+
+
+def commit_memory_change(
+    memory_root: str | Path, paths: list[str], message: str,
+) -> str | None:
+    """Stage exactly ``paths`` (explicit pathspecs — stray files in the
+    tree are never swept in) and commit with ``message``. Returns the
+    short commit id, or ``None`` on any failure (caller decides whether
+    that warrants a warning)."""
+    memory_root = Path(memory_root)
+    if not paths:
+        return None
+    add = _run_git(memory_root, ["add", "--", *paths])
+    if add is None or add.returncode != 0:
+        detail = (add.stderr or add.stdout).strip() if add else "launch failed"
+        logger.warning(
+            "memory git add failed at %s for %s: %s",
+            memory_root, paths, detail,
+        )
+        return None
+    commit = _run_git(memory_root, ["commit", "--quiet", "-m", message])
+    if commit is None or commit.returncode != 0:
+        detail = (commit.stderr or commit.stdout).strip() if commit else "launch failed"
+        logger.warning(
+            "memory git commit failed at %s for %s: %s",
+            memory_root, paths, detail,
+        )
+        return None
+    head = _run_git(memory_root, ["rev-parse", "--short", "HEAD"])
+    if head is None or head.returncode != 0:
+        return None
+    return head.stdout.strip() or None

--- a/src/puffo_agent/agent/memory_store.py
+++ b/src/puffo_agent/agent/memory_store.py
@@ -36,13 +36,12 @@ from .memory import (
     PROFILE_BRIEFING_NAME,
     RECOLLECTION_DIR,
     TOTAL_LIMIT,
-    BriefingCompileError,
-    MemoryStoreError,
     _byte_size,
     _compose_briefing,
     _read_briefing_entries,
     request_prompt_refresh,
 )
+from .memory_errors import BriefingCompileError, MemoryStoreError
 
 # Per-file byte limits (top of the design ranges, like M1's briefing
 # budget). ``imports/`` is never written through the store; its entry
@@ -112,7 +111,10 @@ class MemoryStore:
 
     def read_memory_file(self, path: str) -> dict:
         """Bounded read: ``body`` is capped at the area's file limit
-        (``truncated`` flags a cut); ``size`` is the real file size."""
+        (``truncated`` flags a cut); ``size`` is the real file size.
+        ``lossy`` is True when the file wasn't valid UTF-8 and
+        replacement characters were substituted (the read never
+        raises on stored bytes)."""
         scope, logical = self._validate_logical_path(path)
         physical = self._physical_path(logical)
         if not physical.is_file():
@@ -132,13 +134,23 @@ class MemoryStore:
             # A byte cap can split a multi-byte sequence; drop the
             # trailing partial character rather than emitting garbage.
             body = data[:limit].decode("utf-8", errors="ignore")
+            lossy = False
         else:
-            body = data.decode("utf-8")
+            # Never raise on stored bytes: a non-UTF-8 file is surfaced
+            # with U+FFFD replacements and flagged ``lossy`` instead of
+            # crashing the read with UnicodeDecodeError.
+            try:
+                body = data.decode("utf-8")
+                lossy = False
+            except UnicodeDecodeError:
+                body = data.decode("utf-8", errors="replace")
+                lossy = True
         return {
             "path": str(logical),
             "scope": scope,
             "size": size,
             "truncated": truncated,
+            "lossy": lossy,
             "body": body,
         }
 
@@ -188,7 +200,19 @@ class MemoryStore:
         text = original
         for patch in patches:
             old_text = patch["old_text"]
-            matches = text.count(old_text) if old_text else 2
+            if not old_text:
+                # An empty old_text has no unambiguous match point;
+                # tell direct store callers the truth rather than
+                # faking a "multiple matches" count.
+                raise MemoryStoreError(
+                    "memory_invalid_arguments",
+                    path=str(logical),
+                    suggestion=(
+                        "old_text must be non-empty text that appears "
+                        "exactly once in the file."
+                    ),
+                )
+            matches = text.count(old_text)
             if matches == 0:
                 raise MemoryStoreError(
                     "memory_patch_no_match",
@@ -284,14 +308,15 @@ class MemoryStore:
             ),
         }
 
-    # ── package-internal ─────────────────────────────────────────────
+    # ── daemon-owned writer (not one of the public seven) ────────────
 
-    def _put_memory_file(self, path: str, body: str) -> dict:
+    def put_memory_file(self, path: str, body: str) -> dict:
         """Overwrite-allowed create, for the daemon-owned M1 writers
-        (``MemoryManager.save`` / ``sync_profile_briefing``) — same
-        validation, sizing, atomicity, and briefing dirty hook. Not
-        part of the public seven: agent-facing callers must use
-        create/patch/append so overwrites stay deliberate."""
+        (``MemoryManager.save`` / ``sync_profile_briefing`` /
+        ``migrate_flat_memory``) — same validation, sizing, atomicity,
+        and briefing dirty hook. Not part of the public seven:
+        agent-facing callers must use create/patch/append so overwrites
+        stay deliberate."""
         scope, logical = self._validate_write_path(path)
         physical = self._physical_path(logical)
         size = self._validate_size(scope, logical, body)

--- a/src/puffo_agent/agent/memory_store.py
+++ b/src/puffo_agent/agent/memory_store.py
@@ -39,6 +39,7 @@ from .memory import (
     _byte_size,
     _compose_briefing,
     _read_briefing_entries,
+    compile_briefing,
     request_prompt_refresh,
 )
 from .memory_errors import BriefingCompileError, MemoryStoreError
@@ -51,6 +52,11 @@ RECOLLECTION_FILE_LIMIT = 128 * 1024
 IMPORTS_READ_LIMIT = RECOLLECTION_FILE_LIMIT
 
 READ_BATCH_LIMIT = 16
+
+# list_memory_files bounds (M4 recall): default page size and the hard
+# cap the requested limit is clamped to.
+LIST_DEFAULT_LIMIT = 100
+LIST_MAX_LIMIT = 500
 
 _FILE_LIMITS = {
     BRIEFING_DIR: PER_FILE_LIMIT,
@@ -307,6 +313,111 @@ class MemoryStore:
                 exists and scope == BRIEFING_DIR and logical.suffix == ".md"
             ),
         }
+
+    # ── M4 status + recall (pure filesystem reads, no git) ───────────
+
+    def _iter_scope_files(self, scope: str) -> list[tuple[str, Path]]:
+        """``(logical posix path, physical path)`` pairs under one
+        scope, sorted for deterministic order; hidden segments and
+        symlinks are skipped (same rules as ``memory_tools._scope_files``).
+        Uses ``rglob('*')`` filtered to real files — ``briefing/`` is
+        flat, ``recollection/`` is nested, ``imports/`` may hold
+        non-``.md`` files."""
+        base = self.memory_root / scope
+        if not base.is_dir():
+            return []
+        out: list[tuple[str, Path]] = []
+        for p in sorted(base.rglob("*")):
+            rel = p.relative_to(self.memory_root).as_posix()
+            if any(seg.startswith(".") for seg in rel.split("/")):
+                continue
+            if p.is_symlink() or not p.is_file():
+                continue
+            out.append((rel, p))
+        return out
+
+    def get_memory_status(self) -> dict:
+        """Root health + compiled-briefing size + per-scope
+        ``{files, total_size_bytes}`` — a pure filesystem read (no git,
+        no bodies). The compiled size is computed defensively: an
+        over-budget briefing reports the offending size with
+        ``over_budget=True`` rather than raising, because a status read
+        must never fail closed the way a write does."""
+        try:
+            compiled_size = _byte_size(compile_briefing(self.memory_root))
+            over_budget = False
+        except BriefingCompileError as exc:
+            compiled_size = exc.size or 0
+            over_budget = True
+        scopes: dict = {}
+        for scope in _SCOPES:
+            files = self._iter_scope_files(scope)
+            scopes[scope] = {
+                "files": len(files),
+                "total_size_bytes": sum(p.stat().st_size for _, p in files),
+            }
+        return {
+            "memory_root": str(self.memory_root),
+            "root_exists": self.memory_root.is_dir(),
+            "briefing": {
+                "compiled_size_bytes": compiled_size,
+                "limit_bytes": TOTAL_LIMIT,
+                "over_budget": over_budget,
+            },
+            "scopes": scopes,
+        }
+
+    def list_memory_files(
+        self, scope: str | None = None, limit: int = LIST_DEFAULT_LIMIT,
+    ) -> dict:
+        """Logical paths + lightweight metadata for the requested scope
+        (or all scopes in fixed order), **never** a body. Each entry is
+        ``{path, scope, size, writable, briefing_included}``; the list
+        is capped at ``min(limit, LIST_MAX_LIMIT)`` and ``truncated``
+        flags that more files exist beyond the cap."""
+        if scope is not None and scope not in _SCOPES:
+            raise MemoryStoreError(
+                "memory_path_out_of_scope",
+                path=str(scope),
+                suggestion=(
+                    "scope must be one of briefing, notes, recollection, "
+                    "imports — or omitted to list every scope."
+                ),
+            )
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            raise MemoryStoreError(
+                "memory_invalid_arguments",
+                path="",
+                suggestion=(
+                    f"limit must be a positive integer (default "
+                    f"{LIST_DEFAULT_LIMIT}, max {LIST_MAX_LIMIT})."
+                ),
+            )
+        cap = min(limit, LIST_MAX_LIMIT)
+        files: list[dict] = []
+        truncated = False
+        for sc in _SCOPES:
+            if scope is not None and sc != scope:
+                continue
+            for rel, physical in self._iter_scope_files(sc):
+                if len(files) >= cap:
+                    truncated = True
+                    break
+                logical = PurePosixPath(rel)
+                files.append({
+                    "path": rel,
+                    "scope": sc,
+                    "size": physical.stat().st_size,
+                    "writable": (
+                        self._scope_writable(sc) and logical.suffix == ".md"
+                    ),
+                    "briefing_included": (
+                        sc == BRIEFING_DIR and logical.suffix == ".md"
+                    ),
+                })
+            if truncated:
+                break
+        return {"files": files, "truncated": truncated}
 
     # ── daemon-owned writer (not one of the public seven) ────────────
 

--- a/src/puffo_agent/agent/memory_store.py
+++ b/src/puffo_agent/agent/memory_store.py
@@ -1,0 +1,529 @@
+"""Low-level MemoryStore file API (M2).
+
+The seven primitives from the memory design doc operate on **logical
+memory paths** (``briefing/profile.md``, ``notes/topic.md``,
+``recollection/2026/06/2026-06-04.md``, ``imports/index.md``) — never
+physical filesystem paths. The store boundary enforces:
+
+- path grammar (relative, known scope, no traversal/hidden/symlink
+  escapes; ``briefing/`` stays flat because the compile globs
+  ``briefing/*.md`` non-recursively);
+- per-area scope rules (``imports/`` is importer-owned and read-only;
+  ``recollection/`` writes need the explicit maintenance scope);
+- per-area size limits, validated before any write commits;
+- atomic writes (sibling temp file + ``os.replace``);
+- briefing dirty/rebuild: successful ``briefing/`` mutations drop the
+  M1 ``refresh_agent.flag`` via ``memory.request_prompt_refresh``.
+
+Errors are ``memory.MemoryStoreError`` (briefing-scope size violations
+raise the ``BriefingCompileError`` subclass so M1 callers keep
+working). The primitives deliberately take no ``reason`` — semantic
+reason/audit metadata belongs to the M3 tools layered on top.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path, PurePosixPath
+
+from .memory import (
+    BRIEFING_DIR,
+    IMPORTS_DIR,
+    NOTES_DIR,
+    PER_FILE_LIMIT,
+    PROFILE_BRIEFING_NAME,
+    RECOLLECTION_DIR,
+    TOTAL_LIMIT,
+    BriefingCompileError,
+    MemoryStoreError,
+    _byte_size,
+    _compose_briefing,
+    _read_briefing_entries,
+    request_prompt_refresh,
+)
+
+# Per-file byte limits (top of the design ranges, like M1's briefing
+# budget). ``imports/`` is never written through the store; its entry
+# only bounds reads.
+NOTES_FILE_LIMIT = 64 * 1024
+RECOLLECTION_FILE_LIMIT = 128 * 1024
+IMPORTS_READ_LIMIT = RECOLLECTION_FILE_LIMIT
+
+READ_BATCH_LIMIT = 16
+
+_FILE_LIMITS = {
+    BRIEFING_DIR: PER_FILE_LIMIT,
+    NOTES_DIR: NOTES_FILE_LIMIT,
+    RECOLLECTION_DIR: RECOLLECTION_FILE_LIMIT,
+    IMPORTS_DIR: IMPORTS_READ_LIMIT,
+}
+
+_SCOPES = (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR, IMPORTS_DIR)
+
+_PATH_SUGGESTION = (
+    "Use a relative logical memory path like notes/topic.md under "
+    "briefing/, notes/, recollection/, or imports/."
+)
+
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
+class MemoryStore:
+    """Validated file operations under one agent's memory root.
+
+    ``workspace_dir`` (optional) enables the briefing dirty/rebuild
+    hook; ``maintenance`` is the explicit scope flag that unlocks
+    ``recollection/`` writes (daemon-owned maintenance, not ordinary
+    chat turns).
+    """
+
+    def __init__(
+        self,
+        memory_root: str | Path,
+        workspace_dir: str = "",
+        maintenance: bool = False,
+    ):
+        self.memory_root = Path(memory_root)
+        self.workspace_dir = workspace_dir
+        self.maintenance = maintenance
+
+    # ── the seven primitives ─────────────────────────────────────────
+
+    def create_memory_file(self, path: str, body: str) -> dict:
+        """Create a new file. Fails with ``memory_file_exists`` if the
+        target already exists — overwriting goes through patch/append."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        if physical.exists():
+            raise MemoryStoreError(
+                "memory_file_exists",
+                path=str(logical),
+                suggestion=(
+                    "The file already exists; change it with "
+                    "patch_memory_file or append_memory_file."
+                ),
+            )
+        size = self._validate_size(scope, logical, body)
+        self._write_atomic(physical, body)
+        self._mark_briefing_dirty(scope, "create", logical)
+        return {"path": str(logical), "changed": True, "size": size}
+
+    def read_memory_file(self, path: str) -> dict:
+        """Bounded read: ``body`` is capped at the area's file limit
+        (``truncated`` flags a cut); ``size`` is the real file size."""
+        scope, logical = self._validate_logical_path(path)
+        physical = self._physical_path(logical)
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion=(
+                    "Check the path with get_memory_file_status, or "
+                    "create the file with create_memory_file."
+                ),
+            )
+        limit = _FILE_LIMITS[scope]
+        data = physical.read_bytes()
+        size = len(data)
+        truncated = size > limit
+        if truncated:
+            # A byte cap can split a multi-byte sequence; drop the
+            # trailing partial character rather than emitting garbage.
+            body = data[:limit].decode("utf-8", errors="ignore")
+        else:
+            body = data.decode("utf-8")
+        return {
+            "path": str(logical),
+            "scope": scope,
+            "size": size,
+            "truncated": truncated,
+            "body": body,
+        }
+
+    def read_memory_files(self, paths: list) -> list[dict]:
+        """Pure read batch (≤ ``READ_BATCH_LIMIT`` paths). Each entry
+        is a ``read_memory_file`` result or ``{path, error}`` — one bad
+        path never fails the whole batch. Never writes."""
+        if not isinstance(paths, (list, tuple)):
+            raise MemoryStoreError(
+                "memory_invalid_arguments",
+                path="",
+                suggestion="Pass a list of logical memory paths.",
+            )
+        if len(paths) > READ_BATCH_LIMIT:
+            raise MemoryStoreError(
+                "memory_invalid_arguments",
+                path="",
+                suggestion=(
+                    f"read_memory_files accepts at most {READ_BATCH_LIMIT} "
+                    "paths per call; split the batch."
+                ),
+            )
+        results: list[dict] = []
+        for p in paths:
+            try:
+                results.append(self.read_memory_file(p))
+            except MemoryStoreError as exc:
+                results.append({
+                    "path": p if isinstance(p, str) else str(p),
+                    "error": exc.to_dict(),
+                })
+        return results
+
+    def patch_memory_file(self, path: str, patches: list) -> dict:
+        """Exact text replacement. Each ``{old_text, new_text}`` must
+        match exactly once; the patch list is all-or-nothing — nothing
+        is written unless every patch applies."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion="Create the file with create_memory_file first.",
+            )
+        original = physical.read_text(encoding="utf-8")
+        text = original
+        for patch in patches:
+            old_text = patch["old_text"]
+            matches = text.count(old_text) if old_text else 2
+            if matches == 0:
+                raise MemoryStoreError(
+                    "memory_patch_no_match",
+                    path=str(logical),
+                    suggestion=(
+                        "old_text was not found; read the file again and "
+                        "patch exact current text."
+                    ),
+                )
+            if matches > 1:
+                raise MemoryStoreError(
+                    "memory_patch_multiple_matches",
+                    path=str(logical),
+                    suggestion=(
+                        "old_text matched more than once; include more "
+                        "surrounding context so it matches exactly once."
+                    ),
+                )
+            text = text.replace(old_text, patch["new_text"])
+        size = self._validate_size(scope, logical, text)
+        changed = text != original
+        if changed:
+            self._write_atomic(physical, text)
+            self._mark_briefing_dirty(scope, "patch", logical)
+        return {"path": str(logical), "changed": changed, "size": size}
+
+    def append_memory_file(self, path: str, text: str) -> dict:
+        """Append to the end of an existing file (no separator magic,
+        no prepend/insert mode)."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion="Create the file with create_memory_file first.",
+            )
+        original = physical.read_text(encoding="utf-8")
+        combined = original + text
+        size = self._validate_size(scope, logical, combined)
+        changed = combined != original
+        if changed:
+            self._write_atomic(physical, combined)
+            self._mark_briefing_dirty(scope, "append", logical)
+        return {"path": str(logical), "changed": changed, "size": size}
+
+    def delete_memory_file(self, path: str) -> dict:
+        """Delete a safe memory file: validated writable path, regular
+        file, and never the managed ``briefing/profile.md``."""
+        scope, logical = self._validate_write_path(path)
+        if scope == BRIEFING_DIR and logical.name == PROFILE_BRIEFING_NAME:
+            raise MemoryStoreError(
+                "memory_scope_readonly",
+                path=str(logical),
+                suggestion=(
+                    "briefing/profile.md is the managed profile briefing "
+                    "and cannot be deleted; patch it instead."
+                ),
+            )
+        physical = self._physical_path(logical)
+        if not physical.exists():
+            raise MemoryStoreError(
+                "memory_file_not_found",
+                path=str(logical),
+                suggestion="Nothing to delete at this path.",
+            )
+        if not physical.is_file():
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="Only regular memory files can be deleted.",
+            )
+        physical.unlink()
+        self._mark_briefing_dirty(scope, "delete", logical)
+        return {"path": str(logical), "changed": True}
+
+    def get_memory_file_status(self, path: str) -> dict:
+        """Existence/scope/size/limit/briefing-inclusion metadata —
+        deliberately no ``body``. Works for missing files."""
+        scope, logical = self._validate_logical_path(path)
+        physical = self._physical_path(logical)
+        exists = physical.is_file()
+        writable = self._scope_writable(scope) and logical.suffix == ".md"
+        return {
+            "path": str(logical),
+            "exists": exists,
+            "scope": scope,
+            "size": physical.stat().st_size if exists else None,
+            "limit": _FILE_LIMITS[scope],
+            "writable": writable,
+            "briefing_included": (
+                exists and scope == BRIEFING_DIR and logical.suffix == ".md"
+            ),
+        }
+
+    # ── package-internal ─────────────────────────────────────────────
+
+    def _put_memory_file(self, path: str, body: str) -> dict:
+        """Overwrite-allowed create, for the daemon-owned M1 writers
+        (``MemoryManager.save`` / ``sync_profile_briefing``) — same
+        validation, sizing, atomicity, and briefing dirty hook. Not
+        part of the public seven: agent-facing callers must use
+        create/patch/append so overwrites stay deliberate."""
+        scope, logical = self._validate_write_path(path)
+        physical = self._physical_path(logical)
+        size = self._validate_size(scope, logical, body)
+        changed = not (
+            physical.is_file()
+            and physical.read_text(encoding="utf-8") == body
+        )
+        if changed:
+            self._write_atomic(physical, body)
+            self._mark_briefing_dirty(scope, "put", logical)
+        return {"path": str(logical), "changed": changed, "size": size}
+
+    # ── validation ───────────────────────────────────────────────────
+
+    def _validate_logical_path(
+        self, path: str,
+    ) -> tuple[str, PurePosixPath]:
+        """Enforce the logical path grammar; returns ``(scope, path)``."""
+        if not isinstance(path, str) or not path:
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(path or ""),
+                suggestion=_PATH_SUGGESTION,
+            )
+        if "\x00" in path or "\\" in path:
+            raise MemoryStoreError(
+                "memory_invalid_path", path=path, suggestion=_PATH_SUGGESTION,
+            )
+        if path.startswith("/") or _DRIVE_RE.match(path):
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=path,
+                suggestion="Memory paths are relative, not absolute. "
+                + _PATH_SUGGESTION,
+            )
+        segments = path.split("/")
+        for segment in segments:
+            if not segment:
+                raise MemoryStoreError(
+                    "memory_invalid_path",
+                    path=path,
+                    suggestion=_PATH_SUGGESTION,
+                )
+            if segment in (".", ".."):
+                raise MemoryStoreError(
+                    "memory_invalid_path",
+                    path=path,
+                    suggestion="Path traversal is not allowed. "
+                    + _PATH_SUGGESTION,
+                )
+            if segment.startswith("."):
+                raise MemoryStoreError(
+                    "memory_invalid_path",
+                    path=path,
+                    suggestion="Hidden path segments are not allowed. "
+                    + _PATH_SUGGESTION,
+                )
+        if len(segments) < 2:
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=path,
+                suggestion="Memory files live inside a memory area. "
+                + _PATH_SUGGESTION,
+            )
+        scope = segments[0]
+        if scope not in _SCOPES:
+            raise MemoryStoreError(
+                "memory_path_out_of_scope",
+                path=path,
+                suggestion=(
+                    "Memory paths must start with briefing/, notes/, "
+                    "recollection/, or imports/."
+                ),
+            )
+        if scope == BRIEFING_DIR and len(segments) != 2:
+            # The briefing compile globs briefing/*.md non-recursively;
+            # nested briefing files would be silent dead weight.
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=path,
+                suggestion="briefing/ is flat: use briefing/<topic>.md.",
+            )
+        return scope, PurePosixPath(path)
+
+    def _validate_write_path(
+        self, path: str,
+    ) -> tuple[str, PurePosixPath]:
+        scope, logical = self._validate_logical_path(path)
+        if scope == IMPORTS_DIR:
+            raise MemoryStoreError(
+                "memory_scope_readonly",
+                path=str(logical),
+                suggestion=(
+                    "imports/ is importer-owned and read-only; put your "
+                    f"own content in {NOTES_DIR}/."
+                ),
+            )
+        if scope == RECOLLECTION_DIR and not self.maintenance:
+            raise MemoryStoreError(
+                "memory_scope_readonly",
+                path=str(logical),
+                suggestion=(
+                    "recollection/ writes need the explicit maintenance "
+                    f"scope; ordinary turns should write {NOTES_DIR}/."
+                ),
+            )
+        if logical.suffix != ".md":
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="Memory write targets must end in .md.",
+            )
+        return scope, logical
+
+    def _scope_writable(self, scope: str) -> bool:
+        if scope == IMPORTS_DIR:
+            return False
+        if scope == RECOLLECTION_DIR:
+            return self.maintenance
+        return True
+
+    def _physical_path(self, logical: PurePosixPath) -> Path:
+        """Map a validated logical path onto the filesystem, rejecting
+        symlink targets and any resolution outside the memory root."""
+        root = self.memory_root.resolve()
+        physical = root.joinpath(*logical.parts)
+        if physical.is_symlink():
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="Symlinks are not valid memory files.",
+            )
+        resolved = physical.resolve()
+        if resolved == root or not resolved.is_relative_to(root):
+            raise MemoryStoreError(
+                "memory_invalid_path",
+                path=str(logical),
+                suggestion="The path resolves outside the memory root.",
+            )
+        return physical
+
+    def _validate_size(
+        self, scope: str, logical: PurePosixPath, body: str,
+    ) -> int:
+        """Per-file limit, plus the would-be compiled total for
+        ``briefing/`` (the M1 ``save()`` simulation). Briefing-scope
+        violations raise ``BriefingCompileError`` so M1 callers see
+        the error type they already handle."""
+        size = _byte_size(body)
+        limit = _FILE_LIMITS[scope]
+        if size > limit:
+            if scope == BRIEFING_DIR:
+                raise BriefingCompileError(
+                    "memory_file_too_large",
+                    path=str(logical),
+                    size=size,
+                    limit=limit,
+                    suggestion=(
+                        "Trim this briefing topic; move detail to "
+                        f"memory/{NOTES_DIR}/ (searchable, not injected)."
+                    ),
+                )
+            raise MemoryStoreError(
+                "memory_file_too_large",
+                path=str(logical),
+                size=size,
+                limit=limit,
+                suggestion=(
+                    "Split this file, or move detail into another "
+                    "memory area."
+                ),
+            )
+        if scope == BRIEFING_DIR:
+            self._validate_briefing_total(logical, body)
+        return size
+
+    def _validate_briefing_total(
+        self, logical: PurePosixPath, body: str,
+    ) -> None:
+        profile_body, entries = _read_briefing_entries(
+            self.memory_root, enforce_per_file=False,
+        )
+        entry_map = dict(entries)
+        stripped = body.strip()
+        if logical.name == PROFILE_BRIEFING_NAME:
+            profile_body = stripped
+        elif stripped:
+            entry_map[logical.stem] = stripped
+        else:
+            # The compile drops empty bodies; mirror that exactly.
+            entry_map.pop(logical.stem, None)
+        total = _byte_size(
+            _compose_briefing(profile_body, sorted(entry_map.items()))
+        )
+        if total > TOTAL_LIMIT:
+            raise BriefingCompileError(
+                "memory_briefing_too_large",
+                path=str(logical),
+                size=total,
+                limit=TOTAL_LIMIT,
+                suggestion=(
+                    "This write would push the compiled briefing over "
+                    f"budget; move topics to memory/{NOTES_DIR}/ first."
+                ),
+            )
+
+    # ── write plumbing ───────────────────────────────────────────────
+
+    def _write_atomic(self, physical: Path, body: str) -> None:
+        """Sibling temp file + ``os.replace``: the target is either
+        untouched or fully replaced, never half-written. The temp name
+        is non-``.md`` so a crashed write can't leak into the compile."""
+        physical.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(physical.parent), prefix=".puffo-mem-", suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(body)
+            os.replace(tmp_name, physical)
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    def _mark_briefing_dirty(
+        self, scope: str, op: str, logical: PurePosixPath,
+    ) -> None:
+        if scope != BRIEFING_DIR:
+            return
+        request_prompt_refresh(
+            self.workspace_dir, f"memory_store.{op}:{logical}",
+        )

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -222,21 +222,24 @@ use filenames that identify you (e.g. `notes-from-<your-id>.md`).
 
 ## Memory
 
-Your memory is a small tree under `memory/`:
+A durable memory tree under `memory/`, managed through tools — never
+hand-edit these files:
 
-- `memory/briefing/<topic>.md` — durable facts you always want in
-  context. Compiled into this prompt, bounded: 16KB per file, 64KB
-  total. An over-budget briefing FAILS the prompt rebuild (no silent
-  truncation), so keep topics tight.
-- `memory/briefing/profile.md` — your identity framing; managed by
-  puffo-agent from your profile. Don't edit the managed block.
-- `memory/notes/` — unbounded detail; lives on disk for you to read
-  or grep, never injected into your prompt.
+- **Briefing topics** are always compiled into this prompt. Create and
+  edit them with `mcp__puffo__create_briefing_topic` /
+  `mcp__puffo__patch_briefing_topic`. Bounded: 16KB per topic, 64KB
+  compiled total; an over-budget write FAILS the rebuild (fail closed,
+  no silent truncation), so keep topics tight. A briefing write marks
+  the prompt for rebuild automatically — no `refresh()` step; it lands
+  at your next turn.
+- **Notes** are durable detail that never enters your prompt. Manage
+  them with `mcp__puffo__create_note` / `patch_note` / `append_note`;
+  recall with `mcp__puffo__search_memory` /
+  `mcp__puffo__read_memory_file`.
+- `memory/briefing/profile.md` — your identity framing, managed by
+  puffo-agent from your profile. Don't touch the managed block.
 - `memory/recollection/`, `memory/imports/` — reserved for the
   platform.
-
-Write markdown, then call `refresh()`; briefing changes land in your
-prompt on the next turn.
 
 ## Your two CLAUDE.md layers (cli-local / cli-docker only)
 
@@ -248,10 +251,10 @@ Claude Code concatenates two files:
 2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace
    — yours to edit; puffo-agent never touches it.
 
-Use layer 2 for fast prompt updates; use `memory/briefing/*.md` +
-`refresh()` when you want content labelled as memory. `sdk` and
-codex only have layer 1 — go through `memory/briefing/*.md`.
-Codex's equivalent is `$CODEX_HOME/AGENTS.md`.
+Use layer 2 for fast, free-form prompt notes you keep yourself. For
+durable content labelled as memory, use the briefing tools above —
+they work on every runtime, `sdk` and codex included (those only have
+layer 1). Codex's layer-1 equivalent is `$CODEX_HOME/AGENTS.md`.
 
 ## Permission prompts (cli-local only)
 
@@ -613,7 +616,8 @@ axes; combine them freely.
 | `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, full worker respawn. Implicit fresh session. |
 
 **When to use:**
-- Edited `CLAUDE.md`, `profile.md`, `memory/briefing/*.md` → `refresh()`.
+- Edited `CLAUDE.md` or `profile.md` → `refresh()`. (Briefing topics
+  written via the memory tools rebuild automatically — no `refresh()`.)
 - Installed a new skill / MCP → `refresh()`.
 - Operator added a new skill to their `~/.claude/skills/` → tell them
   to call it "host-sync" and use `refresh(host_sync=True[, session=True])`.

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -3,8 +3,8 @@
 The shared platform primer (``~/.puffo-agent/docker/shared/CLAUDE.md``)
 is folded into each agent's generated CLAUDE.md at worker startup.
 ``ensure_shared_primer`` syncs the baked-in primer to disk on every worker
-startup; ``assemble_claude_md``
-combines primer + profile + memory snapshot into the per-agent prompt.
+startup; ``assemble_claude_md`` combines primer + profile + the compiled
+memory briefing (bounded; see ``agent.memory``) into the per-agent prompt.
 """
 
 from __future__ import annotations
@@ -222,23 +222,35 @@ use filenames that identify you (e.g. `notes-from-<your-id>.md`).
 
 ## Memory
 
-`memory/` snapshot is folded into this prompt. Write markdown to
-`memory/<topic>.md` to remember across sessions; takes effect on
-the next worker restart.
+Your memory is a small tree under `memory/`:
+
+- `memory/briefing/<topic>.md` — durable facts you always want in
+  context. Compiled into this prompt, bounded: 16KB per file, 64KB
+  total. An over-budget briefing FAILS the prompt rebuild (no silent
+  truncation), so keep topics tight.
+- `memory/briefing/profile.md` — your identity framing; managed by
+  puffo-agent from your profile. Don't edit the managed block.
+- `memory/notes/` — unbounded detail; lives on disk for you to read
+  or grep, never injected into your prompt.
+- `memory/recollection/`, `memory/imports/` — reserved for the
+  platform.
+
+Write markdown, then call `refresh()`; briefing changes land in your
+prompt on the next turn.
 
 ## Your two CLAUDE.md layers (cli-local / cli-docker only)
 
 Claude Code concatenates two files:
 
 1. **`~/.claude/CLAUDE.md`** — managed by puffo-agent (this primer
-   + `profile.md` + `memory/` snapshot); overwritten every worker
-   start, don't edit.
+   + `profile.md` + compiled `memory/briefing/`); overwritten on
+   every rebuild, don't edit.
 2. **`./CLAUDE.md`** or **`./.claude/CLAUDE.md`** in your workspace
    — yours to edit; puffo-agent never touches it.
 
-Use layer 2 for fast prompt updates; use `memory/*.md` (folds into
-layer 1 on next restart) when you want content labelled as memory.
-`sdk` and codex only have layer 1 — go through `memory/*.md`.
+Use layer 2 for fast prompt updates; use `memory/briefing/*.md` +
+`refresh()` when you want content labelled as memory. `sdk` and
+codex only have layer 1 — go through `memory/briefing/*.md`.
 Codex's equivalent is `$CODEX_HOME/AGENTS.md`.
 
 ## Permission prompts (cli-local only)
@@ -601,7 +613,7 @@ axes; combine them freely.
 | `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, full worker respawn. Implicit fresh session. |
 
 **When to use:**
-- Edited `CLAUDE.md`, `profile.md`, `memory/*.md` → `refresh()`.
+- Edited `CLAUDE.md`, `profile.md`, `memory/briefing/*.md` → `refresh()`.
 - Installed a new skill / MCP → `refresh()`.
 - Operator added a new skill to their `~/.claude/skills/` → tell them
   to call it "host-sync" and use `refresh(host_sync=True[, session=True])`.
@@ -1196,43 +1208,61 @@ def read_shared_primer(shared_dir: Path) -> str:
         return ""
 
 
-def read_memory_snapshot(memory_dir: Path) -> str:
-    """Concatenate every ``*.md`` in ``memory_dir`` (sorted, so output
-    is deterministic). Returns ``""`` when the directory is missing
-    or empty.
+def compile_agent_memory_briefing(
+    *,
+    memory_dir: Path,
+    profile_text: str,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+) -> str:
+    """Bring the memory tree up to date and return the compiled
+    bounded briefing: ensure the tree, migrate legacy flat
+    ``memory/*.md``, re-sync ``briefing/profile.md`` from the native
+    profile surfaces (agent.yml identity fields + the ``# Soul`` body
+    of agent-root profile.md), then compile ``briefing/``.
+
+    Raises ``memory.BriefingCompileError`` (fail closed — no
+    truncation) when the briefing violates its budget.
     """
-    if not memory_dir.is_dir():
-        return ""
-    parts: list[str] = []
-    for path in sorted(memory_dir.glob("*.md")):
-        if path.name == "README.md":
-            continue
-        try:
-            body = path.read_text(encoding="utf-8").strip()
-        except OSError:
-            continue
-        if not body:
-            continue
-        parts.append(f"### {path.stem}\n\n{body}")
-    return "\n\n".join(parts)
+    from ..portal.profile_sync import extract_soul_body
+    from .memory import (
+        compile_briefing,
+        ensure_memory_tree,
+        migrate_flat_memory,
+        sync_profile_briefing,
+    )
+
+    ensure_memory_tree(memory_dir)
+    migrate_flat_memory(memory_dir)
+    sync_profile_briefing(
+        memory_dir,
+        agent_id=agent_id,
+        display_name=display_name,
+        role=role,
+        role_short=role_short,
+        soul=extract_soul_body(profile_text),
+    )
+    return compile_briefing(memory_dir)
 
 
 def assemble_claude_md(
     *,
     shared_primer: str,
     profile: str,
-    memory_snapshot: str,
+    memory_briefing: str,
 ) -> str:
     """Produce the per-agent CLAUDE.md. Order: primer (platform
-    conventions) → role → memory.
+    conventions) → role → memory (the compiled bounded briefing).
     """
     parts: list[str] = []
     if shared_primer.strip():
         parts.append(shared_primer.strip())
     if profile.strip():
         parts.append("---\n\n# Your role\n\n" + profile.strip())
-    if memory_snapshot.strip():
-        parts.append("---\n\n# Your memory\n\n" + memory_snapshot.strip())
+    if memory_briefing.strip():
+        parts.append("---\n\n# Your memory\n\n" + memory_briefing.strip())
     return "\n\n".join(parts) + "\n"
 
 
@@ -1279,14 +1309,19 @@ def rebuild_agent_codex_md(
     memory_dir: Path,
     workspace_dir: Path,
     codex_user_dir: Path,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> str:
     """Assemble + write one codex agent's AGENTS.md.
 
     Same content shape as ``rebuild_agent_claude_md`` (shared primer +
-    agent profile + memory snapshot), targeting codex's instruction-
-    file path. Skill bodies mirror into ``workspace/.agents/skills/``
-    where codex's project-scope discovery walks; the SKILL.md +
-    frontmatter shape is identical to Claude Code's.
+    agent profile + compiled memory briefing), targeting codex's
+    instruction-file path. Skill bodies mirror into
+    ``workspace/.agents/skills/`` where codex's project-scope discovery
+    walks; the SKILL.md + frontmatter shape is identical to Claude
+    Code's.
     """
     ensure_shared_primer(shared_dir)
     sync_shared_skills_codex(shared_dir, workspace_dir)
@@ -1298,7 +1333,14 @@ def rebuild_agent_codex_md(
     agents_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
-        memory_snapshot=read_memory_snapshot(memory_dir),
+        memory_briefing=compile_agent_memory_briefing(
+            memory_dir=memory_dir,
+            profile_text=profile_text,
+            agent_id=agent_id,
+            display_name=display_name,
+            role=role,
+            role_short=role_short,
+        ),
     )
     write_agents_md(codex_user_dir, agents_md)
     return agents_md
@@ -1312,13 +1354,20 @@ def rebuild_agent_claude_md(
     workspace_dir: Path,
     claude_user_dir: Path,
     gemini_user_dir: Path,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> str:
     """Assemble + write one agent's managed CLAUDE.md / GEMINI.md.
 
     Seeds the shared primer if missing, mirrors shared skills into the
-    workspace, reads the agent's ``profile.md`` + memory snapshot, then
-    writes the combined prompt to the agent's USER-level ``.claude/`` /
-    ``.gemini/`` dirs. Returns the assembled CLAUDE.md string.
+    workspace, reads the agent's ``profile.md``, brings the memory tree
+    up to date (ensure/migrate/profile-sync) and compiles the bounded
+    briefing, then writes the combined prompt to the agent's USER-level
+    ``.claude/`` / ``.gemini/`` dirs. Returns the assembled CLAUDE.md
+    string. Raises ``memory.BriefingCompileError`` when the briefing
+    is over budget (fail closed — the previous artifact is kept).
 
     Shared by the worker's startup path and the ``agent reset-primer``
     CLI command so the assembly sequence lives in exactly one place.
@@ -1333,7 +1382,14 @@ def rebuild_agent_claude_md(
     claude_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
-        memory_snapshot=read_memory_snapshot(memory_dir),
+        memory_briefing=compile_agent_memory_briefing(
+            memory_dir=memory_dir,
+            profile_text=profile_text,
+            agent_id=agent_id,
+            display_name=display_name,
+            role=role,
+            role_short=role_short,
+        ),
     )
     write_claude_md(claude_user_dir, claude_md)
     write_gemini_md(gemini_user_dir, claude_md)

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -243,11 +243,14 @@ def puffo_core_mcp_env(
     rpc_url: str = "http://127.0.0.1:63385",
     runtime_kind: str = "",
     harness: str = "",
+    memory_dir: str = "",
 ) -> dict[str, str]:
     """Env dict for the puffo-core MCP subprocess. The MCP never
     touches ``messages.db`` or ``~/.claude.json`` directly — the
     daemon owns both. cli-docker rewrites the loopback URLs to
-    ``host.docker.internal``."""
+    ``host.docker.internal``. ``memory_dir`` (optional) pins the
+    memory root for the M3 memory tools; when empty the server falls
+    back to the workspace-sibling ``memory/`` dir."""
     env: dict[str, str] = {
         "PUFFO_CORE_SLUG": slug,
         "PUFFO_CORE_DEVICE_ID": device_id,
@@ -266,6 +269,8 @@ def puffo_core_mcp_env(
         env["PUFFO_RUNTIME_KIND"] = runtime_kind
     if harness:
         env["PUFFO_HARNESS"] = harness
+    if memory_dir:
+        env["PUFFO_MEMORY_DIR"] = memory_dir
     # codex only forwards [mcp_servers.puffo.env] to the subprocess,
     # so CODEX_HOME must be pinned explicitly or list_mcp_servers
     # would read the operator's host config instead of the agent's.
@@ -285,6 +290,7 @@ def puffo_core_stdio_sdk_config(
     keystore_dir: str,
     workspace: str,
     agent_id: str,
+    memory_dir: str = "",
 ) -> dict:
     """Return the ``mcp_servers`` config dict for the SDK adapter."""
     return {
@@ -301,6 +307,7 @@ def puffo_core_stdio_sdk_config(
                 workspace=workspace,
                 agent_id=agent_id,
                 runtime_kind="sdk-local",
+                memory_dir=memory_dir,
             ),
         }
     }

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -63,6 +63,15 @@ PUFFO_CORE_TOOL_NAMES = (
     "read_memory_files",
     "search_memory",
     "search_imports",
+    # M4 memory status / recall / history tools (read-only; registered
+    # by mcp.memory_tools). Same reason as the M3 block — the sdk gate
+    # auto-allows every mcp__puffo__ tool in this list, so leaving them
+    # out would register them but deny them at call time on sdk-local.
+    "get_memory_status",
+    "get_memory_file_status",
+    "list_memory_files",
+    "get_memory_history_status",
+    "get_memory_history",
 )
 PUFFO_CORE_TOOL_FQNS = tuple(
     f"mcp__{MCP_SERVER_NAME}__{t}" for t in PUFFO_CORE_TOOL_NAMES

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -49,6 +49,20 @@ PUFFO_CORE_TOOL_NAMES = (
     "leave_space",
     "leave_channel",
     "refresh",
+    # M3 memory tools (registered by mcp.memory_tools). Kept in the
+    # core allowlist so the sdk adapter's gate auto-allows them like
+    # every other mcp__puffo__ tool — otherwise they register but are
+    # denied at call time on sdk-local.
+    "create_note",
+    "patch_note",
+    "append_note",
+    "create_briefing_topic",
+    "patch_briefing_topic",
+    "append_recollection",
+    "read_memory_file",
+    "read_memory_files",
+    "search_memory",
+    "search_imports",
 )
 PUFFO_CORE_TOOL_FQNS = tuple(
     f"mcp__{MCP_SERVER_NAME}__{t}" for t in PUFFO_CORE_TOOL_NAMES

--- a/src/puffo_agent/mcp/memory_tools.py
+++ b/src/puffo_agent/mcp/memory_tools.py
@@ -1,0 +1,685 @@
+"""Semantic memory MCP tools (M3) over the M2 ``MemoryStore``.
+
+Ten agent-facing tools: six semantic writes (``create_note``,
+``patch_note``, ``append_note``, ``create_briefing_topic``,
+``patch_briefing_topic``, ``append_recollection``) and four
+read/search tools (``read_memory_file``, ``read_memory_files``,
+``search_memory``, ``search_imports``). The agent works with memory
+concepts — notes, briefing topics, recollections — never physical
+paths; semantic names are normalized onto logical paths
+(``notes/<name>.md``, ``briefing/<name>.md``, dated
+``recollection/YYYY/MM/YYYY-MM-DD.md``) and every write goes through
+the M2 store, which keeps path grammar, scope rules, size limits, and
+atomicity centralized.
+
+Every successful write is committed to the LOCAL git repo at the
+memory root (``memory_git``), with the caller's ``reason`` recorded in
+the commit body. Writes return the doc's result envelope::
+
+    {ok, tool, changed, paths, commit_id,
+     post_effects: {briefing_rebuilt, provider_reload}, warnings}
+
+``provider_reload`` mapping for the fat agent — which has no hot
+in-session provider reload; a "reload" means the M1
+``refresh_agent.flag`` was written, so the worker rebuilds provider
+prompt artifacts (CLAUDE.md / AGENTS.md) on the next batch and the
+provider picks them up at next spawn/turn:
+
+- ``"not_needed"`` — non-briefing write, or ``changed: false``;
+- ``"requested"`` — briefing changed and the refresh flag was written;
+- ``"failed"`` — briefing changed but the flag write failed (or no
+  workspace is configured): ``ok`` stays true and a
+  ``memory_provider_reload_failed`` warning is attached — post-effect
+  failures never masquerade as write failures.
+
+``briefing_rebuilt`` is true iff the write touched ``briefing/`` and
+changed it (the store revalidated the compiled-total budget before the
+write committed, and the rebuild was triggered via the refresh flag).
+
+Expected failures (validation, scope, size, patch mismatches) surface
+as structured tool errors whose text is the JSON envelope
+``{ok: false, error: {code, message, operation, path, suggestion,
+causes}}`` with M3 error codes; truly unexpected exceptions propagate
+as plain runtime errors.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date as date_type, datetime, timezone
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from ..agent import memory_git
+from ..agent.memory import (
+    BRIEFING_DIR,
+    IMPORTS_DIR,
+    NOTES_DIR,
+    RECOLLECTION_DIR,
+    MemoryStoreError,
+    ensure_memory_tree,
+    request_prompt_refresh,
+)
+from ..agent.memory_store import IMPORTS_READ_LIMIT, MemoryStore
+
+logger = logging.getLogger(__name__)
+
+NAME_MAX_LENGTH = 100
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+SEARCH_DEFAULT_LIMIT = 20
+SEARCH_MAX_LIMIT = 50
+SEARCH_SNIPPET_LIMIT = 200
+SEARCH_PER_FILE_LIMIT = 3
+
+# search_memory scans these, in this fixed order (deterministic
+# results). imports/ is deliberately absent — it is searchable only
+# via search_imports.
+_SEARCH_SCOPES = (BRIEFING_DIR, NOTES_DIR, RECOLLECTION_DIR)
+
+_NAME_SUGGESTION = (
+    "Use a short flat name like 'puffo-memory-mcp': letters, digits, "
+    "dots, dashes; no slashes, no leading dot, at most "
+    f"{NAME_MAX_LENGTH} characters."
+)
+
+
+@dataclass
+class MemoryToolsConfig:
+    """Config for the M3 memory tools.
+
+    ``maintenance`` is store-level and NOT agent-selectable:
+    ``build_server()`` always constructs it as False; the flag exists
+    so a future daemon-maintenance context can flip it and unlock
+    ``recollection/`` writes.
+    """
+
+    memory_root: str
+    workspace: str = ""
+    maintenance: bool = False
+
+
+# ── error envelopes ──────────────────────────────────────────────────
+
+
+def _tool_error(
+    *,
+    code: str,
+    message: str,
+    operation: str,
+    path: str,
+    suggestion: str,
+    causes: list[dict],
+    size: int | None = None,
+    limit: int | None = None,
+) -> ToolError:
+    """Structured tool error: the text IS the JSON envelope, so the
+    agent sees the M3 error shape instead of a transport failure."""
+    err: dict = {
+        "code": code,
+        "message": message,
+        "operation": operation,
+        "path": path,
+    }
+    if size is not None:
+        err["size"] = size
+    if limit is not None:
+        err["limit"] = limit
+    err["suggestion"] = suggestion
+    err["causes"] = causes
+    return ToolError(json.dumps({"ok": False, "error": err}))
+
+
+def _args_error(
+    operation: str,
+    message: str,
+    suggestion: str,
+    *,
+    code: str = "memory_invalid_arguments",
+    path: str = "",
+) -> ToolError:
+    return _tool_error(
+        code=code,
+        message=message,
+        operation=operation,
+        path=path,
+        suggestion=suggestion,
+        causes=[{"layer": "memory_tools", "code": code, "message": message}],
+    )
+
+
+def _store_error(operation: str, exc: MemoryStoreError) -> ToolError:
+    return _tool_error(
+        code=exc.code,
+        message=f"{operation} failed for {exc.path}: {exc.code}.",
+        operation=operation,
+        path=exc.path,
+        suggestion=exc.suggestion,
+        size=exc.size,
+        limit=exc.limit,
+        causes=[
+            {"layer": "memory_store", "code": exc.code, "message": str(exc)},
+        ],
+    )
+
+
+# ── semantic name / date handling ────────────────────────────────────
+
+
+def _invalid_name(operation: str, name: object) -> ToolError:
+    message = f"{operation}: {name!r} is not a valid memory name."
+    return _args_error(
+        operation, message, _NAME_SUGGESTION, code="memory_invalid_name",
+    )
+
+
+def _normalize_name(operation: str, name: object) -> str:
+    """Normalize a semantic name to a safe flat file stem.
+
+    Lowercase; one trailing ``.md`` dropped; spaces/underscores become
+    dashes (runs collapsed); leading/trailing dashes and trailing dots
+    stripped. The result must match ``^[a-z0-9][a-z0-9._-]*$`` and be
+    at most ``NAME_MAX_LENGTH`` chars — so slashes, hidden (dot-led)
+    names, and traversal shapes are all rejected, and the M2 store
+    re-validates the final logical path regardless (defense in depth).
+    """
+    if not isinstance(name, str):
+        raise _invalid_name(operation, name)
+    n = name.strip().lower()
+    if n.endswith(".md"):
+        n = n[:-3]
+    n = re.sub(r"[ _]+", "-", n)
+    n = re.sub(r"-{2,}", "-", n)
+    n = n.strip("-").rstrip(".")
+    if not n or len(n) > NAME_MAX_LENGTH or not _NAME_RE.fullmatch(n):
+        raise _invalid_name(operation, name)
+    return n
+
+
+def _recollection_path(operation: str, date: object) -> str:
+    """Map an optional ``YYYY-MM-DD`` string (default: today UTC) to
+    the dated logical path ``recollection/YYYY/MM/YYYY-MM-DD.md``."""
+    if date in (None, ""):
+        day = datetime.now(timezone.utc).date()
+    else:
+        if not isinstance(date, str) or not _DATE_RE.fullmatch(date):
+            raise _args_error(
+                operation,
+                f"{operation}: date must be a YYYY-MM-DD string, got {date!r}.",
+                "Pass date as YYYY-MM-DD, or omit it for today (UTC).",
+            )
+        try:
+            day = date_type.fromisoformat(date)
+        except ValueError:
+            raise _args_error(
+                operation,
+                f"{operation}: {date!r} is not a real calendar date.",
+                "Pass date as YYYY-MM-DD, or omit it for today (UTC).",
+            ) from None
+    return (
+        f"{RECOLLECTION_DIR}/{day.year:04d}/{day.month:02d}/"
+        f"{day.isoformat()}.md"
+    )
+
+
+def _validate_patches(operation: str, patches: object) -> list[dict]:
+    if not isinstance(patches, (list, tuple)) or not patches:
+        raise _args_error(
+            operation,
+            f"{operation}: patches must be a non-empty list.",
+            "Pass patches as [{old_text, new_text}, ...].",
+        )
+    out: list[dict] = []
+    for patch in patches:
+        if (
+            not isinstance(patch, dict)
+            or not isinstance(patch.get("old_text"), str)
+            or not isinstance(patch.get("new_text"), str)
+        ):
+            raise _args_error(
+                operation,
+                f"{operation}: each patch needs string old_text and new_text.",
+                "Pass patches as [{old_text, new_text}, ...].",
+            )
+        out.append(
+            {"old_text": patch["old_text"], "new_text": patch["new_text"]}
+        )
+    return out
+
+
+# ── shared write pipeline ────────────────────────────────────────────
+
+
+def _ensure(cfg: MemoryToolsConfig) -> None:
+    """Idempotent per-call init: memory tree + local audit repo. Runs
+    lazily on each tool call — never at registration/build time, so
+    ``build_server()`` stays side-effect free."""
+    root = Path(cfg.memory_root)
+    ensure_memory_tree(root)
+    memory_git.ensure_memory_git(root)
+
+
+def _store(cfg: MemoryToolsConfig) -> MemoryStore:
+    # No workspace_dir: the tools layer owns the briefing post-effect
+    # (and its provider_reload/warning mapping) instead of the store.
+    return MemoryStore(
+        cfg.memory_root, workspace_dir="", maintenance=cfg.maintenance,
+    )
+
+
+def _run_write(cfg: MemoryToolsConfig, tool: str, op, reason: str) -> dict:
+    """Primitive → git commit → post-effects → result envelope."""
+    _ensure(cfg)
+    try:
+        res = op(_store(cfg))
+    except MemoryStoreError as exc:
+        raise _store_error(tool, exc) from exc
+    logical = res["path"]
+    changed = bool(res["changed"])
+    warnings: list[dict] = []
+
+    commit_id = None
+    if changed:
+        if memory_git.git_available():
+            message = memory_git.format_commit_message(
+                tool, [logical], reason,
+            )
+            commit_id = memory_git.commit_memory_change(
+                Path(cfg.memory_root), [logical], message,
+            )
+            if commit_id is None:
+                warnings.append({
+                    "code": "memory_git_commit_failed",
+                    "message": (
+                        "Memory changed, but the audit commit failed; "
+                        "the change is saved but not committed."
+                    ),
+                })
+        else:
+            # Graceful degrade — the doc reserves warnings for
+            # post-effect failures; git being absent is just logged
+            # (by ensure_memory_git).
+            logger.info(
+                "memory git unavailable; %s %s left uncommitted",
+                tool, logical,
+            )
+
+    briefing_rebuilt = False
+    provider_reload = "not_needed"
+    if changed and logical.startswith(f"{BRIEFING_DIR}/"):
+        briefing_rebuilt = True
+        reload_ok = request_prompt_refresh(
+            cfg.workspace, f"memory_tools.{tool}:{logical}",
+        )
+        provider_reload = "requested" if reload_ok else "failed"
+        if not reload_ok:
+            warnings.append({
+                "code": "memory_provider_reload_failed",
+                "message": (
+                    "Memory changed, but the provider reload request "
+                    "failed. The next provider spawn will load the "
+                    "updated briefing."
+                ),
+            })
+
+    return {
+        "ok": True,
+        "tool": tool,
+        "changed": changed,
+        "paths": [logical],
+        "commit_id": commit_id,
+        "post_effects": {
+            "briefing_rebuilt": briefing_rebuilt,
+            "provider_reload": provider_reload,
+        },
+        "warnings": warnings,
+    }
+
+
+# ── deterministic search ─────────────────────────────────────────────
+
+
+def _scope_files(root: Path, scope: str, pattern: str) -> list[tuple[str, Path]]:
+    """(logical path, physical path) pairs under one scope, sorted for
+    deterministic scan order; hidden segments and symlinks skipped."""
+    base = root / scope
+    if not base.is_dir():
+        return []
+    out: list[tuple[str, Path]] = []
+    for p in sorted(base.rglob(pattern)):
+        rel = p.relative_to(root).as_posix()
+        if any(seg.startswith(".") for seg in rel.split("/")):
+            continue
+        if p.is_symlink() or not p.is_file():
+            continue
+        out.append((rel, p))
+    return out
+
+
+def _scan_files(
+    files: list[tuple[str, str, Path]],
+    query: str,
+    limit: int,
+    byte_cap: int | None = None,
+) -> tuple[list[dict], bool]:
+    """Case-insensitive substring scan, line by line. ≤
+    ``SEARCH_PER_FILE_LIMIT`` matches per file, ``limit`` total;
+    returns ``(results, truncated)``."""
+    needle = query.lower()
+    results: list[dict] = []
+    for rel, scope, path in files:
+        data = path.read_bytes()
+        if byte_cap is not None:
+            data = data[:byte_cap]
+        text = data.decode("utf-8", errors="ignore")
+        per_file = 0
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if needle not in line.lower():
+                continue
+            if len(results) >= limit:
+                return results, True
+            snippet = line.strip()
+            if len(snippet) > SEARCH_SNIPPET_LIMIT:
+                snippet = snippet[:SEARCH_SNIPPET_LIMIT]
+            results.append({
+                "path": rel,
+                "scope": scope,
+                "line": lineno,
+                "snippet": snippet,
+            })
+            per_file += 1
+            if per_file >= SEARCH_PER_FILE_LIMIT:
+                break
+    return results, False
+
+
+def _validate_search_args(operation: str, query: object, limit: object) -> int:
+    if not isinstance(query, str) or not query.strip():
+        raise _args_error(
+            operation,
+            f"{operation}: query must be a non-empty string.",
+            "Pass the text to look for.",
+        )
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        raise _args_error(
+            operation,
+            f"{operation}: limit must be a positive integer, got {limit!r}.",
+            f"Use 1 ≤ limit ≤ {SEARCH_MAX_LIMIT} (default "
+            f"{SEARCH_DEFAULT_LIMIT}).",
+        )
+    return min(limit, SEARCH_MAX_LIMIT)
+
+
+# ── registration ─────────────────────────────────────────────────────
+
+
+def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
+    """Register the ten M3 semantic memory tools on ``mcp``."""
+
+    # -- write tools ---------------------------------------------------
+
+    @mcp.tool()
+    async def create_note(name: str, body: str, reason: str = "") -> dict:
+        """Create a durable note at notes/<name>.md.
+
+        Notes are searchable long-term memory — detail that should
+        survive but not be injected into every prompt. ``name`` is a
+        semantic name (normalized to a flat lowercase slug), not a
+        path. Fails if the note already exists — change an existing
+        note with patch_note or append_note. ``reason`` (optional) is
+        recorded in the memory audit log.
+        """
+        slug = _normalize_name("create_note", name)
+        path = f"{NOTES_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "create_note",
+            lambda s: s.create_memory_file(path, body), reason,
+        )
+
+    @mcp.tool()
+    async def patch_note(
+        name: str, patches: list[dict], reason: str = "",
+    ) -> dict:
+        """Patch an existing note at notes/<name>.md by exact text
+        replacement.
+
+        ``patches`` is a list of ``{old_text, new_text}``; each
+        old_text must match the current content exactly once, and the
+        list applies all-or-nothing. ``reason`` (optional) is recorded
+        in the memory audit log.
+        """
+        slug = _normalize_name("patch_note", name)
+        checked = _validate_patches("patch_note", patches)
+        path = f"{NOTES_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "patch_note",
+            lambda s: s.patch_memory_file(path, checked), reason,
+        )
+
+    @mcp.tool()
+    async def append_note(name: str, text: str, reason: str = "") -> dict:
+        """Append text to the end of an existing note at
+        notes/<name>.md. ``reason`` (optional) is recorded in the
+        memory audit log.
+        """
+        slug = _normalize_name("append_note", name)
+        path = f"{NOTES_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "append_note",
+            lambda s: s.append_memory_file(path, text), reason,
+        )
+
+    @mcp.tool()
+    async def create_briefing_topic(
+        name: str, body: str, reason: str = "",
+    ) -> dict:
+        """Create a briefing topic at briefing/<name>.md.
+
+        Briefing topics are ALWAYS loaded into your prompt, so keep
+        them small — the store enforces per-file and compiled-total
+        budgets and rejects oversized writes. A successful change
+        marks the provider prompt artifacts for rebuild;
+        ``post_effects.provider_reload`` reports "requested" when the
+        rebuild flag was written (the provider picks it up at its next
+        spawn/turn) and "failed" (with a warning) when it could not
+        be. ``reason`` (optional) is recorded in the memory audit log.
+        """
+        slug = _normalize_name("create_briefing_topic", name)
+        path = f"{BRIEFING_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "create_briefing_topic",
+            lambda s: s.create_memory_file(path, body), reason,
+        )
+
+    @mcp.tool()
+    async def patch_briefing_topic(
+        name: str, patches: list[dict], reason: str = "",
+    ) -> dict:
+        """Patch an existing briefing topic at briefing/<name>.md by
+        exact text replacement (same rules as patch_note).
+
+        A successful change marks the provider prompt artifacts for
+        rebuild; ``post_effects.provider_reload`` reports "requested"
+        when the rebuild flag was written (picked up at the provider's
+        next spawn/turn) and "failed" (with a warning) when it could
+        not be. ``reason`` (optional) is recorded in the memory audit
+        log.
+        """
+        slug = _normalize_name("patch_briefing_topic", name)
+        checked = _validate_patches("patch_briefing_topic", patches)
+        path = f"{BRIEFING_DIR}/{slug}.md"
+        return _run_write(
+            cfg, "patch_briefing_topic",
+            lambda s: s.patch_memory_file(path, checked), reason,
+        )
+
+    @mcp.tool()
+    async def append_recollection(
+        text: str,
+        date: str = "",
+        source_message_ids: list[str] | None = None,
+        related_paths: list[str] | None = None,
+        reason: str = "",
+    ) -> dict:
+        """Append an entry to the dated recollection journal at
+        recollection/YYYY/MM/YYYY-MM-DD.md (``date`` defaults to today
+        UTC; the file is created with a ``# <date>`` header when
+        missing).
+
+        recollection/ is daemon-owned maintenance memory: ordinary
+        conversation turns do NOT have write scope here and get a
+        structured memory_scope_readonly error — put durable detail in
+        notes/ instead. ``source_message_ids`` / ``related_paths``
+        (optional) are recorded as sources:/related: lines; ``reason``
+        (optional) goes to the memory audit log.
+        """
+        path = _recollection_path("append_recollection", date)
+        day = path.rsplit("/", 1)[-1][:-3]
+        lines = [text]
+        if source_message_ids:
+            lines.append(
+                "sources: " + ", ".join(str(i) for i in source_message_ids)
+            )
+        if related_paths:
+            lines.append(
+                "related: " + ", ".join(str(p) for p in related_paths)
+            )
+        entry = "\n" + "\n".join(lines) + "\n"
+
+        def op(store: MemoryStore) -> dict:
+            if store.get_memory_file_status(path)["exists"]:
+                return store.append_memory_file(path, entry)
+            return store.create_memory_file(path, f"# {day}\n" + entry)
+
+        return _run_write(cfg, "append_recollection", op, reason)
+
+    # -- read tools ----------------------------------------------------
+
+    @mcp.tool()
+    async def read_memory_file(path: str) -> dict:
+        """Read one memory file by logical path (briefing/…, notes/…,
+        recollection/…, imports/…). The body is bounded by the area's
+        file limit; ``truncated`` flags a cut read."""
+        _ensure(cfg)
+        try:
+            return _store(cfg).read_memory_file(path)
+        except MemoryStoreError as exc:
+            raise _store_error("read_memory_file", exc) from exc
+
+    @mcp.tool()
+    async def read_memory_files(paths: list[str]) -> dict:
+        """Read up to 16 memory files in one call (pure read, never
+        writes). Each entry is a read result or a per-path error — one
+        bad path does not fail the batch."""
+        _ensure(cfg)
+        try:
+            results = _store(cfg).read_memory_files(paths)
+        except MemoryStoreError as exc:
+            raise _store_error("read_memory_files", exc) from exc
+        return {"ok": True, "results": results}
+
+    # -- search tools --------------------------------------------------
+
+    @mcp.tool()
+    async def search_memory(
+        query: str,
+        scopes: list[str] | None = None,
+        limit: int = SEARCH_DEFAULT_LIMIT,
+    ) -> dict:
+        """Search memory for a case-insensitive substring, line by
+        line. ``scopes`` defaults to ["briefing", "notes",
+        "recollection"] (imports/ is searchable only via
+        search_imports). Deterministic order; at most 3 matches per
+        file; ``limit`` caps total results (default 20, max 50)."""
+        operation = "search_memory"
+        _ensure(cfg)
+        capped = _validate_search_args(operation, query, limit)
+        requested = list(_SEARCH_SCOPES) if scopes is None else list(scopes)
+        if not requested:
+            raise _args_error(
+                operation,
+                "search_memory: scopes must not be empty.",
+                "Omit scopes, or pick from: briefing, notes, recollection.",
+            )
+        for scope in requested:
+            if scope == IMPORTS_DIR:
+                raise _args_error(
+                    operation,
+                    "search_memory does not search imports/.",
+                    "Use search_imports for imported content.",
+                )
+            if scope not in _SEARCH_SCOPES:
+                raise _args_error(
+                    operation,
+                    f"search_memory: unknown scope {scope!r}.",
+                    "Pick scopes from: briefing, notes, recollection.",
+                )
+        root = Path(cfg.memory_root)
+        files = [
+            (rel, scope, p)
+            for scope in _SEARCH_SCOPES
+            if scope in requested
+            for rel, p in _scope_files(root, scope, "*.md")
+        ]
+        try:
+            results, truncated = _scan_files(files, query, capped)
+        except OSError as exc:
+            raise _tool_error(
+                code="memory_search_failed",
+                message=f"search_memory failed: {exc}",
+                operation=operation,
+                path="",
+                suggestion="Retry; if it persists, check the memory dir.",
+                causes=[{
+                    "layer": "memory_tools",
+                    "code": "memory_search_failed",
+                    "message": str(exc),
+                }],
+            ) from exc
+        return {
+            "ok": True, "query": query,
+            "results": results, "truncated": truncated,
+        }
+
+    @mcp.tool()
+    async def search_imports(
+        query: str, limit: int = SEARCH_DEFAULT_LIMIT,
+    ) -> dict:
+        """Search imported (read-only) content under imports/ for a
+        case-insensitive substring. Reads at most 128KB per file;
+        same match/limit rules as search_memory."""
+        operation = "search_imports"
+        _ensure(cfg)
+        capped = _validate_search_args(operation, query, limit)
+        root = Path(cfg.memory_root)
+        files = [
+            (rel, IMPORTS_DIR, p)
+            for rel, p in _scope_files(root, IMPORTS_DIR, "*")
+        ]
+        try:
+            results, truncated = _scan_files(
+                files, query, capped, byte_cap=IMPORTS_READ_LIMIT,
+            )
+        except OSError as exc:
+            raise _tool_error(
+                code="memory_search_failed",
+                message=f"search_imports failed: {exc}",
+                operation=operation,
+                path="",
+                suggestion="Retry; if it persists, check the memory dir.",
+                causes=[{
+                    "layer": "memory_tools",
+                    "code": "memory_search_failed",
+                    "message": str(exc),
+                }],
+            ) from exc
+        return {
+            "ok": True, "query": query,
+            "results": results, "truncated": truncated,
+        }

--- a/src/puffo_agent/mcp/memory_tools.py
+++ b/src/puffo_agent/mcp/memory_tools.py
@@ -67,8 +67,12 @@ from ..agent.memory import (
     ensure_memory_tree,
     request_prompt_refresh,
 )
-from ..agent.memory_errors import MemoryStoreError
-from ..agent.memory_store import IMPORTS_READ_LIMIT, MemoryStore
+from ..agent.memory_errors import MemoryHistoryError, MemoryStoreError
+from ..agent.memory_store import (
+    IMPORTS_READ_LIMIT,
+    LIST_DEFAULT_LIMIT,
+    MemoryStore,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +174,50 @@ def _store_error(operation: str, exc: MemoryStoreError) -> ToolError:
             {"layer": "memory_store", "code": exc.code, "message": str(exc)},
         ],
     )
+
+
+def _history_error(operation: str, exc: MemoryHistoryError) -> ToolError:
+    """Map an M4 history-query error to the same structured envelope as
+    ``_store_error``, tagged with a ``memory_git`` cause layer. History
+    errors carry no path, so ``path`` is empty."""
+    return _tool_error(
+        code=exc.code,
+        message=f"{operation} failed: {exc.message}",
+        operation=operation,
+        path="",
+        suggestion=exc.suggestion,
+        causes=[
+            {"layer": "memory_git", "code": exc.code, "message": str(exc)},
+        ],
+    )
+
+
+def _validate_history_path(
+    cfg: MemoryToolsConfig, operation: str, path: str,
+) -> str:
+    """Validate a history path through the store's logical-path grammar
+    (grammar/scope only — a history query can legitimately reference a
+    since-deleted file, so there is no existence check). Store errors
+    (``memory_invalid_path`` / ``memory_path_out_of_scope``) re-raise as
+    tool errors."""
+    try:
+        _, logical = MemoryStore(cfg.memory_root)._validate_logical_path(path)
+    except MemoryStoreError as exc:
+        raise _store_error(operation, exc) from exc
+    return str(logical)
+
+
+def _briefing_refresh_pending(cfg: MemoryToolsConfig) -> bool:
+    """Whether a briefing change is awaiting a provider rebuild. In the
+    fat-agent model there is one provider-reload signal — the
+    ``refresh_agent.flag`` under ``<workspace>/.puffo-agent/`` — so both
+    ``briefing.dirty`` and ``briefing.provider_reload_required`` derive
+    from its presence. No workspace ⇒ nothing pending."""
+    if not cfg.workspace:
+        return False
+    from ..portal.state import refresh_agent_flag_path
+
+    return refresh_agent_flag_path(Path(cfg.workspace)).is_file()
 
 
 # ── semantic name / date handling ────────────────────────────────────
@@ -711,3 +759,161 @@ def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
             "ok": True, "query": query,
             "results": results, "truncated": truncated,
         }
+
+    # -- M4 status / recall / history (all read-only, agent-facing) ----
+    #
+    # Unlike the M3 read tools, these NEVER call _ensure: a status or
+    # history read must report an uninitialised tree/repo honestly
+    # rather than creating it. None of them expose any write, rollback,
+    # or raw git flag/ref surface.
+
+    @mcp.tool()
+    async def get_memory_status() -> dict:
+        """Read-only health of this agent's memory (no file bodies).
+
+        Reports root existence, whether the local git audit repo is
+        available, the compiled-briefing size with its budget and
+        dirty/reload flags, and per-scope ``{files, total_size_bytes}``.
+        Never creates the memory tree or the audit repo.
+        """
+        root = Path(cfg.memory_root)
+        status = _store(cfg).get_memory_status()
+        status["ok"] = True
+        status["git_enabled"] = (
+            memory_git.git_available() and (root / ".git").is_dir()
+        )
+        pending = _briefing_refresh_pending(cfg)
+        status["briefing"]["dirty"] = pending
+        status["briefing"]["provider_reload_required"] = pending
+        return status
+
+    @mcp.tool()
+    async def get_memory_file_status(path: str) -> dict:
+        """Existence / scope / size / limit / briefing-inclusion for one
+        logical memory path — deliberately NO body.
+
+        Extended (best-effort) with git last-change metadata
+        (``git_tracked`` / ``last_changed_commit_id`` /
+        ``last_changed_at``); when git is unavailable or the audit repo
+        is not initialised those fields are null and file status still
+        works. Read-only; never creates the tree or repo.
+        """
+        try:
+            status = _store(cfg).get_memory_file_status(path)
+        except MemoryStoreError as exc:
+            raise _store_error("get_memory_file_status", exc) from exc
+        git_tracked = None
+        last_commit = None
+        last_at = None
+        try:
+            hist = memory_git.history_status(
+                Path(cfg.memory_root), status["path"],
+            )
+            git_tracked = hist["path_tracked"]
+            last_commit = hist["last_changed_commit_id"]
+            last_at = hist["last_changed_at"]
+        except MemoryHistoryError as exc:
+            # No git / no audit repo just leaves the git fields null;
+            # any other failure is a real error worth surfacing.
+            if exc.code not in (
+                "memory_history_unavailable",
+                "memory_history_not_initialized",
+            ):
+                raise _history_error("get_memory_file_status", exc) from exc
+        status["git_tracked"] = git_tracked
+        status["last_changed_commit_id"] = last_commit
+        status["last_changed_at"] = last_at
+        status["ok"] = True
+        # M4 status is body-less by contract (recall bodies go through
+        # read_memory_file / read_memory_files).
+        assert "body" not in status
+        return status
+
+    @mcp.tool()
+    async def list_memory_files(
+        scope: str = "", limit: int = LIST_DEFAULT_LIMIT,
+    ) -> dict:
+        """List logical memory paths + lightweight metadata — never a
+        body.
+
+        Each entry carries ``path`` / ``scope`` / ``size`` /
+        ``writable`` / ``briefing_included``. ``scope`` (optional)
+        restricts to one area (briefing, notes, recollection, imports);
+        ``limit`` bounds the count and ``truncated`` flags that more
+        files exist. Read-only.
+        """
+        try:
+            result = _store(cfg).list_memory_files(scope or None, limit)
+        except MemoryStoreError as exc:
+            raise _store_error("list_memory_files", exc) from exc
+        return {"ok": True, **result}
+
+    @mcp.tool()
+    async def get_memory_history_status(path: str = "") -> dict:
+        """Read-only health of the memory audit history.
+
+        Reports git availability, whether the audit repo is
+        initialised, the HEAD commit id, and the clean/dirty state of
+        the work tree. When ``path`` (a logical memory path) is given it
+        also reports whether that path is tracked and when it last
+        changed. NOT a git passthrough — no raw git flags or refs are
+        accepted, and this never creates the repo.
+        """
+        logical = (
+            _validate_history_path(cfg, "get_memory_history_status", path)
+            if path else None
+        )
+        try:
+            result = memory_git.history_status(Path(cfg.memory_root), logical)
+        except MemoryHistoryError as exc:
+            raise _history_error("get_memory_history_status", exc) from exc
+        return {"ok": True, **result}
+
+    @mcp.tool()
+    async def get_memory_history(
+        path: str = "",
+        scopes: list[str] | None = None,
+        since: str = "",
+        until: str = "",
+        actor: str = "",
+        operation: str = "",
+        query: str = "",
+        limit: int = memory_git.HISTORY_DEFAULT_LIMIT,
+        include_diff: bool = False,
+    ) -> dict:
+        """Bounded read-only audit query over the local memory git
+        history. NOT a ``git log`` passthrough.
+
+        Only the whitelisted filters are honoured — ``path`` / ``scopes``
+        (which areas), ``since`` / ``until`` (dates), ``actor`` (commit
+        author), ``operation`` (matches the recorded write tool),
+        ``query`` (case-insensitive substring over commit
+        subject/reason/changed-paths — never the diff text), ``limit``,
+        and ``include_diff``. No raw git flags, refs, revision ranges,
+        or rollback are ever accepted: a filter value that looks like a
+        flag (``--all``) or a ref range (``HEAD~5..HEAD``) is treated as
+        a literal value. Each entry carries ``commit_id`` / ``time`` /
+        ``actor`` / ``operation`` / ``reason`` / ``message`` /
+        ``changed_paths`` / ``summary``; ``include_diff`` adds a
+        byte-capped ``diff`` excerpt with a ``diff_truncated`` flag.
+        """
+        logical = (
+            _validate_history_path(cfg, "get_memory_history", path)
+            if path else None
+        )
+        try:
+            result = memory_git.query_history(
+                Path(cfg.memory_root),
+                path=logical,
+                scopes=scopes,
+                since=since,
+                until=until,
+                actor=actor,
+                operation=operation,
+                query=query,
+                limit=limit,
+                include_diff=include_diff,
+            )
+        except MemoryHistoryError as exc:
+            raise _history_error("get_memory_history", exc) from exc
+        return {"ok": True, **result}

--- a/src/puffo_agent/mcp/memory_tools.py
+++ b/src/puffo_agent/mcp/memory_tools.py
@@ -1,10 +1,13 @@
 """Semantic memory MCP tools (M3) over the M2 ``MemoryStore``.
 
-Ten agent-facing tools: six semantic writes (``create_note``,
-``patch_note``, ``append_note``, ``create_briefing_topic``,
-``patch_briefing_topic``, ``append_recollection``) and four
-read/search tools (``read_memory_file``, ``read_memory_files``,
-``search_memory``, ``search_imports``). The agent works with memory
+Ten tools: six semantic writes (``create_note``, ``patch_note``,
+``append_note``, ``create_briefing_topic``, ``patch_briefing_topic``,
+``append_recollection``) and four read/search tools
+(``read_memory_file``, ``read_memory_files``, ``search_memory``,
+``search_imports``). Nine are agent-facing; ``append_recollection``
+registers only under the maintenance scope (recollection/ is
+daemon-owned), so the agent-facing server exposes the other nine. The
+agent works with memory
 concepts — notes, briefing topics, recollections — never physical
 paths; semantic names are normalized onto logical paths
 (``notes/<name>.md``, ``briefing/<name>.md``, dated
@@ -61,10 +64,10 @@ from ..agent.memory import (
     IMPORTS_DIR,
     NOTES_DIR,
     RECOLLECTION_DIR,
-    MemoryStoreError,
     ensure_memory_tree,
     request_prompt_refresh,
 )
+from ..agent.memory_errors import MemoryStoreError
 from ..agent.memory_store import IMPORTS_READ_LIMIT, MemoryStore
 
 logger = logging.getLogger(__name__)
@@ -247,6 +250,15 @@ def _validate_patches(operation: str, patches: object) -> list[dict]:
                 f"{operation}: each patch needs string old_text and new_text.",
                 "Pass patches as [{old_text, new_text}, ...].",
             )
+        if patch["old_text"] == "":
+            # An empty old_text has no single, unambiguous match point;
+            # reject it here rather than letting it reach the store.
+            raise _args_error(
+                operation,
+                f"{operation}: old_text must be a non-empty string.",
+                "old_text must be text that appears exactly once in the "
+                "file; it cannot be empty.",
+            )
         out.append(
             {"old_text": patch["old_text"], "new_text": patch["new_text"]}
         )
@@ -285,13 +297,17 @@ def _run_write(cfg: MemoryToolsConfig, tool: str, op, reason: str) -> dict:
     warnings: list[dict] = []
 
     commit_id = None
+    root = Path(cfg.memory_root)
     if changed:
-        if memory_git.git_available():
+        # Only attempt an audit commit when git is available AND our own
+        # ``.git`` audit repo exists — never stage into an enclosing
+        # repo the memory root happens to sit inside.
+        if memory_git.git_available() and (root / ".git").is_dir():
             message = memory_git.format_commit_message(
                 tool, [logical], reason,
             )
             commit_id = memory_git.commit_memory_change(
-                Path(cfg.memory_root), [logical], message,
+                root, [logical], message,
             )
             if commit_id is None:
                 warnings.append({
@@ -420,7 +436,11 @@ def _validate_search_args(operation: str, query: object, limit: object) -> int:
 
 
 def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
-    """Register the ten M3 semantic memory tools on ``mcp``."""
+    """Register the M3 semantic memory tools on ``mcp``.
+
+    Nine tools always register; ``append_recollection`` registers only
+    when ``cfg.maintenance`` is set, since recollection/ writes need the
+    maintenance scope the agent-facing server never grants."""
 
     # -- write tools ---------------------------------------------------
 
@@ -519,7 +539,6 @@ def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
             lambda s: s.patch_memory_file(path, checked), reason,
         )
 
-    @mcp.tool()
     async def append_recollection(
         text: str,
         date: str = "",
@@ -558,6 +577,15 @@ def register_memory_tools(mcp: FastMCP, cfg: MemoryToolsConfig) -> None:
             return store.create_memory_file(path, f"# {day}\n" + entry)
 
         return _run_write(cfg, "append_recollection", op, reason)
+
+    # recollection/ is daemon-owned maintenance memory; the agent-facing
+    # server (maintenance=False) has no write scope there, so an agent
+    # calling append_recollection would only ever get a
+    # memory_scope_readonly error. Register the tool solely under the
+    # explicit maintenance scope, where it actually works — a future
+    # maintenance server flips ``maintenance`` on.
+    if cfg.maintenance:
+        mcp.tool()(append_recollection)
 
     # -- read tools ----------------------------------------------------
 

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -32,6 +32,7 @@ from .host_tools import (
     _uninstall_skill,
     _write_refresh_model_flag,
 )
+from .memory_tools import MemoryToolsConfig, register_memory_tools
 from .puffo_core_tools import PuffoCoreToolsConfig, register_core_tools
 
 logger = logging.getLogger(__name__)
@@ -232,6 +233,7 @@ def build_server(
     data_service_url: str,
     runtime_kind: str = "",
     harness: str = "",
+    memory_dir: str = "",
 ) -> FastMCP:
     ks = KeyStore(keystore_dir)
     http = PuffoCoreHttpClient(server_url, ks, slug)
@@ -263,6 +265,17 @@ def build_server(
     )
     register_core_tools(mcp, core_cfg)
     _register_local_tools(mcp, workspace, runtime_kind, harness)
+
+    # Memory root: PUFFO_MEMORY_DIR when set; otherwise the default
+    # AgentConfig layout where memory/ and workspace/ are siblings
+    # under the agent dir. ``maintenance`` stays False here — the
+    # agent-facing server never gets recollection/ write scope.
+    if not memory_dir:
+        memory_dir = str(Path(workspace).parent / "memory")
+    mem_cfg = MemoryToolsConfig(
+        memory_root=memory_dir, workspace=workspace, maintenance=False,
+    )
+    register_memory_tools(mcp, mem_cfg)
     return mcp
 
 
@@ -295,6 +308,7 @@ def _cfg_from_env() -> dict[str, str]:
         "data_service_url": data_service_url,
         "runtime_kind": os.environ.get("PUFFO_RUNTIME_KIND", ""),
         "harness": os.environ.get("PUFFO_HARNESS", ""),
+        "memory_dir": os.environ.get("PUFFO_MEMORY_DIR", ""),
     }
 
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -525,7 +525,8 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     )
     cfg.save()
 
-    (target / "memory").mkdir(exist_ok=True)
+    from ..agent.memory import ensure_memory_tree
+    ensure_memory_tree(target / "memory")
 
     profile_path = target / "profile.md"
     if args.profile and Path(args.profile).exists():
@@ -1498,6 +1499,7 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
     """Re-sync the shared primer + rebuild the listed agents' CLAUDE.md.
     ensure_shared_primer runs on every worker startup, so this is only
     needed to force a rebuild without waiting for a message."""
+    from ..agent.memory import BriefingCompileError
     from ..agent.shared_content import (
         ensure_shared_primer,
         rebuild_agent_claude_md,
@@ -1522,14 +1524,23 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
             print(f"error: agent {agent_id!r}: {exc}", file=sys.stderr)
             rc = 2
             continue
-        rebuild_agent_claude_md(
-            shared_dir=shared_dir,
-            profile_path=cfg.resolve_profile_path(),
-            memory_dir=cfg.resolve_memory_dir(),
-            workspace_dir=cfg.resolve_workspace_dir(),
-            claude_user_dir=agent_claude_user_dir(agent_id),
-            gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
-        )
+        try:
+            rebuild_agent_claude_md(
+                shared_dir=shared_dir,
+                profile_path=cfg.resolve_profile_path(),
+                memory_dir=cfg.resolve_memory_dir(),
+                workspace_dir=cfg.resolve_workspace_dir(),
+                claude_user_dir=agent_claude_user_dir(agent_id),
+                gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
+                agent_id=agent_id,
+                display_name=cfg.display_name,
+                role=cfg.role,
+                role_short=cfg.role_short,
+            )
+        except BriefingCompileError as exc:
+            print(f"error: agent {agent_id!r}: {exc}", file=sys.stderr)
+            rc = 2
+            continue
         rebuilt.append(agent_id)
         print(f"rebuilt CLAUDE.md for {agent_id!r}")
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -525,7 +525,7 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     )
     cfg.save()
 
-    from ..agent.memory import ensure_memory_tree
+    from ..agent.memory import ensure_memory_tree, sync_profile_briefing
     ensure_memory_tree(target / "memory")
 
     profile_path = target / "profile.md"
@@ -533,6 +533,20 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
         shutil.copy2(args.profile, profile_path)
     else:
         profile_path.write_text(DEFAULT_PROFILE, encoding="utf-8")
+
+    # Seed briefing/profile.md now so the agent's very first prompt
+    # rebuild has managed identity framing (the worker's memory sync
+    # re-syncs it, but a freshly created agent shouldn't ship without
+    # it). Mirrors shared_content.rebuild_agent_claude_md's profile sync.
+    from .profile_sync import extract_soul_body
+    sync_profile_briefing(
+        target / "memory",
+        agent_id=agent_id,
+        display_name=cfg.display_name,
+        role=role,
+        role_short=role_short,
+        soul=extract_soul_body(profile_path.read_text(encoding="utf-8")),
+    )
 
     print(f"created agent {agent_id!r} at {target}")
     print(
@@ -1499,7 +1513,7 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
     """Re-sync the shared primer + rebuild the listed agents' CLAUDE.md.
     ensure_shared_primer runs on every worker startup, so this is only
     needed to force a rebuild without waiting for a message."""
-    from ..agent.memory import BriefingCompileError
+    from ..agent.memory_errors import BriefingCompileError
     from ..agent.shared_content import (
         ensure_shared_primer,
         rebuild_agent_claude_md,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -138,6 +138,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 keystore_dir=str(agent_dir(agent_cfg.id) / "keys"),
                 workspace=str(agent_cfg.resolve_workspace_dir()),
                 agent_id=agent_cfg.id,
+                memory_dir=str(agent_cfg.resolve_memory_dir()),
             )
         return adapter
 
@@ -220,6 +221,10 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 rpc_url=f"http://host.docker.internal:{daemon_cfg.rpc_service.port}",
                 runtime_kind="cli-docker",
                 harness=agent_cfg.runtime.harness,
+                # MCP runs in-container; the agent dir is bind-mounted
+                # at /home/agent/.puffo-agent-state (docker_cli also
+                # pins this at its env-override sites).
+                memory_dir="/home/agent/.puffo-agent-state/memory",
             )
         return adapter
 
@@ -268,6 +273,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 rpc_url=f"http://127.0.0.1:{daemon_cfg.rpc_service.port}",
                 runtime_kind="cli-local",
                 harness=agent_cfg.runtime.harness,
+                memory_dir=str(agent_cfg.resolve_memory_dir()),
             )
         return adapter
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -57,12 +57,17 @@ def _rebuild_managed_system_prompt(
     profile_path: str,
     memory_path: str,
     workspace_path: str,
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> str:
     """Dispatch wrapper: write the right system-prompt file(s) for the
     agent's harness. Codex agents get ``$CODEX_HOME/AGENTS.md``; every
     other harness goes through the legacy claude-code path (which also
     writes GEMINI.md for the gemini-cli harness sharing the same body).
-    Returns the assembled prompt body either way.
+    Returns the assembled prompt body either way. The identity fields
+    feed the managed ``memory/briefing/profile.md`` re-sync inside the
+    rebuild.
     """
     if harness_name == "codex":
         return rebuild_agent_codex_md(
@@ -71,6 +76,10 @@ def _rebuild_managed_system_prompt(
             memory_dir=Path(memory_path),
             workspace_dir=Path(workspace_path),
             codex_user_dir=agent_codex_user_dir(agent_id),
+            agent_id=agent_id,
+            display_name=display_name,
+            role=role,
+            role_short=role_short,
         )
     return rebuild_agent_claude_md(
         shared_dir=shared_path,
@@ -79,6 +88,10 @@ def _rebuild_managed_system_prompt(
         workspace_dir=Path(workspace_path),
         claude_user_dir=agent_claude_user_dir(agent_id),
         gemini_user_dir=agent_home_dir(agent_id) / ".gemini",
+        agent_id=agent_id,
+        display_name=display_name,
+        role=role,
+        role_short=role_short,
     )
 
 logger = logging.getLogger(__name__)
@@ -1042,16 +1055,19 @@ class Worker:
             memory_path = str(self.agent_cfg.resolve_memory_dir())
             workspace_path = str(self.agent_cfg.resolve_workspace_dir())
             claude_path = str(self.agent_cfg.resolve_claude_dir())
-            Path(memory_path).mkdir(parents=True, exist_ok=True)
             Path(workspace_path).mkdir(parents=True, exist_ok=True)
             _seed_claude_dir(Path(claude_path))
 
             # Assemble managed CLAUDE.md from shared primer + profile
-            # + memory snapshot. Written to user-level (.claude/
-            # CLAUDE.md) so Claude Code auto-discovers it. The
-            # project-level CLAUDE.md is left for the agent to edit.
-            # chat-local / sdk-local don't auto-discover, so the same
-            # string is passed as PuffoAgent's system_prompt.
+            # + compiled memory briefing. The rebuild ensures the
+            # memory tree + migrates legacy flat memory/*.md first.
+            # Written to user-level (.claude/CLAUDE.md) so Claude Code
+            # auto-discovers it. The project-level CLAUDE.md is left
+            # for the agent to edit. chat-local / sdk-local don't
+            # auto-discover, so the same string is passed as
+            # PuffoAgent's system_prompt. An over-budget briefing
+            # raises BriefingCompileError → caught below, worker init
+            # fails with runtime.status="error" (fail closed).
             shared_path = docker_shared_dir()
             claude_md = _rebuild_managed_system_prompt(
                 harness_name=(self.agent_cfg.runtime.harness or "").strip(),
@@ -1060,6 +1076,9 @@ class Worker:
                 profile_path=profile_path,
                 memory_path=memory_path,
                 workspace_path=workspace_path,
+                display_name=self.agent_cfg.display_name,
+                role=self.agent_cfg.role,
+                role_short=self.agent_cfg.role_short,
             )
 
             # One-time migration: remove an older project-level
@@ -1202,6 +1221,9 @@ class Worker:
                 profile_path=profile_path,
                 memory_path=memory_path,
                 workspace_path=workspace_path,
+                display_name=self.agent_cfg.display_name,
+                role=self.agent_cfg.role,
+                role_short=self.agent_cfg.role_short,
                 puffo=puffo,
                 adapter=self._adapter,
                 refresh_agent_flag=refresh_agent_flag_path,
@@ -1587,6 +1609,9 @@ async def _process_refresh_flags(
     refresh_agent_flag: Path,
     refresh_host_sync_flag: Path,
     refresh_session_flag: Path,
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
 ) -> None:
     """Consume any worker-scope refresh flags into a single
     ``adapter.reload(prompt, with_session=…)`` call at turn start.
@@ -1627,6 +1652,9 @@ async def _process_refresh_flags(
                 profile_path=profile_path,
                 memory_path=memory_path,
                 workspace_path=workspace_path,
+                display_name=display_name,
+                role=role,
+                role_short=role_short,
             )
             puffo.system_prompt = new_prompt
             logger.info(

--- a/tests/test_agent_create_flow.py
+++ b/tests/test_agent_create_flow.py
@@ -115,3 +115,38 @@ def test_finalize_from_command_writes_profile(tmp_path, monkeypatch):
 def test_finalize_from_command_unknown_request():
     with pytest.raises(ValueError, match="no pending create"):
         asyncio.run(agent_create.finalize_from_command("acr_missing", {}))
+
+
+def test_cmd_agent_create_seeds_profile_briefing(tmp_path, monkeypatch):
+    """`puffo-agent agent create` seeds briefing/profile.md with the
+    managed identity block, so a freshly created agent's first prompt
+    rebuild already has managed identity framing."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.agent.memory import (
+        PROFILE_MANAGED_BEGIN,
+        PROFILE_MANAGED_END,
+    )
+    from puffo_agent.portal.cli import build_parser
+
+    # cli-local resolves the API key without prompting, so the create
+    # flow runs headless.
+    args = build_parser().parse_args([
+        "agent", "create",
+        "--id", "helper-0001",
+        "--display-name", "Helper",
+        "--role", "coder: writes code",
+        "--runtime", "cli-local",
+    ])
+    assert args.func(args) == 0
+
+    profile_briefing = (
+        tmp_path / "agents" / "helper-0001" / "memory" / "briefing"
+        / "profile.md"
+    )
+    assert profile_briefing.is_file()
+    text = profile_briefing.read_text(encoding="utf-8")
+    assert PROFILE_MANAGED_BEGIN in text
+    assert PROFILE_MANAGED_END in text
+    # Identity fields from the create args land inside the managed block.
+    assert "Helper" in text
+    assert "coder: writes code" in text

--- a/tests/test_memory_m1.py
+++ b/tests/test_memory_m1.py
@@ -232,6 +232,114 @@ def test_migrate_flat_memory_over_total_budget_goes_to_notes(tmp_path):
     compile_briefing(root)  # still within budget after migration
 
 
+# ── symlink injection (host-side compile & migration) ────────────────
+
+
+def test_compile_excludes_symlinked_briefing_topic_outside_root(tmp_path):
+    """A symlinked briefing topic pointing at a file OUTSIDE the memory
+    root must never fold that file's bytes into the compiled prompt."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "briefing" / "real.md").write_text("real fact", encoding="utf-8")
+    secret = tmp_path / "outside-secret.md"
+    secret.write_text("SECRET-OUTSIDE-CONTENT", encoding="utf-8")
+    (root / "briefing" / "evil.md").symlink_to(secret)
+
+    out = compile_briefing(root)  # succeeds, does not raise
+
+    assert "real fact" in out
+    assert "SECRET-OUTSIDE-CONTENT" not in out
+    # The symlink is left on disk untouched, just never compiled.
+    assert (root / "briefing" / "evil.md").is_symlink()
+    assert secret.read_text(encoding="utf-8") == "SECRET-OUTSIDE-CONTENT"
+
+
+def test_compile_excludes_symlinked_briefing_topic_inside_root(tmp_path):
+    """Even a symlink whose target sits inside the root is excluded —
+    briefing topics are never followed through symlinks."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "notes" / "target.md").write_text(
+        "NOTE-TARGET-BYTES", encoding="utf-8",
+    )
+    (root / "briefing" / "link.md").symlink_to(root / "notes" / "target.md")
+
+    out = compile_briefing(root)
+
+    assert "NOTE-TARGET-BYTES" not in out
+
+
+def test_compile_excludes_topic_reached_through_symlinked_briefing_dir(tmp_path):
+    """A real topic file that resolves outside the root through a
+    symlinked briefing/ dir is dropped by the resolve() containment
+    check — exercising the guard beyond leaf symlinks."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    external = tmp_path / "external-briefing"
+    external.mkdir()
+    (external / "leak.md").write_text("EXTERNAL-LEAK-BYTES", encoding="utf-8")
+    briefing = root / "briefing"
+    briefing.rmdir()  # ensure_memory_tree left it empty
+    briefing.symlink_to(external)
+
+    out = compile_briefing(root)  # succeeds, does not raise
+
+    assert "EXTERNAL-LEAK-BYTES" not in out
+
+
+def test_migrate_flat_memory_skips_symlinked_flat_file(tmp_path):
+    """A symlinked flat *.md is never read or migrated — its target's
+    bytes must not enter the tree."""
+    root = tmp_path / "memory"
+    root.mkdir()
+    secret = tmp_path / "host-secret.md"
+    secret.write_text("HOST-SECRET-BYTES", encoding="utf-8")
+    (root / "evil.md").symlink_to(secret)
+    (root / "real.md").write_text("real flat fact", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)  # does not raise
+
+    # The real flat file migrated; the symlink was skipped entirely.
+    assert "briefing/real.md" in moved
+    assert not any("evil" in m for m in moved)
+    # The symlink is left in place; its target was never read or moved.
+    assert (root / "evil.md").is_symlink()
+    assert secret.read_text(encoding="utf-8") == "HOST-SECRET-BYTES"
+    # No regular file in the tree carries the secret bytes.
+    for p in root.rglob("*.md"):
+        if p.is_symlink():
+            continue
+        assert "HOST-SECRET-BYTES" not in p.read_text(encoding="utf-8")
+
+
+def test_migrate_pointer_skipped_when_briefing_budget_full(tmp_path):
+    """When the briefing is so full that even the migrated-notes pointer
+    line would bust the total, the pointer is skipped (fail closed) — the
+    note still migrates and the result still compiles within budget."""
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    # Four ~16KB topics compile to ~10 bytes under the 64KB total,
+    # leaving no room for either the flat note or a pointer topic.
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * 16368, encoding="utf-8",
+        )
+    assert len(compile_briefing(root).encode("utf-8")) <= TOTAL_LIMIT
+    # A small flat note can't fit briefing (total is full) → notes/.
+    (root / "overflow.md").write_text("overflow note body\n", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)  # does not raise
+
+    assert moved == ["notes/overflow.md"]
+    assert (root / "notes" / "overflow.md").is_file()
+    # The pointer write was rejected by the store's budget check before
+    # any file was written, so no migrated-notes topic exists…
+    assert not (root / "briefing" / "migrated-notes.md").exists()
+    # …and the migrated tree still compiles within the total budget.
+    compiled = compile_briefing(root)  # must not raise
+    assert len(compiled.encode("utf-8")) <= TOTAL_LIMIT
+
+
 def test_migrate_flat_memory_name_collision_falls_back(tmp_path):
     root = tmp_path / "memory"
     root.mkdir()

--- a/tests/test_memory_m1.py
+++ b/tests/test_memory_m1.py
@@ -1,0 +1,344 @@
+"""M1 memory acceptance tests: memory tree, bounded briefing compile
+(fail closed), managed profile briefing, flat-memory migration, and
+the MemoryManager compat surface (save → briefing topic + refresh
+flag)."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent.memory import (
+    PER_FILE_LIMIT,
+    TOTAL_LIMIT,
+    BriefingCompileError,
+    MemoryManager,
+    compile_briefing,
+    ensure_memory_tree,
+    migrate_flat_memory,
+    render_profile_briefing,
+    sync_profile_briefing,
+)
+from puffo_agent.agent.shared_content import rebuild_agent_claude_md
+
+
+# ── tree creation ────────────────────────────────────────────────────
+
+
+def test_ensure_memory_tree_creates_layout(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    assert (root / "briefing").is_dir()
+    assert (root / "notes").is_dir()
+    assert (root / "recollection").is_dir()
+    assert (root / "imports" / "index.md").is_file()
+    # Exactly the M1 tree, and every created path is inside the root.
+    created = {
+        p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*")
+    }
+    assert created == {
+        "memory",
+        "memory/briefing",
+        "memory/notes",
+        "memory/recollection",
+        "memory/imports",
+        "memory/imports/index.md",
+    }
+
+
+def test_memory_manager_init_seeds_tree(tmp_path):
+    root = tmp_path / "memory"
+    MemoryManager(str(root))
+    assert (root / "briefing").is_dir()
+    assert (root / "notes").is_dir()
+    assert (root / "recollection").is_dir()
+    assert (root / "imports" / "index.md").is_file()
+
+
+def test_ensure_memory_tree_is_idempotent_and_preserves_content(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "briefing" / "facts.md").write_text("kept", encoding="utf-8")
+    (root / "imports" / "index.md").write_text("edited", encoding="utf-8")
+    ensure_memory_tree(root)
+    assert (root / "briefing" / "facts.md").read_text(encoding="utf-8") == "kept"
+    assert (root / "imports" / "index.md").read_text(encoding="utf-8") == "edited"
+
+
+# ── bounded compile, fail closed ─────────────────────────────────────
+
+
+def test_compile_profile_first_then_sorted_topics(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    (root / "briefing" / "profile.md").write_text(
+        "# Ada\n\nidentity framing", encoding="utf-8",
+    )
+    (root / "briefing" / "zeta.md").write_text("zeta body", encoding="utf-8")
+    (root / "briefing" / "alpha.md").write_text("alpha body", encoding="utf-8")
+    (root / "notes" / "hidden.md").write_text("never injected", encoding="utf-8")
+    out = compile_briefing(root)
+    assert out.startswith("# Ada")
+    assert out.index("### alpha") < out.index("### zeta")
+    assert "never injected" not in out
+
+
+def test_compile_empty_briefing_is_empty_string(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    assert compile_briefing(root) == ""
+
+
+def test_compile_rejects_oversized_file(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    big = root / "briefing" / "big.md"
+    big.write_text("x" * (PER_FILE_LIMIT + 1), encoding="utf-8")
+    with pytest.raises(BriefingCompileError) as ei:
+        compile_briefing(root)
+    err = ei.value
+    assert err.code == "memory_file_too_large"
+    assert err.path == str(big)
+    assert err.size == PER_FILE_LIMIT + 1
+    assert err.limit == PER_FILE_LIMIT
+    assert err.suggestion
+    assert err.to_dict()["code"] == "memory_file_too_large"
+
+
+def test_compile_rejects_oversized_total(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    # 5 × 15KB topics: each under the per-file limit, 75KB total over
+    # the 64KB budget.
+    for i in range(5):
+        (root / "briefing" / f"topic-{i}.md").write_text(
+            "y" * (15 * 1024), encoding="utf-8",
+        )
+    with pytest.raises(BriefingCompileError) as ei:
+        compile_briefing(root)
+    err = ei.value
+    assert err.code == "memory_briefing_too_large"
+    assert err.path == str(root / "briefing")
+    assert err.size > TOTAL_LIMIT
+    assert err.limit == TOTAL_LIMIT
+
+
+# ── briefing/profile.md content ──────────────────────────────────────
+
+
+def test_profile_briefing_has_identity_and_no_instructions(tmp_path):
+    root = tmp_path / "memory"
+    path = sync_profile_briefing(
+        root,
+        agent_id="ada-0001",
+        display_name="Ada",
+        role="Research helper for the ops team",
+        role_short="Research",
+        soul="Curious and kind.",
+    )
+    assert path == root / "briefing" / "profile.md"
+    text = path.read_text(encoding="utf-8")
+    assert "Ada" in text
+    assert "Research helper for the ops team" in text
+    assert "Curious and kind." in text
+    assert re.search(r"^#{1,6}\s*Instructions", text, re.MULTILINE) is None
+
+
+def test_profile_briefing_minimal_default_with_empty_fields(tmp_path):
+    root = tmp_path / "memory"
+    path = sync_profile_briefing(root, agent_id="bot-42")
+    text = path.read_text(encoding="utf-8")
+    assert "You are bot-42 (agent `bot-42`)." in text
+    # Fully empty still renders a usable identity line.
+    assert "You are agent." in render_profile_briefing()
+
+
+def test_profile_briefing_resync_preserves_user_text_outside_markers(tmp_path):
+    root = tmp_path / "memory"
+    path = sync_profile_briefing(
+        root, agent_id="ada-0001", display_name="Ada", role="Old role",
+    )
+    path.write_text(
+        path.read_text(encoding="utf-8") + "\nUser-authored addendum.\n",
+        encoding="utf-8",
+    )
+    sync_profile_briefing(
+        root, agent_id="ada-0001", display_name="Ada", role="New role",
+    )
+    text = path.read_text(encoding="utf-8")
+    assert "New role" in text
+    assert "Old role" not in text
+    assert "User-authored addendum." in text
+
+
+# ── legacy flat-memory migration ─────────────────────────────────────
+
+
+def _tree_snapshot(root: Path) -> dict[str, str]:
+    return {
+        p.relative_to(root).as_posix(): p.read_text(encoding="utf-8")
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def test_migrate_flat_memory_small_to_briefing_big_to_notes(tmp_path):
+    root = tmp_path / "memory"
+    root.mkdir()
+    (root / "small.md").write_text("a small fact", encoding="utf-8")
+    (root / "big.md").write_text("x" * (PER_FILE_LIMIT + 1), encoding="utf-8")
+    (root / "README.md").write_text("readme stays", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)
+
+    assert (root / "briefing" / "small.md").read_text(encoding="utf-8") == "a small fact"
+    assert (root / "notes" / "big.md").is_file()
+    pointer = (root / "briefing" / "migrated-notes.md").read_text(encoding="utf-8")
+    assert "- notes/big.md — migrated from flat memory" in pointer
+    # No flat *.md remain except README.md.
+    assert [p.name for p in root.glob("*.md")] == ["README.md"]
+    assert (root / "README.md").read_text(encoding="utf-8") == "readme stays"
+    assert set(moved) == {"briefing/small.md", "notes/big.md"}
+    # The migrated tree still compiles within budget.
+    assert "a small fact" in compile_briefing(root)
+
+    # Idempotent: a second pass is a no-op.
+    before = _tree_snapshot(root)
+    assert migrate_flat_memory(root) == []
+    assert _tree_snapshot(root) == before
+
+
+def test_migrate_flat_memory_over_total_budget_goes_to_notes(tmp_path):
+    root = tmp_path / "memory"
+    root.mkdir()
+    ensure_memory_tree(root)
+    # Pre-existing briefing takes 60KB of the 64KB budget…
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * (15 * 1024), encoding="utf-8",
+        )
+    # …so a 10KB flat file (fine per-file) no longer fits the total.
+    (root / "overflow.md").write_text("o" * (10 * 1024), encoding="utf-8")
+
+    moved = migrate_flat_memory(root)
+
+    assert moved == ["notes/overflow.md"]
+    assert (root / "notes" / "overflow.md").is_file()
+    assert not (root / "briefing" / "overflow.md").exists()
+    assert "- notes/overflow.md — migrated from flat memory" in (
+        root / "briefing" / "migrated-notes.md"
+    ).read_text(encoding="utf-8")
+    compile_briefing(root)  # still within budget after migration
+
+
+def test_migrate_flat_memory_name_collision_falls_back(tmp_path):
+    root = tmp_path / "memory"
+    root.mkdir()
+    ensure_memory_tree(root)
+    (root / "briefing" / "facts.md").write_text("already here", encoding="utf-8")
+    (root / "notes" / "facts.md").write_text("also here", encoding="utf-8")
+    (root / "facts.md").write_text("flat version", encoding="utf-8")
+
+    moved = migrate_flat_memory(root)
+
+    assert moved == ["notes/facts-migrated.md"]
+    assert (root / "notes" / "facts-migrated.md").read_text(encoding="utf-8") == "flat version"
+    assert (root / "briefing" / "facts.md").read_text(encoding="utf-8") == "already here"
+    assert (root / "notes" / "facts.md").read_text(encoding="utf-8") == "also here"
+
+
+# ── briefing change → artifact rebuilt ───────────────────────────────
+
+
+def _rebuild(root: Path) -> str:
+    return rebuild_agent_claude_md(
+        shared_dir=root / "shared",
+        profile_path=root / "profile.md",
+        memory_dir=root / "memory",
+        workspace_dir=root / "workspace",
+        claude_user_dir=root / ".claude",
+        gemini_user_dir=root / ".gemini",
+        agent_id="tester-0001",
+        display_name="Tester",
+        role="Tests the memory tree",
+        role_short="Tester",
+    )
+
+
+def test_rebuild_picks_up_new_briefing_topic_and_ignores_notes(tmp_path):
+    (tmp_path / "profile.md").write_text(
+        "# Soul\nI verify briefings.", encoding="utf-8",
+    )
+    (tmp_path / "workspace").mkdir()
+    memory = tmp_path / "memory"
+
+    first = _rebuild(tmp_path)
+    assert "I verify briefings." in first
+
+    (memory / "briefing" / "deploys.md").write_text(
+        "Deploy fact ZQX-77.", encoding="utf-8",
+    )
+    (memory / "notes" / "scratch.md").write_text(
+        "NOTE-ONLY-DETAIL-42", encoding="utf-8",
+    )
+    second = _rebuild(tmp_path)
+    assert "Deploy fact ZQX-77." in second
+    assert "NOTE-ONLY-DETAIL-42" not in second
+    assert (tmp_path / ".claude" / "CLAUDE.md").read_text(encoding="utf-8") == second
+    assert (tmp_path / ".gemini" / "GEMINI.md").read_text(encoding="utf-8") == second
+
+
+def test_rebuild_flag_dropped_by_memory_manager_save(tmp_path):
+    workspace = tmp_path / "workspace"
+    mm = MemoryManager(str(tmp_path / "memory"), workspace_dir=str(workspace))
+    mm.save("deploy notes", "The staging box is flaky.")
+    flag = workspace / ".puffo-agent" / "refresh_agent.flag"
+    assert flag.is_file()
+    payload = json.loads(flag.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert payload["reason"].startswith("memory.save:")
+    assert isinstance(payload["requested_at"], int)
+
+
+# ── MemoryManager.save() compat ──────────────────────────────────────
+
+
+def test_save_writes_briefing_topic_with_frontmatter(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    mm.save("deploy notes/prod", "The fact.")
+    path = root / "briefing" / "deploy_notes-prod.md"
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\ntopic: deploy notes/prod\nupdated: ")
+    assert text.endswith("The fact.\n")
+    assert "The fact." in mm.get_context()
+
+
+def test_save_oversized_file_fails_closed_without_partial_state(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    with pytest.raises(BriefingCompileError) as ei:
+        mm.save("big", "x" * (PER_FILE_LIMIT + 1))
+    assert ei.value.code == "memory_file_too_large"
+    assert not (root / "briefing" / "big.md").exists()
+
+
+def test_save_over_total_budget_fails_closed_without_partial_state(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * (15 * 1024), encoding="utf-8",
+        )
+    with pytest.raises(BriefingCompileError) as ei:
+        mm.save("overflow", "o" * (8 * 1024))
+    assert ei.value.code == "memory_briefing_too_large"
+    assert not (root / "briefing" / "overflow.md").exists()
+
+
+def test_save_without_workspace_dir_drops_no_flag(tmp_path):
+    root = tmp_path / "memory"
+    mm = MemoryManager(str(root))
+    mm.save("topic", "content")
+    assert not list(tmp_path.rglob("refresh_agent.flag"))

--- a/tests/test_memory_m2.py
+++ b/tests/test_memory_m2.py
@@ -257,6 +257,20 @@ def test_patch_with_multiple_matches_is_rejected(store, root):
     assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "dup thing dup"
 
 
+def test_patch_with_empty_old_text_is_rejected(store, root):
+    """An empty old_text has no unambiguous match point; the store
+    rejects it with a truthful memory_invalid_arguments error rather
+    than the old ``count if old_text else 2`` fake-multiple-match hack."""
+    store.create_memory_file("notes/n.md", "content")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "", "new_text": "x"},
+        ])
+    assert ei.value.code == "memory_invalid_arguments"
+    assert ei.value.suggestion
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "content"
+
+
 def test_patch_list_is_all_or_nothing(store, root):
     store.create_memory_file("notes/n.md", "alpha beta")
     with pytest.raises(MemoryStoreError) as ei:
@@ -346,6 +360,26 @@ def test_read_memory_files_returns_bounded_reads_without_modifying_memory(store,
 
     # Pure read: the tree is byte-identical afterwards.
     assert _tree_snapshot(root) == before
+
+
+def test_read_non_utf8_file_is_lossy_not_crashing(store, root):
+    """A stored file that isn't valid UTF-8 is surfaced with U+FFFD
+    replacements and flagged ``lossy`` instead of raising
+    UnicodeDecodeError."""
+    (root / "notes" / "x.md").write_bytes(b"\xff\xfe garbage")
+
+    res = store.read_memory_file("notes/x.md")  # must not raise
+
+    assert res["lossy"] is True
+    assert res["truncated"] is False
+    assert "�" in res["body"]
+    assert "garbage" in res["body"]
+
+    # A clean UTF-8 file is not flagged lossy.
+    store.create_memory_file("notes/ok.md", "clean text")
+    ok = store.read_memory_file("notes/ok.md")
+    assert ok["lossy"] is False
+    assert ok["body"] == "clean text"
 
 
 def test_read_memory_files_batch_over_limit_is_rejected(store):

--- a/tests/test_memory_m2.py
+++ b/tests/test_memory_m2.py
@@ -1,0 +1,494 @@
+"""M2 memory acceptance tests: the low-level MemoryStore file API —
+logical-path validation (invalid path / traversal / symlink escape),
+per-area scope rules, per-area size limits with structured errors,
+atomic writes with changed status, bounded batch reads, body-less
+status, and the briefing dirty/rebuild hook.
+
+One test (or small group) per M2 validation scenario in
+docs/user-lead-designs/memory-implementation.md, named after it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent.memory import (
+    PER_FILE_LIMIT,
+    TOTAL_LIMIT,
+    BriefingCompileError,
+    MemoryStoreError,
+    ensure_memory_tree,
+)
+from puffo_agent.agent.memory_store import (
+    NOTES_FILE_LIMIT,
+    READ_BATCH_LIMIT,
+    RECOLLECTION_FILE_LIMIT,
+    MemoryStore,
+)
+
+
+@pytest.fixture
+def root(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    return root
+
+
+@pytest.fixture
+def store(root):
+    return MemoryStore(root)
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def _all_ops(store: MemoryStore, path: str):
+    """Every primitive applied to one path, for reject-everywhere checks."""
+    yield lambda: store.create_memory_file(path, "x")
+    yield lambda: store.read_memory_file(path)
+    yield lambda: store.patch_memory_file(path, [{"old_text": "a", "new_text": "b"}])
+    yield lambda: store.append_memory_file(path, "x")
+    yield lambda: store.delete_memory_file(path)
+    yield lambda: store.get_memory_file_status(path)
+
+
+# ── scenario 1: invalid logical path is rejected ─────────────────────
+
+
+@pytest.mark.parametrize("bad", [
+    "foo.md",                 # top-level, no memory area
+    "briefing",               # a scope alone is not a file
+    "",                       # empty
+    "notes/.hidden.md",       # hidden segment
+    "notes\\evil.md",         # backslash
+    "notes//x.md",            # empty segment
+    "notes/x.md/",            # trailing slash
+    "briefing/sub/deep.md",   # briefing/ is flat (compile globs *.md)
+    "notes/x\x00.md",         # NUL
+])
+def test_invalid_logical_path_is_rejected(store, bad):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file(bad, "body")
+    assert ei.value.code == "memory_invalid_path"
+    assert ei.value.suggestion
+
+
+def test_invalid_logical_path_rejected_for_reads_too(store):
+    for op in _all_ops(store, "foo.md"):
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_invalid_path"
+
+
+def test_absolute_path_is_rejected(store):
+    for bad in ("/etc/passwd", "C:\\evil.md"):
+        with pytest.raises(MemoryStoreError) as ei:
+            store.create_memory_file(bad, "body")
+        assert ei.value.code == "memory_invalid_path"
+    assert Path("/etc/passwd").exists()  # and it was never touched
+
+
+def test_unknown_scope_is_out_of_scope(store):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("secrets/x.md", "body")
+    assert ei.value.code == "memory_path_out_of_scope"
+    assert ei.value.suggestion
+
+
+def test_non_md_write_target_is_rejected(store, root):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("notes/plain.txt", "body")
+    assert ei.value.code == "memory_invalid_path"
+    # …but reads of non-.md files (e.g. under imports/) stay allowed.
+    (root / "imports" / "blob.txt").write_text("raw", encoding="utf-8")
+    assert store.read_memory_file("imports/blob.txt")["body"] == "raw"
+
+
+# ── scenario 2: path traversal is rejected ───────────────────────────
+
+
+@pytest.mark.parametrize("bad", [
+    "notes/../briefing/profile.md",
+    "../outside.md",
+    "notes/../../etc/passwd",
+    "./notes/x.md",
+])
+def test_path_traversal_is_rejected(store, bad):
+    before = _tree_snapshot(store.memory_root)
+    for op in _all_ops(store, bad):
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_invalid_path"
+    assert _tree_snapshot(store.memory_root) == before
+
+
+def test_symlink_escape_is_rejected(tmp_path, root, store):
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret", encoding="utf-8")
+    (root / "notes" / "link.md").symlink_to(outside)
+    for op in _all_ops(store, "notes/link.md"):
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_invalid_path"
+    assert outside.read_text(encoding="utf-8") == "secret"
+    assert (root / "notes" / "link.md").is_symlink()  # left alone
+
+
+def test_symlinked_directory_escape_is_rejected(tmp_path, root, store):
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (root / "notes" / "sub").symlink_to(elsewhere)
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("notes/sub/x.md", "body")
+    assert ei.value.code == "memory_invalid_path"
+    assert list(elsewhere.iterdir()) == []  # nothing escaped the root
+
+
+# ── scenario 3: create existing file is rejected ─────────────────────
+
+
+def test_create_existing_file_is_rejected(store, root):
+    store.create_memory_file("notes/topic.md", "one")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.create_memory_file("notes/topic.md", "two")
+    assert ei.value.code == "memory_file_exists"
+    assert ei.value.suggestion
+    assert (root / "notes" / "topic.md").read_text(encoding="utf-8") == "one"
+
+
+# ── scenario 4: oversized create/append/patch is rejected ────────────
+
+
+def _assert_oversize_shape(err: MemoryStoreError, path: str, limit: int):
+    d = err.to_dict()
+    assert d["code"] == "memory_file_too_large"
+    assert d["path"] == path
+    assert d["size"] > limit
+    assert d["limit"] == limit
+    assert d["suggestion"]
+
+
+def test_oversized_create_is_rejected_per_area(root):
+    cases = [
+        ("briefing/big.md", PER_FILE_LIMIT, MemoryStore(root)),
+        ("notes/big.md", NOTES_FILE_LIMIT, MemoryStore(root)),
+        (
+            "recollection/2026/07/2026-07-06.md",
+            RECOLLECTION_FILE_LIMIT,
+            MemoryStore(root, maintenance=True),
+        ),
+    ]
+    for path, limit, store in cases:
+        with pytest.raises(MemoryStoreError) as ei:
+            store.create_memory_file(path, "x" * (limit + 1))
+        _assert_oversize_shape(ei.value, path, limit)
+        assert not root.joinpath(*path.split("/")).exists()
+    # Briefing-scope size violations surface as BriefingCompileError so
+    # M1 callers keep their error handling.
+    with pytest.raises(BriefingCompileError):
+        MemoryStore(root).create_memory_file(
+            "briefing/big.md", "x" * (PER_FILE_LIMIT + 1),
+        )
+
+
+def test_oversized_append_is_rejected_and_file_unchanged(store, root):
+    store.create_memory_file("notes/n.md", "keep")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.append_memory_file("notes/n.md", "x" * NOTES_FILE_LIMIT)
+    _assert_oversize_shape(ei.value, "notes/n.md", NOTES_FILE_LIMIT)
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "keep"
+
+
+def test_oversized_patch_is_rejected_and_file_unchanged(store, root):
+    store.create_memory_file("notes/n.md", "small MARK end")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "MARK", "new_text": "y" * NOTES_FILE_LIMIT},
+        ])
+    _assert_oversize_shape(ei.value, "notes/n.md", NOTES_FILE_LIMIT)
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "small MARK end"
+
+
+def test_oversized_compiled_briefing_total_is_rejected(store, root):
+    # 4 × 15KB topics: each under the per-file limit, so an extra 8KB
+    # write busts only the 64KB compiled total.
+    for i in range(4):
+        (root / "briefing" / f"seed-{i}.md").write_text(
+            "s" * (15 * 1024), encoding="utf-8",
+        )
+    with pytest.raises(BriefingCompileError) as ei:
+        store.create_memory_file("briefing/overflow.md", "o" * (8 * 1024))
+    d = ei.value.to_dict()
+    assert d["code"] == "memory_briefing_too_large"
+    assert d["path"] == "briefing/overflow.md"
+    assert d["size"] > TOTAL_LIMIT
+    assert d["limit"] == TOTAL_LIMIT
+    assert d["suggestion"]
+    assert not (root / "briefing" / "overflow.md").exists()
+
+
+# ── scenarios 5 & 6: exact patch match counts ────────────────────────
+
+
+def test_patch_with_zero_matches_is_rejected(store, root):
+    store.create_memory_file("notes/n.md", "alpha beta")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "gamma", "new_text": "delta"},
+        ])
+    assert ei.value.code == "memory_patch_no_match"
+    assert ei.value.suggestion
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "alpha beta"
+
+
+def test_patch_with_multiple_matches_is_rejected(store, root):
+    store.create_memory_file("notes/n.md", "dup thing dup")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "dup", "new_text": "one"},
+        ])
+    assert ei.value.code == "memory_patch_multiple_matches"
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "dup thing dup"
+
+
+def test_patch_list_is_all_or_nothing(store, root):
+    store.create_memory_file("notes/n.md", "alpha beta")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.patch_memory_file("notes/n.md", [
+            {"old_text": "alpha", "new_text": "ALPHA"},  # would apply…
+            {"old_text": "missing", "new_text": "x"},    # …but this fails
+        ])
+    assert ei.value.code == "memory_patch_no_match"
+    assert (root / "notes" / "n.md").read_text(encoding="utf-8") == "alpha beta"
+
+
+# ── scenario 7: successful create/append/patch/delete are atomic ─────
+
+
+def test_successful_create_append_patch_delete_return_changed_status(store, root):
+    res = store.create_memory_file("notes/log.md", "one\n")
+    assert res == {"path": "notes/log.md", "changed": True, "size": 4}
+
+    res = store.append_memory_file("notes/log.md", "two\n")
+    assert res == {"path": "notes/log.md", "changed": True, "size": 8}
+    assert (root / "notes" / "log.md").read_text(encoding="utf-8") == "one\ntwo\n"
+
+    res = store.patch_memory_file("notes/log.md", [
+        {"old_text": "two", "new_text": "2"},
+    ])
+    assert res == {"path": "notes/log.md", "changed": True, "size": 6}
+    assert (root / "notes" / "log.md").read_text(encoding="utf-8") == "one\n2\n"
+
+    # A patch that reproduces the current content reports changed=False.
+    res = store.patch_memory_file("notes/log.md", [
+        {"old_text": "one", "new_text": "one"},
+    ])
+    assert res == {"path": "notes/log.md", "changed": False, "size": 6}
+
+    res = store.delete_memory_file("notes/log.md")
+    assert res == {"path": "notes/log.md", "changed": True}
+    assert not (root / "notes" / "log.md").exists()
+
+    # Atomic temp+rename leaves no litter anywhere in the tree.
+    assert set(_tree_snapshot(root)) == {"imports/index.md"}
+
+
+def test_delete_refuses_profile_and_imports(store, root):
+    store.create_memory_file("briefing/profile.md", "# Me\n")
+    with pytest.raises(MemoryStoreError) as ei:
+        store.delete_memory_file("briefing/profile.md")
+    assert ei.value.code == "memory_scope_readonly"
+    assert (root / "briefing" / "profile.md").is_file()
+
+    with pytest.raises(MemoryStoreError) as ei:
+        store.delete_memory_file("imports/index.md")
+    assert ei.value.code == "memory_scope_readonly"
+    assert (root / "imports" / "index.md").is_file()
+
+
+# ── scenario 8: read_memory_files is a pure bounded batch ────────────
+
+
+def test_read_memory_files_returns_bounded_reads_without_modifying_memory(store, root):
+    store.create_memory_file("notes/a.md", "note body")
+    store.create_memory_file("briefing/b.md", "briefing body")
+    # An over-limit file (placed out-of-band) proves reads are bounded.
+    (root / "notes" / "huge.md").write_text(
+        "h" * (NOTES_FILE_LIMIT + 512), encoding="utf-8",
+    )
+    before = _tree_snapshot(root)
+
+    results = store.read_memory_files([
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ])
+
+    assert [r["path"] for r in results] == [
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ]
+    assert results[0]["body"] == "note body"
+    assert results[0]["scope"] == "notes"
+    assert results[0]["truncated"] is False
+    assert results[1]["body"] == "briefing body"
+    assert results[2]["truncated"] is True
+    assert results[2]["size"] == NOTES_FILE_LIMIT + 512
+    assert len(results[2]["body"].encode("utf-8")) == NOTES_FILE_LIMIT
+    assert results[3]["error"]["code"] == "memory_file_not_found"
+    assert results[4]["error"]["code"] == "memory_invalid_path"
+    assert all("body" not in r for r in results[3:])
+
+    # Pure read: the tree is byte-identical afterwards.
+    assert _tree_snapshot(root) == before
+
+
+def test_read_memory_files_batch_over_limit_is_rejected(store):
+    with pytest.raises(MemoryStoreError) as ei:
+        store.read_memory_files(
+            [f"notes/{i}.md" for i in range(READ_BATCH_LIMIT + 1)]
+        )
+    assert ei.value.code == "memory_invalid_arguments"
+    assert ei.value.suggestion
+
+
+# ── scenario 9: get_memory_file_status has no body ───────────────────
+
+
+def test_get_memory_file_status_reports_size_and_scope_without_body(store, root):
+    store.create_memory_file("briefing/facts.md", "hello")
+    st = store.get_memory_file_status("briefing/facts.md")
+    assert st == {
+        "path": "briefing/facts.md",
+        "exists": True,
+        "scope": "briefing",
+        "size": 5,
+        "limit": PER_FILE_LIMIT,
+        "writable": True,
+        "briefing_included": True,
+    }
+    assert "body" not in st
+
+    st = store.get_memory_file_status("notes/absent.md")
+    assert st["exists"] is False
+    assert st["size"] is None
+    assert st["limit"] == NOTES_FILE_LIMIT
+    assert st["writable"] is True
+    assert st["briefing_included"] is False
+
+    st = store.get_memory_file_status("imports/index.md")
+    assert st["exists"] is True
+    assert st["scope"] == "imports"
+    assert st["writable"] is False
+    assert st["briefing_included"] is False
+
+    path = "recollection/2026/07/2026-07-06.md"
+    assert store.get_memory_file_status(path)["writable"] is False
+    maint = MemoryStore(root, maintenance=True)
+    assert maint.get_memory_file_status(path)["writable"] is True
+    assert maint.get_memory_file_status(path)["limit"] == RECOLLECTION_FILE_LIMIT
+
+
+# ── scenario 10: briefing/ writes trigger dirty/rebuild ──────────────
+
+
+def _read_flag(workspace: Path) -> dict:
+    flag = workspace / ".puffo-agent" / "refresh_agent.flag"
+    assert flag.is_file()
+    payload = json.loads(flag.read_text(encoding="utf-8"))
+    flag.unlink()
+    return payload
+
+
+def test_briefing_writes_trigger_dirty_rebuild_flag(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    workspace = tmp_path / "workspace"
+    store = MemoryStore(root, workspace_dir=str(workspace))
+
+    store.create_memory_file("briefing/topic.md", "line one\n")
+    payload = _read_flag(workspace)
+    assert payload["version"] == 1
+    assert isinstance(payload["requested_at"], int)
+    assert payload["reason"] == "memory_store.create:briefing/topic.md"
+
+    store.patch_memory_file("briefing/topic.md", [
+        {"old_text": "one", "new_text": "1"},
+    ])
+    assert _read_flag(workspace)["reason"] == "memory_store.patch:briefing/topic.md"
+
+    store.append_memory_file("briefing/topic.md", "line two\n")
+    assert _read_flag(workspace)["reason"] == "memory_store.append:briefing/topic.md"
+
+    store.delete_memory_file("briefing/topic.md")
+    assert _read_flag(workspace)["reason"] == "memory_store.delete:briefing/topic.md"
+
+    # Non-briefing writes do not mark the briefing dirty…
+    store.create_memory_file("notes/n.md", "note\n")
+    assert not (workspace / ".puffo-agent" / "refresh_agent.flag").exists()
+
+    # …and neither does a briefing no-op (changed=False).
+    store.create_memory_file("briefing/topic.md", "body\n")
+    _read_flag(workspace)
+    res = store.patch_memory_file("briefing/topic.md", [
+        {"old_text": "body", "new_text": "body"},
+    ])
+    assert res["changed"] is False
+    assert not (workspace / ".puffo-agent" / "refresh_agent.flag").exists()
+
+
+def test_store_without_workspace_dir_drops_no_flag(tmp_path):
+    root = tmp_path / "memory"
+    ensure_memory_tree(root)
+    MemoryStore(root).create_memory_file("briefing/topic.md", "body\n")
+    assert not list(tmp_path.rglob("refresh_agent.flag"))
+
+
+# ── scope rules ──────────────────────────────────────────────────────
+
+
+def test_recollection_write_requires_maintenance_scope(root):
+    path = "recollection/2026/07/2026-07-07.md"
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root).create_memory_file(path, "daily digest\n")
+    assert ei.value.code == "memory_scope_readonly"
+    assert ei.value.suggestion
+    assert not (root / "recollection" / "2026").exists()
+
+    maint = MemoryStore(root, maintenance=True)
+    res = maint.create_memory_file(path, "daily digest\n")
+    assert res == {"path": path, "changed": True, "size": 13}
+    physical = root / "recollection" / "2026" / "07" / "2026-07-07.md"
+    assert physical.read_text(encoding="utf-8") == "daily digest\n"
+    # Reads never need the maintenance scope.
+    assert MemoryStore(root).read_memory_file(path)["body"] == "daily digest\n"
+
+
+def test_imports_scope_is_read_only(store, root):
+    index_before = (root / "imports" / "index.md").read_bytes()
+    write_ops = [
+        lambda: store.create_memory_file("imports/new.md", "x"),
+        lambda: store.patch_memory_file(
+            "imports/index.md", [{"old_text": "a", "new_text": "b"}],
+        ),
+        lambda: store.append_memory_file("imports/index.md", "x"),
+        lambda: store.delete_memory_file("imports/index.md"),
+    ]
+    for op in write_ops:
+        with pytest.raises(MemoryStoreError) as ei:
+            op()
+        assert ei.value.code == "memory_scope_readonly"
+        assert ei.value.suggestion
+    assert (root / "imports" / "index.md").read_bytes() == index_before
+    assert not (root / "imports" / "new.md").exists()
+    # Maintenance scope does not unlock imports either.
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root, maintenance=True).create_memory_file(
+            "imports/new.md", "x",
+        )
+    assert ei.value.code == "memory_scope_readonly"

--- a/tests/test_memory_m3.py
+++ b/tests/test_memory_m3.py
@@ -1,0 +1,615 @@
+"""M3 memory acceptance tests: the semantic memory MCP tools layered
+on the M2 MemoryStore — name normalization onto safe logical paths,
+per-scope confinement (notes/, briefing/, recollection/, read-only
+imports/), the write result envelope with git/audit commit ids and
+post-effects, structured tool errors with M3 codes, pure bounded batch
+reads, and deterministic search.
+
+One test (or small group) per M3 validation scenario in
+docs/user-lead-designs/memory-implementation.md, named after it.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from puffo_agent.agent import memory_git
+from puffo_agent.agent.memory import MemoryStoreError, ensure_memory_tree
+from puffo_agent.agent.memory_store import NOTES_FILE_LIMIT, MemoryStore
+from puffo_agent.mcp import memory_tools
+from puffo_agent.mcp.memory_tools import (
+    MemoryToolsConfig,
+    register_memory_tools,
+)
+
+M3_TOOLS = {
+    "create_note",
+    "patch_note",
+    "append_note",
+    "create_briefing_topic",
+    "patch_briefing_topic",
+    "append_recollection",
+    "read_memory_file",
+    "read_memory_files",
+    "search_memory",
+    "search_imports",
+}
+
+
+@pytest.fixture
+def root(tmp_path):
+    # The tools ensure the tree + local git repo lazily on first call.
+    return tmp_path / "memory"
+
+
+def _build(root, workspace="", maintenance=False):
+    mcp = FastMCP("test")
+    register_memory_tools(mcp, MemoryToolsConfig(
+        memory_root=str(root),
+        workspace=str(workspace) if workspace else "",
+        maintenance=maintenance,
+    ))
+    return mcp
+
+
+async def _call(mcp, name, args):
+    result = await mcp.call_tool(name, args)
+    text = "".join(getattr(item, "text", "") for item in result)
+    return json.loads(text)
+
+
+async def _call_err(mcp, name, args):
+    """Call a tool expecting failure; return the structured M3 error
+    envelope extracted from the raised tool error's JSON text."""
+    with pytest.raises(ToolError) as ei:
+        await mcp.call_tool(name, args)
+    text = str(ei.value)
+    payload = json.loads(text[text.index("{"):])
+    assert payload["ok"] is False
+    return payload["error"]
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file() and ".git" not in p.relative_to(root).parts
+    }
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+# ── scenario 1: semantic names normalize to safe logical paths ───────
+
+
+@pytest.mark.asyncio
+async def test_semantic_names_normalize_to_safe_logical_paths(root):
+    mcp = _build(root)
+    res = await _call(mcp, "create_note", {
+        "name": "My Topic  Notes", "body": "body\n",
+    })
+    assert res["paths"] == ["notes/my-topic-notes.md"]
+    assert (root / "notes" / "my-topic-notes.md").is_file()
+
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "Team_Prefs.md", "body": "briefing\n",
+    })
+    assert res["paths"] == ["briefing/team-prefs.md"]
+    assert (root / "briefing" / "team-prefs.md").is_file()
+
+    maint = _build(root, maintenance=True)
+    res = await _call(maint, "append_recollection", {
+        "date": "2026-07-06", "text": "daily entry",
+    })
+    assert res["paths"] == ["recollection/2026/07/2026-07-06.md"]
+    assert (root / "recollection" / "2026" / "07" / "2026-07-06.md").is_file()
+
+    # Omitted date maps to today's (UTC) dated path shape.
+    res = await _call(maint, "append_recollection", {"text": "later entry"})
+    assert re.fullmatch(
+        r"recollection/\d{4}/\d{2}/\d{4}-\d{2}-\d{2}\.md", res["paths"][0],
+    )
+
+
+# ── scenario 2: invalid semantic names are rejected ──────────────────
+
+
+@pytest.mark.parametrize("bad", [
+    "",                # empty
+    ".",               # dot only
+    "../evil",         # traversal shape
+    "a/b",             # slashes: semantic names are flat
+    ".hidden",         # hidden (dot-led)
+    "x" * 101,         # too long
+])
+@pytest.mark.asyncio
+async def test_invalid_semantic_names_are_rejected(root, bad):
+    mcp = _build(root)
+    for tool, args in [
+        ("create_note", {"name": bad, "body": "b"}),
+        ("append_note", {"name": bad, "text": "b"}),
+        ("patch_note", {"name": bad, "patches": [
+            {"old_text": "a", "new_text": "b"},
+        ]}),
+        ("create_briefing_topic", {"name": bad, "body": "b"}),
+        ("patch_briefing_topic", {"name": bad, "patches": [
+            {"old_text": "a", "new_text": "b"},
+        ]}),
+    ]:
+        err = await _call_err(mcp, tool, args)
+        assert err["code"] == "memory_invalid_name"
+        assert err["operation"] == tool
+        assert err["suggestion"]
+
+
+def test_non_string_semantic_name_is_rejected():
+    # FastMCP's schema already blocks non-str args at the transport
+    # boundary; the tools layer still validates (defense in depth).
+    with pytest.raises(ToolError) as ei:
+        memory_tools._normalize_name("create_note", 123)
+    text = str(ei.value)
+    err = json.loads(text[text.index("{"):])["error"]
+    assert err["code"] == "memory_invalid_name"
+
+
+@pytest.mark.asyncio
+async def test_invalid_recollection_date_is_rejected(root):
+    mcp = _build(root, maintenance=True)
+    for bad in ("07/06/2026", "20260706", "2026-7-6", "2026-13-40"):
+        err = await _call_err(mcp, "append_recollection", {
+            "date": bad, "text": "x",
+        })
+        assert err["code"] == "memory_invalid_arguments"
+    assert not (root / "recollection").exists() or not any(
+        (root / "recollection").rglob("*.md")
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_patches_are_rejected(root):
+    mcp = _build(root)
+    # (Non-dict entries like ["nope"] are already rejected by the MCP
+    # schema for list[dict] before the tool body runs.)
+    for bad_patches in ([], [{"old_text": 1, "new_text": "x"}], [{}]):
+        err = await _call_err(mcp, "patch_note", {
+            "name": "n", "patches": bad_patches,
+        })
+        assert err["code"] == "memory_invalid_arguments"
+
+
+# ── scenario 3: note tools cannot write outside notes/ ───────────────
+
+
+@pytest.mark.asyncio
+async def test_note_tools_cannot_write_outside_notes(root):
+    mcp = _build(root)
+    ensure_memory_tree(root)
+    before = _tree_snapshot(root)
+    for bad in ("../evil", "notes/../../etc/passwd", "a/b", ".."):
+        err = await _call_err(mcp, "create_note", {"name": bad, "body": "b"})
+        assert err["code"] == "memory_invalid_name"
+    assert _tree_snapshot(root) == before
+
+    res = await _call(mcp, "create_note", {"name": "safe", "body": "b\n"})
+    assert res["paths"] == ["notes/safe.md"]
+    res = await _call(mcp, "append_note", {"name": "safe", "text": "more\n"})
+    assert res["paths"] == ["notes/safe.md"]
+    res = await _call(mcp, "patch_note", {"name": "safe", "patches": [
+        {"old_text": "more", "new_text": "MORE"},
+    ]})
+    assert res["paths"] == ["notes/safe.md"]
+    # Every new file the note tools produced lives under notes/.
+    new_paths = set(_tree_snapshot(root)) - set(before)
+    assert new_paths == {"notes/safe.md"}
+
+
+# ── scenario 4: briefing tools cannot write outside briefing/ ────────
+
+
+@pytest.mark.asyncio
+async def test_briefing_topic_tools_cannot_write_outside_briefing(root):
+    mcp = _build(root)
+    ensure_memory_tree(root)
+    before = _tree_snapshot(root)
+    for bad in ("../evil", "briefing/../notes/x", "a/b", "sub/topic"):
+        err = await _call_err(mcp, "create_briefing_topic", {
+            "name": bad, "body": "b",
+        })
+        assert err["code"] == "memory_invalid_name"
+    assert _tree_snapshot(root) == before
+
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "prefs", "body": "b\n",
+    })
+    assert res["paths"] == ["briefing/prefs.md"]
+    res = await _call(mcp, "patch_briefing_topic", {"name": "prefs", "patches": [
+        {"old_text": "b\n", "new_text": "B\n"},
+    ]})
+    assert res["paths"] == ["briefing/prefs.md"]
+    # Flat and confined: the only new file sits directly in briefing/.
+    new_paths = set(_tree_snapshot(root)) - set(before)
+    assert new_paths == {"briefing/prefs.md"}
+
+
+# ── scenario 5: recollection/ needs explicit scope ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_conversation_scope_cannot_write_recollection(root):
+    mcp = _build(root)
+    err = await _call_err(mcp, "append_recollection", {
+        "date": "2026-07-06", "text": "entry",
+    })
+    assert err["code"] == "memory_scope_readonly"
+    assert err["suggestion"]
+    assert not (root / "recollection" / "2026").exists()
+
+    # The same write under the explicit maintenance scope succeeds —
+    # the deny above is scope, not breakage.
+    maint = _build(root, maintenance=True)
+    res = await _call(maint, "append_recollection", {
+        "date": "2026-07-06",
+        "text": "learned a thing",
+        "source_message_ids": ["m1", "m2"],
+        "related_paths": ["notes/a.md"],
+    })
+    assert res["ok"] is True and res["changed"] is True
+    body = (
+        root / "recollection" / "2026" / "07" / "2026-07-06.md"
+    ).read_text(encoding="utf-8")
+    assert body.startswith("# 2026-07-06\n")
+    assert "learned a thing" in body
+    assert "sources: m1, m2" in body
+    assert "related: notes/a.md" in body
+
+    # A second entry appends to the same dated file.
+    await _call(maint, "append_recollection", {
+        "date": "2026-07-06", "text": "second entry",
+    })
+    body = (
+        root / "recollection" / "2026" / "07" / "2026-07-06.md"
+    ).read_text(encoding="utf-8")
+    assert body.count("# 2026-07-06") == 1
+    assert "second entry" in body
+
+
+# ── scenario 6: imports are read-only ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_imports_are_read_only(root):
+    mcp = _build(root)
+    res = await _call(mcp, "read_memory_file", {"path": "imports/index.md"})
+    assert res["scope"] == "imports"
+    assert "Imports index" in res["body"]
+
+    res = await _call(mcp, "search_imports", {"query": "provenance"})
+    assert res["results"]
+    assert all(m["path"].startswith("imports/") for m in res["results"])
+
+    # No semantic write tool can produce an imports/ path: names are
+    # flat, so "imports/…" never survives normalization.
+    for tool, args in [
+        ("create_note", {"name": "imports/evil", "body": "b"}),
+        ("append_note", {"name": "imports/index", "text": "b"}),
+        ("create_briefing_topic", {"name": "imports/evil", "body": "b"}),
+    ]:
+        err = await _call_err(mcp, tool, args)
+        assert err["code"] == "memory_invalid_name"
+    assert not (root / "imports" / "evil.md").exists()
+
+    # Store-level defense in depth: a direct imports/ write is denied.
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root).create_memory_file("imports/new.md", "x")
+    assert ei.value.code == "memory_scope_readonly"
+
+
+# ── scenario 7: reason? appears in git/audit metadata ────────────────
+
+
+@pytest.mark.asyncio
+async def test_reason_appears_in_git_audit_metadata(root):
+    mcp = _build(root)
+    res = await _call(mcp, "create_note", {
+        "name": "topic", "body": "body\n", "reason": "user asked",
+    })
+    assert res["commit_id"] == _git(root, "rev-parse", "--short", "HEAD")
+    message = _git(root, "log", "-1", "--format=%B")
+    assert "create_note" in message
+    assert "notes/topic.md" in message
+    assert "reason: user asked" in message
+
+    # A write WITHOUT reason commits with no reason line.
+    res2 = await _call(mcp, "append_note", {"name": "topic", "text": "more\n"})
+    assert res2["commit_id"] == _git(root, "rev-parse", "--short", "HEAD")
+    assert res2["commit_id"] != res["commit_id"]
+    message = _git(root, "log", "-1", "--format=%B")
+    assert "append_note" in message
+    assert "reason:" not in message
+
+
+@pytest.mark.asyncio
+async def test_git_unavailable_degrades_gracefully(root, monkeypatch):
+    monkeypatch.setattr(memory_git, "git_available", lambda: False)
+    mcp = _build(root)
+    res = await _call(mcp, "create_note", {"name": "n", "body": "b\n"})
+    assert res["ok"] is True
+    assert res["changed"] is True
+    assert res["commit_id"] is None
+    # Degrade is logged, not warned — warnings are for post-effect
+    # failures.
+    assert res["warnings"] == []
+    assert (root / "notes" / "n.md").is_file()
+    assert not (root / ".git").exists()
+
+
+# ── scenario 8: write result envelope ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_tools_return_changed_paths_commit_id_post_effects(
+    root, tmp_path,
+):
+    workspace = tmp_path / "workspace"
+    mcp = _build(root, workspace=workspace)
+
+    res = await _call(mcp, "create_note", {"name": "n", "body": "b\n"})
+    assert set(res) == {
+        "ok", "tool", "changed", "paths", "commit_id", "post_effects",
+        "warnings",
+    }
+    assert set(res["post_effects"]) == {"briefing_rebuilt", "provider_reload"}
+    assert res["tool"] == "create_note"
+    assert res["changed"] is True
+    assert isinstance(res["commit_id"], str) and res["commit_id"]
+    assert res["post_effects"] == {
+        "briefing_rebuilt": False, "provider_reload": "not_needed",
+    }
+    assert res["warnings"] == []
+
+    # Briefing write with a real workspace: rebuilt + reload requested,
+    # and the refresh flag actually exists.
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "prefs", "body": "x\n",
+    })
+    assert res["post_effects"] == {
+        "briefing_rebuilt": True, "provider_reload": "requested",
+    }
+    flag = workspace / ".puffo-agent" / "refresh_agent.flag"
+    assert flag.is_file()
+    payload = json.loads(flag.read_text(encoding="utf-8"))
+    assert payload["reason"] == (
+        "memory_tools.create_briefing_topic:briefing/prefs.md"
+    )
+
+    # No-op patch: changed False, nothing committed, no post-effects.
+    head = _git(root, "rev-parse", "HEAD")
+    res = await _call(mcp, "patch_briefing_topic", {"name": "prefs", "patches": [
+        {"old_text": "x", "new_text": "x"},
+    ]})
+    assert res["changed"] is False
+    assert res["commit_id"] is None
+    assert res["post_effects"] == {
+        "briefing_rebuilt": False, "provider_reload": "not_needed",
+    }
+    assert _git(root, "rev-parse", "HEAD") == head
+
+
+@pytest.mark.asyncio
+async def test_briefing_write_with_failed_reload_warns_but_stays_ok(
+    root, monkeypatch,
+):
+    monkeypatch.setattr(
+        memory_tools, "request_prompt_refresh", lambda ws, reason: False,
+    )
+    mcp = _build(root, workspace="")
+    res = await _call(mcp, "create_briefing_topic", {
+        "name": "t", "body": "b\n",
+    })
+    # Post-effect failure after a successful write never pretends the
+    # write failed.
+    assert res["ok"] is True
+    assert res["changed"] is True
+    assert res["post_effects"]["briefing_rebuilt"] is True
+    assert res["post_effects"]["provider_reload"] == "failed"
+    assert [w["code"] for w in res["warnings"]] == [
+        "memory_provider_reload_failed",
+    ]
+    assert res["warnings"][0]["message"]
+
+
+# ── scenario 9: expected failures are structured tool errors ─────────
+
+
+@pytest.mark.asyncio
+async def test_expected_failures_return_structured_tool_errors(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "n", "body": "alpha beta\n"})
+
+    err = await _call_err(mcp, "patch_note", {"name": "n", "patches": [
+        {"old_text": "gamma", "new_text": "delta"},
+    ]})
+    assert set(err) >= {
+        "code", "message", "operation", "path", "suggestion", "causes",
+    }
+    assert err["code"] == "memory_patch_no_match"
+    assert err["operation"] == "patch_note"
+    assert err["path"] == "notes/n.md"
+    assert err["suggestion"]
+    assert err["causes"][0]["layer"] == "memory_store"
+    assert err["causes"][0]["code"] == "memory_patch_no_match"
+
+    err = await _call_err(mcp, "create_note", {"name": "n", "body": "again"})
+    assert err["code"] == "memory_file_exists"
+
+    err = await _call_err(mcp, "create_note", {
+        "name": "big", "body": "x" * (NOTES_FILE_LIMIT + 1),
+    })
+    assert err["code"] == "memory_file_too_large"
+    assert err["limit"] == NOTES_FILE_LIMIT
+    assert err["size"] > err["limit"]
+
+
+# ── scenario 10: read_memory_files is a pure bounded batch ───────────
+
+
+@pytest.mark.asyncio
+async def test_read_memory_files_reads_bounded_files_and_never_writes(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "note a"})
+    await _call(mcp, "create_briefing_topic", {"name": "b", "body": "brief b"})
+    # Over-limit file placed out-of-band proves reads are bounded.
+    (root / "notes" / "huge.md").write_text(
+        "h" * (NOTES_FILE_LIMIT + 512), encoding="utf-8",
+    )
+    head_before = _git(root, "rev-parse", "HEAD")
+    before = _tree_snapshot(root)
+
+    res = await _call(mcp, "read_memory_files", {"paths": [
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ]})
+    results = res["results"]
+    assert [r["path"] for r in results] == [
+        "notes/a.md", "briefing/b.md", "notes/huge.md",
+        "notes/missing.md", "foo.md",
+    ]
+    assert results[0]["body"] == "note a"
+    assert results[1]["body"] == "brief b"
+    assert results[2]["truncated"] is True
+    assert len(results[2]["body"].encode("utf-8")) == NOTES_FILE_LIMIT
+    # One bad path yields a per-entry error, not a batch failure.
+    assert results[3]["error"]["code"] == "memory_file_not_found"
+    assert results[4]["error"]["code"] == "memory_invalid_path"
+
+    # Pure read: tree bytes and git HEAD are both untouched.
+    assert _tree_snapshot(root) == before
+    assert _git(root, "rev-parse", "HEAD") == head_before
+
+
+# ── registration ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_all_ten_m3_tools_are_registered_on_built_server(root, tmp_path):
+    from puffo_agent.mcp.puffo_core_server import build_server
+
+    server = build_server(
+        slug="agent-0001",
+        device_id="dev_test",
+        server_url="http://localhost:3000",
+        space_id="",
+        keystore_dir=str(tmp_path / "keys"),
+        workspace=str(tmp_path / "workspace"),
+        agent_id="agent-0001",
+        data_service_url="http://127.0.0.1:1",
+        memory_dir=str(root),
+    )
+    names = {t.name for t in await server.list_tools()}
+    assert M3_TOOLS <= names
+    # Building the server has no side effects: the memory tree and its
+    # git repo are ensured lazily on first tool call, not at build time.
+    assert not root.exists()
+
+
+# ── search ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_memory_bounded_deterministic_results(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "alpha",
+        "body": "needle one\nplain line\nNEEDLE two\nneedle three\nneedle four\n",
+    })
+    await _call(mcp, "create_note", {
+        "name": "beta", "body": ("x" * 400) + " needle tail\n",
+    })
+    await _call(mcp, "create_briefing_topic", {
+        "name": "gamma", "body": "needle brief\n",
+    })
+
+    res = await _call(mcp, "search_memory", {"query": "NeEdLe"})
+    assert res["ok"] is True and res["query"] == "NeEdLe"
+    paths = [m["path"] for m in res["results"]]
+    # Fixed scope order (briefing before notes), sorted files within.
+    assert paths[0] == "briefing/gamma.md"
+    assert res["results"][0]["scope"] == "briefing"
+    assert res["results"][0]["line"] == 1
+    # ≤ 3 matches per file: alpha has 4 matching lines.
+    assert paths.count("notes/alpha.md") == 3
+    # Snippets are bounded even for very long lines.
+    assert all(len(m["snippet"]) <= 200 for m in res["results"])
+    assert res["truncated"] is False
+
+    # Deterministic: an identical query returns identical results.
+    assert await _call(mcp, "search_memory", {"query": "NeEdLe"}) == res
+
+    # limit is enforced and reported via truncated.
+    res2 = await _call(mcp, "search_memory", {"query": "needle", "limit": 2})
+    assert len(res2["results"]) == 2
+    assert res2["truncated"] is True
+
+    # Scope filtering.
+    res3 = await _call(mcp, "search_memory", {
+        "query": "needle", "scopes": ["notes"],
+    })
+    assert res3["results"]
+    assert all(m["scope"] == "notes" for m in res3["results"])
+
+
+@pytest.mark.asyncio
+async def test_search_memory_rejects_imports_scope_and_bad_arguments(root):
+    mcp = _build(root)
+    err = await _call_err(mcp, "search_memory", {
+        "query": "x", "scopes": ["imports"],
+    })
+    assert err["code"] == "memory_invalid_arguments"
+    assert "search_imports" in err["suggestion"]
+
+    err = await _call_err(mcp, "search_memory", {
+        "query": "x", "scopes": ["bogus"],
+    })
+    assert err["code"] == "memory_invalid_arguments"
+
+    err = await _call_err(mcp, "search_memory", {"query": "x", "limit": 0})
+    assert err["code"] == "memory_invalid_arguments"
+
+    err = await _call_err(mcp, "search_memory", {"query": "   "})
+    assert err["code"] == "memory_invalid_arguments"
+
+    err = await _call_err(mcp, "search_imports", {"query": "x", "limit": -3})
+    assert err["code"] == "memory_invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_search_imports_hits_only_imports(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "n", "body": "provenance mentioned in a note\n",
+    })
+    (root / "imports" / "doc.txt").write_text(
+        "imported provenance data\n", encoding="utf-8",
+    )
+
+    res = await _call(mcp, "search_imports", {"query": "provenance"})
+    paths = [m["path"] for m in res["results"]]
+    assert paths
+    assert all(p.startswith("imports/") for p in paths)
+    assert "imports/doc.txt" in paths
+    assert all(m["scope"] == "imports" for m in res["results"])
+    assert "notes/n.md" not in paths
+
+    # …and search_memory never reaches into imports/.
+    res = await _call(mcp, "search_memory", {"query": "provenance"})
+    assert [m["path"] for m in res["results"]] == ["notes/n.md"]

--- a/tests/test_memory_m3.py
+++ b/tests/test_memory_m3.py
@@ -10,6 +10,7 @@ docs/user-lead-designs/memory-implementation.md, named after it.
 """
 
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -39,6 +40,12 @@ M3_TOOLS = {
     "search_memory",
     "search_imports",
 }
+
+# append_recollection is daemon-owned maintenance memory: it registers
+# only under the explicit maintenance scope, so the agent-facing server
+# exposes the other nine.
+M3_MAINTENANCE_TOOLS = {"append_recollection"}
+M3_AGENT_TOOLS = M3_TOOLS - M3_MAINTENANCE_TOOLS
 
 
 @pytest.fixture
@@ -187,6 +194,23 @@ async def test_invalid_patches_are_rejected(root):
         assert err["code"] == "memory_invalid_arguments"
 
 
+@pytest.mark.asyncio
+async def test_patch_with_empty_old_text_is_rejected(root):
+    """An empty old_text is rejected at the tools layer with a
+    memory_invalid_arguments error before it ever reaches the store."""
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "n", "body": "content\n"})
+    err = await _call_err(mcp, "patch_note", {
+        "name": "n", "patches": [{"old_text": "", "new_text": "x"}],
+    })
+    assert err["code"] == "memory_invalid_arguments"
+    assert err["operation"] == "patch_note"
+    assert err["suggestion"]
+    # The note is untouched.
+    res = await _call(mcp, "read_memory_file", {"path": "notes/n.md"})
+    assert res["body"] == "content\n"
+
+
 # ── scenario 3: note tools cannot write outside notes/ ───────────────
 
 
@@ -245,18 +269,30 @@ async def test_briefing_topic_tools_cannot_write_outside_briefing(root):
 
 
 @pytest.mark.asyncio
-async def test_conversation_scope_cannot_write_recollection(root):
-    mcp = _build(root)
-    err = await _call_err(mcp, "append_recollection", {
-        "date": "2026-07-06", "text": "entry",
-    })
-    assert err["code"] == "memory_scope_readonly"
-    assert err["suggestion"]
+async def test_append_recollection_registered_only_under_maintenance(root):
+    # Agent-facing server (maintenance=False): the tool is not even
+    # registered — recollection/ is daemon-owned, so agent-side calls
+    # could only ever be scope-denied. The other nine tools are present.
+    agent_mcp = _build(root)
+    agent_tools = {t.name for t in await agent_mcp.list_tools()}
+    assert "append_recollection" not in agent_tools
+    assert M3_AGENT_TOOLS <= agent_tools
+
+    # Defense in depth: the store itself denies a conversation-scope
+    # recollection write with a structured scope error, touching nothing.
+    with pytest.raises(MemoryStoreError) as ei:
+        MemoryStore(root).create_memory_file(
+            "recollection/2026/07/2026-07-06.md", "entry\n",
+        )
+    assert ei.value.code == "memory_scope_readonly"
+    assert ei.value.suggestion
     assert not (root / "recollection" / "2026").exists()
 
-    # The same write under the explicit maintenance scope succeeds —
-    # the deny above is scope, not breakage.
+    # Maintenance server (maintenance=True): the tool IS registered and
+    # actually writes — the deny above is scope, not breakage.
     maint = _build(root, maintenance=True)
+    maint_tools = {t.name for t in await maint.list_tools()}
+    assert "append_recollection" in maint_tools
     res = await _call(maint, "append_recollection", {
         "date": "2026-07-06",
         "text": "learned a thing",
@@ -351,6 +387,97 @@ async def test_git_unavailable_degrades_gracefully(root, monkeypatch):
     assert res["warnings"] == []
     assert (root / "notes" / "n.md").is_file()
     assert not (root / ".git").exists()
+
+
+# ── git audit hygiene: containment + env scrubbing ───────────────────
+
+
+def _git_env_scrubbed(root: Path, *args: str) -> str:
+    """git for test assertions, with the location-override env vars
+    stripped so a poisoned ambient GIT_DIR can't skew the check."""
+    env = {
+        k: v for k, v in os.environ.items()
+        if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+    }
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True, text=True, check=True, env=env,
+    ).stdout.strip()
+
+
+def test_commit_refuses_when_memory_root_has_no_local_git(tmp_path):
+    """A memory root nested inside an enclosing repo but WITHOUT its own
+    .git must not have its writes staged/committed into the outer repo."""
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    for cmd in (
+        ["init", "-q"],
+        ["config", "user.email", "t@t"],
+        ["config", "user.name", "t"],
+        ["config", "commit.gpgsign", "false"],
+    ):
+        subprocess.run(["git", "-C", str(outer), *cmd], check=True)
+    (outer / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(outer), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(outer), "commit", "-q", "-m", "seed"], check=True)
+    head_before = _git_env_scrubbed(outer, "rev-parse", "HEAD")
+
+    memory = outer / "memory"
+    ensure_memory_tree(memory)
+    (memory / "notes" / "n.md").write_text("note\n", encoding="utf-8")
+    assert not (memory / ".git").exists()
+
+    result = memory_git.commit_memory_change(
+        memory, ["notes/n.md"], "memory: create notes/n.md\n",
+    )
+
+    # Refused: no commit id, outer HEAD unchanged, nothing staged there.
+    assert result is None
+    assert _git_env_scrubbed(outer, "rev-parse", "HEAD") == head_before
+    assert _git_env_scrubbed(outer, "diff", "--cached", "--name-only") == ""
+
+
+def test_poisoned_git_env_cannot_redirect_audit_commit(tmp_path, monkeypatch):
+    """GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE pointed at a bait repo
+    must not redirect the audit commit: it lands in <root>/.git and the
+    bait repo is untouched."""
+    bait = tmp_path / "bait"
+    bait.mkdir()
+    for cmd in (
+        ["init", "-q"],
+        ["config", "user.email", "b@b"],
+        ["config", "user.name", "b"],
+    ):
+        subprocess.run(["git", "-C", str(bait), *cmd], check=True)
+
+    memory = tmp_path / "memory"
+    ensure_memory_tree(memory)
+    (memory / "notes" / "n.md").write_text("note\n", encoding="utf-8")
+
+    monkeypatch.setenv("GIT_DIR", str(bait / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(bait))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(bait / ".git" / "index"))
+
+    assert memory_git.ensure_memory_git(memory) is True
+    commit_id = memory_git.commit_memory_change(
+        memory, ["notes/n.md"], "memory: create notes/n.md\n",
+    )
+
+    # The audit repo materialised at the memory root and holds the commit.
+    assert commit_id
+    assert (memory / ".git").is_dir()
+    log = _git_env_scrubbed(memory, "log", "-1", "--name-only", "--format=%H")
+    assert "notes/n.md" in log
+    # The bait repo received nothing.
+    bait_head = subprocess.run(
+        ["git", "-C", str(bait), "rev-list", "-n", "1", "--all"],
+        capture_output=True, text=True,
+        env={
+            k: v for k, v in os.environ.items()
+            if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+        },
+    ).stdout.strip()
+    assert bait_head == ""
 
 
 # ── scenario 8: write result envelope ────────────────────────────────
@@ -501,7 +628,7 @@ async def test_read_memory_files_reads_bounded_files_and_never_writes(root):
 
 
 @pytest.mark.asyncio
-async def test_all_ten_m3_tools_are_registered_on_built_server(root, tmp_path):
+async def test_agent_facing_m3_tools_are_registered_on_built_server(root, tmp_path):
     from puffo_agent.mcp.puffo_core_server import build_server
 
     server = build_server(
@@ -516,7 +643,11 @@ async def test_all_ten_m3_tools_are_registered_on_built_server(root, tmp_path):
         memory_dir=str(root),
     )
     names = {t.name for t in await server.list_tools()}
-    assert M3_TOOLS <= names
+    # build_server constructs the memory tools with maintenance=False,
+    # so the nine agent-facing tools register and the daemon-owned
+    # append_recollection does not.
+    assert M3_AGENT_TOOLS <= names
+    assert "append_recollection" not in names
     # Building the server has no side effects: the memory tree and its
     # git repo are ensured lazily on first tool call, not at build time.
     assert not root.exists()

--- a/tests/test_memory_m4.py
+++ b/tests/test_memory_m4.py
@@ -1,0 +1,571 @@
+"""M4 memory acceptance tests: the read-only recall + observability MCP
+tools layered on the M2 store and the M3 local git audit — status
+(``get_memory_status`` / ``get_memory_file_status``), recall
+(``list_memory_files``), and history (``get_memory_history_status`` /
+``get_memory_history``, a bounded audit query that is NOT a ``git log``
+passthrough). M4 adds no write, rollback, or generic git surface.
+
+One test (or small group) per §M4 validation scenario in
+docs/user-lead-designs/memory-implementation.md, named after it.
+"""
+
+import json
+import subprocess
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from puffo_agent.agent import memory_git
+from puffo_agent.agent.memory import (
+    TOTAL_LIMIT,
+    _byte_size,
+    compile_briefing,
+    ensure_memory_tree,
+)
+from puffo_agent.agent.memory_errors import MemoryHistoryError
+from puffo_agent.agent.memory_git import (
+    HISTORY_DIFF_BYTE_CAP,
+    HISTORY_DIFF_MAX_LIMIT,
+    HISTORY_MAX_LIMIT,
+)
+from puffo_agent.agent.memory_store import LIST_MAX_LIMIT
+from puffo_agent.mcp.memory_tools import (
+    MemoryToolsConfig,
+    register_memory_tools,
+)
+
+# The five read-only tools M4 adds. All are agent-facing (unlike the
+# maintenance-only append_recollection).
+M4_TOOLS = {
+    "get_memory_status",
+    "get_memory_file_status",
+    "list_memory_files",
+    "get_memory_history_status",
+    "get_memory_history",
+}
+
+
+@pytest.fixture
+def root(tmp_path):
+    # M4 read tools never ensure the tree/repo; tests that need one seed
+    # it via the M3 write tools (which do).
+    return tmp_path / "memory"
+
+
+def _build(root, workspace="", maintenance=False):
+    mcp = FastMCP("test")
+    register_memory_tools(mcp, MemoryToolsConfig(
+        memory_root=str(root),
+        workspace=str(workspace) if workspace else "",
+        maintenance=maintenance,
+    ))
+    return mcp
+
+
+async def _call(mcp, name, args):
+    result = await mcp.call_tool(name, args)
+    text = "".join(getattr(item, "text", "") for item in result)
+    return json.loads(text)
+
+
+async def _call_err(mcp, name, args):
+    """Call a tool expecting failure; return the structured M4 error
+    envelope extracted from the raised tool error's JSON text."""
+    with pytest.raises(ToolError) as ei:
+        await mcp.call_tool(name, args)
+    text = str(ei.value)
+    payload = json.loads(text[text.index("{"):])
+    assert payload["ok"] is False
+    return payload["error"]
+
+
+def _tree_snapshot(root):
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file() and ".git" not in p.relative_to(root).parts
+    }
+
+
+def _git(root, *args):
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _scope_stats(root, scope):
+    """Independent (files, total_size_bytes) recomputation for a scope —
+    mirrors the store's walk so status numbers are checked, not trusted."""
+    base = root / scope
+    n = 0
+    total = 0
+    if base.is_dir():
+        for p in sorted(base.rglob("*")):
+            rel = p.relative_to(root).as_posix()
+            if any(seg.startswith(".") for seg in rel.split("/")):
+                continue
+            if p.is_symlink() or not p.is_file():
+                continue
+            n += 1
+            total += p.stat().st_size
+    return n, total
+
+
+# ── registration: the five M4 tools register on the real server ──────
+
+
+@pytest.mark.asyncio
+async def test_m4_tools_registered_on_built_server(root, tmp_path):
+    from puffo_agent.mcp.puffo_core_server import build_server
+
+    server = build_server(
+        slug="agent-0001",
+        device_id="dev_test",
+        server_url="http://localhost:3000",
+        space_id="",
+        keystore_dir=str(tmp_path / "keys"),
+        workspace=str(tmp_path / "workspace"),
+        agent_id="agent-0001",
+        data_service_url="http://127.0.0.1:1",
+        memory_dir=str(root),
+    )
+    names = {t.name for t in await server.list_tools()}
+    assert M4_TOOLS <= names
+    # Building the server has no side effects: the memory tree and its
+    # git repo are ensured lazily on first WRITE, never at build time
+    # and never by an M4 read.
+    assert not root.exists()
+
+
+# ── M4 reads are side-effect-free (never create the tree/repo) ───────
+
+
+@pytest.mark.asyncio
+async def test_m4_reads_never_create_tree_or_repo(root):
+    mcp = _build(root)
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["ok"] is True
+    assert status["root_exists"] is False
+    assert status["git_enabled"] is False
+    assert all(v["files"] == 0 for v in status["scopes"].values())
+
+    fs = await _call(mcp, "get_memory_file_status", {"path": "notes/x.md"})
+    assert fs["exists"] is False
+    assert fs["git_tracked"] is None
+
+    lst = await _call(mcp, "list_memory_files", {})
+    assert lst["files"] == [] and lst["truncated"] is False
+
+    # A history read on an uninitialised root reports the truth rather
+    # than materialising a repo (this is what makes
+    # memory_history_not_initialized reachable).
+    err = await _call_err(mcp, "get_memory_history_status", {})
+    assert err["code"] == "memory_history_not_initialized"
+
+    assert not root.exists()
+
+
+# ── scenario: get_memory_status dirty / rebuild / reload ─────────────
+
+
+@pytest.mark.asyncio
+async def test_get_memory_status_dirty_rebuild_reload(root, tmp_path):
+    workspace = tmp_path / "workspace"
+    mcp = _build(root, workspace=workspace)
+
+    # Clean tree, no briefing change pending: dirty/reload both False,
+    # and the budget fields are present.
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["briefing"]["dirty"] is False
+    assert status["briefing"]["provider_reload_required"] is False
+    assert status["briefing"]["limit_bytes"] == TOTAL_LIMIT
+    assert status["briefing"]["over_budget"] is False
+
+    # A note write does not touch the briefing → still not dirty.
+    await _call(mcp, "create_note", {"name": "n1", "body": "hello\n"})
+    await _call(mcp, "create_note", {"name": "n2", "body": "world!\n"})
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["briefing"]["dirty"] is False
+    assert status["scopes"]["notes"]["files"] == 2
+
+    # A briefing write flips dirty + provider_reload_required and drops
+    # the refresh flag under the real workspace.
+    await _call(mcp, "create_briefing_topic", {"name": "prefs", "body": "pb\n"})
+    status = await _call(mcp, "get_memory_status", {})
+    assert status["briefing"]["dirty"] is True
+    assert status["briefing"]["provider_reload_required"] is True
+    assert (workspace / ".puffo-agent" / "refresh_agent.flag").is_file()
+
+    # git is available and the audit repo now exists.
+    assert status["git_enabled"] is True
+
+    # Compiled size + per-scope numbers are numerically correct for the
+    # seeded tree.
+    assert status["briefing"]["compiled_size_bytes"] == _byte_size(
+        compile_briefing(root)
+    )
+    for scope in ("briefing", "notes", "recollection", "imports"):
+        n, total = _scope_stats(root, scope)
+        assert status["scopes"][scope]["files"] == n
+        assert status["scopes"][scope]["total_size_bytes"] == total
+    assert status["scopes"]["briefing"]["files"] == 1
+    assert status["scopes"]["imports"]["files"] == 1
+    assert status["scopes"]["recollection"]["files"] == 0
+
+
+# ── scenario: get_memory_file_status has size/limit and NO body ──────
+
+
+@pytest.mark.asyncio
+async def test_get_memory_file_status_size_limit_no_body(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "topic", "body": "content\n", "reason": "seeded",
+    })
+
+    fs = await _call(mcp, "get_memory_file_status", {"path": "notes/topic.md"})
+    assert "body" not in fs
+    for key in ("size", "limit", "scope", "exists", "briefing_included"):
+        assert key in fs
+    assert fs["exists"] is True
+    assert fs["scope"] == "notes"
+    # A committed write reports non-null last-change git metadata.
+    assert fs["git_tracked"] is True
+    assert fs["last_changed_commit_id"]
+    assert fs["last_changed_at"]
+
+    # A never-written path exists=False with null last-change fields.
+    fs2 = await _call(mcp, "get_memory_file_status", {"path": "notes/nope.md"})
+    assert "body" not in fs2
+    assert fs2["exists"] is False
+    assert fs2["git_tracked"] is False
+    assert fs2["last_changed_commit_id"] is None
+    assert fs2["last_changed_at"] is None
+
+
+# ── scenario: list_memory_files bounded metadata by scope, no bodies ─
+
+
+@pytest.mark.asyncio
+async def test_list_memory_files_bounded_metadata_by_scope(root):
+    # A maintenance server can seed recollection/ too, so all four scopes
+    # carry files.
+    maint = _build(root, maintenance=True)
+    await _call(maint, "create_note", {"name": "a", "body": "note a\n"})
+    await _call(maint, "create_briefing_topic", {"name": "b", "body": "b\n"})
+    await _call(maint, "append_recollection", {
+        "date": "2026-07-06", "text": "an entry",
+    })
+    # imports/index.md exists from ensure_memory_tree.
+
+    lst = await _call(maint, "list_memory_files", {})
+    assert lst["ok"] is True
+    paths = [f["path"] for f in lst["files"]]
+    for f in lst["files"]:
+        assert set(f) == {
+            "path", "scope", "size", "writable", "briefing_included",
+        }
+        assert "body" not in f
+    assert "notes/a.md" in paths
+    assert "briefing/b.md" in paths
+    assert any(p.startswith("recollection/") for p in paths)
+    assert "imports/index.md" in paths
+
+    # scope filter returns only that scope.
+    notes_only = await _call(maint, "list_memory_files", {"scope": "notes"})
+    assert [f["path"] for f in notes_only["files"]] == ["notes/a.md"]
+    assert all(f["scope"] == "notes" for f in notes_only["files"])
+
+    # limit=1 bounds to one entry and flags truncated.
+    one = await _call(maint, "list_memory_files", {"limit": 1})
+    assert len(one["files"]) == 1
+    assert one["truncated"] is True
+
+    # writable / briefing_included are set per-scope.
+    by_path = {f["path"]: f for f in lst["files"]}
+    assert by_path["briefing/b.md"]["briefing_included"] is True
+    assert by_path["briefing/b.md"]["writable"] is True
+    assert by_path["imports/index.md"]["writable"] is False
+    assert by_path["imports/index.md"]["briefing_included"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_memory_files_rejects_bad_scope_and_limit(root):
+    mcp = _build(root)
+    err = await _call_err(mcp, "list_memory_files", {"scope": "bogus"})
+    assert err["code"] == "memory_path_out_of_scope"
+    err = await _call_err(mcp, "list_memory_files", {"limit": 0})
+    assert err["code"] == "memory_invalid_arguments"
+
+
+# ── scenario: search_memory / search_imports unchanged and read-only ─
+
+
+@pytest.mark.asyncio
+async def test_search_tools_unchanged_and_read_only(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "n", "body": "needle here\n"})
+    ensure_memory_tree(root)
+    (root / "imports" / "doc.txt").write_text(
+        "imported needle\n", encoding="utf-8",
+    )
+    before = _tree_snapshot(root)
+
+    res = await _call(mcp, "search_memory", {"query": "needle"})
+    assert res["results"]
+    assert all("path" in m and "scope" in m for m in res["results"])
+    assert all(len(m["snippet"]) <= 200 for m in res["results"])
+
+    imp = await _call(mcp, "search_imports", {"query": "needle"})
+    assert imp["results"]
+    assert all(m["path"].startswith("imports/") for m in imp["results"])
+
+    # Search never writes: tree bytes are unchanged.
+    assert _tree_snapshot(root) == before
+
+
+# ── scenario: get_memory_history_status health + tracked path ────────
+
+
+@pytest.mark.asyncio
+async def test_get_memory_history_status_health_and_tracked_path(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    # Commit the seeded imports/index.md too so the work tree is clean.
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "-m", "seed imports")
+
+    hs = await _call(mcp, "get_memory_history_status", {"path": "notes/a.md"})
+    assert hs["ok"] is True
+    assert hs["git_enabled"] is True
+    assert hs["repo_initialized"] is True
+    assert hs["clean"] is True
+    assert hs["uncommitted_paths"] == []
+    assert hs["head_commit_id"]
+    assert hs["path_tracked"] is True
+    assert hs["last_changed_commit_id"]
+    assert hs["last_changed_at"]
+
+    # An unknown path is not tracked, with null last-change fields.
+    hs2 = await _call(mcp, "get_memory_history_status", {
+        "path": "notes/unknown.md",
+    })
+    assert hs2["path_tracked"] is False
+    assert hs2["last_changed_commit_id"] is None
+    assert hs2["last_changed_at"] is None
+
+    # A dirty work tree is reported, not raised.
+    (root / "notes" / "dirty.md").write_text("uncommitted\n", encoding="utf-8")
+    hs3 = await _call(mcp, "get_memory_history_status", {})
+    assert hs3["clean"] is False
+    assert hs3["uncommitted_paths"]
+
+
+# ── scenario: get_memory_history bounded entries + diff + truncation ─
+
+
+@pytest.mark.asyncio
+async def test_get_memory_history_entries_diff_and_filters(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {
+        "name": "a", "body": "one\n", "reason": "first reason",
+    })
+    await _call(mcp, "append_note", {
+        "name": "a", "text": "two\n", "reason": "second reason",
+    })
+    await _call(mcp, "create_note", {"name": "b", "body": "bee\n"})
+
+    hist = await _call(mcp, "get_memory_history", {})
+    assert hist["ok"] is True
+    for e in hist["entries"]:
+        assert set(e) >= {
+            "commit_id", "time", "actor", "operation", "reason", "message",
+            "changed_paths", "summary",
+        }
+        assert set(e["summary"]) == {
+            "files_changed", "insertions", "deletions",
+        }
+        assert "diff" not in e  # no diff unless include_diff
+
+    # Newest first; operation equals the recorded write tool.
+    assert [e["operation"] for e in hist["entries"]] == [
+        "create_note", "append_note", "create_note",
+    ]
+    # reason reflects the write's reason (or None when omitted).
+    assert hist["entries"][0]["reason"] is None            # create b
+    assert hist["entries"][1]["reason"] == "second reason"  # append a
+    assert hist["entries"][2]["reason"] == "first reason"   # create a
+    # summary numbers are populated for a real change.
+    assert hist["entries"][2]["summary"]["files_changed"] == 1
+    assert hist["entries"][2]["changed_paths"] == ["notes/a.md"]
+
+    # limit=1 bounds to one entry and flags truncated.
+    one = await _call(mcp, "get_memory_history", {"limit": 1})
+    assert len(one["entries"]) == 1
+    assert one["truncated"] is True
+
+    # include_diff attaches a bounded diff excerpt + a truncation flag.
+    diffed = await _call(mcp, "get_memory_history", {
+        "path": "notes/b.md", "include_diff": True, "limit": 1,
+    })
+    e = diffed["entries"][0]
+    assert isinstance(e["diff"], str) and e["diff"]
+    assert e["diff_truncated"] is False
+    assert len(e["diff"].encode("utf-8")) <= HISTORY_DIFF_BYTE_CAP
+
+    # A large write's diff is length-capped and flagged truncated.
+    await _call(mcp, "create_note", {"name": "big", "body": "x" * 5000 + "\n"})
+    big = await _call(mcp, "get_memory_history", {
+        "path": "notes/big.md", "include_diff": True, "limit": 1,
+    })
+    eb = big["entries"][0]
+    assert eb["diff_truncated"] is True
+    assert len(eb["diff"].encode("utf-8")) <= HISTORY_DIFF_BYTE_CAP
+
+    # Each filter narrows the result set.
+    op = await _call(mcp, "get_memory_history", {"operation": "append_note"})
+    assert op["entries"] and all(
+        e["operation"] == "append_note" for e in op["entries"]
+    )
+    by_path = await _call(mcp, "get_memory_history", {"path": "notes/b.md"})
+    assert by_path["entries"] and all(
+        "notes/b.md" in e["changed_paths"] for e in by_path["entries"]
+    )
+    by_scope = await _call(mcp, "get_memory_history", {"scopes": ["notes"]})
+    assert by_scope["entries"]
+    by_query = await _call(mcp, "get_memory_history", {"query": "first reason"})
+    assert by_query["entries"] and all(
+        "notes/a.md" in e["changed_paths"] for e in by_query["entries"]
+    )
+    # actor maps to the recorded commit author (puffo-agent).
+    actor_hit = await _call(mcp, "get_memory_history", {"actor": "puffo-agent"})
+    assert len(actor_hit["entries"]) == len(hist["entries"]) + 1  # +big
+    actor_miss = await _call(mcp, "get_memory_history", {"actor": "nobody-xyz"})
+    assert actor_miss["entries"] == []
+
+
+# ── scenario: raw git is NOT exposed ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_raw_git_is_not_exposed(root):
+    mcp = _build(root)
+    tools = {t.name for t in await mcp.list_tools()}
+    # No registered tool resembles a raw git operation.
+    forbidden = (
+        "git", "checkout", "reset", "revert", "rollback", "stash",
+        "cherry", "rebase", "merge", "push", "log",
+    )
+    for name in tools:
+        assert not any(tok in name for tok in forbidden), name
+
+    for i in range(4):
+        await _call(mcp, "create_note", {"name": f"n{i}", "body": f"b{i}\n"})
+    plain = await _call(mcp, "get_memory_history", {"limit": 100})
+    n_plain = len(plain["entries"])
+    assert n_plain == 4
+
+    # A filter value that looks like a flag or a ref range is a LITERAL,
+    # never a git flag/ref: it can only narrow (never exceed) the plain
+    # committed set, and never injects commits from outside it.
+    for filt in (
+        {"query": "--all"},
+        {"query": "HEAD~5..HEAD"},
+        {"since": "--all"},
+        {"since": "HEAD~5..HEAD"},
+        {"actor": "--all"},
+    ):
+        res = await _call(mcp, "get_memory_history", {**filt, "limit": 100})
+        assert len(res["entries"]) <= n_plain
+        for e in res["entries"]:
+            assert e["commit_id"]
+    # The substring post-filters treat "--all" as literal text (no match).
+    assert await _call(mcp, "get_memory_history", {"query": "--all"}) == {
+        "ok": True, "entries": [], "truncated": False,
+    }
+
+
+# ── scenario: expected failures are structured tool errors ───────────
+
+
+@pytest.mark.asyncio
+async def test_history_git_unavailable_is_structured(root, monkeypatch):
+    ensure_memory_tree(root)
+    memory_git.ensure_memory_git(root)
+    monkeypatch.setattr(memory_git, "git_available", lambda: False)
+    mcp = _build(root)
+    for tool in ("get_memory_history", "get_memory_history_status"):
+        err = await _call_err(mcp, tool, {})
+        assert err["code"] == "memory_history_unavailable"
+        assert err["causes"][0]["layer"] == "memory_git"
+        assert err["suggestion"]
+
+
+@pytest.mark.asyncio
+async def test_history_not_initialized_is_structured(root):
+    # A memory root with no local .git audit repo (M4 reads never
+    # create one).
+    ensure_memory_tree(root)
+    assert not (root / ".git").exists()
+    mcp = _build(root)
+    err = await _call_err(mcp, "get_memory_history", {})
+    assert err["code"] == "memory_history_not_initialized"
+    err = await _call_err(mcp, "get_memory_history_status", {})
+    assert err["code"] == "memory_history_not_initialized"
+
+
+@pytest.mark.asyncio
+async def test_history_bad_args_are_invalid_query(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    for args in ({"limit": 0}, {"scopes": ["bogus"]}, {"limit": -5}):
+        err = await _call_err(mcp, "get_memory_history", {**args})
+        assert err["code"] == "memory_invalid_history_query"
+
+
+def test_query_history_rejects_non_str_filter(root):
+    # FastMCP's schema blocks a non-str query at the transport boundary;
+    # the git layer still validates it (defense in depth).
+    ensure_memory_tree(root)
+    memory_git.ensure_memory_git(root)
+    with pytest.raises(MemoryHistoryError) as ei:
+        memory_git.query_history(root, query=123)
+    assert ei.value.code == "memory_invalid_history_query"
+
+
+@pytest.mark.asyncio
+async def test_history_too_large_is_structured(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    err = await _call_err(mcp, "get_memory_history", {
+        "limit": HISTORY_MAX_LIMIT + 1,
+    })
+    assert err["code"] == "memory_history_query_too_large"
+    err = await _call_err(mcp, "get_memory_history", {
+        "include_diff": True, "limit": HISTORY_DIFF_MAX_LIMIT + 1,
+    })
+    assert err["code"] == "memory_history_query_too_large"
+
+
+@pytest.mark.asyncio
+async def test_history_bad_path_is_structured(root):
+    mcp = _build(root)
+    await _call(mcp, "create_note", {"name": "a", "body": "x\n"})
+    for tool in ("get_memory_history", "get_memory_history_status"):
+        err = await _call_err(mcp, tool, {"path": "../evil"})
+        assert err["code"] == "memory_invalid_path"
+        err = await _call_err(mcp, tool, {"path": "/etc/passwd"})
+        assert err["code"] == "memory_invalid_path"
+        err = await _call_err(mcp, tool, {"path": "bogus/x.md"})
+        assert err["code"] == "memory_path_out_of_scope"
+
+
+# ── constant sanity: the M4 bounds are what the doc/tools advertise ──
+
+
+def test_list_and_history_bounds_are_sane():
+    assert LIST_MAX_LIMIT >= 1
+    assert HISTORY_DIFF_MAX_LIMIT <= HISTORY_MAX_LIMIT
+    assert HISTORY_DIFF_BYTE_CAP > 0

--- a/tests/test_sdk_gate_memory_tools.py
+++ b/tests/test_sdk_gate_memory_tools.py
@@ -1,0 +1,58 @@
+"""The sdk-local adapter runs every tool call through ``_gate``, which
+allows a call only if some configured pattern matches. Puffo MCP tools
+are auto-allowed by seeding the gate's patterns with
+``PUFFO_CORE_TOOL_FQNS``. This pins that the ten M3 memory tools are in
+that set — otherwise they register on the server but get denied at call
+time on sdk-local (the M3 finding this guards against).
+
+``claude_agent_sdk`` is an optional dep the dev extra does NOT install;
+``SDKAdapter.__init__`` defers that import, so the module (and
+``_pattern_matches``) import fine without it, and the gate logic can be
+pinned directly.
+"""
+
+from puffo_agent.agent.adapters.sdk import _pattern_matches
+from puffo_agent.mcp.config import (
+    MCP_SERVER_NAME,
+    PUFFO_CORE_TOOL_FQNS,
+    PUFFO_CORE_TOOL_NAMES,
+)
+
+M3_TOOL_NAMES = (
+    "create_note",
+    "patch_note",
+    "append_note",
+    "create_briefing_topic",
+    "patch_briefing_topic",
+    "append_recollection",
+    "read_memory_file",
+    "read_memory_files",
+    "search_memory",
+    "search_imports",
+)
+
+
+def test_m3_memory_tools_are_in_core_allowlist():
+    assert set(M3_TOOL_NAMES) <= set(PUFFO_CORE_TOOL_NAMES)
+
+
+def test_m3_memory_tool_fqns_pass_the_sdk_gate():
+    # The adapter seeds its gate patterns with PUFFO_CORE_TOOL_FQNS
+    # (see SDKAdapter.__init__ / _gate). Reproduce the exact allow
+    # check the gate performs for each M3 tool's FQN.
+    for name in M3_TOOL_NAMES:
+        fqn = f"mcp__{MCP_SERVER_NAME}__{name}"
+        allowed = any(
+            _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS
+        )
+        assert allowed, f"{fqn} would be denied by the sdk gate"
+
+
+def test_unknown_puffo_tool_is_not_auto_allowed():
+    # Guard the guard: an FQN NOT in the allowlist must not match, so
+    # the assertion above is meaningful rather than vacuously true.
+    fqn = "mcp__puffo__definitely_not_a_real_tool"
+    assert fqn not in PUFFO_CORE_TOOL_FQNS
+    assert not any(
+        _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS
+    )

--- a/tests/test_sdk_gate_memory_tools.py
+++ b/tests/test_sdk_gate_memory_tools.py
@@ -1,9 +1,10 @@
 """The sdk-local adapter runs every tool call through ``_gate``, which
 allows a call only if some configured pattern matches. Puffo MCP tools
 are auto-allowed by seeding the gate's patterns with
-``PUFFO_CORE_TOOL_FQNS``. This pins that the ten M3 memory tools are in
-that set — otherwise they register on the server but get denied at call
-time on sdk-local (the M3 finding this guards against).
+``PUFFO_CORE_TOOL_FQNS``. This pins that the ten M3 memory tools and the
+five M4 read-only tools are in that set — otherwise they register on the
+server but get denied at call time on sdk-local (the finding this
+guards against).
 
 ``claude_agent_sdk`` is an optional dep the dev extra does NOT install;
 ``SDKAdapter.__init__`` defers that import, so the module (and
@@ -31,9 +32,21 @@ M3_TOOL_NAMES = (
     "search_imports",
 )
 
+M4_TOOL_NAMES = (
+    "get_memory_status",
+    "get_memory_file_status",
+    "list_memory_files",
+    "get_memory_history_status",
+    "get_memory_history",
+)
+
 
 def test_m3_memory_tools_are_in_core_allowlist():
     assert set(M3_TOOL_NAMES) <= set(PUFFO_CORE_TOOL_NAMES)
+
+
+def test_m4_memory_tools_are_in_core_allowlist():
+    assert set(M4_TOOL_NAMES) <= set(PUFFO_CORE_TOOL_NAMES)
 
 
 def test_m3_memory_tool_fqns_pass_the_sdk_gate():
@@ -41,6 +54,16 @@ def test_m3_memory_tool_fqns_pass_the_sdk_gate():
     # (see SDKAdapter.__init__ / _gate). Reproduce the exact allow
     # check the gate performs for each M3 tool's FQN.
     for name in M3_TOOL_NAMES:
+        fqn = f"mcp__{MCP_SERVER_NAME}__{name}"
+        allowed = any(
+            _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS
+        )
+        assert allowed, f"{fqn} would be denied by the sdk gate"
+
+
+def test_m4_memory_tool_fqns_pass_the_sdk_gate():
+    # Same gate check for the five M4 read-only tools.
+    for name in M4_TOOL_NAMES:
         fqn = f"mcp__{MCP_SERVER_NAME}__{name}"
         allowed = any(
             _pattern_matches(fqn, {}, pat) for pat in PUFFO_CORE_TOOL_FQNS

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -87,7 +87,8 @@ def test_rebuild_agent_claude_md_assembles_primer_profile_memory():
     profile.write_text("# Soul\nI am a test agent.", encoding="utf-8")
     memory = root / "memory"
     memory.mkdir()
-    (memory / "notes.md").write_text("a remembered fact", encoding="utf-8")
+    # Legacy flat memory file — migrated into briefing/ on rebuild.
+    (memory / "facts.md").write_text("a remembered fact", encoding="utf-8")
     workspace = root / "workspace"
     workspace.mkdir()
     claude_user = root / ".claude"
@@ -100,15 +101,37 @@ def test_rebuild_agent_claude_md_assembles_primer_profile_memory():
         workspace_dir=workspace,
         claude_user_dir=claude_user,
         gemini_user_dir=gemini_user,
+        agent_id="tester-0001",
+        display_name="Tester",
     )
-    # Shared primer is seeded on demand, then primer + profile + memory
-    # all land in the assembled prompt.
+    # Shared primer is seeded on demand, then primer + profile + the
+    # compiled memory briefing all land in the assembled prompt.
     assert "Puffo.ai platform primer" in out
     assert "I am a test agent." in out
     assert "a remembered fact" in out
+    # The flat file was migrated into the briefing tree, and the
+    # managed profile briefing was synced from the identity fields.
+    assert (memory / "briefing" / "facts.md").is_file()
+    assert not (memory / "facts.md").exists()
+    assert (memory / "briefing" / "profile.md").is_file()
+    # notes/ content never lands in the artifact.
+    (memory / "notes" / "scratch.md").write_text(
+        "note-only detail", encoding="utf-8",
+    )
+    out2 = rebuild_agent_claude_md(
+        shared_dir=shared,
+        profile_path=profile,
+        memory_dir=memory,
+        workspace_dir=workspace,
+        claude_user_dir=claude_user,
+        gemini_user_dir=gemini_user,
+        agent_id="tester-0001",
+        display_name="Tester",
+    )
+    assert "note-only detail" not in out2
     # Written to both user-level dirs.
-    assert (claude_user / "CLAUDE.md").read_text(encoding="utf-8") == out
-    assert (gemini_user / "GEMINI.md").read_text(encoding="utf-8") == out
+    assert (claude_user / "CLAUDE.md").read_text(encoding="utf-8") == out2
+    assert (gemini_user / "GEMINI.md").read_text(encoding="utf-8") == out2
 
 
 # ── codex variants strip mcp__puffo__ prefix ───────────────────────


### PR DESCRIPTION
## One PR for the whole memory workstream (supersedes #124/#125/#126/#128/#129 for review)

The fat Python agent's memory system, per the memory design docs, in order:

| Commit range | What | Granular PR |
|---|---|---|
| M1 | memory tree + bounded briefing compile (fail-closed) | #124 |
| M2 | low-level `MemoryStore` file API | #125 |
| M3 | semantic memory MCP tools + local-git audit | #126 |
| fixes | adversarial-review findings on the M1–M3 stack | #128 |
| M4 | read-only recall / status / history APIs | #129 |

Consolidated for review convenience — the granular PRs remain open (close after review, your call).

**HOLD — do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)