### PR TITLE
feat(cloud-agent): keyless-identity fix — skip signed load_identity for bridge agents

### DIFF
--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -45,6 +45,19 @@ class StatusReporter:
         runtime_provider: Optional[Callable[[], dict[str, Any]]] = None,
     ) -> None:
         self._http = http
+        # Keyless (T23 bridge) transport: the agent authenticates with an
+        # egress-injected ``x-sandbox-token`` and holds NO local signing
+        # identity. Every status wire call here goes through the *signed*
+        # ``PuffoCoreHttpClient.post`` path (``_ensure_subkey`` →
+        # ``load_session`` → ``_rotate_subkey`` → ``load_identity``), which
+        # raises "identity not found: <slug>" for a keyless agent — on every
+        # heartbeat, ``begin_turn`` and ``end_turn``. Reading the flag off the
+        # http client (the SAME signal the tools + worker use;
+        # ``getattr(..., False)`` keeps test fakes and native agents at False)
+        # lets us short-circuit those calls so no ``load_identity`` is ever
+        # attempted. Server liveness for bridge agents is tracked via the
+        # bridge WS, not this heartbeat, so the skip is a clean no-op.
+        self._keyless = bool(getattr(http, "keyless", False))
         self._interval = max(10.0, heartbeat_interval_s)
         self._current_status: str = "idle"
         self._current_message_id: str | None = None
@@ -56,6 +69,12 @@ class StatusReporter:
         self._stop = asyncio.Event()
 
     async def run_heartbeat_loop(self) -> None:
+        if self._keyless:
+            # Bridge agents have no signing identity — the signed
+            # /agents/me/heartbeat route can't authenticate keyless (it
+            # would raise "identity not found"). Skip the loop entirely;
+            # the bridge WS is the liveness signal for these agents.
+            return
         # Send one immediately so a fresh agent doesn't sit
         # offline waiting for the first scheduled tick.
         await self._send_heartbeat()
@@ -74,6 +93,13 @@ class StatusReporter:
     async def begin_turn(self, message_id: str) -> str:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
         run_id = f"run_{uuid.uuid4().hex}"
+        if self._keyless:
+            # No signed /processing/* call for bridge agents (see __init__).
+            # Keep the local busy bookkeeping so the state machine is
+            # unchanged; emit nothing over the wire.
+            self._current_status = "busy"
+            self._current_message_id = message_id
+            return run_id
         if _is_local_only_envelope(message_id):
             # Daemon-minted synthetic envelope (e.g. intro-prompt): no
             # server row, so skip /processing/start — but push an
@@ -105,6 +131,12 @@ class StatusReporter:
         succeeded: bool,
         error_text: str | None = None,
     ) -> None:
+        if self._keyless:
+            # Bridge agents: resolve local status, skip the signed
+            # /processing/end POST (see __init__).
+            self._current_status = "idle" if succeeded else "error"
+            self._current_message_id = None
+            return
         if _is_local_only_envelope(message_id):
             # Symmetric to ``begin_turn`` — no server-side row, but push
             # the idle/error status now instead of waiting for the next
@@ -139,6 +171,13 @@ class StatusReporter:
         ``started_at = ended_at = now`` and skip straight to green.
         """
         if not runs:
+            return
+        if self._keyless:
+            # Bridge agents: mirror the batch outcome into local status,
+            # skip the signed /processing/end:batch POST (see __init__).
+            any_failed = any(not r["succeeded"] for r in runs)
+            self._current_status = "error" if any_failed else "idle"
+            self._current_message_id = None
             return
         payload_runs: list[dict[str, Any]] = []
         for r in runs:
@@ -186,6 +225,12 @@ class StatusReporter:
         """Catch-all for unrecoverable failures; cleared by the
         next successful heartbeat.
         """
+        if self._keyless:
+            # Bridge agents: record the error locally, skip the signed
+            # /agents/me/heartbeat POST (see __init__).
+            self._current_status = "error"
+            self._current_message_id = None
+            return
         try:
             await self._http.post(
                 "/agents/me/heartbeat",
@@ -199,6 +244,11 @@ class StatusReporter:
             logger.warning("report_error errored (%s)", exc)
 
     async def _send_heartbeat(self) -> None:
+        if self._keyless:
+            # Defense-in-depth: every public entry point already short-
+            # circuits for keyless, but guard the actual signed POST too so
+            # no future caller can reintroduce an "identity not found" beat.
+            return
         body: dict[str, Any] = {"status": self._current_status}
         if self._current_status == "busy" and self._current_message_id is not None:
             body["current_message_id"] = self._current_message_id

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -84,11 +84,31 @@ async def sync_agent_profile(cfg: AgentConfig, patch: dict[str, Any]) -> None:
     """Push ``patch`` (any subset of display_name / avatar_url /
     role / role_short / soul) to the agent's server identity. Signed
     by the AGENT's subkey — callers own their own authorization
-    gating before reaching here. Raises on HTTP / network failure."""
+    gating before reaching here. Raises on HTTP / network failure.
+
+    Keyless (T23 ``bridge`` transport) agents hold NO local signing
+    identity and authenticate with an egress-injected
+    ``x-sandbox-token``. The signed ``PATCH /identities/self`` here
+    would drive ``_ensure_subkey`` → ``_rotate_subkey`` →
+    ``KeyStore.load_identity`` and raise "identity not found: <slug>"
+    on every warm/startup sync. The bridge exposes no profile-sync
+    method, so there is nothing to route the patch over — skip the
+    signed call entirely (native agents fall through unchanged). This
+    is the single choke point every profile-sync caller reaches
+    (sync_full_profile, cli, api handlers, control link), so the guard
+    belongs here."""
+    pc = cfg.puffo_core
+    if pc.transport == "bridge":
+        logger.debug(
+            "sync_agent_profile: skipping signed PATCH for keyless "
+            "bridge agent=%s (no local identity; no bridge sync route)",
+            cfg.id,
+        )
+        return
+
     from ..crypto.http_client import PuffoCoreHttpClient
     from ..crypto.keystore import KeyStore
 
-    pc = cfg.puffo_core
     ks = KeyStore.for_agent(cfg.id)
     http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
     try:

--- a/tests/test_agent_sync.py
+++ b/tests/test_agent_sync.py
@@ -204,6 +204,92 @@ async def test_sync_full_profile_skips_soul_when_profile_md_absent(monkeypatch):
     assert body["display_name"] == "No MD"
 
 
+# ── keyless (T23 bridge) transport: skip signed PATCH ─────────────
+#
+# A keyless bridge agent has no local signing identity — the signed
+# ``PATCH /identities/self`` would drive ``load_identity`` and raise
+# "identity not found: <slug>" on every warm/startup sync. The fake
+# below makes constructing / using the http client fail loudly, so a
+# leaked signed call surfaces instead of silently no-op'ing.
+
+
+class _ExplodingKeylessHttp:
+    """Mirrors the real keyless failure: the signed PATCH path raising
+    because ``load_identity`` can't find a keyless agent's identity file.
+    A correctly-guarded sync never constructs this client."""
+
+    def __init__(self, *a, **kw):
+        raise RuntimeError("identity not found: bridge-bot")
+
+
+@pytest.mark.asyncio
+async def test_sync_full_profile_skips_signed_patch_for_bridge_agent(monkeypatch):
+    home = isolated_home()
+    write_test_agent(home, "bridge-bot")
+    cfg = AgentConfig.load("bridge-bot")
+    cfg.display_name = "Bridge Bot"
+    # Keyless bridge transport — no local signing identity.
+    cfg.puffo_core.transport = "bridge"
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        _ExplodingKeylessHttp,
+    )
+
+    # Must return cleanly WITHOUT ever building the signed client.
+    await sync_full_profile(cfg)
+
+
+@pytest.mark.asyncio
+async def test_sync_agent_profile_skips_signed_patch_for_bridge_agent(monkeypatch):
+    from puffo_agent.portal.profile_sync import sync_agent_profile
+
+    home = isolated_home()
+    write_test_agent(home, "bridge-bot2")
+    cfg = AgentConfig.load("bridge-bot2")
+    cfg.puffo_core.transport = "bridge"
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        _ExplodingKeylessHttp,
+    )
+
+    await sync_agent_profile(cfg, {"display_name": "x"})
+
+
+@pytest.mark.asyncio
+async def test_native_sync_agent_profile_still_signs(monkeypatch):
+    """The guard is strictly opt-in on ``transport == 'bridge'`` — a
+    native agent (default transport) keeps issuing the signed PATCH."""
+    from puffo_agent.portal.profile_sync import sync_agent_profile
+
+    home = isolated_home()
+    write_test_agent(home, "native-bot")
+    cfg = AgentConfig.load("native-bot")
+    assert cfg.puffo_core.transport == "native"
+
+    posted: list[tuple[str, dict]] = []
+
+    class _FakeHttp:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def patch(self, path: str, body: dict) -> dict:
+            posted.append((path, body))
+            return {}
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        _FakeHttp,
+    )
+    await sync_agent_profile(cfg, {"display_name": "Native"})
+
+    assert posted == [("/identities/self", {"display_name": "Native"})]
+
+
 # ── control-WS op=edit flag differentiation ──────────────────────
 
 

--- a/tests/test_runtime_health_in_progress.py
+++ b/tests/test_runtime_health_in_progress.py
@@ -266,6 +266,7 @@ def test_chain_non_api_error_swallow_falls_back_to_unhandled_error(
 async def test_heartbeat_carries_both_status_and_health():
     from puffo_agent.agent.status_reporter import StatusReporter
     mock_http = AsyncMock()
+    mock_http.keyless = False  # AsyncMock auto-truthies attrs; pin native so the heartbeat isn't skipped
     health_value = {"v": "in_progress"}
     reporter = StatusReporter(
         mock_http,
@@ -291,6 +292,7 @@ async def test_heartbeat_without_provider_omits_health_field():
     tests), heartbeat carries the legacy single-stream shape."""
     from puffo_agent.agent.status_reporter import StatusReporter
     mock_http = AsyncMock()
+    mock_http.keyless = False  # AsyncMock auto-truthies attrs; pin native so the heartbeat isn't skipped
     reporter = StatusReporter(mock_http)
     reporter._current_status = "idle"
     await reporter._send_heartbeat()
@@ -304,6 +306,7 @@ async def test_heartbeat_without_provider_omits_health_field():
 async def test_heartbeat_provider_exception_does_not_break_heartbeat():
     from puffo_agent.agent.status_reporter import StatusReporter
     mock_http = AsyncMock()
+    mock_http.keyless = False  # AsyncMock auto-truthies attrs; pin native so the heartbeat isn't skipped
 
     def broken_provider() -> str:
         raise RuntimeError("runtime not loaded")

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -25,9 +25,13 @@ class FakeHttp:
     HttpError or unexpected exceptions.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, keyless: bool = False) -> None:
         self.calls: list[tuple[str, dict]] = []
         self.side_effect: BaseException | None = None
+        # Mirrors ``PuffoCoreHttpClient.keyless``. Native agents (the
+        # default) leave this False; keyless bridge agents set it True so
+        # the reporter skips every signed status POST.
+        self.keyless = keyless
 
     async def post(self, path: str, body: dict | None = None):
         self.calls.append((path, body or {}))
@@ -379,3 +383,157 @@ async def test_end_turn_batch_all_local_only_skips_http():
     assert path == "/agents/me/heartbeat"
     assert body["status"] == "idle"
     assert rep._current_status == "idle"
+
+
+# ── Keyless (bridge) transport: skip signed load_identity ──────────
+#
+# A keyless bridge agent has no local signing identity; every signed
+# ``post`` would raise "identity not found" inside PuffoCoreHttpClient.
+# The reporter must never reach the wire for these agents. The fake
+# below makes ANY post raise, so a leaked POST fails loudly instead of
+# silently — proving the guards short-circuit before ``self._http.post``.
+
+
+class _ExplodingKeylessHttp:
+    """Keyless http whose ``post`` mimics the real failure — the signed
+    path raising because ``load_identity`` can't find a keyless agent's
+    identity file. A correctly-guarded reporter never calls ``post``, so
+    this exception must never surface."""
+
+    keyless = True
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def post(self, path: str, body: dict | None = None):
+        self.calls.append((path, body or {}))
+        raise RuntimeError("identity not found: agent-abc1")
+
+
+@pytest.mark.asyncio
+async def test_keyless_begin_turn_no_http_returns_run_id():
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    run_id = await rep.begin_turn("msg_42")
+
+    assert run_id.startswith("run_")
+    assert http.calls == []  # never touched the signed wire
+    assert rep._current_status == "busy"
+    assert rep._current_message_id == "msg_42"
+
+
+@pytest.mark.asyncio
+async def test_keyless_end_turn_no_http_flips_status():
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    rep._current_status = "busy"
+    rep._current_message_id = "msg_5"
+
+    await rep.end_turn("msg_5", "run_x", succeeded=True)
+    assert http.calls == []
+    assert rep._current_status == "idle"
+    assert rep._current_message_id is None
+
+    rep._current_status = "busy"
+    await rep.end_turn("msg_5", "run_y", succeeded=False, error_text="boom")
+    assert http.calls == []
+    assert rep._current_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_keyless_end_turn_batch_no_http_flips_status():
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    await rep.end_turn_batch([
+        {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
+        {"run_id": "run_b", "message_id": "msg_b", "succeeded": True},
+    ])
+    assert http.calls == []
+    assert rep._current_status == "idle"
+    assert rep._current_message_id is None
+
+    await rep.end_turn_batch([
+        {"run_id": "run_c", "message_id": "msg_c", "succeeded": False},
+    ])
+    assert http.calls == []
+    assert rep._current_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_keyless_end_turn_batch_empty_still_no_op():
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    await rep.end_turn_batch([])
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_keyless_report_error_no_http_sets_error():
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+
+    await rep.report_error("fatal")
+    assert http.calls == []
+    assert rep._current_status == "error"
+    assert rep._current_message_id is None
+
+
+@pytest.mark.asyncio
+async def test_keyless_heartbeat_loop_is_immediate_noop():
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=10.0)
+
+    # The loop must return at once (not spin waiting on the interval) and
+    # never touch the signed heartbeat route.
+    await asyncio.wait_for(rep.run_heartbeat_loop(), timeout=1.0)
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_heartbeat_guarded_directly():
+    """Defense-in-depth: even a direct ``_send_heartbeat`` call (e.g. a
+    future caller) must not POST for a keyless agent."""
+    http = _ExplodingKeylessHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    rep._current_status = "busy"
+    rep._current_message_id = "msg_z"
+
+    await rep._send_heartbeat()
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_native_reporter_defaults_to_signed_path():
+    """A reporter over a non-keyless http client (FakeHttp default, and
+    every native agent) keeps firing signed POSTs — the guard is strictly
+    opt-in on ``http.keyless``."""
+    http = FakeHttp()  # keyless=False by default
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    assert rep._keyless is False
+
+    run_id = await rep.begin_turn("msg_native")
+    assert http.calls == [
+        ("/messages/msg_native/processing/start", {"run_id": run_id}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reporter_keyless_defaults_false_without_attr():
+    """An http fake lacking the ``keyless`` attribute entirely resolves to
+    native (False) via ``getattr(..., False)`` — no AttributeError."""
+
+    class _BareHttp:
+        def __init__(self):
+            self.calls = []
+
+        async def post(self, path, body=None):
+            self.calls.append((path, body or {}))
+            return {}
+
+    http = _BareHttp()
+    rep = StatusReporter(http, heartbeat_interval_s=999)
+    assert rep._keyless is False
+    await rep.begin_turn("msg_bare")
+    assert len(http.calls) == 1


### PR DESCRIPTION
**Draft for review** — not for merge until approved. Independent of the chat-local tools change (that's a separate PR); no shared files.

## Problem — `identity not found` for keyless bridge agents
Keyless (bridge-transport) cloud agents authenticate with an egress-injected `x-sandbox-token` and hold **no local signing identity** by design. But two subsystems made **signed** HTTP calls, and the signed path chains `post()` → `_ensure_subkey()` → `_rotate_subkey()` → `keystore.load_identity()`, which raises `identity not found: <slug>` for a keyless agent:

1. **`status_reporter.py`** — heartbeat / `begin_turn` / `end_turn` on **every turn**. Non-fatal for messaging (the bridge WS is a separate path), but it produced constant errors and made LLM agents **decline cross-agent operations** ("the Puffo identity lookup is failing").
2. **`profile_sync.py`** — `sync_agent_profile()` issued a signed `PATCH /identities/self` on every warm/startup sync.

## Fix
Guard both on the **existing** keyless signal (`http.keyless`, derived from `transport == "bridge"`) and skip the signed call — bridge agents have no route for it anyway:
- `status_reporter.py` — read `self._keyless` once; short-circuit all wire calls (heartbeat / begin_turn / end_turn / end_turn_batch / report_error / _send_heartbeat), keeping local status bookkeeping. Liveness for bridge agents comes from the bridge WS, so the skip is a clean no-op.
- `profile_sync.py` — `if pc.transport == "bridge": return` at the single choke point every sync caller reaches.

**Hard constraints held:** `crypto/keystore.py` untouched (its error is correct for native agents); native agents byte-for-byte unchanged (`getattr(..., False)` + `transport == "bridge"` guards; the 22 pre-existing `test_status_reporter.py` tests pass unchanged).

## Why other `load_identity` sites are safe
`puffo_core_client.py:619/708` are inside the native `listen()` decrypt path, which `_listen_bridge` returns before reaching. `import_agents.py` / `cli.py` / `daemon.py` are native-agent management paths, not in a bridge agent's runtime loop. Inbound-enrichment reads already degrade to ids on failure.

## Review gate
Built with an adversarial review pass (find issues → independently verify each → fix only confirmed). The `profile_sync` path was **found by review, verified real, and fixed** (it was a second keyless path missed on the first pass); a low-value dead-code finding was verified as a non-issue and correctly not "fixed."

## Tests
`status_report / keyless / bridge / identity` → **198 passed, 1 skipped (pre-existing)**. New tests added in `test_status_reporter.py` and `test_agent_sync.py` (incl. an exploding-keyless-http fake that fails loudly if any signed POST leaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)