### PR TITLE
feat(PUF-373): report inference_level in heartbeat runtime info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Heartbeat reports `inference_level` (PUF-373).** The runtime info in
+  the agent heartbeat now carries the configured inference level so the
+  web edit UI can display the current value instead of always showing
+  the harness default.
+
 - **Per-agent inference level (PUF-373).** `runtime.inference_level`
   (`low|medium|high|xhigh`, empty = harness default) applies to both
   harnesses: codex gets `model_reasoning_effort` in its config.toml

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -979,6 +979,7 @@ class Worker:
             "provider": rt.provider,
             "harness": rt.harness,
             "model": rt.model,
+            "inference_level": rt.inference_level,
         }
 
     async def _run_ws_local(self) -> None:

--- a/tests/test_runtime_reasoning_effort.py
+++ b/tests/test_runtime_reasoning_effort.py
@@ -1,0 +1,15 @@
+
+
+def test_heartbeat_runtime_info_reports_inference_level():
+    from types import SimpleNamespace
+
+    from puffo_agent.portal.worker import Worker
+
+    w = Worker.__new__(Worker)
+    w.agent_cfg = SimpleNamespace(
+        runtime=SimpleNamespace(
+            kind="cli-local", provider="openai", harness="codex",
+            model="gpt-5.5", inference_level="high",
+        ),
+    )
+    assert w._runtime_info()["inference_level"] == "high"


### PR DESCRIPTION
One-field addition to the worker's `_runtime_info()` heartbeat payload so a configured `runtime.inference_level` echoes back to the web edit UI (it currently always displays "(default)").

Pairs with puffo-server#232 (`AgentRuntimeInfo.inference_level`, serde-defaulted) and puffo-core-han-group#356 (web). Old servers ignore the extra key; old daemons deserialize fine against the new server.

Tests: `_runtime_info` reports the field. Full suite 2008 passed / 11 skipped. Unreleased changelog entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)