### PR TITLE
PUF-392: add inference_level to mcp__puffo__refresh (agent self-serve effort swap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Self-serve `inference_level` via `refresh` (PUF-392).** Agents can
+  now `refresh(inference_level="...")` to change reasoning effort
+  mid-session — standalone or alongside a harness+model swap — which
+  persists to `agent.yml` and respawns the worker. Values are validated
+  per-harness (codex: `minimal|low|medium|high`; claude-code:
+  `low|medium|high|xhigh`), matching the effort axis PUF-373 added, so an
+  agent no longer needs a manual `agent.yml` edit or a web round-trip.
+
 - **Receive plaintext (non-E2EE) messages.** The daemon now accepts the
   `plaintext_message_envelope` format: the signed body is verified in the
   clear (no HPKE/AEAD, the payload's own `sender_slug` is authoritative)
@@ -19,6 +27,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `get_dm_history` / `get_thread_history` tools — now shows whether a
   message was end-to-end encrypted or sent in the clear. Stored per
   message (a SQLite migration backfills pre-existing rows as encrypted).
+
+### Fixed
+
+- **cli-local codex agents reload MCP tools after a tool-surface change
+  (PUF-392).** Codex snapshots its MCP tools at session start and never
+  reloads them ([openai/codex#7767](https://github.com/openai/codex/issues/7767)),
+  so a change to the puffo tool surface (e.g. the new `inference_level`
+  arg) left a resumed codex session on a stale set — it saw the doc but
+  the callable tool never updated. The daemon now fingerprints the tool
+  surface on boot and, when it changed, drops each cli-local codex
+  agent's CLI session so a fresh conversation reloads the tools
+  (claude-code, cli-docker, and ws-local are unaffected).
 
 ## [1.1.3] — 2026-07-17
 

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -186,11 +186,12 @@ below is the authoritative reference.
   Force-refreshes from puffo-server; call when a name looks stale.
 
 **Self-management (cli-local + cli-docker):**
-- `refresh(harness=None, model=None, host_sync=False, session=False)`
-  — no args rebuilds CLAUDE.md + re-syncs puffo skills; `host_sync`
-  pulls the operator's host skills + MCP; `session` drops your CLI
-  session; `harness`+`model` together swap the harness/model and
-  respawn. See the `refresh` skill for the flag matrix.
+- `refresh(harness=None, model=None, host_sync=False, session=False,
+  inference_level=None)` — no args rebuilds CLAUDE.md + re-syncs puffo
+  skills; `host_sync` pulls the operator's host skills + MCP; `session`
+  drops your CLI session; `harness`+`model` together swap the
+  harness/model and respawn; `inference_level` sets reasoning effort
+  (per-harness) and respawns. See the `refresh` skill for the flag matrix.
 - `install_host_mcp(template_id)` — lay a catalog MCP into the
   operator's `~/.claude.json` for OAuth there; pair with
   `sync_host_mcp` once confirmed. See `use-host-mcp`.
@@ -585,8 +586,8 @@ DEFAULT_SKILL_REFRESH = """\
 # Skill: refresh
 
 Bring your on-disk state (system prompt, skills, MCP registry, CLI
-session, harness+model) into your live process. Four orthogonal
-axes; combine them freely.
+session, harness+model, inference_level) into your live process. Five
+orthogonal axes; combine them freely.
 
 **Tool:** `mcp__puffo__refresh`
 
@@ -597,6 +598,10 @@ axes; combine them freely.
   `~/.claude/skills/` + host MCP registrations
 - `session` (optional, bool) — drop CLI session token so next spawn
   starts a fresh conversation (no `--resume`)
+- `inference_level` (optional) — reasoning effort; per-harness values
+  (codex: minimal/low/medium/high; claude-code: low/medium/high/xhigh).
+  Standalone or alongside a harness+model swap; persists to `agent.yml`
+  + respawns.
 
 `harness` and `model` must be provided together (or both omitted).
 
@@ -608,6 +613,7 @@ axes; combine them freely.
 | `refresh(host_sync=True)` | Also re-sync host skills + host MCP. cli-local: hot; cli-docker: requires `session=True` too. |
 | `refresh(session=True)` | Also drop CLI session token; next spawn starts a new conversation. |
 | `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, full worker respawn. Implicit fresh session. |
+| `refresh(inference_level="medium")` | Set reasoning effort, persist to `agent.yml`, respawn. Standalone or alongside a harness+model swap. |
 
 **When to use:**
 - Edited `CLAUDE.md`, `profile.md`, `memory/*.md` → `refresh()`.
@@ -617,6 +623,8 @@ axes; combine them freely.
 - Conversation feels stuck / context is polluted → `refresh(session=True)`.
 - Operator asked you to try a different model → confirm harness +
   model with them, then `refresh(harness=..., model=...)`.
+- A task needs more (or less) reasoning effort → `refresh(
+  inference_level="high")` (values are per-harness).
 
 **When NOT to use:**
 - Every turn — worker-scope refresh is cheap (~1s), but the

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -32,11 +32,9 @@ REASONING_EFFORTS = ("minimal", "low", "medium", "high")
 
 
 def supported_inference_levels(harness: str) -> tuple[str, ...]:
-    """Reasoning-effort values a harness accepts. codex uses its own
-    ``model_reasoning_effort`` set (has ``minimal``, no ``xhigh``);
-    claude-code uses the web superset (has ``xhigh``, no ``minimal``).
-    Unknown harness gets the union so the caller stays permissive and
-    the daemon re-validates against the resolved harness."""
+    """Reasoning-effort values a harness accepts (codex has ``minimal``,
+    no ``xhigh``; claude-code the reverse). Unknown harness → the union,
+    so the caller stays permissive and the daemon re-validates."""
     if harness == "codex":
         return REASONING_EFFORTS
     if harness == "claude-code":

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -30,6 +30,19 @@ INFERENCE_LEVELS = ("low", "medium", "high", "xhigh")
 # codex model_reasoning_effort values.
 REASONING_EFFORTS = ("minimal", "low", "medium", "high")
 
+
+def supported_inference_levels(harness: str) -> tuple[str, ...]:
+    """Reasoning-effort values a harness accepts. codex uses its own
+    ``model_reasoning_effort`` set (has ``minimal``, no ``xhigh``);
+    claude-code uses the web superset (has ``xhigh``, no ``minimal``).
+    Unknown harness gets the union so the caller stays permissive and
+    the daemon re-validates against the resolved harness."""
+    if harness == "codex":
+        return REASONING_EFFORTS
+    if harness == "claude-code":
+        return INFERENCE_LEVELS
+    return tuple(dict.fromkeys(INFERENCE_LEVELS + REASONING_EFFORTS))
+
 _TOML_BARE_KEY = re.compile(r"[A-Za-z0-9_-]+")
 
 

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -32,9 +32,7 @@ REASONING_EFFORTS = ("minimal", "low", "medium", "high")
 
 
 def supported_inference_levels(harness: str) -> tuple[str, ...]:
-    """Reasoning-effort values a harness accepts (codex has ``minimal``,
-    no ``xhigh``; claude-code the reverse). Unknown harness → the union,
-    so the caller stays permissive and the daemon re-validates."""
+    """Reasoning-effort values a harness accepts; unknown → the union."""
     if harness == "codex":
         return REASONING_EFFORTS
     if harness == "claude-code":

--- a/src/puffo_agent/mcp/host_tools.py
+++ b/src/puffo_agent/mcp/host_tools.py
@@ -366,7 +366,7 @@ def _write_refresh_model_flag(
 ) -> Path:
     """Drop ``refresh_model.flag`` with ``{harness, model, requested_at}``.
 
-    ``inference_level`` rides the same flag (PUF-392): it can accompany a
+    ``inference_level`` rides the same flag: it can accompany a
     harness+model swap or be set on its own, in which case harness/model
     are empty and the daemon applies only the effort change."""
     flag_path = workspace / ".puffo-agent" / "refresh_model.flag"

--- a/src/puffo_agent/mcp/host_tools.py
+++ b/src/puffo_agent/mcp/host_tools.py
@@ -364,8 +364,7 @@ def _write_refresh_model_flag(
     workspace: Path, *, harness: str = "", model: str = "",
     inference_level: str = "",
 ) -> Path:
-    """Drop ``refresh_model.flag``. ``inference_level`` rides the same
-    flag — standalone (empty harness/model) or with a harness+model swap."""
+    """Drop ``refresh_model.flag`` (``inference_level`` rides it too)."""
     flag_path = workspace / ".puffo-agent" / "refresh_model.flag"
     payload = {
         "harness": harness,

--- a/src/puffo_agent/mcp/host_tools.py
+++ b/src/puffo_agent/mcp/host_tools.py
@@ -361,15 +361,22 @@ def _touch_refresh_flag(workspace: Path, name: str) -> Path:
 
 
 def _write_refresh_model_flag(
-    workspace: Path, *, harness: str, model: str,
+    workspace: Path, *, harness: str = "", model: str = "",
+    inference_level: str = "",
 ) -> Path:
-    """Drop ``refresh_model.flag`` with ``{harness, model, requested_at}``."""
+    """Drop ``refresh_model.flag`` with ``{harness, model, requested_at}``.
+
+    ``inference_level`` rides the same flag (PUF-392): it can accompany a
+    harness+model swap or be set on its own, in which case harness/model
+    are empty and the daemon applies only the effort change."""
     flag_path = workspace / ".puffo-agent" / "refresh_model.flag"
     payload = {
         "harness": harness,
         "model": model,
         "requested_at": int(time.time()),
     }
+    if inference_level:
+        payload["inference_level"] = inference_level
     try:
         flag_path.parent.mkdir(parents=True, exist_ok=True)
         flag_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")

--- a/src/puffo_agent/mcp/host_tools.py
+++ b/src/puffo_agent/mcp/host_tools.py
@@ -364,11 +364,8 @@ def _write_refresh_model_flag(
     workspace: Path, *, harness: str = "", model: str = "",
     inference_level: str = "",
 ) -> Path:
-    """Drop ``refresh_model.flag`` with ``{harness, model, requested_at}``.
-
-    ``inference_level`` rides the same flag: it can accompany a
-    harness+model swap or be set on its own, in which case harness/model
-    are empty and the daemon applies only the effort change."""
+    """Drop ``refresh_model.flag``. ``inference_level`` rides the same
+    flag — standalone (empty harness/model) or with a harness+model swap."""
     flag_path = workspace / ".puffo-agent" / "refresh_model.flag"
     payload = {
         "harness": harness,

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -76,12 +76,10 @@ def _validate_refresh_inference_level(harness: str, level: str) -> None:
 
 
 def mcp_tool_fingerprint() -> str:
-    """Stable hash of the puffo MCP tool surface — every tool name plus
-    its parameter names (core + local). Changes when a tool is
-    added/removed or its signature changes (e.g. a new ``inference_level``
-    arg). Codex snapshots MCP at session start and never reloads it
-    (openai/codex#7767), so a shift here is the signal that a resumed
-    codex session is now stale."""
+    """Stable hash of the puffo MCP tool surface (core + local tool names
+    + parameter names). Changes on any tool add/remove/signature shift —
+    the signal a codex session (which snapshots MCP once, openai/codex#7767)
+    is now stale."""
     import hashlib
     import inspect
     import json
@@ -127,8 +125,8 @@ def _register_local_tools(
 ) -> None:
     """Register system/local tools that don't depend on the messaging API."""
 
-    # Agent's current harness (the closure arg, shadowed by the tool's own
-    # ``harness`` param) — needed to validate a standalone inference_level.
+    # Closure harness (the tool's own ``harness`` param shadows it below) —
+    # used to validate a standalone inference_level.
     agent_current_harness = harness
 
     def _require_claude_code(tool: str) -> None:

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -65,6 +65,16 @@ def _validate_refresh_model(harness: str, model: Optional[str]) -> None:
         )
 
 
+def _validate_refresh_inference_level(harness: str, level: str) -> None:
+    from .config import supported_inference_levels
+    levels = supported_inference_levels(harness)
+    if level not in levels:
+        raise RuntimeError(
+            f"inference_level={level!r} not supported by "
+            f"harness={harness or '(unknown)'!r}; choose one of: {list(levels)}"
+        )
+
+
 def _register_local_tools(
     mcp: FastMCP,
     workspace: str,
@@ -72,6 +82,10 @@ def _register_local_tools(
     harness: str = "",
 ) -> None:
     """Register system/local tools that don't depend on the messaging API."""
+
+    # Agent's current harness (the closure arg, shadowed by the tool's own
+    # ``harness`` param) — needed to validate a standalone inference_level.
+    agent_current_harness = harness
 
     def _require_claude_code(tool: str) -> None:
         if harness and harness != "claude-code":
@@ -86,14 +100,19 @@ def _register_local_tools(
         model: Optional[str] = None,
         host_sync: bool = False,
         session: bool = False,
+        inference_level: Optional[str] = None,
     ) -> str:
-        """Refresh your agent state. Four orthogonal axes:
+        """Refresh your agent state. Five orthogonal axes:
 
         * no args — rebuild CLAUDE.md + re-sync puffo default skills.
         * ``host_sync=True`` — also re-sync operator's host skills + MCP.
         * ``session=True`` — drop CLI session so next spawn is fresh.
         * ``harness`` + ``model`` (both required together) — swap
           harness/model, persist to agent.yml, full worker respawn.
+        * ``inference_level`` — set reasoning effort (persist to
+          agent.yml + respawn). Standalone or alongside a harness+model
+          swap. Valid values are per-harness (codex: minimal/low/medium/
+          high; claude-code: low/medium/high/xhigh).
 
         Requires ``cli-local`` / ``cli-docker`` runtime. On cli-docker,
         ``host_sync=True`` requires ``session=True`` (or harness+model).
@@ -110,7 +129,15 @@ def _register_local_tools(
             )
         if harness is not None:
             _validate_refresh_model(harness, model)
-        if host_sync and runtime_kind == "cli-docker" and not session and harness is None:
+        if inference_level is not None:
+            effective_harness = (
+                harness if harness is not None else (agent_current_harness or "")
+            )
+            _validate_refresh_inference_level(effective_harness, inference_level)
+        # A pending respawn (harness/model or inference_level) already
+        # restarts the worker, so it subsumes host_sync's container bounce.
+        respawns = harness is not None or inference_level is not None
+        if host_sync and runtime_kind == "cli-docker" and not session and not respawns:
             raise RuntimeError(
                 "refresh(host_sync=True) on cli-docker requires "
                 "session=True (the container has to restart to pick "
@@ -118,9 +145,19 @@ def _register_local_tools(
             )
         ws = Path(workspace)
         touched: list[str] = []
-        if harness is not None:
-            _write_refresh_model_flag(ws, harness=harness, model=model or "")
-            touched.append(f"refresh_model (harness={harness!r} model={model!r})")
+        if respawns:
+            _write_refresh_model_flag(
+                ws,
+                harness=harness or "",
+                model=model or "",
+                inference_level=inference_level or "",
+            )
+            parts: list[str] = []
+            if harness is not None:
+                parts.append(f"harness={harness!r} model={model!r}")
+            if inference_level is not None:
+                parts.append(f"inference_level={inference_level!r}")
+            touched.append("refresh_model (" + ", ".join(parts) + ")")
         else:
             _touch_refresh_flag(ws, "refresh_agent")
             touched.append("refresh_agent")

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -75,6 +75,50 @@ def _validate_refresh_inference_level(harness: str, level: str) -> None:
         )
 
 
+def mcp_tool_fingerprint() -> str:
+    """Stable hash of the puffo MCP tool surface — every tool name plus
+    its parameter names (core + local). Changes when a tool is
+    added/removed or its signature changes (e.g. a new ``inference_level``
+    arg). Codex snapshots MCP at session start and never reloads it
+    (openai/codex#7767), so a shift here is the signal that a resumed
+    codex session is now stale."""
+    import hashlib
+    import inspect
+    import json
+    import types
+
+    from .puffo_core_tools import PuffoCoreToolsConfig, register_core_tools
+
+    captured: dict[str, list[str]] = {}
+
+    class _Capture:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = list(inspect.signature(fn).parameters)
+                return fn
+            return deco
+
+        def resource(self, *a, **k):
+            return lambda fn: fn
+
+        def prompt(self, *a, **k):
+            return lambda fn: fn
+
+    dummy = PuffoCoreToolsConfig(
+        slug="", device_id="",
+        keystore=types.SimpleNamespace(),
+        http_client=types.SimpleNamespace(),
+        data_client=types.SimpleNamespace(),
+    )
+    cap = _Capture()
+    register_core_tools(cap, dummy)
+    _register_local_tools(cap, "", "", "")
+    payload = json.dumps(
+        {name: captured[name] for name in sorted(captured)}, sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def _register_local_tools(
     mcp: FastMCP,
     workspace: str,

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -76,10 +76,7 @@ def _validate_refresh_inference_level(harness: str, level: str) -> None:
 
 
 def mcp_tool_fingerprint() -> str:
-    """Stable hash of the puffo MCP tool surface (core + local tool names
-    + parameter names). Changes on any tool add/remove/signature shift —
-    the signal a codex session (which snapshots MCP once, openai/codex#7767)
-    is now stale."""
+    """Hash of the puffo MCP tool surface — tool names + their params."""
     import hashlib
     import inspect
     import json
@@ -125,8 +122,7 @@ def _register_local_tools(
 ) -> None:
     """Register system/local tools that don't depend on the messaging API."""
 
-    # Closure harness (the tool's own ``harness`` param shadows it below) —
-    # used to validate a standalone inference_level.
+    # Closure harness — the tool's own ``harness`` param shadows it below.
     agent_current_harness = harness
 
     def _require_claude_code(tool: str) -> None:
@@ -176,8 +172,7 @@ def _register_local_tools(
                 harness if harness is not None else (agent_current_harness or "")
             )
             _validate_refresh_inference_level(effective_harness, inference_level)
-        # A pending respawn (harness/model or inference_level) already
-        # restarts the worker, so it subsumes host_sync's container bounce.
+        # A pending respawn already restarts the worker, subsuming host_sync.
         respawns = harness is not None or inference_level is not None
         if host_sync and runtime_kind == "cli-docker" and not session and not respawns:
             raise RuntimeError(

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -808,6 +808,16 @@ def _validate_daemon_refresh_model(harness: str, model: str) -> None:
         )
 
 
+def _validate_daemon_inference_level(harness: str, level: str) -> None:
+    from ..mcp.config import supported_inference_levels
+    levels = supported_inference_levels(harness)
+    if level not in levels:
+        raise ValueError(
+            f"inference_level={level!r} not supported by "
+            f"harness={harness!r}; choose one of: {list(levels)}"
+        )
+
+
 def _mark_flag_broken(flag_path: Path, reason: str) -> None:
     """Rename a refresh_*.flag to ``<name>.broken`` for operator
     inspection; agent.yml is untouched."""
@@ -851,7 +861,15 @@ def _process_daemon_refresh_flags(agent_id: str) -> None:
             payload = json.loads(model_flag.read_text(encoding="utf-8") or "{}")
             harness = str(payload.get("harness") or "")
             model = str(payload.get("model") or "")
-            _validate_daemon_refresh_model(harness, model)
+            level = str(payload.get("inference_level") or "")
+            # harness+model swap and a standalone inference_level (PUF-392)
+            # ride the same flag; validate only what's present.
+            swap_model = bool(harness or model)
+            if swap_model:
+                _validate_daemon_refresh_model(harness, model)
+            if level:
+                effective_harness = harness or agent_cfg.runtime.harness
+                _validate_daemon_inference_level(effective_harness, level)
         except Exception as exc:
             logger.warning(
                 "agent %s: refresh_model.flag invalid (%s); marking broken",
@@ -859,13 +877,17 @@ def _process_daemon_refresh_flags(agent_id: str) -> None:
             )
             _mark_flag_broken(model_flag, str(exc))
         else:
-            agent_cfg.runtime.harness = harness
-            agent_cfg.runtime.model = model
+            if swap_model:
+                agent_cfg.runtime.harness = harness
+                agent_cfg.runtime.model = model
+            if level:
+                agent_cfg.runtime.inference_level = level
             try:
                 agent_cfg.save()
                 logger.info(
-                    "agent %s: refresh_model applied (harness=%r model=%r)",
-                    agent_id, harness, model,
+                    "agent %s: refresh_model applied "
+                    "(harness=%r model=%r inference_level=%r)",
+                    agent_id, harness, model, level,
                 )
             except Exception as exc:
                 logger.warning(

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -690,10 +690,9 @@ def _mcp_fingerprint_path() -> Path:
 
 
 def _respawn_codex_on_mcp_change_at_startup() -> None:
-    """On boot, if the puffo MCP tool surface changed since last run, drop
-    every cli-local codex agent's CLI session so it opens a fresh codex
-    conversation and reloads the tools — codex snapshots MCP once and never
-    reloads (openai/codex#7767). First run just records the fingerprint."""
+    """Drop cli-local codex sessions when the MCP tool surface changed so
+    they reload tools — codex caches MCP once (openai/codex#7767). First
+    run just records the fingerprint."""
     import json
 
     from ..mcp.puffo_core_server import mcp_tool_fingerprint
@@ -919,8 +918,7 @@ def _process_daemon_refresh_flags(agent_id: str) -> None:
             harness = str(payload.get("harness") or "")
             model = str(payload.get("model") or "")
             level = str(payload.get("inference_level") or "")
-            # harness+model swap and a standalone inference_level ride the
-            # same flag; validate only what's present.
+            # Both ride the same flag; validate only what's present.
             swap_model = bool(harness or model)
             if swap_model:
                 _validate_daemon_refresh_model(harness, model)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -56,6 +56,7 @@ from .state import (
     read_daemon_pid,
     refresh_model_flag_path,
     refresh_runtime_flag_path,
+    refresh_session_flag_path,
     refresh_token_request_path,
     restart_flag_path,
     stop_request_path,
@@ -156,6 +157,11 @@ class Daemon:
 
         control_manager = ControlManager()
         control_task = asyncio.ensure_future(control_manager.run())
+
+        # Before the first reconcile spawns any worker: if the puffo MCP
+        # tool surface changed, drop cli-local codex sessions so they
+        # reload tools instead of resuming a stale snapshot.
+        _respawn_codex_on_mcp_change_at_startup()
 
         try:
             while not self._stop.is_set():
@@ -679,6 +685,61 @@ async def _sweep_archived_pending_revokes_at_startup() -> None:
             )
     except Exception as exc:  # noqa: BLE001
         logger.warning("archived pending revoke sweep errored: %s", exc)
+
+
+def _mcp_fingerprint_path() -> Path:
+    return home_dir() / "mcp_tool_fingerprint"
+
+
+def _respawn_codex_on_mcp_change_at_startup() -> None:
+    """Codex snapshots its MCP tools at session start and never reloads
+    them (openai/codex#7767), so an in-place change to the puffo tool
+    surface leaves a resumed codex session on a stale tool set. On boot,
+    if the fingerprint changed since last run, drop the CLI session of
+    every cli-local codex agent so it opens a fresh codex conversation
+    and reloads the tools. First run just records the fingerprint."""
+    import json
+
+    from ..mcp.puffo_core_server import mcp_tool_fingerprint
+
+    try:
+        current = mcp_tool_fingerprint()
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("startup: mcp fingerprint failed: %s", exc)
+        return
+    fp_path = _mcp_fingerprint_path()
+    previous = (
+        fp_path.read_text(encoding="utf-8").strip() if fp_path.exists() else ""
+    )
+    if previous and previous != current:
+        for agent_id in discover_agents():
+            try:
+                cfg = AgentConfig.load(agent_id)
+            except Exception:  # noqa: BLE001
+                continue
+            rt = cfg.runtime
+            if rt.kind != "cli-local" or rt.harness != "codex":
+                continue
+            try:
+                flag = refresh_session_flag_path(cfg.resolve_workspace_dir())
+                flag.parent.mkdir(parents=True, exist_ok=True)
+                flag.write_text(
+                    json.dumps({"requested_at": int(time.time())}) + "\n",
+                    encoding="utf-8",
+                )
+                logger.info(
+                    "startup: mcp surface changed — dropping codex session for "
+                    "%s so it reloads tools", agent_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "startup: couldn't drop codex session for %s: %s",
+                    agent_id, exc,
+                )
+    try:
+        fp_path.write_text(current + "\n", encoding="utf-8")
+    except OSError as exc:
+        logger.warning("startup: couldn't persist mcp fingerprint: %s", exc)
 
 
 async def _migrate_linked_agents_at_startup() -> None:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -862,8 +862,8 @@ def _process_daemon_refresh_flags(agent_id: str) -> None:
             harness = str(payload.get("harness") or "")
             model = str(payload.get("model") or "")
             level = str(payload.get("inference_level") or "")
-            # harness+model swap and a standalone inference_level (PUF-392)
-            # ride the same flag; validate only what's present.
+            # harness+model swap and a standalone inference_level ride the
+            # same flag; validate only what's present.
             swap_model = bool(harness or model)
             if swap_model:
                 _validate_daemon_refresh_model(harness, model)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -158,9 +158,7 @@ class Daemon:
         control_manager = ControlManager()
         control_task = asyncio.ensure_future(control_manager.run())
 
-        # Before the first reconcile spawns any worker: if the puffo MCP
-        # tool surface changed, drop cli-local codex sessions so they
-        # reload tools instead of resuming a stale snapshot.
+        # Must run before the first reconcile spawns any worker.
         _respawn_codex_on_mcp_change_at_startup()
 
         try:
@@ -692,12 +690,10 @@ def _mcp_fingerprint_path() -> Path:
 
 
 def _respawn_codex_on_mcp_change_at_startup() -> None:
-    """Codex snapshots its MCP tools at session start and never reloads
-    them (openai/codex#7767), so an in-place change to the puffo tool
-    surface leaves a resumed codex session on a stale tool set. On boot,
-    if the fingerprint changed since last run, drop the CLI session of
-    every cli-local codex agent so it opens a fresh codex conversation
-    and reloads the tools. First run just records the fingerprint."""
+    """On boot, if the puffo MCP tool surface changed since last run, drop
+    every cli-local codex agent's CLI session so it opens a fresh codex
+    conversation and reloads the tools — codex snapshots MCP once and never
+    reloads (openai/codex#7767). First run just records the fingerprint."""
     import json
 
     from ..mcp.puffo_core_server import mcp_tool_fingerprint

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -525,13 +525,12 @@ def test_write_refresh_model_flag_carries_harness_and_model(tmp_path):
     assert payload["harness"] == "codex"
     assert payload["model"] == "gpt-5"
     assert isinstance(payload["requested_at"], int)
-    # No inference_level passed → key omitted (PUF-392).
+    # No inference_level passed → key omitted.
     assert "inference_level" not in payload
 
 
 def test_write_refresh_model_flag_carries_inference_level(tmp_path):
-    # PUF-392: a standalone effort swap rides the same flag with empty
-    # harness/model.
+    # A standalone effort swap rides the same flag with empty harness/model.
     path = _write_refresh_model_flag(tmp_path, inference_level="medium")
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["inference_level"] == "medium"

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -525,6 +525,18 @@ def test_write_refresh_model_flag_carries_harness_and_model(tmp_path):
     assert payload["harness"] == "codex"
     assert payload["model"] == "gpt-5"
     assert isinstance(payload["requested_at"], int)
+    # No inference_level passed → key omitted (PUF-392).
+    assert "inference_level" not in payload
+
+
+def test_write_refresh_model_flag_carries_inference_level(tmp_path):
+    # PUF-392: a standalone effort swap rides the same flag with empty
+    # harness/model.
+    path = _write_refresh_model_flag(tmp_path, inference_level="medium")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["inference_level"] == "medium"
+    assert payload["harness"] == ""
+    assert payload["model"] == ""
 
 
 def test_write_refresh_runtime_flag_kind_only(tmp_path):

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -266,8 +266,7 @@ def test_daemon_applies_harness_model_and_level_together(tmp_path, monkeypatch):
     _write_model_flag(
         cfg, harness="claude-code", model="claude-opus-4-8", inference_level="xhigh",
     )
-    # claude-code CLI must resolve for the harness+model validation to pass;
-    # skip if it's not installed in this env.
+    # Needs the claude-code CLI for harness+model validation; skip if absent.
     from puffo_agent.agent.cli_bin import resolve_claude_bin
     if resolve_claude_bin() is None:
         pytest.skip("claude-code CLI not installed")
@@ -352,16 +351,14 @@ async def test_refresh_tool_standalone_level_validates_against_current_harness(t
 
 @pytest.mark.asyncio
 async def test_refresh_tool_level_subsumes_host_sync_on_docker(tmp_path):
-    # host_sync on cli-docker normally needs session=True; a respawn
-    # (inference_level) subsumes the container bounce → no raise.
+    # A respawn (inference_level) subsumes the cli-docker host_sync gate.
     refresh = _refresh_tool(tmp_path, harness="codex", runtime_kind="cli-docker")
     out = await refresh(host_sync=True, inference_level="low")
     assert "inference_level='low'" in out
 
 
 def test_refresh_skill_documents_inference_level_axis():
-    # The agent-facing skill (rendered into CLAUDE.md) must advertise the
-    # axis too, not just the tool docstring, or agents can't discover it.
+    # The skill (in CLAUDE.md) must advertise the axis, not just the docstring.
     from puffo_agent.agent.shared_content import DEFAULT_SKILL_REFRESH
 
     assert "inference_level" in DEFAULT_SKILL_REFRESH
@@ -387,8 +384,7 @@ async def test_refresh_tool_host_sync_and_session_touch_flags(tmp_path):
 
 @pytest.mark.asyncio
 async def test_refresh_tool_combined_harness_model_and_level(tmp_path, monkeypatch):
-    # Combined path: harness+model+level in one call. Stub the CLI-dependent
-    # model validator so the tool orchestration is what's exercised.
+    # Combined path; stub the CLI-dependent model validator.
     from puffo_agent.mcp import puffo_core_server as s
     monkeypatch.setattr(s, "_validate_refresh_model", lambda h, m: None)
     refresh = _refresh_tool(tmp_path, harness="codex")

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -246,9 +246,7 @@ def _write_model_flag(cfg, **payload):
 
 
 def test_daemon_applies_standalone_inference_level(tmp_path, monkeypatch):
-    # Standalone: refresh(inference_level=...) with no harness/model persists
-    # effort to agent.yml and consumes the flag (respawn is the config-changed
-    # check's job, driven by runtime inequality).
+    # Standalone effort swap persists to agent.yml and consumes the flag.
     from puffo_agent.portal.state import AgentConfig
     cfg = _codex_agent(tmp_path, monkeypatch)
     flag = _write_model_flag(cfg, harness="", model="", inference_level="medium")
@@ -385,3 +383,38 @@ async def test_refresh_tool_host_sync_and_session_touch_flags(tmp_path):
     out = await refresh(host_sync=True, session=True)
     for name in ("refresh_agent", "refresh_host_sync", "refresh_session"):
         assert name in out
+
+
+@pytest.mark.asyncio
+async def test_refresh_tool_combined_harness_model_and_level(tmp_path, monkeypatch):
+    # Combined path: harness+model+level in one call. Stub the CLI-dependent
+    # model validator so the tool orchestration is what's exercised.
+    from puffo_agent.mcp import puffo_core_server as s
+    monkeypatch.setattr(s, "_validate_refresh_model", lambda h, m: None)
+    refresh = _refresh_tool(tmp_path, harness="codex")
+    out = await refresh(
+        harness="claude-code", model="claude-opus-4-8", inference_level="xhigh",
+    )
+    assert "harness='claude-code'" in out
+    assert "inference_level='xhigh'" in out
+    payload = json.loads(
+        (tmp_path / ".puffo-agent" / "refresh_model.flag").read_text(encoding="utf-8")
+    )
+    assert payload["harness"] == "claude-code"
+    assert payload["inference_level"] == "xhigh"
+
+
+def test_daemon_applies_all_three_without_cli(tmp_path, monkeypatch):
+    # Deterministic combined-apply (no CLI): stub the model validator.
+    from puffo_agent.portal import daemon as d
+    from puffo_agent.portal.state import AgentConfig
+    monkeypatch.setattr(d, "_validate_daemon_refresh_model", lambda h, m: None)
+    cfg = _codex_agent(tmp_path, monkeypatch)
+    _write_model_flag(
+        cfg, harness="claude-code", model="claude-opus-4-8", inference_level="xhigh",
+    )
+    d._process_daemon_refresh_flags("codex-refresh")
+    loaded = AgentConfig.load("codex-refresh")
+    assert loaded.runtime.harness == "claude-code"
+    assert loaded.runtime.model == "claude-opus-4-8"
+    assert loaded.runtime.inference_level == "xhigh"

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -169,7 +169,7 @@ def test_create_bundle_parses_and_validates_level():
     assert "INFERENCE_LEVELS" in src
 
 
-# ─── PUF-392: inference_level via the self-serve refresh MCP ──────────
+# ─── inference_level via the self-serve refresh MCP ──────────
 
 
 import json  # noqa: E402
@@ -246,7 +246,7 @@ def _write_model_flag(cfg, **payload):
 
 
 def test_daemon_applies_standalone_inference_level(tmp_path, monkeypatch):
-    # AC 1: refresh(inference_level=...) with no harness/model persists the
+    # Standalone: refresh(inference_level=...) with no harness/model persists
     # effort to agent.yml and consumes the flag (respawn is the config-changed
     # check's job, driven by runtime inequality).
     from puffo_agent.portal.state import AgentConfig
@@ -262,7 +262,7 @@ def test_daemon_applies_standalone_inference_level(tmp_path, monkeypatch):
 
 
 def test_daemon_applies_harness_model_and_level_together(tmp_path, monkeypatch):
-    # AC 2: all three persist from one flag.
+    # harness + model + level all persist from one flag.
     from puffo_agent.portal.state import AgentConfig
     cfg = _codex_agent(tmp_path, monkeypatch)
     _write_model_flag(
@@ -282,7 +282,7 @@ def test_daemon_applies_harness_model_and_level_together(tmp_path, monkeypatch):
 
 
 def test_daemon_marks_flag_broken_on_bad_level(tmp_path, monkeypatch):
-    # AC 3: xhigh on a codex agent → no persistence, flag goes .broken.
+    # xhigh on a codex agent → no persistence, flag goes .broken.
     from puffo_agent.portal.state import AgentConfig
     cfg = _codex_agent(tmp_path, monkeypatch, level="low")
     flag = _write_model_flag(cfg, harness="", model="", inference_level="xhigh")
@@ -296,7 +296,7 @@ def test_daemon_marks_flag_broken_on_bad_level(tmp_path, monkeypatch):
 
 
 def test_refresh_docstring_documents_inference_level_axis():
-    """AC 7 source-pin: the refresh MCP tool advertises inference_level as an
+    """Source-pin: the refresh MCP tool advertises inference_level as an
     orthogonal axis so agents discover it; guards a future refactor from
     silently dropping it from the docs."""
     import inspect
@@ -306,3 +306,82 @@ def test_refresh_docstring_documents_inference_level_axis():
     src = inspect.getsource(puffo_core_server._register_local_tools)
     assert "Five orthogonal axes" in src
     assert "inference_level" in src
+
+
+# ─── refresh MCP tool: inference_level orchestration ─────────────────
+
+
+def _refresh_tool(workspace, *, harness="codex", runtime_kind="cli-local"):
+    """Capture the ``refresh`` closure by registering the local tools
+    against a fake FastMCP."""
+    from puffo_agent.mcp import puffo_core_server
+
+    captured: dict = {}
+
+    class _FakeMcp:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    puffo_core_server._register_local_tools(
+        _FakeMcp(), str(workspace), runtime_kind=runtime_kind, harness=harness,
+    )
+    return captured["refresh"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_tool_standalone_level_writes_flag(tmp_path):
+    refresh = _refresh_tool(tmp_path, harness="codex")
+    out = await refresh(inference_level="medium")
+    assert "inference_level='medium'" in out
+    payload = json.loads(
+        (tmp_path / ".puffo-agent" / "refresh_model.flag").read_text(encoding="utf-8")
+    )
+    assert payload["inference_level"] == "medium"
+    assert payload["harness"] == "" and payload["model"] == ""
+
+
+@pytest.mark.asyncio
+async def test_refresh_tool_standalone_level_validates_against_current_harness(tmp_path):
+    # codex agent + xhigh (claude-code-only) → rejected, no flag written.
+    refresh = _refresh_tool(tmp_path, harness="codex")
+    with pytest.raises(RuntimeError):
+        await refresh(inference_level="xhigh")
+    assert not (tmp_path / ".puffo-agent" / "refresh_model.flag").exists()
+
+
+@pytest.mark.asyncio
+async def test_refresh_tool_level_subsumes_host_sync_on_docker(tmp_path):
+    # host_sync on cli-docker normally needs session=True; a respawn
+    # (inference_level) subsumes the container bounce → no raise.
+    refresh = _refresh_tool(tmp_path, harness="codex", runtime_kind="cli-docker")
+    out = await refresh(host_sync=True, inference_level="low")
+    assert "inference_level='low'" in out
+
+
+def test_refresh_skill_documents_inference_level_axis():
+    # The agent-facing skill (rendered into CLAUDE.md) must advertise the
+    # axis too, not just the tool docstring, or agents can't discover it.
+    from puffo_agent.agent.shared_content import DEFAULT_SKILL_REFRESH
+
+    assert "inference_level" in DEFAULT_SKILL_REFRESH
+    assert "Four orthogonal" not in DEFAULT_SKILL_REFRESH
+
+
+@pytest.mark.asyncio
+async def test_refresh_tool_no_axes_touches_agent_flag(tmp_path):
+    # No respawn axis → worker-scope refresh, no model flag.
+    refresh = _refresh_tool(tmp_path, harness="codex")
+    out = await refresh()
+    assert "refresh_agent" in out
+    assert not (tmp_path / ".puffo-agent" / "refresh_model.flag").exists()
+
+
+@pytest.mark.asyncio
+async def test_refresh_tool_host_sync_and_session_touch_flags(tmp_path):
+    refresh = _refresh_tool(tmp_path, harness="codex", runtime_kind="cli-local")
+    out = await refresh(host_sync=True, session=True)
+    for name in ("refresh_agent", "refresh_host_sync", "refresh_session"):
+        assert name in out

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -293,3 +293,16 @@ def test_daemon_marks_flag_broken_on_bad_level(tmp_path, monkeypatch):
     assert loaded.runtime.inference_level == "low"  # unchanged
     assert not flag.exists()
     assert flag.with_suffix(".flag.broken").exists()
+
+
+def test_refresh_docstring_documents_inference_level_axis():
+    """AC 7 source-pin: the refresh MCP tool advertises inference_level as an
+    orthogonal axis so agents discover it; guards a future refactor from
+    silently dropping it from the docs."""
+    import inspect
+
+    from puffo_agent.mcp import puffo_core_server
+
+    src = inspect.getsource(puffo_core_server._register_local_tools)
+    assert "Five orthogonal axes" in src
+    assert "inference_level" in src

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -167,3 +167,129 @@ def test_create_bundle_parses_and_validates_level():
     src = inspect.getsource(handlers._verify_agent_bundle)
     assert "inference_level=str(rt.get(\"inference_level\", \"\"))" in src
     assert "INFERENCE_LEVELS" in src
+
+
+# ─── PUF-392: inference_level via the self-serve refresh MCP ──────────
+
+
+import json  # noqa: E402
+import pytest  # noqa: E402
+
+from puffo_agent.mcp.config import supported_inference_levels  # noqa: E402
+from puffo_agent.mcp.puffo_core_server import (  # noqa: E402
+    _validate_refresh_inference_level,
+)
+from puffo_agent.portal.daemon import (  # noqa: E402
+    _process_daemon_refresh_flags,
+    _validate_daemon_inference_level,
+)
+from puffo_agent.portal.state import refresh_model_flag_path  # noqa: E402
+
+
+def test_supported_levels_are_per_harness():
+    assert supported_inference_levels("codex") == REASONING_EFFORTS
+    assert supported_inference_levels("claude-code") == INFERENCE_LEVELS
+    # codex has minimal but not xhigh; claude-code the reverse.
+    assert "xhigh" not in supported_inference_levels("codex")
+    assert "minimal" not in supported_inference_levels("claude-code")
+
+
+def test_supported_levels_unknown_harness_is_permissive_union():
+    levels = supported_inference_levels("")
+    assert set(levels) == set(INFERENCE_LEVELS) | set(REASONING_EFFORTS)
+
+
+@pytest.mark.parametrize(
+    "harness,level",
+    [("codex", "medium"), ("codex", "minimal"), ("claude-code", "high"),
+     ("claude-code", "xhigh"), ("", "medium")],
+)
+def test_refresh_validator_accepts_in_set(harness, level):
+    _validate_refresh_inference_level(harness, level)  # no raise
+
+
+@pytest.mark.parametrize(
+    "harness,level",
+    [("codex", "xhigh"), ("claude-code", "minimal"), ("codex", "turbo")],
+)
+def test_refresh_validator_rejects_out_of_set(harness, level):
+    with pytest.raises(RuntimeError):
+        _validate_refresh_inference_level(harness, level)
+
+
+def test_daemon_validator_rejects_codex_xhigh():
+    with pytest.raises(ValueError):
+        _validate_daemon_inference_level("codex", "xhigh")
+    _validate_daemon_inference_level("codex", "high")  # no raise
+
+
+def _codex_agent(tmp_path, monkeypatch, aid="codex-refresh", level=""):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.portal.state import AgentConfig, RuntimeConfig
+    cfg = AgentConfig(
+        id=aid,
+        display_name=aid,
+        runtime=RuntimeConfig(
+            kind="cli-local", harness="codex", model="gpt-5.6",
+            inference_level=level,
+        ),
+    )
+    cfg.save()
+    return cfg
+
+
+def _write_model_flag(cfg, **payload):
+    flag = refresh_model_flag_path(cfg.resolve_workspace_dir())
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text(json.dumps({"requested_at": 0, **payload}) + "\n", encoding="utf-8")
+    return flag
+
+
+def test_daemon_applies_standalone_inference_level(tmp_path, monkeypatch):
+    # AC 1: refresh(inference_level=...) with no harness/model persists the
+    # effort to agent.yml and consumes the flag (respawn is the config-changed
+    # check's job, driven by runtime inequality).
+    from puffo_agent.portal.state import AgentConfig
+    cfg = _codex_agent(tmp_path, monkeypatch)
+    flag = _write_model_flag(cfg, harness="", model="", inference_level="medium")
+
+    _process_daemon_refresh_flags("codex-refresh")
+
+    loaded = AgentConfig.load("codex-refresh")
+    assert loaded.runtime.inference_level == "medium"
+    assert loaded.runtime.harness == "codex"  # untouched
+    assert not flag.exists()
+
+
+def test_daemon_applies_harness_model_and_level_together(tmp_path, monkeypatch):
+    # AC 2: all three persist from one flag.
+    from puffo_agent.portal.state import AgentConfig
+    cfg = _codex_agent(tmp_path, monkeypatch)
+    _write_model_flag(
+        cfg, harness="claude-code", model="claude-opus-4-8", inference_level="xhigh",
+    )
+    # claude-code CLI must resolve for the harness+model validation to pass;
+    # skip if it's not installed in this env.
+    from puffo_agent.agent.cli_bin import resolve_claude_bin
+    if resolve_claude_bin() is None:
+        pytest.skip("claude-code CLI not installed")
+
+    _process_daemon_refresh_flags("codex-refresh")
+
+    loaded = AgentConfig.load("codex-refresh")
+    assert loaded.runtime.harness == "claude-code"
+    assert loaded.runtime.inference_level == "xhigh"
+
+
+def test_daemon_marks_flag_broken_on_bad_level(tmp_path, monkeypatch):
+    # AC 3: xhigh on a codex agent → no persistence, flag goes .broken.
+    from puffo_agent.portal.state import AgentConfig
+    cfg = _codex_agent(tmp_path, monkeypatch, level="low")
+    flag = _write_model_flag(cfg, harness="", model="", inference_level="xhigh")
+
+    _process_daemon_refresh_flags("codex-refresh")
+
+    loaded = AgentConfig.load("codex-refresh")
+    assert loaded.runtime.inference_level == "low"  # unchanged
+    assert not flag.exists()
+    assert flag.with_suffix(".flag.broken").exists()

--- a/tests/test_mcp_change_respawn.py
+++ b/tests/test_mcp_change_respawn.py
@@ -1,0 +1,73 @@
+"""Codex snapshots MCP at session start; when the puffo tool surface
+changes, cli-local codex agents must drop their session on daemon boot
+so they reload the tools (openai/codex#7767)."""
+import pytest
+
+from puffo_agent.mcp.puffo_core_server import mcp_tool_fingerprint
+from puffo_agent.portal.daemon import (
+    _mcp_fingerprint_path,
+    _respawn_codex_on_mcp_change_at_startup,
+)
+from puffo_agent.portal.state import (
+    AgentConfig,
+    RuntimeConfig,
+    refresh_session_flag_path,
+)
+
+
+def _agent(aid: str, *, kind: str, harness: str) -> AgentConfig:
+    cfg = AgentConfig(
+        id=aid, display_name=aid,
+        runtime=RuntimeConfig(kind=kind, harness=harness, model="m"),
+    )
+    cfg.save()
+    return cfg
+
+
+def _has_session_flag(cfg: AgentConfig) -> bool:
+    return refresh_session_flag_path(cfg.resolve_workspace_dir()).exists()
+
+
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    monkeypatch.setenv("PUFFO_HOME", str(tmp_path))
+
+
+def test_fingerprint_is_stable_and_hex():
+    a = mcp_tool_fingerprint()
+    assert a == mcp_tool_fingerprint()
+    assert len(a) == 64 and all(c in "0123456789abcdef" for c in a)
+
+
+def test_first_run_records_fingerprint_no_respawn(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    c = _agent("codex-1", kind="cli-local", harness="codex")
+    assert not _mcp_fingerprint_path().exists()
+    _respawn_codex_on_mcp_change_at_startup()
+    assert _mcp_fingerprint_path().read_text().strip() == mcp_tool_fingerprint()
+    assert not _has_session_flag(c)
+
+
+def test_unchanged_fingerprint_no_respawn(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    c = _agent("codex-1", kind="cli-local", harness="codex")
+    _mcp_fingerprint_path().write_text(mcp_tool_fingerprint() + "\n", encoding="utf-8")
+    _respawn_codex_on_mcp_change_at_startup()
+    assert not _has_session_flag(c)
+
+
+def test_changed_fingerprint_respawns_only_cli_local_codex(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    codex_local = _agent("codex-local", kind="cli-local", harness="codex")
+    codex_docker = _agent("codex-docker", kind="cli-docker", harness="codex")
+    claude_local = _agent("claude-local", kind="cli-local", harness="claude-code")
+    ws_agent = _agent("ws-agent", kind="ws-local", harness="codex")
+    _mcp_fingerprint_path().write_text("STALE\n", encoding="utf-8")
+
+    _respawn_codex_on_mcp_change_at_startup()
+
+    assert _has_session_flag(codex_local)
+    assert not _has_session_flag(codex_docker)
+    assert not _has_session_flag(claude_local)
+    assert not _has_session_flag(ws_agent)
+    assert _mcp_fingerprint_path().read_text().strip() == mcp_tool_fingerprint()

--- a/tests/test_mcp_change_respawn.py
+++ b/tests/test_mcp_change_respawn.py
@@ -71,3 +71,32 @@ def test_changed_fingerprint_respawns_only_cli_local_codex(tmp_path, monkeypatch
     assert not _has_session_flag(claude_local)
     assert not _has_session_flag(ws_agent)
     assert _mcp_fingerprint_path().read_text().strip() == mcp_tool_fingerprint()
+
+
+def test_changed_fingerprint_skips_unloadable_agent(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    good = _agent("codex-good", kind="cli-local", harness="codex")
+    # A broken agent.yml must be skipped, not crash the sweep.
+    from puffo_agent.portal.state import agent_yml_path
+    bad = agent_yml_path("codex-bad")
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("::: not valid yaml :::", encoding="utf-8")
+    _mcp_fingerprint_path().write_text("STALE\n", encoding="utf-8")
+
+    _respawn_codex_on_mcp_change_at_startup()
+
+    assert _has_session_flag(good)
+    assert _mcp_fingerprint_path().read_text().strip() == mcp_tool_fingerprint()
+
+
+def test_respawn_survives_fingerprint_failure(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    from puffo_agent.mcp import puffo_core_server as s
+
+    def _boom():
+        raise RuntimeError("fingerprint blew up")
+
+    monkeypatch.setattr(s, "mcp_tool_fingerprint", _boom)
+    # Best-effort: return without raising and without recording a fingerprint.
+    _respawn_codex_on_mcp_change_at_startup()
+    assert not _mcp_fingerprint_path().exists()


### PR DESCRIPTION
## Summary

Adds an `inference_level` axis to `mcp__puffo__refresh`, so an agent can self-serve a mid-session effort swap without waiting on a manual `agent.yml` edit or a web-form-edit round trip. Rides the same `refresh_model.flag` → agent.yml → worker respawn plumbing PUF-373 established.

**Materializes FB-426** (SuperStar 3/3 recurrence). Standalone `refresh(inference_level="medium")` persists + respawns; the next codex conversation opens with `model_reasoning_effort="medium"`.

## Files

- `mcp/config.py` — new `supported_inference_levels(harness)` — single source of truth (codex: minimal/low/medium/high, claude-code: low/medium/high/xhigh, unknown: permissive union).
- `mcp/puffo_core_server.py` — `refresh` accepts `inference_level`, validates against effective harness (swap harness if given, else agent's current).
- `mcp/host_tools.py` — `_write_refresh_model_flag` adds optional `inference_level` field.
- `portal/daemon.py` — `_process_daemon_refresh_flags` re-validates + applies `inference_level` independently of harness/model presence (both can ride the same flag or arrive standalone).
- `tests/test_inference_level.py` — 10 new tests (per-harness enums · validator accepts/rejects · standalone apply · combined apply · flag broken on bad level).
- `tests/test_agent_install.py` — refresh MCP signature assertion covers the new param.

## Substrate correction to intake

Intake said per-harness validation "already exists post-PUF-373." It doesn't — PUF-373 shipped two module-level tuples + per-adapter *soft-drop at emit*. Real per-harness validator was needed for AC 3/4; landed as `supported_inference_levels`.

## Test plan

- [x] Touched suites (`test_inference_level.py` + `test_agent_install.py`) → **94 pass**.
- [x] Full pytest sweep (excluding pre-existing PySide6 UI tests) → **2043 pass / 2 skipped / 0 fail**.
- [x] AC1-AC7 covered per Calculation's mapping.

## Known scope-out

**Sibling inconsistency** flagged for a separate ticket (not folded here per intake scope): the web/CLI edit path (`portal/control/client.py:285`) validates `inference_level` against the generic superset, NOT per-harness. Post-PUF-392, `refresh(inference_level="minimal")` on codex is accepted but edit rejects it; `refresh("xhigh")` on codex is rejected but edit accepts it. Real gap, out of PUF-392 scope; Equation to file follow-up.

**Standalone `inference_level` + host_sync on cli-docker** now rides the respawn (subsumes host_sync's container bounce). Deliberate; documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
