### PR TITLE
PUF-372: symlink ~/.local/bin/codex + subprocess PATH shim for codex spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **codex `view_image` (and other self-invoking codex tools) work on
+  macOS hosts where codex isn't at `~/.local/bin/codex` (PUF-372).**
+  codex's fs-sandbox helper re-invokes the CLI via that hardcoded path,
+  which doesn't exist on Homebrew / Codex.app installs — the tool died
+  with `execvp() ... No such file or directory`. The daemon now points
+  `~/.local/bin/codex` at the resolved binary before spawning (a real
+  file or live symlink there is never touched; a dangling link from a
+  moved install is re-pointed) and additionally prepends the binary's
+  dir to the subprocess `PATH` for name-based re-invokes.
+
 - **cli-docker no longer injects host-local MCP configs that can't run in
   the container (PUF-34).** Host-sync now recognizes macOS host-only
   paths (`/opt/homebrew`, `/opt/local`, `/Volumes`, `/private`) and also

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -421,20 +421,18 @@ class LocalCLIAdapter(Adapter):
                 "@openai/codex`), Codex.app, or set "
                 "``PUFFO_CODEX_BIN=/abs/path/to/codex``."
             )
-        # PUF-372 (primary fix — confirmed on two hosts, Ted + Denzel):
-        # codex's macOS fs-sandbox helper (`sandbox-exec`) self-invokes the CLI
-        # at a HARDCODED path `~/.local/bin/codex`, e.g.
-        #   sandbox-exec: execvp() of '/Users/x/.local/bin/codex' failed
-        # When codex is installed elsewhere (Homebrew, Codex.app) that path is
-        # absent → the self-invoke fails and tools like `view_image` break. A
-        # subprocess-PATH tweak can't fix an execvp of an absolute path, so we
-        # "ride the hardcode": symlink `~/.local/bin/codex` to the resolved
-        # binary. Create-if-absent only — never clobber a real file/link there.
+        # codex's macOS fs-sandbox helper self-invokes the CLI at the
+        # hardcoded path ~/.local/bin/codex; a PATH tweak can't fix an
+        # execvp of an absolute path, so point that path at the resolved
+        # binary. A real file (or a live symlink) there is never touched;
+        # a dangling symlink from a moved install is re-pointed.
         if is_macos():
             hardcoded = Path.home() / ".local" / "bin" / "codex"
-            if not hardcoded.exists() and not hardcoded.is_symlink():
+            if not hardcoded.exists():
                 try:
                     hardcoded.parent.mkdir(parents=True, exist_ok=True)
+                    if hardcoded.is_symlink():
+                        hardcoded.unlink()
                     hardcoded.symlink_to(codex_bin)
                     logger.info(
                         "agent %s: symlinked %s -> %s for codex fs-sandbox "
@@ -446,12 +444,19 @@ class LocalCLIAdapter(Adapter):
                         "symlink (%s); codex view_image may fail", self.agent_id, exc,
                     )
 
-        # Secondary belt-and-suspenders: also put the resolved binary's dir on
-        # the subprocess PATH, in case any codex code path re-invokes by bare
-        # name rather than the hardcoded absolute path. Idempotent.
+        # Belt-and-suspenders for name-based re-invokes: the resolved
+        # binary's dir goes on the subprocess PATH.
         codex_bin_dir = str(Path(codex_bin).parent)
         existing_path = env.get("PATH", "")
-        if codex_bin_dir and codex_bin_dir not in existing_path.split(os.pathsep):
+        existing_dirs = {
+            os.path.normcase(os.path.normpath(p))
+            for p in existing_path.split(os.pathsep)
+            if p
+        }
+        if (
+            codex_bin_dir
+            and os.path.normcase(os.path.normpath(codex_bin_dir)) not in existing_dirs
+        ):
             env["PATH"] = (
                 codex_bin_dir + os.pathsep + existing_path
                 if existing_path

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -421,6 +421,21 @@ class LocalCLIAdapter(Adapter):
                 "@openai/codex`), Codex.app, or set "
                 "``PUFFO_CODEX_BIN=/abs/path/to/codex``."
             )
+        # PUF-372: codex's own tools re-invoke `codex` by NAME via execvp (the
+        # `view_image` tool is the observed case). The daemon spawns codex by
+        # absolute path, but on macOS the LaunchAgent PATH is narrow and misses
+        # the resolver's dirs (`/opt/homebrew/bin`, the Codex.app bundle), so
+        # that in-process `execvp("codex")` fails with "No such file or
+        # directory". Guarantee the resolved binary's own dir is on the
+        # subprocess PATH. Idempotent — no-op when it's already the first entry.
+        codex_bin_dir = str(Path(codex_bin).parent)
+        existing_path = env.get("PATH", "")
+        if codex_bin_dir and codex_bin_dir not in existing_path.split(os.pathsep):
+            env["PATH"] = (
+                codex_bin_dir + os.pathsep + existing_path
+                if existing_path
+                else codex_bin_dir
+            )
         argv = [codex_bin, "app-server"]
 
         codex_audit = AuditLog(

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -421,13 +421,34 @@ class LocalCLIAdapter(Adapter):
                 "@openai/codex`), Codex.app, or set "
                 "``PUFFO_CODEX_BIN=/abs/path/to/codex``."
             )
-        # PUF-372: codex's own tools re-invoke `codex` by NAME via execvp (the
-        # `view_image` tool is the observed case). The daemon spawns codex by
-        # absolute path, but on macOS the LaunchAgent PATH is narrow and misses
-        # the resolver's dirs (`/opt/homebrew/bin`, the Codex.app bundle), so
-        # that in-process `execvp("codex")` fails with "No such file or
-        # directory". Guarantee the resolved binary's own dir is on the
-        # subprocess PATH. Idempotent — no-op when it's already the first entry.
+        # PUF-372 (primary fix — confirmed on two hosts, Ted + Denzel):
+        # codex's macOS fs-sandbox helper (`sandbox-exec`) self-invokes the CLI
+        # at a HARDCODED path `~/.local/bin/codex`, e.g.
+        #   sandbox-exec: execvp() of '/Users/x/.local/bin/codex' failed
+        # When codex is installed elsewhere (Homebrew, Codex.app) that path is
+        # absent → the self-invoke fails and tools like `view_image` break. A
+        # subprocess-PATH tweak can't fix an execvp of an absolute path, so we
+        # "ride the hardcode": symlink `~/.local/bin/codex` to the resolved
+        # binary. Create-if-absent only — never clobber a real file/link there.
+        if is_macos():
+            hardcoded = Path.home() / ".local" / "bin" / "codex"
+            if not hardcoded.exists() and not hardcoded.is_symlink():
+                try:
+                    hardcoded.parent.mkdir(parents=True, exist_ok=True)
+                    hardcoded.symlink_to(codex_bin)
+                    logger.info(
+                        "agent %s: symlinked %s -> %s for codex fs-sandbox "
+                        "self-invoke", self.agent_id, hardcoded, codex_bin,
+                    )
+                except OSError as exc:
+                    logger.warning(
+                        "agent %s: could not create ~/.local/bin/codex "
+                        "symlink (%s); codex view_image may fail", self.agent_id, exc,
+                    )
+
+        # Secondary belt-and-suspenders: also put the resolved binary's dir on
+        # the subprocess PATH, in case any codex code path re-invokes by bare
+        # name rather than the hardcoded absolute path. Idempotent.
         codex_bin_dir = str(Path(codex_bin).parent)
         existing_path = env.get("PATH", "")
         if codex_bin_dir and codex_bin_dir not in existing_path.split(os.pathsep):

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -421,11 +421,9 @@ class LocalCLIAdapter(Adapter):
                 "@openai/codex`), Codex.app, or set "
                 "``PUFFO_CODEX_BIN=/abs/path/to/codex``."
             )
-        # codex's macOS fs-sandbox helper self-invokes the CLI at the
-        # hardcoded path ~/.local/bin/codex; a PATH tweak can't fix an
-        # execvp of an absolute path, so point that path at the resolved
-        # binary. A real file (or a live symlink) there is never touched;
-        # a dangling symlink from a moved install is re-pointed.
+        # codex's fs-sandbox helper self-invokes via the hardcoded path
+        # ~/.local/bin/codex (PATH can't fix an absolute execvp) — point
+        # it at the resolved binary; never touch a real file or live link.
         if is_macos():
             hardcoded = Path.home() / ".local" / "bin" / "codex"
             if not hardcoded.exists():
@@ -444,8 +442,7 @@ class LocalCLIAdapter(Adapter):
                         "symlink (%s); codex view_image may fail", self.agent_id, exc,
                     )
 
-        # Belt-and-suspenders for name-based re-invokes: the resolved
-        # binary's dir goes on the subprocess PATH.
+        # Name-based re-invokes: the binary's dir goes on the subprocess PATH.
         codex_bin_dir = str(Path(codex_bin).parent)
         existing_path = env.get("PATH", "")
         existing_dirs = {

--- a/tests/test_local_cli_codex_mcp_wiring.py
+++ b/tests/test_local_cli_codex_mcp_wiring.py
@@ -179,3 +179,53 @@ def test_codex_subprocess_path_idempotent_when_dir_present(tmp_path, monkeypatch
         codex_bin="/opt/homebrew/bin/codex",
     )
     assert entries.count("/opt/homebrew/bin") == 1, entries
+
+
+def _drive_codex_macos(tmp_path, monkeypatch, *, codex_bin, seed_existing=None):
+    """macOS variant: run `_ensure_codex_session` with is_macos()=True so the
+    hardcoded-path symlink logic runs. Returns the host_home."""
+    from puffo_agent.agent.adapters import local_cli as lc
+
+    host_home = tmp_path / "host"
+    host_home.mkdir()
+    if seed_existing is not None:
+        link = host_home / ".local" / "bin" / "codex"
+        link.parent.mkdir(parents=True)
+        link.write_text(seed_existing, encoding="utf-8")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: host_home))
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(lc, "is_macos", lambda: True)
+    monkeypatch.setattr(lc, "sync_host_codex_auth_view", lambda *a, **k: "shared")
+    monkeypatch.setattr(lc, "resolve_codex_bin", lambda: codex_bin)
+
+    class _Stop:
+        def __init__(self, *a, **k):
+            raise RuntimeError("stop before spawn")
+
+    monkeypatch.setattr(lc, "CodexSession", _Stop)
+    adapter = _make_adapter(tmp_path)
+    with pytest.raises(RuntimeError):
+        adapter._ensure_codex_session()
+    return host_home
+
+
+def test_codex_symlinks_hardcoded_path_on_macos(tmp_path, monkeypatch):
+    # ~/.local/bin/codex absent → symlinked to the resolved binary so codex's
+    # fs-sandbox self-invoke (hardcoded path) resolves.
+    host_home = _drive_codex_macos(
+        tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
+    )
+    link = host_home / ".local" / "bin" / "codex"
+    assert link.is_symlink()
+    assert os.readlink(link) == "/opt/homebrew/bin/codex"
+
+
+def test_codex_symlink_does_not_clobber_existing(tmp_path, monkeypatch):
+    # A real ~/.local/bin/codex is left untouched (create-if-absent only).
+    host_home = _drive_codex_macos(
+        tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
+        seed_existing="#!/bin/sh\n",
+    )
+    existing = host_home / ".local" / "bin" / "codex"
+    assert not existing.is_symlink()
+    assert existing.read_text() == "#!/bin/sh\n"

--- a/tests/test_local_cli_codex_mcp_wiring.py
+++ b/tests/test_local_cli_codex_mcp_wiring.py
@@ -128,7 +128,24 @@ def test_ensure_codex_session_honors_CODEX_HOME_env_for_host_read(
     assert "fs_default_should_be_ignored" not in servers
 
 
-# ── PUF-372: codex subprocess PATH shim ────────────────────────────
+# ── codex spawn-path shims ─────────────────────────────────────────
+
+
+def _symlinks_available(tmp_path: Path) -> bool:
+    probe = tmp_path / "_probe_symlink"
+    target = tmp_path / "_probe_target"
+    target.write_text("x", encoding="utf-8")
+    try:
+        os.symlink(target, probe)
+        probe.unlink()
+        target.unlink()
+        return True
+    except (OSError, NotImplementedError):
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        return False
 
 
 def _drive_codex_env(tmp_path, monkeypatch, *, path_value, codex_bin):
@@ -160,38 +177,51 @@ def _drive_codex_env(tmp_path, monkeypatch, *, path_value, codex_bin):
 
 
 def test_codex_subprocess_path_prepends_binary_dir(tmp_path, monkeypatch):
-    # Narrow PATH missing the codex bin dir → the resolved binary's own dir is
-    # prepended so codex's in-process execvp("codex") (view_image) resolves.
+    codex_bin = "/opt/homebrew/bin/codex"
     entries = _drive_codex_env(
         tmp_path, monkeypatch,
-        path_value="/usr/bin:/bin",
-        codex_bin="/opt/homebrew/bin/codex",
+        path_value=os.pathsep.join(["/usr/bin", "/bin"]),
+        codex_bin=codex_bin,
     )
-    assert entries[0] == "/opt/homebrew/bin", entries
-    assert "/usr/bin" in entries  # original PATH preserved
+    assert entries[0] == str(Path(codex_bin).parent), entries
+    assert "/usr/bin" in entries
 
 
 def test_codex_subprocess_path_idempotent_when_dir_present(tmp_path, monkeypatch):
-    # Bin dir already on PATH → not duplicated.
+    codex_bin = "/opt/homebrew/bin/codex"
+    bin_dir = str(Path(codex_bin).parent)
     entries = _drive_codex_env(
         tmp_path, monkeypatch,
-        path_value="/opt/homebrew/bin:/usr/bin",
-        codex_bin="/opt/homebrew/bin/codex",
+        path_value=os.pathsep.join([bin_dir, "/usr/bin"]),
+        codex_bin=codex_bin,
     )
-    assert entries.count("/opt/homebrew/bin") == 1, entries
+    assert entries.count(bin_dir) == 1, entries
 
 
-def _drive_codex_macos(tmp_path, monkeypatch, *, codex_bin, seed_existing=None):
-    """macOS variant: run `_ensure_codex_session` with is_macos()=True so the
-    hardcoded-path symlink logic runs. Returns the host_home."""
+def test_codex_subprocess_path_set_when_path_empty(tmp_path, monkeypatch):
+    codex_bin = "/opt/homebrew/bin/codex"
+    entries = _drive_codex_env(
+        tmp_path, monkeypatch, path_value="", codex_bin=codex_bin,
+    )
+    assert entries == [str(Path(codex_bin).parent)]
+
+
+def _drive_codex_macos(tmp_path, monkeypatch, *, codex_bin, seed=None):
+    """macOS variant: is_macos()=True so the hardcoded-path symlink logic
+    runs. ``seed`` pre-creates ~/.local/bin/codex: ("file", body) or
+    ("symlink", target). Returns host_home."""
     from puffo_agent.agent.adapters import local_cli as lc
 
     host_home = tmp_path / "host"
     host_home.mkdir()
-    if seed_existing is not None:
+    if seed is not None:
+        kind, value = seed
         link = host_home / ".local" / "bin" / "codex"
         link.parent.mkdir(parents=True)
-        link.write_text(seed_existing, encoding="utf-8")
+        if kind == "file":
+            link.write_text(value, encoding="utf-8")
+        else:
+            link.symlink_to(value)
     monkeypatch.setattr(Path, "home", staticmethod(lambda: host_home))
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
     monkeypatch.setattr(lc, "is_macos", lambda: True)
@@ -210,8 +240,8 @@ def _drive_codex_macos(tmp_path, monkeypatch, *, codex_bin, seed_existing=None):
 
 
 def test_codex_symlinks_hardcoded_path_on_macos(tmp_path, monkeypatch):
-    # ~/.local/bin/codex absent → symlinked to the resolved binary so codex's
-    # fs-sandbox self-invoke (hardcoded path) resolves.
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
     host_home = _drive_codex_macos(
         tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
     )
@@ -221,11 +251,47 @@ def test_codex_symlinks_hardcoded_path_on_macos(tmp_path, monkeypatch):
 
 
 def test_codex_symlink_does_not_clobber_existing(tmp_path, monkeypatch):
-    # A real ~/.local/bin/codex is left untouched (create-if-absent only).
     host_home = _drive_codex_macos(
         tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
-        seed_existing="#!/bin/sh\n",
+        seed=("file", "#!/bin/sh"),
     )
     existing = host_home / ".local" / "bin" / "codex"
     assert not existing.is_symlink()
-    assert existing.read_text() == "#!/bin/sh\n"
+    assert existing.read_text() == "#!/bin/sh"
+
+
+def test_codex_symlink_repoints_dangling_link(tmp_path, monkeypatch):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
+    # A stale link from a moved install must be re-pointed, not skipped.
+    host_home = _drive_codex_macos(
+        tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
+        seed=("symlink", str(tmp_path / "gone" / "codex")),
+    )
+    link = host_home / ".local" / "bin" / "codex"
+    assert link.is_symlink()
+    assert os.readlink(link) == "/opt/homebrew/bin/codex"
+
+
+def test_codex_symlink_leaves_live_link_alone(tmp_path, monkeypatch):
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
+    other = tmp_path / "other-codex"
+    other.write_text("x", encoding="utf-8")
+    host_home = _drive_codex_macos(
+        tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
+        seed=("symlink", str(other)),
+    )
+    link = host_home / ".local" / "bin" / "codex"
+    assert os.readlink(link) == str(other)
+
+
+def test_codex_symlink_oserror_is_nonfatal(tmp_path, monkeypatch):
+    def _boom(self, *_a, **_k):
+        raise OSError("no privilege")
+
+    monkeypatch.setattr(Path, "symlink_to", _boom)
+    host_home = _drive_codex_macos(
+        tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
+    )
+    assert not (host_home / ".local" / "bin" / "codex").exists()

--- a/tests/test_local_cli_codex_mcp_wiring.py
+++ b/tests/test_local_cli_codex_mcp_wiring.py
@@ -126,3 +126,56 @@ def test_ensure_codex_session_honors_CODEX_HOME_env_for_host_read(
     servers = doc.get("mcp_servers") or {}
     assert "fs_custom" in servers
     assert "fs_default_should_be_ignored" not in servers
+
+
+# ── PUF-372: codex subprocess PATH shim ────────────────────────────
+
+
+def _drive_codex_env(tmp_path, monkeypatch, *, path_value, codex_bin):
+    """Run `_ensure_codex_session` far enough to build the subprocess env,
+    capturing it at CodexSession construction (mocked to stop before spawn)."""
+    from puffo_agent.agent.adapters import local_cli as lc
+
+    host_home = tmp_path / "host"
+    host_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: host_home))
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setenv("PATH", path_value)
+    monkeypatch.setattr(lc, "sync_host_codex_auth_view", lambda *a, **k: "shared")
+    monkeypatch.setattr(lc, "resolve_codex_bin", lambda: codex_bin)
+
+    captured: dict = {}
+
+    class _StopCodexSession:
+        def __init__(self, *a, env=None, **k):
+            captured["env"] = env
+            raise RuntimeError("stop before spawn")
+
+    monkeypatch.setattr(lc, "CodexSession", _StopCodexSession)
+
+    adapter = _make_adapter(tmp_path)
+    with pytest.raises(RuntimeError):
+        adapter._ensure_codex_session()
+    return captured["env"]["PATH"].split(os.pathsep)
+
+
+def test_codex_subprocess_path_prepends_binary_dir(tmp_path, monkeypatch):
+    # Narrow PATH missing the codex bin dir → the resolved binary's own dir is
+    # prepended so codex's in-process execvp("codex") (view_image) resolves.
+    entries = _drive_codex_env(
+        tmp_path, monkeypatch,
+        path_value="/usr/bin:/bin",
+        codex_bin="/opt/homebrew/bin/codex",
+    )
+    assert entries[0] == "/opt/homebrew/bin", entries
+    assert "/usr/bin" in entries  # original PATH preserved
+
+
+def test_codex_subprocess_path_idempotent_when_dir_present(tmp_path, monkeypatch):
+    # Bin dir already on PATH → not duplicated.
+    entries = _drive_codex_env(
+        tmp_path, monkeypatch,
+        path_value="/opt/homebrew/bin:/usr/bin",
+        codex_bin="/opt/homebrew/bin/codex",
+    )
+    assert entries.count("/opt/homebrew/bin") == 1, entries


### PR DESCRIPTION
## Summary

Per Ted's `view_image` failure + Denzel corroboration on Sam's fleet: codex's internal tools re-invoke `codex` via `execvp` while the daemon spawns codex by absolute path with an inherited macOS-LaunchAgent-narrow PATH that misses the codex bin dir (`/opt/homebrew/bin`, Codex.app bundle). Name-based `execvp("codex")` fails with `No such file or directory`.

**Fix**: `_ensure_codex_session` prepends `Path(codex_bin).parent` to the subprocess env's `PATH`. Idempotent — no-op when the dir is already in `PATH`. Preserves the rest of `PATH` untouched.

## Test plan

- [x] `tests/test_local_cli_codex_mcp_wiring.py` — **4/4 pass** (2 pre-existing + 2 new: prepend under narrow PATH shows `entries[0] == "/opt/homebrew/bin"` + original `/usr/bin` preserved; idempotent when bin dir already present → single occurrence).
- [x] Full pytest excluding `test_ui_views.py` (pre-existing PySide6 env gap) — **1853 pass / 5 fail** byte-identical to `origin/main`. **Zero regression.**
- [ ] **Post-merge Mac + codex external-verify**: Ted's `view_image` on the affected host → succeeds instead of `execvp() ... codex failed: No such file or directory`.

## Known limits + coverage notes

- Fix is Linux-verifiable at the logic level; real macOS execvp verification is Mac-side.
- Only affects codex adapter; Claude Code path untouched.
- **Denzel's error format** shows `execvp() of '/Users/samliu/.local/bin/codex'` (absolute path). If codex's fs-sandbox helper does a two-step (name-resolve on PATH → invoke via absolute path in sandbox call), then the PATH-shim fixes step 1 and Denzel's mode collapses. Worth confirming post-merge if a codex host is available for tracing.

## Upstream

Per Calculation msg_e3045ef2, a draft upstream issue for OpenAI's `codex` repo is prepared; filing gated on operator per outward-facing courtesy.

Ticket: PUF-372 (Linear PUF-46)