### PR TITLE
feat(cloud-slim): move chat-local provider SDKs to optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ linking, and `agent` for the bots themselves.
   `https://chat.puffo.ai/relay`; point at a self-hosted server via each
   agent's `puffo_core.server_url`.
 - **Per runtime kind** (see [Runtime kinds](#61-runtime-kinds) below):
-  - `chat-local` — none beyond the provider key.
+  - `chat-local` — `pip install puffo-agent[chat-local]` (the anthropic /
+    openai SDKs, cloud-slimmed out of the base install) + the provider key.
   - `sdk-local` — `pip install puffo-agent[sdk]`.
   - `cli-local` — by default, `claude` CLI on `$PATH` + `claude login`
     on the host. With `runtime.harness=codex`, instead requires the
@@ -381,7 +382,7 @@ The `runtime.kind` in an agent's `agent.yml` decides where its brain runs:
 
 | Runtime&nbsp;kind | What runs | Requires |
 | --- | --- | --- |
-| `chat-local` | Direct LLM call inside the daemon (anthropic / openai / google). **Default.** | provider key |
+| `chat-local` | Direct LLM call inside the daemon (anthropic / openai / google). **Default.** | `puffo-agent[chat-local]` + provider key |
 | `sdk-local` | Claude Agent SDK, in-process (anthropic only). | `puffo-agent[sdk]` |
 | `cli-local` | A CLI harness as a host subprocess — Claude Code, `codex`, or `hermes` (alpha). Shell + skills on the host. | `claude` / `codex` / `hermes` login |
 | `cli-docker` | Same as `cli-local`, in a per-agent container. `claude-code` / `hermes` / `gemini-cli`. | Docker |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,18 @@ dependencies = [
     "aiohttp>=3.9",
     "aiohttp-socks>=0.10",
     "aiosqlite>=0.20",
-    "anthropic>=0.25",
     "cryptography>=43.0",
     "mcp>=1.0",
-    # Pillow: dimension-check + downscale inbound image attachments so
-    # an oversized image can't poison the agent's claude session.
+    # Pillow stays in the BASE install (not an extra): the inbound-image
+    # dimension guard (_downscale_oversized_image) runs on the shared
+    # PuffoCoreClient delivery path for EVERY runtime kind — including the
+    # cloud cli-local template, which is precisely the template that
+    # receives user images. Moving it behind an extra would silently
+    # disable the "prevention half" that keeps an oversized image from
+    # poisoning the claude session. It's lazy-imported, so the keyless
+    # boot chain still never pulls PIL into sys.modules.
     "pillow>=10.0",
     "pyhpke>=0.6",
-    "openai>=1.30",
     "psutil>=5.9",
     "python-socks>=2.4",
     "pyyaml>=6.0",
@@ -51,6 +55,31 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# --- chat-local LLM providers (cloud-slim) ------------------------------
+# The keyless cloud-agent boot chain (daemon + MCP + adapters + bridge)
+# never imports the vendor LLM SDKs: worker.py lazy-imports the providers
+# only when it builds a chat-local legacy provider, and the provider
+# modules import their vendor SDK at module top. So the base install (and
+# the cloud cli-local template) carries NEITHER anthropic NOR openai.
+# (Pillow is deliberately NOT slimmed out — see [project].dependencies.)
+#
+#   pip install puffo-agent[anthropic]   — chat-local provider=anthropic
+#   pip install puffo-agent[openai]      — chat-local provider=openai
+#   pip install puffo-agent[chat-local]  — both providers at once
+#
+# Building a chat-local provider without the matching extra fails with an
+# actionable "rebuild the template with 'pip install puffo-agent[...]'"
+# hint — not a raw ImportError. See worker._build_legacy_provider.
+anthropic = ["anthropic>=0.25"]
+openai = ["openai>=1.30"]
+# Back-compat alias: Pillow now ships in the base install (see above), so
+# this extra is a no-op for a base install. Kept so the historical
+# "pip install puffo-agent[attachments]" hint still resolves.
+attachments = ["pillow>=10.0"]
+# Convenience: everything a chat-local agent might need in one shot.
+# Self-references the component extras so version pins live in ONE place
+# and can't drift from the anthropic/openai/attachments extras above.
+chat-local = ["puffo-agent[anthropic,openai,attachments]"]
 # pip install puffo-agent[gui]  — the PySide6 desktop UI (window + tray).
 # Kept out of the base install so `pip install puffo-agent` stays Qt-free
 # for headless/cloud daemons; `start`/`run_daemon` never import PySide6.
@@ -67,7 +96,12 @@ sdk = ["claude-agent-sdk>=0.1.61"]
 # test_ws_client, test_http_client) declare async test functions via
 # `@pytest.mark.asyncio`. Without it, those tests silently skip and
 # anything using async fixtures errors out.
-dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
+# chat-local pulls the anthropic + openai SDKs (pillow is already in the
+# base install): several pre-existing test modules import those SDKs at
+# module top (test_chat_local_tool_use, test_llm_base_url_routing, the
+# image-guard tests), so a clean CI box running `pip install -e .[dev]`
+# would otherwise error at collection now that the SDKs left the base deps.
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "puffo-agent[chat-local]"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -344,10 +344,16 @@ def _downscale_oversized_image(
     try:
         from PIL import Image
     except ImportError:
+        # Pillow is the cloud-slim ``attachments`` extra, absent from the
+        # base (cli-local template) install. The dimension guard is
+        # best-effort — a missing SDK must NOT crash message delivery — so
+        # we log the actionable fix and no-op rather than raising an
+        # obscure ImportError up the delivery path.
         logger.warning(
             "Pillow missing — inbound images aren't dimension-checked; "
-            "a many-image request can then reject an oversized one "
-            "(pip install pillow)",
+            "a many-image request can then reject an oversized one. "
+            "Rebuild the template with \"pip install "
+            "'puffo-agent[attachments]'\" to enable the image guard.",
         )
         return False
     try:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -318,7 +318,28 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
     base_url = runtime.llm_base_url or None
 
     if provider_name == "anthropic":
-        from ..agent.providers.anthropic_provider import AnthropicProvider
+        try:
+            from ..agent.providers.anthropic_provider import AnthropicProvider
+        except ImportError as exc:
+            # Only re-attribute to a missing extra when the *anthropic*
+            # package itself is what's absent. An ImportError whose missing
+            # module is something else (a broken transitive dep of an
+            # installed anthropic SDK, a partial wheel, an internal
+            # submodule) is a genuine failure — re-raise it unchanged rather
+            # than misdirect the operator to reinstall an already-present
+            # package.
+            if (exc.name or "") != "anthropic" and not (
+                exc.name or ""
+            ).startswith("anthropic."):
+                raise
+            # The Anthropic SDK is a cloud-slim extra, absent from the base
+            # (cli-local template) install. Surface the fix, not a raw
+            # ModuleNotFoundError buried in the worker traceback.
+            raise RuntimeError(
+                "chat-local provider=anthropic needs the Anthropic SDK, "
+                "which isn't in the base install — rebuild the template "
+                "with \"pip install 'puffo-agent[anthropic]'\""
+            ) from exc
         api_key = runtime.api_key or daemon_cfg.anthropic.api_key
         model = runtime.model or daemon_cfg.anthropic.model or "claude-sonnet-4-6"
         if not api_key:
@@ -328,7 +349,20 @@ def _build_legacy_provider(daemon_cfg: DaemonConfig, runtime: RuntimeConfig):
         return AnthropicProvider(api_key=api_key, model=model, base_url=base_url)
 
     if provider_name == "openai":
-        from ..agent.providers.openai_provider import OpenAIProvider
+        try:
+            from ..agent.providers.openai_provider import OpenAIProvider
+        except ImportError as exc:
+            # See the anthropic branch: only re-attribute when the *openai*
+            # package itself is missing; re-raise any other ImportError.
+            if (exc.name or "") != "openai" and not (
+                exc.name or ""
+            ).startswith("openai."):
+                raise
+            raise RuntimeError(
+                "chat-local provider=openai needs the OpenAI SDK, which "
+                "isn't in the base install — rebuild the template with "
+                "\"pip install 'puffo-agent[openai]'\""
+            ) from exc
         api_key = runtime.api_key or daemon_cfg.openai.api_key
         model = runtime.model or daemon_cfg.openai.model or "gpt-4o"
         if not api_key:

--- a/tests/test_slim_packaging_cloud.py
+++ b/tests/test_slim_packaging_cloud.py
@@ -1,0 +1,203 @@
+"""Cloud-slim packaging guard: the keyless cloud-agent boot chain must
+import and run with the chat-local LLM SDKs (anthropic / openai) absent —
+and building a chat-local provider without its extra must fail with the
+actionable "rebuild the template" hint, not a raw ImportError.
+
+anthropic / openai moved out of ``[project].dependencies`` into the
+``anthropic`` / ``openai`` extras (see pyproject), so the base install
+(the cli-local cloud template) carries neither. Pillow deliberately STAYS
+in the base install — the inbound-image dimension guard runs on the shared
+delivery path for every runtime kind, including cli-local — so these tests
+still block PIL via ``sys.modules`` to prove the guard degrades gracefully
+if a template is ever built without it. worker.py lazy-imports the
+providers only when it builds a chat-local legacy provider, and
+puffo_core_client lazy-imports Pillow only on the attachment path — so
+importing the daemon touches none of the three.
+
+Deterministic in any environment: we block the three SDKs via
+``sys.modules[...] = None`` (import raises ImportError even when the
+package happens to be installed) and drop every cached ``puffo_agent``
+module, so the whole boot chain re-executes under the block. That
+asserts the real slim contract rather than "the test box didn't have
+the SDK".
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+# The three cloud-slim SDKs and the submodules the code reaches for.
+# Mapping a name to ``None`` in sys.modules makes ``import <name>`` raise
+# ImportError even when the package is installed.
+_BLOCKED_NAMES = [
+    "anthropic",
+    "openai",
+    "PIL",
+    "PIL.Image",
+]
+
+
+@pytest.fixture
+def sdks_blocked(monkeypatch):
+    """Block anthropic/openai/PIL and drop every cached ``puffo_agent``
+    module so the boot chain re-imports from scratch under the block."""
+    for name in _BLOCKED_NAMES:
+        monkeypatch.setitem(sys.modules, name, None)
+    # Drop cached puffo_agent modules AND any already-cached copy of the
+    # blocked SDKs, so re-imports actually re-run under the block instead
+    # of returning a warm module object.
+    for name in list(sys.modules):
+        if name == "puffo_agent" or name.startswith("puffo_agent."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        elif name in ("anthropic", "openai", "PIL") or name.startswith(
+            ("anthropic.", "openai.", "PIL.")
+        ):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    # Re-apply the block after the delete sweep above cleared it.
+    for name in _BLOCKED_NAMES:
+        monkeypatch.setitem(sys.modules, name, None)
+    yield
+
+
+def test_sdks_are_actually_blocked(sdks_blocked):
+    """Sanity: the fixture makes the three imports raise, so the
+    assertions below mean what they say."""
+    for name in ("anthropic", "openai"):
+        with pytest.raises(ImportError):
+            importlib.import_module(name)
+    with pytest.raises(ImportError):
+        from PIL import Image  # noqa: F401
+
+
+def test_daemon_boot_chain_imports_without_llm_sdks(sdks_blocked):
+    """The keyless cloud-agent boot path (`puffo-agent start` ->
+    run_daemon) must import cleanly with anthropic/openai/pillow absent,
+    and must NOT pull any of them into sys.modules."""
+    daemon = importlib.import_module("puffo_agent.portal.daemon")
+    # run_daemon is the headless entry point cmd_start dispatches to.
+    assert hasattr(daemon, "run_daemon")
+    # Importing the daemon (and everything it eagerly loads) touched
+    # none of the three SDKs — each is still the None block sentinel,
+    # not a real module. If the boot chain had imported one, the import
+    # above would have raised ImportError instead.
+    assert sys.modules.get("anthropic") is None
+    assert sys.modules.get("openai") is None
+    assert sys.modules.get("PIL") is None
+
+
+def _stub_cfgs(provider: str):
+    """Minimal duck-typed daemon_cfg / runtime for
+    ``_build_legacy_provider`` — the SDK import fires before any api_key
+    field is read, so we only need provider + llm_base_url."""
+    runtime = types.SimpleNamespace(provider=provider, llm_base_url=None)
+    daemon_cfg = types.SimpleNamespace(default_provider=provider)
+    return daemon_cfg, runtime
+
+
+def test_chat_local_anthropic_without_extra_raises_actionable_hint(sdks_blocked):
+    worker = importlib.import_module("puffo_agent.portal.worker")
+    daemon_cfg, runtime = _stub_cfgs("anthropic")
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._build_legacy_provider(daemon_cfg, runtime)
+    msg = str(excinfo.value)
+    assert "puffo-agent[anthropic]" in msg
+    assert "Anthropic SDK" in msg
+
+
+def test_chat_local_openai_without_extra_raises_actionable_hint(sdks_blocked):
+    worker = importlib.import_module("puffo_agent.portal.worker")
+    daemon_cfg, runtime = _stub_cfgs("openai")
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._build_legacy_provider(daemon_cfg, runtime)
+    msg = str(excinfo.value)
+    assert "puffo-agent[openai]" in msg
+    assert "OpenAI SDK" in msg
+
+
+def test_attachment_guard_without_pillow_hints_extra_and_no_ops(sdks_blocked):
+    """Missing Pillow must not crash the delivery path — the dimension
+    guard no-ops (returns False) and logs the actionable extras hint."""
+    pcc = importlib.import_module("puffo_agent.agent.puffo_core_client")
+    with pytest.raises(ImportError):
+        from PIL import Image  # noqa: F401  (Pillow really is blocked)
+    # Best-effort guard: no exception, just a False no-op.
+    assert pcc._downscale_oversized_image("/nonexistent/whatever.png") is False
+
+
+def test_attachment_guard_logs_attachments_extra(sdks_blocked, caplog):
+    import logging
+
+    pcc = importlib.import_module("puffo_agent.agent.puffo_core_client")
+    with caplog.at_level(logging.WARNING):
+        pcc._downscale_oversized_image("/nonexistent/whatever.png")
+    assert "puffo-agent[attachments]" in caplog.text
+
+
+# --- positive paths + guard-precision (do NOT use sdks_blocked) ----------
+
+
+def test_daemon_eagerly_imports_worker():
+    """The boot-chain SDK-free guard above relies on importing the daemon
+    transitively walking worker.py (daemon.py has a top-level
+    ``from .worker import Worker``). Pin that eagerness so a future
+    lazy-worker refactor can't silently narrow
+    ``test_daemon_boot_chain_imports_without_llm_sdks`` to a path that no
+    longer covers worker's provider imports."""
+    importlib.import_module("puffo_agent.portal.daemon")
+    assert "puffo_agent.portal.worker" in sys.modules
+
+
+def test_build_legacy_provider_anthropic_happy_path():
+    """Positive path: with the anthropic SDK present, _build_legacy_provider
+    actually constructs an AnthropicProvider — so a regression that broke
+    the happy path (e.g. the try/except shadowing the real provider, or a
+    wrong constructor call) is caught here instead of only at agent spawn."""
+    pytest.importorskip("anthropic")
+    worker = importlib.import_module("puffo_agent.portal.worker")
+    from puffo_agent.agent.providers.anthropic_provider import AnthropicProvider
+
+    runtime = types.SimpleNamespace(
+        provider="anthropic", llm_base_url=None, api_key="sk-test", model=None
+    )
+    daemon_cfg = types.SimpleNamespace(
+        default_provider="anthropic",
+        anthropic=types.SimpleNamespace(api_key="", model=""),
+    )
+    provider = worker._build_legacy_provider(daemon_cfg, runtime)
+    assert isinstance(provider, AnthropicProvider)
+
+
+def test_provider_import_failure_is_not_misattributed_to_missing_extra():
+    """Guard precision: an ImportError raised for a reason OTHER than the
+    anthropic package being absent (e.g. a broken transitive dep, a partial
+    wheel) must propagate as an ImportError — NOT be re-attributed to the
+    'rebuild with puffo-agent[anthropic]' hint, which would misdirect the
+    operator to reinstall an already-present package.
+
+    We simulate this by planting a stub ``anthropic_provider`` module that
+    lacks ``AnthropicProvider``: the ``from ... import AnthropicProvider``
+    then raises an ImportError whose ``.name`` is the provider module, not
+    ``anthropic`` — exactly the shape of a non-missing-SDK failure."""
+    worker = importlib.import_module("puffo_agent.portal.worker")
+    modname = "puffo_agent.agent.providers.anthropic_provider"
+    stub = types.ModuleType(modname)  # deliberately no AnthropicProvider attr
+    runtime = types.SimpleNamespace(provider="anthropic", llm_base_url=None)
+    daemon_cfg = types.SimpleNamespace(default_provider="anthropic")
+    saved = sys.modules.get(modname)
+    sys.modules[modname] = stub
+    try:
+        with pytest.raises(ImportError) as excinfo:
+            worker._build_legacy_provider(daemon_cfg, runtime)
+        # The actionable-extra RuntimeError must NOT have swallowed it.
+        assert not isinstance(excinfo.value, RuntimeError)
+        assert "puffo-agent[anthropic]" not in str(excinfo.value)
+    finally:
+        if saved is not None:
+            sys.modules[modname] = saved
+        else:
+            sys.modules.pop(modname, None)


### PR DESCRIPTION
## What

Move the chat-local provider SDKs (`anthropic`, `openai`) out of the base
`puffo-agent` dependencies into optional pip extras, so a cloud agent that only
drives a CLI harness (codex or claude-code) doesn't carry the SDK it never
imports. This is the packaging half of the per-CLI template split.

## Extras layout

- `[anthropic]` → `anthropic` SDK (only needed for anthropic **chat-local**)
- `[openai]` → `openai` SDK (only needed for openai **chat-local**)
- `[attachments]` → `pillow`
- `[chat-local]` → `puffo-agent[anthropic,openai,attachments]` (the full
  in-process chat runtime)
- `dev` pulls `[chat-local]` so local/test installs are unchanged

**`pillow` stays in base** — cli-local agents downscale inbound images on the
shared delivery path, so it is not chat-local-only. This was caught in review
and is deliberate.

## Why it's safe

Both providers are already lazy-imported (`portal/worker.py` imports the
provider class only when a chat-local adapter is actually built). This PR wraps
those imports in a targeted `ImportError` guard that raises an actionable
`pip install 'puffo-agent[anthropic]'` message if a chat-local agent is booted
on a slim image without the extra. A cli-local agent never hits that path.

## Tests

`tests/test_slim_packaging_cloud.py` asserts the base install imports the
keyless boot path with neither provider SDK present, and that each extra pulls
in exactly its SDK.

## Rollout

Merges independently. The companion cloud-infra template-split PR vendors this
package and installs `[anthropic]`/`[openai]` per image, so this should land
first (or the template build must pin `PUFFO_AGENT_REF` to this branch).
