### PR TITLE
fix(reply): DM fallback replies top-level (render inline), not threaded

### DIFF
--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -4169,7 +4169,12 @@ class PuffoCoreMessageClient:
             space_id=send_space_id,
             channel_id=send_channel_id,
             recipient_slug=recipient_slug,
-            thread_root_id=root_id if root_id else None,
+            # DM fallback replies go top-level so they render inline in the
+            # linear DM conversation. Threading a DM reply under the incoming
+            # message buries it behind a "N replies" thread badge in the main
+            # view — the human never sees the answer inline and it reads as the
+            # agent going silent. Channels keep threading (root_id) as before.
+            thread_root_id=(None if envelope_kind == "dm" else (root_id or None)),
             content_type="text/plain",
             content=text,
             recipients=devices,

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -603,7 +603,9 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             # Only truthy thread keys ride the body. F4: drop the raw parent
             # ref when root validation wiped the thread — no dangling
             # reply_to for a root the send no longer threads under.
-            if resolved_root:
+            # DMs are linear: never thread a DM reply ('@slug'), or it hides
+            # behind an "N replies" badge in the main view instead of inline.
+            if resolved_root and not channel_ref.startswith("@"):
                 body["thread_root_id"] = resolved_root
                 if root_id:
                     body["reply_to_id"] = root_id


### PR DESCRIPTION
> **For @Glimmer0x** — a small mergeable fix + a bigger runtime issue it surfaced. cloud-agent context: the create→config→chat→space→reply plumbing landed on puffo-server `dev` (PRs #197/#198/#199/#201); this is the remaining reply-quality work, which is in `puffo-agent`.

## Part 1 — what this PR changes (reviewable / mergeable)
Two one-line fixes so **DM replies render inline** instead of hiding behind an "N replies" thread badge. Both target the same thing: the reply paths thread DM replies via `root_id` — correct for a channel, wrong for a linear DM.

1. **Fallback path** — `agent/puffo_core_client.py::send_fallback_message`: `thread_root_id = None` for DMs (`envelope_kind == "dm"`); channels keep `root_id`.
2. **`send_message` MCP tool** — `mcp/puffo_core_tools.py::send_message` (keyless path): skip `thread_root_id` when the target is a DM (`'@slug'`).

Verified live on a cloud agent (hot-patched sandbox `icq7r5ccfd…`): channel threading unchanged; DM sends go top-level.

## Part 2 — the bigger issue this surfaced (NOT fixed here — your call)
While debugging we found the fat cloud agent (`chat-local` + LiteLLM) **never actually invokes `send_message`** — the model writes the call as **text**, so `core.py`'s turn router (path 3c) posts the raw assistant text via the fallback:
```
[WARNING] agent.core: … [fallback] [ch_…] @shan-moon-8a1d:
          agent skipped both send_message and [SILENT] markers; posting 1-frame fallback
```
Every turn: `POST litellm-staging/v1/messages → 200 OK`, but **no `tool_use` emitted**.

**Two downstream effects, one cause:**
1. **Tool-call leak** — the fallback posts the assistant text verbatim, so `send_message(channel="…", text="…", root_id="…", visibility_level="human")` shows as visible text before every reply.
2. **Wrong visibility/threading defaults** — replies take the *fallback* policy (`resolve_visibility("default", …)`, `thread_root_id=root_id`), ignoring the model's intended `visibility_level="human"`. The Part-1 fixes are a **stopgap**; the real fix is getting the tool invoked (path 3a).

**To check (chat-local + LiteLLM tool-use path):**
- Is `send_message` exposed as an **invokable tool** in `chat-local`, or only described in the prompt? (`mcp/config.py:28`, `mcp/puffo_core_tools.py:517`, `portal/ws_local/tool_dispatch.py:23`, `portal/ws_local/session.py:173`)
- Does the **LiteLLM request carry `tools`**, and does the runtime **parse `tool_use`** from the Anthropic response?
- Did the assembled system prompt start documenting the call signature inline? (leak worsened right after a `profile.md` push)

**Ask:** make the agent invoke `send_message` via `tool_use` → removes the leak, honors `visibility_level`, lets the agent control DM threading. Fallback stays a safety net, not the default path.

## Env / repro
Agent `agent-0f1c98c89acdd0d8f4fe259f428b6433` ("Sophia"), sandbox `icq7r5ccfdtqli2gujthm`, template `puffo-agent-fat-beta` @ puffo-agent `17c6ead`, `chat-local` / `claude-opus-4-8` via litellm-staging. Repro: create a fat-beta cloud agent with any persona, DM or @-it, observe the raw `send_message(...)` text + `posting 1-frame fallback` in the log.

## Secondary (flag only, non-blocking)
Every turn logs `status_reporter: begin_turn/end_turn errored (identity not found: agent-0f1c98c89…)`. Send still succeeds; noting in case it's a related missing-registration.

*(A separate issue — the DM reply not rendering in the human's **web** session, `kind=dm` sends fine but doesn't reach the web device — is a client/relay handoff for Han, not this PR.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
