### PR TITLE
release: 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.3] — 2026-07-17
+
 ### Added
 
 - **Heartbeat reports `inference_level` (PUF-373).** The runtime info in
@@ -21,29 +23,6 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   (harness-aware dropdown), the local bridge runtime editor, and a
   linked machine's create/edit commands — invalid values are rejected
   at every write surface.
-
-### Fixed
-
-- **Catch-up redelivery loop on large backlogs.** Observed live as a
-  paused-for-weeks agent redelivering the same 200+ messages every
-  ~70s forever. Three compounding causes fixed: per-envelope
-  processing reports stretched catch-up past the WS keepalive window
-  (now buffered into one chunked `end:batch` POST); the single
-  end-of-loop ack lost all progress when the connection died (now
-  acked every 25 envelopes); and WS-frame acks landed in a dead pipe —
-  the server's pings get no pong until the listen loop starts — so
-  catch-up acks now go over HTTP `POST /messages/ack` (matching the
-  web client's pending-drain) and pending shrinks monotonically.
-
-- **Stale channel cache self-heals (PUF-376).** A membership event
-  dropped during a WS reconnect used to leave a genuinely-member
-  channel unaddressable by `send_message` until a daemon restart.
-  The member/channel cache now re-warms on every (re)connect, and a
-  `ch_` lookup miss re-warms (5s-debounced) and re-checks before
-  failing loud — on every runtime, including the cli-local /
-  cli-docker data-service path.
-
-### Added
 
 - **48h catch-up staleness gate (PUF-384).** On WS reconnect / daemon
   restart / resume-from-pause, redelivered messages older than
@@ -72,6 +51,27 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   their DM through one shared constructor, so web/mobile clients show
   consistent Yes/No buttons that post `y`/`n` into the prompt's thread —
   the same replies the daemon already accepts.
+
+### Fixed
+
+- **Catch-up redelivery loop on large backlogs.** Observed live as a
+  paused-for-weeks agent redelivering the same 200+ messages every
+  ~70s forever. Three compounding causes fixed: per-envelope
+  processing reports stretched catch-up past the WS keepalive window
+  (now buffered into one chunked `end:batch` POST); the single
+  end-of-loop ack lost all progress when the connection died (now
+  acked every 25 envelopes); and WS-frame acks landed in a dead pipe —
+  the server's pings get no pong until the listen loop starts — so
+  catch-up acks now go over HTTP `POST /messages/ack` (matching the
+  web client's pending-drain) and pending shrinks monotonically.
+
+- **Stale channel cache self-heals (PUF-376).** A membership event
+  dropped during a WS reconnect used to leave a genuinely-member
+  channel unaddressable by `send_message` until a daemon restart.
+  The member/channel cache now re-warms on every (re)connect, and a
+  `ch_` lookup miss re-warms (5s-debounced) and re-checks before
+  failing loud — on every runtime, including the cli-local /
+  cli-docker data-service path.
 
 ## [1.1.2] — 2026-07-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.1.2"
+version = "1.1.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release **1.1.3** — bumps `pyproject.toml` to `1.1.3` and date-stamps the changelog (2026-07-17).

## What ships

**Added**
- Per-agent inference level (PUF-373) — `runtime.inference_level` applies to codex (`model_reasoning_effort`) and claude-code (`--effort`) across cli-local/cli-docker; settable from portal UI, local bridge editor, and linked-machine create/edit.
- Heartbeat reports `inference_level` (PUF-373) so the web edit UI echoes the current value.
- 48h catch-up staleness gate (PUF-384).
- cli-local command permission over puffo-core (daemon `/permission` transport).
- Operator report on auto-accepted channel invites.

**Changed**
- Every operator y/n ask now renders as a `/permission` card.

**Fixed**
- Catch-up redelivery loop on large backlogs.
- Stale channel cache self-heals (PUF-376).

The two accumulated `### Added` blocks in Unreleased were consolidated into one Added/Changed/Fixed set — no content changed, only ordering. Full detail in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)