### PR TITLE
fix: feed the real is-agent signal into priority banding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   human traffic outranks agent traffic, mentions outrank both floors.
   Behavior change in agent-dense fleets — an agent's DM/mention ranks
   below a human's, and agent channel chatter yields to human channel
-  messages when both are queued.
+  messages when both are queued. The flag is also renamed
+  `sender_is_bot` → `sender_is_agent` throughout, including the
+  message-dict key that rides ws-local bundles (the old key only ever
+  carried a hardcoded `false`, so no consumer could have relied on
+  its value).
 
 - **Dead `followup_messages_since` removed from the primer + code.**
   No code path has emitted the field since thread batching replaced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `human` — the upstream is-bot flag is unset pending a server-side
   signal, but `owner_slug`'s presence is already a reliable agent
   marker); the display value is renamed `bot` → `agent` to match the
-  `(agent)` mention suffix. Priority banding is unchanged.
+  `(agent)` mention suffix.
 
 ### Changed
+
+- **Priority bands now receive the real is-agent signal.** The
+  message-queue priority computation had `sender_is_bot` hardcoded
+  `False` (puffo-core exposes no is-bot flag), so every sender landed
+  in the human bands and the agent bands were dead code. `owner_slug`
+  (agent-only, already fetched per sender) now drives the banding:
+  human traffic outranks agent traffic, mentions outrank both floors.
+  Behavior change in agent-dense fleets — an agent's DM/mention ranks
+  below a human's, and agent channel chatter yields to human channel
+  messages when both are queued.
 
 - **Dead `followup_messages_since` removed from the primer + code.**
   No code path has emitted the field since thread batching replaced

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -108,7 +108,7 @@ class PuffoAgent:
         text: str,
         direct: bool = False,
         attachments: list[str] | None = None,
-        sender_is_bot: bool = False,
+        sender_is_agent: bool = False,
         mentions: list[dict] | None = None,
         on_progress=None,
         post_id: str = "",
@@ -124,7 +124,7 @@ class PuffoAgent:
             channel_id=channel_id,
             root_id=root_id,
             attachments=attachments,
-            sender_is_bot=sender_is_bot,
+            sender_is_agent=sender_is_agent,
             mentions=mentions,
             post_id=post_id,
             create_at=create_at,
@@ -150,7 +150,7 @@ class PuffoAgent:
 
         Each entry in ``batch`` is the same decoded-message dict the
         listen handler used to enqueue (envelope_id, sender_slug,
-        text, attachments, mentions, sent_at, sender_is_bot,
+        text, attachments, mentions, sent_at, sender_is_agent,
         is_dm…). The thread/channel context is constant across the
         batch and rides on ``channel_meta`` (channel_id,
         channel_name, space_id, space_name).
@@ -173,7 +173,7 @@ class PuffoAgent:
                 channel_id=channel_meta.get("channel_id", ""),
                 root_id=root_id,
                 attachments=msg.get("attachments") or [],
-                sender_is_bot=msg.get("sender_is_bot", False),
+                sender_is_agent=msg.get("sender_is_agent", False),
                 mentions=msg.get("mentions") or [],
                 post_id=msg.get("envelope_id", ""),
                 create_at=msg.get("sent_at", 0),
@@ -236,7 +236,7 @@ class PuffoAgent:
                 channel_id=channel_meta.get("channel_id", ""),
                 root_id=root_id,
                 attachments=msg.get("attachments") or [],
-                sender_is_bot=msg.get("sender_is_bot", False),
+                sender_is_agent=msg.get("sender_is_agent", False),
                 mentions=msg.get("mentions") or [],
                 post_id=msg.get("envelope_id", ""),
                 create_at=msg.get("sent_at", 0),
@@ -400,7 +400,7 @@ class PuffoAgent:
         attachments: list[str] | None,
         channel_id: str = "",
         root_id: str = "",
-        sender_is_bot: bool = False,
+        sender_is_agent: bool = False,
         mentions: list[dict] | None = None,
         post_id: str = "",
         create_at: int = 0,
@@ -419,7 +419,7 @@ class PuffoAgent:
             attachments=attachments,
             channel_id=channel_id,
             root_id=root_id,
-            sender_is_bot=sender_is_bot,
+            sender_is_agent=sender_is_agent,
             mentions=mentions,
             post_id=post_id,
             create_at=create_at,
@@ -443,7 +443,7 @@ class PuffoAgent:
         attachments: list[str] | None,
         channel_id: str = "",
         root_id: str = "",
-        sender_is_bot: bool = False,
+        sender_is_agent: bool = False,
         mentions: list[dict] | None = None,
         post_id: str = "",
         create_at: int = 0,
@@ -488,8 +488,8 @@ class PuffoAgent:
         lines.append(f"- sender_slug: {sender}")
         # ``owner_slug`` exists only for agents, so it doubles as the
         # agent signal here. Display-only — priority banding still
-        # runs on the upstream ``sender_is_bot`` flag.
-        sender_type = "agent" if (sender_is_bot or sender_owner_slug) else "human"
+        # runs on the upstream ``sender_is_agent`` flag.
+        sender_type = "agent" if (sender_is_agent or sender_owner_slug) else "human"
         lines.append(f"- sender_type: {sender_type}")
         # ``sender_owner_slug`` fires only for agent senders (their
         # operator); ``is_from_operator`` only when the sender IS the

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -227,6 +227,13 @@ def _compute_priority(direct: bool, sender_is_bot: bool) -> int:
     return PRIORITY_BOT
 
 
+def _priority_for(direct: bool, sender_owner_slug: str) -> int:
+    """``owner_slug`` is agent-only, so its presence is the is-agent
+    signal the bands were designed around: human traffic outranks
+    agent traffic, mentions outrank both floors."""
+    return _compute_priority(direct, sender_is_bot=bool(sender_owner_slug))
+
+
 # Hard cap on the preview length embedded in the redaction
 # placeholder. Big enough to convey the message's flavour to the
 # agent (so it knows whether to bother fetching segments) but
@@ -815,10 +822,6 @@ class PuffoCoreMessageClient:
             else:
                 channel_name = channel_id
 
-            direct = is_dm or is_mention
-            sender_is_bot = False  # puffo-core has no is_bot flag yet
-            priority = _compute_priority(direct, sender_is_bot)
-
             # Thread-batched queue: every message coalesces under
             # its ``root_id`` (the envelope's ``thread_root_id``, or
             # the message itself when it's a top-level post). The
@@ -862,6 +865,10 @@ class PuffoCoreMessageClient:
                 self.operator_slug
                 and payload.sender_slug == self.operator_slug
             )
+
+            direct = is_dm or is_mention
+            sender_is_bot = bool(sender_owner_slug)
+            priority = _priority_for(direct, sender_owner_slug)
 
             # Long-message redaction. Operators paste big chunks of
             # code or transcripts that, combined with the agent's

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -214,24 +214,17 @@ def _parse_operator_pubkey(identity_cert_json: Optional[str]) -> Optional[bytes]
     return op_pk
 
 
-def _compute_priority(direct: bool, sender_is_bot: bool) -> int:
-    """Map (direct, sender_is_bot) to one of the PRIORITY_* bands.
+def _compute_priority(direct: bool, sender_is_agent: bool) -> int:
+    """Map (direct, sender_is_agent) to one of the PRIORITY_* bands.
     PRIORITY_SYSTEM is reserved for a future service-message envelope.
     """
-    if direct and not sender_is_bot:
+    if direct and not sender_is_agent:
         return PRIORITY_MENTIONED_HUMAN
-    if direct and sender_is_bot:
+    if direct and sender_is_agent:
         return PRIORITY_MENTIONED_BOT
-    if not sender_is_bot:
+    if not sender_is_agent:
         return PRIORITY_HUMAN
     return PRIORITY_BOT
-
-
-def _priority_for(direct: bool, sender_owner_slug: str) -> int:
-    """``owner_slug`` is agent-only, so its presence is the is-agent
-    signal the bands were designed around: human traffic outranks
-    agent traffic, mentions outrank both floors."""
-    return _compute_priority(direct, sender_is_bot=bool(sender_owner_slug))
 
 
 # Hard cap on the preview length embedded in the redaction
@@ -866,9 +859,11 @@ class PuffoCoreMessageClient:
                 and payload.sender_slug == self.operator_slug
             )
 
+            # ``owner_slug`` is agent-only — the is-agent signal the
+            # priority bands were designed around.
             direct = is_dm or is_mention
-            sender_is_bot = bool(sender_owner_slug)
-            priority = _priority_for(direct, sender_owner_slug)
+            sender_is_agent = bool(sender_owner_slug)
+            priority = _compute_priority(direct, sender_is_agent)
 
             # Long-message redaction. Operators paste big chunks of
             # code or transcripts that, combined with the agent's
@@ -902,7 +897,7 @@ class PuffoCoreMessageClient:
                 "root_id": payload_thread_root_id or "",
                 "is_dm": is_dm,
                 "attachments": attachment_paths,
-                "sender_is_bot": sender_is_bot,
+                "sender_is_agent": sender_is_agent,
                 "mentions": mentions,
                 "envelope_id": payload.envelope_id,
                 "sent_at": payload.sent_at,
@@ -2650,7 +2645,7 @@ class PuffoCoreMessageClient:
             "root_id": "",
             "is_dm": False,
             "attachments": [],
-            "sender_is_bot": False,
+            "sender_is_agent": False,
             "mentions": [],
             "envelope_id": envelope_id,
             "sent_at": now_ms,
@@ -2990,7 +2985,7 @@ class PuffoCoreMessageClient:
             "root_id": "",
             "is_dm": False,
             "attachments": [],
-            "sender_is_bot": False,
+            "sender_is_agent": False,
             "mentions": [],
             "envelope_id": envelope_id,
             "sent_at": now_ms,

--- a/tests/test_batch_reaches_adapter.py
+++ b/tests/test_batch_reaches_adapter.py
@@ -41,7 +41,7 @@ def _msg(envelope_id: str, sender: str, text: str, sent_at: int) -> dict:
         "sender_email": "",
         "text": text,
         "attachments": [],
-        "sender_is_bot": False,
+        "sender_is_agent": False,
         "mentions": [],
         "sent_at": sent_at,
         "is_dm": False,

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -30,7 +30,7 @@ def test_agent_sender_gets_owner_slug():
     assert "- sender_owner_slug: nova-op-9999" in block
     assert "- is_from_operator:" not in block
     # owner_slug is agent-only, so it flips the displayed type even
-    # while the upstream sender_is_bot flag is still hardcoded False.
+    # while the upstream sender_is_agent flag is still hardcoded False.
     assert "- sender_type: agent" in block
 
 

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -74,7 +74,7 @@ def _msg(envelope_id: str, sender: str = "alice-0001", sent_at: int | None = Non
         "root_id": "",
         "is_dm": False,
         "attachments": [],
-        "sender_is_bot": False,
+        "sender_is_agent": False,
         "mentions": [],
         "envelope_id": envelope_id,
         "sent_at": sent_at if sent_at is not None else _now_ms(),
@@ -95,34 +95,26 @@ def _channel_meta() -> dict:
 
 
 def test_compute_priority_bands():
-    assert _compute_priority(direct=True, sender_is_bot=False) == PRIORITY_MENTIONED_HUMAN
-    assert _compute_priority(direct=True, sender_is_bot=True) == PRIORITY_MENTIONED_BOT
-    assert _compute_priority(direct=False, sender_is_bot=False) == PRIORITY_HUMAN
-    assert _compute_priority(direct=False, sender_is_bot=True) == PRIORITY_BOT
-
-
-def test_priority_for_derives_agent_band_from_owner_slug():
-    """owner_slug presence (agent-only field) drops the sender into
-    the bot bands; humans (empty owner_slug) keep the human bands."""
-    from puffo_agent.agent.puffo_core_client import _priority_for
-
-    assert _priority_for(direct=True, sender_owner_slug="") == PRIORITY_MENTIONED_HUMAN
-    assert _priority_for(direct=True, sender_owner_slug="op-9999") == PRIORITY_MENTIONED_BOT
-    assert _priority_for(direct=False, sender_owner_slug="") == PRIORITY_HUMAN
-    assert _priority_for(direct=False, sender_owner_slug="op-9999") == PRIORITY_BOT
+    assert _compute_priority(direct=True, sender_is_agent=False) == PRIORITY_MENTIONED_HUMAN
+    assert _compute_priority(direct=True, sender_is_agent=True) == PRIORITY_MENTIONED_BOT
+    assert _compute_priority(direct=False, sender_is_agent=False) == PRIORITY_HUMAN
+    assert _compute_priority(direct=False, sender_is_agent=True) == PRIORITY_BOT
 
 
 def test_handle_envelope_admits_with_owner_slug_priority():
     """handle_envelope is a closure inside listen(); pin its admit-time
     priority derivation at the source level so a revert to the old
-    hardcoded sender_is_bot=False can't slip past the unit tests."""
+    hardcoded sender_is_agent=False can't slip past the unit tests."""
     import inspect
 
     from puffo_agent.agent import puffo_core_client as pcc
 
     src = inspect.getsource(pcc.PuffoCoreMessageClient.listen)
-    assert "priority = _priority_for(direct, sender_owner_slug)" in src
-    assert 'sender_is_bot = False  # puffo-core has no is_bot flag yet' not in src
+    assert "sender_is_agent = bool(sender_owner_slug)" in src
+    assert "priority = _compute_priority(direct, sender_is_agent)" in src
+    # No hardcoded flag under either the old or the new spelling.
+    assert "sender_is_agent = False" not in src
+    assert "sender_is_bot" not in src
 
 
 # ─── MessageStore: thread-batch helpers ───────────────────────────

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -101,6 +101,30 @@ def test_compute_priority_bands():
     assert _compute_priority(direct=False, sender_is_bot=True) == PRIORITY_BOT
 
 
+def test_priority_for_derives_agent_band_from_owner_slug():
+    """owner_slug presence (agent-only field) drops the sender into
+    the bot bands; humans (empty owner_slug) keep the human bands."""
+    from puffo_agent.agent.puffo_core_client import _priority_for
+
+    assert _priority_for(direct=True, sender_owner_slug="") == PRIORITY_MENTIONED_HUMAN
+    assert _priority_for(direct=True, sender_owner_slug="op-9999") == PRIORITY_MENTIONED_BOT
+    assert _priority_for(direct=False, sender_owner_slug="") == PRIORITY_HUMAN
+    assert _priority_for(direct=False, sender_owner_slug="op-9999") == PRIORITY_BOT
+
+
+def test_handle_envelope_admits_with_owner_slug_priority():
+    """handle_envelope is a closure inside listen(); pin its admit-time
+    priority derivation at the source level so a revert to the old
+    hardcoded sender_is_bot=False can't slip past the unit tests."""
+    import inspect
+
+    from puffo_agent.agent import puffo_core_client as pcc
+
+    src = inspect.getsource(pcc.PuffoCoreMessageClient.listen)
+    assert "priority = _priority_for(direct, sender_owner_slug)" in src
+    assert 'sender_is_bot = False  # puffo-core has no is_bot flag yet' not in src
+
+
 # ─── MessageStore: thread-batch helpers ───────────────────────────
 
 


### PR DESCRIPTION
## What

Pre-1.1.0-release follow-up to #147, closing the half-fixed state the fleet agents flagged: #147 fixed the **display** layer (`sender_type` derived from `owner_slug`), but the **priority substrate** still ran on the hardcoded flag:

```python
# puffo_core_client.py (before)
sender_is_bot = False  # puffo-core has no is_bot flag yet
priority = _compute_priority(direct, sender_is_bot)
```

Every sender computed into the human bands; `PRIORITY_MENTIONED_BOT` / `PRIORITY_BOT` were dead code since the bands were written.

## Fix

```python
sender_is_agent = bool(sender_owner_slug)
priority = _compute_priority(direct, sender_is_agent)
```

`owner_slug` (agent-only, already resolved per sender since #147, zero extra HTTP) drives the banding. The computation moves below the cursor-dedup early-return next to the `owner_slug` fetch — cursor-rejected envelopes now skip the profile fetch entirely.

Also renamed `sender_is_bot` → `sender_is_agent` throughout (param, locals, msg-dict key, tests): "agent" is the product vocabulary (`sender_type: agent`, `(agent)` mention suffix). The msg-dict key rides ws-local bundles, but its value was hardcoded `false` forever, so no consumer could have relied on it.

Daemon-minted system messages (intro nudge, membership notes) keep `sender_is_agent: False` — they're system, not agents.

## ⚠️ Behavior change (intended, the bands' original design)

| sender | before | after |
|---|---|---|
| agent DM / @-mention | 1 MENTIONED_HUMAN | 2 MENTIONED_BOT |
| agent channel message | 3 HUMAN | 4 BOT |

In agent-dense fleets: an agent's DM/mention now ranks below a human's, and agent channel chatter yields to human messages when both are queued. Display (`sender_type: agent`) and dispatch priority now read the same signal.

## Tests

- `test_compute_priority_bands` — band matrix (existing, renamed arg).
- `test_handle_envelope_admits_with_owner_slug_priority` — source guard pinning the call site (`handle_envelope` is a closure inside `listen()`); rejects a hardcoded flag under either the old or new spelling.
- Full suite: **1828 passed / 7 skipped**.

## Release note

CHANGELOG: appended under the not-yet-released `[1.1.0]` section (`### Changed`) — this ships with 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)