### PR TITLE
fix(cloud-agent): wire transport to subprocess MCP so keyless agents can send (keyless phase-2)

### DIFF
--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -295,9 +295,15 @@ def puffo_core_mcp_env(
         env["PUFFO_HARNESS"] = harness
     if memory_dir:
         env["PUFFO_MEMORY_DIR"] = memory_dir
-    # T23 bridge transport — no caller passes this yet; adapter env
-    # wiring lands with phase 2.
-    if transport:
+    # T23 phase-2: the cli-local / cli-docker worker call sites now
+    # forward ``pc.transport``. Only ``bridge`` flips the subprocess to
+    # keyless (``puffo_core_server.build_server`` does
+    # ``keyless=(transport == "bridge")``), so emit the env var only for
+    # bridge. Native agents (the default transport, a truthy string)
+    # therefore stay byte-for-byte identical — no PUFFO_CORE_TRANSPORT
+    # key, subprocess keeps ``keyless=False`` and its signed keystore
+    # path.
+    if transport == "bridge":
         env["PUFFO_CORE_TRANSPORT"] = transport
     # Test-only egress shim: forward PUFFO_LOCAL_SANDBOX_TOKEN into the
     # subprocess so its keyless http client can simulate the E2B egress

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -228,6 +228,11 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 # at /home/agent/.puffo-agent-state (docker_cli also
                 # pins this at its env-override sites).
                 memory_dir="/home/agent/.puffo-agent-state/memory",
+                # T23 phase-2: forward the transport so a keyless
+                # ``bridge`` agent's subprocess MCP sets keyless=True
+                # (unsigned /v2/cloud-agents/* path). Only "bridge" is
+                # emitted downstream; native is inert.
+                transport=pc.transport,
             )
         return adapter
 
@@ -284,6 +289,12 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
                 runtime_kind="cli-local",
                 harness=agent_cfg.runtime.harness,
                 memory_dir=str(agent_cfg.resolve_memory_dir()),
+                # T23 phase-2: forward the transport so a keyless
+                # ``bridge`` agent's subprocess MCP sets keyless=True
+                # (unsigned /v2/cloud-agents/* path) instead of hitting
+                # the signed keystore path and raising identity-not-found.
+                # Only "bridge" is emitted downstream; native is inert.
+                transport=pc.transport,
             )
         return adapter
 

--- a/tests/test_keyless_transport_wiring.py
+++ b/tests/test_keyless_transport_wiring.py
@@ -1,0 +1,122 @@
+"""T23 phase-2 keyless wiring.
+
+The subprocess MCP server (``puffo_agent.mcp.puffo_core_server``) turns
+on its keyless / bridge path only when ``PUFFO_CORE_TRANSPORT == "bridge"``
+(``build_server`` does ``keyless=(transport == "bridge")``). That env var
+is produced by ``puffo_core_mcp_env`` and must be threaded from
+``agent.yml``'s ``puffo_core.transport`` at the two subprocess-MCP call
+sites in ``worker.build_adapter`` (cli-local and cli-docker).
+
+These tests pin both halves of the seam:
+
+  * the env builder emits ``PUFFO_CORE_TRANSPORT`` for ``bridge`` only,
+    and for no other transport value (so keyless stays False elsewhere);
+  * ``build_adapter`` forwards ``pc.transport`` end-to-end, so a bridge
+    agent's adapter env carries the var while a native agent's does not
+    (native stays byte-for-byte on the signed keystore path).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.mcp.config import puffo_core_mcp_env
+from puffo_agent.portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    PuffoCoreConfig,
+    RuntimeConfig,
+)
+from puffo_agent.portal.worker import build_adapter
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(tmp_path, monkeypatch):
+    """Keep every adapter/config path under a throwaway home so building
+    adapters never touches the real ~/.puffo-agent."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+
+
+_ENV_BASE = dict(
+    slug="bot-0001",
+    device_id="dev_1",
+    server_url="http://localhost:3000",
+    keystore_dir="/tmp/keys",
+    workspace="/workspace",
+)
+
+
+# ── env builder: "bridge" is the only value that emits the var ──────
+
+
+def test_env_builder_emits_transport_for_bridge():
+    env = puffo_core_mcp_env(**_ENV_BASE, transport="bridge")
+    assert env["PUFFO_CORE_TRANSPORT"] == "bridge"
+
+
+@pytest.mark.parametrize("transport", ["", "native", "local"])
+def test_env_builder_omits_transport_for_non_bridge(transport):
+    # "native" (the real default) and any other non-bridge value are
+    # truthy strings, but the subprocess only branches on "bridge", so
+    # emitting them would be dead weight — and would flip the agent's
+    # mcp-config.json off byte-for-byte parity. None must appear.
+    env = puffo_core_mcp_env(**_ENV_BASE, transport=transport)
+    assert "PUFFO_CORE_TRANSPORT" not in env
+
+
+def test_env_builder_default_omits_transport():
+    env = puffo_core_mcp_env(**_ENV_BASE)
+    assert "PUFFO_CORE_TRANSPORT" not in env
+
+
+# ── worker call sites forward pc.transport end-to-end ───────────────
+
+
+def _bridge_puffo_core() -> PuffoCoreConfig:
+    return PuffoCoreConfig(
+        server_url="http://localhost:3000",
+        slug="bot-0001",
+        device_id="dev_1",
+        space_id="sp_test",
+        transport="bridge",
+        sandbox_token="sbx-token",
+    )
+
+
+def _native_puffo_core() -> PuffoCoreConfig:
+    # transport defaults to "native".
+    return PuffoCoreConfig(
+        server_url="http://localhost:3000",
+        slug="bot-0001",
+        device_id="dev_1",
+        space_id="sp_test",
+    )
+
+
+@pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])
+def test_worker_forwards_bridge_transport(kind):
+    cfg = AgentConfig(
+        id=f"{kind}-bridge",
+        runtime=RuntimeConfig(kind=kind),
+        puffo_core=_bridge_puffo_core(),
+    )
+    adapter = build_adapter(DaemonConfig(), cfg)
+    assert adapter.puffo_core_mcp_env is not None
+    assert adapter.puffo_core_mcp_env["PUFFO_CORE_TRANSPORT"] == "bridge"
+
+
+@pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])
+def test_worker_native_agent_omits_transport(kind):
+    cfg = AgentConfig(
+        id=f"{kind}-native",
+        runtime=RuntimeConfig(kind=kind),
+        puffo_core=_native_puffo_core(),
+    )
+    adapter = build_adapter(DaemonConfig(), cfg)
+    assert adapter.puffo_core_mcp_env is not None
+    assert "PUFFO_CORE_TRANSPORT" not in adapter.puffo_core_mcp_env


### PR DESCRIPTION
## Problem
Keyless (bridge-transport) cloud agents on the **cli-local** harness (claude-code) could receive messages and run turns, but **could not reply**: every `send_message` call failed with

```
Error executing tool send_message: identity not found: <slug>
```

`whoami` failed the same way. The agent would either narrate the failure or (when the model produced plain text instead of calling the tool) fall back to an unstructured send — so replies were unreliable and the clean tool path was broken.

## Root cause
cli-local / cli-docker agents run the `puffo_core` MCP server as a **subprocess**. That server enables the keyless send path only when `PUFFO_CORE_TRANSPORT=bridge` is present in its environment:

```python
http = PuffoCoreHttpClient(server_url, ks, slug, keyless=(transport == "bridge"), ...)
transport = os.environ.get("PUFFO_CORE_TRANSPORT", "")
```

When keyless is on, `send_message` / `whoami` use the unsigned `/v2/cloud-agents/*` routes (no local identity). When it's off they take the **signed keystore path** and call `keystore.load_session` / `load_identity`, which for a keyless agent (no local signing identity) raises `identity not found`.

`puffo_core_mcp_env()` already accepted a `transport` param, but its two call sites in `worker.py` never passed it — the code even noted *"no caller passes this yet; adapter env wiring lands with phase 2."* Phase 2 was never wired, so `PUFFO_CORE_TRANSPORT` never reached the subprocess and keyless stayed off.

## Fix
- **`worker.py`** — pass `transport=pc.transport` at both `puffo_core_mcp_env()` call sites (cli-local and cli-docker; the cli-local path also covers codex-under-cli-local, which reuses the same env — no separate builder).
- **`config.py`** — emit `PUFFO_CORE_TRANSPORT` only when `transport == "bridge"`. The default transport is the **truthy** string `"native"`, and the subprocess flips to keyless only on `== "bridge"`, so native/local agents emit nothing and stay byte-for-byte unchanged on the signed path.
- The in-process (chat-local / sdk-local) paths use the injected bridge client and are untouched.

## Tests
`test_keyless_transport_wiring.py`:
- env-builder emits `PUFFO_CORE_TRANSPORT` for `"bridge"` only; omits it for `""`, `"native"`, `"local"`, and default;
- end-to-end `build_adapter` forwards `pc.transport` for both cli-local and cli-docker (bridge agent carries the var; native agent does not).

Full offline suite: 153 passed, 1 skipped (pre-existing unrelated skip).

## Validation
Verified **live** against a keyless claude-code cloud agent: with the fix loaded, the daemon regenerates `mcp-config.json` with `PUFFO_CORE_TRANSPORT=bridge`, the subprocess runs keyless, and a DM turn produces `send_message → {"result":"posted ..."}` on the keyless bridge path — the agent replies in DMs instead of failing with identity-not-found.

Completes the keyless line (follows #174 / #175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
