### PR TITLE
feat(receive): accept plaintext (non-E2EE) messages + surface is_encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Receive plaintext (non-E2EE) messages.** The daemon now accepts the
+  `plaintext_message_envelope` format: the signed body is verified in the
+  clear (no HPKE/AEAD, the payload's own `sender_slug` is authoritative)
+  and routed through the same store/dispatch sink as E2EE. Receive-only —
+  sending stays E2EE. Pairs with the core + puffo-server plaintext work.
+
+- **`is_encrypted` on every message.** Everything the agent sees — the
+  live inbound metadata block and the `get_post` / `get_channel_history` /
+  `get_dm_history` / `get_thread_history` tools — now shows whether a
+  message was end-to-end encrypted or sent in the clear. Stored per
+  message (a SQLite migration backfills pre-existing rows as encrypted).
+
 ## [1.1.3] — 2026-07-17
 
 ### Added

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -478,8 +478,7 @@ class PuffoAgent:
         thread_root = root_id or post_id
         if thread_root:
             lines.append(f"- thread_root_id: {thread_root}")
-        # Always present: was this message end-to-end encrypted or sent in the
-        # clear (plaintext). Legacy/system messages read as encrypted.
+        # Legacy/system messages read as encrypted.
         lines.append(f"- is_encrypted: {str(is_encrypted).lower()}")
         ts_iso = _ms_to_iso(create_at)
         if ts_iso:

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -183,6 +183,7 @@ class PuffoAgent:
                 is_visible_to_human=msg.get("is_visible_to_human", True),
                 sender_owner_slug=msg.get("sender_owner_slug", ""),
                 is_from_operator=msg.get("is_from_operator", False),
+                is_encrypted=msg.get("is_encrypted", True),
             )
             for msg in batch
         ]
@@ -245,6 +246,7 @@ class PuffoAgent:
                 sender_display_name=msg.get("sender_display_name", ""),
                 sender_owner_slug=msg.get("sender_owner_slug", ""),
                 is_from_operator=msg.get("is_from_operator", False),
+                is_encrypted=msg.get("is_encrypted", True),
             ))
         fallback_text = "\n\n".join(fallback_chunks)
 
@@ -410,6 +412,7 @@ class PuffoAgent:
         is_visible_to_human: bool = True,
         sender_owner_slug: str = "",
         is_from_operator: bool = False,
+        is_encrypted: bool = True,
     ):
         content = self._format_user_block(
             channel_name=channel_name,
@@ -429,6 +432,7 @@ class PuffoAgent:
             is_visible_to_human=is_visible_to_human,
             sender_owner_slug=sender_owner_slug,
             is_from_operator=is_from_operator,
+            is_encrypted=is_encrypted,
         )
         self.log.append({"role": "user", "content": content})
         self._truncate_log()
@@ -453,12 +457,15 @@ class PuffoAgent:
         is_visible_to_human: bool = True,
         sender_owner_slug: str = "",
         is_from_operator: bool = False,
+        is_encrypted: bool = True,
     ) -> str:
         # Structured markdown block keeps context metadata distinct
         # from message content, preventing the LLM from echoing
         # "[#channel] @user:" style prefixes back into replies. Format
         # is documented to the model in DEFAULT_SHARED_CLAUDE_MD.
         lines: list[str] = []
+        if post_id:
+            lines.append(f"- post_id: {post_id}")
         if space_name:
             lines.append("- space: " + space_name)
         if space_id:
@@ -466,13 +473,14 @@ class PuffoAgent:
         lines.append("- channel: " + (channel_name or channel_id))
         if channel_id:
             lines.append(f"- channel_id: {channel_id}")
-        if post_id:
-            lines.append(f"- post_id: {post_id}")
         # thread_root_id is the root post id to pass as send_message's
         # root_id. For a top-level post the root is the post itself.
         thread_root = root_id or post_id
         if thread_root:
             lines.append(f"- thread_root_id: {thread_root}")
+        # Always present: was this message end-to-end encrypted or sent in the
+        # clear (plaintext). Legacy/system messages read as encrypted.
+        lines.append(f"- is_encrypted: {str(is_encrypted).lower()}")
         ts_iso = _ms_to_iso(create_at)
         if ts_iso:
             lines.append(f"- timestamp: {ts_iso}")

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS messages (
     sent_at INTEGER NOT NULL,
     received_at INTEGER NOT NULL,
     thread_root_id TEXT,
-    reply_to_id TEXT
+    reply_to_id TEXT,
+    is_encrypted INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_channel
@@ -103,6 +104,8 @@ class StoredMessage:
     received_at: int
     thread_root_id: Optional[str] = None
     reply_to_id: Optional[str] = None
+    # False only for a plaintext (non-E2EE) message; absent/legacy rows are True.
+    is_encrypted: bool = True
 
 
 @dataclass
@@ -140,6 +143,15 @@ class MessageStore:
             "PRAGMA mmap_size=268435456;"
         )
         await self._db.executescript(_SCHEMA)
+        # Backfill is_encrypted on a pre-existing DB — every message stored
+        # before this column existed was E2EE, so default to 1 (encrypted).
+        cur = await self._db.execute("PRAGMA table_info(messages)")
+        cols = {row[1] for row in await cur.fetchall()}
+        if "is_encrypted" not in cols:
+            await self._db.execute(
+                "ALTER TABLE messages ADD COLUMN is_encrypted INTEGER NOT NULL DEFAULT 1"
+            )
+            await self._db.commit()
 
     async def close(self) -> None:
         if self._db:
@@ -166,6 +178,7 @@ class MessageStore:
             sent_at = payload.get("sent_at", _now_ms())
             thread_root_id = payload.get("thread_root_id")
             reply_to_id = payload.get("reply_to_id")
+            is_encrypted = payload.get("is_encrypted", True)
         else:
             envelope_id = payload.envelope_id
             envelope_kind = payload.envelope_kind
@@ -178,6 +191,7 @@ class MessageStore:
             sent_at = payload.sent_at
             thread_root_id = getattr(payload, "thread_root_id", None)
             reply_to_id = getattr(payload, "reply_to_id", None)
+            is_encrypted = getattr(payload, "is_encrypted", True)
 
         content_str = json.dumps(content) if not isinstance(content, str) else content
         if received_at is None:
@@ -187,12 +201,12 @@ class MessageStore:
             """INSERT OR IGNORE INTO messages
             (envelope_id, envelope_kind, sender_slug, channel_id, space_id,
              recipient_slug, content_type, content, sent_at, received_at,
-             thread_root_id, reply_to_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+             thread_root_id, reply_to_id, is_encrypted)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 envelope_id, envelope_kind, sender_slug, channel_id, space_id,
                 recipient_slug, content_type, content_str, sent_at, received_at,
-                thread_root_id, reply_to_id,
+                thread_root_id, reply_to_id, 1 if is_encrypted else 0,
             ),
         )
         await db.commit()
@@ -634,4 +648,5 @@ class MessageStore:
             received_at=row["received_at"],
             thread_root_id=row["thread_root_id"],
             reply_to_id=row["reply_to_id"],
+            is_encrypted=bool(row["is_encrypted"]),
         )

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -143,8 +143,7 @@ class MessageStore:
             "PRAGMA mmap_size=268435456;"
         )
         await self._db.executescript(_SCHEMA)
-        # Backfill is_encrypted on a pre-existing DB — every message stored
-        # before this column existed was E2EE, so default to 1 (encrypted).
+        # Pre-existing DBs: everything before this column was E2EE → default 1.
         cur = await self._db.execute("PRAGMA table_info(messages)")
         cols = {row[1] for row in await cur.fetchall()}
         if "is_encrypted" not in cols:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -28,6 +28,7 @@ from ..crypto.message import (
     RecipientDevice,
     decrypt_message,
     encrypt_message,
+    read_plaintext_message,
 )
 from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
 from ..crypto.ws_client import PuffoCoreWsClient
@@ -671,7 +672,18 @@ class PuffoCoreMessageClient:
             # every other message goes through; the dispatch-to-
             # worker step below short-circuits on ``sender_slug ==
             # self.slug`` to prevent a retrigger loop.
-            sender_slug = envelope.get("sender_slug", "")
+            # Plaintext envelopes carry no outer routing — the sender is
+            # named inside the signed payload; verify in the clear (no decrypt).
+            is_plaintext = envelope.get("type") == "plaintext_message_envelope"
+            if is_plaintext:
+                sender_slug = (
+                    envelope.get("signed_payload", {})
+                    .get("payload", {})
+                    .get("sender_slug", "")
+                )
+            else:
+                sender_slug = envelope.get("sender_slug", "")
+
             try:
                 sender_pks = await self._key_cache.get_signing_keys(sender_slug)
             except Exception as e:
@@ -681,15 +693,18 @@ class PuffoCoreMessageClient:
                 )
                 return
 
-            # Try each pubkey until one decrypts. On total failure,
+            def _open(pk: bytes) -> MessagePayload:
+                if is_plaintext:
+                    return read_plaintext_message(envelope, pk)
+                return decrypt_message(envelope, self.device_id, kem_kp, pk)
+
+            # Try each pubkey until one verifies. On total failure,
             # invalidate + retry once with a fresh pull to handle
             # subkey rotation since the cache was populated.
             payload = None
             for pk in sender_pks:
                 try:
-                    payload = decrypt_message(
-                        envelope, self.device_id, kem_kp, pk,
-                    )
+                    payload = _open(pk)
                     break
                 except Exception:
                     continue
@@ -700,9 +715,7 @@ class PuffoCoreMessageClient:
                     sender_pks = await self._key_cache.get_signing_keys(sender_slug)
                     for pk in sender_pks:
                         try:
-                            payload = decrypt_message(
-                                envelope, self.device_id, kem_kp, pk,
-                            )
+                            payload = _open(pk)
                             break
                         except Exception:
                             continue

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -755,6 +755,7 @@ class PuffoCoreMessageClient:
                 "sent_at": payload.sent_at,
                 "thread_root_id": validated_thread_root_id,
                 "reply_to_id": validated_reply_to_id,
+                "is_encrypted": not is_plaintext,
             })
             # Rebind for downstream code (root_id resolution at the
             # batch-coalesce step, channel_meta construction, etc.) so
@@ -988,6 +989,7 @@ class PuffoCoreMessageClient:
                 "envelope_id": payload.envelope_id,
                 "sent_at": payload.sent_at,
                 "is_visible_to_human": payload.is_visible_to_human,
+                "is_encrypted": not is_plaintext,
             }
             channel_meta = {
                 "channel_id": channel_id,
@@ -2830,6 +2832,7 @@ class PuffoCoreMessageClient:
             "mentions": [],
             "envelope_id": envelope_id,
             "sent_at": now_ms,
+            "is_encrypted": True,
         }
         channel_meta = {
             "channel_id": channel_id,
@@ -3170,6 +3173,7 @@ class PuffoCoreMessageClient:
             "mentions": [],
             "envelope_id": envelope_id,
             "sent_at": now_ms,
+            "is_encrypted": True,
         }
         channel_meta = {
             "channel_id": channel_id,

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -39,13 +39,15 @@ the operator runs; your specific role is in *Your role* below.
 Every user message carries a metadata block:
 
 ```
+- post_id: <msg_<uuid>>          # this envelope's id
 - space: <space_name>            # absent for DMs
 - space_id: <sp_<uuid>>          # absent for DMs
 - channel: <channel_name>        # "Direct message" for DMs
 - channel_id: <ch_<uuid>>        # send_message(channel=...); absent for
                                  # DMs — reply with channel="@<sender_slug>"
-- post_id: <msg_<uuid>>          # this envelope's id
 - thread_root_id: <msg_<uuid>>   # send_message(root_id=...) to reply in-thread
+- is_encrypted: true | false     # true = end-to-end encrypted; false = sent in
+                                 # the clear (plaintext, signature-only)
 - timestamp: <ISO-8601>
 - sender: <display_name>         # human-readable name for prose
 - sender_slug: <slug>            # structural id — @-mentions + DM routing

--- a/src/puffo_agent/crypto/message.py
+++ b/src/puffo_agent/crypto/message.py
@@ -299,6 +299,33 @@ def decrypt_message(
     if payload_dict.get("sender_slug") != envelope["sender_slug"]:
         raise ValueError("sender_slug mismatch")
 
+    return _message_payload_from_dict(payload_dict, envelope_id)
+
+
+def read_plaintext_message(
+    envelope: dict,
+    sender_public_key: bytes,
+) -> MessagePayload:
+    """Verify a non-E2EE ``plaintext_message_envelope`` and return its payload.
+
+    The signed payload rides in the clear (no HPKE/AEAD). The signature
+    covers the canonicalized ``payload`` subtree, exactly as in the E2EE
+    path — there is no outer envelope to cross-check ``sender_slug`` against,
+    so the payload's own ``sender_slug`` is authoritative.
+    """
+    envelope_id = envelope["envelope_id"]
+    signed = envelope["signed_payload"]
+    payload_dict = signed["payload"]
+    sig_bytes = base64url_decode(signed["signature"])
+
+    canonical = canonicalize_for_signing(payload_dict)
+    if not ed25519_verify(sender_public_key, canonical, sig_bytes):
+        raise ValueError("signature verification failed")
+
+    return _message_payload_from_dict(payload_dict, envelope_id)
+
+
+def _message_payload_from_dict(payload_dict: dict, envelope_id: str) -> MessagePayload:
     return MessagePayload(
         payload_type=payload_dict["type"],
         version=payload_dict["version"],

--- a/src/puffo_agent/crypto/message.py
+++ b/src/puffo_agent/crypto/message.py
@@ -308,10 +308,9 @@ def read_plaintext_message(
 ) -> MessagePayload:
     """Verify a non-E2EE ``plaintext_message_envelope`` and return its payload.
 
-    The signed payload rides in the clear (no HPKE/AEAD). The signature
-    covers the canonicalized ``payload`` subtree, exactly as in the E2EE
-    path — there is no outer envelope to cross-check ``sender_slug`` against,
-    so the payload's own ``sender_slug`` is authoritative.
+    No HPKE/AEAD — the signature covers the canonicalized ``payload`` as in
+    the E2EE path. There's no outer envelope, so the payload's own
+    ``sender_slug`` is authoritative (no cross-check).
     """
     envelope_id = envelope["envelope_id"]
     signed = envelope["signed_payload"]

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -259,9 +259,8 @@ def puffo_core_mcp_env(
         "PUFFO_RPC_URL": rpc_url,
         **_python_user_base_env(runtime_kind),
     }
-    # Forward the daemon's PYTHONPATH so a worktree / editable checkout of the
-    # daemon also drives the MCP subprocess. Unset in prod (a no-op); skipped
-    # for docker where a host path is meaningless inside the container.
+    # Forward the daemon's PYTHONPATH so a worktree checkout drives the MCP
+    # subprocess too (unset in prod). Skipped for docker — host path is moot there.
     pythonpath = os.environ.get("PYTHONPATH")
     if pythonpath and "docker" not in runtime_kind:
         env["PYTHONPATH"] = pythonpath

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import re
 import site
+import os
 import sys
 from pathlib import Path
 
@@ -258,6 +259,12 @@ def puffo_core_mcp_env(
         "PUFFO_RPC_URL": rpc_url,
         **_python_user_base_env(runtime_kind),
     }
+    # Forward the daemon's PYTHONPATH so a worktree / editable checkout of the
+    # daemon also drives the MCP subprocess. Unset in prod (a no-op); skipped
+    # for docker where a host path is meaningless inside the container.
+    pythonpath = os.environ.get("PYTHONPATH")
+    if pythonpath and "docker" not in runtime_kind:
+        env["PYTHONPATH"] = pythonpath
     if agent_id:
         env["PUFFO_AGENT_ID"] = agent_id
     if space_id:

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -32,6 +32,7 @@ class StoredMessageDict:
     received_at: int
     thread_root_id: Optional[str]
     reply_to_id: Optional[str]
+    is_encrypted: bool = True
 
 
 # Re-exported from ``message_store`` so both the network-backed
@@ -66,6 +67,7 @@ def _msg_from_dict(d: dict[str, Any]) -> StoredMessageDict:
         received_at=int(d.get("received_at", 0)),
         thread_root_id=d.get("thread_root_id"),
         reply_to_id=d.get("reply_to_id"),
+        is_encrypted=bool(d.get("is_encrypted", True)),
     )
 
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -90,6 +90,13 @@ def _ts_to_iso(ms: int) -> str:
     return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat(timespec="seconds")
 
 
+def _enc_tag(m: Any) -> str:
+    """Per-message transport-security tag so the agent can always tell an
+    E2EE message from one delivered in the clear. Legacy rows read as
+    encrypted."""
+    return "[encrypted]" if getattr(m, "is_encrypted", True) else "[plaintext]"
+
+
 @dataclass
 class PuffoCoreToolsConfig:
     slug: str
@@ -591,7 +598,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                 if entry.reply_count > 0 else ""
             )
             lines.append(
-                f"{ts}  post:{m.envelope_id}  @{m.sender_slug}: {text}{suffix}"
+                f"{ts}  {_enc_tag(m)}  post:{m.envelope_id}  @{m.sender_slug}: {text}{suffix}"
             )
         return "\n".join(lines)
 
@@ -623,7 +630,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
         for m in msgs:
             ts = _ts_to_iso(m.sent_at)
             text = str(m.content).replace("\n", " ") if m.content else ""
-            lines.append(f"{ts}  msg:{m.envelope_id}  @{m.sender_slug}: {text}")
+            lines.append(f"{ts}  {_enc_tag(m)}  msg:{m.envelope_id}  @{m.sender_slug}: {text}")
         return "\n".join(lines)
 
     @mcp.tool()
@@ -669,7 +676,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             ts = _ts_to_iso(m.sent_at)
             text = str(m.content).replace("\n", " ") if m.content else ""
             lines.append(
-                f"{ts}  post:{m.envelope_id}  @{m.sender_slug}: {text}"
+                f"{ts}  {_enc_tag(m)}  post:{m.envelope_id}  @{m.sender_slug}: {text}"
             )
         return "\n".join(lines)
 
@@ -874,6 +881,7 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             lines.append(f"channel_id: {msg.channel_id}")
         if msg.thread_root_id:
             lines.append(f"thread_root_id: {msg.thread_root_id}")
+        lines.append(f"is_encrypted: {str(getattr(msg, 'is_encrypted', True)).lower()}")
         lines.append(f"message:\n{content_str}")
         return "\n".join(lines)
 

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -91,9 +91,7 @@ def _ts_to_iso(ms: int) -> str:
 
 
 def _enc_tag(m: Any) -> str:
-    """Per-message transport-security tag so the agent can always tell an
-    E2EE message from one delivered in the clear. Legacy rows read as
-    encrypted."""
+    """`[encrypted]`/`[plaintext]` tag; legacy rows default to encrypted."""
     return "[encrypted]" if getattr(m, "is_encrypted", True) else "[plaintext]"
 
 

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -358,6 +358,7 @@ def _msg_to_dict(m: Any) -> dict[str, Any]:
         "received_at": m.received_at,
         "thread_root_id": m.thread_root_id,
         "reply_to_id": m.reply_to_id,
+        "is_encrypted": m.is_encrypted,
     }
 
 

--- a/tests/test_is_encrypted_plumbing.py
+++ b/tests/test_is_encrypted_plumbing.py
@@ -1,0 +1,60 @@
+"""is_encrypted threads through the read path + MCP env, so the agent can
+always tell an E2EE message from a plaintext one."""
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.mcp.data_client import _msg_from_dict
+from puffo_agent.mcp.puffo_core_tools import _enc_tag
+from puffo_agent.mcp.config import puffo_core_mcp_env
+from puffo_agent.portal.data_service import _msg_to_dict
+
+
+def test_msg_from_dict_reads_is_encrypted():
+    assert _msg_from_dict({"is_encrypted": False}).is_encrypted is False
+    assert _msg_from_dict({"is_encrypted": True}).is_encrypted is True
+
+
+def test_msg_from_dict_defaults_true_when_absent():
+    assert _msg_from_dict({}).is_encrypted is True
+
+
+def test_msg_to_dict_surfaces_is_encrypted():
+    m = SimpleNamespace(
+        envelope_id="e", envelope_kind="channel", sender_slug="s",
+        channel_id=None, space_id=None, recipient_slug=None,
+        content_type="text/plain", content="hi", sent_at=1, received_at=1,
+        thread_root_id=None, reply_to_id=None, is_encrypted=False,
+    )
+    assert _msg_to_dict(m)["is_encrypted"] is False
+
+
+def test_enc_tag():
+    assert _enc_tag(SimpleNamespace(is_encrypted=True)) == "[encrypted]"
+    assert _enc_tag(SimpleNamespace(is_encrypted=False)) == "[plaintext]"
+    # Legacy object with no attribute → treated as encrypted.
+    assert _enc_tag(SimpleNamespace()) == "[encrypted]"
+
+
+def _env(**over):
+    args = dict(slug="s", device_id="d", server_url="u", keystore_dir="k", workspace="w")
+    args.update(over)
+    return puffo_core_mcp_env(**args)
+
+
+def test_mcp_env_forwards_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "C:/worktree/src")
+    assert _env()["PYTHONPATH"] == "C:/worktree/src"
+
+
+def test_mcp_env_skips_pythonpath_for_docker(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "C:/host/src")
+    assert "PYTHONPATH" not in _env(runtime_kind="cli-docker")
+
+
+def test_mcp_env_no_pythonpath_when_unset(monkeypatch):
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    assert "PYTHONPATH" not in _env()

--- a/tests/test_message_store.py
+++ b/tests/test_message_store.py
@@ -363,3 +363,52 @@ async def test_thread_messages_since_filter():
     # Strictly after reply_1's sent_at → only reply_2.
     assert [m.envelope_id for m in msgs] == ["reply_2"]
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_is_encrypted_defaults_true_when_absent():
+    store = _temp_store()
+    await store.store(_channel_payload("env_enc"))  # payload carries no is_encrypted
+    msg = await store.get_message_by_envelope("env_enc")
+    assert msg is not None and msg.is_encrypted is True
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_is_encrypted_false_for_plaintext():
+    store = _temp_store()
+    p = _channel_payload("env_plain")
+    p["is_encrypted"] = False
+    await store.store(p)
+    msg = await store.get_message_by_envelope("env_plain")
+    assert msg is not None and msg.is_encrypted is False
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_is_encrypted_migration_backfills_legacy_rows_true():
+    import sqlite3
+
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "messages.db")
+    # Legacy schema without is_encrypted + a pre-fix (E2EE) row.
+    con = sqlite3.connect(path)
+    con.execute(
+        "CREATE TABLE messages (envelope_id TEXT PRIMARY KEY, envelope_kind TEXT NOT NULL, "
+        "sender_slug TEXT NOT NULL, channel_id TEXT, space_id TEXT, recipient_slug TEXT, "
+        "content_type TEXT NOT NULL DEFAULT 'text/plain', content TEXT NOT NULL, "
+        "sent_at INTEGER NOT NULL, received_at INTEGER NOT NULL, thread_root_id TEXT, reply_to_id TEXT)"
+    )
+    con.execute(
+        "INSERT INTO messages (envelope_id, envelope_kind, sender_slug, channel_id, "
+        "content_type, content, sent_at, received_at) VALUES "
+        "('env_old','channel','alice-0001','ch_1','text/plain','old msg',1,1)"
+    )
+    con.commit()
+    con.close()
+
+    store = MessageStore(path)
+    await store.open()  # runs the ALTER-TABLE migration
+    msg = await store.get_message_by_envelope("env_old")
+    assert msg is not None and msg.is_encrypted is True  # legacy row backfilled encrypted
+    await store.close()

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -1765,3 +1765,44 @@ async def test_resolve_rejects_unknown_level():
         await resolve_visibility("visible", "ch_x", "hi", "msg_root", http)
     with pytest.raises(RuntimeError):
         await resolve_visibility("", "ch_x", "hi", "msg_root", http)
+
+
+async def _store_msg(ms, eid, *, is_encrypted, channel_id="ch_1", thread_root_id=None):
+    await ms.store({
+        "envelope_id": eid,
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "channel_id": channel_id,
+        "space_id": "sp_test",
+        "content_type": "text/plain",
+        "content": f"body {eid}",
+        "sent_at": _now_ms(),
+        "thread_root_id": thread_root_id,
+        "is_encrypted": is_encrypted,
+    })
+
+
+@pytest.mark.asyncio
+async def test_get_post_shows_is_encrypted():
+    cfg, _, ms = _setup()
+    await _store_msg(ms, "msg_plain", is_encrypted=False)
+    result = await _call(_build_tools(cfg), "get_post", {"post_ref": "msg_plain"})
+    assert "is_encrypted: false" in result
+
+
+@pytest.mark.asyncio
+async def test_get_channel_history_tags_encryption():
+    cfg, _, ms = _setup()
+    await _store_msg(ms, "msg_enc", is_encrypted=True)
+    await _store_msg(ms, "msg_plain", is_encrypted=False)
+    result = await _call(_build_tools(cfg), "get_channel_history", {"channel": "ch_1"})
+    assert "[encrypted]" in result and "[plaintext]" in result
+
+
+@pytest.mark.asyncio
+async def test_get_thread_history_tags_encryption():
+    cfg, _, ms = _setup()
+    await _store_msg(ms, "msg_root", is_encrypted=True)
+    await _store_msg(ms, "msg_reply", is_encrypted=False, thread_root_id="msg_root")
+    result = await _call(_build_tools(cfg), "get_thread_history", {"root_id": "msg_root"})
+    assert "[plaintext]" in result

--- a/tests/test_read_plaintext_message.py
+++ b/tests/test_read_plaintext_message.py
@@ -1,0 +1,99 @@
+"""Receive-side plaintext (non-E2EE) envelope verification."""
+
+import os
+
+import pytest
+
+from puffo_agent.crypto.canonical import canonicalize_for_signing
+from puffo_agent.crypto.encoding import base64url_encode
+from puffo_agent.crypto.message import read_plaintext_message
+from puffo_agent.crypto.primitives import Ed25519KeyPair
+
+
+def _plaintext_envelope(signing_key: Ed25519KeyPair) -> dict:
+    payload = {
+        "type": "message_payload",
+        "version": 1,
+        "envelope_kind": "dm",
+        "sender_slug": "alice-0001",
+        "sender_subkey_id": "sk_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "space_id": None,
+        "channel_id": None,
+        "recipient_slug": "bob-0001",
+        "sent_at": 1_700_000_000_000,
+        "message_nonce": base64url_encode(os.urandom(16)),
+        "thread_root_id": None,
+        "reply_to_id": None,
+        "content_type": "text/plain",
+        "content": "hi in the clear",
+        "is_visible_to_human": True,
+    }
+    sig = signing_key.sign(canonicalize_for_signing(payload))
+    return {
+        "type": "plaintext_message_envelope",
+        "version": 1,
+        "envelope_id": "msg_00000000-0000-4000-8000-0000000000aa",
+        "signed_payload": {"payload": payload, "signature": base64url_encode(sig)},
+    }
+
+
+def test_reads_valid_plaintext_envelope() -> None:
+    signing_key = Ed25519KeyPair.generate()
+    env = _plaintext_envelope(signing_key)
+
+    payload = read_plaintext_message(env, signing_key.public_key_bytes())
+
+    assert payload.envelope_id == env["envelope_id"]
+    assert payload.envelope_kind == "dm"
+    assert payload.sender_slug == "alice-0001"
+    assert payload.recipient_slug == "bob-0001"
+    assert payload.content == "hi in the clear"
+    assert payload.is_visible_to_human is True
+
+
+def test_rejects_wrong_signer() -> None:
+    signing_key = Ed25519KeyPair.generate()
+    wrong_key = Ed25519KeyPair.generate()
+    env = _plaintext_envelope(signing_key)
+
+    with pytest.raises(ValueError, match="signature verification failed"):
+        read_plaintext_message(env, wrong_key.public_key_bytes())
+
+
+def test_rejects_tampered_payload() -> None:
+    signing_key = Ed25519KeyPair.generate()
+    env = _plaintext_envelope(signing_key)
+    env["signed_payload"]["payload"]["content"] = "tampered"
+
+    with pytest.raises(ValueError, match="signature verification failed"):
+        read_plaintext_message(env, signing_key.public_key_bytes())
+
+
+def test_unknown_payload_field_is_ignored() -> None:
+    signing_key = Ed25519KeyPair.generate()
+    payload = {
+        "type": "message_payload",
+        "version": 1,
+        "envelope_kind": "channel",
+        "sender_slug": "alice-0001",
+        "sender_subkey_id": "sk_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "space_id": "sp_00000000-0000-4000-8000-0000000000cc",
+        "channel_id": "ch_00000000-0000-4000-8000-0000000000dd",
+        "recipient_slug": None,
+        "sent_at": 1_700_000_000_000,
+        "message_nonce": base64url_encode(os.urandom(16)),
+        "content_type": "text/plain",
+        "content": "channel in the clear",
+        "future_field": {"anything": [1, 2, 3]},
+    }
+    sig = signing_key.sign(canonicalize_for_signing(payload))
+    env = {
+        "type": "plaintext_message_envelope",
+        "version": 1,
+        "envelope_id": "msg_00000000-0000-4000-8000-0000000000bb",
+        "signed_payload": {"payload": payload, "signature": base64url_encode(sig)},
+    }
+
+    result = read_plaintext_message(env, signing_key.public_key_bytes())
+    assert result.channel_id == "ch_00000000-0000-4000-8000-0000000000dd"
+    assert result.content == "channel in the clear"

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -97,3 +97,19 @@ def test_plaintext_message_block_flags_is_encrypted_false():
 def test_encrypted_message_block_flags_is_encrypted_true():
     block = _block(is_encrypted=True)
     assert "- is_encrypted: true" in block
+
+
+def test_metadata_block_field_order():
+    block = _block(
+        post_id="msg_1", space_id="sp_1", space_name="S", channel_id="ch_1",
+        channel_name="C", root_id="msg_root", is_encrypted=False,
+    )
+    lines = block.splitlines()
+
+    def idx(prefix: str) -> int:
+        return next(i for i, ln in enumerate(lines) if ln.startswith(prefix))
+
+    assert (
+        idx("- post_id:") < idx("- space_id:") < idx("- channel_id:")
+        < idx("- thread_root_id:") < idx("- is_encrypted:") < idx("- sender:")
+    )

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -82,3 +82,18 @@ def test_mention_suffixes_render_from_is_agent():
     assert "  - me-0001 (you)" in block
     assert "  - nova-bot-1234 (agent)" in block
     assert "  - alice-1234 (human)" in block
+
+
+def test_is_encrypted_defaults_true_in_block():
+    block = _block()  # no is_encrypted passed → legacy/default
+    assert "- is_encrypted: true" in block
+
+
+def test_plaintext_message_block_flags_is_encrypted_false():
+    block = _block(is_encrypted=False)
+    assert "- is_encrypted: false" in block
+
+
+def test_encrypted_message_block_flags_is_encrypted_true():
+    block = _block(is_encrypted=True)
+    assert "- is_encrypted: true" in block


### PR DESCRIPTION
Receive-only support for the new plaintext (non-E2EE) message format, plus an `is_encrypted` flag surfaced everywhere the agent sees a message. Sending stays E2EE-only — after this, only puffo-cli can send plaintext; every other client (this daemon, web #363) can receive it. Pairs with core #27 (merged) + puffo-server #231.

## 1. Receive plaintext
- `crypto/message.py` — `read_plaintext_message(envelope, sender_public_key)`: verifies the signed body in the clear (no HPKE/AEAD), mirroring the E2EE verify. The plaintext envelope has no outer routing, so the payload's own `sender_slug` is authoritative. Extracts the shared `MessagePayload` construction into one helper.
- `agent/puffo_core_client.py` — `handle_envelope` branches on the inner envelope `type`; plaintext routes through the same sender-pubkey candidate loop + the same downstream store/dispatch sink. No send path.

## 2. `is_encrypted` on every message
The agent must be able to tell an E2EE message from one sent in the clear — on the live inbound message AND when it pulls history. The flag is carried from ingest all the way to what the LLM sees. Legacy/system messages read as encrypted (the pre-flag default).

- `agent/message_store.py` — `is_encrypted` column (default `1`) + an idempotent `ALTER TABLE` migration that backfills pre-existing rows to encrypted; store + read the flag.
- `portal/data_service.py` + `mcp/data_client.py` — thread the flag through the read path (`_msg_to_dict` / `StoredMessageDict`).
- `mcp/puffo_core_tools.py` — `get_post` shows an `is_encrypted:` line; `get_channel_history` / `get_dm_history` / `get_thread_history` tag every row `[encrypted]` / `[plaintext]`.
- `agent/core.py` — the live inbound block renders `- is_encrypted: <true|false>` on every message, and the block is reordered to `post_id → space → channel → thread_root_id → is_encrypted → timestamp → sender`. Documented in the shared primer.
- `mcp/config.py` — forwards the daemon's `PYTHONPATH` to the MCP subprocess, so a worktree/editable checkout of the daemon drives the MCP tools too (unset in prod → a no-op). Without this the MCP tools resolve `puffo_agent` via the editable install and silently run stale code.

## Tests
- `tests/test_read_plaintext_message.py` — valid/tampered/wrong-key + unknown-field forward-compat.
- `tests/test_message_store.py` — `is_encrypted` defaults true, false for plaintext, legacy-DB migration backfills to true.
- `tests/test_sender_identity_metadata.py` — the inbound block renders `- is_encrypted:` (true default / false for plaintext).
- Full suite: **1991 passed, 11 skipped**.

## Live smoke (local, against puffo-server #231)
Isolated daemon (custom `PUFFO_AGENT_HOME`, no bridge, on this branch) linked to a test operator; agent added to a space. From puffo-cli, sent plaintext + E2EE to the channel. Verified: the agent receives both, stores them with the correct `is_encrypted` (plaintext=false, e2ee=true), and both the live inbound block and `get_post` / `get_channel_history` / `get_thread_history` surface the flag per message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)