### PR TITLE
feat(codex): route codex harness to the LiteLLM gateway via per-agent VK

### DIFF
--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -372,6 +372,23 @@ class LocalCLIAdapter(Adapter):
         # sync_host_mcp_servers.
         merged_extras: dict[str, dict] = dict(self._desired_codex_extras)
         merged_extras.update(host_mcps)
+        # LiteLLM gateway path: when the agent carries a virtual key + gateway
+        # URL (set by AIM in agent.yml), codex authenticates to the gateway with
+        # the VK via the Responses API instead of ChatGPT OAuth. base_url must
+        # end in /v1 (codex POSTs to {base_url}/responses).
+        gateway_provider = None
+        if self.llm_base_url and self.llm_api_key:
+            base = self.llm_base_url.rstrip("/")
+            if not base.endswith("/v1"):
+                base = base + "/v1"
+            gateway_provider = {
+                "name": "litellm",
+                "display_name": "LiteLLM gateway",
+                "base_url": base,
+                "env_key": "OPENAI_API_KEY",
+                "model": self.model or "codex",
+                "wire_api": "responses",
+            }
         if self.puffo_core_mcp_env:
             write_codex_mcp_config(
                 codex_home / "config.toml",
@@ -379,11 +396,13 @@ class LocalCLIAdapter(Adapter):
                 args=["-m", "puffo_agent.mcp.puffo_core_server"],
                 env=self.puffo_core_mcp_env,
                 extra_servers=merged_extras,
+                provider=gateway_provider,
             )
         else:
             write_codex_mcp_config(
                 codex_home / "config.toml",
                 extra_servers=merged_extras,
+                provider=gateway_provider,
             )
             logger.warning(
                 "agent %s: codex MCP tools unavailable — puffo_core is "
@@ -401,18 +420,28 @@ class LocalCLIAdapter(Adapter):
             **os.environ,
             "CODEX_HOME": str(codex_home),
         }
-        auth_mode = sync_host_codex_auth_view(Path.home(), codex_home)
-        if auth_mode == "no-host-file":
-            raise RuntimeError(
-                f"agent {self.agent_id!r}: codex needs auth — run "
-                "`codex login` in your own shell so ~/.codex/auth.json "
-                "exists; cli-local + cli-docker only support codex's "
-                "OAuth (ChatGPT account) credentials, not raw API keys."
+        if gateway_provider:
+            # Gateway/VK path: the custom provider's env_key holds the VK; codex
+            # sends it as the bearer to the LiteLLM gateway. No ChatGPT OAuth,
+            # so the host auth.json gate below is bypassed entirely.
+            env["OPENAI_API_KEY"] = self.llm_api_key
+            logger.info(
+                "agent %s: codex → LiteLLM gateway %s (model=%s, VK auth, no OAuth)",
+                self.agent_id, gateway_provider["base_url"], gateway_provider["model"],
             )
-        logger.info(
-            "agent %s: shared host codex auth (%s)",
-            self.agent_id, auth_mode,
-        )
+        else:
+            auth_mode = sync_host_codex_auth_view(Path.home(), codex_home)
+            if auth_mode == "no-host-file":
+                raise RuntimeError(
+                    f"agent {self.agent_id!r}: codex needs auth — either set "
+                    "runtime.llm_base_url + runtime.api_key (LiteLLM gateway VK "
+                    "path), or run `codex login` in your own shell so "
+                    "~/.codex/auth.json exists (ChatGPT OAuth path)."
+                )
+            logger.info(
+                "agent %s: shared host codex auth (%s)",
+                self.agent_id, auth_mode,
+            )
         # Subprocess argv — ``codex app-server`` is the documented entry
         # point for embedding codex as a long-running agent. Resolve
         # via the shared resolver so PATH + ``PUFFO_CODEX_BIN`` env

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -119,6 +119,7 @@ def write_codex_mcp_config(
     args: list[str] | None = None,
     env: dict[str, str] | None = None,
     extra_servers: dict[str, dict] | None = None,
+    provider: dict | None = None,
 ) -> Path:
     """Serialise the per-agent codex config.toml.
 
@@ -140,6 +141,27 @@ def write_codex_mcp_config(
         "",
         'cli_auth_credentials_store = "file"',
     ]
+    # LiteLLM (or any OpenAI-compatible gateway) custom provider. When present,
+    # codex talks to ``base_url`` via the Responses API using the bearer key in
+    # ``env_key`` (the agent's virtual key) instead of its native ChatGPT OAuth.
+    # ``wire_api = "responses"`` is REQUIRED — codex dropped Chat Completions.
+    if provider and provider.get("base_url"):
+        raw_name = provider.get("name") or "litellm"
+        key = _toml_key(raw_name)
+        model = provider.get("model") or ""
+        if model:
+            lines.append(f'model = "{_toml_escape(model)}"')
+        lines.append(f'model_provider = "{_toml_escape(raw_name)}"')
+        lines.append("")
+        lines.append(f"[model_providers.{key}]")
+        lines.append(
+            f'name = "{_toml_escape(provider.get("display_name") or "LiteLLM gateway")}"'
+        )
+        lines.append(f'base_url = "{_toml_escape(provider["base_url"])}"')
+        lines.append(
+            f'env_key = "{_toml_escape(provider.get("env_key") or "OPENAI_API_KEY")}"'
+        )
+        lines.append(f'wire_api = "{_toml_escape(provider.get("wire_api") or "responses")}"')
     # Host extras first so the puffo entry below shadows any duplicate.
     for name, spec in sorted((extra_servers or {}).items()):
         if name == MCP_SERVER_NAME:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -341,6 +341,13 @@ class Daemon:
     def _register_with_refresher(
         self, agent_cfg: AgentConfig, worker: Worker,
     ) -> None:
+        # Gateway/VK mode: nothing to refresh (static VK via LiteLLM). Skip
+        # registration so the periodic refresh loop never probes the provider
+        # (api.openai.com for codex) and flips refresh_broken.
+        # getattr: a runtime without the field is simply not in gateway mode —
+        # never let a missing optional field crash worker startup.
+        if (getattr(agent_cfg.runtime, "llm_base_url", "") or "").strip():
+            return
         refresher = self._refresher_for(agent_cfg)
         refresher.register_agent(agent_home_dir(agent_cfg.id))
         agent_id = agent_cfg.id
@@ -379,6 +386,14 @@ class Daemon:
         return self._refresher_for(agent_cfg).notify_refresh_needed
 
     def _ensure_fresh_for(self, agent_cfg: AgentConfig):
+        # Gateway/VK mode (runtime.llm_base_url set): the LLM key is a static
+        # per-agent virtual key routed through LiteLLM — there is NO OAuth token
+        # to refresh. Returning None makes the worker skip the pre-delivery
+        # refresh gate, so a turn isn't blocked (and deferred ~40s) by a spurious
+        # api.openai.com probe that 401s. Native-auth harnesses keep the refresh.
+        # getattr: see _register_with_refresher — a missing field means OAuth mode.
+        if (getattr(agent_cfg.runtime, "llm_base_url", "") or "").strip():
+            return None
         return self._refresher_for(agent_cfg).ensure_fresh
 
     def _set_worker_profile_cache(

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -247,3 +247,62 @@ def test_env_keys_with_dots_are_quoted(tmp_path):
     )
     doc = _read_toml(dest)
     assert doc["mcp_servers"]["fs"]["env"]["MY.VAR"] == "value"
+
+
+def test_litellm_provider_block(tmp_path):
+    """Gateway/VK path: a provider dict emits a codex custom model_provider
+    pointing at the LiteLLM gateway with wire_api=responses."""
+    dest = tmp_path / "config.toml"
+    write_codex_mcp_config(
+        dest,
+        provider={
+            "name": "litellm",
+            "base_url": "https://gw.example/v1",
+            "env_key": "OPENAI_API_KEY",
+            "model": "codex",
+            "wire_api": "responses",
+        },
+    )
+    doc = _read_toml(dest)
+    assert doc["model"] == "codex"
+    assert doc["model_provider"] == "litellm"
+    prov = doc["model_providers"]["litellm"]
+    assert prov["base_url"] == "https://gw.example/v1"
+    assert prov["env_key"] == "OPENAI_API_KEY"
+    assert prov["wire_api"] == "responses"
+    # cli_auth store still emitted (unchanged) — codex file-mode auth.
+    assert doc["cli_auth_credentials_store"] == "file"
+
+
+def test_no_provider_block_when_absent(tmp_path):
+    """OAuth path (no provider) must not emit any model_provider — preserves
+    the existing ChatGPT-OAuth behavior."""
+    dest = tmp_path / "config.toml"
+    write_codex_mcp_config(dest)
+    raw = dest.read_text(encoding="utf-8")
+    assert "model_provider" not in raw
+    assert "[model_providers" not in raw
+    doc = _read_toml(dest)
+    assert doc["cli_auth_credentials_store"] == "file"
+
+
+def test_provider_coexists_with_puffo_mcp(tmp_path):
+    """Provider block + puffo_core MCP server in one doc still parses (bare
+    keys before all tables)."""
+    dest = tmp_path / "config.toml"
+    write_codex_mcp_config(
+        dest,
+        command="/usr/bin/python3",
+        args=["-m", "puffo_agent.mcp.puffo_core_server"],
+        env={"PUFFO_CORE_SLUG": "bob-verb-1234"},
+        provider={
+            "name": "litellm",
+            "base_url": "https://gw.example/v1",
+            "env_key": "OPENAI_API_KEY",
+            "model": "gpt-5.2-codex",
+        },
+    )
+    doc = _read_toml(dest)
+    assert doc["model_provider"] == "litellm"
+    assert doc["model_providers"]["litellm"]["wire_api"] == "responses"  # default
+    assert doc["mcp_servers"]["puffo"]["env"]["PUFFO_CORE_SLUG"] == "bob-verb-1234"

--- a/tests/test_codex_gateway_skips_refresh.py
+++ b/tests/test_codex_gateway_skips_refresh.py
@@ -1,0 +1,115 @@
+"""Gateway/VK agents must NOT go through the OAuth credential-refresh path.
+
+Regression cover for the ~40s/turn detour: an agent authenticating to the
+LiteLLM gateway with a static per-agent virtual key has no OAuth token, so
+the daemon must neither (a) register it with the periodic refresher nor
+(b) hand the worker a pre-delivery ``ensure_fresh`` gate. Before the fix,
+both fired and probed ``api.openai.com`` directly, which 401s under VK auth
+— deferring the first turn by ~40s and flipping ``refresh_broken``.
+
+Native-auth (ChatGPT OAuth) codex agents must keep the refresh behaviour.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from puffo_agent.portal.daemon import Daemon
+
+
+class _StubRefresher:
+    def __init__(self) -> None:
+        self.registered: list = []
+        self.success_callbacks: list = []
+
+    def register_agent(self, home) -> None:
+        self.registered.append(home)
+
+    def register_on_refresh_success(self, cb) -> None:
+        self.success_callbacks.append(cb)
+
+    def ensure_fresh(self, *_a, **_k) -> bool:  # pragma: no cover - identity only
+        return True
+
+
+def _daemon() -> Daemon:
+    """A Daemon with just the refresher wiring the guards touch."""
+    d = Daemon.__new__(Daemon)
+    d.codex_refresher = _StubRefresher()
+    d.refresher = _StubRefresher()
+    return d
+
+
+def _cfg(*, llm_base_url: str = "", harness: str = "codex") -> SimpleNamespace:
+    return SimpleNamespace(
+        id="agent-1",
+        runtime=SimpleNamespace(harness=harness, llm_base_url=llm_base_url),
+    )
+
+
+def _worker() -> SimpleNamespace:
+    return SimpleNamespace(
+        runtime=SimpleNamespace(health="ok"),
+        _auth_failed_notification_sent=False,
+        _refresh_success_callback=None,
+    )
+
+
+# ── _ensure_fresh_for: the worker's pre-delivery gate ──
+
+def test_ensure_fresh_is_none_in_gateway_mode():
+    d = _daemon()
+    cfg = _cfg(llm_base_url="https://litellm-staging.puffo.ai")
+    # None => worker skips the gate entirely; no api.openai.com probe.
+    assert d._ensure_fresh_for(cfg) is None
+
+
+def test_ensure_fresh_is_wired_for_oauth_codex():
+    d = _daemon()
+    cfg = _cfg(llm_base_url="")
+    assert d._ensure_fresh_for(cfg) == d.codex_refresher.ensure_fresh
+
+
+def test_ensure_fresh_ignores_blank_llm_base_url():
+    """A whitespace-only base_url is not gateway mode — don't strand OAuth."""
+    d = _daemon()
+    assert d._ensure_fresh_for(_cfg(llm_base_url="   ")) is not None
+
+
+def test_runtime_without_llm_base_url_field_is_oauth_mode():
+    """A runtime object lacking the field entirely must not raise.
+
+    Worker startup runs through these guards; a missing optional attribute
+    must degrade to native-auth mode, never crash the daemon.
+    """
+    d = _daemon()
+    cfg = SimpleNamespace(id="agent-1", runtime=SimpleNamespace(harness="codex"))
+    assert d._ensure_fresh_for(cfg) == d.codex_refresher.ensure_fresh
+    d._register_with_refresher(cfg, _worker())
+    assert len(d.codex_refresher.registered) == 1
+
+
+# ── _register_with_refresher: the periodic background refresh loop ──
+
+def test_gateway_agent_is_not_registered_with_refresher():
+    d = _daemon()
+    cfg = _cfg(llm_base_url="https://litellm-staging.puffo.ai")
+    d._register_with_refresher(cfg, _worker())
+    assert d.codex_refresher.registered == []
+    assert d.refresher.registered == []
+
+
+def test_oauth_codex_agent_is_registered_with_refresher():
+    d = _daemon()
+    d._register_with_refresher(_cfg(llm_base_url=""), _worker())
+    assert len(d.codex_refresher.registered) == 1
+    assert d.refresher.registered == []
+
+
+def test_non_codex_agent_still_uses_claude_refresher():
+    d = _daemon()
+    d._register_with_refresher(
+        _cfg(llm_base_url="", harness="claude-code"), _worker(),
+    )
+    assert len(d.refresher.registered) == 1
+    assert d.codex_refresher.registered == []


### PR DESCRIPTION
Lets a **codex** agent authenticate to the **LiteLLM gateway** with its per-agent **virtual key** instead of ChatGPT OAuth — so cloud/E2B agents can run codex without a real provider key ever entering the sandbox (**Posture B**).

Pairs with **cloud-infra #78** (gateway serves codex; AIM derives the runtime and mints the VK).

**Live and proven:** agent `option-iii` on E2B answers real DMs through the gateway.

## How it works — no fork of codex

We use codex's **own custom-provider config**. `mcp/config.py` now emits, into the per-agent `$CODEX_HOME/config.toml`:

```toml
model_provider = "litellm"

[model_providers.litellm]
base_url = "https://litellm-staging.puffo.ai/v1"
env_key  = "OPENAI_API_KEY"     # holds the VK
wire_api = "responses"
```

`local_cli.py` builds that block from `runtime.llm_base_url` + `runtime.api_key` (both set by AIM in `agent.yml` at create), injects the VK into the codex subprocess env, and **bypasses the ChatGPT-OAuth gate** in gateway mode — that gate would otherwise raise *"codex needs auth — run `codex login`"*, which is impossible headless.

`wire_api = "responses"` is **required**, not a preference: codex speaks only the Responses API since OpenAI removed Chat Completions (Feb 2026).

## The credential-refresh fix (the ~40s/turn bug)

`portal/credential_refresh.py` is **correct** — for OAuth agents. The gap was that the new VK/gateway mode never opted out of it. A gateway agent has **no OAuth token to refresh**, but the daemon was still:
1. registering it with the periodic refresher, and
2. handing the worker a pre-delivery `ensure_fresh` gate.

Both probed `api.openai.com` directly, which **401s under VK auth** → the batch was deferred (~40s + a transient "API Error" flash in the UI) and `refresh_broken` was set. Every turn.

`daemon.py` now no-ops both when `runtime.llm_base_url` is set. **Native-auth codex agents keep the refresh behaviour unchanged.**

**Measured live on E2B: turn latency 48s → 20s**, no error flash. The remaining 20s is model time.

## Tests

- `test_codex_gateway_skips_refresh.py` (new, 7 tests) — gateway mode skips both the refresher registration and the `ensure_fresh` gate; OAuth codex still registers with the codex refresher; non-codex still uses the Claude refresher; a runtime **missing** `llm_base_url` degrades to OAuth mode rather than crashing worker startup.
- `test_codex_config.py` (+3) — the emitted provider block, its absence when unconfigured, and coexistence with the `puffo` MCP server entry.

**Full suite: 2029 passed / 7 failed — identical 7 failures on the clean base** (`test_host_credentials.py` reads the developer's real `~/.claude/.credentials.json` instead of a tmp dir). **Zero regressions.** That test-isolation bug is pre-existing and worth its own ticket.

## Reviewer note

`worker.py` in the vendored FAT tree also carries `_build_chat_local_tool_dispatch` / `ChatOnlyAdapter` wiring that is **not on this base and not mine** — deliberately **excluded** from this PR. If that belongs on this branch it needs its own PR from its author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)