### PR TITLE
Thread-root integrity: receive-side normalization + send-side resolution rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Thread-root integrity, both directions.** Incoming `thread_root_id`
+  now normalizes to the canonical root before a message is stored: a
+  reference to a non-root walks up to the true root, and a reference
+  that is cross-channel, unknown, or corrupt (cycle / over-deep chain)
+  is admitted as a new root instead. Outbound sends apply matching
+  rules — a `root_id` naming a daemon-local system message (which has
+  no server row) ships as a new top-level message, a root from another
+  channel or DM is rejected with a correctable error, and a non-root
+  auto-corrects to its thread root. Previously a reply to a system
+  message triggered a spurious "thread chain looks corrupt" warning,
+  and DM sends skipped root validation entirely.
+
+- **Hidden root-level posts.** Outbound visibility is now decided after
+  thread-root resolution, so a message whose root gets wiped is
+  correctly treated as root-level and forced visible. Previously it
+  could ship hidden — and root-level messages can't fold, so it was
+  invisible in every client.
+
 ### Added
 
 - **Receive plaintext (non-E2EE) messages.** The daemon now accepts the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.1.3"
+version = "1.1.4"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -73,9 +73,8 @@ PRIORITY_SYSTEM = 5
 # tool which force-refreshes regardless of TTL.
 _PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
-# Hops the admit-time thread-root walk will follow. Healthy data resolves in
-# one hop (a root's own thread_root_id is NULL); anything deeper is a corrupt
-# chain we refuse to trust — the reply is admitted as its own root instead.
+# Healthy data resolves in one hop (a root's own thread_root_id is NULL);
+# deeper chains are corrupt and the reply is admitted as its own root.
 _INCOMING_ROOT_MAX_DEPTH = 8
 
 # Mirrors ``adapters/cli_session.MAX_USER_MESSAGE_BYTES``; a test pins them.
@@ -755,17 +754,9 @@ class PuffoCoreMessageClient:
                 )
                 return
 
-            # PUF-227-A: strict cache-validation invariant for incoming
-            # ids. Any thread_root_id / reply_to_id that doesn't point
-            # to a same-channel parent in our local message_store gets
-            # wiped to None before storage — the agent's local view
-            # never honors a thread linkage that can't be resolved here.
-            # Catches the Scout-class symptom: a server / UI / sender
-            # that stamps a cross-channel id can't poison the recipient
-            # daemon's thread state.
-            # thread_root_id additionally resolves to the canonical root: a
-            # sender stamping a reply id would otherwise index this row under
-            # a non-root, and that corruption then rides our own sends out.
+            # Incoming thread linkage normalizes before storage:
+            # thread_root_id resolves to the canonical same-scope root
+            # (else None); reply_to_id must name a cached same-scope parent.
             validated_thread_root_id = await self._resolve_incoming_thread_root(
                 payload.thread_root_id, payload.channel_id, payload.space_id,
             )
@@ -2439,15 +2430,10 @@ class PuffoCoreMessageClient:
         expected_space_id: Optional[str],
     ) -> Optional[str]:
         """Canonical thread root for an incoming ``thread_root_id``, resolved
-        at admit time so the row lands correct in ``messages.db``.
-
-        A sender can stamp a *reply's* envelope id instead of the thread root;
-        walking to the real root here stops that reply from indexing under a
-        non-root (and stops the corrupt chain propagating to what we send).
-        Returns ``None`` — admit as a new root — when the reference isn't
-        cached, leaves the channel/space, or can't be trusted (cycle / too
-        deep). ``reply_to_id`` keeps using ``_validate_incoming_parent_id``:
-        it names the direct parent, not the root.
+        at admit time. Returns ``None`` — admit as a new root — when the
+        reference isn't cached, leaves the channel/space, or can't be
+        trusted (cycle / too deep). ``reply_to_id`` is different: it names
+        the direct parent, not the root.
         """
         if not parent_id:
             return parent_id

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -73,6 +73,11 @@ PRIORITY_SYSTEM = 5
 # tool which force-refreshes regardless of TTL.
 _PROFILE_CACHE_TTL_SECONDS = 10 * 60
 
+# Hops the admit-time thread-root walk will follow. Healthy data resolves in
+# one hop (a root's own thread_root_id is NULL); anything deeper is a corrupt
+# chain we refuse to trust — the reply is admitted as its own root instead.
+_INCOMING_ROOT_MAX_DEPTH = 8
+
 # Mirrors ``adapters/cli_session.MAX_USER_MESSAGE_BYTES``; a test pins them.
 DEFAULT_MAX_INPUT_BYTES = 180 * 1000
 
@@ -758,7 +763,10 @@ class PuffoCoreMessageClient:
             # Catches the Scout-class symptom: a server / UI / sender
             # that stamps a cross-channel id can't poison the recipient
             # daemon's thread state.
-            validated_thread_root_id = await self._validate_incoming_parent_id(
+            # thread_root_id additionally resolves to the canonical root: a
+            # sender stamping a reply id would otherwise index this row under
+            # a non-root, and that corruption then rides our own sends out.
+            validated_thread_root_id = await self._resolve_incoming_thread_root(
                 payload.thread_root_id, payload.channel_id, payload.space_id,
             )
             validated_reply_to_id = await self._validate_incoming_parent_id(
@@ -2376,25 +2384,40 @@ class PuffoCoreMessageClient:
         """
         if not parent_id:
             return parent_id
+        parent = await self._validated_parent(
+            parent_id, expected_channel_id, expected_space_id,
+            log_label="_validate_incoming_parent_id",
+        )
+        return parent_id if parent is not None else None
+
+    async def _validated_parent(
+        self,
+        parent_id: str,
+        expected_channel_id: Optional[str],
+        expected_space_id: Optional[str],
+        *,
+        log_label: str,
+    ) -> Any:
+        """Parent envelope from the local store, or None when it isn't cached
+        or sits in a different channel/space. ``log_label`` keeps the wipe
+        lines greppable per caller.
+        """
         try:
             parent = await self.store.get_message_by_envelope(parent_id)
         except Exception as exc:
             self._log.warning(
-                "_validate_incoming_parent_id: lookup failed for %s: %s",
-                parent_id, exc,
+                "%s: lookup failed for %s: %s", log_label, parent_id, exc,
             )
             return None
         if parent is None:
             self._log.info(
-                "_validate_incoming_parent_id: wiped %s — parent not in local cache",
-                parent_id,
+                "%s: wiped %s — parent not in local cache", log_label, parent_id,
             )
             return None
         if expected_channel_id and parent.channel_id != expected_channel_id:
             self._log.info(
-                "_validate_incoming_parent_id: wiped %s — parent channel "
-                "%r != incoming channel %r",
-                parent_id, parent.channel_id, expected_channel_id,
+                "%s: wiped %s — parent channel %r != incoming channel %r",
+                log_label, parent_id, parent.channel_id, expected_channel_id,
             )
             return None
         if (
@@ -2403,12 +2426,63 @@ class PuffoCoreMessageClient:
             and parent.space_id != expected_space_id
         ):
             self._log.info(
-                "_validate_incoming_parent_id: wiped %s — parent space "
-                "%r != incoming space %r",
-                parent_id, parent.space_id, expected_space_id,
+                "%s: wiped %s — parent space %r != incoming space %r",
+                log_label, parent_id, parent.space_id, expected_space_id,
             )
             return None
-        return parent_id
+        return parent
+
+    async def _resolve_incoming_thread_root(
+        self,
+        parent_id: Optional[str],
+        expected_channel_id: Optional[str],
+        expected_space_id: Optional[str],
+    ) -> Optional[str]:
+        """Canonical thread root for an incoming ``thread_root_id``, resolved
+        at admit time so the row lands correct in ``messages.db``.
+
+        A sender can stamp a *reply's* envelope id instead of the thread root;
+        walking to the real root here stops that reply from indexing under a
+        non-root (and stops the corrupt chain propagating to what we send).
+        Returns ``None`` — admit as a new root — when the reference isn't
+        cached, leaves the channel/space, or can't be trusted (cycle / too
+        deep). ``reply_to_id`` keeps using ``_validate_incoming_parent_id``:
+        it names the direct parent, not the root.
+        """
+        if not parent_id:
+            return parent_id
+        current = parent_id
+        seen: set[str] = set()
+        for _ in range(_INCOMING_ROOT_MAX_DEPTH):
+            if current in seen:
+                self._log.info(
+                    "_resolve_incoming_thread_root: wiped %s — cycle in thread chain",
+                    parent_id,
+                )
+                return None
+            seen.add(current)
+            parent = await self._validated_parent(
+                current, expected_channel_id, expected_space_id,
+                log_label="_resolve_incoming_thread_root",
+            )
+            if parent is None:
+                return None
+            # NULL root = a real root; self-reference = the synthetic system
+            # envelopes, which store their own id as the root.
+            if not parent.thread_root_id or parent.thread_root_id == current:
+                if current != parent_id:
+                    self._log.info(
+                        "_resolve_incoming_thread_root: corrected %s → %s "
+                        "(pointed at a reply, not the root)",
+                        parent_id, current,
+                    )
+                return current
+            current = parent.thread_root_id
+        self._log.info(
+            "_resolve_incoming_thread_root: wiped %s — chain deeper than %d",
+            parent_id, _INCOMING_ROOT_MAX_DEPTH,
+        )
+        return None
 
     async def rewarm_channel_caches(self) -> None:
         """On-miss re-warm; serialized + 5s-debounced (no stampede)."""

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -197,117 +197,30 @@ async def _supplement_missing_devices(
 from ..agent._visibility import resolve_visibility as _resolve_visibility
 
 
-_RESOLVE_ROOT_MAX_DEPTH = 4
+_RESOLVE_ROOT_MAX_DEPTH = 8
 
 
-async def _validate_root_same_channel(
-    resolved_root: Optional[str],
-    expected_channel_id: Optional[str],
-    expected_space_id: Optional[str],
+async def _resolve_outgoing_root(
+    root_id: str,
     data_client: Any,
+    *,
+    self_slug: str,
+    channel_id: Optional[str],
+    space_id: Optional[str],
+    dm_peer: Optional[str],
 ) -> tuple[Optional[str], str]:
-    """PUF-227-A: enforce the operator's strict-cache invariant on
-    send. If ``resolved_root`` is set, look the parent envelope up
-    in the agent's local message store. Wipe the id to ``None``
-    when:
-      - the parent isn't in local cache (strict per operator's
-        Q1(a) — "client should only see thread_root_id that's in
-        its local cache");
-      - the parent's ``channel_id`` differs from the outbound
-        ``expected_channel_id`` (this is the load-bearing PUF-227
-        check — cross-channel thread_root_id is the bug Scout's
-        symptom traced back to);
-      - the parent's ``space_id`` differs from the outbound
-        ``expected_space_id`` (belt-and-braces alongside the
-        channel check).
+    """Resolve the agent-supplied ``root_id`` to a server-valid thread
+    root for an outbound send. Returns ``(root_or_None, note)``:
 
-    On wipe, returns a warning ``note`` for the tool response so
-    the agent can self-correct on its next compose. Pass-through
-    case (parent in cache + same channel/space): returns
-    ``(resolved_root, "")``.
-    """
-    if not resolved_root or not resolved_root.strip():
-        return resolved_root, ""
-    try:
-        msg = await data_client.get_message_by_envelope(resolved_root)
-    except DataNotFound:
-        msg = None
-    except Exception as exc:
-        # Daemon-log grep symmetry with the receiver-side
-        # _validate_incoming_parent_id wipes — same "wiped %s — ..."
-        # shape so operators can filter both sides with one regex.
-        # Transport errors stay at WARNING (vs INFO for the other 3
-        # wipe branches) — distinguishes "we couldn't verify
-        # (operationally interesting)" from "we verified and it
-        # failed validation (expected steady-state)".
-        logger.warning(
-            "validate_root_same_channel: wiped %s — lookup transport error: %s",
-            resolved_root, exc,
-        )
-        return None, (
-            f"\nnote: thread_root_id {resolved_root} could not be verified "
-            "(local cache lookup failed); wiped to null and sent as "
-            "top-level."
-        )
-    if msg is None:
-        logger.info(
-            "validate_root_same_channel: wiped %s — parent not in local cache",
-            resolved_root,
-        )
-        return None, (
-            f"\nnote: thread_root_id {resolved_root} not in local cache; "
-            "wiped to null and sent as top-level. Agents can only reply "
-            "in threads whose root is in their own local message store."
-        )
-    if expected_channel_id and msg.channel_id != expected_channel_id:
-        logger.info(
-            "validate_root_same_channel: wiped %s — parent channel %r != "
-            "outbound channel %r",
-            resolved_root, msg.channel_id, expected_channel_id,
-        )
-        return None, (
-            f"\nnote: thread_root_id {resolved_root} belongs to channel "
-            f"{msg.channel_id!r}, not the outbound channel "
-            f"{expected_channel_id!r}; wiped to null and sent as "
-            "top-level."
-        )
-    if (
-        expected_space_id
-        and msg.space_id
-        and msg.space_id != expected_space_id
-    ):
-        logger.info(
-            "validate_root_same_channel: wiped %s — parent space %r != "
-            "outbound space %r",
-            resolved_root, msg.space_id, expected_space_id,
-        )
-        return None, (
-            f"\nnote: thread_root_id {resolved_root} belongs to space "
-            f"{msg.space_id!r}, not the outbound space "
-            f"{expected_space_id!r}; wiped to null and sent as "
-            "top-level."
-        )
-    return resolved_root, ""
-
-
-async def _resolve_root_id(
-    root_id: str, data_client: Any,
-) -> tuple[Optional[str], str]:
-    """When an agent passes a reply's envelope id as ``root_id``,
-    look that envelope up and substitute its own ``thread_root_id``
-    so the new message threads under the real root instead of
-    silently disappearing into a sub-thread.
-
-    On healthy data ``thread_root_id`` is always a true root (its
-    own ``thread_root_id IS NULL`` per ``message_store.py``'s schema
-    contract), so the loop terminates after at most one hop. The
-    multi-step walk + cycle break are corruption defense for relay
-    data shapes the schema shouldn't produce.
-
-    Returns ``(resolved_root_or_None, note)`` — ``None`` only when
-    ``root_id.strip()`` is empty. Lookup miss / transport failure
-    falls through with the original id plus a soft warning so the
-    send still completes.
+      - daemon-local system envelope (sender ``system`` / self-referencing
+        root) -> ``None``: the server has no such row, so the message goes
+        out as a new top-level root;
+      - reference from another channel/DM -> raises ``RuntimeError`` so
+        the agent can correct itself;
+      - same-scope reply -> walks up and returns the true root;
+      - not in the local store / lookup failure -> ``None`` + note (agents
+        may only thread under roots they hold locally);
+      - cycle / over-deep chain (corrupt data) -> original id + warning.
     """
     if not root_id.strip():
         return None, ""
@@ -316,7 +229,6 @@ async def _resolve_root_id(
     seen: set[str] = set()
     walked = False
     cycle = False
-
     for _ in range(_RESOLVE_ROOT_MAX_DEPTH):
         if current in seen:
             cycle = True
@@ -328,23 +240,72 @@ async def _resolve_root_id(
             msg = None
         except Exception as exc:
             logger.warning(
-                "resolve_root_id: lookup transport error for %s: %s",
-                current, exc,
+                "resolve_outgoing_root: wiped %s — lookup transport error: %s",
+                root_id, exc,
             )
-            return root_id, (
-                f"\nnote: could not verify root_id {root_id} is a thread "
-                "root (lookup failed); sent as-is. If this lands in the "
-                "wrong thread, pass the metadata block's thread_root_id, "
-                "not post_id."
+            return None, (
+                f"\nnote: thread_root_id {root_id} could not be verified "
+                "(local cache lookup failed); sent as top-level."
             )
         if msg is None:
-            return root_id, (
-                f"\nnote: could not verify root_id {root_id} is a thread "
-                "root (message not in local store); sent as-is. If this "
-                "lands in the wrong thread, pass the metadata block's "
-                "thread_root_id, not post_id."
+            logger.info(
+                "resolve_outgoing_root: wiped %s — %s not in local cache",
+                root_id, current,
             )
-        parent_root = msg.thread_root_id
+            return None, (
+                f"\nnote: thread_root_id {root_id} not in local cache; "
+                "sent as top-level. Agents can only reply in threads "
+                "whose root is in their own local message store."
+            )
+        # Cross-scope first: rejecting before the system/self-ref wipe
+        # keeps misdirected content out of the wrong conversation.
+        if dm_peer is not None:
+            kind = getattr(msg, "envelope_kind", None)
+            peer = (
+                getattr(msg, "recipient_slug", None)
+                if getattr(msg, "sender_slug", None) == self_slug
+                else getattr(msg, "sender_slug", None)
+            )
+            if kind != "dm" or peer != dm_peer:
+                logger.info(
+                    "resolve_outgoing_root: rejected %s — not part of the "
+                    "DM with %s (kind=%r peer=%r)",
+                    root_id, dm_peer, kind, peer,
+                )
+                raise RuntimeError(
+                    f"thread_root_id {root_id} does not belong to this DM "
+                    f"with @{dm_peer}; pass a root from this conversation "
+                    "or omit root_id to start a new thread."
+                )
+        else:
+            msg_space = getattr(msg, "space_id", None)
+            if msg.channel_id != channel_id or (
+                space_id and msg_space and msg_space != space_id
+            ):
+                logger.info(
+                    "resolve_outgoing_root: rejected %s — belongs to "
+                    "channel %r, outbound is %r",
+                    root_id, msg.channel_id, channel_id,
+                )
+                raise RuntimeError(
+                    f"thread_root_id {root_id} belongs to channel "
+                    f"{msg.channel_id!r}, not this send's channel "
+                    f"{channel_id!r}; pass a root from the current channel "
+                    "or omit root_id to start a new thread."
+                )
+        parent_root = getattr(msg, "thread_root_id", None)
+        if getattr(msg, "sender_slug", None) == "system" or parent_root == current:
+            # Daemon-minted system envelopes have no server row — threading
+            # under them would dangle. Send as a new root instead.
+            logger.info(
+                "resolve_outgoing_root: wiped %s — daemon-local system thread",
+                root_id,
+            )
+            return None, (
+                f"\nnote: thread_root_id {root_id} refers to a local "
+                "system message that doesn't exist on the server; sent "
+                "as a new top-level message."
+            )
         if parent_root is None:
             if walked:
                 return current, (
@@ -352,13 +313,10 @@ async def _resolve_root_id(
                     f"auto-corrected to {current}. Pass the metadata "
                     "block's thread_root_id, not post_id."
                 )
-            return root_id, ""
+            return current, ""
         walked = True
         current = parent_root
 
-    # Corruption defense: ran out of depth or hit a cycle without
-    # finding a true root. Don't auto-correct to a value we can't
-    # trust — send to the original id and warn loudly.
     reason = (
         "cycle detected in thread chain"
         if cycle
@@ -425,7 +383,10 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             shortcuts are not supported.
         text: message body. Markdown preserved verbatim.
         root_id: optional — reply inside a thread; pass the
-            envelope_id of the message you're replying to.
+            envelope_id of the message you're replying to. Non-root
+            ids auto-correct to their thread root; roots from other
+            channels/DMs are rejected; replies to daemon-local system
+            messages go out as new top-level posts.
         visibility_level: one of ``"human"`` | ``"default"`` |
             ``"agent_only"`` (default: ``"default"``).
             - ``"human"`` — anything a person should read (replies,
@@ -494,14 +455,17 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             decode_secret(sess.subkey_secret_key)
         )
 
-        effective_visible, visibility_note = await _resolve_visibility(
-            visibility_level, channel_ref, text, root_id, cfg.http_client,
-        )
-        resolved_root, root_note = await _resolve_root_id(
+        resolved_root, root_note = await _resolve_outgoing_root(
             root_id, cfg.data_client,
+            self_slug=cfg.slug,
+            channel_id=channel_id,
+            space_id=send_space_id,
+            dm_peer=recipient_slug,
         )
-        resolved_root, validate_note = await _validate_root_same_channel(
-            resolved_root, channel_id, send_space_id, cfg.data_client,
+        # Visibility floors key off the RESOLVED root — a wiped root makes
+        # this a root-level post, which can't fold in the UI.
+        effective_visible, visibility_note = await _resolve_visibility(
+            visibility_level, channel_ref, text, resolved_root or "", cfg.http_client,
         )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
@@ -531,7 +495,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             f"posted {envelope.get('envelope_id', '?')} to {channel}"
             f"{visibility_note}"
             f"{root_note}"
-            f"{validate_note}"
         )
 
     @mcp.tool()
@@ -1110,14 +1073,15 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             "text": caption,
             "attachments": [m.to_dict() for m in attachment_metas],
         }
-        effective_visible, visibility_note = await _resolve_visibility(
-            visibility_level, channel_ref, caption, root_id, cfg.http_client,
-        )
-        resolved_root, root_note = await _resolve_root_id(
+        resolved_root, root_note = await _resolve_outgoing_root(
             root_id, cfg.data_client,
+            self_slug=cfg.slug,
+            channel_id=channel_id,
+            space_id=send_space_id,
+            dm_peer=recipient_slug,
         )
-        resolved_root, validate_note = await _validate_root_same_channel(
-            resolved_root, channel_id, send_space_id, cfg.data_client,
+        effective_visible, visibility_note = await _resolve_visibility(
+            visibility_level, channel_ref, caption, resolved_root or "", cfg.http_client,
         )
         inp = EncryptInput(
             envelope_kind=envelope_kind,
@@ -1150,7 +1114,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             f"(envelope_id {envelope.get('envelope_id', '?')})"
             f"{visibility_note}"
             f"{root_note}"
-            f"{validate_note}"
         )
 
     @mcp.tool()

--- a/tests/test_puffo_core_client_admit_validate.py
+++ b/tests/test_puffo_core_client_admit_validate.py
@@ -248,3 +248,224 @@ async def test_validate_wipes_on_store_lookup_exception(monkeypatch):
     )
     assert out is None
     await store.close()
+
+
+# ── thread-root normalization (admit-time) ────────────────────────
+#
+# thread_root_id additionally resolves to the canonical root so a sender
+# stamping a reply id can't index the row under a non-root. reply_to_id
+# keeps naming the direct parent.
+
+
+async def _seed_reply(
+    store: MessageStore,
+    *,
+    envelope_id: str,
+    thread_root_id: str | None,
+    channel_id: str | None,
+    space_id: str | None,
+) -> None:
+    await store.store({
+        "envelope_id": envelope_id,
+        "envelope_kind": "channel" if channel_id else "dm",
+        "sender_slug": "sam-0001",
+        "channel_id": channel_id,
+        "space_id": space_id,
+        "content_type": "text/plain",
+        "content": f"reply {envelope_id}",
+        "sent_at": _now_ms(),
+        "thread_root_id": thread_root_id,
+        "reply_to_id": None,
+    })
+
+
+@pytest.mark.asyncio
+async def test_resolve_corrects_a_reply_pointer_to_the_real_root():
+    """Rule 1: same channel but not a root → walk up to the root."""
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_root", channel_id="ch_gtm", space_id="sp_1",
+    )
+    await _seed_reply(
+        store, envelope_id="env_reply", thread_root_id="env_root",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_reply", "ch_gtm", "sp_1",
+    )
+    assert out == "env_root"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_walks_a_multi_hop_corrupt_chain():
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_root", channel_id="ch_gtm", space_id="sp_1",
+    )
+    await _seed_reply(
+        store, envelope_id="env_a", thread_root_id="env_root",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    await _seed_reply(
+        store, envelope_id="env_b", thread_root_id="env_a",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_b", "ch_gtm", "sp_1",
+    )
+    assert out == "env_root"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_passes_through_a_real_root():
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_root", channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_root", "ch_gtm", "sp_1",
+    )
+    assert out == "env_root"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_treats_a_self_rooted_envelope_as_a_root():
+    """The synthetic system envelopes (intro nudge) store their own id as
+    thread_root_id — that's a root, not a cycle."""
+    store = await _make_store()
+    await _seed_reply(
+        store, envelope_id="env_intro", thread_root_id="env_intro",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_intro", "ch_gtm", "sp_1",
+    )
+    assert out == "env_intro"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_wipes_a_cross_channel_root():
+    """Rule 2: different channel → no root, admit as a new root."""
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_other", channel_id="ch_other", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_other", "ch_gtm", "sp_1",
+    )
+    assert out is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_wipes_when_a_mid_chain_hop_leaves_the_channel():
+    """The walk re-checks scope at every hop, not just the first."""
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_other", channel_id="ch_other", space_id="sp_1",
+    )
+    await _seed_reply(
+        store, envelope_id="env_reply", thread_root_id="env_other",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_reply", "ch_gtm", "sp_1",
+    )
+    assert out is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_wipes_when_root_not_in_local_cache():
+    store = await _make_store()
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_missing", "ch_gtm", "sp_1",
+    )
+    assert out is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_wipes_on_a_cycle():
+    store = await _make_store()
+    await _seed_reply(
+        store, envelope_id="env_a", thread_root_id="env_b",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    await _seed_reply(
+        store, envelope_id="env_b", thread_root_id="env_a",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_a", "ch_gtm", "sp_1",
+    )
+    assert out is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_wipes_a_chain_deeper_than_the_cap():
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_0", channel_id="ch_gtm", space_id="sp_1",
+    )
+    for i in range(1, 10):
+        await _seed_reply(
+            store, envelope_id=f"env_{i}", thread_root_id=f"env_{i - 1}",
+            channel_id="ch_gtm", space_id="sp_1",
+        )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_9", "ch_gtm", "sp_1",
+    )
+    assert out is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_works_for_dms_where_channel_id_is_none():
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_dm_root", channel_id=None, space_id=None,
+    )
+    await _seed_reply(
+        store, envelope_id="env_dm_reply", thread_root_id="env_dm_root",
+        channel_id=None, space_id=None,
+    )
+    client = _bare_client(store)
+    out = await client._resolve_incoming_thread_root(
+        "env_dm_reply", None, None,
+    )
+    assert out == "env_dm_root"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_reply_to_id_still_names_the_direct_parent():
+    """Only thread_root_id normalizes — reply_to_id must NOT walk up."""
+    store = await _make_store()
+    await _seed_parent(
+        store, envelope_id="env_root", channel_id="ch_gtm", space_id="sp_1",
+    )
+    await _seed_reply(
+        store, envelope_id="env_reply", thread_root_id="env_root",
+        channel_id="ch_gtm", space_id="sp_1",
+    )
+    client = _bare_client(store)
+    out = await client._validate_incoming_parent_id(
+        "env_reply", "ch_gtm", "sp_1",
+    )
+    assert out == "env_reply"
+    await store.close()

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -1878,3 +1878,57 @@ async def test_send_message_wiped_root_forces_visible_as_root_level(monkeypatch)
     assert "not in local cache" in result
     assert captured["inp"].thread_root_id is None
     assert captured["inp"].is_visible_to_human is True
+
+@pytest.mark.asyncio
+async def test_send_message_dm_rejects_channel_root():
+    """DM sends scope-check too: a channel message as root rejects."""
+    cfg, http, ms = _setup()
+    _seed_recipient(http, "alice-0001")
+    http.responses["/certs/sync?slugs=agent-0001,alice-0001"] = (
+        http.responses["/certs/sync?slugs=alice-0001"]
+    )
+    await ms.store({
+        "envelope_id": "msg_channel_root", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "send_message", {
+            "channel": "@alice-0001",
+            "text": "dm reply",
+            "root_id": "msg_channel_root",
+        })
+    assert "DM" in str(excinfo.value)
+    assert "alice-0001" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_send_message_with_attachments_cross_channel_root_rejected(tmp_path):
+    """The attachments send path wires the same scope rejection."""
+    cfg, http, ms = _setup()
+    cfg.workspace = tmp_path
+    (tmp_path / "hello.txt").write_bytes(b"hello attachments")
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    _seed_recipient(http, "alice-0001")
+    http.responses["/blobs/upload"] = {"blob_id": "blob_xyz"}
+    await ms.store({
+        "envelope_id": "msg_elsewhere", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_OTHER",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "send_message_with_attachments", {
+            "channel": "ch_abc",
+            "caption": "misdirected attachment reply",
+            "paths": ["hello.txt"],
+            "root_id": "msg_elsewhere",
+        })
+    assert "ch_OTHER" in str(excinfo.value)

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -15,8 +15,7 @@ from puffo_agent.crypto.primitives import Ed25519KeyPair, KemKeyPair
 from puffo_agent.agent._visibility import resolve_visibility
 from puffo_agent.mcp.puffo_core_tools import (
     PuffoCoreToolsConfig,
-    _resolve_root_id,
-    _validate_root_same_channel,
+    _resolve_outgoing_root,
     register_core_tools,
 )
 
@@ -283,6 +282,13 @@ async def test_send_message_threaded_false_not_coerced():
         }],
         "has_more": False,
     }
+    await ms.store({
+        "envelope_id": "msg_root_abc", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
     mcp = _build_tools(cfg)
     result = await _call(
         mcp,
@@ -363,6 +369,13 @@ async def test_send_message_agent_only_dm_stays_hidden_with_warning():
         ],
         "has_more": False,
     }
+    await ms.store({
+        "envelope_id": "msg_root_dm", "envelope_kind": "dm",
+        "sender_slug": "alice-0001", "channel_id": None,
+        "space_id": None, "recipient_slug": "agent-0001",
+        "content_type": "text/plain", "content": "root",
+        "sent_at": _now_ms(), "thread_root_id": None,
+    })
     mcp = _build_tools(cfg)
     result = await _call(
         mcp,
@@ -374,9 +387,6 @@ async def test_send_message_agent_only_dm_stays_hidden_with_warning():
             "root_id": "msg_root_dm",
         },
     )
-    # NB: msg_root_dm isn't in local cache, so validate_root wipes it
-    # with its own warning note — assert the visibility warning is
-    # present alongside, don't insist on it being alone.
     assert "posted" in result
     assert "sent hidden per" in result
     assert "DM" in result
@@ -1061,7 +1071,7 @@ async def test_send_message_with_attachments_requires_workspace():
     assert "workspace" in str(exc_info.value).lower()
 
 
-# PUF-200: _resolve_root_id
+# Send-side root resolution: walk + scope rejection + system-envelope rules.
 
 
 class _FakeDataClient:
@@ -1080,6 +1090,9 @@ class _FakeDataClient:
         *,
         channel_id: str | None = None,
         space_id: str | None = None,
+        sender_slug: str = "alice-0001",
+        envelope_kind: str = "channel",
+        recipient_slug: str | None = None,
     ) -> None:
         class _Msg:
             pass
@@ -1088,6 +1101,9 @@ class _FakeDataClient:
         m.thread_root_id = thread_root_id
         m.channel_id = channel_id
         m.space_id = space_id
+        m.sender_slug = sender_slug
+        m.envelope_kind = envelope_kind
+        m.recipient_slug = recipient_slug
         self.messages[envelope_id] = m
 
     async def get_message_by_envelope(self, envelope_id: str):
@@ -1097,121 +1113,204 @@ class _FakeDataClient:
         return self.messages.get(envelope_id)
 
 
+async def _resolve(dc, root_id, **kw):
+    defaults = dict(self_slug="agent-0001", channel_id=None, space_id=None, dm_peer=None)
+    defaults.update(kw)
+    return await _resolve_outgoing_root(root_id, dc, **defaults)
+
+
 @pytest.mark.asyncio
-async def test_resolve_root_id_empty_skips_lookup():
+async def test_outgoing_root_empty_skips_lookup():
     dc = _FakeDataClient()
-    resolved, note = await _resolve_root_id("", dc)
-    assert resolved is None
-    assert note == ""
-    assert dc.calls == []
-    # Whitespace-only is also treated as empty.
-    resolved, note = await _resolve_root_id("   ", dc)
-    assert resolved is None and note == ""
-    assert dc.calls == []
+    resolved, note = await _resolve(dc, "")
+    assert resolved is None and note == "" and dc.calls == []
+    resolved, note = await _resolve(dc, "   ")
+    assert resolved is None and note == "" and dc.calls == []
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_true_root_unchanged():
+async def test_outgoing_root_true_root_unchanged():
     dc = _FakeDataClient()
     dc.add("msg_root", thread_root_id=None)
-    resolved, note = await _resolve_root_id("msg_root", dc)
-    assert resolved == "msg_root"
-    assert note == ""
-    assert dc.calls == ["msg_root"]
+    resolved, note = await _resolve(dc, "msg_root")
+    assert resolved == "msg_root" and note == ""
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_reply_auto_corrected():
+async def test_outgoing_root_reply_auto_corrected():
     dc = _FakeDataClient()
     dc.add("msg_root", thread_root_id=None)
     dc.add("msg_reply", thread_root_id="msg_root")
-    resolved, note = await _resolve_root_id("msg_reply", dc)
+    resolved, note = await _resolve(dc, "msg_reply")
     assert resolved == "msg_root"
     assert "auto-corrected" in note
-    assert "msg_reply" in note and "msg_root" in note
-    assert "thread_root_id" in note and "post_id" in note
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_depth_two_chain_walks_to_root():
+async def test_outgoing_root_depth_two_chain_walks_to_root():
     dc = _FakeDataClient()
     dc.add("msg_root", thread_root_id=None)
     dc.add("msg_mid", thread_root_id="msg_root")
     dc.add("msg_leaf", thread_root_id="msg_mid")
-    resolved, note = await _resolve_root_id("msg_leaf", dc)
+    resolved, note = await _resolve(dc, "msg_leaf")
     assert resolved == "msg_root"
-    assert "auto-corrected" in note
     assert dc.calls == ["msg_leaf", "msg_mid", "msg_root"]
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_lookup_miss_falls_through_with_warning():
+async def test_outgoing_root_lookup_miss_wipes_to_none():
     dc = _FakeDataClient()
-    resolved, note = await _resolve_root_id("msg_unknown", dc)
-    assert resolved == "msg_unknown"
-    assert "could not verify" in note
-    assert "not in local store" in note
-    assert "thread_root_id" in note
+    resolved, note = await _resolve(dc, "msg_unknown")
+    assert resolved is None
+    assert "not in local cache" in note
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_transport_error_falls_through_with_warning():
-    dc = _FakeDataClient()
-    dc.exc = RuntimeError("simulated transport blip")
-    resolved, note = await _resolve_root_id("msg_anything", dc)
-    assert resolved == "msg_anything"
-    assert "could not verify" in note
-    assert "lookup failed" in note
-
-
-@pytest.mark.asyncio
-async def test_resolve_root_id_data_not_found_treated_as_lookup_miss():
-    """``DataClient.get_message_by_envelope`` raises ``DataNotFound``
-    (rather than returning None) when the data service is reachable
-    but the agent never recorded the envelope. The resolver should
-    treat that the same as a None return — fall through with the
-    "not in local store" warning, not the broader "lookup failed"
-    one."""
+async def test_outgoing_root_data_not_found_treated_as_miss():
     from puffo_agent.agent.message_store import DataNotFound
     dc = _FakeDataClient()
     dc.exc = DataNotFound("msg_only_on_server")
-    resolved, note = await _resolve_root_id("msg_only_on_server", dc)
-    assert resolved == "msg_only_on_server"
-    assert "could not verify" in note
-    assert "not in local store" in note
-    assert "lookup failed" not in note
+    resolved, note = await _resolve(dc, "msg_only_on_server")
+    assert resolved is None
+    assert "not in local cache" in note
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_cycle_preserves_root_id_with_warning():
-    """Cycle is corrupt data — don't auto-correct to a node we
-    can't trust. Preserve the original ``root_id`` and surface a
-    loud warning so the operator can investigate."""
+async def test_outgoing_root_transport_error_wipes_to_none():
+    dc = _FakeDataClient()
+    dc.exc = RuntimeError("simulated transport blip")
+    resolved, note = await _resolve(dc, "msg_anything")
+    assert resolved is None
+    assert "could not be verified" in note
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_cycle_preserves_root_id_with_warning():
     dc = _FakeDataClient()
     dc.add("msg_a", thread_root_id="msg_b")
     dc.add("msg_b", thread_root_id="msg_a")
-    resolved, note = await _resolve_root_id("msg_a", dc)
+    resolved, note = await _resolve(dc, "msg_a")
     assert resolved == "msg_a"
-    assert "could not resolve" in note
     assert "cycle detected" in note
 
 
 @pytest.mark.asyncio
-async def test_resolve_root_id_depth_cap_preserves_root_id_with_warning():
-    """Same corruption-defense path for a chain deeper than the
-    cap — preserve ``root_id``, warn loudly, don't auto-correct."""
+async def test_outgoing_root_depth_cap_preserves_root_id_with_warning():
     dc = _FakeDataClient()
-    # Chain deeper than _RESOLVE_ROOT_MAX_DEPTH (4): leaf → l4 → l3 → l2 → l1 → root
-    dc.add("msg_leaf", thread_root_id="msg_l4")
-    dc.add("msg_l4", thread_root_id="msg_l3")
-    dc.add("msg_l3", thread_root_id="msg_l2")
-    dc.add("msg_l2", thread_root_id="msg_l1")
-    dc.add("msg_l1", thread_root_id="msg_root")
-    dc.add("msg_root", thread_root_id=None)
-    resolved, note = await _resolve_root_id("msg_leaf", dc)
-    assert resolved == "msg_leaf"
-    assert "could not resolve" in note
+    for i in range(9):
+        dc.add(f"msg_l{i}", thread_root_id=f"msg_l{i + 1}")
+    dc.add("msg_l9", thread_root_id=None)
+    resolved, note = await _resolve(dc, "msg_l0")
+    assert resolved == "msg_l0"
     assert "deeper than" in note
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_system_sender_wiped_to_new_root():
+    """Rule 1: daemon-minted system envelope -> send as a new top-level."""
+    dc = _FakeDataClient()
+    dc.add("intro-prompt-1", thread_root_id="intro-prompt-1", sender_slug="system")
+    resolved, note = await _resolve(dc, "intro-prompt-1")
+    assert resolved is None
+    assert "system message" in note
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_self_reference_wiped_to_new_root():
+    """Rule 2: self-referencing root (non-system sender) -> same wipe."""
+    dc = _FakeDataClient()
+    dc.add("msg_weird", thread_root_id="msg_weird")
+    resolved, note = await _resolve(dc, "msg_weird")
+    assert resolved is None
+    assert "system message" in note
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_walk_into_system_root_wiped():
+    """Rule 1 via rule 4: a reply whose chain tops out at a system
+    envelope wipes instead of auto-correcting to a dangling id."""
+    dc = _FakeDataClient()
+    dc.add("intro-prompt-1", thread_root_id="intro-prompt-1", sender_slug="system")
+    dc.add("msg_reply", thread_root_id="intro-prompt-1")
+    resolved, note = await _resolve(dc, "msg_reply")
+    assert resolved is None
+    assert "system message" in note
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_cross_channel_rejected():
+    """Rule 3: cross-channel reference is an agent error -> reject."""
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None, channel_id="ch_general", space_id="sp_1")
+    with pytest.raises(RuntimeError) as ei:
+        await _resolve(dc, "msg_root", channel_id="ch_gtm", space_id="sp_1")
+    assert "ch_general" in str(ei.value)
+    assert "ch_gtm" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_cross_space_rejected():
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None, channel_id="ch_x", space_id="sp_OTHER")
+    with pytest.raises(RuntimeError):
+        await _resolve(dc, "msg_root", channel_id="ch_x", space_id="sp_1")
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_same_channel_passes_scope():
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None, channel_id="ch_x", space_id="sp_1")
+    resolved, note = await _resolve(dc, "msg_root", channel_id="ch_x", space_id="sp_1")
+    assert resolved == "msg_root" and note == ""
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_dm_target_rejects_channel_message():
+    dc = _FakeDataClient()
+    dc.add("msg_root", thread_root_id=None, channel_id="ch_x")
+    with pytest.raises(RuntimeError) as ei:
+        await _resolve(dc, "msg_root", dm_peer="alice-0001")
+    assert "DM" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_dm_target_rejects_wrong_peer():
+    dc = _FakeDataClient()
+    dc.add(
+        "msg_root", thread_root_id=None, envelope_kind="dm",
+        sender_slug="bob-0002", recipient_slug="agent-0001",
+    )
+    with pytest.raises(RuntimeError):
+        await _resolve(dc, "msg_root", dm_peer="alice-0001")
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_dm_target_accepts_both_directions():
+    dc = _FakeDataClient()
+    dc.add(
+        "msg_in", thread_root_id=None, envelope_kind="dm",
+        sender_slug="alice-0001", recipient_slug="agent-0001",
+    )
+    dc.add(
+        "msg_out", thread_root_id=None, envelope_kind="dm",
+        sender_slug="agent-0001", recipient_slug="alice-0001",
+    )
+    for mid in ("msg_in", "msg_out"):
+        resolved, note = await _resolve(dc, mid, dm_peer="alice-0001")
+        assert resolved == mid and note == ""
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_cross_scope_rejects_before_system_wipe():
+    """A system envelope from ANOTHER channel must reject (rule 3), not
+    silently become a top-level post in the wrong channel (rule 1)."""
+    dc = _FakeDataClient()
+    dc.add(
+        "intro-prompt-1", thread_root_id="intro-prompt-1",
+        sender_slug="system", channel_id="ch_other",
+    )
+    with pytest.raises(RuntimeError):
+        await _resolve(dc, "intro-prompt-1", channel_id="ch_x")
 
 
 def _spy_encrypt_input(monkeypatch):
@@ -1452,116 +1551,7 @@ async def test_core_tools_registered():
     assert expected.issubset(tool_names)
 
 
-# PUF-227-A: _validate_root_same_channel — strict cache + channel-
-# match validation, applied AFTER _resolve_root_id on the sender path.
 
-
-@pytest.mark.asyncio
-async def test_validate_root_passes_through_when_no_root_id():
-    """``resolved_root=None`` is the top-level-post case; helper is a
-    no-op and returns no warning."""
-    dc = _FakeDataClient()
-    out, note = await _validate_root_same_channel(None, "ch_x", "sp_1", dc)
-    assert out is None
-    assert note == ""
-
-
-@pytest.mark.asyncio
-async def test_validate_root_passes_through_when_parent_in_same_channel():
-    """Parent envelope exists locally + matches outbound channel +
-    space → pass through unchanged, no warning."""
-    dc = _FakeDataClient()
-    dc.add("msg_root", thread_root_id=None, channel_id="ch_x", space_id="sp_1")
-    out, note = await _validate_root_same_channel("msg_root", "ch_x", "sp_1", dc)
-    assert out == "msg_root"
-    assert note == ""
-
-
-@pytest.mark.asyncio
-async def test_validate_root_wipes_when_parent_in_different_channel():
-    """Scout's PUF-227 symptom shape on the sender side. Parent
-    exists in cache but its channel doesn't match outbound — wipe
-    to None + emit warning."""
-    dc = _FakeDataClient()
-    dc.add(
-        "msg_root",
-        thread_root_id=None,
-        channel_id="ch_general",
-        space_id="sp_1",
-    )
-    out, note = await _validate_root_same_channel(
-        "msg_root", "ch_gtm", "sp_1", dc,
-    )
-    assert out is None
-    assert "different" in note.lower() or "belongs to" in note.lower()
-    assert "ch_general" in note
-    assert "ch_gtm" in note
-
-
-@pytest.mark.asyncio
-async def test_validate_root_wipes_when_parent_not_in_cache():
-    """Strict per operator's Q1(a): parent-not-in-cache → wipe to
-    None. No permissive fallback."""
-    dc = _FakeDataClient()
-    out, note = await _validate_root_same_channel(
-        "msg_unknown", "ch_x", "sp_1", dc,
-    )
-    assert out is None
-    assert "not in local cache" in note
-    assert "msg_unknown" in note
-
-
-@pytest.mark.asyncio
-async def test_validate_root_wipes_when_parent_in_different_space():
-    """Cross-space parent — same defense as cross-channel."""
-    dc = _FakeDataClient()
-    dc.add(
-        "msg_root",
-        thread_root_id=None,
-        channel_id="ch_x",
-        space_id="sp_OTHER",
-    )
-    out, note = await _validate_root_same_channel(
-        "msg_root", "ch_x", "sp_1", dc,
-    )
-    assert out is None
-    assert "different" in note.lower() or "belongs to space" in note.lower()
-    assert "sp_OTHER" in note
-
-
-@pytest.mark.asyncio
-async def test_validate_root_wipes_on_lookup_transport_error():
-    """Strict mode: if the local-cache lookup itself errors out
-    (sqlite hiccup, DataClient transport blip), treat as 'not
-    verified' and wipe — don't ship an unverifiable id."""
-    dc = _FakeDataClient()
-    dc.exc = RuntimeError("simulated lookup failure")
-    out, note = await _validate_root_same_channel(
-        "msg_any", "ch_x", "sp_1", dc,
-    )
-    assert out is None
-    assert "could not be verified" in note
-    assert "lookup failed" in note
-
-
-@pytest.mark.asyncio
-async def test_validate_root_dm_envelope_no_channel_id_passes_through():
-    """DM context: no channel_id to compare against; helper still
-    enforces cache presence but skips the channel-match check.
-    (Cross-DM-thread validation is out of scope for this ticket per
-    the build plan.)"""
-    dc = _FakeDataClient()
-    dc.add(
-        "msg_dm_root",
-        thread_root_id=None,
-        channel_id=None,
-        space_id=None,
-    )
-    out, note = await _validate_root_same_channel(
-        "msg_dm_root", None, None, dc,
-    )
-    assert out == "msg_dm_root"
-    assert note == ""
 
 
 # resolve_visibility — one entry point that combines level parsing,
@@ -1806,3 +1796,85 @@ async def test_get_thread_history_tags_encryption():
     await _store_msg(ms, "msg_reply", is_encrypted=False, thread_root_id="msg_root")
     result = await _call(_build_tools(cfg), "get_thread_history", {"root_id": "msg_root"})
     assert "[plaintext]" in result
+
+# Send-side thread-root rules, end to end through the send_message tool.
+
+
+@pytest.mark.asyncio
+async def test_send_message_system_root_ships_as_new_top_level(monkeypatch):
+    """Replying to a daemon-minted intro nudge (self-referencing system
+    envelope, no server row) ships as a new top-level message."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    _seed_recipient(http, "alice-0001")
+    await ms.store({
+        "envelope_id": "intro-prompt-xyz", "envelope_kind": "channel",
+        "sender_slug": "system", "channel_id": "ch_abc",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "welcome!", "sent_at": _now_ms(),
+        "thread_root_id": "intro-prompt-xyz",
+    })
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc",
+        "text": "hello, thanks for the intro",
+        "visibility_level": "human",
+        "root_id": "intro-prompt-xyz",
+    })
+
+    assert "posted" in result
+    assert "system message" in result
+    assert captured["inp"].thread_root_id is None
+
+
+@pytest.mark.asyncio
+async def test_send_message_cross_channel_root_rejected():
+    """A root from another channel rejects the send outright — the
+    agent gets a correctable error instead of a misfiled message."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    _seed_recipient(http, "alice-0001")
+    await ms.store({
+        "envelope_id": "msg_elsewhere", "envelope_kind": "channel",
+        "sender_slug": "alice-0001", "channel_id": "ch_OTHER",
+        "space_id": "sp_test", "content_type": "text/plain",
+        "content": "root", "sent_at": _now_ms(),
+        "thread_root_id": None,
+    })
+
+    mcp = _build_tools(cfg)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "send_message", {
+            "channel": "ch_abc",
+            "text": "misdirected reply",
+            "root_id": "msg_elsewhere",
+        })
+    assert "ch_OTHER" in str(excinfo.value)
+    assert "ch_abc" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_send_message_wiped_root_forces_visible_as_root_level(monkeypatch):
+    """Ordering contract: root resolution runs BEFORE the visibility
+    floors. A wiped root makes the message root-level, which cannot fold
+    in the UI — 'default' must coerce it visible instead of shipping an
+    invisible hidden top-level post."""
+    cfg, http, ms = _setup()
+    await _seed_channel(ms, http, "ch_abc", "sp_test", "alice-0001")
+    _seed_recipient(http, "alice-0001")
+    captured = _spy_encrypt_input(monkeypatch)
+
+    mcp = _build_tools(cfg)
+    result = await _call(mcp, "send_message", {
+        "channel": "ch_abc",
+        "text": "agent chatter",
+        "visibility_level": "default",
+        "root_id": "msg_never_recorded",
+    })
+
+    assert "posted" in result
+    assert "not in local cache" in result
+    assert captured["inp"].thread_root_id is None
+    assert captured["inp"].is_visible_to_human is True


### PR DESCRIPTION
Two commits closing the malformed-thread-reference class from both directions.

## Commit 1 — receive side (admit-time normalization)

Incoming `thread_root_id` normalizes to the canonical root **before ack/persist**:
- same-channel/DM non-root reference → walked up to the true root (cycle + depth + per-hop scope guards);
- cross-scope or unresolvable reference → admitted as a new root;
- self-referencing roots accepted as roots (daemon-minted system envelopes store their own id).

`reply_to_id` keeps its existing direct-parent validation.

## Commit 2 — send side (unified outgoing resolution)

One resolver replaces the old `_resolve_root_id` + `_validate_root_same_channel` pipeline, applying four rules to the agent-supplied `root_id`:

1. **Daemon-minted system envelope** (sender `system`) → wiped to `None`; the reply ships as a new top-level message. There is no server row for these, so threading under them dangles server-side. (Previously the walk misread the self-reference as a *cycle* and told the agent the relay's thread chain "looks corrupt" — a spurious alarm on a routine path.)
2. **Self-referencing root** → same wipe.
3. **Root from another channel/DM** → **rejects the send** with an error naming both scopes so the agent can correct itself. Previously a soft wipe silently re-rooted misdirected content into the target conversation. Checked before rules 1/2 (a cross-channel system reference rejects rather than misfiling); DM sends now scope-check too (envelope kind + peer) — they previously skipped validation entirely.
4. **Same-scope non-root** → auto-corrected up to the true root, scope enforced at every hop; depth cap unified with the receive side (8).

Lookup miss / transport failure keep the strict wipe-to-top-level shape; genuine cycles / over-deep chains keep send-as-is + the corrupt-data warning.

**Ordering fix folded in:** root resolution now runs *before* the visibility floors. A wiped root previously produced a *hidden top-level post* — invisible in every client, since root-level messages can't fold.

## Tests

Receive side: covered in commit 1. Send side: resolver unit suite rewritten (19 cases — walk/auto-correct, scope rejection incl. both DM directions and reject-before-wipe ordering, system/self-ref wipes, miss/transport/cycle/depth defenses); 3 `send_message` e2e (system-root reply ships top-level with note, cross-channel reject surfaces both channel ids, wiped root forced visible); 2 visibility tests reseeded with valid roots to test their intended threaded scenarios.

`PYTHONPATH=src python -m pytest`: **2046 passed / 11 skipped** (skips = symlink-less host, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyvHzX7gbRitsFXC3YQtcW
