### PR TITLE
feat: sender relationship classification + list_friends (Puffo Friends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Sender relationship classification (Puffo Friends).** Every inbound
+  message sender is classified against the agent's and its owner's
+  relationships (fetched via the new `/v2/identities/{slug}/relationships`
+  API, cached 10 min): owner-blocked wins, then agent friendship
+  (`owner_and_my_friend`), then owner friendship (`owner_friend`).
+  Non-default tags land in the message metadata block as
+  `sender_relationship` so agents can weigh replies. DMs from blocked
+  senders are acknowledged and dropped client-side — never persisted,
+  never dispatched, invisible to the sender; group messages still flow
+  carrying the tag. New `list_friends` MCP tool on all tool surfaces.
+
 ## [1.1.1] — 2026-07-10
 
 ### Fixed

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -118,6 +118,7 @@ class PuffoAgent:
         space_name: str = "",
         sender_owner_slug: str = "",
         is_from_operator: bool = False,
+        sender_relationship: str = "",
     ) -> str | None:
         self._append_user(
             channel_name, sender, sender_email, text,
@@ -132,6 +133,7 @@ class PuffoAgent:
             space_name=space_name,
             sender_owner_slug=sender_owner_slug,
             is_from_operator=is_from_operator,
+            sender_relationship=sender_relationship,
         )
         return await self._run_turn_and_route(
             channel_name=channel_name,
@@ -183,6 +185,7 @@ class PuffoAgent:
                 is_visible_to_human=msg.get("is_visible_to_human", True),
                 sender_owner_slug=msg.get("sender_owner_slug", ""),
                 is_from_operator=msg.get("is_from_operator", False),
+                sender_relationship=msg.get("sender_relationship", ""),
             )
             for msg in batch
         ]
@@ -245,6 +248,7 @@ class PuffoAgent:
                 sender_display_name=msg.get("sender_display_name", ""),
                 sender_owner_slug=msg.get("sender_owner_slug", ""),
                 is_from_operator=msg.get("is_from_operator", False),
+                sender_relationship=msg.get("sender_relationship", ""),
             ))
         fallback_text = "\n\n".join(fallback_chunks)
 
@@ -410,6 +414,7 @@ class PuffoAgent:
         is_visible_to_human: bool = True,
         sender_owner_slug: str = "",
         is_from_operator: bool = False,
+        sender_relationship: str = "",
     ):
         content = self._format_user_block(
             channel_name=channel_name,
@@ -429,6 +434,7 @@ class PuffoAgent:
             is_visible_to_human=is_visible_to_human,
             sender_owner_slug=sender_owner_slug,
             is_from_operator=is_from_operator,
+            sender_relationship=sender_relationship,
         )
         self.log.append({"role": "user", "content": content})
         self._truncate_log()
@@ -453,6 +459,7 @@ class PuffoAgent:
         is_visible_to_human: bool = True,
         sender_owner_slug: str = "",
         is_from_operator: bool = False,
+        sender_relationship: str = "",
     ) -> str:
         # Structured markdown block keeps context metadata distinct
         # from message content, preventing the LLM from echoing
@@ -497,6 +504,9 @@ class PuffoAgent:
         # don't see keys their primer doesn't document.
         if sender_owner_slug:
             lines.append(f"- sender_owner_slug: {sender_owner_slug}")
+        # Relationship tag emits only when it carries signal.
+        if sender_relationship and sender_relationship != "default":
+            lines.append(f"- sender_relationship: {sender_relationship}")
         if is_from_operator:
             lines.append("- is_from_operator: true")
         lines.append(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -475,6 +475,10 @@ class PuffoCoreMessageClient:
         # Operator's slug — used to DM them on non-auto-acceptable
         # invites. Empty string falls back to log-only handling.
         self.operator_slug = operator_slug
+        # (own, owner) relationship maps: slug -> status. TTL'd like the
+        # profile cache; empty maps on fetch failure so messages flow.
+        self._relationship_maps: tuple[dict, dict] | None = None
+        self._relationship_maps_at = 0.0
         self.auto_accept_space_invitations = bool(auto_accept_space_invitations)
         # Absolute path to the agent's workspace. Inbound attachments
         # are decrypted into ``<workspace>/.puffo/inbox/<envelope_id>/``.
@@ -686,6 +690,9 @@ class PuffoCoreMessageClient:
             validated_reply_to_id = await self._validate_incoming_parent_id(
                 payload.reply_to_id, payload.channel_id, payload.space_id,
             )
+            if await self._drop_blocked_dm(payload):
+                return
+
             await self.store.store({
                 "envelope_id": payload.envelope_id,
                 "envelope_kind": payload.envelope_kind,
@@ -869,6 +876,9 @@ class PuffoCoreMessageClient:
                 self.operator_slug
                 and payload.sender_slug == self.operator_slug
             )
+            sender_relationship = await self._sender_relationship(
+                payload.sender_slug,
+            )
 
             # ``owner_slug`` is agent-only — the is-agent signal the
             # priority bands were designed around.
@@ -903,6 +913,7 @@ class PuffoCoreMessageClient:
                 "sender_display_name": sender_display_name,
                 "sender_owner_slug": sender_owner_slug,
                 "is_from_operator": is_from_operator,
+                "sender_relationship": sender_relationship,
                 "sender_email": "",
                 "text": llm_text,
                 "root_id": payload_thread_root_id or "",
@@ -2146,6 +2157,66 @@ class PuffoCoreMessageClient:
             return None
         self._inviter_root_cache[slug] = root_pk
         return root_pk
+
+    async def _drop_blocked_dm(self, payload) -> bool:
+        """Blocked-DM ack-and-drop: nothing persisted, the sender learns
+        nothing. Group messages still flow (tagged) — the agent decides
+        whether to ignore them."""
+        if payload.channel_id:
+            return False
+        rel = await self._sender_relationship(payload.sender_slug)
+        if rel != "blocked":
+            return False
+        self._log.info(
+            "dropping DM from blocked sender %s (envelope=%s)",
+            payload.sender_slug, payload.envelope_id,
+        )
+        return True
+
+    async def _fetch_relationship_maps(self) -> tuple[dict, dict]:
+        """(own, owner) maps of slug -> status. The agent reads its own
+        relationships plus its owner's (read-only server grant)."""
+        now = time.monotonic()
+        if (
+            self._relationship_maps is not None
+            and now - self._relationship_maps_at < _PROFILE_CACHE_TTL_SECONDS
+        ):
+            return self._relationship_maps
+
+        async def _load(slug: str) -> dict:
+            if not slug:
+                return {}
+            data = await self.http.get(f"/v2/identities/{slug}/relationships")
+            return {
+                r.get("other_slug", ""): r.get("status", "")
+                for r in (data or {}).get("relationships", []) or []
+            }
+
+        try:
+            own = await _load(self.slug)
+            owner = await _load(self.operator_slug)
+            self._relationship_maps = (own, owner)
+        except Exception as exc:  # noqa: BLE001 — classification is best-effort
+            self._log.warning("relationship fetch failed: %s", exc)
+            if self._relationship_maps is None:
+                self._relationship_maps = ({}, {})
+        self._relationship_maps_at = now
+        return self._relationship_maps
+
+    async def _sender_relationship(self, sender_slug: str) -> str:
+        """blocked | owner_and_my_friend | owner_friend | default, by the
+        spec precedence: owner block wins, then agent friendship, then
+        owner friendship."""
+        if not sender_slug or sender_slug == self.operator_slug:
+            return "default"
+        own, owner = await self._fetch_relationship_maps()
+        if owner.get(sender_slug) == "blocked" or own.get(sender_slug) == "blocked":
+            return "blocked"
+        if own.get(sender_slug) == "friend":
+            return "owner_and_my_friend"
+        if owner.get(sender_slug) == "friend":
+            return "owner_friend"
+        return "default"
 
     async def _fetch_display_name(self, slug: str) -> str:
         """display_name via the unified profile cache. Empty string

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -53,6 +53,8 @@ Every user message carries a metadata block:
 - sender_owner_slug: <slug>      # only when sender is an agent — the
                                  # operator who owns it
 - is_from_operator: true         # only when the sender is YOUR operator
+- sender_relationship: <tag>     # only when signal: blocked |
+                                 # owner_friend | owner_and_my_friend
 - is_visible_to_human: true | false
 - mentions:                      # only when @-mentions present
   - puffotest-19b1 (you)
@@ -173,6 +175,7 @@ below is the authoritative reference.
 - `list_channels_in_all_spaces()` — channels across all your spaces,
   grouped by space.
 - `list_channel_members(channel)` — slugs + roles.
+- `list_friends()` — your mutual friends (owner-granted/approved).
 - `get_channel_history(channel, limit=20, since="", before=0, after=0)`
   — recent **root posts** + reply counts. Replies NOT inlined.
 - `get_dm_history(peer, limit=20, before=0)` — recent **direct

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -31,6 +31,7 @@ PUFFO_CORE_TOOL_NAMES = (
     "list_channels_in_all_spaces",
     "list_channels_in_space",
     "list_channel_members",
+    "list_friends",
     "get_channel_history",
     "get_dm_history",
     "get_thread_history",

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -673,6 +673,22 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
+    async def list_friends() -> str:
+        """List this agent's friends (mutual, owner-granted or
+        owner-approved relationships). Friends can DM you and their
+        space invitations are auto-accepted."""
+        data = await cfg.http_client.get(
+            f"/v2/identities/{cfg.slug}/relationships?status=friend"
+        )
+        entries = (data or {}).get("relationships", []) or []
+        if not entries:
+            return "(no friends yet)"
+        lines = [
+            f"- {r.get('other_slug', '')}" for r in entries if r.get("other_slug")
+        ]
+        return "\n".join(lines)
+
+    @mcp.tool()
     async def list_spaces() -> str:
         """List spaces this agent is a member of (id + name).
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -675,8 +675,8 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
     @mcp.tool()
     async def list_friends() -> str:
         """List this agent's friends (mutual, owner-granted or
-        owner-approved relationships). Friends can DM you and their
-        space invitations are auto-accepted."""
+        owner-approved relationships). Friends are your most trusted
+        senders — their messages arrive tagged owner_and_my_friend."""
         data = await cfg.http_client.get(
             f"/v2/identities/{cfg.slug}/relationships?status=friend"
         )

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -31,6 +31,7 @@ WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
     "get_dm_history",
     "get_thread_history",
     "list_channel_members",
+    "list_friends",
     "list_spaces",
     "list_channels_in_space",
     "list_channels_in_all_spaces",

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -82,3 +82,23 @@ def test_mention_suffixes_render_from_is_agent():
     assert "  - me-0001 (you)" in block
     assert "  - nova-bot-1234 (agent)" in block
     assert "  - alice-1234 (human)" in block
+
+
+# --- sender_relationship tag ---
+
+
+def test_relationship_tag_renders_when_signal():
+    block = _block(sender="friend-1234", sender_relationship="owner_and_my_friend")
+    assert "- sender_relationship: owner_and_my_friend" in block
+
+
+def test_relationship_default_is_omitted():
+    block = _block(sender="anyone-1234", sender_relationship="default")
+    assert "- sender_relationship:" not in block
+    block = _block(sender="anyone-1234")
+    assert "- sender_relationship:" not in block
+
+
+def test_relationship_blocked_renders_for_group_messages():
+    block = _block(sender="spammer-1234", sender_relationship="blocked")
+    assert "- sender_relationship: blocked" in block

--- a/tests/test_sender_relationship.py
+++ b/tests/test_sender_relationship.py
@@ -1,0 +1,165 @@
+"""Sender relationship classification: precedence (owner block > agent
+friend > owner friend > default), cache behavior, fetch-failure
+tolerance — plus the list_friends MCP tool surface wiring."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class _FakeHttp:
+    def __init__(self, responses: dict, fail: bool = False):
+        self.responses = responses
+        self.fail = fail
+        self.calls: list[str] = []
+
+    async def get(self, path: str):
+        self.calls.append(path)
+        if self.fail:
+            raise RuntimeError("server unreachable")
+        return self.responses.get(path, {"relationships": []})
+
+
+def _client(responses: dict, *, fail: bool = False) -> PuffoCoreMessageClient:
+    c = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    c.slug = "kai-1234"
+    c.operator_slug = "op-9999"
+    c.http = _FakeHttp(responses, fail=fail)
+    c._relationship_maps = None
+    c._relationship_maps_at = 0.0
+    c._log = logging.getLogger("test-rel")
+    return c
+
+
+def _responses(own: dict, owner: dict) -> dict:
+    def payload(m: dict) -> dict:
+        return {
+            "relationships": [
+                {"other_slug": k, "status": v} for k, v in m.items()
+            ]
+        }
+
+    return {
+        "/v2/identities/kai-1234/relationships": payload(own),
+        "/v2/identities/op-9999/relationships": payload(owner),
+    }
+
+
+def test_owner_block_wins_over_everything():
+    c = _client(_responses(
+        own={"eve-1": "friend"},
+        owner={"eve-1": "blocked"},
+    ))
+    assert _run(c._sender_relationship("eve-1")) == "blocked"
+
+
+def test_agent_friend_beats_owner_friend():
+    c = _client(_responses(
+        own={"bob-1": "friend"},
+        owner={"bob-1": "friend"},
+    ))
+    assert _run(c._sender_relationship("bob-1")) == "owner_and_my_friend"
+
+
+def test_owner_friend_alone_tags_owner_friend():
+    c = _client(_responses(own={}, owner={"bob-1": "friend"}))
+    assert _run(c._sender_relationship("bob-1")) == "owner_friend"
+
+
+def test_allowed_and_unknown_are_default():
+    c = _client(_responses(own={"carol-1": "allowed"}, owner={}))
+    assert _run(c._sender_relationship("carol-1")) == "default"
+    assert _run(c._sender_relationship("stranger-1")) == "default"
+
+
+def test_own_block_also_blocks():
+    c = _client(_responses(own={"eve-2": "blocked"}, owner={}))
+    assert _run(c._sender_relationship("eve-2")) == "blocked"
+
+
+def test_operator_sender_is_always_default():
+    c = _client(_responses(own={}, owner={}))
+    assert _run(c._sender_relationship("op-9999")) == "default"
+    assert c.http.calls == []  # short-circuits before any fetch
+
+
+def test_fetch_failure_defaults_and_does_not_raise():
+    c = _client({}, fail=True)
+    assert _run(c._sender_relationship("anyone-1")) == "default"
+
+
+def test_maps_are_cached_within_ttl():
+    c = _client(_responses(own={}, owner={}))
+
+    async def twice():
+        await c._sender_relationship("x-1")
+        await c._sender_relationship("y-2")
+
+    _run(twice())
+    assert len(c.http.calls) == 2  # one fetch pair, second lookup cached
+
+
+def test_cache_expires_after_ttl(monkeypatch):
+    c = _client(_responses(own={}, owner={}))
+
+    async def flow():
+        await c._sender_relationship("x-1")
+        c._relationship_maps_at = time.monotonic() - 3600
+        await c._sender_relationship("x-1")
+
+    _run(flow())
+    assert len(c.http.calls) == 4
+
+
+def test_list_friends_wired_on_every_surface():
+    from puffo_agent.mcp.config import PUFFO_CORE_TOOL_NAMES
+    from puffo_agent.portal.ws_local import tool_dispatch
+
+    assert "list_friends" in PUFFO_CORE_TOOL_NAMES
+    assert "list_friends" in tool_dispatch.WS_LOCAL_ALLOWED_TOOLS
+    from puffo_agent.agent.shared_content import DEFAULT_SHARED_CLAUDE_MD
+
+    assert "list_friends" in DEFAULT_SHARED_CLAUDE_MD
+    assert "sender_relationship" in DEFAULT_SHARED_CLAUDE_MD
+
+
+class _Payload:
+    def __init__(self, channel_id: str, sender_slug: str):
+        self.channel_id = channel_id
+        self.sender_slug = sender_slug
+        self.envelope_id = "env_test"
+
+
+def test_blocked_dm_is_dropped_before_store():
+    c = _client(_responses(own={}, owner={"eve-1": "blocked"}))
+    assert _run(c._drop_blocked_dm(_Payload("", "eve-1"))) is True
+
+
+def test_blocked_group_message_is_not_dropped():
+    c = _client(_responses(own={}, owner={"eve-1": "blocked"}))
+    assert _run(c._drop_blocked_dm(_Payload("ch_123", "eve-1"))) is False
+
+
+def test_unblocked_dm_is_not_dropped():
+    c = _client(_responses(own={}, owner={}))
+    assert _run(c._drop_blocked_dm(_Payload("", "friendly-1"))) is False
+
+
+def test_drop_check_runs_before_persistence():
+    import re
+    from pathlib import Path
+
+    src = Path("src/puffo_agent/agent/puffo_core_client.py").read_text(
+        encoding="utf-8"
+    )
+    drop = src.index("await self._drop_blocked_dm(payload)")
+    store = src.index("await self.store.store({")
+    assert drop < store, "blocked-DM drop must precede messages.db persistence"

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -33,6 +33,7 @@ def test_allowed_tools_are_the_send_read_and_membership_tools():
         "get_dm_history",
         "get_thread_history",
         "list_channel_members",
+        "list_friends",
         "list_spaces",
         "list_channels_in_space",
         "list_channels_in_all_spaces",


### PR DESCRIPTION
Agent half of Puffo Friends (pairs with puffo-ai/puffo-server#209; requires it server-side).

## What

- **Sender classification** on every inbound message: the daemon fetches the agent's own + its owner's relationship maps (`GET /v2/identities/{slug}/relationships` — agents have read access to their owner's rows), cached 10 min, empty-on-failure so message flow never depends on the relationships API being up. Precedence per the spec appendix: owner block > agent friendship (`owner_and_my_friend`) > owner friendship (`owner_friend`) > `default`.
- **Metadata tag**: non-default classifications emit `- sender_relationship: <tag>` in the structured message block (conditional, like `sender_owner_slug`, so older primers see nothing new). Primer documents the field.
- **Blocked-DM ack-and-drop (client-side per spec)**: a DM from a blocked sender is dropped **before** `messages.db` persistence — never stored, never dispatched, sender learns nothing. Group messages from blocked senders still flow carrying the `blocked` tag (the agent [SILENT]s them by primer guidance).
- **`list_friends` MCP tool** on all surfaces: registration, `PUFFO_CORE_TOOL_NAMES`, primer, ws-local allow-list.

## Tests

17 new: precedence ×5 (owner-block wins over agent-friend, both-friend, owner-only, own-block, allowed/unknown→default), operator short-circuit, fetch-failure tolerance, cache TTL ×2, drop ×3 (blocked DM dropped / blocked group flows / unblocked DM flows), drop-before-persistence ordering guard, format-block emission ×3, all-surfaces wiring. Full suite 1880 passed / 10 skipped.

Merge order: after the server PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)