### PR TITLE
fix(bridge): seed channel->space from list_spaces so member channels post

### DIFF
--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -854,6 +854,14 @@ class PuffoCoreMessageClient:
                 "bridge backfill complete: pending_delivered (count=%s)",
                 frame.get("count"),
             )
+            # Seed the channel→space map for every channel we're already a
+            # member of, so a proactive post to a pre-existing channel works
+            # from boot (not only after the first inbound message there).
+            # Scheduled async — awaiting send_list_spaces inline would deadlock
+            # frames(), which must keep receiving to deliver the 'spaces' reply.
+            task = asyncio.create_task(self._refresh_bridge_spaces())
+            self._ack_tasks.add(task)
+            task.add_done_callback(self._ack_tasks.discard)
         elif kind == "added_to_space":
             # Server push (AgentServerMsg::AddedToSpace) the moment this
             # agent is added to a Space — refresh the known-spaces view
@@ -900,16 +908,23 @@ class PuffoCoreMessageClient:
             )
 
     async def _refresh_bridge_spaces(self, trigger_space_id: str = "") -> None:
-        """Re-issue ``list_spaces`` over the bridge WS after an
-        ``added_to_space`` push so the new space enters the agent's
-        known set eagerly (name cache + disk cache) rather than lazily
-        on the next tool call. Idempotent: a duplicate ``added_to_space``
-        for an already-known space is a harmless re-list (``setdefault``
-        keeps the existing entries). Fail-soft: a failed refresh logs
-        and drops — the MCP ``list_spaces`` tool reads the authoritative
-        route live, so a lost refresh is at worst a stale name cache,
-        never a missed membership. Native transport never calls this
-        (no ``_bridge``).
+        """Re-issue ``list_spaces`` over the bridge WS so the agent's known
+        spaces + channels enter its caches eagerly rather than lazily on the
+        next tool call. Called after an ``added_to_space`` push and once on
+        startup (after ``pending_delivered``).
+
+        As well as the space name/disk caches, this seeds the channel→space
+        map for **every channel the agent can see** — so it can post to a
+        channel it belongs to WITHOUT first receiving a message there. Without
+        this, the daemon's ``lookup_channel_space`` 404s for a member channel
+        until an inbound message arrives, and the post is rejected as "no
+        record of channel".
+
+        Idempotent (``setdefault`` / upserting ``mark_channel_space``).
+        Fail-soft: a failed refresh logs and drops — the MCP ``list_spaces``
+        tool reads the authoritative route live, so a lost refresh is at worst
+        a stale cache, never a missed membership. Native transport never calls
+        this (no ``_bridge``).
         """
         bridge = self._bridge
         if bridge is None:
@@ -917,6 +932,7 @@ class PuffoCoreMessageClient:
         try:
             resp = await bridge.send_list_spaces()
             entries = resp.get("spaces") or []
+            seeded_channels = 0
             for entry in entries:
                 if not isinstance(entry, dict):
                     continue
@@ -927,10 +943,23 @@ class PuffoCoreMessageClient:
                 if sid and name:
                     self._space_name_cache.setdefault(sid, name)
                     disk_cache.persist_space(sid, name)
+                # Seed channel→space for every channel the agent can see
+                # (public + private it's a member of), so a proactive post to
+                # a member channel resolves without an inbound message first.
+                if sid:
+                    for ch in entry.get("channels") or []:
+                        if not isinstance(ch, dict):
+                            continue
+                        cid = ch.get("channel_id") or ch.get("id") or ""
+                        if not cid:
+                            continue
+                        self._channel_space[cid] = sid
+                        await self.store.mark_channel_space(cid, sid)
+                        seeded_channels += 1
             self._log.info(
-                "bridge spaces refresh: %d spaces listed "
+                "bridge spaces refresh: %d spaces listed, %d channels seeded "
                 "(trigger space_id=%s)",
-                len(entries), trigger_space_id or "<missing>",
+                len(entries), seeded_channels, trigger_space_id or "<missing>",
             )
         except Exception:  # noqa: BLE001 — a failed refresh must not crash the loop
             self._log.warning(

--- a/tests/test_channel_space_seed.py
+++ b/tests/test_channel_space_seed.py
@@ -1,0 +1,95 @@
+"""Seed channel->space from list_spaces.
+
+A keyless bridge agent's daemon resolves a channel's space via
+``lookup_channel_space`` before it can post. Previously that map was only
+filled by inbound messages, so posting to a member channel the agent had
+never been messaged in 404'd ("no record of channel"). ``_refresh_bridge_spaces``
+now seeds every channel the ``list_spaces`` reply carries — on startup and on
+``added_to_space`` — so a proactive post works without a message-there-first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent import puffo_core_client as pcc
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import KeyStore
+
+
+class _FakeBridge:
+    def __init__(self, spaces):
+        self._spaces = spaces
+        self.list_spaces_count = 0
+
+    async def send_list_spaces(self, *, timeout: float = 30.0) -> dict:
+        self.list_spaces_count += 1
+        return {"spaces": self._spaces}
+
+
+def _client(tmp_path, bridge, slug="bot-0001") -> PuffoCoreMessageClient:
+    ks = KeyStore(str(tmp_path / "keys"))
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, slug)
+    store = MessageStore(str(tmp_path / "messages.db"))
+    return PuffoCoreMessageClient(
+        slug=slug,
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=store,
+        workspace="",
+        bridge_client=bridge,
+    )
+
+
+def test_refresh_seeds_channel_space_for_member_channels(tmp_path, monkeypatch):
+    # persist_space writes to a real disk cache — no-op it in the test.
+    monkeypatch.setattr(pcc.disk_cache, "persist_space", lambda *a, **k: None)
+    bridge = _FakeBridge(spaces=[
+        {"space_id": "sp_1", "name": "SilverLake", "channels": [
+            {"channel_id": "ch_general", "name": "General"},
+            {"channel_id": "ch_random", "name": "Random"},
+        ]},
+        {"space_id": "sp_2", "name": "Other", "channels": [
+            {"channel_id": "ch_x", "name": "X"},
+        ]},
+    ])
+    c = _client(tmp_path, bridge)
+
+    async def go():
+        await c.store.open()
+        # Before: unknown channel -> the data-service would 404.
+        assert await c.store.lookup_channel_space("ch_general") is None
+
+        await c._refresh_bridge_spaces()
+
+        assert bridge.list_spaces_count == 1
+        # After: every member channel resolves in BOTH the persistent store
+        # (what the data-service reads) and the in-memory cache.
+        for cid, sid in (("ch_general", "sp_1"), ("ch_random", "sp_1"), ("ch_x", "sp_2")):
+            assert c._channel_space[cid] == sid
+            assert await c.store.lookup_channel_space(cid) == sid
+
+    asyncio.run(go())
+
+
+def test_refresh_tolerates_spaces_without_channels(tmp_path, monkeypatch):
+    # Back-compat: an entry with no ``channels`` key must not crash; space
+    # name caching still works.
+    monkeypatch.setattr(pcc.disk_cache, "persist_space", lambda *a, **k: None)
+    bridge = _FakeBridge(spaces=[{"space_id": "sp_1", "name": "Team"}])
+    c = _client(tmp_path, bridge)
+
+    async def go():
+        await c.store.open()
+        await c._refresh_bridge_spaces()
+        assert c._space_name_cache.get("sp_1") == "Team"
+
+    asyncio.run(go())


### PR DESCRIPTION
## Problem
A keyless bridge agent can't post to a channel it's a member of until it has **received a message there first**. Its daemon resolves a channel's space via `lookup_channel_space` before posting, and that `channel_space_map` was only filled by *inbound* messages. So a proactive post to a member channel 404s → the daemon rejects it: *"no record of channel … may not be a channel the agent belongs to."* (Seen live: an agent in a space but told to post to `#General` it hadn't been messaged in.)

## Fix
`_refresh_bridge_spaces` re-issues `list_spaces` (which already returns each space **with its visible channels** — public + private the agent is a member of). It now also **seeds `channel→space` for every one of those channels**, into both the in-memory cache and the persistent `channel_space_map` the data-service reads. Triggered:
- on **`added_to_space`** (as before), and
- **once on startup** (after `pending_delivered`), so channels the agent already belongs to at boot resolve immediately.

Result: an agent can post to any channel it belongs to **without a message-there-first**.

## Why it's safe
- Reuses the existing `channel_space_map` — its schema comment literally describes it as *"channel→space mappings discovered without an inbound message."*
- Idempotent (`mark_channel_space` upserts).
- Bridge-only path; native (signed) agents are unaffected.

## Tests
`tests/test_channel_space_seed.py`: a listed-but-never-messaged channel resolves via `lookup_channel_space` after the refresh (persistent store + in-memory cache); spaces without a `channels` key don't crash. Existing bridge/membership suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)