### PR TITLE
feat(status): report keyless agent status over the bridge

### DIFF
--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -499,6 +499,27 @@ class CloudBridgeClient:
             frame["limit"] = limit
         await ws.send_json(frame)
 
+    async def send_status(
+        self,
+        status: str,
+        *,
+        current_message_id: Optional[str] = None,
+        error_text: Optional[str] = None,
+    ) -> None:
+        """Report runtime status over the bridge — the keyless equivalent of the
+        signed ``POST /agents/me/heartbeat`` + processing-run status flips. A
+        keyless bridge agent has no signing key, so it can't call those HTTP
+        routes; the server folds this frame into the same ``agent_status`` row +
+        WS broadcast, so the operator's status dot + Log are identical.
+        Fire-and-forget (no reply frame)."""
+        ws = await self._require_ws()
+        frame: dict[str, Any] = {"type": "status", "status": status}
+        if current_message_id is not None:
+            frame["current_message_id"] = current_message_id
+        if error_text is not None:
+            frame["error_text"] = error_text
+        await ws.send_json(frame)
+
     def _discard_waiter(
         self, queue: "asyncio.Queue", fut: "asyncio.Future",
     ) -> None:

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import time
 import uuid
-from typing import Any, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 
@@ -43,8 +43,15 @@ class StatusReporter:
         heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
         runtime_health_provider: Optional[Callable[[], str]] = None,
         runtime_provider: Optional[Callable[[], dict[str, Any]]] = None,
+        status_sender: Optional[Callable[..., Awaitable[None]]] = None,
     ) -> None:
         self._http = http
+        # Keyless (bridge) agents can't sign the HTTP status routes, so the
+        # worker hands us this async sender to report status over the bridge WS
+        # instead. The server folds it into the same ``agent_status`` row + WS
+        # broadcast, so the operator's status dot + Log are identical. None on
+        # native agents → the signed HTTP path below is used unchanged.
+        self._status_sender = status_sender
         # Keyless (T23 bridge) transport: the agent authenticates with an
         # egress-injected ``x-sandbox-token`` and holds NO local signing
         # identity. Every status wire call here goes through the *signed*
@@ -54,9 +61,8 @@ class StatusReporter:
         # heartbeat, ``begin_turn`` and ``end_turn``. Reading the flag off the
         # http client (the SAME signal the tools + worker use;
         # ``getattr(..., False)`` keeps test fakes and native agents at False)
-        # lets us short-circuit those calls so no ``load_identity`` is ever
-        # attempted. Server liveness for bridge agents is tracked via the
-        # bridge WS, not this heartbeat, so the skip is a clean no-op.
+        # lets us route those status updates over the bridge WS
+        # (``status_sender``) instead, so no ``load_identity`` is ever attempted.
         self._keyless = bool(getattr(http, "keyless", False))
         self._interval = max(10.0, heartbeat_interval_s)
         self._current_status: str = "idle"
@@ -69,12 +75,8 @@ class StatusReporter:
         self._stop = asyncio.Event()
 
     async def run_heartbeat_loop(self) -> None:
-        if self._keyless:
-            # Bridge agents have no signing identity — the signed
-            # /agents/me/heartbeat route can't authenticate keyless (it
-            # would raise "identity not found"). Skip the loop entirely;
-            # the bridge WS is the liveness signal for these agents.
-            return
+        # Native agents POST /agents/me/heartbeat; keyless bridge agents emit a
+        # status frame over the bridge (``_send_heartbeat`` routes by transport).
         # Send one immediately so a fresh agent doesn't sit
         # offline waiting for the first scheduled tick.
         await self._send_heartbeat()
@@ -90,15 +92,36 @@ class StatusReporter:
     def stop(self) -> None:
         self._stop.set()
 
+    async def _emit_keyless(
+        self,
+        status: str,
+        current_message_id: str | None,
+        error_text: str | None,
+    ) -> None:
+        """Report status over the bridge (keyless agents). Best-effort — a
+        failed send must never block a turn (mirrors the HTTP path's
+        exception-swallowing)."""
+        if self._status_sender is None:
+            return
+        try:
+            await self._status_sender(
+                status,
+                current_message_id=current_message_id,
+                error_text=error_text,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("keyless status emit (%s) failed (%s)", status, exc)
+
     async def begin_turn(self, message_id: str) -> str:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
         run_id = f"run_{uuid.uuid4().hex}"
         if self._keyless:
-            # No signed /processing/* call for bridge agents (see __init__).
-            # Keep the local busy bookkeeping so the state machine is
-            # unchanged; emit nothing over the wire.
+            # No signed /processing/* call for bridge agents (see __init__);
+            # report "busy" over the bridge so the operator's Log gets the
+            # Working row + the yellow dot.
             self._current_status = "busy"
             self._current_message_id = message_id
+            await self._emit_keyless("busy", message_id, None)
             return run_id
         if _is_local_only_envelope(message_id):
             # Daemon-minted synthetic envelope (e.g. intro-prompt): no
@@ -132,10 +155,13 @@ class StatusReporter:
         error_text: str | None = None,
     ) -> None:
         if self._keyless:
-            # Bridge agents: resolve local status, skip the signed
-            # /processing/end POST (see __init__).
+            # Bridge agents: resolve local status + report it over the bridge
+            # (the idle status stamps the Working row's duration + a Ready row).
             self._current_status = "idle" if succeeded else "error"
             self._current_message_id = None
+            await self._emit_keyless(
+                self._current_status, None, None if succeeded else error_text,
+            )
             return
         if _is_local_only_envelope(message_id):
             # Symmetric to ``begin_turn`` — no server-side row, but push
@@ -173,11 +199,12 @@ class StatusReporter:
         if not runs:
             return
         if self._keyless:
-            # Bridge agents: mirror the batch outcome into local status,
-            # skip the signed /processing/end:batch POST (see __init__).
+            # Bridge agents: mirror the batch outcome into local status +
+            # report it over the bridge (see __init__).
             any_failed = any(not r["succeeded"] for r in runs)
             self._current_status = "error" if any_failed else "idle"
             self._current_message_id = None
+            await self._emit_keyless(self._current_status, None, None)
             return
         payload_runs: list[dict[str, Any]] = []
         for r in runs:
@@ -226,10 +253,11 @@ class StatusReporter:
         next successful heartbeat.
         """
         if self._keyless:
-            # Bridge agents: record the error locally, skip the signed
-            # /agents/me/heartbeat POST (see __init__).
+            # Bridge agents: record the error locally + report it over the
+            # bridge (see __init__).
             self._current_status = "error"
             self._current_message_id = None
+            await self._emit_keyless("error", None, error_text[:1024])
             return
         try:
             await self._http.post(
@@ -245,9 +273,15 @@ class StatusReporter:
 
     async def _send_heartbeat(self) -> None:
         if self._keyless:
-            # Defense-in-depth: every public entry point already short-
-            # circuits for keyless, but guard the actual signed POST too so
-            # no future caller can reintroduce an "identity not found" beat.
+            # Keyless bridge agents have no signing identity for the HTTP
+            # /agents/me/heartbeat route — report the current status over the
+            # bridge instead (keeps the operator's status dot fresh + emits a
+            # settled Ready row between turns).
+            await self._emit_keyless(
+                self._current_status,
+                self._current_message_id if self._current_status == "busy" else None,
+                None,
+            )
             return
         body: dict[str, Any] = {"status": self._current_status}
         if self._current_status == "busy" and self._current_message_id is not None:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1117,6 +1117,14 @@ class Worker:
                 client.http,
                 runtime_health_provider=lambda: self.runtime.health,
                 runtime_provider=self._runtime_info,
+                # Keyless bridge agents can't sign the HTTP status routes — report
+                # status over the (already token-authed) bridge WS instead. None
+                # on native agents, so they keep the signed HTTP path unchanged.
+                status_sender=(
+                    client._bridge.send_status
+                    if getattr(client, "_bridge", None) is not None
+                    else None
+                ),
             )
             point = AttachPoint(
                 slug=self.agent_cfg.puffo_core.slug,
@@ -1659,6 +1667,13 @@ class Worker:
                 client.http,
                 runtime_health_provider=lambda: self.runtime.health,
                 runtime_provider=self._runtime_info,
+                # Keyless bridge agents report status over the bridge WS (they
+                # can't sign the HTTP routes); None on native agents.
+                status_sender=(
+                    client._bridge.send_status
+                    if getattr(client, "_bridge", None) is not None
+                    else None
+                ),
             )
             if hasattr(client, "http")
             else None

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -481,13 +481,16 @@ async def test_keyless_report_error_no_http_sets_error():
 
 
 @pytest.mark.asyncio
-async def test_keyless_heartbeat_loop_is_immediate_noop():
+async def test_keyless_heartbeat_loop_never_posts_http():
     http = _ExplodingKeylessHttp()
+    # No status_sender: the loop runs but every keyless beat is a no-op, and
+    # it must NEVER touch the signed heartbeat route.
     rep = StatusReporter(http, heartbeat_interval_s=10.0)
 
-    # The loop must return at once (not spin waiting on the interval) and
-    # never touch the signed heartbeat route.
-    await asyncio.wait_for(rep.run_heartbeat_loop(), timeout=1.0)
+    task = asyncio.ensure_future(rep.run_heartbeat_loop())
+    await asyncio.sleep(0.05)  # let the immediate beat run
+    rep.stop()
+    await asyncio.wait_for(task, timeout=1.0)
     assert http.calls == []
 
 
@@ -537,3 +540,97 @@ async def test_reporter_keyless_defaults_false_without_attr():
     assert rep._keyless is False
     await rep.begin_turn("msg_bare")
     assert len(http.calls) == 1
+
+
+# --- keyless: report status over the bridge (status_sender) ------------------
+
+
+class _CaptureSender:
+    """Fake bridge status sink; records every (status, mid, err) emitted."""
+
+    def __init__(self, *, boom: bool = False) -> None:
+        self.calls: list[tuple[str, str | None, str | None]] = []
+        self._boom = boom
+
+    async def __call__(self, status, *, current_message_id=None, error_text=None):
+        self.calls.append((status, current_message_id, error_text))
+        if self._boom:
+            raise RuntimeError("bridge ws closed")
+
+
+@pytest.mark.asyncio
+async def test_keyless_begin_turn_emits_busy_over_bridge():
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender()
+    rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
+
+    run_id = await rep.begin_turn("msg_42")
+    assert run_id.startswith("run_")
+    assert http.calls == []  # never touched the signed wire
+    assert sender.calls == [("busy", "msg_42", None)]
+    assert rep._current_status == "busy"
+
+
+@pytest.mark.asyncio
+async def test_keyless_end_turn_emits_idle_and_error_over_bridge():
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender()
+    rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
+
+    await rep.end_turn("msg_5", "run_x", succeeded=True)
+    assert sender.calls == [("idle", None, None)]
+
+    sender.calls.clear()
+    await rep.end_turn("msg_6", "run_y", succeeded=False, error_text="boom")
+    assert sender.calls == [("error", None, "boom")]
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_keyless_end_turn_batch_emits_over_bridge():
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender()
+    rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
+
+    await rep.end_turn_batch([
+        {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
+    ])
+    assert sender.calls == [("idle", None, None)]
+    assert http.calls == []
+
+
+@pytest.mark.asyncio
+async def test_keyless_send_heartbeat_emits_current_status_over_bridge():
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender()
+    rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
+    rep._current_status = "busy"
+    rep._current_message_id = "msg_z"
+
+    await rep._send_heartbeat()
+    assert http.calls == []
+    assert sender.calls == [("busy", "msg_z", None)]
+
+
+@pytest.mark.asyncio
+async def test_keyless_report_error_emits_over_bridge():
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender()
+    rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
+
+    await rep.report_error("fatal")
+    assert sender.calls == [("error", None, "fatal")]
+    assert rep._current_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_keyless_emit_failure_is_swallowed():
+    """A failed bridge send must never block a turn (mirrors the HTTP path)."""
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender(boom=True)
+    rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
+
+    # Must not raise despite the sender exploding.
+    run_id = await rep.begin_turn("msg_1")
+    assert run_id.startswith("run_")
+    assert rep._current_status == "busy"


### PR DESCRIPTION
## Problem
A keyless bridge agent can't sign the HTTP status routes (no local signing identity), so `StatusReporter` was **skipping status entirely** for keyless agents. Result: the operator's status dot + Log stayed empty for every cloud agent — even though chat/replies work (they ride the token-authed bridge WS).

## Fix
Emit status over the **same authenticated bridge WS**:
- `CloudBridgeClient.send_status(status, *, current_message_id, error_text)` — sends a `{"type": "status", ...}` frame (fire-and-forget, like `send_fetch_pending`).
- `StatusReporter` takes an optional `status_sender`; for keyless agents the busy/idle/error transitions (`begin_turn`, `end_turn`, `end_turn_batch`, `report_error`) and the heartbeat loop **emit over the bridge** instead of returning early. Best-effort — a failed send never blocks a turn (mirrors the HTTP path's exception-swallowing).
- The worker wires `status_sender = client._bridge.send_status` for keyless agents; `None` on native agents.

## Safety
Native agents are **byte-for-byte unchanged**: with no `status_sender`, `_emit_keyless` is a no-op and the signed HTTP path is used exactly as before.

## Tests
`tests/test_status_reporter.py` +6 emit tests (keyless begin_turn→busy, end_turn→idle/error, batch, heartbeat, report_error, and swallowed-send-failure); existing keyless tests still pass (no `status_sender` → no-op). **33 passed**; the only 2 failures are a pre-existing `machine_id` env leak that fails identically on the pristine branch (unrelated).

## Pairs with
The puffo-server change that accepts the `Status` frame over the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)