### PR TITLE
PUF-363: FIFO greedy-fill-per-turn input-block batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Over-limit message bursts no longer drop the whole batch (PUF-363).**
+  When a thread's queued messages would, concatenated into the single
+  per-turn input block, exceed the harness input-byte budget (Claude
+  Code's 180KB pre-send cap), the consumer now dispatches the largest
+  FIFO prefix that fits and defers the remainder to following turns —
+  split only at message boundaries, nothing dropped, nothing reordered.
+  Previously the adapter rejected the whole over-limit batch with a
+  "reduce or split" reply and every message in it went unprocessed.
+  Codex gets a 4MB safety-net ceiling (it has no adapter input cap).
+
 ### Changed
+
+- **Long-message redaction thresholds raised to 16000/8000 chars**
+  (inline cap / `get_post_segment` page size, from 4000/2000). Per-turn
+  totals are now bounded by greedy-fill batching, so the inline cap only
+  guards session-lifetime context growth — typical code/log pastes
+  inline whole instead of collapsing to a preview placeholder. Both
+  limits now live in one shared `puffo_agent.limits` module, and the
+  redaction placeholder cites `segment_size` explicitly so paging stays
+  aligned on hosts that override the daemon page size.
 
 - **Runbook for Codex Apps connector scope failures.** The `use-host-mcp`
   skill body now explains that Codex Apps connectors (`mcp__codex_apps__*`

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Optional
 
 from ..crypto.encoding import base64url_decode
+from ..limits import MAX_INLINE_MESSAGE_CHARS, MESSAGE_SEGMENT_CHARS
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import (
@@ -460,8 +461,8 @@ class PuffoCoreMessageClient:
         operator_slug: str = "",
         auto_accept_space_invitations: bool = False,
         workspace: str = "",
-        max_inline_chars: int = 16000,
-        segment_chars: int = 8000,
+        max_inline_chars: int = MAX_INLINE_MESSAGE_CHARS,
+        segment_chars: int = MESSAGE_SEGMENT_CHARS,
         agent_created_at: int = 0,
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
         max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -65,17 +65,11 @@ PRIORITY_SYSTEM = 5
 # tool which force-refreshes regardless of TTL.
 _PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
-# Per-turn input-block byte budget for greedy-fill batching. Mirrors the
-# Claude Code pre-send cap in ``adapters/cli_session.MAX_USER_MESSAGE_BYTES``
-# — a test asserts the two stay in sync. Codex has no such cap; the worker
-# passes it a far larger ceiling.
+# Mirrors ``adapters/cli_session.MAX_USER_MESSAGE_BYTES``; a test pins them.
 DEFAULT_MAX_INPUT_BYTES = 180 * 1000
 
-# Conservative per-message overhead for the ``_format_user_block`` metadata
-# header (channel/space/sender/slugs/timestamp/… lines). The greedy-fill
-# byte estimate adds this to the raw text so it OVER-counts the real block
-# — over-counting only defers a message one turn early, it never overflows
-# the cap.
+# Deliberately over-counts the ``_format_user_block`` metadata header so a
+# near-boundary split lands one turn early, never over the cap.
 _BLOCK_METADATA_OVERHEAD_BYTES = 2048
 
 
@@ -1258,11 +1252,8 @@ class PuffoCoreMessageClient:
             )
 
     def _message_block_bytes(self, msg: dict) -> int:
-        """Conservative UTF-8 byte estimate of one message's formatted
-        ``_format_user_block``. Over-counts (fixed metadata overhead plus
-        per-item slack for attachments/mentions) so the greedy-fill never
-        under-estimates and lets an over-cap block through to the adapter.
-        """
+        """Conservative byte estimate of one formatted block — over-counts
+        so greedy-fill never lets an over-cap block through."""
         n = len((msg.get("text") or "").encode("utf-8"))
         for att in (msg.get("attachments") or []):
             n += len(str(att).encode("utf-8")) + 16
@@ -1271,12 +1262,9 @@ class PuffoCoreMessageClient:
         return n + _BLOCK_METADATA_OVERHEAD_BYTES
 
     def _greedy_fit_prefix(self, messages: list[dict]) -> int:
-        """Largest prefix length K such that the concatenated
-        blocks of ``messages[:K]`` fit ``_max_input_bytes``. Always >= 1
-        so a single over-budget message still dispatches alone (the
-        adapter's own pre-send cap is the backstop) rather than stalling
-        the thread forever.
-        """
+        """Largest K where ``messages[:K]`` fits ``_max_input_bytes``.
+        Always >= 1 — a lone over-budget message dispatches alone (the
+        adapter cap is the backstop) instead of stalling the thread."""
         budget = self._max_input_bytes
         total = 0
         for i, msg in enumerate(messages):
@@ -1330,14 +1318,9 @@ class PuffoCoreMessageClient:
             all_msgs = entry.messages
             channel_meta = entry.channel_meta
 
-            # Safety net: paranoid in-batch dedup before the greedy-fill
-            # split, so byte accounting + the split boundary act on the
-            # real, deduplicated set. ``_admit_thread_message``'s in-queue
-            # dedup plus ``dispatching_ids`` should already guarantee
-            # ``all_msgs`` is duplicate-free, but if some upstream race we
-            # haven't characterised slips a duplicate past both, we must
-            # NOT hand the same envelope to the agent twice. The warning
-            # log lets us spot the offending path if it ever fires.
+            # Paranoid in-batch dedup (before the split, so byte accounting
+            # sees the real set). Admit-time dedup should make this a no-op;
+            # the warning exposes any upstream race that slips one through.
             seen_ids: set[str] = set()
             deduped: list[dict] = []
             dropped: list[str] = []
@@ -1356,8 +1339,8 @@ class PuffoCoreMessageClient:
                     len(dropped), root_id, dropped,
                 )
 
-            # Greedy-fill: dispatch only the FIFO prefix whose concatenated
-            # block fits the input-byte budget; the remainder stays queued.
+            # Greedy-fill: dispatch the FIFO prefix that fits the byte
+            # budget; the remainder stays queued.
             split = self._greedy_fit_prefix(deduped)
             batch = deduped[:split]
             deferred = deduped[split:]
@@ -1365,11 +1348,9 @@ class PuffoCoreMessageClient:
                 m.get("envelope_id") for m in batch if m.get("envelope_id")
             }
             if deferred:
-                # Keep the slot OPEN so a mid-dispatch arrival appends after
-                # the deferred tail (FIFO) instead of taking the reopen
-                # branch, which would overwrite ``messages``. The durable
-                # cursor only advances over ``batch``, so the deferred stay
-                # re-readable across a restart.
+                # Slot stays OPEN so a mid-dispatch arrival appends after the
+                # deferred tail instead of overwriting via the reopen branch;
+                # the cursor covers only ``batch``, so deferred survive restart.
                 entry.messages = deferred
                 entry.in_queue = True
                 self._queue_seq += 1

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -65,6 +65,22 @@ PRIORITY_SYSTEM = 5
 # tool which force-refreshes regardless of TTL.
 _PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
+# PUF-363: FIFO greedy-fill input batching. When a thread's queued
+# messages would, once concatenated into one per-turn block, exceed the
+# harness input-byte budget, the consumer dispatches only the prefix that
+# fits and defers the rest to the next turn(s). Mirrors the Claude Code
+# pre-send cap in ``adapters/cli_session.MAX_USER_MESSAGE_BYTES`` — a test
+# asserts the two stay in sync. Codex has no such cap and the worker
+# passes it a far larger ceiling.
+DEFAULT_MAX_INPUT_BYTES = 180 * 1000
+
+# Conservative per-message overhead for the ``_format_user_block`` metadata
+# header (channel/space/sender/slugs/timestamp/… lines). The greedy-fill
+# byte estimate adds this to the raw text so it OVER-counts the real block
+# — over-counting only defers a message one turn early, it never overflows
+# the cap.
+_BLOCK_METADATA_OVERHEAD_BYTES = 2048
+
 
 @dataclass
 class _ThreadEntry:
@@ -456,6 +472,7 @@ class PuffoCoreMessageClient:
         segment_chars: int = 2000,
         agent_created_at: int = 0,
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
+        max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -478,6 +495,8 @@ class PuffoCoreMessageClient:
         # 200k-context model with a verbose system prompt.
         self._max_inline_chars = max(1, int(max_inline_chars))
         self._segment_chars = max(1, int(segment_chars))
+        # PUF-363: per-turn input-block byte budget for greedy-fill batching.
+        self._max_input_bytes = max(1, int(max_input_bytes))
         self._image_edge_px = int(image_edge_px) or _DEFAULT_IMAGE_EDGE_PX
         self.keystore = keystore
         self.http = http_client
@@ -1242,6 +1261,36 @@ class PuffoCoreMessageClient:
                 root_id,
             )
 
+    def _message_block_bytes(self, msg: dict) -> int:
+        """Conservative UTF-8 byte estimate of one message's formatted
+        ``_format_user_block``. Over-counts (fixed metadata overhead plus
+        per-item slack for attachments/mentions) so the greedy-fill never
+        under-estimates and lets an over-cap block through to the adapter.
+        """
+        n = len((msg.get("text") or "").encode("utf-8"))
+        for att in (msg.get("attachments") or []):
+            n += len(str(att).encode("utf-8")) + 16
+        for mention in (msg.get("mentions") or []):
+            n += len(str(mention).encode("utf-8")) + 8
+        return n + _BLOCK_METADATA_OVERHEAD_BYTES
+
+    def _greedy_fit_prefix(self, messages: list[dict]) -> int:
+        """PUF-363: largest prefix length K such that the concatenated
+        blocks of ``messages[:K]`` fit ``_max_input_bytes``. Always >= 1
+        so a single over-budget message still dispatches alone (the
+        adapter's own pre-send cap is the backstop) rather than stalling
+        the thread forever.
+        """
+        budget = self._max_input_bytes
+        total = 0
+        for i, msg in enumerate(messages):
+            size = self._message_block_bytes(msg)
+            sep = 2 if i > 0 else 0  # blocks join with a blank line "\n\n"
+            if i > 0 and total + sep + size > budget:
+                return i
+            total += sep + size
+        return len(messages)
+
     async def _consume_queue(
         self,
         on_message_batch: Callable[..., Coroutine[Any, Any, Any]],
@@ -1282,26 +1331,21 @@ class PuffoCoreMessageClient:
             # arriving mid-dispatch can be rejected at admit time
             # (the durable cursor hasn't advanced yet, so it can't
             # catch it).
-            batch = entry.messages
+            all_msgs = entry.messages
             channel_meta = entry.channel_meta
-            entry.messages = []
-            entry.in_queue = False
-            entry.dispatching_ids = {
-                m.get("envelope_id") for m in batch if m.get("envelope_id")
-            }
 
-            # Safety net: paranoid in-batch dedup right before
-            # dispatch. ``_admit_thread_message``'s in-queue dedup
-            # plus ``dispatching_ids`` should already guarantee
-            # ``batch`` is duplicate-free, but if some upstream race
-            # we haven't characterised slips a duplicate envelope_id
-            # past both, we must NOT hand the same envelope to the
-            # agent twice in one turn. The warning log lets us spot
-            # the offending path if it ever fires.
+            # Safety net: paranoid in-batch dedup before the greedy-fill
+            # split, so byte accounting + the split boundary act on the
+            # real, deduplicated set. ``_admit_thread_message``'s in-queue
+            # dedup plus ``dispatching_ids`` should already guarantee
+            # ``all_msgs`` is duplicate-free, but if some upstream race we
+            # haven't characterised slips a duplicate past both, we must
+            # NOT hand the same envelope to the agent twice. The warning
+            # log lets us spot the offending path if it ever fires.
             seen_ids: set[str] = set()
             deduped: list[dict] = []
             dropped: list[str] = []
-            for m in batch:
+            for m in all_msgs:
                 mid = m.get("envelope_id", "")
                 if mid and mid in seen_ids:
                     dropped.append(mid)
@@ -1315,7 +1359,42 @@ class PuffoCoreMessageClient:
                     "for thread %s before dispatch: %s",
                     len(dropped), root_id, dropped,
                 )
-                batch = deduped
+
+            # PUF-363: greedy-fill. Dispatch only the FIFO prefix whose
+            # concatenated block fits the harness input-byte budget; keep
+            # the remainder queued for a following turn. Nothing dropped,
+            # nothing reordered, split only at message boundaries.
+            split = self._greedy_fit_prefix(deduped)
+            batch = deduped[:split]
+            deferred = deduped[split:]
+            entry.dispatching_ids = {
+                m.get("envelope_id") for m in batch if m.get("envelope_id")
+            }
+            if deferred:
+                # Keep the slot OPEN with the remainder so a mid-dispatch
+                # arrival appends AFTER the deferred tail (FIFO) instead of
+                # taking ``_admit_thread_message``'s reopen branch, which
+                # would overwrite ``messages``. Re-enqueue a fresh tuple so
+                # the serial consumer drains the remainder next turn (the
+                # durable cursor only advances over ``batch``'s tail, so the
+                # deferred — higher ``sent_at`` — stays uncovered + safe
+                # across a restart).
+                entry.messages = deferred
+                entry.in_queue = True
+                self._queue_seq += 1
+                entry.current_seq = self._queue_seq
+                await self._queue.put(
+                    (entry.current_priority, entry.current_seq, root_id)
+                )
+                self._log.info(
+                    "greedy-fill: thread %s dispatching %d/%d msgs, "
+                    "deferring %d to next turn (budget=%d bytes)",
+                    root_id, len(batch), len(deduped), len(deferred),
+                    self._max_input_bytes,
+                )
+            else:
+                entry.messages = []
+                entry.in_queue = False
 
             # Pre-dispatch jitter. When several agents on the same
             # host get activated by the same message (e.g. a channel

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -65,12 +65,9 @@ PRIORITY_SYSTEM = 5
 # tool which force-refreshes regardless of TTL.
 _PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
-# PUF-363: FIFO greedy-fill input batching. When a thread's queued
-# messages would, once concatenated into one per-turn block, exceed the
-# harness input-byte budget, the consumer dispatches only the prefix that
-# fits and defers the rest to the next turn(s). Mirrors the Claude Code
-# pre-send cap in ``adapters/cli_session.MAX_USER_MESSAGE_BYTES`` — a test
-# asserts the two stay in sync. Codex has no such cap and the worker
+# Per-turn input-block byte budget for greedy-fill batching. Mirrors the
+# Claude Code pre-send cap in ``adapters/cli_session.MAX_USER_MESSAGE_BYTES``
+# — a test asserts the two stay in sync. Codex has no such cap; the worker
 # passes it a far larger ceiling.
 DEFAULT_MAX_INPUT_BYTES = 180 * 1000
 
@@ -495,7 +492,6 @@ class PuffoCoreMessageClient:
         # 200k-context model with a verbose system prompt.
         self._max_inline_chars = max(1, int(max_inline_chars))
         self._segment_chars = max(1, int(segment_chars))
-        # PUF-363: per-turn input-block byte budget for greedy-fill batching.
         self._max_input_bytes = max(1, int(max_input_bytes))
         self._image_edge_px = int(image_edge_px) or _DEFAULT_IMAGE_EDGE_PX
         self.keystore = keystore
@@ -1275,7 +1271,7 @@ class PuffoCoreMessageClient:
         return n + _BLOCK_METADATA_OVERHEAD_BYTES
 
     def _greedy_fit_prefix(self, messages: list[dict]) -> int:
-        """PUF-363: largest prefix length K such that the concatenated
+        """Largest prefix length K such that the concatenated
         blocks of ``messages[:K]`` fit ``_max_input_bytes``. Always >= 1
         so a single over-budget message still dispatches alone (the
         adapter's own pre-send cap is the backstop) rather than stalling
@@ -1360,10 +1356,8 @@ class PuffoCoreMessageClient:
                     len(dropped), root_id, dropped,
                 )
 
-            # PUF-363: greedy-fill. Dispatch only the FIFO prefix whose
-            # concatenated block fits the harness input-byte budget; keep
-            # the remainder queued for a following turn. Nothing dropped,
-            # nothing reordered, split only at message boundaries.
+            # Greedy-fill: dispatch only the FIFO prefix whose concatenated
+            # block fits the input-byte budget; the remainder stays queued.
             split = self._greedy_fit_prefix(deduped)
             batch = deduped[:split]
             deferred = deduped[split:]
@@ -1371,14 +1365,11 @@ class PuffoCoreMessageClient:
                 m.get("envelope_id") for m in batch if m.get("envelope_id")
             }
             if deferred:
-                # Keep the slot OPEN with the remainder so a mid-dispatch
-                # arrival appends AFTER the deferred tail (FIFO) instead of
-                # taking ``_admit_thread_message``'s reopen branch, which
-                # would overwrite ``messages``. Re-enqueue a fresh tuple so
-                # the serial consumer drains the remainder next turn (the
-                # durable cursor only advances over ``batch``'s tail, so the
-                # deferred — higher ``sent_at`` — stays uncovered + safe
-                # across a restart).
+                # Keep the slot OPEN so a mid-dispatch arrival appends after
+                # the deferred tail (FIFO) instead of taking the reopen
+                # branch, which would overwrite ``messages``. The durable
+                # cursor only advances over ``batch``, so the deferred stay
+                # re-readable across a restart.
                 entry.messages = deferred
                 entry.in_queue = True
                 self._queue_seq += 1

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -299,7 +299,8 @@ def _maybe_redact_long_text(
         f"  preview: {raw_preview}\n"
         "Retrieve the full body one chunk at a time with "
         "mcp__puffo__get_post_segment("
-        f"envelope_id=\"{envelope_id}\", segment=N) where N runs "
+        f"envelope_id=\"{envelope_id}\", segment=N, "
+        f"segment_size={segment_chars}) where N runs "
         f"0..{seg_count - 1}. Fetch only the segments you actually "
         "need — the placeholder above already tells you what kind "
         "of content it is."
@@ -459,8 +460,8 @@ class PuffoCoreMessageClient:
         operator_slug: str = "",
         auto_accept_space_invitations: bool = False,
         workspace: str = "",
-        max_inline_chars: int = 4000,
-        segment_chars: int = 2000,
+        max_inline_chars: int = 16000,
+        segment_chars: int = 8000,
         agent_created_at: int = 0,
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
         max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,

--- a/src/puffo_agent/limits.py
+++ b/src/puffo_agent/limits.py
@@ -1,0 +1,10 @@
+"""Shared message-size limits — single definition, imported everywhere."""
+
+# A single inbound message's text above this many chars is redacted from
+# the prompt to a placeholder; the full body pages back on demand via
+# ``get_post_segment``.
+MAX_INLINE_MESSAGE_CHARS = 16000
+
+# Page size (chars) that ``get_post_segment`` returns redacted bodies in;
+# the redaction placeholder cites it so paging stays aligned.
+MESSAGE_SEGMENT_CHARS = 8000

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -34,6 +34,7 @@ from ..crypto.message import (
     encrypt_message_with_content_key,
 )
 from ..crypto.primitives import Ed25519KeyPair
+from ..limits import MESSAGE_SEGMENT_CHARS
 from .data_client import DataClient, DataNotFound
 from ._host_mcp import PuffoRpcClient
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -879,7 +879,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     async def get_post_segment(
         envelope_id: str,
         segment: int,
-        segment_size: int = 8000,
+        segment_size: int = MESSAGE_SEGMENT_CHARS,
     ) -> str:
         """Page a long message body back in chunks.
 
@@ -901,9 +901,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
           * unknown envelope_id → "message <id> not found in local storage"
           * empty content       → "message <id> has no text body"
 
-        ``segment_size`` defaults to 8000 to match the daemon's
-        default redaction page size; pass the value the placeholder
-        cited if the operator has overridden it on their host.
+        ``segment_size`` defaults to the daemon's default redaction
+        page size; pass the value the placeholder cited if the operator
+        has overridden it on their host.
         """
         envelope_id = (envelope_id or "").strip()
         if not envelope_id:

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -879,7 +879,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     async def get_post_segment(
         envelope_id: str,
         segment: int,
-        segment_size: int = 2000,
+        segment_size: int = 8000,
     ) -> str:
         """Page a long message body back in chunks.
 
@@ -901,7 +901,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
           * unknown envelope_id → "message <id> not found in local storage"
           * empty content       → "message <id> has no text body"
 
-        ``segment_size`` defaults to 2000 to match the daemon's
+        ``segment_size`` defaults to 8000 to match the daemon's
         default redaction page size; pass the value the placeholder
         cited if the operator has overridden it on their host.
         """

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -842,12 +842,11 @@ class DaemonConfig:
     # the agent fetches the full content one chunk at a time via
     # the ``get_post_segment`` MCP tool. The original envelope is
     # stored unmodified in ``messages.db`` — only the prompt-budget
-    # view is redacted. Tuned for Claude's 200k window minus a
-    # generous system-prompt + history headroom; defaults pinned at
-    # 4000/2000 so a single 8-segment paste fits comfortably even
-    # with a verbose primer.
-    max_inline_message_chars: int = 4000
-    segment_chars: int = 2000
+    # view is redacted. Per-turn totals are bounded by greedy-fill
+    # batching, so this only guards session-lifetime context growth;
+    # 16000 inlines typical code/log pastes whole.
+    max_inline_message_chars: int = 16000
+    segment_chars: int = 8000
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(
         default_factory=lambda: DataServiceConfig(),
@@ -872,8 +871,8 @@ class DaemonConfig:
             runtime_heartbeat_seconds=float(raw.get("runtime_heartbeat_seconds", 5.0)),
             docker_memory_limit=raw.get("docker_memory_limit", "1.5g"),
             docker_memory_reservation=raw.get("docker_memory_reservation", "500m"),
-            max_inline_message_chars=int(raw.get("max_inline_message_chars", 4000)),
-            segment_chars=int(raw.get("segment_chars", 2000)),
+            max_inline_message_chars=int(raw.get("max_inline_message_chars", 16000)),
+            segment_chars=int(raw.get("segment_chars", 8000)),
         )
         for name in ("anthropic", "openai", "google"):
             p = raw.get(name) or {}

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -32,6 +32,8 @@ from typing import Any
 import psutil
 import yaml
 
+from ..limits import MAX_INLINE_MESSAGE_CHARS, MESSAGE_SEGMENT_CHARS
+
 
 # Where daemon.yml, agents/, etc. live.
 def home_dir() -> Path:
@@ -845,8 +847,8 @@ class DaemonConfig:
     # view is redacted. Per-turn totals are bounded by greedy-fill
     # batching, so this only guards session-lifetime context growth;
     # 16000 inlines typical code/log pastes whole.
-    max_inline_message_chars: int = 16000
-    segment_chars: int = 8000
+    max_inline_message_chars: int = MAX_INLINE_MESSAGE_CHARS
+    segment_chars: int = MESSAGE_SEGMENT_CHARS
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(
         default_factory=lambda: DataServiceConfig(),
@@ -871,8 +873,10 @@ class DaemonConfig:
             runtime_heartbeat_seconds=float(raw.get("runtime_heartbeat_seconds", 5.0)),
             docker_memory_limit=raw.get("docker_memory_limit", "1.5g"),
             docker_memory_reservation=raw.get("docker_memory_reservation", "500m"),
-            max_inline_message_chars=int(raw.get("max_inline_message_chars", 16000)),
-            segment_chars=int(raw.get("segment_chars", 8000)),
+            max_inline_message_chars=int(
+                raw.get("max_inline_message_chars", MAX_INLINE_MESSAGE_CHARS)
+            ),
+            segment_chars=int(raw.get("segment_chars", MESSAGE_SEGMENT_CHARS)),
         )
         for name in ("anthropic", "openai", "google"):
             p = raw.get(name) or {}

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -384,10 +384,8 @@ def _build_puffo_core_client(
     else:
         model = agent_cfg.runtime.model or (daemon_cfg.anthropic.model if daemon_cfg else "")
 
-    # PUF-363: per-turn input-block byte budget for greedy-fill batching.
-    # Claude Code hard-rejects a single user block over ~180KB pre-send, so
-    # split batches to stay under it. Codex has no such input cap — give it a
-    # far larger ceiling that only trips as a runaway safety net.
+    # Claude Code hard-rejects a single user block over ~180KB pre-send;
+    # Codex has no input cap, so its ceiling is only a runaway safety net.
     max_input_bytes = 4_000_000 if is_codex else DEFAULT_MAX_INPUT_BYTES
 
     return PuffoCoreMessageClient(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -370,10 +370,10 @@ def _build_puffo_core_client(
     ms = MessageStore(str(agent_dir(agent_id) / "messages.db"))
 
     max_inline = (
-        daemon_cfg.max_inline_message_chars if daemon_cfg is not None else 4000
+        daemon_cfg.max_inline_message_chars if daemon_cfg is not None else 16000
     )
     segment_chars = (
-        daemon_cfg.segment_chars if daemon_cfg is not None else 2000
+        daemon_cfg.segment_chars if daemon_cfg is not None else 8000
     )
 
     # The inbound-image downscale cap follows the harness's effective model

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -370,10 +370,10 @@ def _build_puffo_core_client(
     ms = MessageStore(str(agent_dir(agent_id) / "messages.db"))
 
     max_inline = (
-        daemon_cfg.max_inline_message_chars if daemon_cfg is not None else 16000
+        daemon_cfg.max_inline_message_chars if daemon_cfg is not None else MAX_INLINE_MESSAGE_CHARS
     )
     segment_chars = (
-        daemon_cfg.segment_chars if daemon_cfg is not None else 8000
+        daemon_cfg.segment_chars if daemon_cfg is not None else MESSAGE_SEGMENT_CHARS
     )
 
     # The inbound-image downscale cap follows the harness's effective model

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -21,6 +21,7 @@ from typing import Awaitable, Callable, Optional
 
 from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
+from ..limits import MAX_INLINE_MESSAGE_CHARS, MESSAGE_SEGMENT_CHARS
 from ..agent.status_reporter import StatusReporter
 from .runtime_matrix import (
     RUNTIME_CLI_DOCKER,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -354,7 +354,11 @@ def _build_puffo_core_client(
     the dataclass defaults.
     """
     from ..agent.message_store import MessageStore
-    from ..agent.puffo_core_client import PuffoCoreMessageClient, max_image_edge_px
+    from ..agent.puffo_core_client import (
+        DEFAULT_MAX_INPUT_BYTES,
+        PuffoCoreMessageClient,
+        max_image_edge_px,
+    )
     from ..crypto.http_client import PuffoCoreHttpClient
     from ..crypto.keystore import KeyStore
 
@@ -374,10 +378,17 @@ def _build_puffo_core_client(
 
     # The inbound-image downscale cap follows the harness's effective model
     # (Opus 4.7+ resolves 2576px, else 1568px).
-    if (agent_cfg.runtime.harness or "claude-code") == "codex":
+    is_codex = (agent_cfg.runtime.harness or "claude-code") == "codex"
+    if is_codex:
         model = agent_cfg.runtime.model or (daemon_cfg.openai.model if daemon_cfg else "")
     else:
         model = agent_cfg.runtime.model or (daemon_cfg.anthropic.model if daemon_cfg else "")
+
+    # PUF-363: per-turn input-block byte budget for greedy-fill batching.
+    # Claude Code hard-rejects a single user block over ~180KB pre-send, so
+    # split batches to stay under it. Codex has no such input cap — give it a
+    # far larger ceiling that only trips as a runaway safety net.
+    max_input_bytes = 4_000_000 if is_codex else DEFAULT_MAX_INPUT_BYTES
 
     return PuffoCoreMessageClient(
         slug=pc.slug,
@@ -393,6 +404,7 @@ def _build_puffo_core_client(
         segment_chars=segment_chars,
         agent_created_at=agent_cfg.created_at,
         image_edge_px=max_image_edge_px(model),
+        max_input_bytes=max_input_bytes,
     )
 
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -384,8 +384,7 @@ def _build_puffo_core_client(
     else:
         model = agent_cfg.runtime.model or (daemon_cfg.anthropic.model if daemon_cfg else "")
 
-    # Claude Code hard-rejects a single user block over ~180KB pre-send;
-    # Codex has no input cap, so its ceiling is only a runaway safety net.
+    # Codex has no adapter input cap; its ceiling is a runaway safety net.
     max_input_bytes = 4_000_000 if is_codex else DEFAULT_MAX_INPUT_BYTES
 
     return PuffoCoreMessageClient(

--- a/tests/test_api_error_recovery_state.py
+++ b/tests/test_api_error_recovery_state.py
@@ -8,7 +8,10 @@ from typing import Any
 
 import pytest
 
-from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.agent.puffo_core_client import (
+    DEFAULT_MAX_INPUT_BYTES,
+    PuffoCoreMessageClient,
+)
 from puffo_agent.agent.core import AgentAPIError
 from puffo_agent.portal.worker import Worker
 
@@ -29,6 +32,10 @@ def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
     client.slug = "tester-1234"
     client._log = logging.getLogger("test-puf-255")
     client.MAX_API_ERROR_RETRIES = max_retries  # type: ignore[attr-defined]
+    # PUF-363: the ``_consume_queue`` success-branch test drives greedy-fill,
+    # which reads this budget. Large enough to never split these tiny batches.
+    client._queue_seq = 0
+    client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
 
     class _StubStore:
         async def mark_thread_processed(self, *args, **kwargs):

--- a/tests/test_api_error_recovery_state.py
+++ b/tests/test_api_error_recovery_state.py
@@ -32,7 +32,6 @@ def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
     client.slug = "tester-1234"
     client._log = logging.getLogger("test-puf-255")
     client.MAX_API_ERROR_RETRIES = max_retries  # type: ignore[attr-defined]
-    # Greedy-fill reads this budget; large enough to never split here.
     client._queue_seq = 0
     client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
 

--- a/tests/test_api_error_recovery_state.py
+++ b/tests/test_api_error_recovery_state.py
@@ -32,8 +32,7 @@ def _make_client(max_retries: int = 1) -> PuffoCoreMessageClient:
     client.slug = "tester-1234"
     client._log = logging.getLogger("test-puf-255")
     client.MAX_API_ERROR_RETRIES = max_retries  # type: ignore[attr-defined]
-    # PUF-363: the ``_consume_queue`` success-branch test drives greedy-fill,
-    # which reads this budget. Large enough to never split these tiny batches.
+    # Greedy-fill reads this budget; large enough to never split here.
     client._queue_seq = 0
     client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
 

--- a/tests/test_invite_poll_cadence.py
+++ b/tests/test_invite_poll_cadence.py
@@ -414,3 +414,67 @@ def test_build_puffo_core_client_threads_agent_created_at(monkeypatch, tmp_path)
         "PuffoCoreMessageClient(agent_created_at=...) "
         f"— got {captured.get('agent_created_at')!r}"
     )
+
+
+@pytest.mark.parametrize(
+    ("harness", "expected_budget"),
+    [
+        ("claude-code", 180_000),
+        ("codex", 4_000_000),
+    ],
+)
+def test_build_puffo_core_client_selects_harness_input_budget(
+    monkeypatch, tmp_path, harness, expected_budget,
+):
+    """The per-harness greedy-fill budget must thread through the worker:
+    Claude Code gets the adapter-cap default, Codex the safety-net ceiling."""
+    from puffo_agent.portal import worker
+    from puffo_agent.portal.state import AgentConfig, PuffoCoreConfig, RuntimeConfig
+
+    cfg = AgentConfig(
+        id="agent-test-1234",
+        puffo_core=PuffoCoreConfig(
+            server_url="https://example.test",
+            slug="agent-test-1234",
+            device_id="dev-1",
+            space_id="",
+            operator_slug="",
+        ),
+        runtime=RuntimeConfig(
+            kind="chat-local",
+            harness=harness,
+        ),
+    )
+
+    monkeypatch.setattr(
+        worker, "_ensure_agent_identity_imported", lambda *_a, **_k: None,
+    )
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "puffo_agent.agent.puffo_core_client.PuffoCoreMessageClient",
+        DummyClient,
+    )
+    monkeypatch.setattr(
+        "puffo_agent.crypto.keystore.KeyStore",
+        lambda *_a, **_k: object(),
+    )
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        lambda *_a, **_k: object(),
+    )
+    monkeypatch.setattr(
+        "puffo_agent.agent.message_store.MessageStore",
+        lambda *_a, **_k: object(),
+    )
+    monkeypatch.setattr(
+        AgentConfig, "resolve_workspace_dir", lambda self: tmp_path,
+    )
+
+    worker._build_puffo_core_client(cfg, "agent-test-1234")
+
+    assert captured.get("max_input_bytes") == expected_budget

--- a/tests/test_long_message_redaction.py
+++ b/tests/test_long_message_redaction.py
@@ -95,7 +95,7 @@ def test_redact_emits_placeholder_with_envelope_id_and_segments():
     assert "segments: 3 (0-indexed, up to 2000 chars each)" in out
     assert "sender: @Alice (alice)" in out
     assert "mcp__puffo__get_post_segment" in out
-    assert "segment=N) where N runs 0..2" in out
+    assert "segment=N, segment_size=2000) where N runs 0..2" in out
     # The placeholder itself shouldn't be longer than the
     # original by an order of magnitude (sanity — a buggy preview
     # that includes the whole payload would defeat the redaction).

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -25,8 +25,11 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+import logging
+
 from puffo_agent.agent.message_store import MessageStore
 from puffo_agent.agent.puffo_core_client import (
+    DEFAULT_MAX_INPUT_BYTES,
     PRIORITY_BOT,
     PRIORITY_HUMAN,
     PRIORITY_MENTIONED_BOT,
@@ -59,6 +62,10 @@ def _make_client_for_queue(store: MessageStore) -> PuffoCoreMessageClient:
     client._queue = asyncio.PriorityQueue()
     client._queue_seq = 0
     client._thread_state = {}
+    # PUF-363: greedy-fill needs a byte budget + a logger. Default budget
+    # is large so pre-existing small-batch tests never trigger a split.
+    client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
+    client._log = logging.getLogger("puffo-core-client-test")
     return client
 
 
@@ -910,4 +917,174 @@ async def test_pre_existing_cursor_blocks_redelivered_messages():
     assert await store.get_last_processed_sent_at("env_root") == 500
     # A fresh root has no entry → returns 0 → admits everything.
     assert await store.get_last_processed_sent_at("env_fresh") == 0
+    await store.close()
+
+
+# ─── PUF-363: greedy-fill input batching ─────────────────────────
+
+
+def _sized_msg(envelope_id: str, text_bytes: int, sent_at: int) -> dict:
+    m = _msg(envelope_id, sent_at=sent_at)
+    m["text"] = "x" * text_bytes
+    return m
+
+
+async def _run_consumer_n_batches(
+    client: PuffoCoreMessageClient,
+    n: int,
+    on_first=None,
+) -> list[tuple[str, list[dict], dict]]:
+    """Drive ``_consume_queue`` until it dispatches ``n`` batches. If
+    ``on_first`` is given it's awaited during the FIRST dispatch (to
+    simulate a mid-dispatch arrival)."""
+    received: list[tuple[str, list[dict], dict]] = []
+    done = asyncio.Event()
+
+    async def callback(root_id, batch, channel_meta):
+        received.append((root_id, batch, channel_meta))
+        if len(received) == 1 and on_first is not None:
+            await on_first()
+        if len(received) >= n:
+            done.set()
+
+    task = asyncio.create_task(client._consume_queue(callback))
+    try:
+        await asyncio.wait_for(done.wait(), timeout=5.0)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    assert len(received) == n
+    return received
+
+
+def test_default_max_input_bytes_matches_adapter_cap():
+    """Drift guard: the greedy-fill budget default must track the Claude
+    Code adapter's own pre-send cap, or the split stops protecting it."""
+    from puffo_agent.agent.adapters.cli_session import MAX_USER_MESSAGE_BYTES
+
+    assert DEFAULT_MAX_INPUT_BYTES == MAX_USER_MESSAGE_BYTES
+
+
+def test_greedy_fit_prefix_selects_largest_fitting_prefix():
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client._max_input_bytes = 12_000
+    # Each block ≈ 2048 overhead + 3000 text = 5048 bytes; 2 fit under
+    # 12000 (10098), the 3rd would push to 15148.
+    msgs = [_sized_msg(f"e{i}", 3000, 100 + i) for i in range(5)]
+    assert client._greedy_fit_prefix(msgs) == 2
+
+
+def test_greedy_fit_prefix_empty_and_all_fit():
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
+    assert client._greedy_fit_prefix([]) == 0
+    small = [_sized_msg(f"e{i}", 10, 100 + i) for i in range(4)]
+    assert client._greedy_fit_prefix(small) == 4
+
+
+def test_greedy_fit_prefix_single_over_budget_message_goes_alone():
+    """A lone message bigger than the whole budget can't be split at a
+    boundary — it must still dispatch (K=1) so the thread never stalls;
+    the adapter's own pre-send cap is the backstop."""
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client._max_input_bytes = 4_000
+    huge = [_sized_msg("e_huge", 50_000, 100)]
+    assert client._greedy_fit_prefix(huge) == 1
+
+
+def test_message_block_bytes_over_counts_real_content():
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    m = _sized_msg("e0", 100, 100)
+    m["attachments"] = ["/a/b.png"]
+    m["mentions"] = ["bob-0002"]
+    # text(100) + attachment(8+16) + mention(8+8) + overhead(2048) all counted.
+    assert client._message_block_bytes(m) >= 100 + 2048
+
+
+@pytest.mark.asyncio
+async def test_consume_greedy_fill_defers_overflow(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.agent.puffo_core_client.random.uniform", lambda a, b: 0.0
+    )
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+    client._max_input_bytes = 12_000  # ~2 messages/turn at 5048 bytes each
+
+    for i in range(5):
+        await client._admit_thread_message(
+            root_id="env_root",
+            priority=PRIORITY_HUMAN,
+            msg_dict=_sized_msg(f"e{i}", 3000, 100 + i),
+            channel_meta=_channel_meta(),
+        )
+
+    batches = await _run_consumer_n_batches(client, 3)
+    ids = [[m["envelope_id"] for m in b] for (_r, b, _m) in batches]
+    # FIFO preserved, split at message boundaries, nothing dropped.
+    assert ids == [["e0", "e1"], ["e2", "e3"], ["e4"]]
+    # Cursor only ever covers the last DISPATCHED message.
+    assert await store.get_last_processed_sent_at("env_root") == 104
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_greedy_fill_mid_dispatch_arrival_keeps_fifo(monkeypatch):
+    """A message that arrives WHILE the first (fitting) batch is being
+    dispatched must land AFTER the deferred tail, not ahead of it."""
+    monkeypatch.setattr(
+        "puffo_agent.agent.puffo_core_client.random.uniform", lambda a, b: 0.0
+    )
+    store = await _make_store()
+    client = _make_client_for_queue(store)
+    client._max_input_bytes = 12_000
+
+    for i in range(3):  # batch1 = [e0, e1]; deferred = [e2]
+        await client._admit_thread_message(
+            root_id="env_root",
+            priority=PRIORITY_HUMAN,
+            msg_dict=_sized_msg(f"e{i}", 3000, 100 + i),
+            channel_meta=_channel_meta(),
+        )
+
+    async def late_arrival():
+        await client._admit_thread_message(
+            root_id="env_root",
+            priority=PRIORITY_HUMAN,
+            msg_dict=_sized_msg("e_late", 3000, 200),
+            channel_meta=_channel_meta(),
+        )
+
+    batches = await _run_consumer_n_batches(client, 2, on_first=late_arrival)
+    ids = [[m["envelope_id"] for m in b] for (_r, b, _m) in batches]
+    # Deferred e2 stays ahead of the mid-dispatch arrival e_late.
+    assert ids == [["e0", "e1"], ["e2", "e_late"]]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_greedy_fill_noop_when_batch_fits(monkeypatch):
+    """Budget comfortably above the batch → single dispatch, no defer,
+    slot closes exactly like the pre-PUF-363 path."""
+    monkeypatch.setattr(
+        "puffo_agent.agent.puffo_core_client.random.uniform", lambda a, b: 0.0
+    )
+    store = await _make_store()
+    client = _make_client_for_queue(store)  # default large budget
+
+    for i in range(3):
+        await client._admit_thread_message(
+            root_id="env_root",
+            priority=PRIORITY_HUMAN,
+            msg_dict=_sized_msg(f"e{i}", 500, 100 + i),
+            channel_meta=_channel_meta(),
+        )
+
+    root_id, batch, _ = await _run_consumer_one_batch(client)
+    assert [m["envelope_id"] for m in batch] == ["e0", "e1", "e2"]
+    assert client._thread_state["env_root"].in_queue is False
+    assert client._thread_state["env_root"].messages == []
+    assert await store.get_last_processed_sent_at("env_root") == 102
     await store.close()

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -62,7 +62,6 @@ def _make_client_for_queue(store: MessageStore) -> PuffoCoreMessageClient:
     client._queue = asyncio.PriorityQueue()
     client._queue_seq = 0
     client._thread_state = {}
-    # Budget large by default so small-batch tests never trigger a split.
     client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
     client._log = logging.getLogger("puffo-core-client-test")
     return client

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -1088,3 +1088,18 @@ async def test_greedy_fill_noop_when_batch_fits(monkeypatch):
     assert client._thread_state["env_root"].messages == []
     assert await store.get_last_processed_sent_at("env_root") == 102
     await store.close()
+
+
+def test_greedy_fit_prefix_harness_budget_drives_split():
+    """Per-harness budget: the SAME batch that a Claude Code client
+    (180KB) splits fits in a single dispatch under a Codex-scale budget
+    (the worker's 4MB safety-net ceiling). Proves ``max_input_bytes`` —
+    not the message set — decides the split boundary."""
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    msgs = [_sized_msg(f"e{i}", 60_000, 100 + i) for i in range(5)]  # ~62KB each
+
+    client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES  # 180KB (Claude Code)
+    assert client._greedy_fit_prefix(msgs) == 2  # 2 blocks fit, 3rd overflows
+
+    client._max_input_bytes = 4_000_000  # Codex safety-net ceiling
+    assert client._greedy_fit_prefix(msgs) == 5  # whole batch fits, no split

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -62,8 +62,7 @@ def _make_client_for_queue(store: MessageStore) -> PuffoCoreMessageClient:
     client._queue = asyncio.PriorityQueue()
     client._queue_seq = 0
     client._thread_state = {}
-    # PUF-363: greedy-fill needs a byte budget + a logger. Default budget
-    # is large so pre-existing small-batch tests never trigger a split.
+    # Budget large by default so small-batch tests never trigger a split.
     client._max_input_bytes = DEFAULT_MAX_INPUT_BYTES
     client._log = logging.getLogger("puffo-core-client-test")
     return client
@@ -920,7 +919,7 @@ async def test_pre_existing_cursor_blocks_redelivered_messages():
     await store.close()
 
 
-# ─── PUF-363: greedy-fill input batching ─────────────────────────
+# ─── greedy-fill input batching ──────────────────────────────────
 
 
 def _sized_msg(envelope_id: str, text_bytes: int, sent_at: int) -> dict:


### PR DESCRIPTION
## Summary

Per Vase spec (`msg_329576f7` verbatim): when the messages queued for a thread would, once concatenated into the single per-turn input block, exceed the harness input-byte cap — split at message boundaries, hand the agent the FIFO prefix that fits this turn, leave the tail queued, greedy-fill again next turn. Strict FIFO, nothing dropped, nothing reordered, nothing truncated.

**Current failure mode fixed**: on `main`, when a batch's concatenated block exceeds Claude Code's `MAX_USER_MESSAGE_BYTES` (180KB), `_one_turn` short-circuits pre-send with a "reduce or split" friendly reply and **spawns no turn** — the entire over-limit batch's messages are dropped, unprocessed. That's the P1 failure Vase described.

**Fix at `_consume_queue` (claim point)**:
- New `_greedy_fit_prefix(messages)` returns the largest K where the concatenated blocks fit `_max_input_bytes`; always ≥ 1 so a single over-budget message still dispatches alone (falls through to the adapter's own pre-send cap as the backstop, not made worse by this change).
- Per-message byte estimate `_message_block_bytes` is deliberately conservative (adds a fixed metadata overhead + per-item slack for attachments/mentions) so the greedy-fill **over-counts** the real formatted block — near-boundary splits happen one turn early, never one turn too late.
- Deferred tail keeps the slot OPEN (`entry.in_queue = True`), so a mid-dispatch arrival appends AFTER the deferred tail (FIFO) instead of taking `_admit_thread_message`'s reopen branch (which would overwrite `messages`).
- Re-enqueue with `_queue_seq += 1` under the same priority band — deferred lands at the tail of its band.
- Durable cursor (`mark_thread_processed`) only advances over `batch[-1].sent_at` — the deferred (higher `sent_at`) stays uncovered, so a restart re-reads them from the store cleanly.

**Per-harness budget wired in `worker.py::_build_puffo_core_client`**:
- Claude Code → `DEFAULT_MAX_INPUT_BYTES = 180_000` bytes (mirrors `cli_session.MAX_USER_MESSAGE_BYTES`; a drift-guard test pins them equal so a future bump to one bumps the other or fails loud).
- Codex → 4MB runaway ceiling (Codex adapter has no input-size hard cap; the ceiling only trips as a safety net).

## Test plan

- [x] `test_thread_queue.py` + `test_api_error_recovery_state.py` — **39/39 pass** (31 pre-existing + 8 new):
  - `test_default_max_input_bytes_matches_adapter_cap` — drift-guard on the byte cap.
  - `test_greedy_fit_prefix_selects_largest_fitting_prefix` — K-selection.
  - `test_greedy_fit_prefix_empty_and_all_fit` — empty list + all-fit edges.
  - `test_greedy_fit_prefix_single_over_budget_message_goes_alone` — single over-cap always dispatches.
  - `test_message_block_bytes_over_counts_real_content` — over-count safety pinned.
  - `test_consume_greedy_fill_defers_overflow` — end-to-end 5-msg / budget≈2 → `[e0,e1][e2,e3][e4]` FIFO, cursor only covers dispatched.
  - `test_greedy_fill_mid_dispatch_arrival_keeps_fifo` — mid-dispatch arrival lands after the deferred tail.
  - `test_greedy_fill_noop_when_batch_fits` — slot closes exactly like pre-PUF-363 when nothing overflows.
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1832 pass / 5 fail** byte-identical to `origin/main` (`diff /tmp/puf363-main-fails.txt /tmp/puf363-pr-fails.txt` clean). **Zero regression.**
- [ ] Post-merge external-verify: burst-post 6-8 large messages into a single thread on a Claude Code fleet agent → agent should process all of them in FIFO across successive turns instead of dropping the batch.

## Known limits (by design)

- The demonstrated drop-bug is **Claude-Code-specific**; Codex has no input cap on `main` today. Codex gets a 4MB safety-net ceiling — implemented cleanly, not tested directly (byte cap on the Claude side is what has the drift-guard).
- Per-message byte estimate is a **conservative proxy** — near-boundary batches may defer one message early. Safe (never overflows). The adapter's own 180KB reject stays as the ultimate backstop.
- A single message larger than the whole budget still dispatches alone (splitting content isn't in scope per spec); it hits the adapter's friendly "reduce or split" reply. Not worse than today.
- Handles the **per-turn block only**, not cumulative context-window growth (out of scope per intake).

**Composes-with**:
- PUF-360 (cron-stdout drain, shipped) — same file (`_one_turn`), sequenced correctly since PUF-360 landed pre-branch.
- PUF-361 (metadata enrichment, shipped) — same envelope-processing path, no conflict.

Ticket: PUF-363 (Linear PUF-41)
Detail: `/home/hanchen/.puffo-agent/shared/PUF-363.md`