### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.1.1] — 2026-07-10
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.1.0"
+version = "1.1.1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump + changelog dating for the 1.1.1 release. Six fixes since 1.1.0:

- **PUF-363** — over-limit message bursts greedy-fill across turns instead of dropping the batch
- **PUF-36** — profile edits take effect on refresh (changed primer/profile slice → fresh CLI session; memory-only rebuilds keep the conversation); role edits reach profile.md
- **PUF-34** — cli-docker skips host-local MCP configs (incl. macOS paths + args-hidden paths) instead of injecting dead config
- **PUF-372** — codex self-invoking tools (view_image) work on Homebrew/Codex.app installs via the hardcoded-path symlink + PATH shim
- **relay TLS** — system CA store + certifi trust for all relay HTTPS/WSS (fixes empty-cert-store hosts, keeps corporate proxies working)
- **Changed**: long-message redaction thresholds raised to 16000/8000 chars, hoisted to a shared `puffo_agent.limits` module

After merge: `gh release create v1.1.1` fires the PyPI publish workflow, which pauses at the `pypi` environment gate for your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)