### PR TITLE
PUF-375: codex task_timeout_seconds knob + legible timeout + mid-reconnect retry (work-loss fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-agent codex turn timeout: `runtime.task_timeout_seconds` in
+  `agent.yml` (PUF-375).** Default stays 600s; raise it for agents
+  running long reasoning or complex tasks. A timed-out turn now posts
+  an operator-facing "⏱ Task exceeded the N-minute timeout" reply
+  instead of silence (and says whether the codex session was reset).
+
 ### Fixed
+
+- **codex mid-reconnect turn failures no longer drop the batch or flip
+  a false red (PUF-375).** A `turn failed: Reconnecting... N/M` from
+  the codex App Server is transient — it now routes into the existing
+  retry substrate (re-enqueue + backoff) instead of being swallowed as
+  an unhandled error, and it no longer counts toward the wedged-thread
+  rotation threshold.
 
 - **codex is now discovered inside ChatGPT.app on macOS (PUF-372
   follow-up).** A ChatGPT desktop-app update moved the bundled codex

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -101,6 +101,14 @@ def _looks_like_codex_thread_limit(err_text: str) -> bool:
     return any(p.search(err_text or "") for p in _CODEX_THREAD_LIMIT_PATTERNS)
 
 
+def _timeout_budget_label(seconds: float) -> str:
+    """Human label for a turn-timeout budget: minutes when >=60s, else seconds
+    (so a sub-minute budget doesn't render as a nonsensical '0-minute')."""
+    if seconds >= 60:
+        return f"{int(seconds // 60)}-minute"
+    return f"{int(seconds)}-second"
+
+
 # Verbatim Codex auth-failure signals — anchored so we don't auto-flip on
 # legitimate model/quota errors. ``invalid thread id ... found 0`` is a
 # downstream symptom of an empty conversation_id, not auth — kept out.
@@ -366,11 +374,12 @@ class CodexSession:
                     # PUF-375 (b'): replace the bare empty reply with an
                     # operator-facing line so a timeout doesn't surface as
                     # silence. Routed as a normal reply by core.py.
-                    timeout_min = int(self.task_timeout_seconds // 60)
                     return TurnResult(
                         reply=(
-                            f"⏱ Task exceeded the {timeout_min}-minute timeout; "
-                            "the codex session state was cleared for the next turn."
+                            f"⏱ Task exceeded the "
+                            f"{_timeout_budget_label(self.task_timeout_seconds)} "
+                            "timeout; the codex session state was cleared for "
+                            "the next turn."
                         ),
                         metadata={
                             "codex_turn_timeout": True,

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -228,6 +228,7 @@ class CodexSession:
         permission_mode: str = "bypassPermissions",
         sandbox: str = "danger-full-access",
         model: str = "",
+        task_timeout_seconds: float = TURN_TIMEOUT_SECONDS,
         audit: Optional[AuditLog] = None,
     ):
         self.agent_id = agent_id
@@ -243,6 +244,9 @@ class CodexSession:
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
+        # Per-agent turn wall-clock budget (PUF-375). Defaults to the module
+        # constant; agents running long reasoning tasks raise it via agent.yml.
+        self.task_timeout_seconds = task_timeout_seconds
         self.audit = audit
 
         self._proc: asyncio.subprocess.Process | None = None
@@ -336,12 +340,12 @@ class CodexSession:
             else:
                 try:
                     await asyncio.wait_for(
-                        turn.completed, timeout=TURN_TIMEOUT_SECONDS,
+                        turn.completed, timeout=self.task_timeout_seconds,
                     )
                 except asyncio.TimeoutError:
                     logger.warning(
                         "agent %s: codex turn timed out after %ds",
-                        self.agent_id, TURN_TIMEOUT_SECONDS,
+                        self.agent_id, self.task_timeout_seconds,
                     )
                     # Best-effort interrupt so the server stops streaming
                     # output we'll never read.
@@ -359,8 +363,15 @@ class CodexSession:
                     rotated_in_branch = self._propagate_turn_outcome(
                         outcome="timeout",
                     )
+                    # PUF-375 (b'): replace the bare empty reply with an
+                    # operator-facing line so a timeout doesn't surface as
+                    # silence. Routed as a normal reply by core.py.
+                    timeout_min = int(self.task_timeout_seconds // 60)
                     return TurnResult(
-                        reply="",
+                        reply=(
+                            f"⏱ Task exceeded the {timeout_min}-minute timeout; "
+                            "the codex session state was cleared for the next turn."
+                        ),
                         metadata={
                             "codex_turn_timeout": True,
                             "codex_thread_rotated": rotated_in_branch,

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -101,6 +101,18 @@ def _looks_like_codex_thread_limit(err_text: str) -> bool:
     return any(p.search(err_text or "") for p in _CODEX_THREAD_LIMIT_PATTERNS)
 
 
+# PUF-375 (b): codex App Server reconnecting to its backend mid-turn surfaces
+# as ``codex turn failed: Reconnecting... N/M``. It's transient + self-heals,
+# so it must NOT drop the batch or count as a wedged strike.
+_CODEX_RECONNECT_PATTERN: re.Pattern[str] = re.compile(
+    r"\bReconnecting\b", re.IGNORECASE
+)
+
+
+def _looks_like_codex_reconnect(err_text: str) -> bool:
+    return bool(_CODEX_RECONNECT_PATTERN.search(err_text or ""))
+
+
 def _timeout_budget_label(seconds: float) -> str:
     """Human label for a turn-timeout budget: minutes when >=60s, else seconds
     (so a sub-minute budget doesn't render as a nonsensical '0-minute')."""
@@ -395,6 +407,21 @@ class CodexSession:
 
         if turn_failed_exc is not None:
             err_text = str(turn_failed_exc)
+            # PUF-375 (b) ε: a mid-reconnect failure is transient — codex is
+            # re-establishing its backend and will self-heal. Route it through
+            # the retry substrate (non-auth AgentAPIError → the consumer
+            # re-enqueues the batch + backs off) instead of the raw RuntimeError
+            # that the worker swallows + drops (work loss) while flipping
+            # unhandled_error (false red). Don't count it as a wedged strike.
+            if _looks_like_codex_reconnect(err_text):
+                from ..core import AgentAPIError
+                logger.info(
+                    "agent %s: codex mid-reconnect; deferring batch for retry "
+                    "(not a wedged strike): %s", self.agent_id, err_text,
+                )
+                raise AgentAPIError(
+                    f"codex reconnecting (transient): {err_text}", is_auth=False,
+                ) from turn_failed_exc
             self._propagate_turn_outcome(
                 outcome="turn_failed", err_text=err_text,
             )

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -101,9 +101,8 @@ def _looks_like_codex_thread_limit(err_text: str) -> bool:
     return any(p.search(err_text or "") for p in _CODEX_THREAD_LIMIT_PATTERNS)
 
 
-# PUF-375 (b): codex App Server reconnecting to its backend mid-turn surfaces
-# as ``codex turn failed: Reconnecting... N/M``. It's transient + self-heals,
-# so it must NOT drop the batch or count as a wedged strike.
+# Mid-turn ``turn failed: Reconnecting... N/M`` is transient — the App
+# Server self-heals; don't drop the batch or count a wedged strike.
 _CODEX_RECONNECT_PATTERN: re.Pattern[str] = re.compile(
     r"\bReconnecting\b", re.IGNORECASE
 )
@@ -264,8 +263,7 @@ class CodexSession:
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
-        # Per-agent turn wall-clock budget (PUF-375). Defaults to the module
-        # constant; agents running long reasoning tasks raise it via agent.yml.
+        # Per-agent turn wall-clock budget; raised via agent.yml for long tasks.
         self.task_timeout_seconds = task_timeout_seconds
         self.audit = audit
 
@@ -383,16 +381,16 @@ class CodexSession:
                     rotated_in_branch = self._propagate_turn_outcome(
                         outcome="timeout",
                     )
-                    # PUF-375 (b'): replace the bare empty reply with an
-                    # operator-facing line so a timeout doesn't surface as
-                    # silence. Routed as a normal reply by core.py.
+                    # Operator-facing reply so a timeout doesn't surface as
+                    # silence; only claim a reset when rotation actually fired.
+                    label = _timeout_budget_label(self.task_timeout_seconds)
+                    suffix = (
+                        "; the codex session was reset for the next turn."
+                        if rotated_in_branch
+                        else "."
+                    )
                     return TurnResult(
-                        reply=(
-                            f"⏱ Task exceeded the "
-                            f"{_timeout_budget_label(self.task_timeout_seconds)} "
-                            "timeout; the codex session state was cleared for "
-                            "the next turn."
-                        ),
+                        reply=f"⏱ Task exceeded the {label} timeout{suffix}",
                         metadata={
                             "codex_turn_timeout": True,
                             "codex_thread_rotated": rotated_in_branch,
@@ -407,12 +405,9 @@ class CodexSession:
 
         if turn_failed_exc is not None:
             err_text = str(turn_failed_exc)
-            # PUF-375 (b) ε: a mid-reconnect failure is transient — codex is
-            # re-establishing its backend and will self-heal. Route it through
-            # the retry substrate (non-auth AgentAPIError → the consumer
-            # re-enqueues the batch + backs off) instead of the raw RuntimeError
-            # that the worker swallows + drops (work loss) while flipping
-            # unhandled_error (false red). Don't count it as a wedged strike.
+            # Transient mid-reconnect: non-auth AgentAPIError routes the batch
+            # to the consumer's re-enqueue/backoff instead of the raw
+            # RuntimeError drop; not a wedged strike.
             if _looks_like_codex_reconnect(err_text):
                 from ..core import AgentAPIError
                 logger.info(

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -65,27 +65,19 @@ _NOTIFICATION_PREFIXES = (
     "turn/", "turn.",
 )
 
-# Methods we issue to the App Server. These names are pinned from the
-# live server's error response (it helpfully enumerates every method
-# it knows about when handed an unknown one) — codex 0.x rejects
-# camelCase ``sendUserTurn``/``newConversation`` and ships the
-# slash-namespaced ``thread/*`` and ``turn/*`` families instead.
+# Method names pinned from the live server's unknown-method error:
+# codex 0.x rejects camelCase, ships slash-namespaced thread/* + turn/*.
 METHOD_INITIALIZE = "initialize"
 METHOD_NEW_CONVERSATION = "thread/start"
 METHOD_SEND_USER_TURN = "turn/start"
 METHOD_RESUME_CONVERSATION = "thread/resume"
 METHOD_INTERRUPT_TURN = "turn/interrupt"
 
-# How long to wait for the App Server to acknowledge a request before
-# giving up. The first ``newConversation`` after spawn can be slow
-# (cold model load); ``sendUserTurn`` should be quick to ACK
-# (streaming starts immediately after).
+# Request-ACK timeout; first thread/start after spawn is slow (cold model load).
 REQUEST_TIMEOUT_SECONDS = 60.0
 
-# Turn-level timeout — wall-clock budget for a single user turn from
-# send to ``turn/completed``. Generous; the daemon also caps things
-# at the worker level. Mostly defensive against a wedged App Server
-# that ACKs the request but never streams.
+# Default per-turn wall-clock budget; defensive against an App Server
+# that ACKs but never streams.
 TURN_TIMEOUT_SECONDS = 600.0
 
 # Reacts fast in a small fleet, absorbs single transient hiccups.
@@ -120,22 +112,17 @@ def _timeout_budget_label(seconds: float) -> str:
     return f"{int(seconds)}-second"
 
 
-# Verbatim Codex auth-failure signals — anchored so we don't auto-flip on
-# legitimate model/quota errors. ``invalid thread id ... found 0`` is a
-# downstream symptom of an empty conversation_id, not auth — kept out.
-# ``invalidated oauth token`` is codex's human-readable form (distinct from
-# the ``token_invalidated`` JSON field), observed live on a relogin.
+# Verbatim codex auth-failure signals, anchored so model/quota errors
+# don't flip auth. "invalid thread id ... found 0" = empty-conversation
+# symptom, not auth. "invalidated oauth token" = human-readable form, seen live.
 _CODEX_AUTH_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"refresh token (?:was )?revoked", re.IGNORECASE),
     re.compile(r"\btoken_invalidated\b", re.IGNORECASE),
     re.compile(r"invalidated\s+oauth\s+token", re.IGNORECASE),
 )
 
-# A 401 in an OAuth/auth context. Codex surfaces a broken token as a 401 on
-# its API endpoints (``/responses``, ``/backend-api/codex/...``), so require
-# an auth-context marker within the same clause as the ``401`` rather than
-# pinning a single path — bounded distance + no sentence break keeps an
-# unrelated 401 in a log line from tripping it.
+# 401 counts only with an auth-context marker in the same clause; keeps
+# an unrelated 401 in a log line from tripping it.
 _AUTH_401_CONTEXT = (
     r"(?:oauth|invalidated|auth[\s_]error|identity_edge|/responses|/backend-api/codex)"
 )
@@ -156,26 +143,17 @@ def _looks_like_codex_auth_error(err_text: str) -> bool:
         return True
     return any(p.search(text) for p in _CODEX_AUTH_401_PATTERNS)
 
-# Tool names of the puffo MCP server's "this counts as posting a
-# reply" family. When the agent invokes one of these and it completes
-# successfully, the worker treats the turn as "agent already replied"
-# (skipping the [SILENT]-fallback shell auto-post). Names match
-# ``mcp.config.PUFFO_CORE_TOOL_NAMES`` — kept inline as a frozenset to
-# avoid an import-cycle with the MCP package.
+# Puffo MCP "counts as a reply" tools; success skips the [SILENT]-fallback
+# auto-post. Inline frozenset avoids an MCP import cycle.
 _PUFFO_SEND_MESSAGE_TOOLS = frozenset({
     "send_message",
     "send_message_with_attachments",
 })
 
 
-# StreamReader buffer size for the codex subprocess's stdout. The
-# asyncio default is 64 KiB; single notifications from codex
-# (mcpServer/startupStatus/updated carrying the full tool catalog,
-# thread/started carrying a session snapshot, etc.) routinely exceed
-# that, which raises ``LimitOverrunError`` from ``readline()`` and
-# wedges the reader loop. 16 MiB matches ClaudeSession's choice —
-# bounds per-agent memory while comfortably covering every event size
-# seen in practice.
+# codex's chunky single-line notifications (tool catalogs, session
+# snapshots) overrun asyncio's 64 KiB default -> LimitOverrunError wedges
+# the reader. 16 MiB matches ClaudeSession.
 STREAM_READER_LIMIT_BYTES = 16 * 1024 * 1024
 
 
@@ -201,10 +179,8 @@ class _PendingTurn:
     reply_chunks: list[str] = field(default_factory=list)
     # ``tool_use`` events counted for TurnResult.tool_calls metric.
     tool_calls: int = 0
-    # When the agent invoked a puffo MCP send-message tool, the worker
-    # reads this list off TurnResult.metadata to decide "agent already
-    # posted; don't run the [SILENT]-fallback path". Each entry mirrors
-    # the claude-code adapter's shape: ``{channel, root_id}``.
+    # Worker reads this to skip the [SILENT] fallback ("agent already posted").
+    # Entry shape mirrors the claude-code adapter: {channel, root_id}.
     send_message_targets: list[dict] = field(default_factory=list)
     # Per-turn usage = delta of codex's per-thread cumulative totals from the
     # value standing when this turn's first request completed.
@@ -275,10 +251,8 @@ class CodexSession:
         self._active_turn: _PendingTurn | None = None
         self._lock = asyncio.Lock()
         self._conversation_id: str = self._load_conversation_id()
-        # ``sandbox`` (+ the other thread/start params) aren't re-sent on
-        # resume, so a sandbox change would silently keep the old policy.
-        # Drop the persisted thread when it was created under a different
-        # sandbox; the next start re-applies the current one.
+        # thread/start params aren't re-sent on resume; a sandbox change would
+        # silently keep the old policy. Drop the thread, next start re-applies.
         if self._conversation_id:
             persisted_sandbox = self._load_persisted_sandbox()
             if persisted_sandbox != self.sandbox:
@@ -288,10 +262,8 @@ class CodexSession:
                     self.agent_id, persisted_sandbox, self.sandbox,
                 )
                 self._conversation_id = ""
-        # The latest system prompt we've been handed. Stored so
-        # ``reload`` can detect a no-op vs a real change, and so a
-        # respawn can re-issue ``newConversation`` with current
-        # instructions when the conversation id is missing or rotted.
+        # Latest system prompt; lets reload detect no-ops and respawn re-issue
+        # thread/start with current instructions.
         self.current_instructions: str = ""
         # Resets on next success; hits THRESHOLD → rotate (drop the
         # persisted conversation id; next _ensure_running starts fresh).
@@ -333,10 +305,7 @@ class CodexSession:
         turn_failed_exc: BaseException | None = None
         rotated_in_branch: bool = False
         try:
-            # turn/start params per codex-rs/app-server protocol:
-            # ``threadId``, ``input`` (array of structured items —
-            # NOT a bare string), plus optional config overrides we
-            # leave out for v1.
+            # ``input`` is an array of structured items, NOT a bare string.
             turn_response = await self._send_raw_request(
                 turn.request_id,
                 METHOD_SEND_USER_TURN,
@@ -347,10 +316,8 @@ class CodexSession:
                     ],
                 },
             )
-            # Some App Server versions complete the turn synchronously
-            # and put the final items in the response payload; others
-            # stream item/* + turn/completed notifications and return
-            # only ``{turn: {id, status: "running"}}``. Handle both.
+            # Some builds complete the turn synchronously in the response; others
+            # stream item/* + turn/completed. Handle both.
             sync_resolved = self._absorb_sync_turn_response(turn, turn_response)
             if sync_resolved:
                 # No need to wait — server already gave us everything.
@@ -420,10 +387,8 @@ class CodexSession:
             self._propagate_turn_outcome(
                 outcome="turn_failed", err_text=err_text,
             )
-            # Codex auth-failures are sticky + operator-actionable (re-run
-            # ``codex login``). Convert to AgentAPIError so the worker's
-            # auth_failed substrate (state-flip + operator DM + refresher
-            # kick) reuses the Claude path.
+            # Sticky + operator-actionable (re-run ``codex login``); is_auth=True
+            # reuses the worker's Claude auth_failed substrate.
             if _looks_like_codex_auth_error(err_text):
                 from ..core import AgentAPIError
                 raise AgentAPIError(
@@ -449,10 +414,8 @@ class CodexSession:
                 duration_ms=int((time.time() - turn.started_at) * 1000),
             )
         self._propagate_turn_outcome(outcome="success")
-        # core.py's reply-routing check: a non-empty
-        # ``send_message_targets`` list means "agent already posted via
-        # MCP, skip the shell fallback." Mirrors the claude-code adapter
-        # shape so the routing logic is harness-agnostic.
+        # Non-empty send_message_targets = already posted via MCP, skip shell
+        # fallback; mirrors the claude-code adapter shape.
         return TurnResult(
             reply=reply,
             input_tokens=turn.input_tokens,
@@ -655,10 +618,8 @@ class CodexSession:
         proc_alive = self._proc is not None and self._proc.returncode is None
         if proc_alive and self._conversation_id:
             return
-        # A live proc with an empty cid (corrupt session load + warm
-        # race) would make run_turn send ``threadId=""`` and wedge —
-        # respawn so _spawn re-establishes a thread (it raises if
-        # thread/start returns no id).
+        # Live proc + empty cid (corrupt load + warm race) would send
+        # threadId="" and wedge; respawn re-establishes the thread.
         if proc_alive:
             logger.info(
                 "agent %s: codex session has alive proc but empty "
@@ -683,11 +644,7 @@ class CodexSession:
                 cwd=self.cwd,
                 env=self.env,
                 **no_window_kwargs(),
-                # Override asyncio's default 64 KiB StreamReader buffer
-                # — codex emits very chunky single-line JSON
-                # notifications (full tool catalogs on
-                # mcpServer/startupStatus/updated, session snapshots
-                # on thread/started, etc.) that overrun it.
+                # codex's chunky notifications overrun the 64 KiB default.
                 limit=STREAM_READER_LIMIT_BYTES,
             )
         except FileNotFoundError as exc:
@@ -705,10 +662,8 @@ class CodexSession:
             self._stderr_loop(proc.stderr), name=f"codex-stderr-{self.agent_id}",
         )
 
-        # Anything below this point that raises must tear the process
-        # back down — otherwise ``_ensure_running`` on the next turn
-        # sees a "live" proc and skips spawn, sending turn requests
-        # against a half-initialised App Server.
+        # Any raise below must tear the proc down, else next turn sees a "live"
+        # proc and skips spawn against a half-initialised server.
         try:
             await self._bootstrap_session()
         except Exception:
@@ -719,11 +674,8 @@ class CodexSession:
         """Run the initialize handshake + thread/start (or thread/resume).
         Separated from ``_spawn`` so the spawn path can wrap it in a
         try/except that tears down the proc on any failure."""
-        # 1. JSON-RPC initialize handshake. Most JSON-RPC servers
-        # require this before accepting other methods; codex is no
-        # exception. Send a minimal clientInfo + capabilities envelope
-        # and ignore the response — we don't read server capabilities
-        # back yet.
+        # JSON-RPC initialize handshake, required before other methods;
+        # response ignored.
         try:
             await self._send_raw_request(
                 self._reserve_id(),
@@ -776,23 +728,10 @@ class CodexSession:
                 )
                 self._conversation_id = ""
 
-        # thread/start params per codex-rs/app-server-protocol/src/
-        # protocol/v2.rs. The on-wire schema is camelCase (NOT
-        # snake_case — the Python SDK FAQ that suggested otherwise is
-        # describing the Python SDK's wrapper field names, not the
-        # wire JSON). The thread-level sandbox field is bare ``sandbox``
-        # (not ``sandbox_mode``, not ``sandboxMode``) — a single word.
-        #
-        # ``approvalPolicy: "never"`` means **auto-approve everything
-        # without bothering the client**. Confusing name; verified by
-        # live behaviour. Puffo trust model = operator vouches for the
-        # agent + machine, all tools allowed.
-        #
-        # ``sandbox`` is codex's sandbox policy (read-only |
-        # workspace-write | danger-full-access), per-agent via agent.yml.
-        # Default keeps it fully open — cli-local runs as the operator's
-        # UID, so codex's in-process sandbox is mostly cosmetic; the real
-        # boundary is cli-docker's container.
+        # Wire schema is camelCase; the thread-level field is bare ``sandbox``.
+        # ``approvalPolicy: "never"`` = auto-approve everything (confusing name;
+        # verified live). Sandbox default stays open: cli-local runs as the
+        # operator's UID, the real boundary is cli-docker's container.
         new_conv_params: dict[str, Any] = {
             "cwd": self.cwd or os.getcwd(),
             "approvalPolicy": (
@@ -1046,10 +985,8 @@ class CodexSession:
             return
 
         if method == "item/permissions/requestApproval":
-            # Mirror back whatever permissions were requested. The
-            # README's example showed result.permissions matching the
-            # request's permission shape; we trust the request body
-            # since approvalPolicy is "never" + bypassPermissions.
+            # Mirror requested permissions back; approvalPolicy "never" +
+            # bypassPermissions.
             requested = params.get("permissions") if isinstance(params, dict) else None
             if accept and requested:
                 await self._reply_to_server_request(
@@ -1063,10 +1000,8 @@ class CodexSession:
             return
 
         if method == "item/tool/call":
-            # codex is invoking a client-registered dynamic tool. We
-            # don't register any (yet). Respond with the contract
-            # shape but mark success=false so codex surfaces the
-            # right error to the model.
+            # No dynamic tools registered; contract shape with success=false so
+            # codex surfaces the right error to the model.
             await self._reply_to_server_request(
                 request_id,
                 {
@@ -1156,17 +1091,12 @@ class CodexSession:
             if not turn.completed.done():
                 turn.completed.set_result(None)
             return
-        # codex emits both ``turn/failed`` AND a top-level ``error``
-        # notification, depending on whether the error happens
-        # client-side validation or upstream from the model. Treat
-        # both as turn-fatal so the turn future resolves with a clear
-        # error message instead of timing out into "no reply".
+        # turn/failed OR top-level error, depending on where it failed; both
+        # are turn-fatal, else the turn times out into "no reply".
         if (m == "error" or m.startswith("turn/failed")) and turn is not None:
             err = (params or {}).get("error") or params or "(no detail)"
-            # Codex's ``error`` notification wraps the upstream error
-            # JSON-as-string under params.error.message. Unwrap so the
-            # operator sees the actual reason ("model not supported"
-            # etc.) rather than a JSON-soup blob.
+            # error wraps the upstream JSON-as-string under params.error.message;
+            # unwrap for a readable reason.
             err_text = _readable_error(err)
             if not turn.completed.done():
                 turn.completed.set_exception(
@@ -1235,11 +1165,8 @@ class CodexSession:
                         id=str(item.get("id") or ""),
                     )
             elif kind == "mcptoolcall":
-                # Real codex shape per debug logs: ``item/completed``
-                # with ``item.type == "mcpToolCall"``, ``item.server``
-                # == server name, ``item.tool`` == tool name,
-                # ``item.status`` ∈ {"completed", "failed", ...},
-                # ``item.arguments`` == the tool's JSON input.
+                # Real shape: item/completed with item.type == "mcpToolCall" and
+                # server/tool/status/arguments fields.
                 turn.tool_calls += 1
                 status = (item.get("status") or "").lower()
                 server = item.get("server") or ""
@@ -1276,10 +1203,8 @@ class CodexSession:
             pass
 
     def _absorb_turn_usage(self, turn: _PendingTurn, params: dict) -> None:
-        # Fallback for builds that DO inline usage on turn/completed (top-level
-        # or nested under ``turn``). Live codex reports it via
-        # ``thread/tokenUsage/updated`` instead — so don't clobber a value
-        # already captured there with a zero.
+        # Some builds inline usage on turn/completed; live codex reports via
+        # thread/tokenUsage/updated, so don't clobber that with a zero.
         usage = params.get("usage")
         if not usage and isinstance(params.get("turn"), dict):
             usage = params["turn"].get("usage")

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -61,10 +61,8 @@ logger = logging.getLogger(__name__)
 # denying. Exposed to the hook via PUFFO_PERMISSION_TIMEOUT.
 PERMISSION_HOOK_TIMEOUT_SECONDS = 300
 
-# Tools the PreToolUse hook intercepts in ``default`` mode. Reads
-# (Read/Glob/Grep) and MCP tools deliberately pass through unsurveyed:
-# reads auto-approve, and MCP tools are the agent's talking-to-the-
-# user path so per-call DMs would be self-referential.
+# PreToolUse-intercepted tools in ``default`` mode. Reads + MCP tools
+# pass through: reads auto-approve, MCP is the talking-to-the-user path.
 PERMISSION_HOOK_FULL_MATCHER = "Bash|Edit|Write|MultiEdit|NotebookEdit|WebFetch|WebSearch"
 
 # ``acceptEdits`` mode: file-edit tools auto-approve, so the hook
@@ -78,10 +76,8 @@ PERMISSION_HOOK_NON_EDIT_MATCHER = "Bash|WebFetch|WebSearch"
 _HOOK_COMMAND_MARKER = "puffo_agent.hooks.permission"
 
 
-# Claude Code accepts five permission modes; only ``bypassPermissions``
-# currently ships working here — the others depend on a permission-
-# proxy DM flow that still needs work. Anything else falls back to
-# ``bypassPermissions`` with a WARNING.
+# Only ``bypassPermissions`` ships working; others need the permission-
+# proxy DM flow. Anything else falls back with a WARNING.
 VALID_PERMISSION_MODES = frozenset({
     "bypassPermissions",
 })
@@ -209,11 +205,8 @@ class LocalCLIAdapter(Adapter):
         self.harness = harness
         self.puffo_core_mcp_env: dict[str, str] | None = None
         self._verified = False
-        # claude-code path uses ClaudeSession (long-lived stream-json);
-        # codex path uses CodexSession (long-lived JSON-RPC). hermes
-        # has no long-lived session — every turn is a fresh
-        # ``hermes chat`` subprocess, continuity comes from hermes'
-        # own state.db indexed by per-agent HERMES_HOME + sentinel.
+        # ClaudeSession = long-lived stream-json; CodexSession = long-lived
+        # JSON-RPC; hermes = fresh subprocess per turn (state in HERMES_HOME).
         self._session: ClaudeSession | None = None
         self._codex_session: CodexSession | None = None
         self._hermes_bin: str | None = None
@@ -242,10 +235,7 @@ class LocalCLIAdapter(Adapter):
         self._verify()
         await self._install_desired()
         if self.harness.name() == "codex":
-            # codex has no equivalent of claude-code's cheap "resume
-            # kick" — the App Server doesn't expose a resume-with-
-            # tickle handle in v1. Re-send the full payload, same as
-            # a fresh turn would.
+            # codex has no resume-kick; re-send the full payload like a fresh turn.
             session = self._ensure_codex_session()
             return await session.run_turn(
                 fallback_user_message, ctx.system_prompt,
@@ -279,10 +269,8 @@ class LocalCLIAdapter(Adapter):
             await session.warm(system_prompt)
             return
         if self.harness.name() == "hermes":
-            # hermes is one-shot per turn; no subprocess to keep
-            # warm. ``_verify`` already validated the binary +
-            # seeded HERMES_HOME, so there's nothing left to do
-            # until the first message arrives.
+            # hermes is one-shot per turn; nothing to warm (_verify already seeded
+            # HERMES_HOME).
             return
         session = self._ensure_session()
         if not session.has_persisted_session():
@@ -345,20 +333,15 @@ class LocalCLIAdapter(Adapter):
 
         codex_home = agent_codex_user_dir(self.agent_id)
         codex_home.mkdir(parents=True, exist_ok=True)
-        # AGENTS.md investment goes here so codex picks it up on
-        # ``newConversation``; the file body itself is written by
-        # ``profile_sync.rebuild_agent_codex_md`` (worker startup +
-        # refresh). Writing the dir is just to make sure codex has a
-        # HOME to read from.
+        # AGENTS.md body is written by profile_sync.rebuild_agent_codex_md;
+        # here we only ensure codex has a HOME to read from.
         agents_md = codex_home / "AGENTS.md"
         if not agents_md.exists():
             agents_md.write_text("", encoding="utf-8")
 
-        # Pin ``cli_auth_credentials_store=file`` so codex reads
-        # ``$CODEX_HOME/auth.json`` (not macOS Keychain) — required for
-        # our view/refresh model. Host's own ``~/.codex/config.toml``
-        # MCP entries are merged in so the agent inherits the
-        # operator's catalog (puffo entry below shadows same-name).
+        # cli_auth_credentials_store=file -> codex reads $CODEX_HOME/auth.json
+        # (not Keychain), required for the view/refresh model. Host MCP entries
+        # merged; the puffo entry below shadows same-name.
         host_mcps = read_host_codex_mcp_servers(Path.home())
         # Host wins on collision so the operator's local override
         # beats the catalog default — same precedence as claude's
@@ -406,14 +389,9 @@ class LocalCLIAdapter(Adapter):
             "agent %s: shared host codex auth (%s)",
             self.agent_id, auth_mode,
         )
-        # Subprocess argv — ``codex app-server`` is the documented entry
-        # point for embedding codex as a long-running agent. Resolve
-        # via the shared resolver so PATH + ``PUFFO_CODEX_BIN`` env
-        # override + macOS / Windows / Linux .app bundle paths all
-        # work. LaunchAgent on macOS has a narrow PATH that misses
-        # both ``/opt/homebrew/bin`` and the Codex.app bundle, so the
-        # plain ``shutil.which`` would fail even when the operator
-        # has Codex installed via the desktop app.
+        # ``codex app-server`` is the embedding entry point. Shared resolver
+        # covers $PUFFO_CODEX_BIN + PATH + app bundles (LaunchAgent's narrow
+        # PATH misses /opt/homebrew/bin and the .app bundles).
         codex_bin = resolve_codex_bin()
         if codex_bin is None:
             raise RuntimeError(
@@ -484,13 +462,9 @@ class LocalCLIAdapter(Adapter):
         return self._codex_session
 
     # ── hermes (cli-local) ────────────────────────────────────────────
-    # hermes is one-shot per turn: every turn spawns
-    # ``hermes chat --quiet -q <prompt>``. No long-lived session
-    # process to keep warm. State lives in the per-agent
-    # ``HERMES_HOME=<agent_home_dir>/.hermes`` directory which we
-    # seed from the operator's ``~/.hermes`` on first verify so the
-    # agent inherits the operator's provider keys + ``hermes setup``
-    # choices without sharing the operator's chat history.
+    # One-shot per turn: ``hermes chat --quiet -q <prompt>``. HERMES_HOME
+    # seeded from operator's ~/.hermes on first verify (keys + setup
+    # choices, not chat history).
 
     def _verify_hermes(self) -> None:
         """Resolve hermes binary + seed per-agent HERMES_HOME from
@@ -714,10 +688,8 @@ class LocalCLIAdapter(Adapter):
                     self.agent_id, exc,
                 )
 
-        # Hermes turns are always silent — ``--quiet`` stdout doesn't
-        # surface MCP calls, so we can't tell whether send_message
-        # fired. Skip the fallback regardless; reply text kept in
-        # metadata for debug.
+        # --quiet stdout can't show MCP calls, so send_message detection is
+        # impossible; always skip the fallback. Reply kept in metadata for debug.
         return TurnResult(
             reply="",
             tool_calls=len(tool_calls),
@@ -775,11 +747,8 @@ class LocalCLIAdapter(Adapter):
             return
 
         servers = config.setdefault("mcp_servers", {})
-        # No ``tools:`` field — hermes' interactive add saves
-        # ``tools: {include: [...]}`` only when the operator filters.
-        # Omitting it leaves all discovered tools enabled. A bare-list
-        # ``tools:`` is interpreted as a filter and silently drops
-        # everything.
+        # No ``tools:`` field: omitting enables all discovered tools; a
+        # bare-list ``tools:`` acts as a filter and silently drops everything.
         servers["puffo"] = {
             "command": default_python_executable(),
             "args": ["-m", "puffo_agent.mcp.puffo_core_server"],
@@ -955,23 +924,11 @@ class LocalCLIAdapter(Adapter):
         # symmetry with the docker adapter.
         del env_overrides
         cmd = ["claude"]
-        # ``--dangerously-skip-permissions`` bypasses BOTH the per-tool
-        # approval prompt AND the per-project trust dialog. Claude
-        # code's stream-json mode has no UI surface to accept the
-        # trust dialog, so anything short of this flag leaves the
-        # cwd un-trusted, which silently drops MCP servers supplied
-        # via ``--mcp-config`` — exactly the "agent can't see the
-        # puffo MCP" symptom on cli-local. ``--permission-mode
-        # bypassPermissions`` (the previous flag here) only handles
-        # the per-tool prompt path, not the trust dialog, so the MCP
-        # was getting dropped before its tools could even register.
-        # When the bypass mode is anything other than
-        # ``bypassPermissions`` (e.g. the future ``default`` /
-        # ``acceptEdits`` modes that route through the PreToolUse
-        # hook), fall back to ``--permission-mode <mode>`` so the
-        # hook controls each tool category — those modes implicitly
-        # require an operator-supervised setup where the trust
-        # dialog has already been accepted in a real claude session.
+        # --dangerously-skip-permissions bypasses BOTH the per-tool prompt AND
+        # the per-project trust dialog; stream-json has no UI for the dialog,
+        # and an untrusted cwd silently drops --mcp-config servers. Non-bypass
+        # modes route through the PreToolUse hook and presuppose an operator-
+        # accepted trust dialog.
         if self.permission_mode == "bypassPermissions":
             cmd.append("--dangerously-skip-permissions")
         else:
@@ -1008,10 +965,8 @@ class LocalCLIAdapter(Adapter):
         if self._verified:
             return
         if self.harness.name() == "codex":
-            # codex has its own binary check (see CodexSession._spawn).
-            # We deliberately skip the claude-seed / link-credentials
-            # bookkeeping below — none of it applies to codex, and
-            # touching ~/.claude/* for a codex agent would be confusing.
+            # codex has its own binary check; the claude-seed / link-credentials
+            # bookkeeping below doesn't apply.
             self._verified = True
             return
         if self.harness.name() == "hermes":
@@ -1042,10 +997,8 @@ class LocalCLIAdapter(Adapter):
             "agent %s: wrote host credential view (%s)",
             self.agent_id, mode,
         )
-        # One-way sync of host skills + MCP registrations. Runs
-        # every start so host edits propagate. The unreachable-
-        # command list is ignored: cli-local runs on the host, so
-        # absolute host paths in MCP commands resolve naturally.
+        # One-way host skills + MCP sync on every start. Unreachable-command
+        # list ignored: cli-local runs on the host, absolute paths resolve.
         skill_count = sync_host_skills(host_home, self.agent_home_dir)
         if skill_count:
             logger.info(
@@ -1059,10 +1012,8 @@ class LocalCLIAdapter(Adapter):
                 "agent %s: merged %d host MCP server registration(s) "
                 "into per-agent .claude.json", self.agent_id, merged_mcp,
             )
-        # Plugins layer — pairs the actual plugin code tree with the
-        # ``enabledPlugins`` array Claude reads from settings.json.
-        # Without both, plugin-provided MCP servers (imessage,
-        # chrome-devtools-mcp, etc.) silently never register.
+        # Plugin tree + enabledPlugins must both land or plugin MCP servers
+        # silently never register.
         plugins_mode = sync_host_plugins(host_home, self.agent_home_dir)
         if plugins_mode not in ("no-host-dir",):
             logger.info(

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -164,6 +164,7 @@ class LocalCLIAdapter(Adapter):
         owner_username: str = "",
         permission_mode: str = "default",
         sandbox: str = "danger-full-access",
+        task_timeout_seconds: float = 600.0,
         harness=None,
         desired_skills: list[str] | None = None,
         desired_mcps: list[str] | None = None,
@@ -184,6 +185,7 @@ class LocalCLIAdapter(Adapter):
         self.owner_username = owner_username
         self.permission_mode = _sanitise_permission_mode(permission_mode, agent_id)
         self.sandbox = _sanitise_sandbox(sandbox, agent_id)
+        self.task_timeout_seconds = task_timeout_seconds
         self.desired_skills = list(desired_skills or [])
         self.desired_mcps = list(desired_mcps or [])
         self.puffo_core_server_url = puffo_core_server_url
@@ -474,6 +476,7 @@ class LocalCLIAdapter(Adapter):
             permission_mode=self.permission_mode,
             sandbox=self.sandbox,
             model=self.model,
+            task_timeout_seconds=self.task_timeout_seconds,
             audit=codex_audit,
         )
         return self._codex_session

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1026,8 +1026,8 @@ class RuntimeConfig:
     # codex (cli-local) sandbox policy: read-only | workspace-write |
     # danger-full-access. Default leaves codex's sandbox fully open.
     sandbox: str = "danger-full-access"
-    # codex (cli-local) per-turn wall-clock budget in seconds (PUF-375).
-    # Default 600s; raise for agents running long reasoning/complex tasks.
+    # codex (cli-local) per-turn wall-clock budget in seconds; raise for
+    # agents running long reasoning/complex tasks.
     task_timeout_seconds: float = 600.0
     # Agent engine (CLI kinds only):
     #   - ``claude-code``: ``claude`` CLI with our stream-json session

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1026,6 +1026,9 @@ class RuntimeConfig:
     # codex (cli-local) sandbox policy: read-only | workspace-write |
     # danger-full-access. Default leaves codex's sandbox fully open.
     sandbox: str = "danger-full-access"
+    # codex (cli-local) per-turn wall-clock budget in seconds (PUF-375).
+    # Default 600s; raise for agents running long reasoning/complex tasks.
+    task_timeout_seconds: float = 600.0
     # Agent engine (CLI kinds only):
     #   - ``claude-code``: ``claude`` CLI with our stream-json session
     #     protocol, --resume, --model, and the puffo MCP tool suite.
@@ -1133,6 +1136,7 @@ class AgentConfig:
                 docker_memory_reservation=rt.get("docker_memory_reservation", ""),
                 permission_mode=rt.get("permission_mode", "bypassPermissions"),
                 sandbox=rt.get("sandbox", "danger-full-access"),
+                task_timeout_seconds=float(rt.get("task_timeout_seconds", 600.0)),
                 harness=harness,
                 max_turns=int(rt.get("max_turns", 10)),
             ),

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -95,13 +95,9 @@ def shared_fs_dir() -> Path:
     return home_dir() / "shared"
 
 
-# Files copied from the operator's $HOME into a per-agent virtual
-# $HOME on first use. Lift OAuth-essential files only.
-# Note: ``.claude.json`` is a sibling of the ``.claude/`` dir; Claude
-# CLI reads it from ``$HOME/.claude.json`` so we mirror that layout.
-# ``.credentials.json`` is intentionally excluded — set up separately
-# via ``sync_host_claude_code_auth_view`` so every agent tracks live OAuth
-# state (matches cli-docker's bind-mount model).
+# OAuth-essential files seeded into the per-agent virtual $HOME.
+# ``.claude.json`` is a sibling of ``.claude/``. ``.credentials.json``
+# excluded; sync_host_claude_code_auth_view owns live OAuth state.
 _CLAUDE_HOME_SEED_PATHS = (
     ".claude/settings.json",
     ".claude.json",
@@ -624,10 +620,7 @@ def sync_host_enabled_plugins(host_home: Path, agent_home: Path) -> int:
     except (OSError, ValueError):
         return 0
     enabled = host_data.get("enabledPlugins")
-    # Claude Code has used both shapes historically — dict
-    # (``{name: true}``) on newer versions, list (``[name, ...]``)
-    # on older. Pass either through unchanged so we don't reshape
-    # something Claude is about to read.
+    # Claude Code has shipped both shapes (dict + list); pass through unchanged.
     if not isinstance(enabled, (list, dict)) or not enabled:
         return 0
 
@@ -864,23 +857,14 @@ class DaemonConfig:
     skills_dir: str = ""  # absolute path; empty = no shared skills
     reconcile_interval_seconds: float = 2.0
     runtime_heartbeat_seconds: float = 5.0
-    # cli-docker memory caps. Defaults bound each container so one
-    # runaway claude can't poison the VM (vm.overcommit_memory=1 +
-    # uncapped containers can drain swap and surface ENOMEM on
-    # unrelated reads). Operators can opt out with empty strings;
-    # per-agent overrides live on ``runtime``.
+    # cli-docker memory caps: one runaway claude must not drain the VM's
+    # swap. Empty string = opt out; per-agent overrides on ``runtime``.
     docker_memory_limit: str = "1.5g"
     docker_memory_reservation: str = "500m"
-    # Inbound message redaction. When an envelope's text exceeds
-    # ``max_inline_message_chars`` the daemon replaces the body the
-    # LLM sees with a system-message placeholder (carrying
-    # envelope_id, total length, segment count, and a preview), and
-    # the agent fetches the full content one chunk at a time via
-    # the ``get_post_segment`` MCP tool. The original envelope is
-    # stored unmodified in ``messages.db`` — only the prompt-budget
-    # view is redacted. Per-turn totals are bounded by greedy-fill
-    # batching, so this only guards session-lifetime context growth;
-    # 16000 inlines typical code/log pastes whole.
+    # Inbound redaction: over-limit envelope bodies become a placeholder
+    # (id, length, segments, preview); the agent pages via get_post_segment.
+    # Only the prompt view is redacted, messages.db keeps the original.
+    # Guards session-lifetime growth; 16000 inlines typical code/log pastes.
     max_inline_message_chars: int = MAX_INLINE_MESSAGE_CHARS
     segment_chars: int = MESSAGE_SEGMENT_CHARS
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
@@ -971,10 +955,8 @@ class TriggerRules:
     on_dm: bool = True
 
 
-## Default puffo-core server. Override per-agent via
-## ``puffo_core.server_url`` for self-hosted relays or local dev.
-## ``api.puffo.ai`` is platform-internal only; client traffic goes
-## through the public ``chat.puffo.ai/relay`` edge.
+## Default puffo-core server; per-agent override via puffo_core.server_url.
+## api.puffo.ai is platform-internal; clients use chat.puffo.ai/relay.
 DEFAULT_PUFFO_SERVER_URL = "https://chat.puffo.ai/relay"
 
 
@@ -1029,15 +1011,10 @@ class RuntimeConfig:
     # codex (cli-local) per-turn wall-clock budget in seconds; raise for
     # agents running long reasoning/complex tasks.
     task_timeout_seconds: float = 600.0
-    # Agent engine (CLI kinds only):
-    #   - ``claude-code``: ``claude`` CLI with our stream-json session
-    #     protocol, --resume, --model, and the puffo MCP tool suite.
-    #   - ``hermes``: ``hermes chat -q`` one-shot per turn against
-    #     Anthropic, using Claude Code's credential store.
-    #   - ``gemini-cli``: declared, not yet implemented.
-    # Hermes + anthropic billing note: third-party OAuth clients route
-    # to Anthropic's ``extra_usage`` pool, NOT a Claude subscription.
-    # Same token, different ledger.
+    # Agent engine (CLI kinds only): ``claude-code`` (stream-json + resume +
+    # puffo MCP), ``hermes`` (one-shot ``hermes chat -q``), ``gemini-cli``
+    # (declared, unimplemented). Hermes OAuth bills to Anthropic
+    # extra_usage, not a Claude subscription.
     harness: str = "claude-code"  # claude-code | hermes
     # sdk only: cap on agentic-loop iterations per turn. 10 is fine
     # for short Q&A; multi-step work often needs 30-50. CLI kinds
@@ -1057,13 +1034,9 @@ class AgentConfig:
     display_name: str = ""
     # Cached chat avatar URL; server is source of truth.
     avatar_url: str = ""
-    # ``role`` is the long-form (<=140 chars) "what does this agent do"
-    # string; ``role_short`` is the chip label rendered by clients in
-    # member lists. Mirror of the server-side identity profile fields
-    # added in puffo-server's identity_role migration. On every edit
-    # the daemon syncs both up to ``PATCH /identities/self``; the
-    # server derives ``role_short`` from ``role`` when the client
-    # omits it.
+    # role = long-form (<=140 chars); role_short = client chip label.
+    # Synced to PATCH /identities/self on edit; server derives role_short
+    # when omitted.
     role: str = ""
     role_short: str = ""
     puffo_core: PuffoCoreConfig = field(default_factory=PuffoCoreConfig)
@@ -1207,35 +1180,17 @@ class RuntimeState:
     msg_count: int = 0
     last_event_at: int = 0
     error: str = ""
-    # Worker-side health, independent of ``status``. Values:
-    #   "ok"                  — refresh-ping passed, a turn cleared a
-    #                           prior abandon, or a credential refresh
-    #                           cleared a prior auth_failed
-    #   "in_progress"         — turn mid-flight; overrides any sticky
-    #                           red so the UI reads alive
-    #   "auth_failed"         — adapter saw 401 / authentication_error
-    #                           (set in worker._handle_suppressed_reply);
-    #                           cleared by the CredentialRefresher's
-    #                           refresh-success callback (PUF-258 wired
-    #                           the clear; PUF-221 owns the set lane)
-    #   "api_error_abandoned" — kick-retry exhausted, batch silently
-    #                           abandoned; cleared on next successful turn
-    #                           (PUF-255's on_turn_success lane)
-    #   "refresh_broken"      — daemon saw N consecutive non-success
-    #                           refresh outcomes; cleared by next
-    #                           REFRESHED. Does not overwrite the two
-    #                           stronger downstream signals above.
-    #   "unhandled_error"     — non-AgentAPIError raised in the turn and
-    #                           no category red was set; cleared by
-    #                           next successful turn
-    #   "codex_thread_wedged" — codex thread rotated after N consecutive
-    #                           turn timeouts/failures OR the verbatim
-    #                           "agent thread limit reached" error.
-    #                           Auto-recovers on next inbound message;
-    #                           cleared on next successful turn. Does
-    #                           NOT overwrite the stronger downstream
-    #                           signals above.
-    #   "unknown"             — no probe yet
+    # Worker-side health, independent of ``status``:
+    #   "ok"                  - clean turn / cleared red
+    #   "in_progress"         - turn mid-flight; overrides sticky reds
+    #   "auth_failed"         - adapter saw 401; cleared by refresh success
+    #   "api_error_abandoned" - kick-retry exhausted; cleared on next good turn
+    #   "refresh_broken"      - N consecutive refresh failures; cleared by next
+    #                           REFRESHED; never overwrites the reds above
+    #   "unhandled_error"     - uncategorised turn raise; cleared on next good turn
+    #   "codex_thread_wedged" - thread rotated (timeouts/failures/thread-limit);
+    #                           auto-recovers; never overwrites stronger reds
+    #   "unknown"             - no probe yet
     health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | refresh_broken | unhandled_error | codex_thread_wedged | unknown
 
     @classmethod

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -234,6 +234,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             owner_username=operator,
             permission_mode=agent_cfg.runtime.permission_mode,
             sandbox=agent_cfg.runtime.sandbox,
+            task_timeout_seconds=agent_cfg.runtime.task_timeout_seconds,
             harness=harness,
             desired_skills=agent_cfg.desired_skills,
             desired_mcps=agent_cfg.desired_mcps,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -185,10 +185,8 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             puffo_core_slug=agent_cfg.puffo_core.slug,
             puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
         )
-        # When puffo_core is configured, give the adapter env to spawn
-        # ``python -m puffo_agent.mcp.puffo_core_server``. The adapter
-        # rewrites path-typed env values to container bind-mount paths
-        # at config-write time.
+        # Env for spawning the puffo_core MCP server; path-typed values are
+        # rewritten to container bind-mount paths at config-write time.
         if agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_mcp_env
             pc = agent_cfg.puffo_core
@@ -407,12 +405,9 @@ def _build_puffo_core_client(
     )
 
 
-# PUF-214: auth-class patterns — definitive evidence of OAuth /
-# API-key failure. Shared by the leak filter (suppress the leak)
-# and by health-flip detection (`runtime.health=auth_failed`).
-# Anchored / unambiguous-token patterns only, per the doc-citation
-# audit; high-FP markers like "401" / "unauthorized" / "api_error"
-# stay OUT — they collide with legitimate agent prose.
+# Auth-class patterns: definitive OAuth/API-key failure only. Shared by
+# the leak filter and the auth_failed health flip. High-FP markers
+# (401, unauthorized, api_error) stay out; they collide with agent prose.
 _AUTH_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*Not logged in[\s\S]*Please run /login", re.IGNORECASE),
     re.compile(r"^\s*OAuth token (?:revoked|has expired)\b", re.IGNORECASE),
@@ -452,10 +447,8 @@ _WORKER_ERROR_LEAK_PATTERNS: tuple[re.Pattern[str], ...] = (
     *_NON_AUTH_LEAK_PATTERNS,
 )
 
-# Backoff range applied after a suppressed leak fires. Random in
-# [15, 60] drops the steady-state leak frequency ~30× without
-# grounding the agent — single-batch leaks self-clear during the
-# sleep; sustained limit conditions get sampled, not hammered.
+# Post-leak backoff: random 15-60s samples sustained limits instead of
+# hammering; single-batch leaks self-clear during the sleep.
 _SUPPRESSION_BACKOFF_MIN_SECONDS = 15.0
 _SUPPRESSION_BACKOFF_MAX_SECONDS = 60.0
 
@@ -838,15 +831,10 @@ class Worker:
         # Set for ws-local agents; the Worker idles and registers an
         # attach point instead of running a harness consumer.
         self._ws_local_hub = ws_local_hub
-        # PUF-221: daemon-owned CredentialRefresher hook. Fired from
-        # the auth-class leak branch in _handle_suppressed_reply so a
-        # 401 surfacing in a reply short-circuits the daemon's 2-min
-        # poll instead of waiting for the next tick.
+        # CredentialRefresher hook: a 401 in a reply short-circuits the 2-min poll.
         self._notify_refresh_needed = notify_refresh_needed
-        # Pre-delivery gate: blocking refresh through the daemon's
-        # mutex. Returns True iff post-refresh the token has >0s
-        # remaining. ``None`` for runtimes that don't go through
-        # claude OAuth (api-puffo, ws-local).
+        # Blocking pre-delivery refresh via the daemon mutex; True iff the token
+        # has time left. None for runtimes without claude OAuth (api-puffo, ws-local).
         self._ensure_fresh_token = ensure_fresh_token
         # In-memory dedup for the auth_failed ENTER operator DM;
         # re-armed on credential refresh-success (daemon
@@ -1057,12 +1045,9 @@ class Worker:
             Path(workspace_path).mkdir(parents=True, exist_ok=True)
             _seed_claude_dir(Path(claude_path))
 
-            # Assemble managed CLAUDE.md from shared primer + profile
-            # + memory snapshot. Written to user-level (.claude/
-            # CLAUDE.md) so Claude Code auto-discovers it. The
-            # project-level CLAUDE.md is left for the agent to edit.
-            # chat-local / sdk-local don't auto-discover, so the same
-            # string is passed as PuffoAgent's system_prompt.
+            # Managed CLAUDE.md (primer + profile + memory) written user-level for
+            # auto-discovery; project-level stays agent-editable. chat/sdk-local
+            # get the same string as system_prompt.
             shared_path = docker_shared_dir()
             claude_md = _rebuild_managed_system_prompt(
                 harness_name=(self.agent_cfg.runtime.harness or "").strip(),
@@ -1118,11 +1103,8 @@ class Worker:
             self._warm_done.set()
             return
 
-        # PUF-221: per-agent refresh_ping retired — daemon-level
-        # CredentialRefresher (portal/credential_refresh.py) owns
-        # OAuth refresh + writes back to ``~/.claude/.credentials.json``
-        # as a single writer. Agents just read the disk file via the
-        # per-agent symlink the daemon refresher maintains.
+        # Per-agent refresh_ping retired; daemon-level CredentialRefresher is
+        # the single writer of ~/.claude/.credentials.json.
 
         # Warm the adapter so persisted-session agents re-spawn their
         # subprocess now rather than on the first DM. Non-fatal.
@@ -1187,22 +1169,15 @@ class Worker:
             """
             if not batch:
                 return
-            # Diagnostic: log every dispatched batch so we can trace
-            # cross-batch duplicates (same envelope_id surfacing in
-            # consecutive turns). If the SAME envelope_id appears
-            # across two log lines for one agent within a few
-            # seconds, the cursor or dispatching_ids check missed it.
+            # Duplicate tracer: same envelope_id in two lines within seconds =
+            # cursor or dispatching_ids miss.
             batch_ids = [m.get("envelope_id", "") for m in batch]
             logger.info(
                 "agent %s: on_message_batch root=%s size=%d envelopes=%s",
                 agent_id, root_id, len(batch), batch_ids,
             )
-            # Status telemetry is now per-thread-batch. The first
-            # message in arrival order gets the /processing/start
-            # call (yellow dot lands there) — that's what the human
-            # who triggered the agent will see go yellow first. The
-            # rest of the batch flips straight from white to green
-            # via /processing/end:batch at the end of the turn.
+            # Per-batch telemetry: first message gets /processing/start (yellow
+            # dot); the rest flip white->green via /processing/end:batch.
             first_post_id = batch[0].get("envelope_id", "")
             channel_id = channel_meta.get("channel_id", "")
 
@@ -1237,13 +1212,9 @@ class Worker:
             # New batch while auth_failed: wake the refresher to check
             # for a re-login now (the flip below would mask auth_failed).
             self._maybe_wake_refresher_if_auth_failed(agent_id)
-            # Pre-delivery gate: before handing the batch to the
-            # adapter, make sure the daemon-owned credential is fresh.
-            # The rotating single-use refresh_token race isn't macOS-
-            # specific — N agents reading the same on-disk RT and
-            # POSTing to Anthropic in parallel loses N-1 with
-            # invalid_grant regardless of OS. Skipped only for non-
-            # claude runtimes (ws-local, api-puffo).
+            # Pre-delivery credential gate. The single-use refresh_token race is
+            # OS-agnostic: N agents refreshing in parallel lose N-1 with
+            # invalid_grant. Skipped for non-claude runtimes (ws-local, api-puffo).
             if (
                 self._ensure_fresh_token is not None
                 and self.agent_cfg.runtime.kind in (
@@ -1252,15 +1223,9 @@ class Worker:
             ):
                 ok = await self._ensure_fresh_token()
                 if not ok:
-                    # Mutex-guarded refresh failed → token is stuck.
-                    # ``_enter_auth_failed`` flips runtime.health,
-                    # wakes the refresher, and (via
-                    # ``_on_auth_failed_enter`` + the
-                    # ``_auth_failed_notification_sent`` dedup) DMs
-                    # the operator ONCE per expiration episode. Raise
-                    # to push the batch back into the consumer's
-                    # retry path so it redelivers once the operator
-                    # recovers.
+                    # Token stuck: _enter_auth_failed flips health + DMs the operator once
+                    # per episode; raise pushes the batch into the consumer retry path so
+                    # it redelivers on recovery.
                     logger.warning(
                         "agent %s: pre-delivery token refresh failed; "
                         "flagging auth_failed and deferring batch",
@@ -1330,10 +1295,8 @@ class Worker:
                         get_reporter().emit(agent_id, "error", {"error": turn_error})
                     )
                 if run_id is not None and first_post_id:
-                    # Build the batch payload: first row reuses the
-                    # /start run_id (server UPDATEs its row); the
-                    # rest get fresh run_ids and are UPSERTed by the
-                    # server with started_at = ended_at = now.
+                    # First row reuses the /start run_id (server UPDATE); the rest get
+                    # fresh run_ids (server UPSERT, started_at = ended_at = now).
                     runs: list[dict] = [{
                         "run_id": run_id,
                         "message_id": first_post_id,
@@ -1506,15 +1469,11 @@ class Worker:
                 except asyncio.TimeoutError:
                     pass
 
-        # PUF-221: per-agent credential_refresh coroutine retired —
-        # CredentialRefresher in portal/credential_refresh.py owns the
-        # refresh loop daemon-wide. Single writer = no multi-process
-        # rotation race on Anthropic's single-use refresh tokens.
+        # Per-agent credential_refresh coroutine retired; CredentialRefresher
+        # owns the loop daemon-wide (single writer, no rotation race).
 
-        # Server-side status reporter: own heartbeat task; begin_turn /
-        # end_turn fire inline from on_message via this closure. Falls
-        # back to a no-op when the client has no http client (tests).
-        # Lazy provider so each heartbeat reads live runtime.health.
+        # Status reporter: heartbeat task + inline begin/end_turn; no-op
+        # without an http client (tests). Lazy provider reads live runtime.health.
         reporter = (
             StatusReporter(
                 client.http,

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -567,11 +567,8 @@ while True:
 
 
 def test_reconnect_turn_routes_to_retry_not_drop(tmp_path):
-    # PUF-375 (b) ε: a mid-reconnect turn failure must surface as a (non-auth)
-    # AgentAPIError — routed to the consumer's re-enqueue/retry path so the
-    # batch isn't dropped — NOT the raw RuntimeError the worker swallows +
-    # drops (work loss) while flipping unhandled_error (false red). And it must
-    # NOT count toward the wedged threshold.
+    # Non-auth AgentAPIError = the consumer's re-enqueue path; a raw
+    # RuntimeError would be swallowed + dropped by the worker.
     from puffo_agent.agent.core import AgentAPIError
 
     fake = _write_fake(tmp_path, RECONNECT_SCRIPT)
@@ -609,6 +606,53 @@ def test_looks_like_codex_reconnect():
     assert not _looks_like_codex_reconnect("model overloaded")
     assert not _looks_like_codex_reconnect("agent thread limit reached")
     assert not _looks_like_codex_reconnect("")
+
+
+TIMEOUT_SCRIPT = '''\
+absorb_initialize()
+
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "t1"}}})
+
+# ACK every request (turn/start, turn/interrupt) but never complete a turn.
+while True:
+    msg = r()
+    if msg is None:
+        break
+    if msg.get("id") is not None:
+        w({"jsonrpc": "2.0", "id": msg["id"], "result": None})
+'''
+
+
+def test_timeout_reply_reset_claim_matches_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "home"))
+    fake = _write_fake(tmp_path, TIMEOUT_SCRIPT)
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+        task_timeout_seconds=1.0,
+    )
+
+    async def _run():
+        await cs.warm("sys")
+        try:
+            r1 = await cs.run_turn("hi", "sys")
+            r2 = await cs.run_turn("still there?", "sys")
+            return r1, r2
+        finally:
+            await cs.aclose()
+
+    r1, r2 = asyncio.run(_run())
+    # First timeout: below the wedged threshold — no rotation, no reset claim.
+    assert "1-second timeout" in r1.reply
+    assert r1.metadata["codex_turn_timeout"] is True
+    assert r1.metadata["codex_thread_rotated"] is False
+    assert "reset" not in r1.reply
+    # Second consecutive timeout rotates; the reply may now claim the reset.
+    assert r2.metadata["codex_thread_rotated"] is True
+    assert "reset for the next turn" in r2.reply
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -608,6 +608,59 @@ def test_looks_like_codex_reconnect():
     assert not _looks_like_codex_reconnect("")
 
 
+RECONNECT_THEN_RECOVER_SCRIPT = '''\
+absorb_initialize()
+
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "c1"}}})
+
+# Turn 1 fails mid-reconnect.
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": None})
+w({"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {"error": {"message": "Reconnecting... 2/5"}}})
+
+# Turn 2 (the retry) succeeds on the same thread.
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": None})
+w({"jsonrpc": "2.0", "method": "item/agentMessage/delta",
+   "params": {"threadId": "c1", "turnId": "u2", "itemId": "m", "delta": "recovered"}})
+w({"jsonrpc": "2.0", "method": "turn/completed", "params": {}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+'''
+
+
+def test_reconnect_then_retry_recovers_on_same_session(tmp_path):
+    # Mirrors the worker retry path: run_retry_turn re-enters run_turn on the
+    # same session after the AgentAPIError.
+    from puffo_agent.agent.core import AgentAPIError
+
+    fake = _write_fake(tmp_path, RECONNECT_THEN_RECOVER_SCRIPT)
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+    async def _run():
+        await cs.warm("sys")
+        try:
+            with pytest.raises(AgentAPIError):
+                await cs.run_turn("hi", "sys")
+            return await cs.run_turn("hi again", "sys")
+        finally:
+            await cs.aclose()
+
+    result = asyncio.run(_run())
+    assert result.reply == "recovered"
+    assert cs._consecutive_thread_failures == 0
+
+
 TIMEOUT_SCRIPT = '''\
 absorb_initialize()
 

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -547,6 +547,70 @@ def test_turn_failed_raises(tmp_path):
     assert "model overloaded" in err
 
 
+RECONNECT_SCRIPT = '''\
+absorb_initialize()
+
+msg = r()
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "c1"}}})
+
+msg = r()
+turn_id = msg["id"]
+w({"jsonrpc": "2.0", "id": turn_id, "result": None})
+w({"jsonrpc": "2.0", "method": "turn/failed",
+   "params": {"error": {"message": "Reconnecting... 2/5"}}})
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+'''
+
+
+def test_reconnect_turn_routes_to_retry_not_drop(tmp_path):
+    # PUF-375 (b) ε: a mid-reconnect turn failure must surface as a (non-auth)
+    # AgentAPIError — routed to the consumer's re-enqueue/retry path so the
+    # batch isn't dropped — NOT the raw RuntimeError the worker swallows +
+    # drops (work loss) while flipping unhandled_error (false red). And it must
+    # NOT count toward the wedged threshold.
+    from puffo_agent.agent.core import AgentAPIError
+
+    fake = _write_fake(tmp_path, RECONNECT_SCRIPT)
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+    )
+
+    async def _run():
+        await cs.warm("sys")
+        try:
+            await cs.run_turn("hi", "sys")
+            return ("none", None)
+        except AgentAPIError as exc:
+            return ("apierror", exc)
+        except RuntimeError as exc:
+            return ("runtime", exc)
+        finally:
+            await cs.aclose()
+
+    kind, exc = asyncio.run(_run())
+    assert kind == "apierror", f"expected AgentAPIError retry route, got {kind}"
+    assert exc.is_auth is False
+    assert "Reconnecting" in str(exc)
+    # Transient — not a wedged strike.
+    assert cs._consecutive_thread_failures == 0
+
+
+def test_looks_like_codex_reconnect():
+    from puffo_agent.agent.adapters.codex_session import _looks_like_codex_reconnect
+    assert _looks_like_codex_reconnect("codex turn failed: Reconnecting... 2/5")
+    assert _looks_like_codex_reconnect("reconnecting to backend")
+    assert not _looks_like_codex_reconnect("model overloaded")
+    assert not _looks_like_codex_reconnect("agent thread limit reached")
+    assert not _looks_like_codex_reconnect("")
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # reload() updates current_instructions without restarting the process
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_task_timeout_knob.py
+++ b/tests/test_task_timeout_knob.py
@@ -1,0 +1,64 @@
+"""PUF-375 (a): RuntimeConfig.task_timeout_seconds round-trips through
+agent.yml, defaults to 600s, and reaches the CodexSession."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_default_is_600():
+    from puffo_agent.portal.state import RuntimeConfig
+    assert RuntimeConfig().task_timeout_seconds == 600.0
+
+
+def test_round_trips(home):
+    from puffo_agent.portal.state import AgentConfig, RuntimeConfig
+    cfg = AgentConfig(
+        id="codex-slow",
+        display_name="codex-slow",
+        runtime=RuntimeConfig(kind="cli-local", harness="codex", task_timeout_seconds=1800.0),
+    )
+    cfg.save()
+    assert AgentConfig.load("codex-slow").runtime.task_timeout_seconds == 1800.0
+
+
+def test_legacy_yml_without_field_defaults_600(home):
+    from puffo_agent.portal.state import AgentConfig, agent_yml_path
+    aid = "legacy-codex"
+    yml = agent_yml_path(aid)
+    yml.parent.mkdir(parents=True, exist_ok=True)
+    yml.write_text(
+        "id: legacy-codex\n"
+        "state: running\n"
+        "display_name: legacy-codex\n"
+        "created_at: 0\n"
+        "puffo_core: {server_url: 'https://api.puffo.ai', slug: '', "
+        "device_id: '', space_id: '', operator_slug: ''}\n"
+        "runtime: {kind: cli-local, provider: '', model: '', harness: codex, "
+        "sandbox: danger-full-access}\n"
+        "profile: profile.md\n"
+        "memory_dir: memory\n"
+        "workspace_dir: workspace\n"
+        "triggers: {on_mention: true, on_dm: true}\n",
+        encoding="utf-8",
+    )
+    assert AgentConfig.load(aid).runtime.task_timeout_seconds == 600.0
+
+
+def test_codex_session_stores_timeout():
+    from puffo_agent.agent.adapters.codex_session import CodexSession
+    s = CodexSession(
+        agent_id="a",
+        session_file=Path("/tmp/nonexistent-codex-session.json"),
+        argv=["codex", "app-server"],
+        task_timeout_seconds=42.0,
+    )
+    assert s.task_timeout_seconds == 42.0

--- a/tests/test_task_timeout_knob.py
+++ b/tests/test_task_timeout_knob.py
@@ -1,5 +1,5 @@
-"""PUF-375 (a): RuntimeConfig.task_timeout_seconds round-trips through
-agent.yml, defaults to 600s, and reaches the CodexSession."""
+"""RuntimeConfig.task_timeout_seconds round-trips through agent.yml,
+defaults to 600s, and reaches the CodexSession."""
 
 from __future__ import annotations
 
@@ -64,9 +64,45 @@ def test_codex_session_stores_timeout():
     assert s.task_timeout_seconds == 42.0
 
 
+def test_local_cli_adapter_plumbs_timeout_to_codex_session(tmp_path, monkeypatch):
+    from puffo_agent.agent.adapters import local_cli as lc
+    from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+    from puffo_agent.agent.harness import CodexHarness
+
+    host_home = tmp_path / "host"
+    host_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: host_home))
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(lc, "is_macos", lambda: False)
+    monkeypatch.setattr(lc, "sync_host_codex_auth_view", lambda *a, **k: "shared")
+    monkeypatch.setattr(lc, "resolve_codex_bin", lambda: str(tmp_path / "codex"))
+
+    captured: dict = {}
+
+    class _Capture:
+        def __init__(self, *a, **k):
+            captured.update(k)
+            raise RuntimeError("stop before spawn")
+
+    monkeypatch.setattr(lc, "CodexSession", _Capture)
+    adapter = LocalCLIAdapter(
+        agent_id="a",
+        model="",
+        workspace_dir=str(tmp_path / "ws"),
+        claude_dir=str(tmp_path / "cl"),
+        session_file=str(tmp_path / "s.json"),
+        mcp_config_file=str(tmp_path / "mcp.json"),
+        agent_home_dir=str(tmp_path / "agents" / "a"),
+        harness=CodexHarness(),
+        permission_mode="bypassPermissions",
+        task_timeout_seconds=123.0,
+    )
+    with pytest.raises(RuntimeError, match="stop before spawn"):
+        adapter._ensure_codex_session()
+    assert captured["task_timeout_seconds"] == 123.0
+
+
 def test_timeout_budget_label():
-    # PUF-375 (b') sub-60s polish: minutes when >=60s, else seconds — never
-    # a nonsensical "0-minute".
     from puffo_agent.agent.adapters.codex_session import _timeout_budget_label
     assert _timeout_budget_label(600.0) == "10-minute"
     assert _timeout_budget_label(1800.0) == "30-minute"

--- a/tests/test_task_timeout_knob.py
+++ b/tests/test_task_timeout_knob.py
@@ -102,6 +102,29 @@ def test_local_cli_adapter_plumbs_timeout_to_codex_session(tmp_path, monkeypatch
     assert captured["task_timeout_seconds"] == 123.0
 
 
+def test_build_adapter_plumbs_timeout_to_local_cli(home):
+    from types import SimpleNamespace
+
+    from puffo_agent.portal.state import AgentConfig, RuntimeConfig
+    from puffo_agent.portal.worker import build_adapter
+
+    cfg = AgentConfig(
+        id="codex-knob",
+        display_name="codex-knob",
+        runtime=RuntimeConfig(
+            kind="cli-local", harness="codex", task_timeout_seconds=777.0,
+        ),
+    )
+    daemon = SimpleNamespace(
+        openai=SimpleNamespace(model=""),
+        anthropic=SimpleNamespace(model=""),
+        data_service=SimpleNamespace(port=63388),
+        rpc_service=SimpleNamespace(port=63389),
+    )
+    adapter = build_adapter(daemon, cfg)
+    assert adapter.task_timeout_seconds == 777.0
+
+
 def test_timeout_budget_label():
     from puffo_agent.agent.adapters.codex_session import _timeout_budget_label
     assert _timeout_budget_label(600.0) == "10-minute"

--- a/tests/test_task_timeout_knob.py
+++ b/tests/test_task_timeout_knob.py
@@ -62,3 +62,14 @@ def test_codex_session_stores_timeout():
         task_timeout_seconds=42.0,
     )
     assert s.task_timeout_seconds == 42.0
+
+
+def test_timeout_budget_label():
+    # PUF-375 (b') sub-60s polish: minutes when >=60s, else seconds — never
+    # a nonsensical "0-minute".
+    from puffo_agent.agent.adapters.codex_session import _timeout_budget_label
+    assert _timeout_budget_label(600.0) == "10-minute"
+    assert _timeout_budget_label(1800.0) == "30-minute"
+    assert _timeout_budget_label(90.0) == "1-minute"
+    assert _timeout_budget_label(45.0) == "45-second"
+    assert _timeout_budget_label(5.0) == "5-second"


### PR DESCRIPTION
## Summary

Full FB-401 fix for codex mid-reconnect false-red + dropped-inbound work loss. Three folded changes:

### (a) `task_timeout_seconds` per-agent knob
Vase-directed. New `RuntimeConfig.task_timeout_seconds: float = 600.0`, plumbed through `LocalCLIAdapter` → `CodexSession` → the turn `asyncio.wait_for`. Back-compat default preserved. Long-running agents (reasoning-high, complex tasks) override via agent.yml.

### (b') Legible timeout message
Replaces the bare empty reply on timeout with an operator-facing `"⏱ Task exceeded the N-minute timeout; the codex session state was cleared for the next turn."` — routed as a normal reply. `_timeout_budget_label` handles sub-60s budgets as `"N-second"` (no nonsensical `"0-minute"`).

### (b) ε — the work-loss fix
A codex mid-reconnect turn failure (`RuntimeError: codex turn failed: Reconnecting… N/M`) now:
- raises a **non-auth `AgentAPIError`** → worker's existing retry substrate (`on_api_error_retry`) re-enqueues the batch + backs off (**retried, not dropped**);
- is **not counted** as a wedged-threshold strike (`_consecutive_thread_failures` untouched).

Covers Nova's **Path A** (single-strike `unhandled_error` + drop) *and* **Path B** (2-strike wedged false-count via reconnect chain).

### Signal-lock

Verbatim string from Nova's log pull (Sam's machine, three incidents 2026-07-03 → 07-06):
```
RuntimeError: codex turn failed: Reconnecting... 2/5
```
Regex `\bReconnecting\b` case-insensitive at `_looks_like_codex_reconnect`; positive/negative tests included.

### Mechanism choice — post-fail-retry (not pre-send gate)

Reuses the proven `AgentAPIError` re-enqueue substrate. Trade-off: post-fail sends one doomed turn per reconnect before retrying (bounded by consumer retry-cap + backoff; per D2, ~57s self-heal). Pre-send `session_configured` gate is a clean follow-up if Nova prefers it.

## Files

- `portal/state.py` — `RuntimeConfig.task_timeout_seconds`.
- `portal/worker.py` — passes to adapter.
- `agent/adapters/local_cli.py` — stores + plumbs to CodexSession.
- `agent/adapters/codex_session.py` — `_looks_like_codex_reconnect`, `_timeout_budget_label`, mid-reconnect → `AgentAPIError` at the turn_failed branch, legible timeout reply.

## Test plan

- [x] `tests/test_task_timeout_knob.py` — default 600 · round-trip via agent.yml · legacy-yml default · CodexSession stores · `_timeout_budget_label` edges (5s, 45s, 90s, 600s, 1800s).
- [x] `tests/test_codex_session.py` — `test_reconnect_turn_routes_to_retry_not_drop` (real fake-codex script emits Reconnecting; assert `AgentAPIError(is_auth=False)`, no raw RuntimeError, wedged counter = 0) · `test_looks_like_codex_reconnect` (positive: verbatim string, "reconnecting to backend"; negative: model overloaded, thread limit, empty).
- [x] Existing `tests/test_codex_thread_rotation.py` unbroken — Path B rotation still fires on non-reconnect 2-strike turn_failed.
- [x] Full pytest sweep — **1878 pass / 2 skipped / 0 fail**. Zero regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)