### PR TITLE
cloud-agent: fix reply-once (thread-dedup cursor drops same-ms envelopes) — HELD

### DIFF
--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -41,13 +41,20 @@ CREATE INDEX IF NOT EXISTS idx_messages_thread_root
 -- Per-thread cursor used by the thread-batched priority queue. After
 -- ``on_message_batch`` finishes successfully, the consumer advances
 -- this to the ``sent_at`` of the last message in the dispatched
--- batch. The listen handler then drops any inbound message whose
--- ``sent_at`` is <= the stored cursor, so server-side pending-message
--- redeliveries after a daemon restart don't re-trigger the agent on
--- already-processed threads.
+-- batch, plus the envelope_ids of the batch messages that share that
+-- exact ``sent_at`` (JSON array). The listen handler then drops any
+-- inbound message whose ``sent_at`` is strictly below the cursor, or
+-- equal to it with an envelope_id already recorded at the watermark —
+-- so server-side pending-message redeliveries after a daemon restart
+-- don't re-trigger the agent, while a genuinely-NEW message that
+-- merely shares the watermark ``sent_at`` (same-millisecond burst
+-- from a programmatic sender; the wire timestamp is epoch-ms) is
+-- still admitted. Reject-on-equal alone caused the "reply once then
+-- silent" bug (T27).
 CREATE TABLE IF NOT EXISTS thread_processing_state (
     root_id TEXT PRIMARY KEY,
-    last_processed_sent_at INTEGER NOT NULL
+    last_processed_sent_at INTEGER NOT NULL,
+    last_processed_envelope_ids TEXT NOT NULL DEFAULT '[]'
 );
 
 -- One row per channel the agent has been auto-prompted to introduce
@@ -140,6 +147,25 @@ class MessageStore:
             "PRAGMA mmap_size=268435456;"
         )
         await self._db.executescript(_SCHEMA)
+        await self._migrate(self._db)
+
+    @staticmethod
+    async def _migrate(db: aiosqlite.Connection) -> None:
+        """Bring a pre-existing DB up to the current schema.
+        ``CREATE TABLE IF NOT EXISTS`` never alters an existing table,
+        so columns added after first ship need an explicit ALTER here.
+        Idempotent and backward-compatible (new columns carry a
+        DEFAULT, so old rows keep working)."""
+        async with db.execute(
+            "PRAGMA table_info(thread_processing_state)"
+        ) as cursor:
+            cols = {row[1] for row in await cursor.fetchall()}
+        if "last_processed_envelope_ids" not in cols:
+            await db.execute(
+                "ALTER TABLE thread_processing_state "
+                "ADD COLUMN last_processed_envelope_ids TEXT NOT NULL DEFAULT '[]'"
+            )
+            await db.commit()
 
     async def close(self) -> None:
         if self._db:
@@ -540,39 +566,94 @@ class MessageStore:
     async def get_last_processed_sent_at(self, root_id: str) -> int:
         """``sent_at`` of the last message in the most recently
         dispatched batch for this thread, or ``0`` if the agent has
-        never processed it. Used at enqueue time to drop redelivered
-        messages whose work has already been done.
+        never processed it. Prefer ``get_thread_cursor`` at the
+        inbound gate — the bare watermark can't distinguish a
+        redelivered envelope from a NEW message that shares the
+        watermark ``sent_at``.
+        """
+        sent_at, _ids = await self.get_thread_cursor(root_id)
+        return sent_at
+
+    async def get_thread_cursor(self, root_id: str) -> tuple[int, set[str]]:
+        """The per-thread dedup cursor: ``(last_processed_sent_at,
+        envelope_ids processed AT that exact sent_at)``. ``(0, set())``
+        when the agent has never processed the thread. The id set only
+        ever holds the ties at the watermark millisecond (a handful at
+        most), never the whole history — anything strictly below the
+        watermark is covered by the timestamp comparison alone.
+        Rows written before the ``last_processed_envelope_ids`` column
+        existed yield an empty set (fail-open: a same-``sent_at``
+        redelivery right after upgrade may re-dispatch once, which is
+        the safe direction — never silently dropping new messages).
         """
         if not root_id:
-            return 0
+            return 0, set()
         db = await self._ensure_db()
         async with db.execute(
-            "SELECT last_processed_sent_at FROM thread_processing_state "
-            "WHERE root_id = ?",
+            "SELECT last_processed_sent_at, last_processed_envelope_ids "
+            "FROM thread_processing_state WHERE root_id = ?",
             (root_id,),
         ) as cursor:
             row = await cursor.fetchone()
-        return int(row[0]) if row else 0
+        if row is None:
+            return 0, set()
+        try:
+            ids_raw = json.loads(row[1]) if row[1] else []
+        except (ValueError, TypeError):
+            ids_raw = []
+        ids = {str(i) for i in ids_raw if i} if isinstance(ids_raw, list) else set()
+        return int(row[0]), ids
 
     async def mark_thread_processed(
-        self, root_id: str, sent_at: int,
+        self,
+        root_id: str,
+        sent_at: int,
+        envelope_ids: list[str] | None = None,
     ) -> None:
-        """Upsert the per-thread cursor. ``MAX(existing, new)`` so
-        out-of-order writes (extremely unlikely but cheap to guard)
-        never regress the cursor.
+        """Upsert the per-thread cursor. Never regresses: a lower
+        ``sent_at`` is a no-op; an equal ``sent_at`` unions
+        ``envelope_ids`` into the recorded watermark set (two batches
+        can legitimately end on the same millisecond); a higher
+        ``sent_at`` replaces both the watermark and the id set.
+        ``envelope_ids`` should be the ids of the just-dispatched
+        batch messages whose ``sent_at`` equals the new watermark.
+
+        Single atomic upsert — the equal-watermark union runs in SQL.
+        No read-then-write window, and the same execute+commit shape
+        the pre-ids cursor had, so a caller cancelled right after its
+        dispatch callback still gets the write through.
         """
         if not root_id:
             return
+        new_ids = [i for i in (envelope_ids or []) if i]
         db = await self._ensure_db()
         await db.execute(
-            """INSERT INTO thread_processing_state (root_id, last_processed_sent_at)
-               VALUES (?, ?)
+            """INSERT INTO thread_processing_state
+                 (root_id, last_processed_sent_at, last_processed_envelope_ids)
+               VALUES (?, ?, ?)
                ON CONFLICT(root_id) DO UPDATE SET
+                 last_processed_envelope_ids = CASE
+                   WHEN excluded.last_processed_sent_at
+                        > thread_processing_state.last_processed_sent_at
+                     THEN excluded.last_processed_envelope_ids
+                   WHEN excluded.last_processed_sent_at
+                        = thread_processing_state.last_processed_sent_at
+                     THEN (
+                       SELECT json_group_array(value) FROM (
+                         SELECT value FROM json_each(
+                           thread_processing_state.last_processed_envelope_ids)
+                         UNION
+                         SELECT value FROM json_each(
+                           excluded.last_processed_envelope_ids)
+                       )
+                     )
+                   ELSE thread_processing_state.last_processed_envelope_ids
+                 END,
                  last_processed_sent_at = MAX(
                    thread_processing_state.last_processed_sent_at,
                    excluded.last_processed_sent_at
                  )""",
-            (root_id, sent_at),
+            (root_id, sent_at, json.dumps(new_ids)),
         )
         await db.commit()
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -239,6 +239,24 @@ def _compute_priority(direct: bool, sender_is_bot: bool) -> int:
 _LONG_MESSAGE_PREVIEW_CHARS = 240
 
 
+def _batch_tail_cursor(batch: list[dict]) -> tuple[int, list[str]]:
+    """The cursor advance for a successfully dispatched batch:
+    ``batch[-1].sent_at`` (the high-water mark just covered) plus the
+    envelope_ids of every batch message sharing that exact ``sent_at``.
+    Recording the watermark ties lets the inbound gate tell a
+    redelivered already-processed envelope (same id — drop) from a
+    genuinely-new same-millisecond arrival (different id — admit);
+    see ``MessageStore.mark_thread_processed``.
+    """
+    tail_sent_at = batch[-1].get("sent_at", 0) if batch else 0
+    tail_ids = [
+        m.get("envelope_id", "")
+        for m in batch
+        if m.get("envelope_id") and m.get("sent_at", 0) == tail_sent_at
+    ]
+    return tail_sent_at, tail_ids
+
+
 def _maybe_redact_long_text(
     text: str,
     *,
@@ -1125,13 +1143,25 @@ class PuffoCoreMessageClient:
 
         # Cross-restart dedup: after a daemon restart the server
         # redelivers anything in /messages/pending. If we already
-        # dispatched a batch that covers ``payload.sent_at``,
-        # skip — the agent has seen this.
-        last_processed = await self.store.get_last_processed_sent_at(root_id)
-        if payload.sent_at <= last_processed:
+        # dispatched a batch that covers ``payload.sent_at``, skip —
+        # the agent has seen this. ``sent_at`` is epoch-MILLISECONDS
+        # but NOT unique: a programmatic burst (agent→agent, server-
+        # stamped bridge sends) can put two distinct envelopes on the
+        # same root in the same ms. Rejecting on bare
+        # ``sent_at <= watermark`` dropped the genuinely-new second
+        # message and the agent went silent after one reply (T27), so
+        # equality alone is not enough — at the watermark we only
+        # reject an envelope_id we have actually processed.
+        last_processed, processed_ids = await self.store.get_thread_cursor(
+            root_id,
+        )
+        if payload.sent_at < last_processed or (
+            payload.sent_at == last_processed
+            and payload.envelope_id in processed_ids
+        ):
             self._log.info(
                 "handle_envelope: cursor-rejected duplicate envelope=%s "
-                "(sent_at=%d <= last_processed=%d, root=%s)",
+                "(sent_at=%d, last_processed=%d, root=%s)",
                 payload.envelope_id, payload.sent_at,
                 last_processed, root_id,
             )
@@ -1276,10 +1306,10 @@ class PuffoCoreMessageClient:
           and gets skipped on pop via the ``current_seq`` mismatch
           check in ``_consume_queue``.
 
-        Caller must have already filtered out messages whose
-        ``sent_at`` is at or below
-        ``store.get_last_processed_sent_at(root_id)``; this method
-        doesn't re-check the durable cursor.
+        Caller must have already run the durable-cursor gate
+        (``store.get_thread_cursor(root_id)``: drop when ``sent_at``
+        is below the watermark, or equal to it with an envelope_id
+        recorded at the watermark); this method doesn't re-check it.
         """
         entry = self._thread_state.get(root_id)
         incoming_id = msg_dict.get("envelope_id", "")
@@ -1432,10 +1462,10 @@ class PuffoCoreMessageClient:
                 # the retry. Advance cursor past the failed batch
                 # so we don't re-trigger on redelivery.
                 if batch:
-                    tail_sent_at = batch[-1].get("sent_at", 0)
+                    tail_sent_at, tail_ids = _batch_tail_cursor(batch)
                     try:
                         await self.store.mark_thread_processed(
-                            root_id, tail_sent_at,
+                            root_id, tail_sent_at, tail_ids,
                         )
                     except Exception:
                         self._log.exception(
@@ -1671,11 +1701,15 @@ class PuffoCoreMessageClient:
 
             # Success: persist the cursor so a restart-then-redeliver
             # doesn't re-trigger this thread. ``batch[-1].sent_at`` is
-            # the high-water mark we just covered.
+            # the high-water mark we just covered; the watermark ties'
+            # envelope_ids ride along so a same-ms NEW arrival is
+            # still admitted later.
             if batch:
-                tail_sent_at = batch[-1].get("sent_at", 0)
+                tail_sent_at, tail_ids = _batch_tail_cursor(batch)
                 try:
-                    await self.store.mark_thread_processed(root_id, tail_sent_at)
+                    await self.store.mark_thread_processed(
+                        root_id, tail_sent_at, tail_ids,
+                    )
                 except Exception:
                     self._log.exception(
                         "mark_thread_processed(%s, %d) failed; agent "

--- a/tests/test_reply_once_cursor.py
+++ b/tests/test_reply_once_cursor.py
@@ -1,0 +1,357 @@
+"""T27 regression: the reply-once / "agent replies once then silent" bug.
+
+The persisted per-thread dedup cursor (``thread_processing_state``)
+used to reject any inbound message with ``sent_at <= watermark``. But
+``sent_at`` is epoch-milliseconds and NOT unique — a programmatic
+burst (agent→agent traffic; the server stamps consecutive bridge
+``Send`` frames with its own ``now_ms``) can put two DISTINCT
+envelopes on the same thread root in the same millisecond. The second,
+genuinely-new message was then dropped as a "duplicate" and the agent
+never took a second turn.
+
+The fix keys equality on the envelope_id: the cursor now records the
+envelope_ids processed AT the watermark ``sent_at``, and the inbound
+gate rejects only ``sent_at < watermark`` or (``sent_at == watermark``
+AND the envelope_id is recorded). Both properties are pinned here:
+
+  (i)  a NEW same-``sent_at`` message on an active root IS admitted
+       and dispatched (DM case + channel-thread case);
+  (ii) a genuinely-redelivered already-processed envelope (same
+       envelope_id + sent_at, e.g. /messages/pending replay after a
+       daemon restart) is STILL dropped — including across a
+       simulated restart (fresh client, same sqlite store).
+
+These tests drive the REAL inbound tail (``_handle_plaintext_payload``
+→ cursor gate → ``_admit_thread_message`` → ``_consume_queue``), not
+the queue internals, so the gate itself is under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import puffo_agent.agent.puffo_core_client as pcc_mod
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import KeyStore
+from puffo_agent.crypto.message import MessagePayload
+
+T = 1_700_000_000_000  # one fixed millisecond — the collision under test
+
+
+@pytest.fixture(autouse=True)
+def _no_jitter(monkeypatch):
+    # The consumer sleeps random.uniform(0, 1.5) before dispatch; zero
+    # it so batch-callback tests don't wait wall-clock seconds.
+    monkeypatch.setattr(pcc_mod.random, "uniform", lambda a, b: 0.0)
+
+
+async def _make_client(tmp_path, db: str, *, store: MessageStore | None = None):
+    """A native-config message client with offline HTTP so every
+    enrichment helper degrades to ids-for-names. Pass ``store`` to
+    share one sqlite DB across two clients (restart simulation)."""
+    ks = KeyStore(str(tmp_path / f"keys-{db}"))
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, "bot-0001")
+    store = store or MessageStore(str(tmp_path / db))
+    client = PuffoCoreMessageClient(
+        slug="bot-0001",
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=store,
+    )
+
+    async def _empty_get(path, *a, **k):
+        return {}
+
+    client.http.get = _empty_get  # type: ignore[method-assign]
+    client._queue = asyncio.PriorityQueue()
+    client._queue_seq = 0
+    client._thread_state = {}
+    await client.store.open()
+    return client
+
+
+def _dm(envelope_id: str, *, sent_at: int, thread_root_id: str | None = None):
+    return MessagePayload(
+        payload_type="puffo.message", version=1,
+        envelope_id=envelope_id, envelope_kind="dm",
+        sender_slug="alice-0001", sender_subkey_id="", sent_at=sent_at,
+        message_nonce="", content_type="text/plain",
+        content=f"dm body {envelope_id}", is_visible_to_human=True,
+        recipient_slug="bot-0001", thread_root_id=thread_root_id,
+    )
+
+
+def _channel_msg(
+    envelope_id: str, *, sent_at: int, thread_root_id: str | None = None,
+):
+    return MessagePayload(
+        payload_type="puffo.message", version=1,
+        envelope_id=envelope_id, envelope_kind="channel",
+        sender_slug="alice-0001", sender_subkey_id="", sent_at=sent_at,
+        message_nonce="", content_type="text/plain",
+        content=f"channel body {envelope_id}", is_visible_to_human=True,
+        space_id="sp_1", channel_id="ch_1", thread_root_id=thread_root_id,
+    )
+
+
+async def _consume_one_batch(client, timeout: float = 2.0):
+    """Run the consumer until exactly one batch dispatches; return
+    ``(root_id, [envelope_ids])``. ``done`` keys on ``on_turn_success``
+    — which the consumer fires AFTER persisting the cursor — so the
+    cancel below can't race the ``mark_thread_processed`` write."""
+    received: list[tuple[str, list[str]]] = []
+    done = asyncio.Event()
+
+    async def on_batch(root_id, batch, channel_meta):
+        received.append((root_id, [m["envelope_id"] for m in batch]))
+
+    async def on_turn_success(root_id, batch, channel_meta):
+        done.set()
+
+    task = asyncio.create_task(
+        client._consume_queue(on_batch, None, None, on_turn_success),
+    )
+    try:
+        await asyncio.wait_for(done.wait(), timeout=timeout)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    assert len(received) == 1
+    return received[0]
+
+
+def _queued_envelope_ids(client, root_id: str) -> list[str]:
+    entry = client._thread_state.get(root_id)
+    if entry is None or not entry.in_queue:
+        return []
+    return [m["envelope_id"] for m in entry.messages]
+
+
+# ─── (i) NEW same-sent_at message on an active root gets a 2nd turn ──
+
+
+@pytest.mark.asyncio
+async def test_dm_same_sent_at_new_envelope_gets_second_turn(tmp_path):
+    """DM case: message A (sent_at=T) is processed; message B — a
+    DIFFERENT envelope on the same root (threaded DM reply), same
+    sent_at=T — must be admitted and dispatched as a second turn.
+    Before the fix, B was cursor-rejected and the agent went silent."""
+    client = await _make_client(tmp_path, "dm_second_turn.db")
+    try:
+        await client._handle_plaintext_payload(_dm("env_dm_a", sent_at=T))
+        root_id, first = await _consume_one_batch(client)
+        assert root_id == "env_dm_a"
+        assert first == ["env_dm_a"]
+
+        # B arrives on the SAME root (thread_root_id → A, which is in
+        # the local store, so admit-time validation keeps it) in the
+        # SAME ms.
+        await client._handle_plaintext_payload(
+            _dm("env_dm_b", sent_at=T, thread_root_id="env_dm_a"),
+        )
+        assert _queued_envelope_ids(client, "env_dm_a") == ["env_dm_b"], (
+            "new same-sent_at DM must be admitted, not cursor-rejected"
+        )
+        root_id_2, second = await _consume_one_batch(client)
+        assert root_id_2 == "env_dm_a"
+        assert second == ["env_dm_b"], "agent must take a 2nd turn for the DM"
+    finally:
+        # Always close: a lingering aiosqlite thread (non-daemon)
+        # blocks interpreter exit and hangs the whole pytest run.
+        await client.store.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_thread_same_sent_at_new_envelope_gets_second_turn(tmp_path):
+    """Thread case: same collision on a channel thread root."""
+    client = await _make_client(tmp_path, "thread_second_turn.db")
+    try:
+        await client._handle_plaintext_payload(
+            _channel_msg("env_th_a", sent_at=T),
+        )
+        root_id, first = await _consume_one_batch(client)
+        assert root_id == "env_th_a"
+        assert first == ["env_th_a"]
+
+        await client._handle_plaintext_payload(
+            _channel_msg("env_th_b", sent_at=T, thread_root_id="env_th_a"),
+        )
+        assert _queued_envelope_ids(client, "env_th_a") == ["env_th_b"], (
+            "new same-sent_at thread reply must be admitted, "
+            "not cursor-rejected"
+        )
+        root_id_2, second = await _consume_one_batch(client)
+        assert root_id_2 == "env_th_a"
+        assert second == ["env_th_b"], (
+            "agent must take a 2nd turn for the thread"
+        )
+    finally:
+        await client.store.close()
+
+
+# ─── (ii) redelivered already-processed envelopes are STILL dropped ──
+
+
+@pytest.mark.asyncio
+async def test_redelivered_processed_envelopes_still_dropped_across_restart(tmp_path):
+    """Cross-restart replay: after A and B (same sent_at) were both
+    processed, a fresh client over the SAME sqlite store (fresh
+    in-memory queue/thread state, i.e. a daemon restart) must drop the
+    server's /messages/pending redelivery of BOTH — the cursor keeps
+    its dedup property at the watermark via the recorded ids."""
+    store = MessageStore(str(tmp_path / "restart_dedup.db"))
+    try:
+        client = await _make_client(tmp_path, "restart_dedup.db", store=store)
+
+        await client._handle_plaintext_payload(_dm("env_r_a", sent_at=T))
+        await _consume_one_batch(client)
+        await client._handle_plaintext_payload(
+            _dm("env_r_b", sent_at=T, thread_root_id="env_r_a"),
+        )
+        await _consume_one_batch(client)
+        assert await store.get_thread_cursor("env_r_a") == (
+            T, {"env_r_a", "env_r_b"},
+        )
+
+        # "Restart": new client, same store, empty in-memory state.
+        client2 = await _make_client(
+            tmp_path, "restart_dedup.db", store=store,
+        )
+        await client2._handle_plaintext_payload(_dm("env_r_a", sent_at=T))
+        await client2._handle_plaintext_payload(
+            _dm("env_r_b", sent_at=T, thread_root_id="env_r_a"),
+        )
+        assert client2._queue.qsize() == 0, (
+            "redelivered envelopes must not re-queue"
+        )
+        assert client2._thread_state == {}
+
+        # An older message on the same root (below the watermark) is
+        # likewise still dropped.
+        await client2._handle_plaintext_payload(
+            _dm("env_r_old", sent_at=T - 1, thread_root_id="env_r_a"),
+        )
+        assert client2._queue.qsize() == 0
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_redelivery_dropped_same_session_after_dispatch(tmp_path):
+    """Same-session replay (WS reconnect + fetch_pending): once B's
+    batch has dispatched and the cursor covers it, a redelivered B is
+    dropped by the durable gate even though dispatching_ids was
+    already cleared."""
+    client = await _make_client(tmp_path, "session_dedup.db")
+    try:
+        await client._handle_plaintext_payload(
+            _channel_msg("env_s_a", sent_at=T),
+        )
+        await _consume_one_batch(client)
+        await client._handle_plaintext_payload(
+            _channel_msg("env_s_b", sent_at=T, thread_root_id="env_s_a"),
+        )
+        await _consume_one_batch(client)
+
+        await client._handle_plaintext_payload(
+            _channel_msg("env_s_b", sent_at=T, thread_root_id="env_s_a"),
+        )
+        assert _queued_envelope_ids(client, "env_s_a") == []
+        assert client._queue.qsize() == 0
+    finally:
+        await client.store.close()
+
+
+# ─── store-level semantics ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_thread_processed_watermark_id_semantics(tmp_path):
+    store = MessageStore(str(tmp_path / "cursor_semantics.db"))
+    await store.open()
+    try:
+        # Fresh root: (0, empty).
+        assert await store.get_thread_cursor("root") == (0, set())
+
+        # First advance records the watermark ties.
+        await store.mark_thread_processed("root", 1000, ["e1"])
+        assert await store.get_thread_cursor("root") == (1000, {"e1"})
+
+        # Equal sent_at unions the ids (a later batch ending on the
+        # same ms).
+        await store.mark_thread_processed("root", 1000, ["e2"])
+        assert await store.get_thread_cursor("root") == (1000, {"e1", "e2"})
+
+        # Regress is a no-op (ids untouched too).
+        await store.mark_thread_processed("root", 500, ["e_old"])
+        assert await store.get_thread_cursor("root") == (1000, {"e1", "e2"})
+
+        # A higher watermark replaces both — stale ties don't
+        # accumulate forever.
+        await store.mark_thread_processed("root", 2000, ["e3"])
+        assert await store.get_thread_cursor("root") == (2000, {"e3"})
+
+        # Legacy call shape (no ids) still advances the watermark.
+        await store.mark_thread_processed("root", 3000)
+        assert await store.get_thread_cursor("root") == (3000, set())
+        assert await store.get_last_processed_sent_at("root") == 3000
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_migration_adds_envelope_ids_column(tmp_path):
+    """A DB created by the OLD schema (no ``last_processed_envelope_ids``
+    column, one populated cursor row) opens cleanly: the column is
+    added, the legacy row reads as an empty id set (fail-open at the
+    watermark), and new writes union/replace as normal."""
+    import aiosqlite
+
+    db_path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.execute(
+            "CREATE TABLE thread_processing_state ("
+            " root_id TEXT PRIMARY KEY,"
+            " last_processed_sent_at INTEGER NOT NULL)"
+        )
+        await db.execute(
+            "INSERT INTO thread_processing_state VALUES ('root_legacy', 500)"
+        )
+        await db.commit()
+
+    store = MessageStore(str(db_path))
+    await store.open()
+    try:
+        assert await store.get_thread_cursor("root_legacy") == (500, set())
+        # Equal-watermark write on the migrated row unions into the
+        # (empty) set.
+        await store.mark_thread_processed("root_legacy", 500, ["e_new"])
+        assert await store.get_thread_cursor("root_legacy") == (
+            500, {"e_new"},
+        )
+        # Migration is idempotent across reopen; data survives.
+        await store.close()
+        await store.open()
+        assert await store.get_thread_cursor("root_legacy") == (
+            500, {"e_new"},
+        )
+        # And the persisted column really is JSON.
+        db2 = await store._ensure_db()
+        async with db2.execute(
+            "SELECT last_processed_envelope_ids FROM thread_processing_state "
+            "WHERE root_id = 'root_legacy'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert json.loads(row[0]) == ["e_new"]
+    finally:
+        await store.close()


### PR DESCRIPTION
## HELD — do not merge without an explicit GO

Fixes the cloud agent **replying once to a DM/thread then going silent** (Shan, 07-10 / "Problem 2" / T27).

### Root cause
`puffo_core_client.py` `handle_envelope` rejected any inbound with `payload.sent_at <= last_processed_sent_at` (a per-`root_id` persisted cursor, meant only to drop cross-restart *redelivered* messages). `sent_at` is epoch-**milliseconds** and **not unique**: the server stamps consecutive bridge `Send` frames with its own `now_ms`, so a programmatic burst (e.g. agent-to-agent traffic, or two quick messages) can put two *distinct* envelopes on one thread root in the **same millisecond**. A DM conversation / thread has a stable `root_id`, so after the first message is processed (`mark_thread_processed(root, msg.sent_at)`), a genuinely-new second message sharing that ms hit `<=` and was dropped as a "duplicate" → no second turn.

### Fix
Key the thread-dedup cursor on the **`envelope_id` at the `sent_at` watermark**, not the bare timestamp:
- **`message_store.py`** — `thread_processing_state` now also remembers the envelope_id(s) processed *at* the high-water `sent_at`; `get_last_processed_sent_at`/`mark_thread_processed` extended (backward-compatible; migration/default). Reject only a message whose `sent_at < watermark`, OR `sent_at == watermark` **and** its `envelope_id` was already processed.
- **`puffo_core_client.py`** — the cursor check uses that boundary set, so a NEW envelope at the same ms is admitted while a genuinely-redelivered one is still dropped. (Not a bare `<=`→`<`, which would regress cross-restart dedup.)

### Verified
- New `tests/test_reply_once_cursor.py` (6 tests): a distinct second envelope at the SAME `sent_at` on one root IS admitted (was dropped); a true redelivery (same envelope_id + sent_at) is STILL dropped; DM + thread cases.
- Full gate `pytest --ignore=tests/test_host_credentials.py` → **exit 0** (independently re-run by the coordinator; only the 4 standard PySide6/platform skips).

Coordinator note: I traced the root cause directly (`handle_envelope`→cursor); a focused agent implemented + tested; I re-ran the gate before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
