### PR TITLE
PUF-376: self-heal stale channel cache (re-warm on send-miss + on reconnect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale channel cache self-heals (PUF-376).** A membership event
+  dropped during a WS reconnect used to leave a genuinely-member
+  channel unaddressable by `send_message` until a daemon restart.
+  The member/channel cache now re-warms on every (re)connect, and a
+  `ch_` lookup miss re-warms (5s-debounced) and re-checks before
+  failing loud — on every runtime, including the cli-local /
+  cli-docker data-service path.
+
 ### Added
 
 - **48h catch-up staleness gate (PUF-384).** On WS reconnect / daemon

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -2282,6 +2282,12 @@ class PuffoCoreMessageClient:
         Serialized + 5s-debounced so a burst of misses doesn't stampede
         the server; no-op if a re-warm already ran in the last few
         seconds.
+
+        Trade-off: a *different* channel that goes stale within the 5s
+        window won't get its own re-warm and fails loud until the window
+        lapses — acceptable because a full warm re-syncs *all* the
+        agent's channels at once (one miss heals the rest), and the
+        on-(re)connect warm covers the steady state.
         """
         async with self._rewarm_lock:
             now = time.monotonic()
@@ -2294,7 +2300,10 @@ class PuffoCoreMessageClient:
         """Re-warm caches on every (re)connect so a membership event
         missed during the reconnect window self-heals rather than
         staying stale until a daemon restart (PUF-376 γ). Fire-and-
-        forget so it doesn't block catch-up / listen.
+        forget so it doesn't block catch-up / listen — unlike the
+        on-miss path (``rewarm_channel_caches`` behind
+        ``lookup_channel_space``), which awaits because it must re-check
+        the store before deciding to fail loud.
         """
         asyncio.ensure_future(self._warm_member_caches())
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -562,10 +562,10 @@ class PuffoCoreMessageClient:
         # the message arrived from. Falls back to ``self.space_id``
         # when no inbound envelope on this channel has been seen.
         self._channel_space: dict[str, str] = {}
-        # PUF-376: serialize + debounce on-demand cache re-warms so
-        # concurrent channel-cache misses don't stampede the server.
+        # Serialize + debounce on-demand cache re-warms (no stampede).
         self._rewarm_lock = asyncio.Lock()
         self._last_rewarm = 0.0
+        self._warm_task: asyncio.Future | None = None
 
         # Lazy caches for human-readable space + channel names; names
         # aren't on the WS payload so we resolve via ``GET /spaces``
@@ -1011,9 +1011,8 @@ class PuffoCoreMessageClient:
         )
         self._ws.on_message = handle_envelope
         self._ws.on_event = self._handle_event
-        # Warm the member/channel caches on every (re)connect (PUF-376).
-        # Fires on the first connect too, so no separate startup warm
-        # task is needed; fire-and-forget so it doesn't block listen.
+        # Warm the member/channel caches on every (re)connect
+        # (covers the first connect — no separate startup warm).
         self._ws.on_connect = self._on_ws_connect
         await self.store.open()
         try:
@@ -1021,7 +1020,11 @@ class PuffoCoreMessageClient:
         finally:
             consumer_task.cancel()
             invite_poll_task.cancel()
-            for task in (consumer_task, invite_poll_task):
+            if self._warm_task is not None:
+                self._warm_task.cancel()
+            for task in (consumer_task, invite_poll_task, self._warm_task):
+                if task is None:
+                    continue
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
@@ -2373,18 +2376,9 @@ class PuffoCoreMessageClient:
         return parent_id
 
     async def rewarm_channel_caches(self) -> None:
-        """On-demand re-warm when a cache-miss looks like a genuinely-
-        member channel dropped during a WS reconnect (PUF-376 α).
-        Serialized + 5s-debounced so a burst of misses doesn't stampede
-        the server; no-op if a re-warm already ran in the last few
-        seconds.
-
-        Trade-off: a *different* channel that goes stale within the 5s
-        window won't get its own re-warm and fails loud until the window
-        lapses — acceptable because a full warm re-syncs *all* the
-        agent's channels at once (one miss heals the rest), and the
-        on-(re)connect warm covers the steady state.
-        """
+        """On-miss cache re-warm, serialized + 5s-debounced so a burst
+        of misses doesn't stampede the server. A full warm re-syncs
+        every channel at once, so one miss heals the rest."""
         async with self._rewarm_lock:
             now = time.monotonic()
             if now - self._last_rewarm < 5.0:
@@ -2393,15 +2387,11 @@ class PuffoCoreMessageClient:
             self._last_rewarm = now
 
     async def _on_ws_connect(self) -> None:
-        """Re-warm caches on every (re)connect so a membership event
-        missed during the reconnect window self-heals rather than
-        staying stale until a daemon restart (PUF-376 γ). Fire-and-
-        forget so it doesn't block catch-up / listen — unlike the
-        on-miss path (``rewarm_channel_caches`` behind
-        ``lookup_channel_space``), which awaits because it must re-check
-        the store before deciding to fail loud.
-        """
-        asyncio.ensure_future(self._warm_member_caches())
+        """Re-warm on every (re)connect so a membership event missed in
+        the reconnect window self-heals. Fire-and-forget so catch-up
+        isn't blocked; the handle is kept — asyncio only weak-refs
+        scheduled tasks."""
+        self._warm_task = asyncio.ensure_future(self._warm_member_caches())
 
     async def _warm_member_caches(self) -> None:
         """Background prefetch on ``listen()`` startup: walks ``GET
@@ -2459,14 +2449,9 @@ class PuffoCoreMessageClient:
         )
 
     async def _warm_channels_for_space(self, space_id: str) -> None:
-        # PUF-376 invariant: GET /spaces/<sid>/channels is filtered by
-        # channel membership server-side. The self-heal rests on this —
-        # a channel appearing here proves membership, absence proves
-        # non-membership. If the server ever returns all space channels
-        # regardless of membership, the re-warm silently regresses to
-        # proving space-access (the bug the removed /spaces fallback
-        # had). test_channel_cache_selfheal pins it: a non-member
-        # channel must NOT get cached.
+        # Invariant: GET /spaces/<sid>/channels is membership-filtered
+        # server-side — presence proves membership, absence proves not.
+        # The cache self-heal rests on this; a test pins it.
         try:
             resp = await self.http.get(f"/spaces/{space_id}/channels")
         except Exception:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1011,8 +1011,7 @@ class PuffoCoreMessageClient:
         )
         self._ws.on_message = handle_envelope
         self._ws.on_event = self._handle_event
-        # Warm the member/channel caches on every (re)connect
-        # (covers the first connect — no separate startup warm).
+        # Re-warms caches on every (re)connect, first connect included.
         self._ws.on_connect = self._on_ws_connect
         await self.store.open()
         try:
@@ -2376,9 +2375,7 @@ class PuffoCoreMessageClient:
         return parent_id
 
     async def rewarm_channel_caches(self) -> None:
-        """On-miss cache re-warm, serialized + 5s-debounced so a burst
-        of misses doesn't stampede the server. A full warm re-syncs
-        every channel at once, so one miss heals the rest."""
+        """On-miss re-warm; serialized + 5s-debounced (no stampede)."""
         async with self._rewarm_lock:
             now = time.monotonic()
             if now - self._last_rewarm < 5.0:
@@ -2387,10 +2384,7 @@ class PuffoCoreMessageClient:
             self._last_rewarm = now
 
     async def _on_ws_connect(self) -> None:
-        """Re-warm on every (re)connect so a membership event missed in
-        the reconnect window self-heals. Fire-and-forget so catch-up
-        isn't blocked; the handle is kept — asyncio only weak-refs
-        scheduled tasks."""
+        """Fire-and-forget re-warm; handle kept (asyncio weak-refs tasks)."""
         self._warm_task = asyncio.ensure_future(self._warm_member_caches())
 
     async def _warm_member_caches(self) -> None:
@@ -2449,9 +2443,8 @@ class PuffoCoreMessageClient:
         )
 
     async def _warm_channels_for_space(self, space_id: str) -> None:
-        # Invariant: GET /spaces/<sid>/channels is membership-filtered
-        # server-side — presence proves membership, absence proves not.
-        # The cache self-heal rests on this; a test pins it.
+        # Invariant: this endpoint is membership-filtered server-side;
+        # the cache self-heal rests on that (a test pins it).
         try:
             resp = await self.http.get(f"/spaces/{space_id}/channels")
         except Exception:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -548,6 +548,10 @@ class PuffoCoreMessageClient:
         # the message arrived from. Falls back to ``self.space_id``
         # when no inbound envelope on this channel has been seen.
         self._channel_space: dict[str, str] = {}
+        # PUF-376: serialize + debounce on-demand cache re-warms so
+        # concurrent channel-cache misses don't stampede the server.
+        self._rewarm_lock = asyncio.Lock()
+        self._last_rewarm = 0.0
 
         # Lazy caches for human-readable space + channel names; names
         # aren't on the WS payload so we resolve via ``GET /spaces``
@@ -941,11 +945,6 @@ class PuffoCoreMessageClient:
             self._consume_queue(on_message, on_api_error_retry, on_api_error_abandon, on_turn_success),
         )
         invite_poll_task = asyncio.ensure_future(self._invite_poll_loop())
-        # Fire-and-forget; the WS subscribe below doesn't wait for
-        # the warmup. Worst case the first message pays the lazy
-        # fetch as before.
-        warm_task = asyncio.ensure_future(self._warm_member_caches())
-
         self._ws = PuffoCoreWsClient(
             server_url=self.keystore.load_identity(self.slug).server_url,
             keystore=self.keystore,
@@ -954,14 +953,17 @@ class PuffoCoreMessageClient:
         )
         self._ws.on_message = handle_envelope
         self._ws.on_event = self._handle_event
+        # Warm the member/channel caches on every (re)connect (PUF-376).
+        # Fires on the first connect too, so no separate startup warm
+        # task is needed; fire-and-forget so it doesn't block listen.
+        self._ws.on_connect = self._on_ws_connect
         await self.store.open()
         try:
             await self._ws.run()
         finally:
             consumer_task.cancel()
             invite_poll_task.cancel()
-            warm_task.cancel()
-            for task in (consumer_task, invite_poll_task, warm_task):
+            for task in (consumer_task, invite_poll_task):
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
@@ -2274,6 +2276,28 @@ class PuffoCoreMessageClient:
             return None
         return parent_id
 
+    async def rewarm_channel_caches(self) -> None:
+        """On-demand re-warm when a cache-miss looks like a genuinely-
+        member channel dropped during a WS reconnect (PUF-376 α).
+        Serialized + 5s-debounced so a burst of misses doesn't stampede
+        the server; no-op if a re-warm already ran in the last few
+        seconds.
+        """
+        async with self._rewarm_lock:
+            now = time.monotonic()
+            if now - self._last_rewarm < 5.0:
+                return
+            await self._warm_member_caches()
+            self._last_rewarm = now
+
+    async def _on_ws_connect(self) -> None:
+        """Re-warm caches on every (re)connect so a membership event
+        missed during the reconnect window self-heals rather than
+        staying stale until a daemon restart (PUF-376 γ). Fire-and-
+        forget so it doesn't block catch-up / listen.
+        """
+        asyncio.ensure_future(self._warm_member_caches())
+
     async def _warm_member_caches(self) -> None:
         """Background prefetch on ``listen()`` startup: walks ``GET
         /spaces`` and fans out parallel member + channel fetches per
@@ -2330,6 +2354,14 @@ class PuffoCoreMessageClient:
         )
 
     async def _warm_channels_for_space(self, space_id: str) -> None:
+        # PUF-376 invariant: GET /spaces/<sid>/channels is filtered by
+        # channel membership server-side. The self-heal rests on this —
+        # a channel appearing here proves membership, absence proves
+        # non-membership. If the server ever returns all space channels
+        # regardless of membership, the re-warm silently regresses to
+        # proving space-access (the bug the removed /spaces fallback
+        # had). test_channel_cache_selfheal pins it: a non-member
+        # channel must NOT get cached.
         try:
             resp = await self.http.get(f"/spaces/{space_id}/channels")
         except Exception:

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -57,6 +57,10 @@ class PuffoCoreWsClient:
         self.on_message: MessageHandler | None = None
         self.on_event: EventHandler | None = None
         self.on_cert_update: CertHandler | None = None
+        # Fires after every successful (re)connect handshake, before
+        # catch-up. Lets the daemon re-warm caches that a reconnect
+        # window may have left stale (PUF-376).
+        self.on_connect: Callable[[], Coroutine[Any, Any, None]] | None = None
 
     def _build_connect_frame(self) -> str:
         sess = self.keystore.load_session(self.slug)
@@ -168,6 +172,11 @@ class PuffoCoreWsClient:
             self._ws = ws
             self.session_id = await self._handshake(ws)
             logger.info("[%s] WS connected, session=%s", self.slug, self.session_id)
+            if self.on_connect:
+                try:
+                    await self.on_connect()
+                except Exception:
+                    logger.exception("on_connect callback failed")
             await self._catchup()
             await self._listen_loop()
 

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -58,8 +58,7 @@ class PuffoCoreWsClient:
         self.on_event: EventHandler | None = None
         self.on_cert_update: CertHandler | None = None
         # Fires after every successful (re)connect handshake, before
-        # catch-up. Lets the daemon re-warm caches that a reconnect
-        # window may have left stale (PUF-376).
+        # catch-up — lets the daemon re-warm reconnect-stale caches.
         self.on_connect: Callable[[], Coroutine[Any, Any, None]] | None = None
 
     def _build_connect_frame(self) -> str:

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -57,8 +57,7 @@ class PuffoCoreWsClient:
         self.on_message: MessageHandler | None = None
         self.on_event: EventHandler | None = None
         self.on_cert_update: CertHandler | None = None
-        # Fires after every successful (re)connect handshake, before
-        # catch-up — lets the daemon re-warm reconnect-stale caches.
+        # Fires after every (re)connect handshake, before catch-up.
         self.on_connect: Callable[[], Coroutine[Any, Any, None]] | None = None
 
     def _build_connect_frame(self) -> str:

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -74,11 +74,12 @@ async def _resolve_channel_space(cfg: Any, channel_id: str) -> str:
                 f"channel id, call list_channels_in_all_spaces."
             )
         raise RuntimeError(
-            f"agent has no record of channel {channel_id} — it may not "
-            f"be a channel the agent belongs to, or the id may be "
-            f"wrong. Membership events are cached as they arrive over "
-            f"the WS, so a fresh channel becomes addressable as soon "
-            f"as the invite/accept/create event lands."
+            f"agent has no record of channel {channel_id} — either it "
+            f"isn't a channel the agent belongs to, the id is wrong, or "
+            f"you were just added and the membership hasn't propagated to "
+            f"this agent yet (retrying shortly resolves that last case). "
+            f"Call list_channels_in_all_spaces to see the channels the "
+            f"agent can currently reach."
         )
     return space_id
 

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -29,7 +29,12 @@ from .credential_refresh import (
     FileBackend,
     KeychainBackend,
 )
-from .data_service import set_profile_setter, start_data_service, stop_data_service
+from .data_service import (
+    set_client_resolver,
+    set_profile_setter,
+    start_data_service,
+    stop_data_service,
+)
 from .host_mcp_handler import HostMcpContext
 from .rpc_service import set_rpc_resolver, start_rpc_service, stop_rpc_service
 from .state import (
@@ -128,6 +133,7 @@ class Daemon:
             self.daemon_cfg.bridge, ws_local_hub=self.ws_local_hub,
         )
         set_profile_setter(self._set_worker_profile_cache)
+        set_client_resolver(self._resolve_message_client)
         set_rpc_resolver(self._resolve_host_mcp_context)
         # Bridge pins 63387 (browser clients hard-code it). Both
         # fallbacks scan from 63388 onward so neither collides with
@@ -191,6 +197,7 @@ class Daemon:
                     pass
             await stop_api_server(api_runner)
             set_profile_setter(None)
+            set_client_resolver(None)
             set_rpc_resolver(None)
             await stop_data_service(data_runner)
             await stop_rpc_service(rpc_runner)
@@ -401,6 +408,11 @@ class Daemon:
         if worker is None:
             return None
         return worker.host_mcp_context()
+
+    def _resolve_message_client(self, agent_id: str):
+        """Data-service shim for the on-miss channel-cache re-warm."""
+        ctx = self._resolve_host_mcp_context(agent_id)
+        return ctx.message_client if ctx is not None else None
 
     async def _stop_worker(self, agent_id: str) -> None:
         worker = self.workers.pop(agent_id, None)

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -49,6 +49,28 @@ def set_profile_setter(
     _PROFILE_SETTER = fn
 
 
+# Resolves an agent's live PuffoCoreMessageClient so a ``ch_`` lookup
+# miss can re-warm the channel cache before failing loud.
+_CLIENT_RESOLVER: Optional[Callable[[str], Any]] = None
+
+
+def set_client_resolver(fn: Optional[Callable[[str], Any]]) -> None:
+    """Daemon-side hook; ``None`` clears (tests + shutdown)."""
+    global _CLIENT_RESOLVER
+    _CLIENT_RESOLVER = fn
+
+
+def _client_for(agent_id: str) -> Any:
+    resolver = _CLIENT_RESOLVER
+    if resolver is None:
+        return None
+    try:
+        return resolver(agent_id)
+    except Exception:  # noqa: BLE001
+        logger.exception("data-service: client resolver raised")
+        return None
+
+
 @dataclass
 class _AppState:
     # One MessageStore per agent_id, opened lazily and held for the
@@ -103,6 +125,14 @@ async def lookup_channel_space(request: web.Request) -> web.Response:
         return web.json_response({"error": "agent db not found"}, status=404)
     try:
         space_id = await store.lookup_channel_space(channel_id)
+        if not space_id and channel_id.startswith("ch_"):
+            # Same self-heal as the in-process path: a membership event
+            # dropped in a reconnect window leaves a member channel
+            # uncached — re-warm from the server, then re-check.
+            client = _client_for(agent_id)
+            if client is not None:
+                await client.rewarm_channel_caches()
+                space_id = await store.lookup_channel_space(channel_id)
     except Exception as exc:
         logger.exception(
             "data-service: lookup_channel_space failed (agent=%s ch=%s)",

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -49,8 +49,7 @@ def set_profile_setter(
     _PROFILE_SETTER = fn
 
 
-# Resolves an agent's live PuffoCoreMessageClient so a ``ch_`` lookup
-# miss can re-warm the channel cache before failing loud.
+# Resolves an agent's live message client for the on-miss re-warm.
 _CLIENT_RESOLVER: Optional[Callable[[str], Any]] = None
 
 
@@ -126,9 +125,7 @@ async def lookup_channel_space(request: web.Request) -> web.Response:
     try:
         space_id = await store.lookup_channel_space(channel_id)
         if not space_id and channel_id.startswith("ch_"):
-            # Same self-heal as the in-process path: a membership event
-            # dropped in a reconnect window leaves a member channel
-            # uncached — re-warm from the server, then re-check.
+            # Reconnect-dropped membership event → re-warm, re-check.
             client = _client_for(agent_id)
             if client is not None:
                 await client.rewarm_channel_caches()

--- a/src/puffo_agent/portal/ws_local/in_process_data_client.py
+++ b/src/puffo_agent/portal/ws_local/in_process_data_client.py
@@ -33,13 +33,9 @@ class InProcessDataClient:
     async def lookup_channel_space(self, channel_id: str) -> str | None:
         space_id = await self._store.lookup_channel_space(channel_id)
         if space_id is None and channel_id.startswith("ch_"):
-            # PUF-376 (α): a genuinely-member channel can be missing from
-            # the cache if its membership event was dropped during a WS
-            # reconnect (the warm runs on connect, not per-message). Re-
-            # warm from the server — /spaces/<sid>/channels is filtered by
-            # membership, so a re-appear proves membership and an absence
-            # is an authoritative non-member — then re-check before the
-            # caller fails loud. Self-heals on the send attempt itself.
+            # A member channel can be missing if its membership event was
+            # dropped in a reconnect window — re-warm (membership-filtered)
+            # and re-check before the caller fails loud.
             await self._client.rewarm_channel_caches()
             space_id = await self._store.lookup_channel_space(channel_id)
         return space_id

--- a/src/puffo_agent/portal/ws_local/in_process_data_client.py
+++ b/src/puffo_agent/portal/ws_local/in_process_data_client.py
@@ -33,9 +33,7 @@ class InProcessDataClient:
     async def lookup_channel_space(self, channel_id: str) -> str | None:
         space_id = await self._store.lookup_channel_space(channel_id)
         if space_id is None and channel_id.startswith("ch_"):
-            # A member channel can be missing if its membership event was
-            # dropped in a reconnect window — re-warm (membership-filtered)
-            # and re-check before the caller fails loud.
+            # Reconnect-dropped membership event → re-warm, re-check.
             await self._client.rewarm_channel_caches()
             space_id = await self._store.lookup_channel_space(channel_id)
         return space_id

--- a/src/puffo_agent/portal/ws_local/in_process_data_client.py
+++ b/src/puffo_agent/portal/ws_local/in_process_data_client.py
@@ -31,7 +31,18 @@ class InProcessDataClient:
         return None
 
     async def lookup_channel_space(self, channel_id: str) -> str | None:
-        return await self._store.lookup_channel_space(channel_id)
+        space_id = await self._store.lookup_channel_space(channel_id)
+        if space_id is None and channel_id.startswith("ch_"):
+            # PUF-376 (α): a genuinely-member channel can be missing from
+            # the cache if its membership event was dropped during a WS
+            # reconnect (the warm runs on connect, not per-message). Re-
+            # warm from the server — /spaces/<sid>/channels is filtered by
+            # membership, so a re-appear proves membership and an absence
+            # is an authoritative non-member — then re-check before the
+            # caller fails loud. Self-heals on the send attempt itself.
+            await self._client.rewarm_channel_caches()
+            space_id = await self._store.lookup_channel_space(channel_id)
+        return space_id
 
     async def get_channel_roots(
         self,

--- a/tests/test_channel_cache_selfheal.py
+++ b/tests/test_channel_cache_selfheal.py
@@ -1,0 +1,123 @@
+"""PUF-376: channel-cache self-heal.
+
+A membership event missed during a WS reconnect used to leave a
+genuinely-member channel uncached — send-path fail-loud with no
+self-heal until daemon restart, while list-path (server-query) showed
+it. Fixes:
+  (α) on a ``ch_`` cache-miss the in-process data client re-warms from
+      the server (membership-filtered) + re-checks before failing loud.
+  (γ) the warm re-runs on every WS (re)connect, not just first connect.
+Plus Nova's membership-filter invariant: the warm only caches channels
+the server returns (proving membership), never all space channels.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from puffo_agent.agent import puffo_core_client as pcc
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.portal.ws_local.in_process_data_client import InProcessDataClient
+
+
+def _data_client() -> tuple[InProcessDataClient, MagicMock, MagicMock]:
+    store = MagicMock()
+    daemon = MagicMock()
+    daemon.rewarm_channel_caches = AsyncMock()
+    return InProcessDataClient(store, daemon), store, daemon
+
+
+# ── (α) on-miss re-warm ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_lookup_rewarms_and_rechecks_on_ch_miss():
+    client, store, daemon = _data_client()
+    # Miss, then the re-warm "heals" the store so the re-check hits.
+    store.lookup_channel_space = AsyncMock(side_effect=[None, "sp_healed"])
+    out = await client.lookup_channel_space("ch_stale")
+    assert out == "sp_healed"
+    daemon.rewarm_channel_caches.assert_awaited_once()
+    assert store.lookup_channel_space.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_none_when_rewarm_doesnt_heal():
+    client, store, daemon = _data_client()
+    store.lookup_channel_space = AsyncMock(return_value=None)  # genuine non-member
+    out = await client.lookup_channel_space("ch_ghost")
+    assert out is None
+    daemon.rewarm_channel_caches.assert_awaited_once()  # tried, but authoritative miss
+
+
+@pytest.mark.asyncio
+async def test_lookup_no_rewarm_on_bare_slug_miss():
+    client, store, daemon = _data_client()
+    store.lookup_channel_space = AsyncMock(return_value=None)
+    out = await client.lookup_channel_space("alice-1a")  # not a ch_ id → DM path
+    assert out is None
+    daemon.rewarm_channel_caches.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lookup_hit_skips_rewarm():
+    client, store, daemon = _data_client()
+    store.lookup_channel_space = AsyncMock(return_value="sp_x")
+    assert await client.lookup_channel_space("ch_42") == "sp_x"
+    daemon.rewarm_channel_caches.assert_not_awaited()
+
+
+# ── membership-filter invariant (Nova's insurance) ───────────────────
+
+@pytest.mark.asyncio
+async def test_warm_caches_only_server_returned_channels(monkeypatch):
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client._channel_space = {}
+    client._channel_name_cache = {}
+    client.http = MagicMock()
+    # Server returns ONLY the member channel (it is membership-filtered).
+    client.http.get = AsyncMock(
+        return_value={"channels": [{"channel_id": "ch_member", "name": "general"}]}
+    )
+    client.store = MagicMock()
+    client.store.mark_channel_space = AsyncMock()
+    monkeypatch.setattr(pcc.disk_cache, "persist_channel", lambda *a, **k: None)
+
+    await client._warm_channels_for_space("sp_1")
+
+    # The one member channel is cached; nothing the server withheld appears.
+    assert client._channel_space == {"ch_member": "sp_1"}
+    client.store.mark_channel_space.assert_awaited_once_with("ch_member", "sp_1")
+
+
+# ── (γ) warm on (re)connect ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_on_ws_connect_schedules_warm():
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    warmed = asyncio.Event()
+
+    async def fake_warm():
+        warmed.set()
+
+    client._warm_member_caches = fake_warm
+    await client._on_ws_connect()  # fire-and-forget
+    await asyncio.wait_for(warmed.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_rewarm_is_debounced():
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client._rewarm_lock = asyncio.Lock()
+    client._last_rewarm = 0.0
+    calls: list[int] = []
+
+    async def fake_warm():
+        calls.append(1)
+
+    client._warm_member_caches = fake_warm
+    await client.rewarm_channel_caches()
+    await client.rewarm_channel_caches()  # within the 5s window → skipped
+    assert len(calls) == 1

--- a/tests/test_channel_cache_selfheal.py
+++ b/tests/test_channel_cache_selfheal.py
@@ -1,15 +1,6 @@
-"""PUF-376: channel-cache self-heal.
-
-A membership event missed during a WS reconnect used to leave a
-genuinely-member channel uncached — send-path fail-loud with no
-self-heal until daemon restart, while list-path (server-query) showed
-it. Fixes:
-  (α) on a ``ch_`` cache-miss the in-process data client re-warms from
-      the server (membership-filtered) + re-checks before failing loud.
-  (γ) the warm re-runs on every WS (re)connect, not just first connect.
-Plus Nova's membership-filter invariant: the warm only caches channels
-the server returns (proving membership), never all space channels.
-"""
+"""Channel-cache self-heal: on a ``ch_`` lookup miss the data
+clients re-warm from the server (membership-filtered) and re-check
+before failing loud; the warm also re-runs on every WS (re)connect."""
 
 from __future__ import annotations
 
@@ -69,7 +60,7 @@ async def test_lookup_hit_skips_rewarm():
     daemon.rewarm_channel_caches.assert_not_awaited()
 
 
-# ── membership-filter invariant (Nova's insurance) ───────────────────
+# ── membership-filter invariant ──────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_warm_caches_only_server_returned_channels(monkeypatch):
@@ -121,3 +112,111 @@ async def test_rewarm_is_debounced():
     await client.rewarm_channel_caches()
     await client.rewarm_channel_caches()  # within the 5s window → skipped
     assert len(calls) == 1
+
+
+# ── data-service (cli-local / cli-docker MCP path) on-miss re-warm ───
+
+def _isolated_home() -> str:
+    import os
+    import tempfile
+    from pathlib import Path
+
+    home = tempfile.mkdtemp(prefix="puffo-agent-selfheal-")
+    os.environ["PUFFO_AGENT_HOME"] = home
+    os.environ["PUFFO_HOME"] = home
+    Path(home, "agents").mkdir(parents=True, exist_ok=True)
+    return home
+
+
+async def _seed_empty_agent(home: str, agent_id: str):
+    from pathlib import Path
+
+    from puffo_agent.agent.message_store import MessageStore
+
+    agent_path = Path(home) / "agents" / agent_id
+    agent_path.mkdir(parents=True, exist_ok=True)
+    db_path = agent_path / "messages.db"
+    store = MessageStore(db_path)
+    await store.open()
+    await store.close()
+    return db_path
+
+
+@pytest.mark.asyncio
+async def test_data_service_lookup_rewarms_and_heals():
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from puffo_agent.agent.message_store import MessageStore
+    from puffo_agent.portal import data_service as ds
+
+    home = _isolated_home()
+    db_path = await _seed_empty_agent(home, "agent-heal-1")
+
+    class _FakeClient:
+        async def rewarm_channel_caches(self):
+            # The real warm writes through to the same messages.db.
+            store = MessageStore(db_path)
+            await store.open()
+            await store.mark_channel_space("ch_healed", "sp_9")
+            await store.close()
+
+    ds.set_client_resolver(lambda aid: _FakeClient() if aid == "agent-heal-1" else None)
+    try:
+        app = ds.build_app(ds.DataServiceConfig())
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/v1/data/agent-heal-1/channels/ch_healed/space")
+            assert resp.status == 200
+            assert (await resp.json())["space_id"] == "sp_9"
+    finally:
+        ds.set_client_resolver(None)
+
+
+@pytest.mark.asyncio
+async def test_data_service_lookup_404_when_rewarm_doesnt_heal():
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from puffo_agent.portal import data_service as ds
+
+    home = _isolated_home()
+    await _seed_empty_agent(home, "agent-heal-2")
+    rewarmed: list[int] = []
+
+    class _FakeClient:
+        async def rewarm_channel_caches(self):
+            rewarmed.append(1)
+
+    ds.set_client_resolver(lambda aid: _FakeClient())
+    try:
+        app = ds.build_app(ds.DataServiceConfig())
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/v1/data/agent-heal-2/channels/ch_ghost/space")
+            assert resp.status == 404
+            assert rewarmed == [1]  # tried; authoritative miss
+    finally:
+        ds.set_client_resolver(None)
+
+
+@pytest.mark.asyncio
+async def test_data_service_lookup_404_without_resolver():
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from puffo_agent.portal import data_service as ds
+
+    home = _isolated_home()
+    await _seed_empty_agent(home, "agent-heal-3")
+    ds.set_client_resolver(None)
+    app = ds.build_app(ds.DataServiceConfig())
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/data/agent-heal-3/channels/ch_x/space")
+        assert resp.status == 404
+
+
+def test_daemon_registers_client_resolver():
+    """Source pin: the daemon wires + clears the data-service resolver."""
+    import inspect
+
+    from puffo_agent.portal import daemon as daemon_mod
+
+    src = inspect.getsource(daemon_mod)
+    assert "set_client_resolver(self._resolve_message_client)" in src
+    assert "set_client_resolver(None)" in src

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -492,9 +492,8 @@ async def test_callback_exception_does_not_kill_loop():
 
 @pytest.mark.asyncio
 async def test_on_connect_failure_does_not_kill_the_loop():
-    """PUF-376: on_connect fires the cache re-warm; a warm that throws
-    (e.g. a network blip mid-warm) must not tear down the connection —
-    catch-up + listen still run."""
+    """An on_connect callback that throws must not tear down the
+    connection — catch-up + listen still run."""
     ks, _ = _make_keystore()
     server = FakeWsServer()
     await server.start()

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -488,3 +488,46 @@ async def test_callback_exception_does_not_kill_loop():
     assert "env_fail" in acked_ids, "failed message should still be ACKed"
     assert "env_ok" in acked_ids, "second message should be ACKed"
     await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_connect_failure_does_not_kill_the_loop():
+    """PUF-376: on_connect fires the cache re-warm; a warm that throws
+    (e.g. a network blip mid-warm) must not tear down the connection —
+    catch-up + listen still run."""
+    ks, _ = _make_keystore()
+    server = FakeWsServer()
+    await server.start()
+
+    received = []
+
+    async def on_msg(envelope):
+        received.append(envelope)
+
+    async def boom():
+        raise RuntimeError("warm blew up")
+
+    http = FakeHttpClient()
+    http.pending_messages = [
+        {"seq": 1, "envelope": {"envelope_id": "env_p1", "sender_slug": "bob"}},
+    ]
+
+    client = PuffoCoreWsClient(
+        f"http://127.0.0.1:{server.port}", ks, "alice-0001", http,
+    )
+    client.ws_url = f"ws://127.0.0.1:{server.port}"
+    client.on_message = on_msg
+    client.on_connect = boom  # raises — must be swallowed, not kill the WS
+
+    task = asyncio.create_task(client.connect_once())
+    await asyncio.sleep(0.5)
+    client.stop()
+    try:
+        await asyncio.wait_for(task, timeout=2)
+    except (websockets.exceptions.ConnectionClosed, asyncio.CancelledError, OSError):
+        pass
+
+    # Catch-up still delivered the pending message → the on_connect
+    # exception was caught, not propagated out of connect_once.
+    assert [e["envelope_id"] for e in received] == ["env_p1"]
+    await server.stop()


### PR DESCRIPTION
Fixes FB-403: an agent's `send_message` to a channel it belongs to fail-louds `agent has no record of channel <id>`, while `list_channels_in_all_spaces` shows that channel — for 10+ min, no self-heal until a daemon restart.

## Root cause (source-walk answered Kai's before-restart test)
The send-path validates against the local `_channel_space` cache (fed by WS membership events + a startup warm); the list-path server-queries fresh. The warm (`_warm_member_caches`) fires **once** at `listen()` start (was line 947) — **not on WS reconnect**. So a membership event dropped during a reconnect leaves a genuinely-member channel uncached until restart. That's exactly the "only daemon-restart heals" case Kai's test was meant to distinguish, so no need to wait on it.

## Fix (keep-together, α + γ + legibility + invariant)
- **(γ)** New `PuffoCoreWsClient.on_connect` hook fires the warm on **every (re)connect** (`_on_ws_connect`, fire-and-forget). Replaces the one-shot startup warm.
- **(α)** On a `ch_` cache-miss, `InProcessDataClient.lookup_channel_space` calls `rewarm_channel_caches()` (5s-debounced lock, no stampede) and re-checks the store before failing loud — self-heals **on the send attempt itself**. The re-warm uses `/spaces/<sid>/channels`, which is membership-filtered, so a re-appear proves membership and an absence is an authoritative non-member (preserves the fail-loud design intent the removed `/spaces` fallback had).
- **Legibility:** the `ch_` miss error now names the 3 causes (not-a-member / wrong-id / not-yet-propagated) + a retry hint.
- **Nova's membership-filter invariant:** a code comment at the warm site + a test asserting the warm caches **only** server-returned channels, never all space channels — cheap insurance against server-semantics drift silently regressing the repair to space-access.

## Tests
New `test_channel_cache_selfheal.py` — 7 tests: (α) re-warm-and-recheck / authoritative-miss / no-rewarm-on-bare-slug / hit-skips-rewarm; the membership-filter invariant; (γ) on_connect schedules the warm; re-warm debounce. Full suite green bar the pre-existing `test_ui_mcp_scanner.py` PySide6 gap (byte-identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)