### PR TITLE
cloud-agent: handle added_to_space push → eager spaces refresh (pairs w/ server #202) — HELD

### DIFF
--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -494,10 +494,11 @@ class PuffoCoreMessageClient:
         # non-None, listen() runs the bridge lifecycle loop instead of
         # the signed WS client — no identity file is ever loaded.
         self._bridge = bridge_client
-        # In-flight ack tasks scheduled off the bridge dispatch loop
-        # (F1). Held so the tasks aren't GC'd mid-flight; each removes
+        # In-flight fire-and-forget tasks scheduled off the bridge
+        # dispatch loop (F1 acks + added_to_space spaces refreshes).
+        # Held so the tasks aren't GC'd mid-flight; each removes
         # itself via a done-callback. Native transport never populates
-        # this — the ack lives only in the bridge dispatcher.
+        # this — both producers live only in the bridge dispatcher.
         self._ack_tasks: set[asyncio.Task] = set()
         # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
         # "reply to whoever just DMed me". Single-slot is fine since
@@ -847,6 +848,24 @@ class PuffoCoreMessageClient:
                 "bridge backfill complete: pending_delivered (count=%s)",
                 frame.get("count"),
             )
+        elif kind == "added_to_space":
+            # Server push (AgentServerMsg::AddedToSpace) the moment this
+            # agent is added to a Space — refresh the known-spaces view
+            # eagerly instead of waiting for the next lazy list_spaces.
+            # Scheduled async, same shape as the F1 ack: awaiting
+            # send_list_spaces inline would deadlock the frames() loop,
+            # which must keep receiving to deliver the 'spaces' reply
+            # that resolves the request future.
+            space_id = frame.get("space_id") or ""
+            self._log.info(
+                "bridge: added to space %s — refreshing spaces",
+                space_id or "<missing space_id>",
+            )
+            task = asyncio.create_task(
+                self._refresh_bridge_spaces(space_id)
+            )
+            self._ack_tasks.add(task)
+            task.add_done_callback(self._ack_tasks.discard)
         elif kind == "error":
             self._log.warning(
                 "bridge error frame: code=%s message=%s",
@@ -872,6 +891,45 @@ class PuffoCoreMessageClient:
             self._log.warning(
                 "bridge ack failed (envelope_ids=%s)",
                 envelope_ids, exc_info=True,
+            )
+
+    async def _refresh_bridge_spaces(self, trigger_space_id: str = "") -> None:
+        """Re-issue ``list_spaces`` over the bridge WS after an
+        ``added_to_space`` push so the new space enters the agent's
+        known set eagerly (name cache + disk cache) rather than lazily
+        on the next tool call. Idempotent: a duplicate ``added_to_space``
+        for an already-known space is a harmless re-list (``setdefault``
+        keeps the existing entries). Fail-soft: a failed refresh logs
+        and drops — the MCP ``list_spaces`` tool reads the authoritative
+        route live, so a lost refresh is at worst a stale name cache,
+        never a missed membership. Native transport never calls this
+        (no ``_bridge``).
+        """
+        bridge = self._bridge
+        if bridge is None:
+            return
+        try:
+            resp = await bridge.send_list_spaces()
+            entries = resp.get("spaces") or []
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                # The wire spec names the id field ``id``; the signed
+                # HTTP route uses ``space_id`` — read both defensively.
+                sid = entry.get("space_id") or entry.get("id") or ""
+                name = (entry.get("name") or "").strip()
+                if sid and name:
+                    self._space_name_cache.setdefault(sid, name)
+                    disk_cache.persist_space(sid, name)
+            self._log.info(
+                "bridge spaces refresh: %d spaces listed "
+                "(trigger space_id=%s)",
+                len(entries), trigger_space_id or "<missing>",
+            )
+        except Exception:  # noqa: BLE001 — a failed refresh must not crash the loop
+            self._log.warning(
+                "bridge spaces refresh failed (trigger space_id=%s)",
+                trigger_space_id, exc_info=True,
             )
 
     def _preseed_frame_display_name(

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -71,6 +71,7 @@ class FakeBridge:
         scripted: list[dict] | None = None,
         ack: dict | None = None,
         blobs: dict[str, bytes] | None = None,
+        spaces: list[dict] | None = None,
     ):
         self._scripted = list(scripted or [])
         self._ack = ack or {
@@ -82,6 +83,11 @@ class FakeBridge:
         # F1: every send_ack call records its envelope_ids, so a test can
         # assert exactly one ack per handled bridge message.
         self.acked: list[list[str]] = []
+        # added_to_space: send_list_spaces calls are counted so a test
+        # can assert the re-list refresh fired; ``spaces`` is the canned
+        # entry list the reply carries.
+        self.list_spaces_count = 0
+        self._spaces = list(spaces or [])
         self.connect_count = 0
         self.fetch_pending_count = 0
         self.close_count = 0
@@ -115,6 +121,10 @@ class FakeBridge:
     ) -> dict:
         self.acked.append(list(envelope_ids))
         return {"type": "ack_result", "acked": list(envelope_ids)}
+
+    async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
+        self.list_spaces_count += 1
+        return {"type": "spaces", "spaces": list(self._spaces)}
 
     async def send_send(
         self, *, plaintext, recipient_slug=None, space_id=None,
@@ -1572,3 +1582,138 @@ def test_message_payload_to_dict_omits_attachments():
     )
     d = p.to_payload_dict()
     assert "attachments" not in d
+
+
+# --------------------------------------------------------------------------
+# added_to_space: server push on Space add triggers an eager spaces refresh
+# --------------------------------------------------------------------------
+
+
+def _persist_space_spy(monkeypatch):
+    """Divert ``disk_cache.persist_space`` into a recorder so the tests
+    neither write into the real ``home_dir()`` cache nor depend on it."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        pcc_mod.disk_cache, "persist_space",
+        lambda sid, name: calls.append((sid, name)),
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_added_to_space_triggers_list_spaces_refresh(
+    tmp_path, monkeypatch,
+):
+    """An inbound ``{"type": "added_to_space", "space_id": ...}`` frame
+    (server ``AgentServerMsg::AddedToSpace``) schedules exactly one
+    ``list_spaces`` re-issue off the dispatcher — async, never awaited
+    inline (which would deadlock ``frames()``) — and the reply warms the
+    space-name + disk caches so the new space is in the known set."""
+    persisted = _persist_space_spy(monkeypatch)
+    bridge = FakeBridge(spaces=[{"id": "sp_new", "name": "New Space"}])
+    client = await _open_dispatch_client(tmp_path, bridge, db="ats.db")
+
+    await client._dispatch_bridge_frame(
+        {"type": "added_to_space", "space_id": "sp_new"},
+    )
+    # Scheduled, not awaited inline: one task in flight after dispatch.
+    assert len(client._ack_tasks) == 1
+    await asyncio.gather(*client._ack_tasks)
+
+    assert bridge.list_spaces_count == 1
+    assert client._space_name_cache["sp_new"] == "New Space"
+    assert ("sp_new", "New Space") in persisted
+    # The done-callback cleaned the task set up afterwards.
+    assert client._ack_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_added_to_space_duplicate_is_harmless_relist(
+    tmp_path, monkeypatch,
+):
+    """A duplicate ``added_to_space`` for an already-known space is a
+    harmless re-list: the refresh runs again but ``setdefault`` keeps the
+    existing cache entry, and nothing raises."""
+    _persist_space_spy(monkeypatch)
+    bridge = FakeBridge(spaces=[{"id": "sp_known", "name": "Server Name"}])
+    client = await _open_dispatch_client(tmp_path, bridge, db="ats_dup.db")
+    client._space_name_cache["sp_known"] = "Cached Name"
+
+    for _ in range(2):
+        await client._dispatch_bridge_frame(
+            {"type": "added_to_space", "space_id": "sp_known"},
+        )
+        await asyncio.gather(*client._ack_tasks)
+
+    assert bridge.list_spaces_count == 2
+    # setdefault: the pre-existing entry survives the duplicate push.
+    assert client._space_name_cache["sp_known"] == "Cached Name"
+    assert client._ack_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_added_to_space_missing_space_id_and_failed_refresh_survive(
+    tmp_path, monkeypatch, caplog,
+):
+    """Malformed push (no ``space_id``) still refreshes without raising,
+    and a refresh whose ``list_spaces`` blows up logs + drops instead of
+    crashing the dispatch loop (fail-soft, like the F1 ack)."""
+    _persist_space_spy(monkeypatch)
+    bridge = FakeBridge(spaces=[{"id": "sp_1", "name": "One"}])
+    client = await _open_dispatch_client(tmp_path, bridge, db="ats_bad.db")
+
+    # Missing space_id → refresh still runs, nothing raises.
+    await client._dispatch_bridge_frame({"type": "added_to_space"})
+    await asyncio.gather(*client._ack_tasks)
+    assert bridge.list_spaces_count == 1
+    assert client._space_name_cache.get("sp_1") == "One"
+
+    # list_spaces failure → warning, loop survives.
+    async def _boom(*, timeout=30.0):
+        raise RuntimeError("bridge fell over")
+
+    bridge.send_list_spaces = _boom  # type: ignore[method-assign]
+    with caplog.at_level(logging.WARNING):
+        await client._dispatch_bridge_frame(
+            {"type": "added_to_space", "space_id": "sp_2"},
+        )
+        await asyncio.gather(*client._ack_tasks)
+    assert "bridge spaces refresh failed" in caplog.text
+    assert client._ack_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_added_to_space_over_full_listen_loop(tmp_path, monkeypatch):
+    """End-to-end over ``_listen_bridge``: a live ``added_to_space``
+    frame drives the ``list_spaces`` refresh on the real loop (not just a
+    direct dispatch call)."""
+    persisted = _persist_space_spy(monkeypatch)
+
+    class _RefreshBridge(FakeBridge):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.refreshed = asyncio.Event()
+
+        async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
+            resp = await super().send_list_spaces(timeout=timeout)
+            self.refreshed.set()
+            return resp
+
+    bridge = _RefreshBridge(
+        scripted=[{"type": "added_to_space", "space_id": "sp_live"}],
+        spaces=[{"id": "sp_live", "name": "Live Space"}],
+    )
+    client = _bridge_client(tmp_path, bridge, db="ats_live.db")
+
+    async def on_message(root_id, batch, channel_meta):  # pragma: no cover
+        pass
+
+    await _drive_listen_until(
+        client, on_message=on_message, done=bridge.refreshed,
+    )
+    if client._ack_tasks:
+        await asyncio.gather(*client._ack_tasks, return_exceptions=True)
+
+    assert bridge.list_spaces_count == 1
+    assert client._space_name_cache.get("sp_live") == "Live Space"
+    assert ("sp_live", "Live Space") in persisted


### PR DESCRIPTION
## HELD — do not merge without an explicit GO

The **puffo-agent side** of the space-join notify (pairs with puffo-server **#202**). The server now pushes `{"type":"added_to_space","space_id":…}` (`AgentServerMsg::AddedToSpace`) over the bridge control WS the moment a cloud agent is auto-added to a Space; this makes the agent react instead of only finding out lazily on its next `list_spaces`.

### Change
- **`puffo_core_client.py`** — new `added_to_space` branch in `_dispatch_bridge_frame` (the inbound-bridge-frame router, alongside `message`/`pending_delivered`). It schedules `_refresh_bridge_spaces(space_id)` fire-and-forget (same pattern as the ack tasks — awaiting inline would deadlock `frames()`, which must keep receiving to resolve the `spaces` reply).
- **`_refresh_bridge_spaces`** — re-issues `list_spaces` via the existing keyless `bridge.send_list_spaces()` primitive, then warms `_space_name_cache` + persists via `disk_cache.persist_space`. Idempotent (duplicate push = harmless re-list), fail-soft (a failed refresh logs a warning, never crashes the listen loop), defensive on entry keys (`space_id`/`id`).

### Verified
- 4 new tests in `test_cloud_bridge_msgflow.py` (frame → exactly one `list_spaces` + caches warmed; duplicate harmless; missing-id/failed-refresh survive; end-to-end over the real `_listen_bridge`). Module: 35 passed.
- Full gate `pytest --ignore=tests/test_host_credentials.py` → **2004 passed, 4 skipped** (exit 0).

Completes the T26 loop end-to-end (server #202 emits → agent refreshes). Bridge transport only; native/desktop signed-HTTP path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
