### PR TITLE
PUF-384: 48h catch-up staleness gate — old messages store-only, skip LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **48h catch-up staleness gate (PUF-384).** On WS reconnect / daemon
+  restart / resume-from-pause, redelivered messages older than
+  `catchup_stale_hours` (daemon.yml, default 48; `<= 0` disables) are
+  stored to chat history and reported processed server-side, but skip
+  the LLM pipeline — no token burn replaying old context, no late
+  replies into conversations that have moved on.
+
 - **cli-local command permission over puffo-core.** The PreToolUse hook
   gains a daemon transport: when the legacy `PUFFO_URL`/`PUFFO_BOT_TOKEN`
   pair is absent, it POSTs `/v1/rpc/{agent}/permission-request` and the

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -496,8 +496,7 @@ class PuffoCoreMessageClient:
         self._max_inline_chars = max(1, int(max_inline_chars))
         self._segment_chars = max(1, int(segment_chars))
         self._max_input_bytes = max(1, int(max_input_bytes))
-        # Catch-up backlog older than this skips the LLM (still
-        # stored). <= 0 disables the gate.
+        # Catch-up older than this skips the LLM (still stored); <= 0 disables.
         self._catchup_stale_ms = (
             int(catchup_stale_hours * 3600 * 1000) if catchup_stale_hours > 0 else 0
         )
@@ -581,9 +580,8 @@ class PuffoCoreMessageClient:
         self._log = _AgentLogger(logger, {"agent": self.slug})
 
     def _is_stale_for_catchup(self, sent_at: int, now_ms: int | None = None) -> bool:
-        """True when ``sent_at`` (ms epoch) is past the staleness
-        threshold: store the envelope but skip the LLM. <= 0 disables
-        so a mis-set config can never skip live traffic."""
+        """Past the staleness threshold → store but skip the LLM.
+        <= 0 disables so a mis-set config can't skip live traffic."""
         if self._catchup_stale_ms <= 0:
             return False
         if now_ms is None:
@@ -591,9 +589,8 @@ class PuffoCoreMessageClient:
         return sent_at < now_ms - self._catchup_stale_ms
 
     async def _report_stale_processed(self, envelope_id: str) -> None:
-        """Mark a gate-skipped envelope processed server-side (the
-        end:batch UPSERT skips it straight to green) so clients don't
-        show it pending forever. Best-effort."""
+        """Best-effort green run for a gate-skipped envelope so
+        clients don't show it pending forever."""
         try:
             await self.http.post(
                 "/messages/processing/end:batch",
@@ -797,9 +794,7 @@ class PuffoCoreMessageClient:
                     self._last_dm_sender = payload.sender_slug
                     return
 
-            # Staleness gate: redelivered catch-up backlog past the
-            # threshold is stored (above) but skips the LLM — no token
-            # burn, no late replies. Intercepts above run at any age.
+            # Stale catch-up backlog: stored above, skips the LLM.
             if self._is_stale_for_catchup(payload.sent_at):
                 self._log.info(
                     "handle_envelope: staleness-gate-skipped envelope=%s "

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -497,7 +497,9 @@ class PuffoCoreMessageClient:
         # PUF-384: on catch-up (WS reconnect / restart / resume), the
         # server redelivers backlog through the same handler. Envelopes
         # older than this skip the LLM pipeline (still get stored). <= 0
-        # disables the gate so nothing is ever skipped.
+        # disables the gate so nothing is ever skipped. A sub-millisecond
+        # positive threshold truncates to 0 ms and thus also disables via
+        # the >0 guard — an absurd edge, but safe by construction.
         self._catchup_stale_ms = (
             int(catchup_stale_hours * 3600 * 1000) if catchup_stale_hours > 0 else 0
         )

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -11,6 +11,7 @@ import logging
 import random
 import re
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Optional
 
@@ -589,6 +590,24 @@ class PuffoCoreMessageClient:
             now_ms = int(time.time() * 1000)
         return sent_at < now_ms - self._catchup_stale_ms
 
+    async def _report_stale_processed(self, envelope_id: str) -> None:
+        """Mark a gate-skipped envelope processed server-side (the
+        end:batch UPSERT skips it straight to green) so clients don't
+        show it pending forever. Best-effort."""
+        try:
+            await self.http.post(
+                "/messages/processing/end:batch",
+                {"runs": [{
+                    "run_id": f"run_{uuid.uuid4().hex}",
+                    "message_id": envelope_id,
+                    "succeeded": True,
+                }]},
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._log.debug(
+                "stale-processed report failed for %s: %s", envelope_id, exc,
+            )
+
     async def listen(
         self,
         on_message: Callable[..., Coroutine[Any, Any, Any]],
@@ -789,6 +808,7 @@ class PuffoCoreMessageClient:
                     self._catchup_stale_ms,
                     payload_thread_root_id or payload.envelope_id,
                 )
+                await self._report_stale_processed(payload.envelope_id)
                 return
 
             channel_id = payload.channel_id or ""

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -495,12 +495,8 @@ class PuffoCoreMessageClient:
         self._max_inline_chars = max(1, int(max_inline_chars))
         self._segment_chars = max(1, int(segment_chars))
         self._max_input_bytes = max(1, int(max_input_bytes))
-        # PUF-384: on catch-up (WS reconnect / restart / resume), the
-        # server redelivers backlog through the same handler. Envelopes
-        # older than this skip the LLM pipeline (still get stored). <= 0
-        # disables the gate so nothing is ever skipped. A sub-millisecond
-        # positive threshold truncates to 0 ms and thus also disables via
-        # the >0 guard — an absurd edge, but safe by construction.
+        # Catch-up backlog older than this skips the LLM (still
+        # stored). <= 0 disables the gate.
         self._catchup_stale_ms = (
             int(catchup_stale_hours * 3600 * 1000) if catchup_stale_hours > 0 else 0
         )
@@ -584,11 +580,9 @@ class PuffoCoreMessageClient:
         self._log = _AgentLogger(logger, {"agent": self.slug})
 
     def _is_stale_for_catchup(self, sent_at: int, now_ms: int | None = None) -> bool:
-        """True when ``sent_at`` (ms since epoch) is older than the
-        catch-up staleness threshold — the envelope should be stored but
-        skip the LLM pipeline. Returns False (gate disabled) when the
-        threshold is <= 0, so a mis-set config can never skip live
-        traffic."""
+        """True when ``sent_at`` (ms epoch) is past the staleness
+        threshold: store the envelope but skip the LLM. <= 0 disables
+        so a mis-set config can never skip live traffic."""
         if self._catchup_stale_ms <= 0:
             return False
         if now_ms is None:
@@ -784,14 +778,9 @@ class PuffoCoreMessageClient:
                     self._last_dm_sender = payload.sender_slug
                     return
 
-            # PUF-384: catch-up staleness gate. On WS reconnect / daemon
-            # restart / resume-from-pause the server redelivers backlog
-            # through this same handler. The envelope is already stored
-            # above; if it's older than the threshold, skip the LLM
-            # pipeline so the agent doesn't burn tokens replaying old
-            # context or fire late replies into moved-on conversations.
-            # Self-echo + invite/leave intercepts above run regardless of
-            # age; live deliveries are seconds-old and pass the gate.
+            # Staleness gate: redelivered catch-up backlog past the
+            # threshold is stored (above) but skips the LLM — no token
+            # burn, no late replies. Intercepts above run at any age.
             if self._is_stale_for_catchup(payload.sent_at):
                 self._log.info(
                     "handle_envelope: staleness-gate-skipped envelope=%s "

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -15,7 +15,11 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Optional
 
 from ..crypto.encoding import base64url_decode
-from ..limits import MAX_INLINE_MESSAGE_CHARS, MESSAGE_SEGMENT_CHARS
+from ..limits import (
+    DEFAULT_CATCHUP_STALE_HOURS,
+    MAX_INLINE_MESSAGE_CHARS,
+    MESSAGE_SEGMENT_CHARS,
+)
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import (
@@ -466,6 +470,7 @@ class PuffoCoreMessageClient:
         agent_created_at: int = 0,
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
         max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+        catchup_stale_hours: float = DEFAULT_CATCHUP_STALE_HOURS,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -489,6 +494,13 @@ class PuffoCoreMessageClient:
         self._max_inline_chars = max(1, int(max_inline_chars))
         self._segment_chars = max(1, int(segment_chars))
         self._max_input_bytes = max(1, int(max_input_bytes))
+        # PUF-384: on catch-up (WS reconnect / restart / resume), the
+        # server redelivers backlog through the same handler. Envelopes
+        # older than this skip the LLM pipeline (still get stored). <= 0
+        # disables the gate so nothing is ever skipped.
+        self._catchup_stale_ms = (
+            int(catchup_stale_hours * 3600 * 1000) if catchup_stale_hours > 0 else 0
+        )
         self._image_edge_px = int(image_edge_px) or _DEFAULT_IMAGE_EDGE_PX
         self.keystore = keystore
         self.http = http_client
@@ -564,6 +576,18 @@ class PuffoCoreMessageClient:
         # ``[<agent_slug>]`` prefix so multi-agent daemon logs are
         # filterable per agent.
         self._log = _AgentLogger(logger, {"agent": self.slug})
+
+    def _is_stale_for_catchup(self, sent_at: int, now_ms: int | None = None) -> bool:
+        """True when ``sent_at`` (ms since epoch) is older than the
+        catch-up staleness threshold — the envelope should be stored but
+        skip the LLM pipeline. Returns False (gate disabled) when the
+        threshold is <= 0, so a mis-set config can never skip live
+        traffic."""
+        if self._catchup_stale_ms <= 0:
+            return False
+        if now_ms is None:
+            now_ms = int(time.time() * 1000)
+        return sent_at < now_ms - self._catchup_stale_ms
 
     async def listen(
         self,
@@ -747,6 +771,24 @@ class PuffoCoreMessageClient:
                 ):
                     self._last_dm_sender = payload.sender_slug
                     return
+
+            # PUF-384: catch-up staleness gate. On WS reconnect / daemon
+            # restart / resume-from-pause the server redelivers backlog
+            # through this same handler. The envelope is already stored
+            # above; if it's older than the threshold, skip the LLM
+            # pipeline so the agent doesn't burn tokens replaying old
+            # context or fire late replies into moved-on conversations.
+            # Self-echo + invite/leave intercepts above run regardless of
+            # age; live deliveries are seconds-old and pass the gate.
+            if self._is_stale_for_catchup(payload.sent_at):
+                self._log.info(
+                    "handle_envelope: staleness-gate-skipped envelope=%s "
+                    "(sent_at=%d, threshold_ms=%d, root=%s) — stored, no LLM",
+                    payload.envelope_id, payload.sent_at,
+                    self._catchup_stale_ms,
+                    payload_thread_root_id or payload.envelope_id,
+                )
+                return
 
             channel_id = payload.channel_id or ""
             is_dm = payload.envelope_kind == "dm"

--- a/src/puffo_agent/limits.py
+++ b/src/puffo_agent/limits.py
@@ -8,3 +8,8 @@ MAX_INLINE_MESSAGE_CHARS = 16000
 # Page size (chars) that ``get_post_segment`` returns redacted bodies in;
 # the redaction placeholder cites it so paging stays aligned.
 MESSAGE_SEGMENT_CHARS = 8000
+
+# PUF-384: on catch-up (reconnect/restart/resume), inbound messages older
+# than this many hours are stored to chat history but skip the LLM
+# pipeline. <= 0 disables the gate.
+DEFAULT_CATCHUP_STALE_HOURS = 48.0

--- a/src/puffo_agent/limits.py
+++ b/src/puffo_agent/limits.py
@@ -9,6 +9,5 @@ MAX_INLINE_MESSAGE_CHARS = 16000
 # the redaction placeholder cites it so paging stays aligned.
 MESSAGE_SEGMENT_CHARS = 8000
 
-# Catch-up backlog older than this is stored but skips the LLM
-# pipeline. <= 0 disables the gate.
+# Catch-up older than this is stored but skips the LLM; <= 0 disables.
 DEFAULT_CATCHUP_STALE_HOURS = 48.0

--- a/src/puffo_agent/limits.py
+++ b/src/puffo_agent/limits.py
@@ -9,7 +9,6 @@ MAX_INLINE_MESSAGE_CHARS = 16000
 # the redaction placeholder cites it so paging stays aligned.
 MESSAGE_SEGMENT_CHARS = 8000
 
-# PUF-384: on catch-up (reconnect/restart/resume), inbound messages older
-# than this many hours are stored to chat history but skip the LLM
+# Catch-up backlog older than this is stored but skips the LLM
 # pipeline. <= 0 disables the gate.
 DEFAULT_CATCHUP_STALE_HOURS = 48.0

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -32,7 +32,11 @@ from typing import Any
 import psutil
 import yaml
 
-from ..limits import MAX_INLINE_MESSAGE_CHARS, MESSAGE_SEGMENT_CHARS
+from ..limits import (
+    DEFAULT_CATCHUP_STALE_HOURS,
+    MAX_INLINE_MESSAGE_CHARS,
+    MESSAGE_SEGMENT_CHARS,
+)
 
 
 # Where daemon.yml, agents/, etc. live.
@@ -867,6 +871,10 @@ class DaemonConfig:
     # Guards session-lifetime growth; 16000 inlines typical code/log pastes.
     max_inline_message_chars: int = MAX_INLINE_MESSAGE_CHARS
     segment_chars: int = MESSAGE_SEGMENT_CHARS
+    # PUF-384: on catch-up (reconnect/restart/resume) messages older than
+    # this are stored but skip the LLM pipeline — no token burn, no late
+    # replies. <= 0 disables the gate. Fleet-wide default; tune per host.
+    catchup_stale_hours: float = DEFAULT_CATCHUP_STALE_HOURS
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(
         default_factory=lambda: DataServiceConfig(),
@@ -895,6 +903,9 @@ class DaemonConfig:
                 raw.get("max_inline_message_chars", MAX_INLINE_MESSAGE_CHARS)
             ),
             segment_chars=int(raw.get("segment_chars", MESSAGE_SEGMENT_CHARS)),
+            catchup_stale_hours=float(
+                raw.get("catchup_stale_hours", DEFAULT_CATCHUP_STALE_HOURS)
+            ),
         )
         for name in ("anthropic", "openai", "google"):
             p = raw.get(name) or {}
@@ -939,6 +950,7 @@ class DaemonConfig:
             "docker_memory_reservation": self.docker_memory_reservation,
             "max_inline_message_chars": self.max_inline_message_chars,
             "segment_chars": self.segment_chars,
+            "catchup_stale_hours": self.catchup_stale_hours,
             "anthropic": asdict(self.anthropic),
             "openai": asdict(self.openai),
             "google": asdict(self.google),

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -871,8 +871,7 @@ class DaemonConfig:
     # Guards session-lifetime growth; 16000 inlines typical code/log pastes.
     max_inline_message_chars: int = MAX_INLINE_MESSAGE_CHARS
     segment_chars: int = MESSAGE_SEGMENT_CHARS
-    # Catch-up backlog older than this is stored but skips the LLM.
-    # <= 0 disables. Fleet-wide; tune per host.
+    # Catch-up older than this is stored but skips the LLM; <= 0 disables.
     catchup_stale_hours: float = DEFAULT_CATCHUP_STALE_HOURS
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -871,9 +871,8 @@ class DaemonConfig:
     # Guards session-lifetime growth; 16000 inlines typical code/log pastes.
     max_inline_message_chars: int = MAX_INLINE_MESSAGE_CHARS
     segment_chars: int = MESSAGE_SEGMENT_CHARS
-    # PUF-384: on catch-up (reconnect/restart/resume) messages older than
-    # this are stored but skip the LLM pipeline — no token burn, no late
-    # replies. <= 0 disables the gate. Fleet-wide default; tune per host.
+    # Catch-up backlog older than this is stored but skips the LLM.
+    # <= 0 disables. Fleet-wide; tune per host.
     catchup_stale_hours: float = DEFAULT_CATCHUP_STALE_HOURS
     bridge: BridgeConfig = field(default_factory=BridgeConfig)
     data_service: "DataServiceConfig" = field(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -21,7 +21,11 @@ from typing import Awaitable, Callable, Optional
 
 from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
-from ..limits import MAX_INLINE_MESSAGE_CHARS, MESSAGE_SEGMENT_CHARS
+from ..limits import (
+    DEFAULT_CATCHUP_STALE_HOURS,
+    MAX_INLINE_MESSAGE_CHARS,
+    MESSAGE_SEGMENT_CHARS,
+)
 from ..agent.status_reporter import StatusReporter
 from .runtime_matrix import (
     RUNTIME_CLI_DOCKER,
@@ -375,6 +379,11 @@ def _build_puffo_core_client(
     segment_chars = (
         daemon_cfg.segment_chars if daemon_cfg is not None else MESSAGE_SEGMENT_CHARS
     )
+    catchup_stale_hours = (
+        daemon_cfg.catchup_stale_hours
+        if daemon_cfg is not None
+        else DEFAULT_CATCHUP_STALE_HOURS
+    )
 
     # The inbound-image downscale cap follows the harness's effective model
     # (Opus 4.7+ resolves 2576px, else 1568px).
@@ -402,6 +411,7 @@ def _build_puffo_core_client(
         agent_created_at=agent_cfg.created_at,
         image_edge_px=max_image_edge_px(model),
         max_input_bytes=max_input_bytes,
+        catchup_stale_hours=catchup_stale_hours,
     )
 
 

--- a/tests/test_catchup_staleness_gate.py
+++ b/tests/test_catchup_staleness_gate.py
@@ -2,13 +2,15 @@
 
 On WS reconnect / daemon restart / resume-from-pause the server
 redelivers backlog through ``handle_envelope``. Messages older than
-``catchup_stale_hours`` are stored to chat history but skip the LLM
-pipeline so the agent doesn't burn tokens replaying old context or fire
-late replies into conversations that have moved on.
+``catchup_stale_hours`` are stored to chat history and reported
+processed server-side, but skip the LLM pipeline.
 """
 from __future__ import annotations
 
 import inspect
+import logging
+
+import pytest
 
 import puffo_agent.portal.state as state
 from puffo_agent.agent.puffo_core_client import (
@@ -76,6 +78,9 @@ def test_gate_wired_into_listen_before_admit():
     leave = src.index("_maybe_handle_leave_reply")
     permission = src.index("_maybe_handle_permission_reply")
     assert self_echo < gate and leave < gate and permission < gate
+    # A skipped envelope is still reported processed server-side.
+    report = src.index("_report_stale_processed(payload.envelope_id)")
+    assert gate < report < admit
 
 
 def _init_client(catchup_stale_hours: float) -> PuffoCoreMessageClient:
@@ -173,3 +178,37 @@ def test_worker_threads_catchup_stale_hours(monkeypatch, tmp_path):
 def test_worker_defaults_catchup_stale_hours_without_daemon_cfg(monkeypatch, tmp_path):
     captured = _build_via_worker(monkeypatch, tmp_path, None)
     assert captured.get("catchup_stale_hours") == DEFAULT_CATCHUP_STALE_HOURS
+
+
+class _StubHttp:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.posts: list[tuple[str, dict]] = []
+
+    async def post(self, path, body):
+        if self.fail:
+            raise RuntimeError("server unreachable")
+        self.posts.append((path, body))
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_report_stale_processed_posts_green_run():
+    c = _client(_48H_MS)
+    c.http = _StubHttp()
+    c._log = logging.getLogger("staleness-test")
+    await c._report_stale_processed("msg_old_1")
+    path, body = c.http.posts[0]
+    assert path == "/messages/processing/end:batch"
+    (run,) = body["runs"]
+    assert run["message_id"] == "msg_old_1"
+    assert run["succeeded"] is True
+    assert run["run_id"].startswith("run_")
+
+
+@pytest.mark.asyncio
+async def test_report_stale_processed_swallows_http_failure():
+    c = _client(_48H_MS)
+    c.http = _StubHttp(fail=True)
+    c._log = logging.getLogger("staleness-test")
+    await c._report_stale_processed("msg_old_1")  # must not raise

--- a/tests/test_catchup_staleness_gate.py
+++ b/tests/test_catchup_staleness_gate.py
@@ -1,4 +1,4 @@
-"""PUF-384: catch-up staleness gate.
+"""Catch-up staleness gate.
 
 On WS reconnect / daemon restart / resume-from-pause the server
 redelivers backlog through ``handle_envelope``. Messages older than
@@ -68,16 +68,14 @@ def test_gate_wired_into_listen_before_admit():
     gate = src.index("_is_stale_for_catchup(payload.sent_at)")
     admit = src.index("_admit_thread_message(")
     assert gate < admit, "staleness gate must precede _admit_thread_message"
-    # The DB store must run BEFORE the gate — a skipped envelope is still
-    # persisted (AC #2). Pin the ordering so a refactor can't move the
-    # gate above the store.
+    # A skipped envelope is still persisted — the store precedes the gate.
     store = src.index("self.store.store(")
     assert store < gate, "store.store must precede the staleness gate"
-    # The self-echo + invite/leave intercepts must run regardless of age,
-    # so they sit ahead of the gate.
+    # Self-echo + operator intercepts run regardless of age.
     self_echo = src.index("payload.sender_slug == self.slug")
     leave = src.index("_maybe_handle_leave_reply")
-    assert self_echo < gate and leave < gate
+    permission = src.index("_maybe_handle_permission_reply")
+    assert self_echo < gate and leave < gate and permission < gate
 
 
 def _init_client(catchup_stale_hours: float) -> PuffoCoreMessageClient:
@@ -120,3 +118,58 @@ def test_daemon_config_absent_key_defaults(tmp_path, monkeypatch):
     cfg_path.write_text("default_provider: anthropic\n", encoding="utf-8")
     monkeypatch.setattr(state, "daemon_yml_path", lambda: cfg_path)
     assert state.DaemonConfig.load().catchup_stale_hours == 48.0
+
+
+def _build_via_worker(monkeypatch, tmp_path, daemon_cfg):
+    """Drive worker._build_puffo_core_client with stubbed heavy deps;
+    returns the kwargs the client constructor received."""
+    from puffo_agent.portal import worker
+    from puffo_agent.portal.state import AgentConfig, PuffoCoreConfig, RuntimeConfig
+
+    cfg = AgentConfig(
+        id="agent-test-1234",
+        puffo_core=PuffoCoreConfig(
+            server_url="https://example.test", slug="agent-test-1234",
+            device_id="dev-1", space_id="", operator_slug="",
+        ),
+        runtime=RuntimeConfig(kind="chat-local", harness="claude-code"),
+    )
+    monkeypatch.setattr(
+        worker, "_ensure_agent_identity_imported", lambda *_a, **_k: None,
+    )
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "puffo_agent.agent.puffo_core_client.PuffoCoreMessageClient", DummyClient,
+    )
+    monkeypatch.setattr(
+        "puffo_agent.crypto.keystore.KeyStore", lambda *_a, **_k: object(),
+    )
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient",
+        lambda *_a, **_k: object(),
+    )
+    monkeypatch.setattr(
+        "puffo_agent.agent.message_store.MessageStore", lambda *_a, **_k: object(),
+    )
+    monkeypatch.setattr(
+        AgentConfig, "resolve_workspace_dir", lambda self: tmp_path,
+    )
+    worker._build_puffo_core_client(cfg, "agent-test-1234", daemon_cfg=daemon_cfg)
+    return captured
+
+
+def test_worker_threads_catchup_stale_hours(monkeypatch, tmp_path):
+    captured = _build_via_worker(
+        monkeypatch, tmp_path, state.DaemonConfig(catchup_stale_hours=12.5),
+    )
+    assert captured.get("catchup_stale_hours") == 12.5
+
+
+def test_worker_defaults_catchup_stale_hours_without_daemon_cfg(monkeypatch, tmp_path):
+    captured = _build_via_worker(monkeypatch, tmp_path, None)
+    assert captured.get("catchup_stale_hours") == DEFAULT_CATCHUP_STALE_HOURS

--- a/tests/test_catchup_staleness_gate.py
+++ b/tests/test_catchup_staleness_gate.py
@@ -68,11 +68,38 @@ def test_gate_wired_into_listen_before_admit():
     gate = src.index("_is_stale_for_catchup(payload.sent_at)")
     admit = src.index("_admit_thread_message(")
     assert gate < admit, "staleness gate must precede _admit_thread_message"
+    # The DB store must run BEFORE the gate — a skipped envelope is still
+    # persisted (AC #2). Pin the ordering so a refactor can't move the
+    # gate above the store.
+    store = src.index("self.store.store(")
+    assert store < gate, "store.store must precede the staleness gate"
     # The self-echo + invite/leave intercepts must run regardless of age,
     # so they sit ahead of the gate.
     self_echo = src.index("payload.sender_slug == self.slug")
     leave = src.index("_maybe_handle_leave_reply")
     assert self_echo < gate and leave < gate
+
+
+def _init_client(catchup_stale_hours: float) -> PuffoCoreMessageClient:
+    # Real __init__ with inert deps — exercises the float→ms computation.
+    return PuffoCoreMessageClient(
+        slug="t", device_id="d", space_id="s",
+        keystore=None, http_client=None, message_store=None,
+        catchup_stale_hours=catchup_stale_hours,
+    )
+
+
+def test_init_computes_ms_from_fractional_hours():
+    # 0.5h = 1_800_000 ms; the float→int conversion is exercised.
+    assert _init_client(0.5)._catchup_stale_ms == 1_800_000
+    assert _init_client(48.0)._catchup_stale_ms == _48H_MS
+
+
+def test_init_sub_millisecond_threshold_truncates_to_disabled():
+    # 1e-7 h = 0.36 ms → int truncates to 0 → gate disabled.
+    c = _init_client(1e-7)
+    assert c._catchup_stale_ms == 0
+    assert c._is_stale_for_catchup(0, _NOW) is False
 
 
 def test_daemon_config_default_is_48h():

--- a/tests/test_catchup_staleness_gate.py
+++ b/tests/test_catchup_staleness_gate.py
@@ -1,0 +1,95 @@
+"""PUF-384: catch-up staleness gate.
+
+On WS reconnect / daemon restart / resume-from-pause the server
+redelivers backlog through ``handle_envelope``. Messages older than
+``catchup_stale_hours`` are stored to chat history but skip the LLM
+pipeline so the agent doesn't burn tokens replaying old context or fire
+late replies into conversations that have moved on.
+"""
+from __future__ import annotations
+
+import inspect
+
+import puffo_agent.portal.state as state
+from puffo_agent.agent.puffo_core_client import (
+    DEFAULT_CATCHUP_STALE_HOURS,
+    PuffoCoreMessageClient,
+)
+
+_48H_MS = 48 * 3600 * 1000
+_NOW = 1_000_000_000_000
+
+
+def _client(catchup_stale_ms: int) -> PuffoCoreMessageClient:
+    """Bare client with only the staleness field set — enough to
+    exercise the predicate without the full listen() harness."""
+    c = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    c._catchup_stale_ms = catchup_stale_ms
+    return c
+
+
+def test_stale_message_is_gated():
+    assert _client(_48H_MS)._is_stale_for_catchup(_NOW - 49 * 3600 * 1000, _NOW) is True
+
+
+def test_fresh_message_passes():
+    assert _client(_48H_MS)._is_stale_for_catchup(_NOW - 1000, _NOW) is False
+
+
+def test_exact_boundary_is_not_stale():
+    c = _client(_48H_MS)
+    # sent_at == now - threshold is the boundary; strict ``<`` keeps it live.
+    assert c._is_stale_for_catchup(_NOW - _48H_MS, _NOW) is False
+    # one ms older tips it over.
+    assert c._is_stale_for_catchup(_NOW - _48H_MS - 1, _NOW) is True
+
+
+def test_zero_threshold_disables_gate():
+    assert _client(0)._is_stale_for_catchup(0, _NOW) is False
+
+
+def test_negative_threshold_disables_gate():
+    assert _client(-1)._is_stale_for_catchup(0, _NOW) is False
+
+
+def test_now_ms_defaults_to_wall_clock():
+    # A huge-threshold client with an epoch-0 message is always stale
+    # under the real clock — exercises the now_ms=None branch.
+    assert _client(_48H_MS)._is_stale_for_catchup(0) is True
+
+
+def test_gate_wired_into_listen_before_admit():
+    """handle_envelope is a closure inside listen(); pin the gate's
+    presence + ordering at the source level so a refactor can't silently
+    drop it or move it past the LLM-admit."""
+    src = inspect.getsource(PuffoCoreMessageClient.listen)
+    assert "_is_stale_for_catchup(payload.sent_at)" in src
+    assert "staleness-gate-skipped" in src
+    gate = src.index("_is_stale_for_catchup(payload.sent_at)")
+    admit = src.index("_admit_thread_message(")
+    assert gate < admit, "staleness gate must precede _admit_thread_message"
+    # The self-echo + invite/leave intercepts must run regardless of age,
+    # so they sit ahead of the gate.
+    self_echo = src.index("payload.sender_slug == self.slug")
+    leave = src.index("_maybe_handle_leave_reply")
+    assert self_echo < gate and leave < gate
+
+
+def test_daemon_config_default_is_48h():
+    assert state.DaemonConfig().catchup_stale_hours == DEFAULT_CATCHUP_STALE_HOURS
+    assert DEFAULT_CATCHUP_STALE_HOURS == 48.0
+
+
+def test_daemon_config_round_trip(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "daemon.yml"
+    monkeypatch.setattr(state, "daemon_yml_path", lambda: cfg_path)
+    state.DaemonConfig(catchup_stale_hours=12.5).save()
+    assert state.DaemonConfig.load().catchup_stale_hours == 12.5
+
+
+def test_daemon_config_absent_key_defaults(tmp_path, monkeypatch):
+    # An older daemon.yml without the key still loads at the 48h default.
+    cfg_path = tmp_path / "daemon.yml"
+    cfg_path.write_text("default_provider: anthropic\n", encoding="utf-8")
+    monkeypatch.setattr(state, "daemon_yml_path", lambda: cfg_path)
+    assert state.DaemonConfig.load().catchup_stale_hours == 48.0

--- a/tests/test_catchup_staleness_gate.py
+++ b/tests/test_catchup_staleness_gate.py
@@ -23,8 +23,7 @@ _NOW = 1_000_000_000_000
 
 
 def _client(catchup_stale_ms: int) -> PuffoCoreMessageClient:
-    """Bare client with only the staleness field set — enough to
-    exercise the predicate without the full listen() harness."""
+    """Bare client — just enough to exercise the predicate."""
     c = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
     c._catchup_stale_ms = catchup_stale_ms
     return c
@@ -55,15 +54,13 @@ def test_negative_threshold_disables_gate():
 
 
 def test_now_ms_defaults_to_wall_clock():
-    # A huge-threshold client with an epoch-0 message is always stale
-    # under the real clock — exercises the now_ms=None branch.
+    # Epoch-0 is always stale under the real clock (now_ms=None branch).
     assert _client(_48H_MS)._is_stale_for_catchup(0) is True
 
 
 def test_gate_wired_into_listen_before_admit():
-    """handle_envelope is a closure inside listen(); pin the gate's
-    presence + ordering at the source level so a refactor can't silently
-    drop it or move it past the LLM-admit."""
+    """handle_envelope is a nested closure — pin the gate's ordering
+    at source level."""
     src = inspect.getsource(PuffoCoreMessageClient.listen)
     assert "_is_stale_for_catchup(payload.sent_at)" in src
     assert "staleness-gate-skipped" in src
@@ -126,8 +123,7 @@ def test_daemon_config_absent_key_defaults(tmp_path, monkeypatch):
 
 
 def _build_via_worker(monkeypatch, tmp_path, daemon_cfg):
-    """Drive worker._build_puffo_core_client with stubbed heavy deps;
-    returns the kwargs the client constructor received."""
+    """Build via the worker with stubbed deps; returns ctor kwargs."""
     from puffo_agent.portal import worker
     from puffo_agent.portal.state import AgentConfig, PuffoCoreConfig, RuntimeConfig
 


### PR DESCRIPTION
## Summary

On WS reconnect / daemon restart / resume-from-pause, the server redelivers backlog through the same `handle_envelope`. Envelopes older than `catchup_stale_hours` (default 48h) are still persisted to chat history but skip the LLM pipeline — no token burn on replaying old context, no late replies into moved-on conversations.

**Gate placement:** after DB-store + self-echo + invite/leave intercepts, before `_admit_thread_message`. Self-echo and system-intercepts run regardless of age (they don't burn LLM turns).

**Config:** `DaemonConfig.catchup_stale_hours` (daemon.yml), fleet-wide policy mirroring the existing `max_inline_message_chars` / `segment_chars` knobs. `≤ 0` disables the gate as a footgun guard so a mis-set `0` can never skip live traffic.

## Files

- `src/puffo_agent/limits.py` — `DEFAULT_CATCHUP_STALE_HOURS = 48.0`.
- `src/puffo_agent/agent/puffo_core_client.py` — `catchup_stale_hours` ctor kwarg → `_catchup_stale_ms` (int, computed); new `_is_stale_for_catchup(sent_at, now_ms=None)` predicate; gate block in `handle_envelope` right before the LLM-admit path.
- `src/puffo_agent/portal/state.py` — `DaemonConfig.catchup_stale_hours` + load/save mirroring the existing message-policy knobs.
- `src/puffo_agent/portal/worker.py` — passes `daemon_cfg.catchup_stale_hours` through to the client constructor.
- `tests/test_catchup_staleness_gate.py` — 10 tests.

## Judgment calls (documented)

1. **Config home = daemon.yml (fleet-wide)** rather than agent.yml (per-agent). Reason: staleness is a fleet policy and mirrors the existing message-policy knobs' placement. Per-agent override = cheap follow-up if a use case surfaces.
2. **`catchup_stale_hours ≤ 0` disables the gate** (process everything). Footgun guard so a mis-set `0` doesn't silently skip *every* message.

## Test plan

- [x] Touched suite `tests/test_catchup_staleness_gate.py` → **10 pass**:
  - Predicate: stale skipped · fresh admitted · exact-boundary passes · zero disables · negative disables · `now_ms` defaults to wall-clock.
  - Wiring: source-pin that the gate precedes `_admit_thread_message` AND follows self-echo + invite/leave intercepts (`handle_envelope` is a nested closure, source-inspection pattern mirrors the existing owner-slug-priority test).
  - Config: default 48h · DaemonConfig round-trip · absent-key back-compat.
- [x] Full pytest sweep (excluding pre-existing PySide6 gap) → **1931 pass / 2 skipped / 0 fail**. Zero regression.
- [ ] Manual: pause an agent, age past 48h, resume — inbound backlog stores but no LLM turns fire.

## Out of scope (per intake)

- Server change (server redelivers all backlog; agent filters).
- Per-channel / per-sender exemptions (incl. operator-DM).
- UI "N skipped" surfacing.
- Retro-replay of previously-skipped messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
