### PR TITLE
docs: changelog for unified /permission prompts (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **cli-local command permission over puffo-core.** The PreToolUse hook
+  gains a daemon transport: when the legacy `PUFFO_URL`/`PUFFO_BOT_TOKEN`
+  pair is absent, it POSTs `/v1/rpc/{agent}/permission-request` and the
+  daemon DMs the operator a `/permission` card, resolves their threaded
+  `y`/`n`, and returns allow/deny/timeout for the hook's exit protocol.
+  A late reply to a timed-out request gets an "already timed out — I did
+  NOT run it" note instead of a false confirmation.
+
+- **Operator report on auto-accepted channel invites.** Space-owner
+  channel invites are server-auto-accepted with no approval ask; the
+  agent now DMs the operator an informational report (inviter, channel,
+  space) instead of joining silently.
+
+### Changed
+
+- **Every operator y/n ask now renders as a `/permission` card.** Space
+  and channel invite prompts and agent-requested leave approvals build
+  their DM through one shared constructor, so web/mobile clients show
+  consistent Yes/No buttons that post `y`/`n` into the prompt's thread —
+  the same replies the daemon already accepts.
+
 ## [1.1.2] — 2026-07-14
 
 ### Added


### PR DESCRIPTION
Adds the #178 feature set to the Unreleased changelog section (missed before merge): the shared /permission prompt constructor for invite/leave asks, the cli-local command-permission daemon transport with the stale-reply note, and the auto-accepted channel-invite operator report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)