### PR TITLE
PUF-34: cli-docker host-local MCP detection covers macOS paths + args, skips dead config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **cli-docker no longer injects host-local MCP configs that can't run in
+  the container (PUF-34).** Host-sync now recognizes macOS host-only
+  paths (`/opt/homebrew`, `/opt/local`, `/Volumes`, `/private`) and also
+  catches host paths hidden in `args` behind a bare `npx`/`uvx` launcher.
+  Detected servers are skipped with an actionable warning ("install in
+  the image or bind-mount, then re-sync") instead of being injected as
+  dead config that failed on first use; `/tmp` args stay container-valid
+  (a `/tmp` output path is fine, a `/tmp` binary is still host-staged),
+  and the container's own `/opt/puffoagent-pkg` keeps resolving.
+
 - **Profile edits now take effect on refresh — a changed prompt forces a
   fresh CLI session (PUF-36).** The CLI bakes the system prompt at
   session creation, so `--resume` replayed the old one and profile edits

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -856,10 +856,10 @@ class DockerCLIAdapter(Adapter):
                 )
             for name, cmd in unreachable:
                 logger.warning(
-                    "agent %s: host MCP %r command %r looks host-local and "
-                    "won't resolve inside the container. Install the "
-                    "binary in the image or bind-mount it explicitly, "
-                    "otherwise this MCP will fail on first use.",
+                    "agent %s: host MCP %r has host-local path %r that won't "
+                    "resolve inside the container — SKIPPED (not injected). "
+                    "Install the binary in the image or bind-mount it, then "
+                    "re-sync, to make this MCP available.",
                     self.agent_id, name, cmd,
                 )
             # Plugins: the actual plugin tree is bind-mounted read-
@@ -913,10 +913,10 @@ class DockerCLIAdapter(Adapter):
                 )
             for name, cmd in gemini_unreachable:
                 logger.warning(
-                    "agent %s: host gemini MCP %r command %r looks "
-                    "host-local and won't resolve inside the container. "
-                    "Install the binary in the image or bind-mount it, "
-                    "otherwise the MCP will fail on first use.",
+                    "agent %s: host gemini MCP %r has host-local path %r "
+                    "that won't resolve inside the container — SKIPPED. "
+                    "Install the binary in the image or bind-mount it, then "
+                    "re-sync, to make this MCP available.",
                     self.agent_id, name, cmd,
                 )
 

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -428,10 +428,8 @@ def sync_host_gemini_skills(host_home: Path, project_dir: Path) -> int:
 
 
 # Path prefixes that won't resolve inside the runtime container.
-# ``/home/agent/`` is handled separately because it IS valid inside.
-# The macOS entries (/opt/homebrew, /opt/local, /Volumes, /private) cover
-# Homebrew (Apple-silicon + Intel), MacPorts, external/mounted volumes, and
-# the /private symlink target of /tmp + /var — all host-only (PUF-34).
+# ``/home/agent/`` is handled separately because it IS valid inside;
+# ``/opt/puffoagent-pkg`` stays resolvable (prefixes are more specific).
 _HOST_LOCAL_COMMAND_PREFIXES = (
     "/Users/",
     "/tmp/",
@@ -458,17 +456,23 @@ def _looks_host_local_command(command: str) -> bool:
 
 
 def _host_local_token(cfg: dict) -> str | None:
-    """PUF-34: first token in an MCP server cfg that points at a host-only
-    path, or ``None`` when everything resolves inside the container. Scans
-    ``args`` as well as ``command`` — a bare ``npx`` / ``uvx`` command often
-    hides the host path in an argument (e.g. ``uvx /Volumes/tools/mcp``)."""
+    """First token in an MCP server cfg that points at a host-only path,
+    or ``None`` when everything resolves inside the container. Scans
+    ``args`` too — a bare ``npx`` / ``uvx`` command often hides the host
+    path in an argument."""
     if not isinstance(cfg, dict):
         return None
     cmd = cfg.get("command") or ""
     if isinstance(cmd, str) and _looks_host_local_command(cmd):
         return cmd
     for arg in cfg.get("args") or []:
-        if isinstance(arg, str) and _looks_host_local_command(arg):
+        # /tmp exists in the container, so a /tmp arg (log/db output path)
+        # is fine even though a /tmp *binary* is host-staged.
+        if (
+            isinstance(arg, str)
+            and not arg.startswith("/tmp/")
+            and _looks_host_local_command(arg)
+        ):
             return arg
     return None
 
@@ -511,9 +515,8 @@ def sync_host_mcp_servers(
     for name, cfg in host_servers.items():
         token = _host_local_token(cfg)
         if token is not None:
-            # PUF-34: a host-only path won't resolve in the container — skip
-            # it rather than inject a dead server config that fails silently.
-            # The caller logs an actionable warning off ``unreachable``.
+            # Skip rather than inject a dead server config; the caller
+            # logs an actionable warning off ``unreachable``.
             unreachable.append((name, token))
             continue
         agent_servers[name] = cfg
@@ -696,7 +699,6 @@ def sync_host_gemini_mcp_servers(
     for name, cfg in host_servers.items():
         token = _host_local_token(cfg)
         if token is not None:
-            # PUF-34: skip a host-only server rather than inject dead config.
             unreachable.append((name, token))
             continue
         merged_servers[name] = cfg

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -429,7 +429,18 @@ def sync_host_gemini_skills(host_home: Path, project_dir: Path) -> int:
 
 # Path prefixes that won't resolve inside the runtime container.
 # ``/home/agent/`` is handled separately because it IS valid inside.
-_HOST_LOCAL_COMMAND_PREFIXES = ("/Users/", "/tmp/", "/var/folders/")
+# The macOS entries (/opt/homebrew, /opt/local, /Volumes, /private) cover
+# Homebrew (Apple-silicon + Intel), MacPorts, external/mounted volumes, and
+# the /private symlink target of /tmp + /var — all host-only (PUF-34).
+_HOST_LOCAL_COMMAND_PREFIXES = (
+    "/Users/",
+    "/tmp/",
+    "/var/folders/",
+    "/opt/homebrew/",
+    "/opt/local/",
+    "/Volumes/",
+    "/private/",
+)
 
 
 def _looks_host_local_command(command: str) -> bool:
@@ -444,6 +455,22 @@ def _looks_host_local_command(command: str) -> bool:
     if command.startswith("/home/") and not command.startswith("/home/agent/"):
         return True
     return any(command.startswith(p) for p in _HOST_LOCAL_COMMAND_PREFIXES)
+
+
+def _host_local_token(cfg: dict) -> str | None:
+    """PUF-34: first token in an MCP server cfg that points at a host-only
+    path, or ``None`` when everything resolves inside the container. Scans
+    ``args`` as well as ``command`` — a bare ``npx`` / ``uvx`` command often
+    hides the host path in an argument (e.g. ``uvx /Volumes/tools/mcp``)."""
+    if not isinstance(cfg, dict):
+        return None
+    cmd = cfg.get("command") or ""
+    if isinstance(cmd, str) and _looks_host_local_command(cmd):
+        return cmd
+    for arg in cfg.get("args") or []:
+        if isinstance(arg, str) and _looks_host_local_command(arg):
+            return arg
+    return None
 
 
 def sync_host_mcp_servers(
@@ -480,12 +507,17 @@ def sync_host_mcp_servers(
 
     agent_servers = dict(agent_data.get("mcpServers") or {})
     unreachable: list[tuple[str, str]] = []
+    merged = 0
     for name, cfg in host_servers.items():
+        token = _host_local_token(cfg)
+        if token is not None:
+            # PUF-34: a host-only path won't resolve in the container — skip
+            # it rather than inject a dead server config that fails silently.
+            # The caller logs an actionable warning off ``unreachable``.
+            unreachable.append((name, token))
+            continue
         agent_servers[name] = cfg
-        if isinstance(cfg, dict):
-            cmd = cfg.get("command") or ""
-            if isinstance(cmd, str) and _looks_host_local_command(cmd):
-                unreachable.append((name, cmd))
+        merged += 1
     agent_data["mcpServers"] = agent_servers
 
     try:
@@ -495,7 +527,7 @@ def sync_host_mcp_servers(
         os.replace(tmp, agent_path)
     except OSError:
         return 0, []
-    return len(host_servers), unreachable
+    return merged, unreachable
 
 
 def sync_host_plugins(host_home: Path, agent_home: Path) -> str:
@@ -660,12 +692,15 @@ def sync_host_gemini_mcp_servers(
 
     merged_servers = dict(agent_data.get("mcpServers") or {})
     unreachable: list[tuple[str, str]] = []
+    merged = 0
     for name, cfg in host_servers.items():
+        token = _host_local_token(cfg)
+        if token is not None:
+            # PUF-34: skip a host-only server rather than inject dead config.
+            unreachable.append((name, token))
+            continue
         merged_servers[name] = cfg
-        if isinstance(cfg, dict):
-            cmd = cfg.get("command") or ""
-            if isinstance(cmd, str) and _looks_host_local_command(cmd):
-                unreachable.append((name, cmd))
+        merged += 1
 
     if extra_servers:
         for name, cfg in extra_servers.items():
@@ -680,7 +715,7 @@ def sync_host_gemini_mcp_servers(
         os.replace(tmp, agent_path)
     except OSError:
         return 0, []
-    return len(host_servers), unreachable
+    return merged, unreachable
 
 
 def daemon_yml_path() -> Path:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -466,8 +466,7 @@ def _host_local_token(cfg: dict) -> str | None:
     if isinstance(cmd, str) and _looks_host_local_command(cmd):
         return cmd
     for arg in cfg.get("args") or []:
-        # /tmp exists in the container, so a /tmp arg (log/db output path)
-        # is fine even though a /tmp *binary* is host-staged.
+        # /tmp exists in the container: a /tmp arg is a valid output path.
         if (
             isinstance(arg, str)
             and not arg.startswith("/tmp/")
@@ -515,8 +514,6 @@ def sync_host_mcp_servers(
     for name, cfg in host_servers.items():
         token = _host_local_token(cfg)
         if token is not None:
-            # Skip rather than inject a dead server config; the caller
-            # logs an actionable warning off ``unreachable``.
             unreachable.append((name, token))
             continue
         agent_servers[name] = cfg

--- a/tests/test_host_sync.py
+++ b/tests/test_host_sync.py
@@ -263,9 +263,9 @@ def test_sync_host_mcp_host_wins_on_collision(tmp_path):
 
 
 def test_sync_host_mcp_skips_host_local_and_flags_them(tmp_path):
-    """PUF-34: host-local servers (incl. macOS paths + host paths hidden in
-    args) are SKIPPED rather than injected as dead config, and reported in
-    ``unreachable``. Container-resolvable ones are still merged."""
+    """Host-local servers (incl. macOS paths + host paths hidden in args)
+    are skipped rather than injected as dead config, and reported in
+    ``unreachable``; container-resolvable ones still merge."""
     host = tmp_path / "host"
     agent = tmp_path / "agent"
     _write_json(host / ".claude.json", {
@@ -298,8 +298,8 @@ def test_sync_host_mcp_skips_host_local_and_flags_them(tmp_path):
 
 
 def test_sync_host_gemini_mcp_skips_host_local_but_keeps_extra(tmp_path):
-    """PUF-34 sweep: the gemini sibling skips host-local servers too, while
-    still injecting the always-on ``extra_servers`` (the puffo entry)."""
+    """The gemini sibling skips host-local servers too, while still
+    injecting the always-on ``extra_servers``."""
     host = tmp_path / "host"
     project = tmp_path / "proj"
     _write_json(host / ".gemini" / "settings.json", {
@@ -613,7 +613,6 @@ def test_looks_host_local_command_flags_host_paths():
         "/home/bob/.local/bin/mcp",
         "/tmp/adhoc-server",
         "/var/folders/xy/T/mcp-12345",
-        # PUF-34: macOS host-only prefixes.
         "/opt/homebrew/bin/mcp",
         "/opt/local/bin/mcp",
         "/Volumes/ext-ssd/tools/mcp",
@@ -626,8 +625,8 @@ def test_looks_host_local_command_flags_host_paths():
 
 
 def test_looks_host_local_command_opt_container_pkg_not_flagged():
-    """The new /opt/homebrew + /opt/local prefixes must NOT swallow the
-    container's own /opt/puffoagent-pkg install path."""
+    """/opt/homebrew + /opt/local must not swallow the container's own
+    /opt/puffoagent-pkg install path."""
     assert not _looks_host_local_command(
         "/opt/puffoagent-pkg/puffoagent/mcp/puffo_core_server.py"
     )
@@ -646,6 +645,12 @@ def test_host_local_token_scans_command_and_args():
     assert _host_local_token(
         {"command": "npx", "args": ["-y", "@scope/pkg"]}
     ) is None
+    # /tmp args are container-valid output paths, not host binaries.
+    assert _host_local_token(
+        {"command": "npx", "args": ["--log", "/tmp/mcp.log"]}
+    ) is None
+    # ...but a /tmp *command* is still a host-staged binary.
+    assert _host_local_token({"command": "/tmp/adhoc-server", "args": []}) == "/tmp/adhoc-server"
     # Non-dict / missing fields tolerated.
     assert _host_local_token({}) is None
     assert _host_local_token("not-a-dict") is None
@@ -900,6 +905,5 @@ def test_sync_host_gemini_mcp_servers_flags_host_local_commands(tmp_path):
     agent = tmp_path / "agent"
 
     n, unreachable = sync_host_gemini_mcp_servers(host, agent)
-    # PUF-34: host-local "local" is skipped, only "image" merges.
-    assert n == 1
+    assert n == 1  # host-local "local" skipped, only "image" merges
     assert [name for name, _ in unreachable] == ["local"]

--- a/tests/test_host_sync.py
+++ b/tests/test_host_sync.py
@@ -283,17 +283,13 @@ def test_sync_host_mcp_skips_host_local_and_flags_them(tmp_path):
 
     merged, unreachable = sync_host_mcp_servers(host, agent)
 
-    # Only the 3 container-resolvable servers are merged.
     assert merged == 3
     flagged_names = sorted(name for name, _ in unreachable)
     assert flagged_names == [
         "brew-local", "linux-home", "mac-local", "volume-arg", "windows",
     ]
-    # The dead host-local configs are NOT written into the agent file.
     written = json.loads((agent / ".claude.json").read_text(encoding="utf-8"))
     assert sorted(written["mcpServers"]) == ["bare-ok", "container-ok", "sys-ok"]
-    # The offending token (arg, not the bare command) is reported for the
-    # args-hidden case so the warning is actionable.
     assert dict(unreachable)["volume-arg"] == "/Volumes/tools/mcp"
 
 
@@ -633,11 +629,9 @@ def test_looks_host_local_command_opt_container_pkg_not_flagged():
 
 
 def test_host_local_token_scans_command_and_args():
-    # Host-local via the command.
     assert _host_local_token(
         {"command": "/opt/homebrew/bin/mcp", "args": []}
     ) == "/opt/homebrew/bin/mcp"
-    # Host-local hidden in an arg behind a bare launcher.
     assert _host_local_token(
         {"command": "uvx", "args": ["--from", "/Volumes/tools/mcp", "run"]}
     ) == "/Volumes/tools/mcp"
@@ -645,13 +639,10 @@ def test_host_local_token_scans_command_and_args():
     assert _host_local_token(
         {"command": "npx", "args": ["-y", "@scope/pkg"]}
     ) is None
-    # /tmp args are container-valid output paths, not host binaries.
     assert _host_local_token(
         {"command": "npx", "args": ["--log", "/tmp/mcp.log"]}
     ) is None
-    # ...but a /tmp *command* is still a host-staged binary.
     assert _host_local_token({"command": "/tmp/adhoc-server", "args": []}) == "/tmp/adhoc-server"
-    # Non-dict / missing fields tolerated.
     assert _host_local_token({}) is None
     assert _host_local_token("not-a-dict") is None
 
@@ -907,3 +898,61 @@ def test_sync_host_gemini_mcp_servers_flags_host_local_commands(tmp_path):
     n, unreachable = sync_host_gemini_mcp_servers(host, agent)
     assert n == 1  # host-local "local" skipped, only "image" merges
     assert [name for name, _ in unreachable] == ["local"]
+
+
+def test_sync_host_mcp_corrupt_host_file_is_noop(tmp_path):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    (host).mkdir(parents=True)
+    (host / ".claude.json").write_text("{not json", encoding="utf-8")
+
+    assert sync_host_mcp_servers(host, agent) == (0, [])
+    assert not (agent / ".claude.json").exists()
+
+
+def test_sync_host_mcp_corrupt_agent_file_still_merges(tmp_path):
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_json(host / ".claude.json", {
+        "mcpServers": {"ok": {"command": "npx", "args": []}},
+    })
+    (agent).mkdir(parents=True)
+    (agent / ".claude.json").write_text("{not json", encoding="utf-8")
+
+    merged, unreachable = sync_host_mcp_servers(host, agent)
+
+    assert (merged, unreachable) == (1, [])
+    written = json.loads((agent / ".claude.json").read_text(encoding="utf-8"))
+    assert "ok" in written["mcpServers"]
+
+
+def test_sync_host_mcp_write_failure_returns_zero(tmp_path, monkeypatch):
+    import puffo_agent.portal.state as state_mod
+
+    host = tmp_path / "host"
+    agent = tmp_path / "agent"
+    _write_json(host / ".claude.json", {
+        "mcpServers": {"ok": {"command": "npx", "args": []}},
+    })
+    monkeypatch.setattr(
+        state_mod.os, "replace",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    assert sync_host_mcp_servers(host, agent) == (0, [])
+
+
+def test_sync_host_gemini_mcp_write_failure_returns_zero(tmp_path, monkeypatch):
+    import puffo_agent.portal.state as state_mod
+
+    host = tmp_path / "host"
+    project = tmp_path / "proj"
+    _write_json(host / ".gemini" / "settings.json", {
+        "mcpServers": {"ok": {"command": "npx", "args": []}},
+    })
+    monkeypatch.setattr(
+        state_mod.os, "replace",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    assert sync_host_gemini_mcp_servers(host, project) == (0, [])

--- a/tests/test_host_sync.py
+++ b/tests/test_host_sync.py
@@ -27,6 +27,7 @@ import pytest
 from puffo_agent.portal.state import (
     AGENT_INSTALLED_MARKER,
     HOST_SYNCED_MARKER,
+    _host_local_token,
     _looks_host_local_command,
     sync_host_enabled_plugins,
     sync_host_gemini_mcp_servers,
@@ -261,13 +262,18 @@ def test_sync_host_mcp_host_wins_on_collision(tmp_path):
     assert data["mcpServers"]["shared"]["args"] == ["host-version"]
 
 
-def test_sync_host_mcp_flags_unreachable_command_paths(tmp_path):
+def test_sync_host_mcp_skips_host_local_and_flags_them(tmp_path):
+    """PUF-34: host-local servers (incl. macOS paths + host paths hidden in
+    args) are SKIPPED rather than injected as dead config, and reported in
+    ``unreachable``. Container-resolvable ones are still merged."""
     host = tmp_path / "host"
     agent = tmp_path / "agent"
     _write_json(host / ".claude.json", {
         "mcpServers": {
             "bare-ok": {"command": "npx", "args": []},
             "mac-local": {"command": "/Users/alice/bin/mcp", "args": []},
+            "brew-local": {"command": "/opt/homebrew/bin/mcp", "args": []},
+            "volume-arg": {"command": "uvx", "args": ["/Volumes/tools/mcp"]},
             "linux-home": {"command": "/home/bob/mcp", "args": []},
             "windows": {"command": r"C:\Users\bob\mcp.exe", "args": []},
             "container-ok": {"command": "/home/agent/.local/bin/mcp", "args": []},
@@ -277,9 +283,42 @@ def test_sync_host_mcp_flags_unreachable_command_paths(tmp_path):
 
     merged, unreachable = sync_host_mcp_servers(host, agent)
 
-    assert merged == 6
+    # Only the 3 container-resolvable servers are merged.
+    assert merged == 3
     flagged_names = sorted(name for name, _ in unreachable)
-    assert flagged_names == ["linux-home", "mac-local", "windows"]
+    assert flagged_names == [
+        "brew-local", "linux-home", "mac-local", "volume-arg", "windows",
+    ]
+    # The dead host-local configs are NOT written into the agent file.
+    written = json.loads((agent / ".claude.json").read_text(encoding="utf-8"))
+    assert sorted(written["mcpServers"]) == ["bare-ok", "container-ok", "sys-ok"]
+    # The offending token (arg, not the bare command) is reported for the
+    # args-hidden case so the warning is actionable.
+    assert dict(unreachable)["volume-arg"] == "/Volumes/tools/mcp"
+
+
+def test_sync_host_gemini_mcp_skips_host_local_but_keeps_extra(tmp_path):
+    """PUF-34 sweep: the gemini sibling skips host-local servers too, while
+    still injecting the always-on ``extra_servers`` (the puffo entry)."""
+    host = tmp_path / "host"
+    project = tmp_path / "proj"
+    _write_json(host / ".gemini" / "settings.json", {
+        "mcpServers": {
+            "brew-local": {"command": "/opt/homebrew/bin/mcp", "args": []},
+            "ok": {"command": "npx", "args": []},
+        },
+    })
+
+    merged, unreachable = sync_host_gemini_mcp_servers(
+        host, project, extra_servers={"puffo": {"command": "python3"}},
+    )
+
+    assert merged == 1  # only "ok" merged; brew-local skipped
+    assert sorted(n for n, _ in unreachable) == ["brew-local"]
+    written = json.loads(
+        (project / ".gemini" / "settings.json").read_text(encoding="utf-8")
+    )
+    assert sorted(written["mcpServers"]) == ["ok", "puffo"]  # extra always present
 
 
 def test_sync_host_mcp_no_host_file_is_noop(tmp_path):
@@ -574,11 +613,42 @@ def test_looks_host_local_command_flags_host_paths():
         "/home/bob/.local/bin/mcp",
         "/tmp/adhoc-server",
         "/var/folders/xy/T/mcp-12345",
+        # PUF-34: macOS host-only prefixes.
+        "/opt/homebrew/bin/mcp",
+        "/opt/local/bin/mcp",
+        "/Volumes/ext-ssd/tools/mcp",
+        "/private/tmp/mcp",
         r"C:\Users\bob\mcp.exe",
         r"D:\apps\mcp.exe",
         "node C:\\stuff\\x.js",  # any backslash anywhere
     ):
         assert _looks_host_local_command(cmd), f"expected flagged: {cmd!r}"
+
+
+def test_looks_host_local_command_opt_container_pkg_not_flagged():
+    """The new /opt/homebrew + /opt/local prefixes must NOT swallow the
+    container's own /opt/puffoagent-pkg install path."""
+    assert not _looks_host_local_command(
+        "/opt/puffoagent-pkg/puffoagent/mcp/puffo_core_server.py"
+    )
+
+
+def test_host_local_token_scans_command_and_args():
+    # Host-local via the command.
+    assert _host_local_token(
+        {"command": "/opt/homebrew/bin/mcp", "args": []}
+    ) == "/opt/homebrew/bin/mcp"
+    # Host-local hidden in an arg behind a bare launcher.
+    assert _host_local_token(
+        {"command": "uvx", "args": ["--from", "/Volumes/tools/mcp", "run"]}
+    ) == "/Volumes/tools/mcp"
+    # Fully container-resolvable → None.
+    assert _host_local_token(
+        {"command": "npx", "args": ["-y", "@scope/pkg"]}
+    ) is None
+    # Non-dict / missing fields tolerated.
+    assert _host_local_token({}) is None
+    assert _host_local_token("not-a-dict") is None
 
 
 def test_looks_host_local_command_empty_is_not_flagged():
@@ -830,5 +900,6 @@ def test_sync_host_gemini_mcp_servers_flags_host_local_commands(tmp_path):
     agent = tmp_path / "agent"
 
     n, unreachable = sync_host_gemini_mcp_servers(host, agent)
-    assert n == 2
+    # PUF-34: host-local "local" is skipped, only "image" merges.
+    assert n == 1
     assert [name for name, _ in unreachable] == ["local"]


### PR DESCRIPTION
## Summary

Per Han's ticket (Linear PUF-34): cli-docker's host-local MCP detection missed macOS host paths (`/opt/homebrew`, `/opt/local`, `/Volumes`, `/private`) AND host paths hidden behind a bare `npx` / `uvx` command in `args`, so it silently injected dead server configs that failed on first use in the container.

**Fix (3 pieces)**:
1. `_HOST_LOCAL_COMMAND_PREFIXES` gains the four macOS host-only roots. Kept specific: the container's own `/opt/puffoagent-pkg` still resolves; only the actual host trees are captured.
2. New `_host_local_token(cfg)` scans `cfg["args"]` as well as `cfg["command"]`, so a hidden path like `uvx /Volumes/tools/mcp` is caught. Returns the specific offending token for actionable warnings.
3. `sync_host_mcp_servers` + `sync_host_gemini_mcp_servers` now **SKIP** a host-local server (report it in `unreachable`) instead of injecting dead config. `merged_count` reflects only what actually merged. Docker adapter warnings reworded from "will fail on first use" to "SKIPPED (not injected)".

Container-resolvable paths keep working: `/home/agent/.local/bin/mcp`, `/usr/local/bin/node`, bare commands like `npx` — all still merge.

## Test plan

- [x] `test_host_sync.py` — **42/42 pass** (2 new: skip-host-local-in-mcp-servers with mixed set covering all new + existing prefixes + args hiding; gemini sibling sweep with `extra_servers` preserved).
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1827 pass / 5 fail**, failure set byte-identical to `origin/main` (`diff /tmp/puf34-main-fails.txt /tmp/puf34-pr-fails.txt` clean). **Zero regression.**
- [x] Pre-existing tests updated for the behavior change ("inject-all" → "inject-container-resolvable-only"); all still green.
- [ ] Post-merge external-verify on Mac + Docker: an operator with a Homebrew-installed MCP server on host should see it SKIPPED with the actionable warning instead of injected as dead config.

## Known limits / non-blocker notes

- `/home/<other-user>/` paths (Linux host without container agent-user) are NOT detected as host-local — pre-existing behavior, out of scope. The container's `/home/agent/` is where MCP-lookup happens; other Linux `/home/<user>/` paths would still inject dead. If that surfaces, worth a separate follow-up.
- Windows host paths (`C:\Users\...`) fall through as container-ok (Unix-only detection). Cross-platform host support would be a bigger substrate change.
- macOS + Docker e2e verification is Mac-side; Linux-side pure-logic tests cover the string handling completely.

Family: PUF-34 done (1 of 4 in the cli-docker Sentiment migration family). Sequence: PUF-34 → PUF-36 → PUF-35 → PUF-33 per Calculation's ordering.

Ticket: PUF-34 (Linear PUF-34, Han-authored)