### PR TITLE
feat(cloud-agent): route keyless read tools to /v2/cloud-agents/* (agent half of dropping SubkeyOrSandboxTokenAuth)

### DIFF
--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any
 
 import aiohttp
@@ -15,6 +16,36 @@ from .keystore import KeyStore, Session, decode_secret
 from .primitives import Ed25519KeyPair
 
 logger = logging.getLogger(__name__)
+
+# Signed read routes that have a keyless ``/v2/cloud-agents/*`` twin
+# (server-side ``SandboxTokenAuth``, added incrementally through puffo-server
+# and completed by #222's channel-members route). A keyless bridge agent has
+# no subkey to sign with, so it rewrites these to the twin and sends them
+# unsigned — the E2B egress proxy injects ``x-sandbox-token`` (see
+# ``_egress_headers``). Routes NOT listed here (``/spaces/{id}/events``,
+# ``/spaces/events``) have no twin and stay on the signed path; a keyless
+# agent still can't reach them, exactly as before this migration.
+_CLOUD_AGENT_READ_ROUTES = (
+    re.compile(r"^/spaces$"),
+    re.compile(r"^/spaces/[^/]+/channels$"),
+    re.compile(r"^/spaces/[^/]+/members$"),
+    re.compile(r"^/spaces/[^/]+/channels/[^/]+/members$"),
+    re.compile(r"^/identities/profiles$"),
+)
+
+
+def cloud_agent_read_twin(path: str) -> str | None:
+    """Return the ``/v2/cloud-agents/*`` twin of a signed read ``path`` (query
+    preserved), or ``None`` when the path has no keyless twin.
+
+    Splitting on ``?`` keeps ``/identities/profiles?slugs=...`` matchable while
+    the query rides along untouched. Anchored patterns mean ``/spaces/events``
+    and ``/spaces/{id}/events`` deliberately DON'T match — they have no twin.
+    """
+    base, sep, query = path.partition("?")
+    if any(rx.match(base) for rx in _CLOUD_AGENT_READ_ROUTES):
+        return f"/v2/cloud-agents{base}{sep}{query}"
+    return None
 
 
 class HttpError(Exception):
@@ -145,6 +176,14 @@ class PuffoCoreHttpClient:
             return resp.status, data
 
     async def get(self, path: str) -> Any:
+        # Keyless bridge agents can't sign: transparently route the twinned
+        # read routes to ``/v2/cloud-agents/*`` (unsigned; egress injects the
+        # sandbox token). Native (signed) agents leave ``keyless`` False and
+        # this branch never fires — call sites are byte-for-byte unchanged.
+        if self.keyless:
+            twin = cloud_agent_read_twin(path)
+            if twin is not None:
+                return await self.get_unsigned(twin)
         _, data = await self._request("GET", path)
         return data
 

--- a/tests/test_cloud_agent_read_twin.py
+++ b/tests/test_cloud_agent_read_twin.py
@@ -1,0 +1,60 @@
+"""Keyless read-route rewriting for cloud (bridge) agents.
+
+A keyless bridge agent has no subkey, so signed read routes are transparently
+rewritten to their ``/v2/cloud-agents/*`` twins (server-side SandboxTokenAuth).
+The matcher must rewrite exactly the routes that HAVE a twin and leave every
+other path — most importantly the events routes, which have no twin — alone.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from puffo_agent.crypto.http_client import cloud_agent_read_twin
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # ── routes WITH a /v2/cloud-agents twin → rewritten ──
+        ("/spaces", "/v2/cloud-agents/spaces"),
+        ("/spaces/sp_123/channels", "/v2/cloud-agents/spaces/sp_123/channels"),
+        ("/spaces/sp_123/members", "/v2/cloud-agents/spaces/sp_123/members"),
+        (
+            "/spaces/sp_123/channels/ch_456/members",
+            "/v2/cloud-agents/spaces/sp_123/channels/ch_456/members",
+        ),
+        ("/identities/profiles", "/v2/cloud-agents/identities/profiles"),
+        # query string preserved
+        (
+            "/identities/profiles?slugs=alice-0001,bob-0002",
+            "/v2/cloud-agents/identities/profiles?slugs=alice-0001,bob-0002",
+        ),
+        # ── routes WITHOUT a twin → left alone (None) ──
+        ("/spaces/sp_123/events", None),   # per-space event log — no twin
+        ("/spaces/events", None),          # global event stream — no twin
+        ("/spaces/sp_123", None),          # a bare space id is not a read route
+        ("/certs/sync?slugs=x", None),
+        ("/devices/subkeys", None),
+        ("/cloud-agents/messages", None),  # already a keyless send route, not a read
+        # never double-prefix an already-rewritten path
+        ("/v2/cloud-agents/spaces", None),
+    ],
+)
+def test_cloud_agent_read_twin(path, expected):
+    assert cloud_agent_read_twin(path) == expected
+
+
+def test_events_routes_are_not_swept_up_by_the_spaces_matcher():
+    """Regression guard: the `/spaces/{id}/...` patterns are anchored so the
+    events routes (which look similar but have no twin) never match."""
+    assert cloud_agent_read_twin("/spaces/sp_abc/events") is None
+    assert cloud_agent_read_twin("/spaces/events") is None
+    # but a real twinned route under the same space id still rewrites
+    assert (
+        cloud_agent_read_twin("/spaces/sp_abc/members")
+        == "/v2/cloud-agents/spaces/sp_abc/members"
+    )

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -434,6 +434,7 @@ class TestHttpClientKeylessEgress(AioHTTPTestCase):
         _make_keystore_with_session(self.ks, self.subkey)
         self.captured_headers = {}
         self.captured_body = b""
+        self.captured_path = ""
         super().setUp()
 
     async def get_application(self):
@@ -441,7 +442,12 @@ class TestHttpClientKeylessEgress(AioHTTPTestCase):
         app.router.add_route("POST", "/v2/cloud-agents/blobs/upload", self._echo)
         app.router.add_route("POST", "/v2/cloud-agents/messages", self._echo)
         app.router.add_route("GET", "/v2/cloud-agents/spaces", self._echo)
-        # Signed routes — used to prove the shim never touches them.
+        app.router.add_route(
+            "GET", "/v2/cloud-agents/spaces/{sid}/members", self._echo
+        )
+        # Signed routes — used to prove the shim never touches them, and that
+        # a native (keyless=False) client keeps hitting the un-rewritten path.
+        app.router.add_route("GET", "/spaces", self._echo)
         app.router.add_route("GET", "/health", self._echo)
         app.router.add_route("POST", "/messages", self._echo)
         return app
@@ -449,6 +455,7 @@ class TestHttpClientKeylessEgress(AioHTTPTestCase):
     async def _echo(self, request: web.Request):
         self.captured_headers = {k.lower(): v for k, v in request.headers.items()}
         self.captured_body = await request.read()
+        self.captured_path = request.path
         return web.json_response({"ok": True, "blob_id": "b1"})
 
     @unittest_run_loop
@@ -508,6 +515,42 @@ class TestHttpClientKeylessEgress(AioHTTPTestCase):
                     "/v2/cloud-agents/blobs/upload", b"x",
                 )
                 assert "x-sandbox-token" not in self.captured_headers
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_keyless_get_routes_twinned_read_to_cloud_agents(self):
+        # A keyless agent's plain get() of a twinned read route is transparently
+        # rewritten to /v2/cloud-agents/* and sent UNSIGNED (egress token only).
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001", keyless=True)
+        try:
+            with patch.dict(os.environ, {"PUFFO_LOCAL_SANDBOX_TOKEN": "tok-abc"}):
+                result = await client.get("/spaces")
+                assert result["ok"] is True
+                assert self.captured_path == "/v2/cloud-agents/spaces"
+                assert "x-puffo-signature" not in self.captured_headers
+                assert self.captured_headers.get("x-sandbox-token") == "tok-abc"
+
+                # a deeper twinned route (incl. the #222 channel-members one)
+                await client.get("/spaces/sp_1/members")
+                assert (
+                    self.captured_path == "/v2/cloud-agents/spaces/sp_1/members"
+                )
+                assert "x-puffo-signature" not in self.captured_headers
+        finally:
+            await client.close()
+
+    @unittest_run_loop
+    async def test_native_get_is_not_rewritten(self):
+        # A native (signed) client must keep hitting the un-rewritten path and
+        # sign it — the shim is keyless-only.
+        url = f"http://localhost:{self.server.port}"
+        client = PuffoCoreHttpClient(url, self.ks, "alice-0001")  # keyless=False
+        try:
+            await client.get("/spaces")
+            assert self.captured_path == "/spaces"
+            assert "x-puffo-signature" in self.captured_headers
         finally:
             await client.close()
 


### PR DESCRIPTION
The **agent half** of the `SubkeyOrSandboxTokenAuth` consolidation. Pairs with the merged puffo-server side (**#222** + the existing `/v2/cloud-agents/*` read routes).

## Problem

A keyless bridge (cloud) agent has **no subkey to sign with**, so the signed read routes never worked for it:

`/spaces` · `/spaces/{id}/channels` · `/spaces/{id}/members` · `/spaces/{id}/channels/{id}/members` · `/identities/profiles`

Result today: sender names render as raw slugs, and `list_channel_members` / `get_user_info` / `list_channels` / `list_spaces` are effectively dead for cloud agents. The code says as much — *"signed HTTP endpoints that can't work keyless; names render as ids until those are rewired."*

## Fix — one routing shim, not 15 call-site edits

`PuffoCoreHttpClient.get()` gains a keyless branch: a read route that has a `/v2/cloud-agents/*` twin is transparently rewritten to that twin and sent **unsigned** — the E2B egress proxy injects `x-sandbox-token` (same mechanism the existing keyless send/blob paths use). Every `self.http.get(...)` call site stays byte-for-byte unchanged, and **native (signed) agents leave `keyless=False` and never hit the branch.**

```python
async def get(self, path):
    if self.keyless:
        twin = cloud_agent_read_twin(path)   # None unless the path has a twin
        if twin is not None:
            return await self.get_unsigned(twin)
    ...signed path...
```

`keyless=(transport == "bridge")` is already wired at both hot construction sites (`worker.py`, `mcp/puffo_core_server.py`), so the shim fires exactly for cloud agents.

## The one subtlety — the events routes

`/spaces/events` and `/spaces/{id}/events` have **no** `/v2/cloud-agents` twin. The matcher's patterns are anchored so those deliberately **don't** rewrite — they stay signed and remain unavailable keyless, exactly as before. There's an explicit regression test for this (`test_events_routes_are_not_swept_up_by_the_spaces_matcher`).

## Tests

- `test_cloud_agent_read_twin.py` (new, 14 cases) — every twinned route rewrites (query preserved); events routes and non-read paths return `None`; no double-prefixing.
- `test_http_client.py` (+2) — a keyless `get("/spaces")` lands on `/v2/cloud-agents/spaces` **unsigned** with the egress token; a native `get("/spaces")` stays on `/spaces` **signed**.
- Related sweep: **414 passed, 0 failed.**

## Scope / follow-up

This migrates the **transport**. The on-demand read tools work immediately (they call `self.http.get` directly). A **follow-up** can un-gate the background `_warm_member_caches` / `_invite_poll_loop` tasks for bridge agents — they were skipped only because reads didn't work keyless, which is no longer true.

## Sequencing

This unblocks dropping `SubkeyOrSandboxTokenAuth` server-side. Order (do not reorder): **merge this → re-vendor + rebuild E2B template (beta7) → verify live → then drop the union extractor.** Dropping server-side before this ships would strand every cloud agent's reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)