### PR TITLE
fix(http): recover PuffoCoreHttpClient session after a dead connection

### DIFF
--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -14,6 +15,15 @@ from .keystore import KeyStore, Session, decode_secret
 from .primitives import Ed25519KeyPair
 
 logger = logging.getLogger(__name__)
+
+# aiohttp raises one of these when a pooled keep-alive connection is dead.
+# The common trigger for a cloud agent is an E2B pause/resume: the sandbox is
+# snapshotted mid-connection and resumes with a socket that *looks* open but is
+# dead on the far end (the same failure mode as the codex wake dead-zone). The
+# cached ``ClientSession`` is neither ``None`` nor ``.closed``, so ``_get_session``
+# keeps handing it back and every reused-session request fails forever. Recovery
+# is to drop the session and retry once on a fresh connection.
+_CONNECTION_ERRORS = (aiohttp.ClientConnectionError, asyncio.TimeoutError)
 
 
 class HttpError(Exception):
@@ -39,6 +49,20 @@ class PuffoCoreHttpClient:
         if self._session and not self._session.closed:
             await self._session.close()
             self._session = None
+
+    async def _reset_session(self) -> None:
+        """Drop the cached session so the next request opens a fresh connection.
+
+        Called after a connection error: the pooled socket is dead (e.g. frozen
+        across an E2B pause/resume) and would otherwise fail every reused-session
+        request forever, since ``_get_session`` only rebuilds when the session is
+        ``.closed``."""
+        sess, self._session = self._session, None
+        if sess is not None and not sess.closed:
+            try:
+                await sess.close()
+            except Exception as exc:  # noqa: BLE001 - best-effort teardown of a dead session
+                logger.debug("error closing stale session (%s)", exc)
 
     def _load_signing_key(self) -> tuple[Ed25519KeyPair, str]:
         sess = self.keystore.load_session(self.slug)
@@ -121,7 +145,19 @@ class PuffoCoreHttpClient:
         auth = sign_request(signing_key, self.slug, signer_id, method, path, body)
         headers = auth.to_dict()
         url = f"{self.server_url}{path}"
+        try:
+            return await self._issue_json(method, url, body, headers)
+        except _CONNECTION_ERRORS as exc:
+            logger.info(
+                "connection error on %s %s (%s); resetting session and retrying once",
+                method, path, exc,
+            )
+            await self._reset_session()
+            return await self._issue_json(method, url, body, headers)
 
+    async def _issue_json(
+        self, method: str, url: str, body: bytes, headers: dict,
+    ) -> tuple[int, Any]:
         http = await self._get_session()
         async with http.request(method, url, data=body or None, headers=headers) as resp:
             text = await resp.text()
@@ -147,6 +183,17 @@ class PuffoCoreHttpClient:
         auth = sign_request(signing_key, self.slug, signer_id, method, path, b"")
         headers = auth.to_dict()
         url = f"{self.server_url}{path}"
+        try:
+            return await self._issue_bytes(method, url, headers)
+        except _CONNECTION_ERRORS as exc:
+            logger.info(
+                "connection error on %s %s (%s); resetting session and retrying once",
+                method, path, exc,
+            )
+            await self._reset_session()
+            return await self._issue_bytes(method, url, headers)
+
+    async def _issue_bytes(self, method: str, url: str, headers: dict) -> bytes:
         http = await self._get_session()
         async with http.request(method, url, headers=headers) as resp:
             if resp.status == 401:

--- a/tests/test_http_client_resume.py
+++ b/tests/test_http_client_resume.py
@@ -1,0 +1,163 @@
+"""PuffoCoreHttpClient recovery from a stale keep-alive connection.
+
+Regression for the cloud-agent status-Log bug: after an E2B pause/resume the
+cached aiohttp session's pooled socket is dead but the session is neither
+``None`` nor ``.closed``, so every reused-session request failed forever and the
+agent stopped reporting status. The client must drop the session and retry once
+on a fresh connection.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import time
+
+import aiohttp
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.crypto import http_client as hc
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import KeyStore, Session, StoredIdentity, encode_secret
+from puffo_agent.crypto.primitives import Ed25519KeyPair
+
+
+def _client() -> PuffoCoreHttpClient:
+    d = tempfile.mkdtemp()
+    ks = KeyStore(os.path.join(d, "keys"))
+    device_key = Ed25519KeyPair.generate()
+    ks.save_identity(
+        StoredIdentity(
+            slug="alice-0001",
+            device_id="dev_test",
+            root_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+            device_signing_secret_key=encode_secret(device_key.secret_bytes()),
+            kem_secret_key=encode_secret(Ed25519KeyPair.generate().secret_bytes()),
+            server_url="http://localhost:3000",
+        )
+    )
+    subkey = Ed25519KeyPair.generate()
+    ks.save_session(
+        Session(
+            slug="alice-0001",
+            subkey_id="sk_test",
+            subkey_secret_key=encode_secret(subkey.secret_bytes()),
+            expires_at=int(time.time() * 1000) + 3_600_000,  # fresh -> no rotation/network
+        )
+    )
+    return PuffoCoreHttpClient("http://localhost:3000", ks, "alice-0001")
+
+
+class _FakeResp:
+    def __init__(self, status=200, text='{"ok": true}'):
+        self._status = status
+        self._text = text
+
+    @property
+    def status(self):
+        return self._status
+
+    async def text(self):
+        return self._text
+
+    async def read(self):
+        return self._text.encode()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _RaisingCM:
+    """Async ctx manager that raises on enter — models a dead pooled socket."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    async def __aenter__(self):
+        raise self._exc
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, *, raise_exc=None, resp=None):
+        self.closed = False
+        self._raise_exc = raise_exc  # raised on the FIRST request, then cleared
+        self._resp = resp or _FakeResp()
+        self.request_calls = 0
+
+    def request(self, method, url, **kw):
+        self.request_calls += 1
+        if self._raise_exc is not None:
+            exc, self._raise_exc = self._raise_exc, None
+            return _RaisingCM(exc)
+        return self._resp
+
+    async def close(self):
+        self.closed = True
+
+
+def _patch_sessions(monkeypatch, sessions):
+    it = iter(sessions)
+    monkeypatch.setattr(hc, "create_remote_http_session", lambda url, **k: next(it))
+
+
+def test_resets_and_retries_on_stale_connection(monkeypatch):
+    # First (post-resume) session's socket is dead; second is fresh.
+    s1 = _FakeSession(raise_exc=aiohttp.ServerDisconnectedError("stale keep-alive"))
+    s2 = _FakeSession(resp=_FakeResp(200, '{"ok": true}'))
+    _patch_sessions(monkeypatch, [s1, s2])
+
+    c = _client()
+    out = asyncio.run(c.post("/agents/me/heartbeat", {"status": "busy"}))
+
+    assert out == {"ok": True}
+    assert s1.closed is True          # dead session torn down
+    assert s2.request_calls == 1      # retried on a fresh connection
+
+
+def test_retries_on_timeout(monkeypatch):
+    s1 = _FakeSession(raise_exc=asyncio.TimeoutError())
+    s2 = _FakeSession(resp=_FakeResp(200, '{"ok": true}'))
+    _patch_sessions(monkeypatch, [s1, s2])
+
+    c = _client()
+    out = asyncio.run(c.get("/spaces"))
+
+    assert out == {"ok": True}
+    assert s1.closed is True
+    assert s2.request_calls == 1
+
+
+def test_no_reset_on_success(monkeypatch):
+    s1 = _FakeSession(resp=_FakeResp(200, '{"ok": true}'))
+    _patch_sessions(monkeypatch, [s1])
+
+    c = _client()
+    out = asyncio.run(c.post("/agents/me/heartbeat", {"status": "idle"}))
+
+    assert out == {"ok": True}
+    assert s1.closed is False         # healthy session reused, not torn down
+    assert s1.request_calls == 1
+
+
+def test_gives_up_after_one_retry(monkeypatch):
+    # Both attempts hit dead sockets -> the connection error propagates.
+    s1 = _FakeSession(raise_exc=aiohttp.ServerDisconnectedError("dead"))
+    s2 = _FakeSession(raise_exc=aiohttp.ServerDisconnectedError("still dead"))
+    _patch_sessions(monkeypatch, [s1, s2])
+
+    c = _client()
+    raised = False
+    try:
+        asyncio.run(c.post("/agents/me/heartbeat", {"status": "busy"}))
+    except aiohttp.ClientConnectionError:
+        raised = True
+    assert raised is True
+    assert s1.closed is True           # reset once
+    assert s2.request_calls == 1       # exactly one retry, no infinite loop


### PR DESCRIPTION
## Bug
`PuffoCoreHttpClient._get_session` reuses a cached `aiohttp.ClientSession` and rebuilds it only when `.closed`. If the pooled socket dies while the session object stays open (e.g. a long idle gap, or a paused/resumed process leaving a stale keep-alive), every subsequent request on that session fails and never recovers — nothing resets the session on a connection error, and the retry path only covers `401`.

In practice this made an agent's periodic status POSTs stop landing after the first connection drop.

## Fix
On a connection error (`aiohttp.ClientConnectionError` / `asyncio.TimeoutError`), drop the stale session and retry once on a fresh connection — both the JSON (`_do_request`) and bytes (`_do_request_bytes`) paths, via a new `_reset_session()` plus extracted `_issue_json` / `_issue_bytes` helpers.

Retries are safe for the affected endpoints (idempotent heartbeat upsert; processing-start is idempotent on its client-issued run id).

## Tests
`tests/test_http_client_resume.py` (4 new):
- stale connection (`ServerDisconnectedError`) → reset + retry succeeds, dead session torn down
- read timeout → reset + retry
- success path → session reused, not reset
- both attempts dead → error propagates after exactly one retry (no infinite loop)

22/22 pass (18 existing `test_http_client.py` + 4 new); `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)