### PR TITLE
feat(cloud-agent): proactive profile hot-reload (idle ≤250ms watcher + SIGHUP), WS-preserving

### DIFF
--- a/docs/FAT-CLOUD-ARCHITECTURE.md
+++ b/docs/FAT-CLOUD-ARCHITECTURE.md
@@ -295,6 +295,19 @@ is cited.
   `// TODO(phase-2): notify runtime via AgentServerMsg::ConfigUpdate` **WS push is
   superseded by config-sync F** — there is no live `ConfigUpdate` frame; the mtime-watch
   replaces it.
+  - **Proactive (idle) reload — [BUILT].** Independently of the DESIGNED mtime-watch,
+    profile hot-reload no longer waits for the next turn: a between-turns **refresh
+    watcher** (`refresh_watcher` in `portal/worker.py`, idle poll ≤250 ms) plus an
+    optional guarded **SIGHUP** hook (`_install_posix_sighup_handler` +
+    `Daemon.notify_refresh_all`) both funnel into the **existing** turn-start
+    `_process_refresh_flags` → `adapter.reload` primitive. So a `refresh_agent.flag`
+    drop applies while the agent is IDLE (flag-to-swap **< 500 ms**), not only lazily
+    at the next message. The reload is **adapter-only** — the bridge WS (`Worker._client`)
+    and the worker are preserved, no restart / CLI re-spawn. A shared `_reload_lock` +
+    `_turn_active` guard keeps consume-once and never applies mid-generation. Target is
+    the cloud agent (`runtime.kind: cli-local` + `puffo_core.transport: bridge`); this is
+    distinct from — and does not implement — the `_process_config_mtime_reload`
+    mtime-watch, which stays DESIGNED.
 - **Metadata reads over token-HTTP.** Four membership-scoped read routes
   (`GET /spaces`, `GET /spaces/{id}/channels`, `.../members`, `GET /identities/profiles`)
   need to accept the `x-sandbox-token` as an alternative to subkey-signing so a

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -201,6 +201,14 @@ class Daemon:
     def request_stop(self) -> None:
         self._stop.set()
 
+    def notify_refresh_all(self) -> None:
+        """Wake every worker's proactive refresh watcher. Each watcher
+        then consumes whatever refresh flags exist on disk — no flags are
+        written here, so consume-once is preserved. Fired by the SIGHUP
+        handler for sub-poll reload latency."""
+        for worker in self.workers.values():
+            worker.notify_refresh()
+
     def _load_agent_cfg_cached(self, agent_id: str) -> "AgentConfig":
         """Reuses a cached parse when (mtime_ns, size) is unchanged.
         Same exceptions as ``AgentConfig.load`` on parse failure."""
@@ -942,6 +950,30 @@ def _install_posix_stop_handlers(loop, handle_signal) -> bool:
     return installed
 
 
+def _install_posix_sighup_handler(loop, handle_sighup) -> bool:
+    """Install a SIGHUP handler that wakes every worker's proactive
+    refresh watcher (which then consumes whatever refresh flags exist).
+    Returns whether it did. Safe no-op — returns ``False`` without
+    raising — off the main thread (where ``add_signal_handler`` →
+    ``set_wakeup_fd`` raises), on platforms with no ``SIGHUP`` (Windows),
+    and where the loop doesn't support ``add_signal_handler``. Adds no
+    new trigger surface: SIGHUP only wakes watchers, it writes no flags,
+    so consume-once is preserved.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        return False
+    sig = getattr(signal, "SIGHUP", None)
+    if sig is None:
+        # No SIGHUP on this platform (Windows).
+        return False
+    try:
+        loop.add_signal_handler(sig, handle_sighup)
+        return True
+    except NotImplementedError:
+        # Loop doesn't support add_signal_handler (e.g. Windows proactor).
+        return False
+
+
 async def run_daemon(with_local_bridge: bool = False) -> int:
     # Single-daemon enforcement. ``start`` against an already-running
     # daemon exits 0 (the user wanted a running daemon; one exists) —
@@ -976,6 +1008,16 @@ async def run_daemon(with_local_bridge: bool = False) -> int:
         daemon.request_stop()
 
     posix_handlers_installed = _install_posix_stop_handlers(loop, handle_signal)
+
+    # SIGHUP → proactive profile reload: wake every worker's refresh
+    # watcher so a between-turns profile.md / host-sync / session edit
+    # applies immediately (sub-poll latency) instead of on the next
+    # idle tick. Safe no-op where SIGHUP is unavailable.
+    def handle_sighup() -> None:
+        logger.info("received SIGHUP; waking worker refresh watchers")
+        daemon.notify_refresh_all()
+
+    _install_posix_sighup_handler(loop, handle_sighup)
 
     # Windows fallback: synchronous C-runtime Ctrl+C handler dispatched
     # back onto the loop via call_soon_threadsafe. Without this the

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -905,6 +905,80 @@ class Worker:
         # Signalled when warm() finishes (success, failure, or skipped).
         # Daemon awaits this to serialise heavy startup across workers.
         self._warm_done = asyncio.Event()
+        # Proactive (between-turns) profile reload state. The refresh
+        # watcher (see ``_run``) and the turn-start ``_process_refresh_flags``
+        # call share this lock so a flag is consumed exactly once —
+        # whichever path wins takes it; the loser hits the early-return
+        # when the flags are already gone. ``_turn_active`` gates the
+        # watcher so it never applies mid-generation (deferred to the
+        # turn-start path). ``_refresh_now`` is a signal-driven wake so
+        # SIGHUP can beat the 250 ms idle poll.
+        self._reload_lock = asyncio.Lock()
+        self._turn_active = False
+        self._refresh_now = asyncio.Event()
+
+    def notify_refresh(self) -> None:
+        """Wake the proactive refresh watcher now (sub-poll latency).
+        Called from the daemon's SIGHUP handler, which runs on the loop
+        thread. No-op safe: setting an already-set Event is idempotent,
+        and if the worker has no watcher yet (pre-``_run``) the flag is
+        simply observed on the first watcher tick."""
+        self._refresh_now.set()
+
+    async def _proactive_refresh_tick(self, flag_paths, apply) -> bool:
+        """One proactive-watcher iteration's decision + apply. Skips when
+        a turn owns flag consumption (``_turn_active``) or no flag in
+        ``flag_paths`` is pending; otherwise takes ``_reload_lock`` (the
+        same lock the turn-start path holds → consume-once), re-checks
+        ``_turn_active``, and awaits ``apply`` (the bound
+        ``_process_refresh_flags`` call). Returns whether ``apply`` ran.
+        Exceptions from ``apply`` are swallowed so the watcher never
+        kills the worker — the turn-start path is the backstop."""
+        if self._turn_active:
+            # A turn owns flag consumption; never apply mid-turn.
+            return False
+        if not any(p.exists() for p in flag_paths):
+            # Cheap exists() check before taking the lock.
+            return False
+        async with self._reload_lock:
+            if self._turn_active:
+                # A turn started between the check and the lock; defer to
+                # the turn-start path.
+                return False
+            try:
+                await apply()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "agent %s: proactive refresh failed: %s",
+                    self.agent_cfg.id, exc,
+                )
+            return True
+
+    async def _refresh_watcher_loop(
+        self, flag_paths, apply, *, interval: float = 0.25,
+    ) -> None:
+        """Proactive between-turns profile reload loop. Polls
+        ``flag_paths`` every ``interval`` s (waking immediately when
+        ``notify_refresh()`` fires) so a ``profile.md`` / host-sync /
+        session edit takes effect while the agent is IDLE — instead of
+        only lazily at the next turn. Each pending flag is funneled into
+        ``apply``, the bound turn-start ``_process_refresh_flags`` /
+        ``adapter.reload`` primitive (adapter-only reload: the bridge WS
+        on ``self._client`` and the worker are untouched). No-op unless a
+        flag is present, so native/desktop runtimes see no behavioral
+        change beyond applying an already-written flag sooner. Runs as a
+        sibling task of ``heartbeat``; ends when ``_stop`` is set."""
+        while not self._stop.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._refresh_now.wait(), timeout=interval,
+                )
+            except asyncio.TimeoutError:
+                pass
+            self._refresh_now.clear()
+            if self._stop.is_set():
+                break
+            await self._proactive_refresh_tick(flag_paths, apply)
 
     def start(self) -> asyncio.Task:
         if self._task is not None and not self._task.done():
@@ -1231,6 +1305,13 @@ class Worker:
             """
             if not batch:
                 return
+            # Own this turn: block the proactive refresh watcher from
+            # applying mid-turn. Held True through the entire turn —
+            # including the ``puffo.handle_message_batch`` LLM call — and
+            # cleared in the finally below. The turn-start
+            # ``_process_refresh_flags`` call (under ``_reload_lock``)
+            # owns flag consumption while this is True.
+            self._turn_active = True
             # Diagnostic: log every dispatched batch so we can trace
             # cross-batch duplicates (same envelope_id surfacing in
             # consecutive turns). If the SAME envelope_id appears
@@ -1250,22 +1331,26 @@ class Worker:
             first_post_id = batch[0].get("envelope_id", "")
             channel_id = channel_meta.get("channel_id", "")
 
-            await _process_refresh_flags(
-                agent_id=agent_id,
-                harness_name=(self.agent_cfg.runtime.harness or "").strip(),
-                shared_path=shared_path,
-                profile_path=profile_path,
-                memory_path=memory_path,
-                workspace_path=workspace_path,
-                display_name=self.agent_cfg.display_name,
-                role=self.agent_cfg.role,
-                role_short=self.agent_cfg.role_short,
-                puffo=puffo,
-                adapter=self._adapter,
-                refresh_agent_flag=refresh_agent_flag_path,
-                refresh_host_sync_flag=refresh_host_sync_flag_path,
-                refresh_session_flag=refresh_session_flag_path,
-            )
+            # Serialized against the proactive watcher so a flag is
+            # consumed exactly once (whichever path takes the lock first
+            # applies; the other sees the early-return-when-no-flags).
+            async with self._reload_lock:
+                await _process_refresh_flags(
+                    agent_id=agent_id,
+                    harness_name=(self.agent_cfg.runtime.harness or "").strip(),
+                    shared_path=shared_path,
+                    profile_path=profile_path,
+                    memory_path=memory_path,
+                    workspace_path=workspace_path,
+                    display_name=self.agent_cfg.display_name,
+                    role=self.agent_cfg.role,
+                    role_short=self.agent_cfg.role_short,
+                    puffo=puffo,
+                    adapter=self._adapter,
+                    refresh_agent_flag=refresh_agent_flag_path,
+                    refresh_host_sync_flag=refresh_host_sync_flag_path,
+                    refresh_session_flag=refresh_session_flag_path,
+                )
             try:
                 current_turn_path.parent.mkdir(parents=True, exist_ok=True)
                 current_turn_path.write_text(
@@ -1426,6 +1511,9 @@ class Worker:
                     current_turn_path.unlink()
                 except OSError:
                     pass
+                # Turn is over (incl. the LLM call): release the guard so
+                # the proactive watcher may apply between-turns edits.
+                self._turn_active = False
             # One batch = one "message" for the runtime counter; the
             # display still reads as "N messages processed."
             self.runtime.msg_count += 1
@@ -1553,6 +1641,33 @@ class Worker:
                 except asyncio.TimeoutError:
                     pass
 
+        # Proactive between-turns reload: bind the turn-start
+        # ``_process_refresh_flags`` primitive over this run's locals so
+        # the watcher applies the SAME reload the turn-start path does.
+        refresh_flag_paths = (
+            refresh_agent_flag_path,
+            refresh_host_sync_flag_path,
+            refresh_session_flag_path,
+        )
+
+        async def apply_refresh() -> None:
+            await _process_refresh_flags(
+                agent_id=agent_id,
+                harness_name=(self.agent_cfg.runtime.harness or "").strip(),
+                shared_path=shared_path,
+                profile_path=profile_path,
+                memory_path=memory_path,
+                workspace_path=workspace_path,
+                display_name=self.agent_cfg.display_name,
+                role=self.agent_cfg.role,
+                role_short=self.agent_cfg.role_short,
+                puffo=puffo,
+                adapter=self._adapter,
+                refresh_agent_flag=refresh_agent_flag_path,
+                refresh_host_sync_flag=refresh_host_sync_flag_path,
+                refresh_session_flag=refresh_session_flag_path,
+            )
+
         # PUF-221: per-agent credential_refresh coroutine retired —
         # CredentialRefresher in portal/credential_refresh.py owns the
         # refresh loop daemon-wide. Single writer = no multi-process
@@ -1589,6 +1704,9 @@ class Worker:
 
         hb_task = asyncio.ensure_future(heartbeat())
         status_task = asyncio.ensure_future(reporter.run_heartbeat_loop())
+        watch_task = asyncio.ensure_future(
+            self._refresh_watcher_loop(refresh_flag_paths, apply_refresh)
+        )
         try:
             while not self._stop.is_set():
                 try:
@@ -1623,7 +1741,8 @@ class Worker:
             reporter.stop()
             hb_task.cancel()
             status_task.cancel()
-            for task in (hb_task, status_task):
+            watch_task.cancel()
+            for task in (hb_task, status_task, watch_task):
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):

--- a/tests/test_proactive_reload.py
+++ b/tests/test_proactive_reload.py
@@ -1,0 +1,462 @@
+"""Proactive (between-turns) in-process profile reload for the CLOUD agent.
+
+A ``profile.md`` / host-sync / session edit takes effect **proactively**
+— while the agent is IDLE, target < 500 ms — by running the EXISTING
+turn-start reload primitive (``_process_refresh_flags`` → ``adapter.reload``)
+between turns and on ``SIGHUP``, instead of only lazily at the next turn.
+
+These tests drive the REAL watcher code (``Worker._refresh_watcher_loop`` /
+``Worker._proactive_refresh_tick``) and the REAL reload primitive
+(``_process_refresh_flags`` + ``_rebuild_managed_system_prompt``) with a
+fake adapter + fake puffo + real temp flag files. The bridge WS lives on
+``Worker._client``; the reload is adapter-only, so WS-preservation /
+no-restart is true by construction — the tests guard it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+import threading
+import time
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.portal import daemon as daemon_mod
+from puffo_agent.portal import worker as worker_mod
+from puffo_agent.portal.daemon import Daemon, _install_posix_sighup_handler
+from puffo_agent.portal.runtime_matrix import RUNTIME_CLI_LOCAL
+from puffo_agent.portal.state import AgentConfig, DaemonConfig, RuntimeState
+from puffo_agent.portal.worker import Worker, _process_refresh_flags
+
+
+# ── fakes ──────────────────────────────────────────────────────────────────
+
+
+class _FakeAdapter:
+    """Records reload/warm/close so tests can prove the proactive path
+    is adapter-``reload``-only (no warm, no close, no restart)."""
+
+    def __init__(self):
+        self.reload_calls: list[tuple[str, bool]] = []
+        self.warm_calls = 0
+        self.close_calls = 0
+
+    async def reload(self, new_system_prompt, *, with_session=False):
+        self.reload_calls.append((new_system_prompt, with_session))
+
+    async def warm(self, system_prompt):
+        self.warm_calls += 1
+
+    async def aclose(self):
+        self.close_calls += 1
+
+
+class _FakePuffo:
+    def __init__(self, prompt="old prompt"):
+        self.system_prompt = prompt
+
+
+class _FakeBridgeClient:
+    """Stand-in for the bridge WS handle on ``Worker._client``. Any
+    close / stop / reconnect call is recorded so the tests can assert
+    the proactive reload never touches it."""
+
+    def __init__(self):
+        self.close_calls = 0
+        self.stop_calls = 0
+        self.connect_calls = 0
+        self.listen_calls = 0
+
+    async def stop(self):
+        self.stop_calls += 1
+
+    async def aclose(self):
+        self.close_calls += 1
+
+    async def close(self):
+        self.close_calls += 1
+
+    async def connect(self):
+        self.connect_calls += 1
+
+    async def listen(self, *a, **k):
+        self.listen_calls += 1
+
+
+# ── builders ────────────────────────────────────────────────────────────────
+
+
+def _make_worker() -> Worker:
+    """A cloud-shaped worker: ``runtime.kind = cli-local`` +
+    ``puffo_core.transport = bridge``. Mirrors the constructor pattern in
+    test_worker_pre_delivery_token_check."""
+    cfg = MagicMock(spec=AgentConfig)
+    cfg.id = "t"
+    cfg.runtime = MagicMock()
+    cfg.runtime.kind = RUNTIME_CLI_LOCAL
+    cfg.runtime.harness = "claude-code"
+    cfg.display_name = "Test"
+    cfg.role = "Tester"
+    cfg.role_short = "test"
+    cfg.puffo_core = MagicMock()
+    cfg.puffo_core.transport = "bridge"
+    w = Worker(DaemonConfig(), cfg)
+    w.runtime = RuntimeState(status="running")
+    return w
+
+
+def _reload_env(tmp_path, adapter, puffo, monkeypatch, marker="PROACTIVE_MARKER_v2"):
+    """Real temp profile.md + flag files + an ``apply`` closure bound over
+    the REAL ``_process_refresh_flags`` (exactly what ``_run`` binds for
+    the watcher). ``HOME`` / ``PUFFO_AGENT_HOME`` are redirected to temp
+    dirs so the host-sync branch and prompt rebuild stay hermetic."""
+    home = tmp_path / "agent_home"
+    home.mkdir()
+    host_home = tmp_path / "host_home"
+    host_home.mkdir()
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(home))
+    monkeypatch.setenv("HOME", str(host_home))
+
+    profile = tmp_path / "profile.md"
+    profile.write_text(f"{marker} — the new profile body", encoding="utf-8")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    mem = tmp_path / "memory"
+    mem.mkdir()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    pa = tmp_path / ".puffo-agent"
+    pa.mkdir()
+    agent_flag = pa / "refresh_agent.flag"
+    host_flag = pa / "refresh_host_sync.flag"
+    session_flag = pa / "refresh_session.flag"
+    flag_paths = (agent_flag, host_flag, session_flag)
+
+    async def apply():
+        await _process_refresh_flags(
+            agent_id="t",
+            harness_name="claude-code",
+            shared_path=shared,
+            profile_path=str(profile),
+            memory_path=str(mem),
+            workspace_path=str(ws),
+            display_name="Test",
+            role="Tester",
+            role_short="test",
+            puffo=puffo,
+            adapter=adapter,
+            refresh_agent_flag=agent_flag,
+            refresh_host_sync_flag=host_flag,
+            refresh_session_flag=session_flag,
+        )
+
+    return types.SimpleNamespace(
+        profile=profile,
+        agent_flag=agent_flag,
+        host_flag=host_flag,
+        session_flag=session_flag,
+        flag_paths=flag_paths,
+        apply=apply,
+        marker=marker,
+    )
+
+
+# ── criterion 2: idle-proactive apply (no inbound message) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_idle_proactive_apply_no_message(tmp_path, monkeypatch):
+    """No message arrives: writing profile.md + dropping the flags and
+    running one watcher tick rebuilds the prompt from disk, calls
+    adapter.reload exactly once, and unlinks all three flags."""
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo()
+    env = _reload_env(tmp_path, adapter, puffo, monkeypatch)
+
+    # Spy on the REAL rebuild so we prove (a) it ran AND (b) the new
+    # profile.md content actually flows into puffo.system_prompt.
+    orig_rebuild = worker_mod._rebuild_managed_system_prompt
+    rebuild_calls: list[dict] = []
+
+    def spy_rebuild(**kw):
+        rebuild_calls.append(kw)
+        return orig_rebuild(**kw)
+
+    monkeypatch.setattr(worker_mod, "_rebuild_managed_system_prompt", spy_rebuild)
+
+    # Drop all three flags — NO inbound message / on_message_batch.
+    env.agent_flag.write_text("{}", encoding="utf-8")
+    env.host_flag.write_text("{}", encoding="utf-8")
+    env.session_flag.write_text("{}", encoding="utf-8")
+
+    worker = _make_worker()
+    applied = await worker._proactive_refresh_tick(env.flag_paths, env.apply)
+
+    assert applied is True
+    # (a) rebuild ran and the new profile.md content is in the prompt.
+    assert rebuild_calls, "_rebuild_managed_system_prompt did not run"
+    assert env.marker in puffo.system_prompt
+    # (b) adapter.reload called exactly once.
+    assert len(adapter.reload_calls) == 1
+    # (c) all three flag files unlinked.
+    assert not env.agent_flag.exists()
+    assert not env.host_flag.exists()
+    assert not env.session_flag.exists()
+
+
+# ── criterion 3: latency < 500 ms via the real watcher loop ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_proactive_reload_latency_under_500ms(tmp_path, monkeypatch):
+    """The real ``_refresh_watcher_loop`` (production 0.25 s poll) applies
+    a flag written while idle in well under 500 ms."""
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo()
+    env = _reload_env(tmp_path, adapter, puffo, monkeypatch)
+    worker = _make_worker()
+
+    applied_at: dict[str, float] = {}
+
+    async def apply_and_stop():
+        await env.apply()
+        applied_at["t"] = time.monotonic()
+        worker._stop.set()  # let the loop exit after the first apply
+
+    # Default interval is the production 0.25 s; drive the real loop.
+    task = asyncio.ensure_future(
+        worker._refresh_watcher_loop(env.flag_paths, apply_and_stop)
+    )
+    await asyncio.sleep(0)  # let the loop enter its poll wait
+    t0 = time.monotonic()
+    env.agent_flag.write_text("{}", encoding="utf-8")
+    await asyncio.wait_for(task, timeout=3.0)
+
+    assert len(adapter.reload_calls) == 1
+    assert applied_at["t"] - t0 < 0.5, applied_at["t"] - t0
+
+
+# ── criterion 4: WS-preserving / no restart (cloud config) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_ws_preserving_no_restart(tmp_path, monkeypatch):
+    """Proactive reload on a cli-local + bridge worker keeps the adapter
+    and the bridge/WS handle identical, re-runs neither warm nor build,
+    and never re-invokes _run/start."""
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo()
+    env = _reload_env(tmp_path, adapter, puffo, monkeypatch)
+    worker = _make_worker()
+
+    # Cloud config sanity.
+    assert worker.agent_cfg.runtime.kind == RUNTIME_CLI_LOCAL
+    assert worker.agent_cfg.puffo_core.transport == "bridge"
+
+    ws = _FakeBridgeClient()
+    worker._client = ws
+    worker._adapter = adapter
+    adapter_before = worker._adapter
+    client_before = worker._client
+
+    # Guards: the proactive path must not rebuild the adapter or restart
+    # the worker. None of these should ever be reached.
+    build_calls: list = []
+    run_calls: list = []
+    start_calls: list = []
+    monkeypatch.setattr(
+        worker_mod, "build_adapter", lambda *a, **k: build_calls.append(1)
+    )
+    monkeypatch.setattr(Worker, "_run", lambda self: run_calls.append(1))
+    monkeypatch.setattr(Worker, "start", lambda self: start_calls.append(1))
+
+    env.agent_flag.write_text("{}", encoding="utf-8")
+    applied = await worker._proactive_refresh_tick(env.flag_paths, env.apply)
+
+    assert applied is True
+    assert len(adapter.reload_calls) == 1
+    # Same adapter object; warm NOT re-called; adapter never re-built.
+    assert worker._adapter is adapter_before
+    assert adapter.warm_calls == 0
+    assert build_calls == []
+    # Bridge/WS handle identity-unchanged and never closed / reconnected.
+    assert worker._client is client_before
+    assert ws.close_calls == 0
+    assert ws.stop_calls == 0
+    assert ws.connect_calls == 0
+    assert ws.listen_calls == 0
+    # Worker._run / start not re-invoked.
+    assert run_calls == []
+    assert start_calls == []
+
+
+# ── criterion 5: no mid-turn apply / consume-once ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_apply_mid_turn(tmp_path, monkeypatch):
+    """A turn is active: the watcher defers — no reload, flag preserved
+    for the turn-start path."""
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo()
+    env = _reload_env(tmp_path, adapter, puffo, monkeypatch)
+    worker = _make_worker()
+
+    worker._turn_active = True
+    env.agent_flag.write_text("{}", encoding="utf-8")
+
+    applied = await worker._proactive_refresh_tick(env.flag_paths, env.apply)
+
+    assert applied is False
+    assert adapter.reload_calls == []
+    assert env.agent_flag.exists()  # deferred to turn-start
+
+
+@pytest.mark.asyncio
+async def test_consume_once_turn_start_and_watcher(tmp_path, monkeypatch):
+    """Turn-start consumption and a concurrent watcher tick share the
+    reload lock, so a single pending flag reloads EXACTLY once total."""
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo()
+    env = _reload_env(tmp_path, adapter, puffo, monkeypatch)
+    worker = _make_worker()
+
+    env.agent_flag.write_text("{}", encoding="utf-8")
+
+    async def turn_start():
+        # Mirrors on_message_batch: same lock, same primitive.
+        async with worker._reload_lock:
+            await env.apply()
+
+    async def watcher_tick():
+        await worker._proactive_refresh_tick(env.flag_paths, env.apply)
+
+    await asyncio.gather(turn_start(), watcher_tick())
+
+    assert len(adapter.reload_calls) == 1  # consume-once
+    assert not env.agent_flag.exists()
+
+
+# ── criterion 6: SIGHUP wiring + safe no-op ──────────────────────────────────
+
+
+def test_sighup_handler_wakes_all_workers():
+    """The installed SIGHUP handler wakes (notify_refresh → _refresh_now)
+    every ``Daemon.workers`` entry."""
+    daemon = Daemon.__new__(Daemon)  # avoid keychain/home side effects
+    daemon.workers = {"a": _make_worker(), "b": _make_worker()}
+
+    def handle_sighup():
+        daemon.notify_refresh_all()
+
+    class _RecordingLoop:
+        def __init__(self):
+            self.registered: list[tuple] = []
+
+        def add_signal_handler(self, sig, cb):
+            self.registered.append((sig, cb))
+
+    loop = _RecordingLoop()
+    installed = _install_posix_sighup_handler(loop, handle_sighup)
+
+    # Main thread + real SIGHUP present → installs the handler.
+    assert installed is True
+    assert loop.registered == [(signal.SIGHUP, handle_sighup)]
+
+    for w in daemon.workers.values():
+        assert not w._refresh_now.is_set()
+
+    # Fire the installed handler exactly as the signal would.
+    _sig, registered_cb = loop.registered[0]
+    registered_cb()
+
+    for w in daemon.workers.values():
+        assert w._refresh_now.is_set()
+
+
+@pytest.mark.asyncio
+async def test_watcher_applies_immediately_when_refresh_now_set(tmp_path, monkeypatch):
+    """A watcher whose ``_refresh_now`` is set (as SIGHUP sets it) applies
+    the pending flags immediately, without waiting the poll interval."""
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo()
+    env = _reload_env(tmp_path, adapter, puffo, monkeypatch)
+    worker = _make_worker()
+
+    env.agent_flag.write_text("{}", encoding="utf-8")
+    worker.notify_refresh()  # what the SIGHUP fan-out does
+
+    async def apply_and_stop():
+        await env.apply()
+        worker._stop.set()
+
+    t0 = time.monotonic()
+    # A long poll interval proves the apply is driven by _refresh_now, not
+    # by the timeout.
+    await asyncio.wait_for(
+        worker._refresh_watcher_loop(env.flag_paths, apply_and_stop, interval=30.0),
+        timeout=3.0,
+    )
+    elapsed = time.monotonic() - t0
+
+    assert len(adapter.reload_calls) == 1
+    assert elapsed < 1.0, elapsed  # immediate, not after the 30 s poll
+
+
+def test_install_posix_sighup_handler_missing_sighup(monkeypatch):
+    """No SIGHUP on the platform (e.g. Windows) → safe no-op / False."""
+    fake_signal = types.SimpleNamespace()  # no SIGHUP attribute
+    monkeypatch.setattr(daemon_mod, "signal", fake_signal)
+
+    class _RecordingLoop:
+        def __init__(self):
+            self.registered: list = []
+
+        def add_signal_handler(self, sig, cb):
+            self.registered.append((sig, cb))
+
+    loop = _RecordingLoop()
+    assert _install_posix_sighup_handler(loop, lambda: None) is False
+    assert loop.registered == []
+
+
+def test_install_posix_sighup_handler_not_implemented():
+    """Loop can't register signal handlers (e.g. Windows proactor) →
+    NotImplementedError is swallowed, returns False."""
+
+    class _RaisingLoop:
+        def add_signal_handler(self, sig, cb):
+            raise NotImplementedError
+
+    # Runs on the main thread with a real SIGHUP present.
+    assert _install_posix_sighup_handler(_RaisingLoop(), lambda: None) is False
+
+
+def test_install_posix_sighup_handler_off_main_thread():
+    """Off the main thread ``add_signal_handler`` → ``set_wakeup_fd``
+    raises; the installer must skip (return False) without raising."""
+    out: dict = {}
+
+    def run():
+        loop = asyncio.new_event_loop()
+        try:
+            out["installed"] = _install_posix_sighup_handler(loop, lambda: None)
+        except BaseException as exc:  # noqa: BLE001
+            out["error"] = repr(exc)
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+
+    assert "error" not in out, out.get("error")
+    assert out["installed"] is False


### PR DESCRIPTION
**For the cloud agent** (`cli-local` + `transport: bridge` in E2B): a `profile.md` edit now applies to an **idle** agent within **<500ms** — **no worker restart, no bridge-WS drop, no CLI re-spawn** — enabling live profile hot-edit / self-improvement.

## What & why
~90% of this already existed on `dev` (the turn-start reload primitive: `_process_refresh_flags` → `_rebuild_managed_system_prompt` → `adapter.reload`, triggered by `refresh_agent.flag`). The one gap: it applied **lazily at the next turn**, so an **idle** agent waited for a message. This PR makes the SAME primitive fire **proactively between turns + on SIGHUP**.

## Changes (puffo-agent only)
- **`worker.py`**: a ≤250ms `_refresh_watcher_loop` + `_refresh_now` `asyncio.Event` (SIGHUP wake for sub-poll latency), run as a concurrent task alongside `heartbeat`/`status` in `_run` only. `_proactive_refresh_tick` = consume-once guard + **never hot-swaps mid-turn** + swallows exceptions so the watcher can't kill the worker. **WS-preserving by construction** — the bridge WS lives on `Worker._client`, untouched by `adapter.reload`.
- **`daemon.py`**: guarded `_install_posix_sighup_handler` (safe no-op off-main-thread / Windows / unsupported) → `notify_refresh_all()` fan-out.
- **`tests/test_proactive_reload.py`** (new, 10 tests): idle-proactive apply, **<500ms latency**, WS-preservation/no-restart, consume-once + no-mid-turn, SIGHUP wiring + the 3 safe-no-op installer paths.
- No new socket/HTTP server (reuses the existing flag writers: `refresh` MCP tool, `POST /v1/agents/{id}/restart`, CLI, bridge profile-edit).

## Gate
Full suite **2010–2014 passed / 4 skipped (env)**; the new module **10/10**. **HELD — do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)