### PR TITLE
PUF-372 follow-up: resolve codex from ChatGPT.app bundle + legible not-found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **codex is now discovered inside ChatGPT.app on macOS (PUF-372
+  follow-up).** A ChatGPT desktop-app update moved the bundled codex
+  binary out of Codex.app, leaving agents unable to spawn. The resolver
+  now checks `ChatGPT.app/Contents/Resources/codex` (system and
+  per-user `Applications`, preferred over a leftover Codex.app copy),
+  which also re-points the `~/.local/bin/codex` fs-sandbox shim at the
+  new location. The "codex binary not found" error now names the bundle
+  paths tried and the restart-after-app-update remedy.
+
 ## [1.1.1] — 2026-07-10
 
 ### Fixed

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -415,10 +415,12 @@ class LocalCLIAdapter(Adapter):
         codex_bin = resolve_codex_bin()
         if codex_bin is None:
             raise RuntimeError(
-                "codex binary not found. Tried $PUFFO_CODEX_BIN, "
-                "$PATH, and the Codex.app / Windows / Linux bundle "
-                "paths. Install the Codex CLI (`npm install -g "
-                "@openai/codex`), Codex.app, or set "
+                "codex binary not found. Tried $PUFFO_CODEX_BIN, $PATH, "
+                "and the Codex.app / ChatGPT.app / Windows / Linux bundle "
+                "paths. If you recently updated the ChatGPT or Codex "
+                "desktop app, restart puffo-agent so it re-resolves the "
+                "binary. Otherwise install the Codex CLI (`npm install -g "
+                "@openai/codex`) or set "
                 "``PUFFO_CODEX_BIN=/abs/path/to/codex``."
             )
         # codex's fs-sandbox helper self-invokes via the hardcoded path

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -416,7 +416,7 @@ class LocalCLIAdapter(Adapter):
         if codex_bin is None:
             raise RuntimeError(
                 "codex binary not found. Tried $PUFFO_CODEX_BIN, $PATH, "
-                "and the Codex.app / ChatGPT.app / Windows / Linux bundle "
+                "and the ChatGPT.app / Codex.app / Windows / Linux bundle "
                 "paths. If you recently updated the ChatGPT or Codex "
                 "desktop app, restart puffo-agent so it re-resolves the "
                 "binary. Otherwise install the Codex CLI (`npm install -g "

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -196,9 +196,13 @@ def _write_path_cache(name: str, path: str) -> None:
 
 def _codex_bundle_paths() -> list[Path]:
     if sys.platform == "darwin":
+        # ChatGPT.app bundles codex too (as of the desktop app update that
+        # migrated the binary out of Codex.app) — check both.
         return _expand(
             "/Applications/Codex.app/Contents/Resources/codex",
             "~/Applications/Codex.app/Contents/Resources/codex",
+            "/Applications/ChatGPT.app/Contents/Resources/codex",
+            "~/Applications/ChatGPT.app/Contents/Resources/codex",
         )
     if sys.platform == "win32":
         return _expand(

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -196,12 +196,13 @@ def _write_path_cache(name: str, path: str) -> None:
 
 def _codex_bundle_paths() -> list[Path]:
     if sys.platform == "darwin":
-        # Newer ChatGPT.app builds bundle codex (moved out of Codex.app).
+        # ChatGPT.app first — newer builds bundle codex there (moved out
+        # of Codex.app), so a leftover Codex.app copy is the stale one.
         return _expand(
-            "/Applications/Codex.app/Contents/Resources/codex",
-            "~/Applications/Codex.app/Contents/Resources/codex",
             "/Applications/ChatGPT.app/Contents/Resources/codex",
             "~/Applications/ChatGPT.app/Contents/Resources/codex",
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "~/Applications/Codex.app/Contents/Resources/codex",
         )
     if sys.platform == "win32":
         return _expand(

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -196,8 +196,7 @@ def _write_path_cache(name: str, path: str) -> None:
 
 def _codex_bundle_paths() -> list[Path]:
     if sys.platform == "darwin":
-        # ChatGPT.app bundles codex too (as of the desktop app update that
-        # migrated the binary out of Codex.app) — check both.
+        # Newer ChatGPT.app builds bundle codex (moved out of Codex.app).
         return _expand(
             "/Applications/Codex.app/Contents/Resources/codex",
             "~/Applications/Codex.app/Contents/Resources/codex",

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -80,7 +80,7 @@ def test_claude_resolver_uses_its_own_env(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize("platform_value,want_first", [
-    ("darwin", "/Applications/Codex.app/Contents/Resources/codex"),
+    ("darwin", "/Applications/ChatGPT.app/Contents/Resources/codex"),
     ("win32", "codex.exe"),  # contains-check
 ])
 def test_bundle_paths_per_platform(platform_value, want_first, monkeypatch):
@@ -107,9 +107,10 @@ def test_darwin_bundle_paths_include_chatgpt_app(monkeypatch):
         and p != "/Applications/ChatGPT.app/Contents/Resources/codex"
         for p in paths
     ), "expected the ~/Applications ChatGPT.app path too"
-    # Codex.app retained AND preferred — _first_existing takes the first hit.
-    assert paths.index("/Applications/Codex.app/Contents/Resources/codex") < paths.index(
-        "/Applications/ChatGPT.app/Contents/Resources/codex"
+    # ChatGPT.app preferred over a leftover Codex.app copy — _first_existing
+    # takes the first hit.
+    assert paths.index("/Applications/ChatGPT.app/Contents/Resources/codex") < paths.index(
+        "/Applications/Codex.app/Contents/Resources/codex"
     )
 
 

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -99,8 +99,6 @@ def test_bundle_paths_per_platform(platform_value, want_first, monkeypatch):
 
 
 def test_darwin_bundle_paths_include_chatgpt_app(monkeypatch):
-    # PUF-372 follow-up: ChatGPT.app bundles codex after the desktop-app
-    # update that moved the binary out of Codex.app — both must be covered.
     monkeypatch.setattr(cli_bin.sys, "platform", "darwin")
     paths = [p.as_posix() for p in cli_bin._codex_bundle_paths()]
     assert "/Applications/ChatGPT.app/Contents/Resources/codex" in paths
@@ -109,8 +107,10 @@ def test_darwin_bundle_paths_include_chatgpt_app(monkeypatch):
         and p != "/Applications/ChatGPT.app/Contents/Resources/codex"
         for p in paths
     ), "expected the ~/Applications ChatGPT.app path too"
-    # Codex.app paths retained (added, not replaced).
-    assert "/Applications/Codex.app/Contents/Resources/codex" in paths
+    # Codex.app retained AND preferred — _first_existing takes the first hit.
+    assert paths.index("/Applications/Codex.app/Contents/Resources/codex") < paths.index(
+        "/Applications/ChatGPT.app/Contents/Resources/codex"
+    )
 
 
 def test_hermes_env_override_wins(tmp_path, monkeypatch):

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -98,6 +98,21 @@ def test_bundle_paths_per_platform(platform_value, want_first, monkeypatch):
         assert want_first in str(paths[0]).lower()
 
 
+def test_darwin_bundle_paths_include_chatgpt_app(monkeypatch):
+    # PUF-372 follow-up: ChatGPT.app bundles codex after the desktop-app
+    # update that moved the binary out of Codex.app — both must be covered.
+    monkeypatch.setattr(cli_bin.sys, "platform", "darwin")
+    paths = [p.as_posix() for p in cli_bin._codex_bundle_paths()]
+    assert "/Applications/ChatGPT.app/Contents/Resources/codex" in paths
+    assert any(
+        p.endswith("Applications/ChatGPT.app/Contents/Resources/codex")
+        and p != "/Applications/ChatGPT.app/Contents/Resources/codex"
+        for p in paths
+    ), "expected the ~/Applications ChatGPT.app path too"
+    # Codex.app paths retained (added, not replaced).
+    assert "/Applications/Codex.app/Contents/Resources/codex" in paths
+
+
 def test_hermes_env_override_wins(tmp_path, monkeypatch):
     """``$PUFFO_HERMES_BIN`` beats PATH + bundle paths."""
     fake = _make_exe(tmp_path, "fake_hermes")

--- a/tests/test_local_cli_codex_mcp_wiring.py
+++ b/tests/test_local_cli_codex_mcp_wiring.py
@@ -317,3 +317,51 @@ def test_codex_symlink_oserror_is_nonfatal(tmp_path, monkeypatch):
         tmp_path, monkeypatch, codex_bin="/opt/homebrew/bin/codex",
     )
     assert not (host_home / ".local" / "bin" / "codex").exists()
+
+
+def test_bundle_discovery_composes_with_stale_symlink_retarget(tmp_path, monkeypatch):
+    # FB-400 end-to-end: codex now resolves via a bundle path (as ChatGPT.app
+    # does after the app update) AND ~/.local/bin/codex is a corpse from the
+    # moved-out install. One worker start must BOTH discover the binary via the
+    # bundle path AND re-target the dead symlink to it.
+    if not _symlinks_available(tmp_path):
+        pytest.skip("symlinks unavailable on this host")
+    from puffo_agent.agent import cli_bin
+    from puffo_agent.agent.adapters import local_cli as lc
+
+    host_home = tmp_path / "host"
+    host_home.mkdir()
+    bundle_codex = tmp_path / "ChatGPT.app" / "Contents" / "Resources" / "codex"
+    bundle_codex.parent.mkdir(parents=True)
+    bundle_codex.write_text("#!/bin/sh\n", encoding="utf-8")
+    bundle_codex.chmod(0o755)
+    link = host_home / ".local" / "bin" / "codex"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(tmp_path / "Codex.app" / "Contents" / "Resources" / "codex")  # corpse
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: host_home))
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(lc, "is_macos", lambda: True)
+    monkeypatch.setattr(lc, "sync_host_codex_auth_view", lambda *a, **k: "shared")
+    # Force resolution to the bundle path (env + PATH miss), cache-isolated so
+    # neither our resolution nor a prior test's leaks across the boundary.
+    monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
+    monkeypatch.setattr("shutil.which", lambda *a, **k: None)
+    monkeypatch.setattr(cli_bin, "_real_path", lambda: "")
+    monkeypatch.setattr(cli_bin, "_real_path_cache", None)
+    cli_bin._resolve_memcache.clear()
+    monkeypatch.setattr(cli_bin, "_codex_bundle_paths", lambda: [bundle_codex])
+
+    class _Stop:
+        def __init__(self, *a, **k):
+            raise RuntimeError("stop before spawn")
+
+    monkeypatch.setattr(lc, "CodexSession", _Stop)
+    adapter = _make_adapter(tmp_path)
+    try:
+        with pytest.raises(RuntimeError):
+            adapter._ensure_codex_session()
+        # Item 2: the corpse symlink now points at the bundle-discovered binary.
+        assert os.readlink(link) == str(bundle_codex)
+    finally:
+        cli_bin._resolve_memcache.clear()

--- a/tests/test_local_cli_codex_mcp_wiring.py
+++ b/tests/test_local_cli_codex_mcp_wiring.py
@@ -287,8 +287,6 @@ def test_codex_symlink_leaves_live_link_alone(tmp_path, monkeypatch):
 
 
 def test_codex_not_found_error_is_legible(tmp_path, monkeypatch):
-    # PUF-372 follow-up: the pre-spawn "not found" error must name ChatGPT.app
-    # and the restart-after-app-update remedy, not a bare red.
     from puffo_agent.agent.adapters import local_cli as lc
 
     host_home = tmp_path / "host"
@@ -320,10 +318,8 @@ def test_codex_symlink_oserror_is_nonfatal(tmp_path, monkeypatch):
 
 
 def test_bundle_discovery_composes_with_stale_symlink_retarget(tmp_path, monkeypatch):
-    # FB-400 end-to-end: codex now resolves via a bundle path (as ChatGPT.app
-    # does after the app update) AND ~/.local/bin/codex is a corpse from the
-    # moved-out install. One worker start must BOTH discover the binary via the
-    # bundle path AND re-target the dead symlink to it.
+    # One start must both discover codex via a bundle path AND re-target
+    # the dangling ~/.local/bin/codex left by the moved-out install.
     if not _symlinks_available(tmp_path):
         pytest.skip("symlinks unavailable on this host")
     from puffo_agent.agent import cli_bin
@@ -343,8 +339,7 @@ def test_bundle_discovery_composes_with_stale_symlink_retarget(tmp_path, monkeyp
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
     monkeypatch.setattr(lc, "is_macos", lambda: True)
     monkeypatch.setattr(lc, "sync_host_codex_auth_view", lambda *a, **k: "shared")
-    # Force resolution to the bundle path (env + PATH miss), cache-isolated so
-    # neither our resolution nor a prior test's leaks across the boundary.
+    # Force bundle-path resolution; isolate both resolver cache layers.
     monkeypatch.delenv("PUFFO_CODEX_BIN", raising=False)
     monkeypatch.setattr("shutil.which", lambda *a, **k: None)
     monkeypatch.setattr(cli_bin, "_real_path", lambda: "")
@@ -359,9 +354,8 @@ def test_bundle_discovery_composes_with_stale_symlink_retarget(tmp_path, monkeyp
     monkeypatch.setattr(lc, "CodexSession", _Stop)
     adapter = _make_adapter(tmp_path)
     try:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="stop before spawn"):
             adapter._ensure_codex_session()
-        # Item 2: the corpse symlink now points at the bundle-discovered binary.
         assert os.readlink(link) == str(bundle_codex)
     finally:
         cli_bin._resolve_memcache.clear()

--- a/tests/test_local_cli_codex_mcp_wiring.py
+++ b/tests/test_local_cli_codex_mcp_wiring.py
@@ -286,6 +286,28 @@ def test_codex_symlink_leaves_live_link_alone(tmp_path, monkeypatch):
     assert os.readlink(link) == str(other)
 
 
+def test_codex_not_found_error_is_legible(tmp_path, monkeypatch):
+    # PUF-372 follow-up: the pre-spawn "not found" error must name ChatGPT.app
+    # and the restart-after-app-update remedy, not a bare red.
+    from puffo_agent.agent.adapters import local_cli as lc
+
+    host_home = tmp_path / "host"
+    host_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: host_home))
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(lc, "is_macos", lambda: False)
+    monkeypatch.setattr(lc, "sync_host_codex_auth_view", lambda *a, **k: "shared")
+    monkeypatch.setattr(lc, "resolve_codex_bin", lambda: None)
+
+    adapter = _make_adapter(tmp_path)
+    with pytest.raises(RuntimeError) as ei:
+        adapter._ensure_codex_session()
+    msg = str(ei.value)
+    assert "codex binary not found" in msg
+    assert "ChatGPT.app" in msg
+    assert "restart puffo-agent" in msg
+
+
 def test_codex_symlink_oserror_is_nonfatal(tmp_path, monkeypatch):
     def _boom(self, *_a, **_k):
         raise OSError("no privilege")


### PR DESCRIPTION
## Summary

Follow-up to PUF-372 addressing the FB-400 codex-migration outage (3 agents blocked when ChatGPT.app update moved the codex binary out of Codex.app).

- **Item 1 (the heal):** `_codex_bundle_paths()` now includes `/Applications/ChatGPT.app/Contents/Resources/codex` + `~/Applications/…`. `resolve_codex_bin` feeds both spawn discovery and the fs-sandbox symlink target, so the one add heals discovery AND re-points the shim.
- **Item 3a (legible error):** the "codex binary not found" error now names ChatGPT.app + the restart-after-app-update remedy. Already reaches operator as `runtime.error` via the worker; this makes the red actually actionable.

## Scope decisions

- **Item 2 (stale symlink):** confirmed no-op — already shipped. Merged PUF-372 block re-targets dangling links (`if not hardcoded.exists()` → dangling link resolves False → unlink + recreate), covered by `test_codex_symlink_repoints_dangling_link` on main. Only gap vs literal `is_file()` is symlink→directory, which never happens for `~/.local/bin/codex`.
- **Item 3b (proactive operator DM):** deferred pending Nova. 3a makes the error legible via existing `runtime.error` surface; a proactive DM (like `on_auth_failed_enter`) is a separate alert-machinery change. Fold on request.

## Files

- `agent/cli_bin.py` — darwin bundle list adds both ChatGPT.app variants; retains Codex.app.
- `agent/adapters/local_cli.py` — pre-spawn error message rewritten.
- Tests: `test_darwin_bundle_paths_include_chatgpt_app`, `test_codex_not_found_error_is_legible`.

## Test plan

- [x] Touched suites (`test_cli_bin.py` + `test_local_cli_codex_mcp_wiring.py`) → **39 pass**.
- [x] Full sweep `tests/ --ignore=tests/test_ui_views.py` → **1873 pass / 2 skipped / 0 fail**. Zero regression.
- [x] Verified on-main dangling-symlink recovery path — `Path.exists()` returns False for dead symlinks, `is_symlink()` still True, unlink+recreate proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)