### PR TITLE
cloud-agent: make chat-local tool-capable (send_message via tool_use, not text) — HELD

### DIFF
--- a/src/puffo_agent/agent/adapters/chat_only.py
+++ b/src/puffo_agent/agent/adapters/chat_only.py
@@ -1,30 +1,227 @@
 """Chat-only adapter.
 
 Wraps the message-completion providers (Anthropic/OpenAI) so existing
-agents keep working without the SDK or CLI runtimes. Does not run
-tools, does not touch the filesystem, ignores workspace/claude dirs.
+agents keep working without the SDK or CLI runtimes. Does not touch
+the filesystem and ignores workspace/claude dirs, but can run the
+puffo_core send tools when the worker injects ``tool_dispatch`` and
+the provider supports structured tool use (AnthropicProvider) — the
+model's ``send_message(...)`` then posts for real instead of leaking
+as plain text through the core turn-router's fallback.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from .base import Adapter, TurnContext, TurnResult
+
+logger = logging.getLogger(__name__)
+
+# Ceiling on one in-turn tool execution; a hung network call surfaces
+# as an is_error tool_result instead of wedging the turn thread.
+_TOOL_CALL_TIMEOUT_SECONDS = 120.0
+
+# Tool names whose successful call means "the reply was posted via
+# puffo_core" — the core turn-router skips its raw-text fallback when
+# metadata carries a target for one of these.
+_SEND_TOOL_NAMES = ("send_message", "send_message_with_attachments")
+
+# Anthropic tool schemas for the puffo_core send tools, mirroring the
+# ``mcp.puffo_core_tools`` handler signatures + docstrings. Only tools
+# present in the injected dispatch are advertised to the model.
+CHAT_TOOL_SCHEMAS: dict[str, dict] = {
+    "send_message": {
+        "name": "send_message",
+        "description": (
+            "Post a message to a Puffo.ai channel or DM a user. This is "
+            "how you reply — call it instead of writing the reply as "
+            "plain text. channel: '@<slug>' for a DM (e.g. '@alice-1234') "
+            "or a raw channel id (e.g. 'ch_<uuid>'); '#name' shortcuts "
+            "are not supported."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": (
+                        "'@<slug>' for a DM, or a raw channel id "
+                        "('ch_<uuid>')."
+                    ),
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message body. Markdown preserved verbatim.",
+                },
+                "root_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional — reply inside a thread; pass the "
+                        "envelope_id of the message you're replying to."
+                    ),
+                },
+                "visibility_level": {
+                    "type": "string",
+                    "enum": ["human", "default", "agent_only"],
+                    "description": (
+                        "'human' for anything a person should read, "
+                        "'default' for agent-to-agent chatter (folded in "
+                        "human clients), 'agent_only' to skip the "
+                        "DM/@-mention visibility safety net."
+                    ),
+                },
+            },
+            "required": ["channel", "text"],
+        },
+    },
+    "send_message_with_attachments": {
+        "name": "send_message_with_attachments",
+        "description": (
+            "Send a message carrying one or more workspace files to a "
+            "channel or DM. All files ride in a single envelope."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Workspace-relative file paths. '..' and absolute "
+                        "paths are rejected."
+                    ),
+                },
+                "channel": {
+                    "type": "string",
+                    "description": (
+                        "Same syntax as send_message ('@<slug>' or a raw "
+                        "channel id)."
+                    ),
+                },
+                "caption": {
+                    "type": "string",
+                    "description": "Optional text alongside the files.",
+                },
+                "root_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional thread reply, same semantics as "
+                        "send_message's root_id."
+                    ),
+                },
+                "visibility_level": {
+                    "type": "string",
+                    "enum": ["human", "default", "agent_only"],
+                    "description": "Same semantics as send_message.",
+                },
+            },
+            "required": ["paths", "channel"],
+        },
+    },
+}
 
 
 class ChatOnlyAdapter(Adapter):
     def __init__(self, provider):
-        # ``provider`` exposes blocking
-        # ``complete(system_prompt, messages) -> (str, int, int)``.
+        # ``provider`` exposes blocking ``complete(...)``. Legacy
+        # providers (OpenAI) return ``(str, int, int)``; tool-capable
+        # providers (AnthropicProvider, ``supports_tools = True``)
+        # accept ``tools``/``dispatch`` kwargs and return a
+        # ``CompletionResult``.
         self._provider = provider
+        # ``{tool_name: async handler}`` injected by worker.py when
+        # the agent has a puffo_core block. None → legacy text-only
+        # turns, byte-identical to the pre-tool behavior.
+        self.tool_dispatch: dict | None = None
 
     async def run_turn(self, ctx: TurnContext) -> TurnResult:
-        reply, input_tokens, output_tokens = await asyncio.to_thread(
-            self._provider.complete, ctx.system_prompt, ctx.messages,
-        )
+        tools = self._advertised_tools()
+        if tools:
+            dispatch = self._make_dispatch(asyncio.get_running_loop())
+            result = await asyncio.to_thread(
+                self._provider.complete,
+                ctx.system_prompt,
+                ctx.messages,
+                tools,
+                dispatch,
+            )
+        else:
+            result = await asyncio.to_thread(
+                self._provider.complete, ctx.system_prompt, ctx.messages,
+            )
+
+        # Legacy provider shape (OpenAI, or a test double): plain
+        # 3-tuple, no tool metadata — unchanged behavior.
+        if isinstance(result, tuple):
+            reply, input_tokens, output_tokens = result
+            return TurnResult(
+                reply=reply,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                tool_calls=0,
+            )
+
+        # CompletionResult: mirror SDKAdapter's metadata contract so
+        # the core turn-router (core.py reply routing) recognizes a
+        # send_message call and skips the raw-text fallback.
+        tool_names_used: list[str] = []
+        send_message_targets: list[dict] = []
+        for call in result.tool_calls:
+            name = call.get("name", "")
+            tool_names_used.append(name)
+            if name in _SEND_TOOL_NAMES and not call.get("is_error"):
+                tool_input = call.get("input") or {}
+                send_message_targets.append({
+                    "channel": str(tool_input.get("channel", "")),
+                    "root_id": str(tool_input.get("root_id", "")),
+                })
         return TurnResult(
-            reply=reply,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            tool_calls=0,
+            reply=result.reply_text,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            tool_calls=len(result.tool_calls),
+            metadata={
+                "tool_names": tool_names_used,
+                "send_message_targets": send_message_targets,
+                "assistant_text_parts": list(result.assistant_text_parts),
+            },
         )
+
+    def _advertised_tools(self) -> list[dict] | None:
+        """Anthropic tool schemas to advertise this turn, or None when
+        the turn should stay a plain completion (no dispatch injected,
+        or the provider can't do structured tool use)."""
+        if not self.tool_dispatch:
+            return None
+        if not getattr(self._provider, "supports_tools", False):
+            return None
+        tools = [
+            CHAT_TOOL_SCHEMAS[name]
+            for name in CHAT_TOOL_SCHEMAS
+            if name in self.tool_dispatch
+        ]
+        return tools or None
+
+    def _make_dispatch(self, loop: asyncio.AbstractEventLoop):
+        """Blocking ``dispatch(name, input) -> str`` for the provider's
+        agentic loop. ``complete()`` runs in a worker thread (via
+        ``asyncio.to_thread``), so the async puffo_core handlers are
+        scheduled back onto the daemon event loop and awaited from the
+        thread. Exceptions propagate to the provider, which feeds them
+        back to the model as ``is_error`` tool_results.
+        """
+        handlers = dict(self.tool_dispatch or {})
+
+        def dispatch(tool_name: str, tool_input: dict) -> str:
+            handler = handlers.get(tool_name)
+            if handler is None:
+                raise RuntimeError(
+                    f"tool {tool_name!r} is not available on this agent"
+                )
+            future = asyncio.run_coroutine_threadsafe(
+                handler(**tool_input), loop,
+            )
+            return str(future.result(timeout=_TOOL_CALL_TIMEOUT_SECONDS))
+
+        return dispatch

--- a/src/puffo_agent/agent/providers/anthropic_provider.py
+++ b/src/puffo_agent/agent/providers/anthropic_provider.py
@@ -1,7 +1,41 @@
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
 import anthropic
 
 
+@dataclass
+class CompletionResult:
+    """Rich result of one ``AnthropicProvider.complete()`` call.
+
+    ``tool_calls`` records every executed ``tool_use`` block as
+    ``{"name", "input", "is_error"}`` in execution order;
+    ``assistant_text_parts`` keeps the raw text blocks so the
+    chat-only adapter can mirror SDKAdapter's metadata contract.
+    """
+
+    reply_text: str
+    input_tokens: int
+    output_tokens: int
+    tool_calls: list[dict] = field(default_factory=list)
+    assistant_text_parts: list[str] = field(default_factory=list)
+
+
+# ``dispatch(tool_name, tool_input) -> str`` — blocking callback that
+# executes one tool call and returns its textual result. Raising maps
+# to an ``is_error`` tool_result so the model can recover in-loop.
+ToolDispatch = Callable[[str, dict], str]
+
+
 class AnthropicProvider:
+    # Marker read by ChatOnlyAdapter: this provider accepts the
+    # ``tools``/``dispatch`` kwargs and returns a CompletionResult.
+    supports_tools = True
+
+    # Hard cap on model→tool round-trips per turn so a pathological
+    # tool loop can't spin forever against the API.
+    MAX_TOOL_ITERATIONS = 8
+
     def __init__(self, api_key: str, model: str, base_url: str | None = None):
         # ``base_url`` routes completions through a proxy (e.g. a LiteLLM
         # virtual-key endpoint) instead of api.anthropic.com. Passed to
@@ -13,14 +47,89 @@ class AnthropicProvider:
             self.client = anthropic.Anthropic(api_key=api_key)
         self.model = model
 
-    def complete(self, system_prompt: str, messages: list[dict]) -> tuple[str, int, int]:
-        """Returns (reply_text, input_tokens, output_tokens)."""
-        response = self.client.messages.create(
-            model=self.model,
-            max_tokens=2048,
-            system=system_prompt,
-            messages=messages,
+    def complete(
+        self,
+        system_prompt: str,
+        messages: list[dict],
+        tools: Optional[list[dict]] = None,
+        dispatch: Optional[ToolDispatch] = None,
+    ) -> CompletionResult:
+        """Run one turn, executing structured tool calls in-loop.
+
+        With ``tools`` set, the request advertises them and the loop
+        re-calls the API while ``stop_reason == "tool_use"``: each
+        ``tool_use`` block is executed via ``dispatch`` and fed back
+        as a ``tool_result``. Without ``tools`` this is a single
+        plain completion (legacy chat-local behavior).
+        """
+        convo = [dict(m) for m in messages]
+        request_kwargs: dict = {}
+        if tools:
+            request_kwargs["tools"] = tools
+
+        total_input = 0
+        total_output = 0
+        text_parts: list[str] = []
+        executed_calls: list[dict] = []
+
+        for _ in range(self.MAX_TOOL_ITERATIONS):
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=2048,
+                system=system_prompt,
+                messages=convo,
+                **request_kwargs,
+            )
+            total_input += response.usage.input_tokens
+            total_output += response.usage.output_tokens
+
+            # Iterate blocks by type — never blind-index [0].text: a
+            # tool_use (or future block type) first would crash/mislead.
+            tool_use_blocks = []
+            for block in response.content:
+                block_type = getattr(block, "type", "")
+                if block_type == "text":
+                    text_parts.append(block.text)
+                elif block_type == "tool_use":
+                    tool_use_blocks.append(block)
+
+            if (
+                response.stop_reason != "tool_use"
+                or not tool_use_blocks
+                or dispatch is None
+            ):
+                break
+
+            # Echo the assistant turn (tool_use blocks included), then
+            # answer every tool_use with a matching tool_result.
+            convo.append({"role": "assistant", "content": response.content})
+            tool_results: list[dict] = []
+            for block in tool_use_blocks:
+                tool_input = dict(block.input or {})
+                try:
+                    output = str(dispatch(block.name, tool_input))
+                    is_error = False
+                except Exception as exc:  # noqa: BLE001 — feed back to model
+                    output = f"{type(exc).__name__}: {exc}"
+                    is_error = True
+                executed_calls.append({
+                    "name": block.name,
+                    "input": tool_input,
+                    "is_error": is_error,
+                })
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": output,
+                    "is_error": is_error,
+                })
+            convo.append({"role": "user", "content": tool_results})
+
+        reply_text = "\n".join(p for p in text_parts if p).strip()
+        return CompletionResult(
+            reply_text=reply_text,
+            input_tokens=total_input,
+            output_tokens=total_output,
+            tool_calls=executed_calls,
+            assistant_text_parts=text_parts,
         )
-        input_tokens = response.usage.input_tokens
-        output_tokens = response.usage.output_tokens
-        return response.content[0].text, input_tokens, output_tokens

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -107,6 +107,11 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
     if kind == "chat-local":
         from ..agent.adapters.chat_only import ChatOnlyAdapter
         provider = _build_legacy_provider(daemon_cfg, agent_cfg.runtime)
+        # Tool wiring is deferred: the in-process puffo_core dispatch
+        # needs the live message client, which Worker._run() builds
+        # after this adapter — it injects ``adapter.tool_dispatch``
+        # there via _build_chat_local_tool_dispatch(). Mirrors how
+        # sdk-local wires its MCP tools below, minus the subprocess.
         return ChatOnlyAdapter(provider)
 
     if kind == "sdk-local":
@@ -322,6 +327,38 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
         return OpenAIProvider(api_key=api_key, model=model, base_url=base_url)
 
     raise RuntimeError(f"unknown provider {provider_name!r}")
+
+
+def _build_chat_local_tool_dispatch(client) -> dict:
+    """In-process puffo_core tool dispatch for the chat-local adapter.
+
+    Mirrors ``ws_local.route._build_tool_dispatch``: the same
+    PuffoCoreToolsConfig wired off the live message client, narrowed
+    to the send tools the chat-local provider advertises as Anthropic
+    tool schemas. Without this executor, the model's ``tool_use``
+    blocks would parse but never post.
+    """
+    from ..mcp.puffo_core_tools import PuffoCoreToolsConfig
+    from .ws_local.in_process_data_client import InProcessDataClient
+    from .ws_local.tool_dispatch import build_dispatch
+
+    cfg = PuffoCoreToolsConfig(
+        slug=client.slug,
+        device_id=client.device_id,
+        keystore=client.keystore,
+        http_client=client.http,
+        data_client=InProcessDataClient(client.store, client),
+        space_id=getattr(client, "space_id", None),
+        workspace=getattr(client, "workspace", None),
+        message_client=client,
+        # T23: only the daemon-owned bridge WS may drive keyless sends;
+        # None on native agents keeps the signed-crypto path.
+        bridge_client=getattr(client, "_bridge", None),
+    )
+    return build_dispatch(
+        cfg,
+        allowed=frozenset({"send_message", "send_message_with_attachments"}),
+    )
 
 
 def _puffo_cli_keystore_dir() -> Path:
@@ -1153,6 +1190,16 @@ class Worker:
                 self.agent_cfg, agent_id, daemon_cfg=self.daemon_cfg,
             )
             self._client = client
+
+            # chat-local: now that the message client exists, inject
+            # the in-process puffo_core send-tool dispatch so the
+            # model's structured send_message calls post for real
+            # (the counterpart of sdk-local's mcp_servers_override).
+            from ..agent.adapters.chat_only import ChatOnlyAdapter
+            if isinstance(self._adapter, ChatOnlyAdapter):
+                self._adapter.tool_dispatch = (
+                    _build_chat_local_tool_dispatch(client)
+                )
         except Exception as e:
             logger.error("agent %s: failed to initialise: %s", agent_id, e, exc_info=True)
             self.runtime.status = "error"

--- a/tests/test_chat_local_tool_use.py
+++ b/tests/test_chat_local_tool_use.py
@@ -1,0 +1,250 @@
+"""chat-local structured tool use (AnthropicProvider + ChatOnlyAdapter).
+
+The fat cloud agent on ``runtime.kind: chat-local`` must emit
+``send_message`` as a structured ``tool_use`` (executed via the
+injected puffo_core dispatch) rather than plain text — otherwise the
+core turn-router falls back to posting the raw assistant prose
+(leaking ``send_message(channel=..., ...)`` into the channel).
+
+Covers:
+  - the provider's agentic loop (tools advertised, tool_use parsed,
+    dispatch executed, tool_result echoed back, usage summed);
+  - the adapter's SDKAdapter-mirroring metadata contract
+    (``send_message_targets`` + ``assistant_text_parts``);
+  - the core turn-router NOT taking the raw-text fallback when a
+    send_message tool call landed;
+  - plain-text (no tool) responses still returning normally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from puffo_agent.agent.adapters.base import TurnContext
+from puffo_agent.agent.adapters.chat_only import ChatOnlyAdapter
+from puffo_agent.agent.core import PuffoAgent
+from puffo_agent.agent.providers.anthropic_provider import AnthropicProvider
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+
+def _text_block(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool_use_block(block_id: str, name: str, tool_input: dict) -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", id=block_id, name=name, input=tool_input)
+
+
+def _response(content: list, stop_reason: str, in_tok: int = 10, out_tok: int = 5):
+    return SimpleNamespace(
+        content=content,
+        stop_reason=stop_reason,
+        usage=SimpleNamespace(input_tokens=in_tok, output_tokens=out_tok),
+    )
+
+
+class _FakeMessages:
+    def __init__(self, responses: list):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._responses.pop(0)
+
+
+class _FakeAnthropicClient:
+    def __init__(self, responses: list):
+        self.messages = _FakeMessages(responses)
+
+
+def _provider(responses: list) -> AnthropicProvider:
+    provider = AnthropicProvider(api_key="test-key", model="claude-test")
+    provider.client = _FakeAnthropicClient(responses)
+    return provider
+
+
+def _adapter_with_dispatch(responses: list, sent_calls: list) -> ChatOnlyAdapter:
+    """ChatOnlyAdapter wired the way worker.py wires chat-local:
+    tool-capable provider + injected puffo_core send dispatch."""
+
+    async def fake_send_message(
+        channel: str,
+        text: str,
+        root_id: str = "",
+        visibility_level: str = "default",
+    ) -> str:
+        sent_calls.append({
+            "channel": channel,
+            "text": text,
+            "root_id": root_id,
+            "visibility_level": visibility_level,
+        })
+        return "message sent (envelope_id: env_123)"
+
+    adapter = ChatOnlyAdapter(_provider(responses))
+    adapter.tool_dispatch = {"send_message": fake_send_message}
+    return adapter
+
+
+def _ctx() -> TurnContext:
+    return TurnContext(
+        system_prompt="you are a test bot",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+
+_TOOL_USE_TURN = lambda: [  # noqa: E731 — fresh responses per test
+    _response(
+        [
+            _text_block("Replying via send_message."),
+            _tool_use_block(
+                "toolu_1",
+                "send_message",
+                {"channel": "ch_abc", "text": "hello!", "root_id": "r-9"},
+            ),
+        ],
+        stop_reason="tool_use",
+    ),
+    _response([_text_block("Posted.")], stop_reason="end_turn"),
+]
+
+
+# ── tool_use path: parsed + dispatched + metadata populated ─────────────────
+
+
+def test_tool_use_parsed_dispatched_and_metadata_populated():
+    sent: list[dict] = []
+    adapter = _adapter_with_dispatch(_TOOL_USE_TURN(), sent)
+
+    result = asyncio.run(adapter.run_turn(_ctx()))
+
+    # The tool call was executed through the dispatch.
+    assert sent == [{
+        "channel": "ch_abc",
+        "text": "hello!",
+        "root_id": "r-9",
+        "visibility_level": "default",
+    }]
+    # Metadata mirrors SDKAdapter's contract → core skips fallback.
+    assert result.metadata["send_message_targets"] == [
+        {"channel": "ch_abc", "root_id": "r-9"},
+    ]
+    assert result.metadata["tool_names"] == ["send_message"]
+    assert result.metadata["assistant_text_parts"] == [
+        "Replying via send_message.",
+        "Posted.",
+    ]
+    assert result.tool_calls == 1
+    # Usage summed across both API round-trips.
+    assert result.input_tokens == 20
+    assert result.output_tokens == 10
+
+    # Wire shape: first call advertised tools; second call echoed the
+    # assistant turn and fed the tool_result back under the same id.
+    messages_api = adapter._provider.client.messages
+    assert len(messages_api.calls) == 2
+    first, second = messages_api.calls
+    assert [t["name"] for t in first["tools"]] == ["send_message"]
+    tool_result = second["messages"][-1]["content"][0]
+    assert tool_result["type"] == "tool_result"
+    assert tool_result["tool_use_id"] == "toolu_1"
+    assert tool_result["is_error"] is False
+
+
+def test_core_fallback_not_taken_when_send_message_tool_used(tmp_path):
+    """End-to-end through the core turn-router: a structured
+    send_message call must suppress the raw-text fallback post
+    (handle_message returns None — nothing leaks to the channel)."""
+    sent: list[dict] = []
+    agent = PuffoAgent(
+        adapter=_adapter_with_dispatch(_TOOL_USE_TURN(), sent),
+        system_prompt="you are a test bot",
+        memory_dir=str(tmp_path),
+    )
+    result = asyncio.run(agent.handle_message(
+        channel_id="ch_abc",
+        channel_name="general",
+        sender="u",
+        sender_email="u@x",
+        text="hi",
+        post_id="p-1",
+        root_id="",
+    ))
+    assert result is None  # fallback NOT taken
+    assert len(sent) == 1  # the reply went out via the tool
+
+
+def test_dispatch_error_feeds_is_error_tool_result_and_no_target():
+    """A failing tool call is fed back as an is_error tool_result and
+    does NOT count as a landed send — the fallback stays available."""
+
+    async def broken_send(**kwargs) -> str:
+        raise RuntimeError("channel not found")
+
+    adapter = ChatOnlyAdapter(_provider(_TOOL_USE_TURN()))
+    adapter.tool_dispatch = {"send_message": broken_send}
+
+    result = asyncio.run(adapter.run_turn(_ctx()))
+
+    assert result.metadata["send_message_targets"] == []
+    assert result.metadata["tool_names"] == ["send_message"]
+    second_call = adapter._provider.client.messages.calls[1]
+    tool_result = second_call["messages"][-1]["content"][0]
+    assert tool_result["is_error"] is True
+    assert "channel not found" in tool_result["content"]
+
+
+# ── plain-text path: no tool → normal return ────────────────────────────────
+
+
+def test_plain_text_response_returns_normally():
+    """No tool_use in the response: single API call, reply returned,
+    no send targets — the core's normal routing applies."""
+    sent: list[dict] = []
+    adapter = _adapter_with_dispatch(
+        [_response([_text_block("Hello!")], stop_reason="end_turn")], sent,
+    )
+
+    result = asyncio.run(adapter.run_turn(_ctx()))
+
+    assert result.reply == "Hello!"
+    assert result.metadata["send_message_targets"] == []
+    assert result.metadata["assistant_text_parts"] == ["Hello!"]
+    assert sent == []
+    assert len(adapter._provider.client.messages.calls) == 1
+
+
+def test_no_dispatch_injected_keeps_legacy_single_completion():
+    """Without an injected dispatch (e.g. tests, misconfigured agent)
+    the provider is called with NO tools — legacy behavior."""
+    adapter = ChatOnlyAdapter(
+        _provider([_response([_text_block("plain")], stop_reason="end_turn")]),
+    )
+
+    result = asyncio.run(adapter.run_turn(_ctx()))
+
+    assert result.reply == "plain"
+    assert "tools" not in adapter._provider.client.messages.calls[0]
+
+
+def test_legacy_tuple_provider_still_supported():
+    """OpenAI-style providers return (reply, in, out) and don't take
+    tool kwargs — the adapter must keep them working unchanged."""
+
+    class _TupleProvider:
+        def complete(self, system_prompt, messages):
+            return "legacy reply", 3, 4
+
+    adapter = ChatOnlyAdapter(_TupleProvider())
+    adapter.tool_dispatch = {"send_message": None}  # ignored: no supports_tools
+
+    result = asyncio.run(adapter.run_turn(_ctx()))
+
+    assert result.reply == "legacy reply"
+    assert result.input_tokens == 3
+    assert result.output_tokens == 4
+    assert result.metadata == {}


### PR DESCRIPTION
## HELD — do not merge without an explicit GO

Fixes the fat **cloud agent** leaking `send_message(...)` as raw text (with space-ids/debug) into channels instead of actually sending — Shan's #159 Part 2 / "Problem 3". Root cause: the `chat-local` runtime is a text-only completion path — `AnthropicProvider.complete()` sent no `tools=` and never parsed `tool_use`, and the `worker.py` chat-local branch wired no MCP dispatch, so the model's `send_message(...)` call arrived as prose and the core turn-router posted it via the raw-text fallback. This makes `chat-local` genuinely tool-capable (the `SDKAdapter` contract), so `send_message` is invoked as a real `tool_use`.

### Change (3 parts, mirrors `SDKAdapter`; native/desktop untouched)
1. **`agent/providers/anthropic_provider.py`** — `complete()` takes optional `tools=` + a `dispatch(name,input)` callback, runs an agentic loop while `stop_reason == "tool_use"` (executes each block, appends `tool_result`, `is_error` on handler failure, capped at 8 iterations), iterates `content` by block type (no blind `[0].text`), sums usage, returns a `CompletionResult` (reply, tokens, executed `tool_calls`, `assistant_text_parts`). OpenAI's legacy 3-tuple contract is preserved.
2. **`agent/adapters/chat_only.py`** — `ChatOnlyAdapter` gains a worker-injected `tool_dispatch`; when set + provider `supports_tools`, it advertises `send_message`/`send_message_with_attachments`, bridges the async puffo_core handlers via `run_coroutine_threadsafe` (120s timeout; `complete()` in `asyncio.to_thread`), and populates `TurnResult.metadata` (`send_message_targets`/`assistant_text_parts`/`tool_names`) exactly like `SDKAdapter` so `core.py` skips the raw-text fallback. Failed sends aren't counted as targets (fallback stays available).
3. **`portal/worker.py`** — `_build_chat_local_tool_dispatch(client)` (mirrors sdk-local's `mcp_servers_override`, reuses `build_dispatch`/`PuffoCoreToolsConfig`), injected in `Worker._run()` after the live puffo_core client exists.

### Verified
- New `tests/test_chat_local_tool_use.py` (6 tests): tool_use parsed+dispatched+`metadata` populated + wire shape (`tools=` on call 1, `tool_result` w/ matching id on call 2); **end-to-end through `handle_message` asserting the fallback is NOT taken**; dispatch-error → `is_error` tool_result + no target; plain-text still works; legacy no-dispatch + OpenAI tuple paths unchanged.
- `pytest --ignore=tests/test_host_credentials.py` → **2006 passed, 4 skipped** (exit 0).
- `git diff --stat`: only the 3 modules + new test; `sdk.py`/`local_cli.py`/`docker_cli.py`/`core.py` byte-identical.

### Notes / follow-ups
- Still depends on the **LiteLLM gateway passing through Anthropic `tool_use`** (same as any tool path) — a Shan coordination point to confirm live.
- The separate **reply-once-then-silent** bug (T27) is NOT in this PR (under investigation; will be its own fix).
- Chosen over baking the claude-CLI (`cli-local`): this fixes the runtime the agent actually runs today, no real-cloud template rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
