### PR TITLE
fix(portal): trust certifi's CA bundle for all relay TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   "reduce or split" reply and every message in it went unprocessed.
   Codex gets a 4MB safety-net ceiling (it has no adapter input cap).
 
+- **Relay TLS now trusts certifi's CA bundle, so linking works on hosts
+  without a populated OpenSSL cert store.** Linking against
+  `https://chat.puffo.ai` died with `SSL: CERTIFICATE_VERIFY_FAILED —
+  unable to get local issuer certificate` on interpreters whose ambient
+  cert store isn't set up (python.org's macOS Python before running
+  "Install Certificates.command", some uv-managed builds); local testing
+  never caught it because it ran against plain `http://localhost:3000`.
+  `create_remote_http_session` now builds a module-level
+  `ssl.create_default_context(cafile=certifi.where())` and applies it to
+  both the SOCKS `ProxyConnector` and the default `TCPConnector`, and
+  every relay-facing HTTPS/WSS call site (link code mint / redeem /
+  approval poll / unlink, the control-WS reverse channel + `/me` liveness,
+  active-recipient fetch, slug-binding finalize) now routes through that
+  factory instead of a bare `aiohttp.ClientSession()`. `certifi` is now a
+  declared dependency.
+
 ### Changed
 
 - **Long-message redaction thresholds raised to 16000/8000 chars**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   cert store isn't set up (python.org's macOS Python before running
   "Install Certificates.command", some uv-managed builds); local testing
   never caught it because it ran against plain `http://localhost:3000`.
-  `create_remote_http_session` now builds a module-level
-  `ssl.create_default_context(cafile=certifi.where())` and applies it to
-  both the SOCKS `ProxyConnector` and the default `TCPConnector`, and
+  `create_remote_http_session` now builds a module-level SSL context
+  that trusts the system store PLUS certifi's bundle (so corporate-proxy
+  roots keep working) and applies it to both the SOCKS `ProxyConnector`
+  and the default `TCPConnector`, and
   every relay-facing HTTPS/WSS call site (link code mint / redeem /
   approval poll / unlink, the control-WS reverse channel + `/me` liveness,
   active-recipient fetch, slug-binding finalize) now routes through that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ dependencies = [
     "aiohttp-socks>=0.10",
     "aiosqlite>=0.20",
     "anthropic>=0.25",
-    # certifi's CA bundle backs relay TLS verification regardless of the
-    # host's ambient OpenSSL cert store (see crypto/http_session.py).
+    # Relay TLS trust bundle for hosts with an empty OpenSSL cert store.
     "certifi>=2024.2.2",
     "cryptography>=43.0",
     "mcp>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "aiohttp-socks>=0.10",
     "aiosqlite>=0.20",
     "anthropic>=0.25",
+    # certifi's CA bundle backs relay TLS verification regardless of the
+    # host's ambient OpenSSL cert store (see crypto/http_session.py).
+    "certifi>=2024.2.2",
     "cryptography>=43.0",
     "mcp>=1.0",
     # Pillow: dimension-check + downscale inbound image attachments so

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.9
 aiohttp-socks>=0.10
 anthropic>=0.25
+certifi>=2024.2.2
 mcp>=1.0
 openai>=1.30
 psutil>=5.9

--- a/src/puffo_agent/crypto/http_session.py
+++ b/src/puffo_agent/crypto/http_session.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import ssl
 from urllib.parse import urlsplit
 from urllib.request import getproxies, proxy_bypass
 
 import aiohttp
+import certifi
 from aiohttp_socks import ProxyConnector
 
 
 _SOCKS_SCHEMES = {"socks4", "socks4a", "socks5", "socks5h"}
+
+# Trust certifi's CA bundle rather than the host's ambient OpenSSL store,
+# which isn't populated on some interpreters (python.org macOS Python before
+# "Install Certificates.command", some uv-managed builds). Without this the
+# relay's TLS cert fails to verify and linking dies at the handshake.
+_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
 
 def _env_proxy_for_url(url: str) -> str | None:
@@ -35,7 +43,8 @@ def create_remote_http_session(
 
     proxy_url = _env_proxy_for_url(base_url)
     if proxy_url and _is_socks_proxy(proxy_url):
-        connector = ProxyConnector.from_url(proxy_url)
+        connector = ProxyConnector.from_url(proxy_url, ssl=_SSL_CONTEXT)
         return aiohttp.ClientSession(connector=connector, trust_env=False, **kwargs)
 
-    return aiohttp.ClientSession(trust_env=True, **kwargs)
+    connector = aiohttp.TCPConnector(ssl=_SSL_CONTEXT)
+    return aiohttp.ClientSession(connector=connector, trust_env=True, **kwargs)

--- a/src/puffo_agent/crypto/http_session.py
+++ b/src/puffo_agent/crypto/http_session.py
@@ -11,9 +11,8 @@ from aiohttp_socks import ProxyConnector
 
 _SOCKS_SCHEMES = {"socks4", "socks4a", "socks5", "socks5h"}
 
-# System store PLUS certifi: some interpreters ship an empty ambient store
-# (python.org macOS Python before "Install Certificates.command"), while
-# corporate-proxy hosts need their OS-installed roots — trust both.
+# System store first, certifi on top: some interpreters ship an empty
+# ambient store; corporate-proxy hosts need their OS-installed roots.
 _SSL_CONTEXT = ssl.create_default_context()
 _SSL_CONTEXT.load_verify_locations(cafile=certifi.where())
 

--- a/src/puffo_agent/crypto/http_session.py
+++ b/src/puffo_agent/crypto/http_session.py
@@ -11,11 +11,11 @@ from aiohttp_socks import ProxyConnector
 
 _SOCKS_SCHEMES = {"socks4", "socks4a", "socks5", "socks5h"}
 
-# Trust certifi's CA bundle rather than the host's ambient OpenSSL store,
-# which isn't populated on some interpreters (python.org macOS Python before
-# "Install Certificates.command", some uv-managed builds). Without this the
-# relay's TLS cert fails to verify and linking dies at the handshake.
-_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+# System store PLUS certifi: some interpreters ship an empty ambient store
+# (python.org macOS Python before "Install Certificates.command"), while
+# corporate-proxy hosts need their OS-installed roots — trust both.
+_SSL_CONTEXT = ssl.create_default_context()
+_SSL_CONTEXT.load_verify_locations(cafile=certifi.where())
 
 
 def _env_proxy_for_url(url: str) -> str | None:

--- a/src/puffo_agent/portal/control/agent_create.py
+++ b/src/puffo_agent/portal/control/agent_create.py
@@ -307,9 +307,12 @@ async def post_slug_binding(server_url: str, slug_binding: dict, pending_token: 
     token + self-signature are the gate; no auth header)."""
     import aiohttp
 
+    from ...crypto.http_session import create_remote_http_session
+
     url = f"{server_url.rstrip('/')}/certs/slug_binding"
     body = {"pending_token": pending_token, "slug_binding": slug_binding}
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with create_remote_http_session(server_url, timeout=timeout) as session:
         async with session.post(url, json=body) as resp:
             if resp.status >= 400:
                 text = await resp.text()

--- a/src/puffo_agent/portal/control/agent_message.py
+++ b/src/puffo_agent/portal/control/agent_message.py
@@ -14,6 +14,7 @@ import aiohttp
 
 from ...crypto.canonical import canonicalize_for_signing
 from ...crypto.encoding import base64url_decode, base64url_encode
+from ...crypto.http_session import create_remote_http_session
 from ...crypto.primitives import (
     aead_encrypt,
     ed25519_verify,
@@ -126,7 +127,7 @@ async def fetch_active_recipients(
     path = f"/v2/machines/{machine.machine_id}/operators/{operator_slug}/devices/active"
     headers = machine_auth.signed_headers(machine, "GET", path)
     try:
-        async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
+        async with create_remote_http_session(base_url, timeout=HTTP_TIMEOUT) as session:
             async with session.get(f"{base_url.rstrip('/')}{path}", headers=headers) as resp:
                 if resp.status >= 400:
                     return []

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -11,6 +11,7 @@ import logging
 
 import aiohttp
 
+from ...crypto.http_session import create_remote_http_session
 from ..state import (
     AgentConfig,
     agent_yml_path,
@@ -386,7 +387,7 @@ class MachineControlClient:
         if not pairings:
             return
         base = next(iter(pairings.values())).server_url.rstrip("/")
-        async with aiohttp.ClientSession() as session:
+        async with create_remote_http_session(base) as session:
             async with session.ws_connect(_ws_url(base), heartbeat=None) as ws:
                 await self._send(ws, machine_auth.ws_connect_frame(self.machine))
                 # Initial capability snapshot on connect.
@@ -548,7 +549,7 @@ class ControlManager:
                     body = json.dumps({"agents": len(discover_agents())}).encode()
                     headers = machine_auth.signed_headers(machine, "POST", "/v2/machines/me", body)
                     headers["content-type"] = "application/json"
-                    async with aiohttp.ClientSession() as session:
+                    async with create_remote_http_session(base) as session:
                         await session.post(f"{base}/v2/machines/me", data=body, headers=headers)
             except Exception as exc:  # noqa: BLE001 — best-effort liveness
                 log.debug("control: /me report failed: %s", exc)

--- a/src/puffo_agent/portal/control/link.py
+++ b/src/puffo_agent/portal/control/link.py
@@ -9,8 +9,7 @@ import socket
 import sys
 import webbrowser
 
-import aiohttp
-
+from ...crypto.http_session import create_remote_http_session
 from ..api.ownership import is_owner
 from ..state import AgentConfig, discover_agents
 from . import machine_auth
@@ -107,7 +106,7 @@ async def mint_link_code(server_url: str, hostname: str) -> tuple[str, str]:
     ``(code, base)``; the machine private key never leaves disk."""
     machine = load_or_create_machine()
     base = server_url.rstrip("/")
-    async with aiohttp.ClientSession() as session:
+    async with create_remote_http_session(base) as session:
         cert = machine_auth.machine_cert(machine, hostname)
         async with session.post(f"{base}/v2/machines", json={"machine_cert": cert}) as resp:
             if resp.status != 200:
@@ -132,7 +131,7 @@ async def redeem_link_code(server_url: str, hostname: str, code: str) -> str:
     machine = load_or_create_machine()
     base = server_url.rstrip("/")
     path = f"/v2/machines/links/{code}/redeem"
-    async with aiohttp.ClientSession() as session:
+    async with create_remote_http_session(base) as session:
         cert = machine_auth.machine_cert(machine, hostname)
         async with session.post(f"{base}/v2/machines", json={"machine_cert": cert}) as resp:
             if resp.status != 200:
@@ -156,7 +155,7 @@ async def await_link_approval(
     where status is ``approved`` / ``expired`` / ``timeout``."""
     machine = load_or_create_machine()
     waited = 0.0
-    async with aiohttp.ClientSession() as session:
+    async with create_remote_http_session(base) as session:
         while waited < timeout:
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
             waited += POLL_INTERVAL_SECONDS
@@ -355,7 +354,7 @@ async def run_unlink(operator_slug: str, expected_server_url: str | None = None)
     headers = machine_auth.signed_headers(machine, "POST", "/v2/machines/links/unlink", body)
     headers["content-type"] = "application/json"
     try:
-        async with aiohttp.ClientSession() as session:
+        async with create_remote_http_session(base) as session:
             async with session.post(
                 f"{base}/v2/machines/links/unlink", data=body, headers=headers
             ) as resp:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -116,17 +116,40 @@ def test_remote_http_session_uses_socks_proxy_env(monkeypatch):
     asyncio.run(run())
 
 
+def _assert_certifi_and_system_trust(ctx):
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    loaded = ctx.get_ca_certs()
+    certifi_only = ssl.create_default_context(cafile=certifi.where())
+    missing = [c for c in certifi_only.get_ca_certs() if c not in loaded]
+    assert not missing, f"{len(missing)} certifi CAs not loaded"
+    system_only = ssl.create_default_context()
+    missing = [c for c in system_only.get_ca_certs() if c not in loaded]
+    assert not missing, f"{len(missing)} system CAs not loaded"
+
+
 def test_remote_http_session_trusts_certifi_ca_bundle(monkeypatch):
     _clear_proxy_env(monkeypatch)
 
     async def run():
         session = create_remote_http_session("https://api.puffo.ai")
         try:
-            ctx = session.connector._ssl
-            assert isinstance(ctx, ssl.SSLContext)
-            assert ctx.verify_mode == ssl.CERT_REQUIRED
-            reference = ssl.create_default_context(cafile=certifi.where())
-            assert ctx.get_ca_certs() == reference.get_ca_certs()
+            _assert_certifi_and_system_trust(session.connector._ssl)
+        finally:
+            await session.close()
+
+    asyncio.run(run())
+
+
+def test_remote_http_session_socks_connector_gets_same_trust(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "socks5://127.0.0.1:9")
+
+    async def run():
+        session = create_remote_http_session("https://api.puffo.ai")
+        try:
+            assert isinstance(session.connector, ProxyConnector)
+            _assert_certifi_and_system_trust(session.connector._ssl)
         finally:
             await session.close()
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
 import os
+import ssl
 import sys
 import tempfile
 import time
 
 import aiohttp
+import certifi
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from aiohttp_socks import ProxyConnector
@@ -108,6 +110,23 @@ def test_remote_http_session_uses_socks_proxy_env(monkeypatch):
         try:
             assert getattr(session, "_trust_env", None) is False
             assert isinstance(session.connector, ProxyConnector)
+        finally:
+            await session.close()
+
+    asyncio.run(run())
+
+
+def test_remote_http_session_trusts_certifi_ca_bundle(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+
+    async def run():
+        session = create_remote_http_session("https://api.puffo.ai")
+        try:
+            ctx = session.connector._ssl
+            assert isinstance(ctx, ssl.SSLContext)
+            assert ctx.verify_mode == ssl.CERT_REQUIRED
+            reference = ssl.create_default_context(cafile=certifi.where())
+            assert ctx.get_ca_certs() == reference.get_ca_certs()
         finally:
             await session.close()
 

--- a/tests/test_link_code_redeem.py
+++ b/tests/test_link_code_redeem.py
@@ -87,7 +87,9 @@ class _FakeSession:
 
 def _patch_session(monkeypatch, routes):
     session = _FakeSession(routes)
-    monkeypatch.setattr(link_mod.aiohttp, "ClientSession", lambda *a, **k: session)
+    monkeypatch.setattr(
+        link_mod, "create_remote_http_session", lambda *a, **k: session
+    )
     return session
 
 


### PR DESCRIPTION
## Why

Linking against `https://chat.puffo.ai` fails at the TLS handshake with:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate
```

on machines whose ambient OpenSSL cert store isn't populated — python.org's macOS Python before running *Install Certificates.command*, and some uv-managed interpreters. The daemon's outbound HTTP/WS to the relay used aiohttp's **default** SSL context (which trusts that store), so verification blows up wherever the store is empty. Local testing never caught it because it ran against plain `http://localhost:3000` (no TLS). `certifi` already shipped transitively but the connection code never used it.

## Changes

- **`crypto/http_session.py`** — build a module-level `ssl.create_default_context(cafile=certifi.where())` and apply it to **both** connector paths in `create_remote_http_session`: the SOCKS `ProxyConnector` and a new default `TCPConnector`. `trust_env` / proxy behavior unchanged.
- **Route every bare `aiohttp.ClientSession()` relay call site** through `create_remote_http_session(...)`:
  - `portal/control/link.py` — `mint_link_code`, `await_link_approval`, and the unlink session.
  - `portal/control/client.py` — the control-WS reverse-channel `ws_connect` and the `/me` liveness POST.
  - `portal/control/agent_message.py` — active-recipient fetch (passes `timeout=`).
  - `portal/control/agent_create.py` — slug-binding finalize (passes `timeout=`).
- **Declare `certifi>=2024.2.2`** in `pyproject.toml` and `requirements.txt` (was transitive only).
- **`tests/test_http_client.py`** — assert the connector's SSL context is `CERT_REQUIRED` and its loaded CA certs match `certifi.where()`.
- **`CHANGELOG.md`** — entry under `## [Unreleased]` → `### Fixed`.

Out of scope (loopback / local-bridge, not relay TLS): `portal/ws_local/ws_local_client.py`, `mcp/_host_mcp.py`, `mcp/data_client.py`.

## Verification

`pytest -p no:warnings` → **1749 passed**, 2 skipped. The 7 failures in `tests/test_host_credentials.py` are pre-existing (macOS symlink-credential tests) and fail identically on `main`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)