### PR TITLE
refactor: rename mention entry key is_bot → is_agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `sender_is_bot` → `sender_is_agent` throughout, including the
   message-dict key that rides ws-local bundles (the old key only ever
   carried a hardcoded `false`, so no consumer could have relied on
-  its value).
+  its value). Mention entries follow suit: `is_bot` → `is_agent`
+  (same bundle surface; the rendered `(agent)` / `(human)` suffixes
+  are unchanged).
 
 - **Dead `followup_messages_since` removed from the primer + code.**
   No code path has emitted the field since thread batching replaced

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -511,7 +511,7 @@ class PuffoAgent:
                 if m.get("is_self"):
                     suffix = " (you)"
                 else:
-                    kind = "agent" if m.get("is_bot") else "human"
+                    kind = "agent" if m.get("is_agent") else "human"
                     suffix = f" ({kind})"
                 lines.append(f"  - {m['username']}{suffix}")
         if attachments:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -786,12 +786,12 @@ class PuffoCoreMessageClient:
             mentions: list[dict] = []
             for slug in parsed:
                 if slug == self_slug_lower:
-                    mentions.append({"username": self.slug, "is_bot": True, "is_self": True})
+                    mentions.append({"username": self.slug, "is_agent": True, "is_self": True})
                     continue
                 if space_members and slug not in space_members:
                     continue
-                is_bot = space_members.get(slug) == "agent"
-                mentions.append({"username": slug, "is_bot": is_bot, "is_self": False})
+                is_agent = space_members.get(slug) == "agent"
+                mentions.append({"username": slug, "is_agent": is_agent, "is_self": False})
 
             # Self-mention rewrite: `@<our-slug>` → `@you(<our-slug>)`
             # (the documented "addressed to you" signal).

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -69,3 +69,16 @@ def test_fields_sit_between_sender_type_and_visibility():
     ow = next(i for i, ln in enumerate(lines) if ln.startswith("- sender_owner_slug:"))
     vis = next(i for i, ln in enumerate(lines) if ln.startswith("- is_visible_to_human:"))
     assert st < ow < vis
+
+
+def test_mention_suffixes_render_from_is_agent():
+    """Mention entries carry ``is_agent`` (renamed from ``is_bot``);
+    the block renders (you) / (agent) / (human) suffixes from it."""
+    block = _block(mentions=[
+        {"username": "me-0001", "is_agent": True, "is_self": True},
+        {"username": "nova-bot-1234", "is_agent": True, "is_self": False},
+        {"username": "alice-1234", "is_agent": False, "is_self": False},
+    ])
+    assert "  - me-0001 (you)" in block
+    assert "  - nova-bot-1234 (agent)" in block
+    assert "  - alice-1234 (human)" in block


### PR DESCRIPTION
## What

Companion to #153 (merged): the `sender_is_bot` → `sender_is_agent` rename left the mention-entry key behind — mention dicts still carried `is_bot`:

```python
mentions.append({"username": slug, "is_bot": is_bot, "is_self": False})
```

Renamed to `is_agent` at the producer (`handle_envelope` mention scoping, `puffo_core_client.py:789-794`) and the consumer (`_format_user_block` suffix rendering, `core.py:514`). Rendered `(you)` / `(agent)` / `(human)` suffixes are unchanged.

Same external-surface reasoning as #153: the key rides ws-local bundles, but suffix rendering is the only in-repo consumer and the vocabulary now matches `sender_type: agent` / `sender_is_agent` everywhere.

## Tests

- `test_mention_suffixes_render_from_is_agent` — new pin for the suffix rendering (previously untested).
- Full suite: **1829 passed / 7 skipped**.

## Release note

Extended the existing `[1.1.0]` rename bullet — ships with 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)