### PR TITLE
feat(dm): unified /permission prompts for every operator y/n ask

### DIFF
--- a/src/puffo_agent/agent/permission_prompt.py
+++ b/src/puffo_agent/agent/permission_prompt.py
@@ -1,16 +1,8 @@
 """Shared constructor for operator-facing ``/permission`` prompts.
 
-Every daemon flow that asks the operator for a y/n decision (space and
-channel invites, agent-requested leaves, cli-local command permission,
-foreign-DM approval) builds its DM through ``format_permission_prompt``
-so the web/mobile clients render one consistent actionable card: the
-``/permission`` prefix triggers Yes/No buttons, which post ``y``/``n``
-into the prompt's own thread — the same replies the daemon-side
-intercepts already accept.
-
-The prompt must be sent as a root-level DM to the operator (the card
-only renders there); the returned envelope_id keys the pending entry
-the y/n reply routes back to.
+The ``/permission`` prefix renders an actionable Yes/No card in the
+web/mobile clients; the buttons post ``y``/``n`` into the prompt's own
+thread. Must be sent as a root-level DM (the card only renders there).
 """
 
 from __future__ import annotations
@@ -22,14 +14,9 @@ def format_permission_prompt(
     detail: str = "",
     reply_note: str = "",
 ) -> str:
-    """``/permission <intent>`` + the standard Yes/No instruction.
-
-    intent: one sentence asking the question (may carry markdown).
-    detail: optional context rendered as a quote block (a message
-        preview, a command summary, a reason).
-    reply_note: optional extra reply semantics appended to the
-        instruction line (e.g. bulk-reply behavior).
-    """
+    """``/permission <intent>`` + the standard Yes/No instruction;
+    ``detail`` renders as a quote block, ``reply_note`` extends the
+    instruction line."""
     line = f"/permission {intent.strip()} Tap Yes/No, or reply `y`/`n` in this thread"
     line += f" — {reply_note.strip()}." if reply_note.strip() else "."
     if detail.strip():

--- a/src/puffo_agent/agent/permission_prompt.py
+++ b/src/puffo_agent/agent/permission_prompt.py
@@ -1,0 +1,38 @@
+"""Shared constructor for operator-facing ``/permission`` prompts.
+
+Every daemon flow that asks the operator for a y/n decision (space and
+channel invites, agent-requested leaves, cli-local command permission,
+foreign-DM approval) builds its DM through ``format_permission_prompt``
+so the web/mobile clients render one consistent actionable card: the
+``/permission`` prefix triggers Yes/No buttons, which post ``y``/``n``
+into the prompt's own thread — the same replies the daemon-side
+intercepts already accept.
+
+The prompt must be sent as a root-level DM to the operator (the card
+only renders there); the returned envelope_id keys the pending entry
+the y/n reply routes back to.
+"""
+
+from __future__ import annotations
+
+
+def format_permission_prompt(
+    intent: str,
+    *,
+    detail: str = "",
+    reply_note: str = "",
+) -> str:
+    """``/permission <intent>`` + the standard Yes/No instruction.
+
+    intent: one sentence asking the question (may carry markdown).
+    detail: optional context rendered as a quote block (a message
+        preview, a command summary, a reason).
+    reply_note: optional extra reply semantics appended to the
+        instruction line (e.g. bulk-reply behavior).
+    """
+    line = f"/permission {intent.strip()} Tap Yes/No, or reply `y`/`n` in this thread"
+    line += f" — {reply_note.strip()}." if reply_note.strip() else "."
+    if detail.strip():
+        quoted = "\n".join(f"> {ln}" for ln in detail.strip().splitlines())
+        line += f"\n\n{quoted}"
+    return line

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -543,8 +543,7 @@ class PuffoCoreMessageClient:
         self._pending_leave_dms: dict[str, dict[str, Any]] = {}
         self._gate_left_spaces: set[str] = set()
         # cli-local command-permission prompts awaiting operator y/n,
-        # keyed by prompt-DM envelope_id. In-memory only — the hook
-        # times out and re-asks after a daemon restart.
+        # keyed by prompt-DM envelope_id. In-memory only.
         self._pending_command_permissions: dict[str, asyncio.Future[bool]] = {}
 
         # channel_id → space_id learned from inbound envelopes. The
@@ -1609,8 +1608,7 @@ class PuffoCoreMessageClient:
                     "accepted channel (space=%s channel=%s)",
                     space_id, channel_id,
                 )
-            # Auto-accepts skip the /permission ask, so tell the
-            # operator after the fact rather than joining silently.
+            # No /permission ask on auto-accept — report, don't join silently.
             await self._report_auto_accepted_channel_invite(
                 inviter_slug=original_invite.get("signer_slug") or "",
                 space_id=space_id,
@@ -2115,9 +2113,8 @@ class PuffoCoreMessageClient:
     async def _report_auto_accepted_channel_invite(
         self, *, inviter_slug: str, space_id: str, channel_id: str,
     ) -> None:
-        """Tell the operator the server auto-accepted a space-owner's
-        channel invite on the agent's behalf (auto_accept_owner_invite).
-        Best-effort."""
+        """Best-effort operator report for a server-auto-accepted
+        owner channel invite."""
         if not self.operator_slug:
             return
         # Names only — raw ids are operator noise.
@@ -3204,10 +3201,8 @@ class PuffoCoreMessageClient:
     async def request_command_permission(
         self, *, tool_name: str, summary: str, timeout_s: int,
     ) -> str:
-        """DM the operator a ``/permission`` prompt for a tool call the
-        PreToolUse hook intercepted, and block until they answer or the
-        timeout lapses. Returns ``"allow"`` / ``"deny"`` / ``"timeout"``
-        for the hook to translate into its exit protocol."""
+        """Block on the operator's y/n for a hook-intercepted tool
+        call. Returns ``allow`` / ``deny`` / ``timeout``."""
         if not self.operator_slug:
             raise RuntimeError("no operator_slug configured")
         text = format_permission_prompt(
@@ -3223,8 +3218,8 @@ class PuffoCoreMessageClient:
         try:
             approved = await asyncio.wait_for(fut, timeout=timeout_s)
         except asyncio.TimeoutError:
-            # Register before the notice send so a reply racing either
-            # window (pre-pop or later) gets the stale-prompt note.
+            # Register before the notice send — a racing reply must
+            # see the timeout.
             self._timed_out_command_permissions[env_id] = time.time()
             while len(self._timed_out_command_permissions) > 64:
                 self._timed_out_command_permissions.pop(
@@ -3258,8 +3253,7 @@ class PuffoCoreMessageClient:
             approved = False
         else:
             return False
-        # Late answer to an already-timed-out prompt: never claim it
-        # ran — tell them it's stale instead.
+        # Late answer to a timed-out prompt: never claim it ran.
         if thread_root_id in self._timed_out_command_permissions:
             try:
                 await self._send_dm(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -543,9 +543,8 @@ class PuffoCoreMessageClient:
         self._pending_leave_dms: dict[str, dict[str, Any]] = {}
         self._gate_left_spaces: set[str] = set()
         # cli-local command-permission prompts awaiting operator y/n,
-        # keyed by prompt-DM envelope_id. The future resolves to the
-        # decision; in-memory only — the requesting hook re-asks or
-        # times out on a daemon restart.
+        # keyed by prompt-DM envelope_id. In-memory only — the hook
+        # times out and re-asks after a daemon restart.
         self._pending_command_permissions: dict[str, asyncio.Future[bool]] = {}
 
         # channel_id → space_id learned from inbound envelopes. The
@@ -2121,8 +2120,7 @@ class PuffoCoreMessageClient:
         Best-effort."""
         if not self.operator_slug:
             return
-        # Names only — ids are noise to the operator; bare id is the
-        # fallback when a name can't be resolved.
+        # Names only — raw ids are operator noise.
         space_name = await self._resolve_space_name(space_id)
         channel_name = await self._resolve_channel_name(
             space_id=space_id, channel_id=channel_id,
@@ -3247,7 +3245,9 @@ class PuffoCoreMessageClient:
         """Operator ``y``/``n`` on a pending command-permission DM.
         Threaded only. Returns ``True`` when consumed."""
         fut = self._pending_command_permissions.get(thread_root_id)
-        if fut is None:
+        # done() = wait_for already timed out but the entry isn't popped
+        # yet; a reply in that window must not be confirmed as acted-on.
+        if fut is None or fut.done():
             return False
         normalized = text.strip().lower()
         if normalized in ("y", "yes"):
@@ -3256,8 +3256,7 @@ class PuffoCoreMessageClient:
             approved = False
         else:
             return False
-        if not fut.done():
-            fut.set_result(approved)
+        fut.set_result(approved)
         confirm = "Approved ✓ — running it." if approved else "Denied — I won't run it."
         try:
             await self._send_dm(self.operator_slug, confirm, root_id=thread_root_id)

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -3223,6 +3223,13 @@ class PuffoCoreMessageClient:
         try:
             approved = await asyncio.wait_for(fut, timeout=timeout_s)
         except asyncio.TimeoutError:
+            # Register before the notice send so a reply racing either
+            # window (pre-pop or later) gets the stale-prompt note.
+            self._timed_out_command_permissions[env_id] = time.time()
+            while len(self._timed_out_command_permissions) > 64:
+                self._timed_out_command_permissions.pop(
+                    next(iter(self._timed_out_command_permissions)),
+                )
             try:
                 await self._send_dm(
                     self.operator_slug,
@@ -3244,17 +3251,28 @@ class PuffoCoreMessageClient:
     ) -> bool:
         """Operator ``y``/``n`` on a pending command-permission DM.
         Threaded only. Returns ``True`` when consumed."""
-        fut = self._pending_command_permissions.get(thread_root_id)
-        # done() = wait_for already timed out but the entry isn't popped
-        # yet; a reply in that window must not be confirmed as acted-on.
-        if fut is None or fut.done():
-            return False
         normalized = text.strip().lower()
         if normalized in ("y", "yes"):
             approved = True
         elif normalized in ("n", "no"):
             approved = False
         else:
+            return False
+        # Late answer to an already-timed-out prompt: never claim it
+        # ran — tell them it's stale instead.
+        if thread_root_id in self._timed_out_command_permissions:
+            try:
+                await self._send_dm(
+                    self.operator_slug,
+                    "That request already timed out — I did NOT run it. "
+                    "Ask me to try again if you still want it.",
+                    root_id=thread_root_id,
+                )
+            except Exception:
+                self._log.exception("permission: failed to send stale note")
+            return True
+        fut = self._pending_command_permissions.get(thread_root_id)
+        if fut is None or fut.done():
             return False
         fut.set_result(approved)
         confirm = "Approved ✓ — running it." if approved else "Denied — I won't run it."

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -2121,19 +2121,19 @@ class PuffoCoreMessageClient:
         Best-effort."""
         if not self.operator_slug:
             return
+        # Names only — ids are noise to the operator; bare id is the
+        # fallback when a name can't be resolved.
         space_name = await self._resolve_space_name(space_id)
         channel_name = await self._resolve_channel_name(
             space_id=space_id, channel_id=channel_id,
         )
-        space_label = f"**{space_name}**({space_id})" if space_name else space_id
-        channel_label = (
-            f"**{channel_name}**({channel_id})" if channel_name else channel_id
-        )
+        space_label = f"**{space_name or space_id}**"
+        channel_label = f"**{channel_name or channel_id}**"
         inviter_label = f"@{inviter_slug}" if inviter_slug else "the space owner"
         if inviter_slug:
             inviter_display = await self._fetch_display_name(inviter_slug)
             if inviter_display:
-                inviter_label = f"**{inviter_display}**(@{inviter_slug})"
+                inviter_label = f"**{inviter_display}**"
         text = (
             f"Auto-accepted {inviter_label}'s invite to channel "
             f"{channel_label} in space {space_label} "

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -29,6 +29,7 @@ from ..crypto.ws_client import PuffoCoreWsClient
 from . import disk_cache
 from ._invite_strings import format_invite_error, format_leave_error
 from .core import AgentAPIError
+from .permission_prompt import format_permission_prompt
 from .events import random_nonce, sign_event
 from .event_kinds import EventKind
 from .message_store import MessageStore
@@ -541,6 +542,11 @@ class PuffoCoreMessageClient:
         # so the WS echo's ``_on_left_space`` skips its now-duplicate DM.
         self._pending_leave_dms: dict[str, dict[str, Any]] = {}
         self._gate_left_spaces: set[str] = set()
+        # cli-local command-permission prompts awaiting operator y/n,
+        # keyed by prompt-DM envelope_id. The future resolves to the
+        # decision; in-memory only — the requesting hook re-asks or
+        # times out on a daemon restart.
+        self._pending_command_permissions: dict[str, asyncio.Future[bool]] = {}
 
         # channel_id → space_id learned from inbound envelopes. The
         # agent's config carries one "home" space_id, but cross-space
@@ -743,6 +749,12 @@ class PuffoCoreMessageClient:
                 # threaded-only — each leave is confirmed in its own
                 # thread (no direct/bulk path).
                 if await self._maybe_handle_leave_reply(
+                    thread_root_id=payload_thread_root_id or "", text=text_raw,
+                ):
+                    self._last_dm_sender = payload.sender_slug
+                    return
+                # Same gate for cli-local command-permission prompts.
+                if await self._maybe_handle_permission_reply(
                     thread_root_id=payload_thread_root_id or "", text=text_raw,
                 ):
                     self._last_dm_sender = payload.sender_slug
@@ -3148,6 +3160,70 @@ class PuffoCoreMessageClient:
             return f"channel {channel_label} in space {space_label}"
         return f"space {space_label}"
 
+    # ── cli-local command permission (operator-gated) ─────────────────
+
+    async def request_command_permission(
+        self, *, tool_name: str, summary: str, timeout_s: int,
+    ) -> str:
+        """DM the operator a ``/permission`` prompt for a tool call the
+        PreToolUse hook intercepted, and block until they answer or the
+        timeout lapses. Returns ``"allow"`` / ``"deny"`` / ``"timeout"``
+        for the hook to translate into its exit protocol."""
+        if not self.operator_slug:
+            raise RuntimeError("no operator_slug configured")
+        text = format_permission_prompt(
+            f"I want to run **{tool_name}** — allow it?",
+            detail=summary,
+        )
+        envelope = await self._send_dm(self.operator_slug, text, root_id="")
+        env_id = envelope.get("envelope_id", "") if envelope else ""
+        if not env_id:
+            raise RuntimeError("could not deliver the permission DM")
+        fut: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        self._pending_command_permissions[env_id] = fut
+        try:
+            approved = await asyncio.wait_for(fut, timeout=timeout_s)
+        except asyncio.TimeoutError:
+            try:
+                await self._send_dm(
+                    self.operator_slug,
+                    f"Timed out after {timeout_s}s — I did NOT run "
+                    f"`{tool_name}`.",
+                    root_id=env_id,
+                )
+            except Exception:
+                self._log.exception(
+                    "permission: failed to send timeout notice",
+                )
+            return "timeout"
+        finally:
+            self._pending_command_permissions.pop(env_id, None)
+        return "allow" if approved else "deny"
+
+    async def _maybe_handle_permission_reply(
+        self, *, thread_root_id: str, text: str,
+    ) -> bool:
+        """Operator ``y``/``n`` on a pending command-permission DM.
+        Threaded only. Returns ``True`` when consumed."""
+        fut = self._pending_command_permissions.get(thread_root_id)
+        if fut is None:
+            return False
+        normalized = text.strip().lower()
+        if normalized in ("y", "yes"):
+            approved = True
+        elif normalized in ("n", "no"):
+            approved = False
+        else:
+            return False
+        if not fut.done():
+            fut.set_result(approved)
+        confirm = "Approved ✓ — running it." if approved else "Denied — I won't run it."
+        try:
+            await self._send_dm(self.operator_slug, confirm, root_id=thread_root_id)
+        except Exception:
+            self._log.exception("permission: failed to confirm decision")
+        return True
+
     # ── Agent-initiated leave (operator-gated, mirrors invite) ────────
 
     async def request_leave_approval(
@@ -3184,10 +3260,9 @@ class PuffoCoreMessageClient:
             )
         else:
             target = f"space **{space_label}**({space_id})"
-        reason_line = f" Reason: {reason.strip()}" if reason.strip() else ""
-        text = (
-            f"I'd like to leave {target}.{reason_line} "
-            f"Reply `y` in this thread to approve, or `n` to keep me there."
+        text = format_permission_prompt(
+            f"I'd like to leave {target} — approve, or keep me there?",
+            detail=f"Reason: {reason.strip()}" if reason.strip() else "",
         )
         envelope = await self._send_dm(self.operator_slug, text, root_id="")
         env_id = envelope.get("envelope_id", "") if envelope else ""
@@ -3492,22 +3567,20 @@ class PuffoCoreMessageClient:
         )
         space_label = f"**{space_name}**({space_id})" if space_name else space_id
         if kind == EventKind.INVITE_TO_SPACE:
-            text = (
-                f"{inviter_label} invited me to space {space_label}. "
-                f"They aren't my registered operator. "
-                f"Reply `y` to accept or `n` to reject — in this thread for "
-                f"this one, or a direct `y`/`n` for all your pending invites."
-            )
+            target = f"space {space_label}"
         else:
             channel_label = (
                 f"**{channel_name}**({channel_id})" if channel_name else channel_id
             )
-            text = (
-                f"{inviter_label} invited me to channel {channel_label} in "
-                f"space {space_label}. They aren't my registered operator. "
-                f"Reply `y` to accept or `n` to reject — in this thread for "
-                f"this one, or a direct `y`/`n` for all your pending invites."
-            )
+            target = f"channel {channel_label} in space {space_label}"
+        text = format_permission_prompt(
+            f"{inviter_label} invited me to {target}. "
+            f"They aren't my registered operator — accept?",
+            reply_note=(
+                "a direct (non-threaded) `y`/`n` answers all your "
+                "pending invites at once"
+            ),
+        )
         try:
             envelope = await self._send_dm(self.operator_slug, text, root_id="")
         except Exception:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1592,7 +1592,8 @@ class PuffoCoreMessageClient:
             # real signed accept that's bouncing back over WS.
             # ``original_invite`` is the canonical marker — the
             # operator-signed path never embeds the source invite.
-            if not isinstance(payload.get("original_invite"), dict):
+            original_invite = payload.get("original_invite")
+            if not isinstance(original_invite, dict):
                 return
             space_id = payload.get("space_id") or ""
             channel_id = payload.get("channel_id") or ""
@@ -1609,6 +1610,13 @@ class PuffoCoreMessageClient:
                     "accepted channel (space=%s channel=%s)",
                     space_id, channel_id,
                 )
+            # Auto-accepts skip the /permission ask, so tell the
+            # operator after the fact rather than joining silently.
+            await self._report_auto_accepted_channel_invite(
+                inviter_slug=original_invite.get("signer_slug") or "",
+                space_id=space_id,
+                channel_id=channel_id,
+            )
             return
 
         # Membership-exit events. Pair-wise: the kick path
@@ -2103,6 +2111,39 @@ class PuffoCoreMessageClient:
         except Exception:
             self._log.exception(
                 "failed to report auto-accepted space invite to operator",
+            )
+
+    async def _report_auto_accepted_channel_invite(
+        self, *, inviter_slug: str, space_id: str, channel_id: str,
+    ) -> None:
+        """Tell the operator the server auto-accepted a space-owner's
+        channel invite on the agent's behalf (auto_accept_owner_invite).
+        Best-effort."""
+        if not self.operator_slug:
+            return
+        space_name = await self._resolve_space_name(space_id)
+        channel_name = await self._resolve_channel_name(
+            space_id=space_id, channel_id=channel_id,
+        )
+        space_label = f"**{space_name}**({space_id})" if space_name else space_id
+        channel_label = (
+            f"**{channel_name}**({channel_id})" if channel_name else channel_id
+        )
+        inviter_label = f"@{inviter_slug}" if inviter_slug else "the space owner"
+        if inviter_slug:
+            inviter_display = await self._fetch_display_name(inviter_slug)
+            if inviter_display:
+                inviter_label = f"**{inviter_display}**(@{inviter_slug})"
+        text = (
+            f"Auto-accepted {inviter_label}'s invite to channel "
+            f"{channel_label} in space {space_label} "
+            f"(space-owner invites are auto-accepted)."
+        )
+        try:
+            await self._send_dm(self.operator_slug, text, root_id="")
+        except Exception:
+            self._log.exception(
+                "failed to report auto-accepted channel invite to operator",
             )
 
     async def _inviter_is_operator(self, inviter_slug: str) -> bool:

--- a/src/puffo_agent/hooks/permission.py
+++ b/src/puffo_agent/hooks/permission.py
@@ -192,17 +192,15 @@ def request_via_rpc(
     summary: str,
     timeout_s: int,
 ) -> None:
-    """puffo-core transport: the daemon owns the operator DM. POST the
-    request to the daemon's rpc service, which sends a ``/permission``
-    DM and long-polls the y/n for us; translate its decision into the
-    PreToolUse exit protocol. Never returns."""
+    """puffo-core transport: the daemon DMs the operator and
+    long-polls the y/n; translate its decision into the PreToolUse
+    exit protocol. Never returns."""
     try:
         resp = _http_post(
             f"{rpc_url.rstrip('/')}/v1/rpc/{agent_id}/permission-request",
             {"Content-Type": "application/json"},
             {"tool_name": tool_name, "summary": summary, "timeout_s": timeout_s},
-            # The daemon holds the request open for the whole decision
-            # window; pad so the transport outlives it.
+            # Pad past the daemon's decision window.
             timeout=timeout_s + 30,
         )
     except Exception as exc:

--- a/src/puffo_agent/hooks/permission.py
+++ b/src/puffo_agent/hooks/permission.py
@@ -14,11 +14,14 @@ that CLI flag is non-interactive-mode only.
 
 Env vars set by the spawning adapter:
 
-  PUFFO_URL                base URL (required)
-  PUFFO_BOT_TOKEN          bot's personal access token (required)
-  PUFFO_OPERATOR_USERNAME  who to DM (required; empty -> fail-open)
-  PUFFO_AGENT_ID           shown in the DM (default "unknown")
-  PUFFO_PERMISSION_TIMEOUT poll timeout seconds (default 300)
+  PUFFO_URL                legacy base URL (with PUFFO_BOT_TOKEN)
+  PUFFO_BOT_TOKEN          legacy bot token
+  PUFFO_RPC_URL            puffo-core daemon rpc — used when the
+                           legacy pair is absent; daemon DMs the
+                           operator a /permission card
+  PUFFO_OPERATOR_USERNAME  who to DM (legacy path; empty -> fail-open)
+  PUFFO_AGENT_ID           agent id (rpc path routing + shown in DM)
+  PUFFO_PERMISSION_TIMEOUT decision timeout seconds (default 300)
 
 stdlib-only (urllib + json + time + sys + os) so it can run from
 a minimal interpreter without importing the rest of puffo-agent.
@@ -225,10 +228,8 @@ def main() -> None:
     except ValueError:
         timeout_s = 300
 
-    # puffo-core deployments have no PUFFO_URL/PUFFO_BOT_TOKEN — route
-    # through the daemon's rpc service instead (it DMs the operator a
-    # /permission card). Legacy Mattermost transport keeps priority
-    # when both are configured.
+    # No legacy creds (puffo-core deployment) → route through the
+    # daemon's rpc service, which DMs the operator a /permission card.
     if not (base_url and bot_token):
         if rpc_url:
             try:

--- a/src/puffo_agent/hooks/permission.py
+++ b/src/puffo_agent/hooks/permission.py
@@ -182,9 +182,42 @@ def poll_for_reply(
     return None
 
 
+def request_via_rpc(
+    rpc_url: str,
+    agent_id: str,
+    tool_name: str,
+    summary: str,
+    timeout_s: int,
+) -> None:
+    """puffo-core transport: the daemon owns the operator DM. POST the
+    request to the daemon's rpc service, which sends a ``/permission``
+    DM and long-polls the y/n for us; translate its decision into the
+    PreToolUse exit protocol. Never returns."""
+    try:
+        resp = _http_post(
+            f"{rpc_url.rstrip('/')}/v1/rpc/{agent_id}/permission-request",
+            {"Content-Type": "application/json"},
+            {"tool_name": tool_name, "summary": summary, "timeout_s": timeout_s},
+            # The daemon holds the request open for the whole decision
+            # window; pad so the transport outlives it.
+            timeout=timeout_s + 30,
+        )
+    except Exception as exc:
+        _fail_open(f"daemon permission request failed: {exc}")
+    decision = (resp.get("message") or "").strip().lower()
+    if decision == "allow":
+        _allow("operator approved via chat")
+    if decision == "deny":
+        _deny("operator denied via chat")
+    if decision == "timeout":
+        _deny(f"permission request timed out after {timeout_s}s (no operator reply)")
+    _fail_open(f"unexpected daemon decision {decision!r}")
+
+
 def main() -> None:
     base_url = (os.environ.get("PUFFO_URL") or "").rstrip("/")
     bot_token = os.environ.get("PUFFO_BOT_TOKEN") or ""
+    rpc_url = os.environ.get("PUFFO_RPC_URL") or ""
     operator = os.environ.get("PUFFO_OPERATOR_USERNAME") or ""
     agent_id = os.environ.get("PUFFO_AGENT_ID") or "unknown"
     try:
@@ -192,7 +225,24 @@ def main() -> None:
     except ValueError:
         timeout_s = 300
 
+    # puffo-core deployments have no PUFFO_URL/PUFFO_BOT_TOKEN — route
+    # through the daemon's rpc service instead (it DMs the operator a
+    # /permission card). Legacy Mattermost transport keeps priority
+    # when both are configured.
     if not (base_url and bot_token):
+        if rpc_url:
+            try:
+                raw = sys.stdin.read() or "{}"
+                payload = json.loads(raw)
+            except Exception as exc:
+                _fail_open(f"could not parse hook payload: {exc}")
+            request_via_rpc(
+                rpc_url,
+                agent_id,
+                payload.get("tool_name", "unknown"),
+                summarise_tool_input(payload.get("tool_input", {})),
+                timeout_s,
+            )
         _fail_open("PUFFO_URL / PUFFO_BOT_TOKEN not set")
     if not operator:
         _fail_open("PUFFO_OPERATOR_USERNAME empty — no operator to DM")

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -496,9 +496,8 @@ async def request_command_permission(
     summary: str,
     timeout_s: object,
 ) -> str:
-    """PreToolUse hook asked for operator sign-off on a tool call —
-    hand off to the message client, which sends the ``/permission`` DM
-    and blocks until y/n or timeout. Returns allow/deny/timeout."""
+    """Hand a hook's permission ask to the message client; blocks
+    until y/n or timeout. Returns allow/deny/timeout."""
     client = ctx.message_client
     if client is None:
         raise RuntimeError(

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -487,3 +487,32 @@ async def request_leave(
         channel_id=channel_id,
         reason=reason or "",
     )
+
+
+async def request_command_permission(
+    ctx: HostMcpContext,
+    *,
+    tool_name: str,
+    summary: str,
+    timeout_s: object,
+) -> str:
+    """PreToolUse hook asked for operator sign-off on a tool call —
+    hand off to the message client, which sends the ``/permission`` DM
+    and blocks until y/n or timeout. Returns allow/deny/timeout."""
+    client = ctx.message_client
+    if client is None:
+        raise RuntimeError(
+            "agent isn't fully warm yet — try again in a moment"
+        )
+    if not tool_name:
+        raise RuntimeError("tool_name is required")
+    try:
+        timeout = int(timeout_s) if timeout_s is not None else 300
+    except (TypeError, ValueError):
+        timeout = 300
+    timeout = max(5, min(timeout, 3600))
+    return await client.request_command_permission(
+        tool_name=str(tool_name),
+        summary=str(summary or ""),
+        timeout_s=timeout,
+    )

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -105,9 +105,8 @@ async def leave_request_route(request: web.Request) -> web.Response:
 
 async def permission_request_route(request: web.Request) -> web.Response:
     """POST /v1/rpc/{agent_id}/permission-request —
-    ``{tool_name, summary, timeout_s}``. Long-polls until the operator
-    answers the ``/permission`` DM or the timeout lapses; the response
-    ``message`` is ``allow`` / ``deny`` / ``timeout``."""
+    ``{tool_name, summary, timeout_s}``. Long-poll; ``message`` is
+    ``allow`` / ``deny`` / ``timeout``."""
     return await _dispatch(
         request, host_mcp_handler.request_command_permission,
         body_keys=("tool_name", "summary", "timeout_s"),

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -103,6 +103,17 @@ async def leave_request_route(request: web.Request) -> web.Response:
     )
 
 
+async def permission_request_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/permission-request —
+    ``{tool_name, summary, timeout_s}``. Long-polls until the operator
+    answers the ``/permission`` DM or the timeout lapses; the response
+    ``message`` is ``allow`` / ``deny`` / ``timeout``."""
+    return await _dispatch(
+        request, host_mcp_handler.request_command_permission,
+        body_keys=("tool_name", "summary", "timeout_s"),
+    )
+
+
 def build_app(cfg: RpcServiceConfig) -> web.Application:
     app = web.Application()
     app.router.add_post(
@@ -116,6 +127,10 @@ def build_app(cfg: RpcServiceConfig) -> web.Application:
     app.router.add_post(
         "/v1/rpc/{agent_id}/leave-request",
         leave_request_route,
+    )
+    app.router.add_post(
+        "/v1/rpc/{agent_id}/permission-request",
+        permission_request_route,
     )
     return app
 

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -605,9 +605,12 @@ async def test_synthetic_auto_accept_reports_to_operator():
     # Informational, not a /permission ask — nothing to decide.
     assert not report["text"].startswith("/permission")
     assert "Auto-accepted" in report["text"]
-    assert "**Alice**(@alice-0001)" in report["text"]
-    assert "**general**(ch_1)" in report["text"]
-    assert "**Team**(sp_1)" in report["text"]
+    # Names only — raw ids are operator noise.
+    assert "**Alice**" in report["text"]
+    assert "**general**" in report["text"]
+    assert "**Team**" in report["text"]
+    assert "ch_1" not in report["text"]
+    assert "sp_1" not in report["text"]
     await store.close()
 
 

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -573,8 +573,7 @@ async def test_handle_event_fires_intro_on_synthetic_auto_accept():
 
 @pytest.mark.asyncio
 async def test_synthetic_auto_accept_reports_to_operator():
-    """Auto-accepting must not be silent — the operator gets an
-    informational DM naming the inviter, channel, and space."""
+    """Auto-accepts DM the operator a report instead of joining silently."""
     store = await _make_store()
     client = _make_client(store)
     client.slug = "agent-1"

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -16,6 +16,7 @@ wrapper on top — covered by manual smoke tests.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 import tempfile
@@ -56,6 +57,9 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     client._channel_space = {}
     # Written by ``_handle_event``'s ``invite_to_*`` branch.
     client._inviter_by_invitation_event_id = {}
+    # Empty → the auto-accept operator report short-circuits; the
+    # report itself is covered by its own test below.
+    client.operator_slug = ""
 
     async def _stub_space_name(space_id: str) -> str:
         return "Team" if space_id == "sp_1" else space_id
@@ -564,6 +568,46 @@ async def test_handle_event_fires_intro_on_synthetic_auto_accept():
 
     assert client._queue.qsize() == 1
     assert await store.has_channel_intro_been_prompted("ch_1") is True
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_synthetic_auto_accept_reports_to_operator():
+    """Auto-accepting must not be silent — the operator gets an
+    informational DM naming the inviter, channel, and space."""
+    store = await _make_store()
+    client = _make_client(store)
+    client.slug = "agent-1"
+    client.operator_slug = "op-1"
+    client._log = logging.getLogger("nudge-test")
+
+    sent: list[dict] = []
+
+    async def _stub_send_dm(slug, text, root_id=""):
+        sent.append({"to": slug, "text": text, "root_id": root_id})
+        return {"envelope_id": "env_report_1"}
+
+    async def _stub_display_name(slug):
+        return "Alice"
+
+    client._send_dm = _stub_send_dm  # type: ignore[assignment]
+    client._fetch_display_name = _stub_display_name  # type: ignore[assignment]
+
+    event = _synthetic_accept_event(
+        agent_slug="agent-1", space_id="sp_1", channel_id="ch_1",
+    )
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert len(sent) == 1
+    report = sent[0]
+    assert report["to"] == "op-1"
+    assert report["root_id"] == ""
+    # Informational, not a /permission ask — nothing to decide.
+    assert not report["text"].startswith("/permission")
+    assert "Auto-accepted" in report["text"]
+    assert "**Alice**(@alice-0001)" in report["text"]
+    assert "**general**(ch_1)" in report["text"]
+    assert "**Team**(sp_1)" in report["text"]
     await store.close()
 
 

--- a/tests/test_command_permission_rpc.py
+++ b/tests/test_command_permission_rpc.py
@@ -133,6 +133,7 @@ async def test_permission_request_end_to_end_over_socket(app_client_factory):
     client.slug = "agent-1"
     client.operator_slug = "op-1"
     client._pending_command_permissions = {}
+    client._timed_out_command_permissions = {}
     client._log = logging.getLogger("rpc-e2e-test")
     sent: list[dict] = []
 

--- a/tests/test_command_permission_rpc.py
+++ b/tests/test_command_permission_rpc.py
@@ -1,0 +1,234 @@
+"""cli-local command permission over the daemon RPC: the
+/v1/rpc/{agent}/permission-request route, the host_mcp_handler
+validation layer, and the hook's puffo-core transport."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from puffo_agent.portal import rpc_service
+from puffo_agent.portal import host_mcp_handler
+from puffo_agent.portal.host_mcp_handler import HostMcpContext
+
+
+class _StubMessageClient:
+    def __init__(self, decision: str = "allow"):
+        self.decision = decision
+        self.calls: list[dict[str, Any]] = []
+
+    async def request_command_permission(self, *, tool_name, summary, timeout_s):
+        self.calls.append(
+            {"tool_name": tool_name, "summary": summary, "timeout_s": timeout_s}
+        )
+        return self.decision
+
+
+def _stub_ctx(agent_id: str = "agent_test", message_client=None) -> HostMcpContext:
+    return HostMcpContext(
+        agent_id=agent_id,
+        slug="bot-test",
+        operator_slug="op-test",
+        host_home=Any,
+        agent_home=Any,
+        harness="claude-code",
+        keystore=None,
+        http_client=None,
+        message_client=message_client,
+    )
+
+
+@pytest.fixture
+def app_client_factory():
+    created: list = []
+    async def _make():
+        cfg = rpc_service.RpcServiceConfig(enabled=True, port=0)
+        app = rpc_service.build_app(cfg)
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        created.append(client)
+        return client
+    yield _make
+    rpc_service.set_rpc_resolver(None)
+
+
+@pytest.mark.asyncio
+async def test_permission_request_roundtrips_decision(app_client_factory):
+    mc = _StubMessageClient("allow")
+    rpc_service.set_rpc_resolver(lambda aid: _stub_ctx(aid, message_client=mc))
+    app_client = await app_client_factory()
+
+    resp = await app_client.post(
+        "/v1/rpc/agent_a/permission-request",
+        json={"tool_name": "Bash", "summary": "- command: ls", "timeout_s": 42},
+    )
+    assert resp.status == 200
+    assert (await resp.json()) == {"message": "allow"}
+    assert mc.calls == [
+        {"tool_name": "Bash", "summary": "- command: ls", "timeout_s": 42}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_permission_request_defaults_and_clamps_timeout(app_client_factory):
+    mc = _StubMessageClient("deny")
+    rpc_service.set_rpc_resolver(lambda aid: _stub_ctx(aid, message_client=mc))
+    app_client = await app_client_factory()
+
+    # Missing timeout → 300; absurd timeout → clamped to 3600.
+    await app_client.post(
+        "/v1/rpc/agent_a/permission-request", json={"tool_name": "Bash"},
+    )
+    await app_client.post(
+        "/v1/rpc/agent_a/permission-request",
+        json={"tool_name": "Bash", "timeout_s": 999999},
+    )
+    assert [c["timeout_s"] for c in mc.calls] == [300, 3600]
+    # Non-numeric timeout → default, not a 500.
+    resp = await app_client.post(
+        "/v1/rpc/agent_a/permission-request",
+        json={"tool_name": "Bash", "timeout_s": "soon"},
+    )
+    assert resp.status == 200
+    assert mc.calls[-1]["timeout_s"] == 300
+
+
+@pytest.mark.asyncio
+async def test_permission_request_requires_tool_name(app_client_factory):
+    rpc_service.set_rpc_resolver(
+        lambda aid: _stub_ctx(aid, message_client=_StubMessageClient()),
+    )
+    app_client = await app_client_factory()
+    resp = await app_client.post(
+        "/v1/rpc/agent_a/permission-request", json={"summary": "x"},
+    )
+    assert resp.status == 400
+    assert "tool_name" in (await resp.json())["error"]
+
+
+@pytest.mark.asyncio
+async def test_permission_request_400_when_worker_cold(app_client_factory):
+    rpc_service.set_rpc_resolver(lambda aid: _stub_ctx(aid, message_client=None))
+    app_client = await app_client_factory()
+    resp = await app_client.post(
+        "/v1/rpc/agent_a/permission-request", json={"tool_name": "Bash"},
+    )
+    assert resp.status == 400
+    assert "warm" in (await resp.json())["error"]
+
+
+# ─── hook transport (puffo-core branch) ───────────────────────────────
+
+
+def _run_rpc_hook(monkeypatch, capsys, *, response=None, error=None):
+    """Drive hooks.permission.request_via_rpc with a stubbed transport;
+    returns (SystemExit.code, stdout, stderr)."""
+    from puffo_agent.hooks import permission as hook
+
+    def _stub_post(url, headers, payload, timeout=10.0):
+        _stub_post.called = {"url": url, "payload": payload, "timeout": timeout}
+        if error is not None:
+            raise error
+        return response
+
+    _stub_post.called = None
+    monkeypatch.setattr(hook, "_http_post", _stub_post)
+    with pytest.raises(SystemExit) as exc:
+        hook.request_via_rpc("http://127.0.0.1:63385", "agent-1", "Bash", "- x", 60)
+    out = capsys.readouterr()
+    return exc.value.code, out.out, out.err, _stub_post.called
+
+
+def test_hook_rpc_allow_emits_allow_json(monkeypatch, capsys):
+    code, out, _err, called = _run_rpc_hook(
+        monkeypatch, capsys, response={"message": "allow"},
+    )
+    assert code == 0
+    decision = json.loads(out)
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert called["url"].endswith("/v1/rpc/agent-1/permission-request")
+    assert called["payload"]["tool_name"] == "Bash"
+    # Transport padded past the decision window.
+    assert called["timeout"] > 60
+
+
+def test_hook_rpc_deny_exits_2(monkeypatch, capsys):
+    code, _out, err, _ = _run_rpc_hook(
+        monkeypatch, capsys, response={"message": "deny"},
+    )
+    assert code == 2
+    assert "denied" in err
+
+
+def test_hook_rpc_timeout_exits_2(monkeypatch, capsys):
+    code, _out, err, _ = _run_rpc_hook(
+        monkeypatch, capsys, response={"message": "timeout"},
+    )
+    assert code == 2
+    assert "timed out" in err
+
+
+def test_hook_rpc_transport_error_fails_open(monkeypatch, capsys):
+    code, out, err, _ = _run_rpc_hook(
+        monkeypatch, capsys, error=OSError("connection refused"),
+    )
+    assert code == 0
+    assert out == ""  # no allow JSON — claude falls through to native flow
+    assert "fail-open" in err
+
+
+def test_hook_rpc_unexpected_decision_fails_open(monkeypatch, capsys):
+    code, out, _err, _ = _run_rpc_hook(
+        monkeypatch, capsys, response={"message": "maybe"},
+    )
+    assert code == 0
+    assert out == ""
+
+
+def test_hook_main_routes_to_rpc_when_no_legacy_creds(monkeypatch, capsys):
+    from puffo_agent.hooks import permission as hook
+
+    monkeypatch.delenv("PUFFO_URL", raising=False)
+    monkeypatch.delenv("PUFFO_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("PUFFO_RPC_URL", "http://127.0.0.1:63385")
+    monkeypatch.setenv("PUFFO_AGENT_ID", "agent-9")
+    monkeypatch.setenv("PUFFO_PERMISSION_TIMEOUT", "45")
+
+    captured: dict[str, Any] = {}
+
+    def _stub_rpc(rpc_url, agent_id, tool_name, summary, timeout_s):
+        captured.update(
+            rpc_url=rpc_url, agent_id=agent_id, tool_name=tool_name,
+            summary=summary, timeout_s=timeout_s,
+        )
+        raise SystemExit(0)
+
+    monkeypatch.setattr(hook, "request_via_rpc", _stub_rpc)
+    import io
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "ls"}}
+        )),
+    )
+    with pytest.raises(SystemExit):
+        hook.main()
+    assert captured["agent_id"] == "agent-9"
+    assert captured["tool_name"] == "Bash"
+    assert "ls" in captured["summary"]
+    assert captured["timeout_s"] == 45
+
+
+def test_hook_main_fails_open_without_any_transport(monkeypatch, capsys):
+    from puffo_agent.hooks import permission as hook
+
+    for var in ("PUFFO_URL", "PUFFO_BOT_TOKEN", "PUFFO_RPC_URL"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(SystemExit) as exc:
+        hook.main()
+    assert exc.value.code == 0
+    assert "fail-open" in capsys.readouterr().err

--- a/tests/test_command_permission_rpc.py
+++ b/tests/test_command_permission_rpc.py
@@ -121,6 +121,49 @@ async def test_permission_request_400_when_worker_cold(app_client_factory):
     assert "warm" in (await resp.json())["error"]
 
 
+@pytest.mark.asyncio
+async def test_permission_request_end_to_end_over_socket(app_client_factory):
+    """Route → handler → real request_command_permission over a live
+    socket, with the operator's `y` landing while the RPC is held open."""
+    import asyncio
+    import logging
+    from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.operator_slug = "op-1"
+    client._pending_command_permissions = {}
+    client._log = logging.getLogger("rpc-e2e-test")
+    sent: list[dict] = []
+
+    async def _stub_send_dm(slug, text, root_id=""):
+        env_id = f"env_{len(sent) + 1}"
+        sent.append({"to": slug, "text": text, "root_id": root_id, "env_id": env_id})
+        return {"envelope_id": env_id}
+
+    client._send_dm = _stub_send_dm  # type: ignore[assignment]
+    rpc_service.set_rpc_resolver(lambda aid: _stub_ctx(aid, message_client=client))
+    app_client = await app_client_factory()
+
+    async def _reply_when_prompted():
+        while not sent:
+            await asyncio.sleep(0.01)
+        await client._maybe_handle_permission_reply(
+            thread_root_id=sent[0]["env_id"], text="y",
+        )
+
+    replier = asyncio.ensure_future(_reply_when_prompted())
+    resp = await app_client.post(
+        "/v1/rpc/agent-1/permission-request",
+        json={"tool_name": "Bash", "summary": "- command: ls", "timeout_s": 10},
+    )
+    await replier
+    assert resp.status == 200
+    assert (await resp.json()) == {"message": "allow"}
+    assert sent[0]["text"].startswith("/permission ")
+    assert any("Approved" in d["text"] for d in sent)
+
+
 # ─── hook transport (puffo-core branch) ───────────────────────────────
 
 
@@ -221,6 +264,20 @@ def test_hook_main_routes_to_rpc_when_no_legacy_creds(monkeypatch, capsys):
     assert captured["tool_name"] == "Bash"
     assert "ls" in captured["summary"]
     assert captured["timeout_s"] == 45
+
+
+def test_hook_main_rpc_branch_fails_open_on_bad_stdin(monkeypatch, capsys):
+    from puffo_agent.hooks import permission as hook
+
+    monkeypatch.delenv("PUFFO_URL", raising=False)
+    monkeypatch.delenv("PUFFO_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("PUFFO_RPC_URL", "http://127.0.0.1:63385")
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
+    with pytest.raises(SystemExit) as exc:
+        hook.main()
+    assert exc.value.code == 0
+    assert "could not parse hook payload" in capsys.readouterr().err
 
 
 def test_hook_main_fails_open_without_any_transport(monkeypatch, capsys):

--- a/tests/test_invite_reply_routing.py
+++ b/tests/test_invite_reply_routing.py
@@ -272,5 +272,6 @@ def test_invite_prompt_copy_mentions_direct_all_pending():
     )
     with open(src_path, "r", encoding="utf-8") as fh:
         body = fh.read()
-    # both invite_to_space + invite_to_channel branches carry it
-    assert body.count("for all your pending invites") >= 2
+    # Space + channel branches share one format_permission_prompt call,
+    # so the bulk-reply note appears once and covers both.
+    assert "pending invites at once" in body

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -205,6 +205,32 @@ async def test_command_permission_ignores_non_yn_reply():
 
 
 @pytest.mark.asyncio
+async def test_late_reply_in_timeout_window_is_not_confirmed():
+    """Race: wait_for already timed out (future cancelled) but the
+    pending entry isn't popped yet — a `y` landing while the timeout
+    notice is being sent must NOT get an "Approved — running it"
+    confirmation for a tool that never ran."""
+    client = _make_client()
+    orig_send = client._send_dm
+    late: dict = {}
+
+    async def _send_with_interleaved_reply(slug, text, root_id=""):
+        if "Timed out" in text and "handled" not in late:
+            late["handled"] = await client._maybe_handle_permission_reply(
+                thread_root_id=root_id, text="y",
+            )
+        return await orig_send(slug, text, root_id)
+
+    client._send_dm = _send_with_interleaved_reply  # type: ignore[assignment]
+    result = await client.request_command_permission(
+        tool_name="Bash", summary="", timeout_s=0,
+    )
+    assert result == "timeout"
+    assert late["handled"] is False  # falls through to the LLM instead
+    assert not any("Approved" in d["text"] for d in client._sent_dms)
+
+
+@pytest.mark.asyncio
 async def test_command_permission_requires_operator():
     client = _make_client(operator_slug="")
     with pytest.raises(RuntimeError):

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -207,10 +207,8 @@ async def test_command_permission_ignores_non_yn_reply():
 
 @pytest.mark.asyncio
 async def test_late_reply_in_timeout_window_gets_stale_note():
-    """Race: wait_for already timed out but the pending entry isn't
-    popped yet — a `y` landing while the timeout notice is being sent
-    must NOT get an "Approved — running it" confirmation for a tool
-    that never ran; it gets the stale-prompt note instead."""
+    """A `y` racing the timeout-notice send must get the stale note,
+    never "Approved — running it" for a tool that never ran."""
     client = _make_client()
     orig_send = client._send_dm
     late: dict = {}

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -1,0 +1,239 @@
+"""format_permission_prompt + the prompts built through it."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+
+from puffo_agent.agent.permission_prompt import format_permission_prompt
+
+
+def test_basic_prompt_has_prefix_and_instruction():
+    text = format_permission_prompt("Do the thing?")
+    assert text.startswith("/permission Do the thing? ")
+    assert text.endswith("Tap Yes/No, or reply `y`/`n` in this thread.")
+    assert "\n" not in text
+
+
+def test_detail_renders_as_quote_block():
+    text = format_permission_prompt("Run it?", detail="line one\nline two")
+    head, _, tail = text.partition("\n\n")
+    assert head.startswith("/permission Run it?")
+    assert tail == "> line one\n> line two"
+
+
+def test_reply_note_extends_instruction_line():
+    text = format_permission_prompt("Accept?", reply_note="a direct `y` answers all")
+    assert text.endswith(
+        "Tap Yes/No, or reply `y`/`n` in this thread — a direct `y` answers all."
+    )
+
+
+def test_whitespace_only_detail_omitted():
+    text = format_permission_prompt("Go?", detail="   \n  ")
+    assert "\n" not in text
+
+
+# ─── the client prompts route through the helper ──────────────────────
+
+
+def _make_client(*, operator_slug: str = "op-1"):
+    from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client.operator_slug = operator_slug
+    client._pending_invite_dms = {}
+    client._pending_leave_dms = {}
+    client._pending_command_permissions = {}
+    client._gate_left_spaces = set()
+    client._last_dm_sender = ""
+    client._log = logging.getLogger("permission-prompt-test")
+
+    sent_dms: list[dict[str, Any]] = []
+
+    async def _stub_send_dm(slug, text, root_id=""):
+        env_id = f"env_{len(sent_dms) + 1}"
+        sent_dms.append({"to": slug, "text": text, "root_id": root_id, "env_id": env_id})
+        return {"envelope_id": env_id}
+
+    async def _stub_fetch_display_name(slug):
+        return slug.split("-")[0].title()
+
+    async def _resolve_space_name(space_id):
+        return "Team"
+
+    client._send_dm = _stub_send_dm  # type: ignore[assignment]
+    client._fetch_display_name = _stub_fetch_display_name  # type: ignore[assignment]
+    client._resolve_space_name = _resolve_space_name  # type: ignore[assignment]
+    client._sent_dms = sent_dms  # type: ignore[attr-defined]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_invite_prompt_is_permission_card():
+    from puffo_agent.agent.event_kinds import EventKind
+
+    client = _make_client()
+    await client._notify_operator_of_invite(
+        kind=EventKind.INVITE_TO_SPACE,
+        invitation_event_id="evt_1",
+        inviter_slug="mallory-9",
+        space_id="sp_1",
+        space_name="Team",
+        channel_id="",
+        channel_name=None,
+    )
+    dm = client._sent_dms[0]
+    assert dm["to"] == "op-1"
+    assert dm["root_id"] == ""  # card renders on root-level DMs only
+    assert dm["text"].startswith("/permission ")
+    assert "**Team**" in dm["text"]
+    assert "pending invites" in dm["text"]
+    # Prompt registered for the threaded y/n intercept.
+    assert dm["env_id"] in client._pending_invite_dms
+
+
+@pytest.mark.asyncio
+async def test_leave_prompt_is_permission_card_with_reason_quote():
+    client = _make_client()
+    out = await client.request_leave_approval(
+        kind="leave_space", space_id="sp_1", channel_id="", reason="too noisy",
+    )
+    dm = client._sent_dms[0]
+    assert dm["root_id"] == ""
+    assert dm["text"].startswith("/permission ")
+    assert "> Reason: too noisy" in dm["text"]
+    assert dm["env_id"] in client._pending_leave_dms
+    assert "Asked your operator" in out
+
+
+@pytest.mark.asyncio
+async def test_leave_prompt_omits_empty_reason():
+    client = _make_client()
+    await client.request_leave_approval(
+        kind="leave_space", space_id="sp_1", channel_id="", reason="  ",
+    )
+    text = client._sent_dms[0]["text"]
+    assert "Reason:" not in text
+    assert "\n" not in text
+
+
+# ─── cli-local command permission ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_command_permission_allow_roundtrip():
+    client = _make_client()
+    task = asyncio.ensure_future(
+        client.request_command_permission(
+            tool_name="Bash", summary="- command: rm -rf ./build", timeout_s=5,
+        )
+    )
+    await asyncio.sleep(0)  # let the prompt DM go out
+    prompt = client._sent_dms[0]
+    assert prompt["text"].startswith("/permission ")
+    assert "**Bash**" in prompt["text"]
+    assert "> - command: rm -rf ./build" in prompt["text"]
+    assert prompt["root_id"] == ""
+
+    handled = await client._maybe_handle_permission_reply(
+        thread_root_id=prompt["env_id"], text="y",
+    )
+    assert handled is True
+    assert await task == "allow"
+    # In-thread confirmation.
+    confirm = client._sent_dms[1]
+    assert confirm["root_id"] == prompt["env_id"]
+    assert "Approved" in confirm["text"]
+    assert client._pending_command_permissions == {}
+
+
+@pytest.mark.asyncio
+async def test_command_permission_deny():
+    client = _make_client()
+    task = asyncio.ensure_future(
+        client.request_command_permission(
+            tool_name="WebFetch", summary="", timeout_s=5,
+        )
+    )
+    await asyncio.sleep(0)
+    prompt = client._sent_dms[0]
+    assert await client._maybe_handle_permission_reply(
+        thread_root_id=prompt["env_id"], text="No",
+    )
+    assert await task == "deny"
+    assert "Denied" in client._sent_dms[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_command_permission_timeout_notifies_thread():
+    client = _make_client()
+    result = await client.request_command_permission(
+        tool_name="Bash", summary="", timeout_s=0,
+    )
+    assert result == "timeout"
+    prompt, notice = client._sent_dms
+    assert notice["root_id"] == prompt["env_id"]
+    assert "Timed out" in notice["text"]
+    assert client._pending_command_permissions == {}
+
+
+@pytest.mark.asyncio
+async def test_command_permission_ignores_non_yn_reply():
+    client = _make_client()
+    task = asyncio.ensure_future(
+        client.request_command_permission(
+            tool_name="Bash", summary="", timeout_s=5,
+        )
+    )
+    await asyncio.sleep(0)
+    prompt = client._sent_dms[0]
+    handled = await client._maybe_handle_permission_reply(
+        thread_root_id=prompt["env_id"], text="why do you need this?",
+    )
+    assert handled is False
+    assert not task.done()
+    # Then approve so the task finishes cleanly.
+    await client._maybe_handle_permission_reply(
+        thread_root_id=prompt["env_id"], text="yes",
+    )
+    assert await task == "allow"
+
+
+@pytest.mark.asyncio
+async def test_command_permission_requires_operator():
+    client = _make_client(operator_slug="")
+    with pytest.raises(RuntimeError):
+        await client.request_command_permission(
+            tool_name="Bash", summary="", timeout_s=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_permission_raises_when_dm_undeliverable():
+    client = _make_client()
+
+    async def _no_envelope(slug, text, root_id=""):
+        return None  # recipient has no resolvable devices
+
+    client._send_dm = _no_envelope  # type: ignore[assignment]
+    with pytest.raises(RuntimeError):
+        await client.request_command_permission(
+            tool_name="Bash", summary="", timeout_s=5,
+        )
+    assert client._pending_command_permissions == {}
+
+
+@pytest.mark.asyncio
+async def test_unknown_thread_reply_not_consumed():
+    client = _make_client()
+    assert (
+        await client._maybe_handle_permission_reply(
+            thread_root_id="env_nope", text="y",
+        )
+        is False
+    )

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -49,6 +49,7 @@ def _make_client(*, operator_slug: str = "op-1"):
     client._pending_invite_dms = {}
     client._pending_leave_dms = {}
     client._pending_command_permissions = {}
+    client._timed_out_command_permissions = {}
     client._gate_left_spaces = set()
     client._last_dm_sender = ""
     client._log = logging.getLogger("permission-prompt-test")
@@ -205,11 +206,11 @@ async def test_command_permission_ignores_non_yn_reply():
 
 
 @pytest.mark.asyncio
-async def test_late_reply_in_timeout_window_is_not_confirmed():
-    """Race: wait_for already timed out (future cancelled) but the
-    pending entry isn't popped yet — a `y` landing while the timeout
-    notice is being sent must NOT get an "Approved — running it"
-    confirmation for a tool that never ran."""
+async def test_late_reply_in_timeout_window_gets_stale_note():
+    """Race: wait_for already timed out but the pending entry isn't
+    popped yet — a `y` landing while the timeout notice is being sent
+    must NOT get an "Approved — running it" confirmation for a tool
+    that never ran; it gets the stale-prompt note instead."""
     client = _make_client()
     orig_send = client._send_dm
     late: dict = {}
@@ -226,8 +227,47 @@ async def test_late_reply_in_timeout_window_is_not_confirmed():
         tool_name="Bash", summary="", timeout_s=0,
     )
     assert result == "timeout"
-    assert late["handled"] is False  # falls through to the LLM instead
+    assert late["handled"] is True  # consumed — not fed to the LLM
     assert not any("Approved" in d["text"] for d in client._sent_dms)
+    assert any("already timed out" in d["text"] for d in client._sent_dms)
+
+
+@pytest.mark.asyncio
+async def test_late_reply_after_timeout_gets_stale_note():
+    client = _make_client()
+    result = await client.request_command_permission(
+        tool_name="Bash", summary="", timeout_s=0,
+    )
+    assert result == "timeout"
+    prompt_env = client._sent_dms[0]["env_id"]
+    # Minutes later the operator replies in the dead prompt's thread.
+    handled = await client._maybe_handle_permission_reply(
+        thread_root_id=prompt_env, text="y",
+    )
+    assert handled is True
+    note = client._sent_dms[-1]
+    assert note["root_id"] == prompt_env
+    assert "already timed out" in note["text"]
+    # Non-y/n chatter in that thread still falls through to the LLM.
+    assert (
+        await client._maybe_handle_permission_reply(
+            thread_root_id=prompt_env, text="what was this about?",
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_timed_out_registry_is_capped():
+    client = _make_client()
+    for i in range(70):
+        client._timed_out_command_permissions[f"env_old_{i}"] = float(i)
+    await client.request_command_permission(
+        tool_name="Bash", summary="", timeout_s=0,
+    )
+    assert len(client._timed_out_command_permissions) <= 65
+    # Oldest evicted first; the fresh timeout is retained.
+    assert "env_old_0" not in client._timed_out_command_permissions
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Every place the daemon asks the operator for a y/n decision now builds its DM through one shared helper — `agent/permission_prompt.py: format_permission_prompt(intent, detail=, reply_note=)` — so the web/mobile clients render the consistent `/permission` actionable card (Yes/No buttons that post `y`/`n` into the prompt's own thread, which the existing daemon-side intercepts already accept).

### Converted prompts
1. **Space/channel invite** (`_notify_operator_of_invite`) — the two branches now share one construction; the "a direct `y`/`n` answers all pending invites" semantics is noted on the card and unchanged.
2. **Agent-requested leave** (`request_leave_approval`) — reason renders as a quote block.

### New: cli-local command permission over puffo-core
The PreToolUse hook previously supported only the legacy transport (`PUFFO_URL`/`PUFFO_BOT_TOKEN`) and failed open on puffo-core deployments. It now has a daemon transport:

- hook → `POST /v1/rpc/{agent_id}/permission-request` (long-poll, timeout+30s transport pad)
- daemon (`request_command_permission`) sends the operator a `/permission` card and blocks on a future
- a new `handle_envelope` intercept (`_maybe_handle_permission_reply`) resolves the operator's threaded `y`/`n`, confirms the decision in-thread, and the RPC returns `allow` / `deny` / `timeout` for the hook's exit protocol
- legacy transport keeps priority when configured; no transport at all still fails open

Timeouts notify the thread ("I did NOT run …") so a stale card can't be mistaken for a live ask.

## Tests
- `test_permission_prompt.py` (14): helper formatting; invite/leave prompts are root-level `/permission` DMs registered for the intercept; allow/deny/timeout/non-y-n/no-operator/undeliverable paths of the command-permission flow.
- `test_command_permission_rpc.py` (11): RPC route decision passthrough, timeout default+clamp, missing tool_name, cold worker; hook transport allow/deny/timeout/transport-error/unexpected-decision + env routing and no-transport fail-open.
- Full suite: 1947 passed, 11 skipped.

## Notes
- PR #113 (DM gate) builds its `/permission` prompt inline; once this lands it can rebase onto the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)