### PR TITLE
fix(dm): batch stale-processed reports off the catch-up path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Catch-up redelivery loop on large stale backlogs.** The staleness
+  gate reported each skipped envelope with its own awaited HTTP POST;
+  a weeks-long backlog stretched catch-up past the WS keepalive window,
+  the batch ack never sent, and the same backlog redelivered on every
+  reconnect. Reports are now buffered and flushed as one chunked
+  end:batch POST off the catch-up path.
+
 - **Stale channel cache self-heals (PUF-376).** A membership event
   dropped during a WS reconnect used to leave a genuinely-member
   channel unaddressable by `send_message` until a daemon restart.

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -566,6 +566,9 @@ class PuffoCoreMessageClient:
         self._rewarm_lock = asyncio.Lock()
         self._last_rewarm = 0.0
         self._warm_task: asyncio.Future | None = None
+        # Gate-skipped envelopes awaiting a batched processing report.
+        self._stale_report_buf: list[str] = []
+        self._stale_flush_task: asyncio.Future | None = None
 
         # Lazy caches for human-readable space + channel names; names
         # aren't on the WS payload so we resolve via ``GET /spaces``
@@ -592,22 +595,48 @@ class PuffoCoreMessageClient:
             now_ms = int(time.time() * 1000)
         return sent_at < now_ms - self._catchup_stale_ms
 
-    async def _report_stale_processed(self, envelope_id: str) -> None:
-        """Best-effort green run for a gate-skipped envelope so
-        clients don't show it pending forever."""
-        try:
-            await self.http.post(
-                "/messages/processing/end:batch",
-                {"runs": [{
-                    "run_id": f"run_{uuid.uuid4().hex}",
-                    "message_id": envelope_id,
-                    "succeeded": True,
-                }]},
+    def _report_stale_processed(self, envelope_id: str) -> None:
+        """Best-effort green run for a gate-skipped envelope so clients
+        don't show it pending forever. Buffered + flushed as ONE
+        end:batch POST — a per-envelope await here stretched a big
+        catch-up past the WS keepalive window, so the batch ack never
+        sent and the same backlog redelivered forever."""
+        self._stale_report_buf.append(envelope_id)
+        if self._stale_flush_task is None or self._stale_flush_task.done():
+            self._stale_flush_task = asyncio.ensure_future(
+                self._flush_stale_reports()
             )
-        except Exception as exc:  # noqa: BLE001
-            self._log.debug(
-                "stale-processed report failed for %s: %s", envelope_id, exc,
-            )
+
+    async def _flush_stale_reports(self) -> None:
+        # Let the catch-up burst finish accumulating before flushing.
+        await asyncio.sleep(1.0)
+        # Loop: envelopes appended while a chunk POST is in flight get
+        # picked up here instead of stranding until the next report.
+        while self._stale_report_buf:
+            buf, self._stale_report_buf = self._stale_report_buf, []
+            await self._post_stale_runs(buf)
+
+    async def _post_stale_runs(self, buf: list[str]) -> None:
+        runs = [
+            {
+                "run_id": f"run_{uuid.uuid4().hex}",
+                "message_id": mid,
+                "succeeded": True,
+            }
+            for mid in buf
+        ]
+        # Chunked so a weeks-long backlog stays under request-size limits.
+        for i in range(0, len(runs), 200):
+            try:
+                await self.http.post(
+                    "/messages/processing/end:batch",
+                    {"runs": runs[i:i + 200]},
+                )
+            except Exception as exc:  # noqa: BLE001
+                self._log.debug(
+                    "stale-processed flush failed (%d runs): %s",
+                    len(runs[i:i + 200]), exc,
+                )
 
     async def listen(
         self,
@@ -807,7 +836,7 @@ class PuffoCoreMessageClient:
                     self._catchup_stale_ms,
                     payload_thread_root_id or payload.envelope_id,
                 )
-                await self._report_stale_processed(payload.envelope_id)
+                self._report_stale_processed(payload.envelope_id)
                 return
 
             channel_id = payload.channel_id or ""

--- a/tests/test_catchup_staleness_gate.py
+++ b/tests/test_catchup_staleness_gate.py
@@ -188,23 +188,71 @@ class _StubHttp:
         return {}
 
 
-@pytest.mark.asyncio
-async def test_report_stale_processed_posts_green_run():
+def _report_client(fail: bool = False):
+    import asyncio as _a
+
     c = _client(_48H_MS)
-    c.http = _StubHttp()
+    c.http = _StubHttp(fail=fail)
     c._log = logging.getLogger("staleness-test")
-    await c._report_stale_processed("msg_old_1")
+    c._stale_report_buf = []
+    c._stale_flush_task = None
+    return c
+
+
+@pytest.mark.asyncio
+async def test_reports_batch_into_one_post():
+    """A catch-up burst must flush as ONE end:batch POST — the old
+    per-envelope await stretched catch-up past the WS keepalive window
+    and the backlog redelivered forever."""
+    c = _report_client()
+    for i in range(3):
+        c._report_stale_processed(f"msg_old_{i}")
+    await c._stale_flush_task
+    assert len(c.http.posts) == 1
     path, body = c.http.posts[0]
     assert path == "/messages/processing/end:batch"
-    (run,) = body["runs"]
-    assert run["message_id"] == "msg_old_1"
-    assert run["succeeded"] is True
-    assert run["run_id"].startswith("run_")
+    assert [r["message_id"] for r in body["runs"]] == [
+        "msg_old_0", "msg_old_1", "msg_old_2",
+    ]
+    assert all(r["succeeded"] is True for r in body["runs"])
+    assert c._stale_report_buf == []
 
 
 @pytest.mark.asyncio
-async def test_report_stale_processed_swallows_http_failure():
-    c = _client(_48H_MS)
-    c.http = _StubHttp(fail=True)
-    c._log = logging.getLogger("staleness-test")
-    await c._report_stale_processed("msg_old_1")  # must not raise
+async def test_reports_chunk_at_200():
+    c = _report_client()
+    for i in range(450):
+        c._report_stale_processed(f"msg_{i}")
+    await c._stale_flush_task
+    sizes = [len(b["runs"]) for _p, b in c.http.posts]
+    assert sizes == [200, 200, 50]
+
+
+@pytest.mark.asyncio
+async def test_report_during_flush_is_not_stranded():
+    import asyncio
+
+    c = _report_client()
+    orig_post = c.http.post
+    late: dict = {}
+
+    async def _post_and_inject(path, body):
+        # A new stale envelope lands while the first chunk POST is in
+        # flight — the flush loop must pick it up.
+        if "injected" not in late:
+            late["injected"] = True
+            c._report_stale_processed("msg_late")
+        return await orig_post(path, body)
+
+    c.http.post = _post_and_inject
+    c._report_stale_processed("msg_first")
+    await c._stale_flush_task
+    reported = [r["message_id"] for _p, b in c.http.posts for r in b["runs"]]
+    assert "msg_first" in reported and "msg_late" in reported
+
+
+@pytest.mark.asyncio
+async def test_report_flush_swallows_http_failure():
+    c = _report_client(fail=True)
+    c._report_stale_processed("msg_old_1")
+    await c._stale_flush_task  # must not raise


### PR DESCRIPTION
## Bug

Found live on an agent resumed after ~6 weeks paused (204 stale envelopes pending): the staleness gate (from #179's review pass) reported each gate-skipped envelope as processed with its **own awaited HTTP POST** inside `handle_envelope`. 204 sequential round-trips stretched WS catch-up past the keepalive window — the listen loop (which answers pings) doesn't start until catch-up finishes — so the connection died with `keepalive ping timeout` **before the batch ack was sent**. The server redelivered the same 204 envelopes on the next connect, forever: 258 identical cycles / 41k log lines / ~204 POSTs per cycle observed.

## Fix

`_report_stale_processed` no longer awaits: it buffers the envelope id and schedules a flusher. The flusher sleeps 1s to coalesce the catch-up burst, then emits **one** `/messages/processing/end:batch` POST (chunked at 200 runs), re-sweeping anything appended mid-flush. Catch-up returns to milliseconds; the ack lands; the loop is gone.

## Tests

- burst → single batch POST (ordered, succeeded runs)
- 450 ids → 200/200/50 chunks
- envelope landing while a chunk POST is in flight is not stranded
- HTTP failure swallowed (best-effort)
- Full suite: 1983 passed / 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)