### PR TITLE
PUF-394 (agent, 1 of 3): daemon-layer persistent per-agent scheduler + MCP tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     # Relay TLS trust bundle for hosts with an empty OpenSSL cert store.
     "certifi>=2024.2.2",
     # Crontab-expression parsing for the daemon-layer persistent scheduler.
-    "croniter>=2.0",
+    # Upper-bounded: croniter major versions differ on DST/edge-case behavior.
+    "croniter>=2.0,<3.0",
     "cryptography>=43.0",
     "mcp>=1.0",
     # Pillow: dimension-check + downscale inbound image attachments so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "anthropic>=0.25",
     # Relay TLS trust bundle for hosts with an empty OpenSSL cert store.
     "certifi>=2024.2.2",
+    # Crontab-expression parsing for the daemon-layer persistent scheduler.
+    "croniter>=2.0",
     "cryptography>=43.0",
     "mcp>=1.0",
     # Pillow: dimension-check + downscale inbound image attachments so

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -39,6 +39,8 @@ from .permission_prompt import format_permission_prompt
 from .events import random_nonce, sign_event
 from .event_kinds import EventKind
 from .message_store import MessageStore
+from . import scheduler_ops
+from .scheduler_store import SchedulerStore
 
 logger = logging.getLogger(__name__)
 
@@ -474,6 +476,7 @@ class PuffoCoreMessageClient:
         image_edge_px: int = _DEFAULT_IMAGE_EDGE_PX,
         max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
         catchup_stale_hours: float = DEFAULT_CATCHUP_STALE_HOURS,
+        scheduler_store: "SchedulerStore | None" = None,
     ):
         self.slug = slug
         self.device_id = device_id
@@ -505,6 +508,10 @@ class PuffoCoreMessageClient:
         self.keystore = keystore
         self.http = http_client
         self.store = message_store
+        # PUF-394: the daemon-owned per-agent scheduler DB. The Worker's
+        # scheduler engine + this client's cron tools + fire path all share
+        # this one instance (single connection on the daemon loop).
+        self.scheduler_store = scheduler_store
         self._key_cache = DeviceKeyCache(http_client)
         self._ws: Optional[PuffoCoreWsClient] = None
         # Most recent DM sender. ``send_fallback_message(channel_id="")`` means
@@ -2913,6 +2920,115 @@ class PuffoCoreMessageClient:
             "enqueued channel-intro nudge for channel=%s (space=%s)",
             channel_id, space_id,
         )
+
+    # ── PUF-394: persistent scheduler ────────────────────────────────
+
+    async def fire_cron_job(self, job: dict, envelope_id: str) -> None:
+        """Inject a due scheduled job's directive as a synthetic system turn.
+
+        Mirrors ``_enqueue_channel_intro_nudge``: persist the envelope to
+        ``messages.db`` then admit it at ``PRIORITY_SYSTEM``. ``envelope_id``
+        is the ``cron-<job>-<ts>`` id the engine minted (also the thread root,
+        so ``on_turn_success`` can close the run)."""
+        channel_id = job.get("channel_id") or ""
+        now_ms = int(time.time() * 1000)
+        space_id = ""
+        channel_name = channel_id
+        space_name = ""
+        if channel_id:
+            space_id = (await self.store.lookup_channel_space(channel_id)) or ""
+            channel_name = await self._resolve_channel_name(space_id, channel_id)
+            if space_id:
+                space_name = await self._resolve_space_name(space_id)
+
+        prompt_text = (
+            "[puffo-agent system message] Your scheduled job "
+            f"\"{job['name']}\" ({job['cron_expr']}) is now due. Carry out the "
+            "following instruction, then stop — this is a recurring automated "
+            f"run, not a conversation:\n\n{job['prompt']}"
+        )
+        msg_dict = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "sender_slug": "system",
+            "sender_display_name": "",
+            "sender_email": "",
+            "text": prompt_text,
+            "root_id": "",
+            "is_dm": False,
+            "attachments": [],
+            "sender_is_agent": False,
+            "mentions": [],
+            "envelope_id": envelope_id,
+            "sent_at": now_ms,
+            "is_encrypted": True,
+        }
+        channel_meta = {
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "space_id": space_id,
+            "space_name": space_name,
+            "is_dm": False,
+        }
+        store_payload = {
+            "envelope_id": envelope_id,
+            "envelope_kind": "channel",
+            "sender_slug": "system",
+            "channel_id": channel_id,
+            "space_id": space_id,
+            "content_type": "text/plain",
+            "content": prompt_text,
+            "sent_at": now_ms,
+            "thread_root_id": envelope_id,
+            "reply_to_id": None,
+        }
+        try:
+            await self.store.store(store_payload)
+        except Exception as exc:  # noqa: BLE001 — persistence is best-effort
+            self._log.warning(
+                "cron-fire: failed to persist envelope=%s: %s", envelope_id, exc,
+            )
+        await self._admit_thread_message(
+            root_id=envelope_id,
+            priority=PRIORITY_SYSTEM,
+            msg_dict=msg_dict,
+            channel_meta=channel_meta,
+        )
+        self._log.info(
+            "fired cron job %s (envelope=%s channel=%s)",
+            job.get("id"), envelope_id, channel_id,
+        )
+
+    async def cron_create(
+        self, *, name: str, cron_expr: str, prompt: str, channel_id: str | None
+    ) -> str:
+        return await scheduler_ops.create_op(
+            self.scheduler_store, name=name, cron_expr=cron_expr,
+            prompt=prompt, channel_id=channel_id,
+        )
+
+    async def cron_list(self) -> str:
+        return await scheduler_ops.list_op(self.scheduler_store)
+
+    async def cron_update(
+        self,
+        *,
+        job_id: str,
+        name: str | None = None,
+        cron_expr: str | None = None,
+        prompt: str | None = None,
+        channel_id: str | None = None,
+        enabled: bool | None = None,
+    ) -> str:
+        return await scheduler_ops.update_op(
+            self.scheduler_store, job_id=job_id, name=name, cron_expr=cron_expr,
+            prompt=prompt, channel_id=channel_id, enabled=enabled,
+        )
+
+    async def cron_delete(self, *, job_id: str) -> str:
+        return await scheduler_ops.delete_op(self.scheduler_store, job_id=job_id)
 
     async def _maybe_announce_membership_change(
         self, kind: str, event: dict, payload: dict,

--- a/src/puffo_agent/agent/scheduler.py
+++ b/src/puffo_agent/agent/scheduler.py
@@ -9,6 +9,11 @@ engine is unit-testable without a live client. openworker-modeled:
   fires once and reschedules to the next future slot, not five times.
 - **no-overlap**: a job with an open run (prior fire still processing) is
   skipped for this occurrence (status ``skipped``) and rescheduled.
+
+The engine tick is driven by the Worker's normal harness ``_run`` loop
+(cli-local / cli-docker / codex — the FB-425 target). ws-local-idle agents get
+the store (CRUD via the MCP tools works) but no tick, so their jobs won't fire
+until they run under the harness path — a documented follow-up, not a bug.
 """
 from __future__ import annotations
 
@@ -68,7 +73,10 @@ class SchedulerEngine:
             envelope_id = f"cron-{job['id']}-{now}"
             await self._store.open_run(job["id"], envelope_id, now)
             # Advance next_run_at BEFORE firing so a crash mid-fire can't
-            # re-fire the same slot on the next tick.
+            # re-fire the same slot on the next tick. Trade-off (intended): a
+            # hard crash (SIGKILL) between here and the fire leaves next_run_at
+            # advanced with an open run that never completes — that occurrence
+            # is skipped, not retried. Preferred over double-firing.
             await self._store.record_fire(job["id"], now, nxt)
             try:
                 await self._fire(job, envelope_id)

--- a/src/puffo_agent/agent/scheduler.py
+++ b/src/puffo_agent/agent/scheduler.py
@@ -1,0 +1,87 @@
+"""PUF-394: the scheduler engine — crontab next-run compute + the tick.
+
+Runs as a per-agent Worker background task (holds `self._client` to fire).
+Pure-ish: the actual turn-injection is an injected `fire` callback so the
+engine is unit-testable without a live client. openworker-modeled:
+
+- **catch-up-once**: `next_run_at` after a fire is always computed from *now*,
+  never from the stale slot — so a daemon that was down for 5 hourly slots
+  fires once and reschedules to the next future slot, not five times.
+- **no-overlap**: a job with an open run (prior fire still processing) is
+  skipped for this occurrence (status ``skipped``) and rescheduled.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Awaitable, Callable
+
+from croniter import croniter
+
+from .scheduler_store import SchedulerStore
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def is_valid_cron(cron_expr: str) -> bool:
+    return croniter.is_valid(cron_expr)
+
+
+def next_run(cron_expr: str, after_ms: int) -> int:
+    """Next crontab occurrence strictly after `after_ms`, in ms-epoch (UTC)."""
+    base = datetime.fromtimestamp(after_ms / 1000, tz=timezone.utc)
+    return int(croniter(cron_expr, base).get_next(datetime).timestamp() * 1000)
+
+
+# fire(job_dict, envelope_id) → admits the synthetic cron turn onto the queue.
+FireFn = Callable[[dict, str], Awaitable[None]]
+
+
+class SchedulerEngine:
+    def __init__(
+        self,
+        store: SchedulerStore,
+        fire: FireFn,
+        *,
+        now_fn: Callable[[], int] = _now_ms,
+    ) -> None:
+        self._store = store
+        self._fire = fire
+        self._now = now_fn
+
+    async def tick(self) -> int:
+        """Fire every due job once; return the count fired. A single tick on
+        startup does the catch-up-once (due_jobs returns all past-due, each
+        reschedules forward from now)."""
+        now = self._now()
+        fired = 0
+        for job in await self._store.due_jobs(now):
+            nxt = next_run(job["cron_expr"], now)
+            # No-overlap: a prior fire still in flight → skip this occurrence.
+            if await self._store.has_open_run(job["id"]):
+                await self._store.update_job(
+                    job["id"], next_run_at=nxt, last_run_status="skipped"
+                )
+                continue
+            envelope_id = f"cron-{job['id']}-{now}"
+            await self._store.open_run(job["id"], envelope_id, now)
+            # Advance next_run_at BEFORE firing so a crash mid-fire can't
+            # re-fire the same slot on the next tick.
+            await self._store.record_fire(job["id"], now, nxt)
+            try:
+                await self._fire(job, envelope_id)
+                fired += 1
+            except Exception:  # noqa: BLE001 — a bad fire shouldn't wedge the tick
+                await self._store.close_run(envelope_id, "error", self._now())
+                await self._store.set_last_status(job["id"], "error")
+        return fired
+
+    async def record_completion(self, envelope_id: str, status: str) -> None:
+        """Called by the Worker when a fired cron turn finishes: close the run
+        + stamp the job's last_run_status."""
+        job_id = await self._store.job_for_open_envelope(envelope_id)
+        await self._store.close_run(envelope_id, status, self._now())
+        if job_id is not None:
+            await self._store.set_last_status(job_id, status)

--- a/src/puffo_agent/agent/scheduler_ops.py
+++ b/src/puffo_agent/agent/scheduler_ops.py
@@ -1,0 +1,125 @@
+"""PUF-394: agent-facing scheduler operations (create/list/update/delete).
+
+The single place the CRUD + validation + LLM-facing formatting lives, called
+by BOTH dispatch paths — the ws-local `PuffoCoreMessageClient` (in-process) and
+the harness RPC handler (`host_mcp_handler`). Each returns a plain string that
+becomes the MCP tool result the agent reads.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .scheduler import _now_ms, is_valid_cron, next_run
+from .scheduler_store import SchedulerStore
+
+
+def _fmt_ts(ms: int | None) -> str:
+    if not ms:
+        return "never"
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime(
+        "%Y-%m-%d %H:%M UTC"
+    )
+
+
+def _fmt_job(job: dict) -> str:
+    state = "enabled" if job["enabled"] else "disabled"
+    where = f" → {job['channel_id']}" if job.get("channel_id") else ""
+    last = ""
+    if job.get("last_run_at"):
+        last = f"; last {_fmt_ts(job['last_run_at'])} ({job.get('last_run_status') or '?'})"
+    return (
+        f"{job['id']} \"{job['name']}\" [{job['cron_expr']}] {state}{where}; "
+        f"next {_fmt_ts(job['next_run_at'])}{last}"
+    )
+
+
+def server_snapshot(jobs: list[dict]) -> list[dict]:
+    """Map local job rows → the server-mirror wire shape (state-replace)."""
+    return [
+        {
+            "job_id": j["id"],
+            "name": j["name"],
+            "cron_expr": j["cron_expr"],
+            "enabled": bool(j["enabled"]),
+            "last_run_at": j["last_run_at"],
+            "last_run_status": j["last_run_status"],
+            "next_run_at": j["next_run_at"],
+        }
+        for j in jobs
+    ]
+
+
+async def create_op(
+    store: SchedulerStore,
+    *,
+    name: str,
+    cron_expr: str,
+    prompt: str,
+    channel_id: str | None,
+    now_ms: int | None = None,
+) -> str:
+    if not (name or "").strip():
+        return "error: name is required"
+    if not (prompt or "").strip():
+        return "error: prompt is required (the instruction to run each time)"
+    if not is_valid_cron(cron_expr or ""):
+        return f'error: invalid cron_expr {cron_expr!r} (use standard crontab, e.g. "0 9 * * *")'
+    nxt = next_run(cron_expr, now_ms if now_ms is not None else _now_ms())
+    job = await store.create_job(
+        name=name.strip(),
+        cron_expr=cron_expr,
+        prompt=prompt,
+        channel_id=channel_id or None,
+        next_run_at=nxt,
+    )
+    return (
+        f"Created recurring job {job['id']} \"{job['name']}\" [{cron_expr}]; "
+        f"next run {_fmt_ts(nxt)}. This persists across session/daemon restart."
+    )
+
+
+async def list_op(store: SchedulerStore) -> str:
+    jobs = await store.list_jobs()
+    if not jobs:
+        return "No recurring jobs."
+    return "\n".join(_fmt_job(j) for j in jobs)
+
+
+async def update_op(
+    store: SchedulerStore,
+    *,
+    job_id: str,
+    name: str | None = None,
+    cron_expr: str | None = None,
+    prompt: str | None = None,
+    channel_id: str | None = None,
+    enabled: bool | None = None,
+    now_ms: int | None = None,
+) -> str:
+    if await store.get_job(job_id) is None:
+        return f"error: no job {job_id!r}"
+    fields: dict = {}
+    if name is not None:
+        fields["name"] = name.strip()
+    if prompt is not None:
+        fields["prompt"] = prompt
+    if channel_id is not None:
+        fields["channel_id"] = channel_id
+    if enabled is not None:
+        fields["enabled"] = 1 if enabled else 0
+    if cron_expr is not None:
+        if not is_valid_cron(cron_expr):
+            return f"error: invalid cron_expr {cron_expr!r}"
+        fields["cron_expr"] = cron_expr
+        fields["next_run_at"] = next_run(
+            cron_expr, now_ms if now_ms is not None else _now_ms()
+        )
+    updated = await store.update_job(job_id, **fields)
+    assert updated is not None
+    return f"Updated {_fmt_job(updated)}"
+
+
+async def delete_op(store: SchedulerStore, *, job_id: str) -> str:
+    if await store.delete_job(job_id):
+        return f"Deleted recurring job {job_id}."
+    return f"error: no job {job_id!r}"

--- a/src/puffo_agent/agent/scheduler_store.py
+++ b/src/puffo_agent/agent/scheduler_store.py
@@ -1,0 +1,225 @@
+"""PUF-394: SQLite persistence for the daemon-layer per-agent scheduler.
+
+One `scheduler.db` per agent dir (peer of `messages.db`), owned by the daemon
+Worker. Survives session drop / daemon restart / worker respawn — the whole
+point vs the session-local Claude Code SDK Cron* tools. Mirrors the aiosqlite
++ WAL idiom of `message_store.py`. All access is on the daemon event loop and
+awaited serially (single writer); `busy_timeout` covers the rare overlap with
+the co-located MCP/RPC path.
+
+Timestamps are ms-epoch ints. `jobs` is the schedule; `runs` is history + the
+no-overlap guard (an open row — `ended_at IS NULL` — means a fire is still in
+flight).
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import aiosqlite
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS jobs (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    cron_expr       TEXT NOT NULL,
+    prompt          TEXT NOT NULL,
+    channel_id      TEXT,
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    last_run_at     INTEGER,
+    last_run_status TEXT,
+    next_run_at     INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runs (
+    id          TEXT PRIMARY KEY,
+    job_id      TEXT NOT NULL,
+    started_at  INTEGER NOT NULL,
+    ended_at    INTEGER,
+    status      TEXT,
+    envelope_id TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_runs_job ON runs(job_id);
+CREATE INDEX IF NOT EXISTS idx_runs_open ON runs(job_id) WHERE ended_at IS NULL;
+"""
+
+# Fields a caller may mutate via update_job (id/created_at are immutable).
+_MUTABLE = frozenset(
+    {
+        "name",
+        "cron_expr",
+        "prompt",
+        "channel_id",
+        "enabled",
+        "next_run_at",
+        "last_run_at",
+        "last_run_status",
+    }
+)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+class SchedulerStore:
+    def __init__(self, db_path: Path | str) -> None:
+        self.db_path = Path(db_path)
+        self._db: aiosqlite.Connection | None = None
+
+    async def open(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = await aiosqlite.connect(str(self.db_path))
+        self._db.row_factory = aiosqlite.Row
+        await self._db.executescript(
+            "PRAGMA journal_mode=WAL;"
+            "PRAGMA synchronous=NORMAL;"
+            "PRAGMA busy_timeout=5000;"
+        )
+        await self._db.executescript(_SCHEMA)
+
+    async def close(self) -> None:
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+
+    async def _ensure_db(self) -> aiosqlite.Connection:
+        if self._db is None:
+            await self.open()
+        assert self._db is not None
+        return self._db
+
+    # ── jobs CRUD ────────────────────────────────────────────────────────
+
+    async def create_job(
+        self,
+        *,
+        name: str,
+        cron_expr: str,
+        prompt: str,
+        channel_id: str | None,
+        next_run_at: int,
+    ) -> dict:
+        db = await self._ensure_db()
+        now = _now_ms()
+        job_id = _new_id("cronjob")
+        await db.execute(
+            "INSERT INTO jobs (id, name, cron_expr, prompt, channel_id, enabled, "
+            "created_at, updated_at, last_run_at, last_run_status, next_run_at) "
+            "VALUES (?, ?, ?, ?, ?, 1, ?, ?, NULL, NULL, ?)",
+            (job_id, name, cron_expr, prompt, channel_id, now, now, next_run_at),
+        )
+        await db.commit()
+        job = await self.get_job(job_id)
+        assert job is not None
+        return job
+
+    async def get_job(self, job_id: str) -> dict | None:
+        db = await self._ensure_db()
+        cur = await db.execute("SELECT * FROM jobs WHERE id = ?", (job_id,))
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+    async def list_jobs(self) -> list[dict]:
+        db = await self._ensure_db()
+        cur = await db.execute("SELECT * FROM jobs ORDER BY created_at")
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def update_job(self, job_id: str, **fields) -> dict | None:
+        sets = {k: v for k, v in fields.items() if k in _MUTABLE and v is not None}
+        if not sets:
+            return await self.get_job(job_id)
+        sets["updated_at"] = _now_ms()
+        db = await self._ensure_db()
+        assignments = ", ".join(f"{k} = ?" for k in sets)
+        cur = await db.execute(
+            f"UPDATE jobs SET {assignments} WHERE id = ?",
+            (*sets.values(), job_id),
+        )
+        await db.commit()
+        if cur.rowcount == 0:
+            return None
+        return await self.get_job(job_id)
+
+    async def delete_job(self, job_id: str) -> bool:
+        db = await self._ensure_db()
+        cur = await db.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
+        await db.commit()
+        return cur.rowcount > 0
+
+    # ── engine helpers ───────────────────────────────────────────────────
+
+    async def due_jobs(self, now_ms: int) -> list[dict]:
+        """Enabled jobs whose next_run_at has arrived, oldest-due first."""
+        db = await self._ensure_db()
+        cur = await db.execute(
+            "SELECT * FROM jobs WHERE enabled = 1 AND next_run_at <= ? "
+            "ORDER BY next_run_at",
+            (now_ms,),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def has_open_run(self, job_id: str) -> bool:
+        """True if a prior fire of this job is still in flight (no-overlap)."""
+        db = await self._ensure_db()
+        cur = await db.execute(
+            "SELECT 1 FROM runs WHERE job_id = ? AND ended_at IS NULL LIMIT 1",
+            (job_id,),
+        )
+        return (await cur.fetchone()) is not None
+
+    async def job_for_open_envelope(self, envelope_id: str) -> str | None:
+        """job_id of the still-open run for a fired envelope, if any."""
+        db = await self._ensure_db()
+        cur = await db.execute(
+            "SELECT job_id FROM runs WHERE envelope_id = ? AND ended_at IS NULL",
+            (envelope_id,),
+        )
+        row = await cur.fetchone()
+        return row["job_id"] if row else None
+
+    async def open_run(self, job_id: str, envelope_id: str, started_at: int) -> str:
+        db = await self._ensure_db()
+        run_id = _new_id("cronrun")
+        await db.execute(
+            "INSERT INTO runs (id, job_id, started_at, ended_at, status, envelope_id) "
+            "VALUES (?, ?, ?, NULL, NULL, ?)",
+            (run_id, job_id, started_at, envelope_id),
+        )
+        await db.commit()
+        return run_id
+
+    async def close_run(self, envelope_id: str, status: str, ended_at: int) -> bool:
+        """Close the open run for a fired envelope (called on turn completion)."""
+        db = await self._ensure_db()
+        cur = await db.execute(
+            "UPDATE runs SET ended_at = ?, status = ? "
+            "WHERE envelope_id = ? AND ended_at IS NULL",
+            (ended_at, status, envelope_id),
+        )
+        await db.commit()
+        return cur.rowcount > 0
+
+    async def record_fire(self, job_id: str, last_run_at: int, next_run_at: int) -> None:
+        """After firing: stamp last_run_at + advance next_run_at."""
+        db = await self._ensure_db()
+        await db.execute(
+            "UPDATE jobs SET last_run_at = ?, next_run_at = ?, updated_at = ? "
+            "WHERE id = ?",
+            (last_run_at, next_run_at, _now_ms(), job_id),
+        )
+        await db.commit()
+
+    async def set_last_status(self, job_id: str, status: str) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            "UPDATE jobs SET last_run_status = ?, updated_at = ? WHERE id = ?",
+            (status, _now_ms(), job_id),
+        )
+        await db.commit()

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -22,7 +22,7 @@ DEFAULT_HEARTBEAT_INTERVAL_S = 60.0
 
 # Synthetic local envelopes have no server row; /messages/<id>/processing/*
 # would 404, so skip the HTTP round-trip (the worker still tracks the run).
-_LOCAL_ONLY_ENVELOPE_PREFIXES = ("intro-prompt-",)
+_LOCAL_ONLY_ENVELOPE_PREFIXES = ("intro-prompt-", "cron-")
 
 
 def _is_local_only_envelope(message_id: str) -> bool:

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -112,3 +112,36 @@ class PuffoRpcClient:
                 "reason": reason,
             },
         )
+
+    # ── PUF-394: persistent scheduler ────────────────────────────────
+
+    async def cron_create(
+        self, *, name: str, cron_expr: str, prompt: str, channel_id: str = "",
+    ) -> str:
+        return await self._post(
+            "cron-create",
+            {"name": name, "cron_expr": cron_expr, "prompt": prompt,
+             "channel_id": channel_id},
+        )
+
+    async def cron_list(self) -> str:
+        return await self._post("cron-list", {})
+
+    async def cron_update(
+        self,
+        *,
+        job_id: str,
+        name: Optional[str] = None,
+        cron_expr: Optional[str] = None,
+        prompt: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> str:
+        return await self._post(
+            "cron-update",
+            {"job_id": job_id, "name": name, "cron_expr": cron_expr,
+             "prompt": prompt, "channel_id": channel_id, "enabled": enabled},
+        )
+
+    async def cron_delete(self, *, job_id: str) -> str:
+        return await self._post("cron-delete", {"job_id": job_id})

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -1293,3 +1293,81 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             reason=reason,
         )
 
+    _CRON_UNAVAILABLE = (
+        "scheduler unavailable — PUFFO_RPC_URL not set on this MCP "
+        "runtime, so the puffo-agent daemon isn't reachable."
+    )
+
+    @mcp.tool()
+    async def cron_create(
+        name: str, cron_expr: str, prompt: str, channel_id: str = ""
+    ) -> str:
+        """Create a PERSISTENT recurring job. Unlike the built-in Cron*
+        tools (which vanish when your session ends), this survives session
+        end, daemon restart, and worker respawn — the daemon owns it.
+
+        name: a short label (e.g. "daily-report").
+        cron_expr: standard crontab, UTC (e.g. "0 9 * * *" = 09:00 daily,
+            "*/30 * * * *" = every 30 min).
+        prompt: the instruction to carry out each run (e.g. "Post today's
+            status summary to #general using send_message").
+        channel_id: optional target channel the run is scoped to.
+
+        When due, you receive a "[puffo-agent system message]" turn with the
+        prompt; do the work and stop. Returns the job id + next run time.
+        """
+        if cfg.message_client is not None:
+            return await cfg.message_client.cron_create(
+                name=name, cron_expr=cron_expr, prompt=prompt,
+                channel_id=(channel_id or None),
+            )
+        if cfg.rpc_client is None:
+            raise RuntimeError(_CRON_UNAVAILABLE)
+        return await cfg.rpc_client.cron_create(
+            name=name, cron_expr=cron_expr, prompt=prompt, channel_id=channel_id,
+        )
+
+    @mcp.tool()
+    async def cron_list() -> str:
+        """List your persistent recurring jobs (id, name, schedule, next
+        run, last-run status)."""
+        if cfg.message_client is not None:
+            return await cfg.message_client.cron_list()
+        if cfg.rpc_client is None:
+            raise RuntimeError(_CRON_UNAVAILABLE)
+        return await cfg.rpc_client.cron_list()
+
+    @mcp.tool()
+    async def cron_update(
+        job_id: str,
+        name: str = "",
+        cron_expr: str = "",
+        prompt: str = "",
+        channel_id: str = "",
+        enabled: Optional[bool] = None,
+    ) -> str:
+        """Update a recurring job. Only the fields you pass change; omit the
+        rest. Set ``enabled=false`` to pause a job without deleting it."""
+        kw = dict(
+            job_id=job_id,
+            name=(name or None),
+            cron_expr=(cron_expr or None),
+            prompt=(prompt or None),
+            channel_id=(channel_id or None),
+            enabled=enabled,
+        )
+        if cfg.message_client is not None:
+            return await cfg.message_client.cron_update(**kw)
+        if cfg.rpc_client is None:
+            raise RuntimeError(_CRON_UNAVAILABLE)
+        return await cfg.rpc_client.cron_update(**kw)
+
+    @mcp.tool()
+    async def cron_delete(job_id: str) -> str:
+        """Delete a recurring job by id."""
+        if cfg.message_client is not None:
+            return await cfg.message_client.cron_delete(job_id=job_id)
+        if cfg.rpc_client is None:
+            raise RuntimeError(_CRON_UNAVAILABLE)
+        return await cfg.rpc_client.cron_delete(job_id=job_id)
+

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ..agent import scheduler_ops
 from ..crypto.encoding import base64url_decode
 from ..crypto.http_client import PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
@@ -41,6 +42,8 @@ class HostMcpContext:
     # The worker's live PuffoCoreMessageClient, for tools that drive
     # daemon-side state (leave requests). None until warm().
     message_client: Any = None
+    # PUF-394: the worker's SchedulerStore, for the cron_* RPC handlers.
+    scheduler_store: Any = None
 
 
 # ── filesystem helpers (host & agent .claude.json) ─────────────────
@@ -515,3 +518,66 @@ async def request_command_permission(
         summary=str(summary or ""),
         timeout_s=timeout,
     )
+
+
+# ── PUF-394: cron_* RPC handlers (harness runtimes reach the daemon-owned
+# scheduler store through these; ws-local drives the client directly) ──────
+
+
+def _norm(v):
+    """Coerce an omitted/blank RPC field to None (so update leaves it be)."""
+    return v if v else None
+
+
+async def cron_create(
+    ctx: HostMcpContext,
+    *,
+    name: str,
+    cron_expr: str,
+    prompt: str,
+    channel_id: str,
+) -> str:
+    if ctx.scheduler_store is None:
+        raise RuntimeError("agent isn't fully warm yet — try again in a moment")
+    return await scheduler_ops.create_op(
+        ctx.scheduler_store,
+        name=name or "",
+        cron_expr=cron_expr or "",
+        prompt=prompt or "",
+        channel_id=_norm(channel_id),
+    )
+
+
+async def cron_list(ctx: HostMcpContext) -> str:
+    if ctx.scheduler_store is None:
+        raise RuntimeError("agent isn't fully warm yet — try again in a moment")
+    return await scheduler_ops.list_op(ctx.scheduler_store)
+
+
+async def cron_update(
+    ctx: HostMcpContext,
+    *,
+    job_id: str,
+    name: str,
+    cron_expr: str,
+    prompt: str,
+    channel_id: str,
+    enabled,
+) -> str:
+    if ctx.scheduler_store is None:
+        raise RuntimeError("agent isn't fully warm yet — try again in a moment")
+    return await scheduler_ops.update_op(
+        ctx.scheduler_store,
+        job_id=job_id or "",
+        name=_norm(name),
+        cron_expr=_norm(cron_expr),
+        prompt=_norm(prompt),
+        channel_id=_norm(channel_id),
+        enabled=enabled,
+    )
+
+
+async def cron_delete(ctx: HostMcpContext, *, job_id: str) -> str:
+    if ctx.scheduler_store is None:
+        raise RuntimeError("agent isn't fully warm yet — try again in a moment")
+    return await scheduler_ops.delete_op(ctx.scheduler_store, job_id=job_id or "")

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -113,6 +113,35 @@ async def permission_request_route(request: web.Request) -> web.Response:
     )
 
 
+async def cron_create_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/cron-create — ``{name, cron_expr, prompt, channel_id}``."""
+    return await _dispatch(
+        request, host_mcp_handler.cron_create,
+        body_keys=("name", "cron_expr", "prompt", "channel_id"),
+    )
+
+
+async def cron_list_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/cron-list — no body."""
+    return await _dispatch(request, host_mcp_handler.cron_list, body_keys=())
+
+
+async def cron_update_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/cron-update —
+    ``{job_id, name?, cron_expr?, prompt?, channel_id?, enabled?}``."""
+    return await _dispatch(
+        request, host_mcp_handler.cron_update,
+        body_keys=("job_id", "name", "cron_expr", "prompt", "channel_id", "enabled"),
+    )
+
+
+async def cron_delete_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/cron-delete — ``{job_id}``."""
+    return await _dispatch(
+        request, host_mcp_handler.cron_delete, body_keys=("job_id",),
+    )
+
+
 def build_app(cfg: RpcServiceConfig) -> web.Application:
     app = web.Application()
     app.router.add_post(
@@ -131,6 +160,10 @@ def build_app(cfg: RpcServiceConfig) -> web.Application:
         "/v1/rpc/{agent_id}/permission-request",
         permission_request_route,
     )
+    app.router.add_post("/v1/rpc/{agent_id}/cron-create", cron_create_route)
+    app.router.add_post("/v1/rpc/{agent_id}/cron-list", cron_list_route)
+    app.router.add_post("/v1/rpc/{agent_id}/cron-update", cron_update_route)
+    app.router.add_post("/v1/rpc/{agent_id}/cron-delete", cron_delete_route)
     return app
 
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -365,6 +365,7 @@ def _build_puffo_core_client(
         PuffoCoreMessageClient,
         max_image_edge_px,
     )
+    from ..agent.scheduler_store import SchedulerStore
     from ..crypto.http_client import PuffoCoreHttpClient
     from ..crypto.keystore import KeyStore
 
@@ -374,6 +375,7 @@ def _build_puffo_core_client(
     ks = KeyStore(ks_dir)
     http = PuffoCoreHttpClient(pc.server_url, ks, pc.slug)
     ms = MessageStore(str(agent_dir(agent_id) / "messages.db"))
+    scheduler_store = SchedulerStore(str(agent_dir(agent_id) / "scheduler.db"))
 
     max_inline = (
         daemon_cfg.max_inline_message_chars if daemon_cfg is not None else MAX_INLINE_MESSAGE_CHARS
@@ -407,6 +409,7 @@ def _build_puffo_core_client(
         keystore=ks,
         http_client=http,
         message_store=ms,
+        scheduler_store=scheduler_store,
         workspace=str(agent_cfg.resolve_workspace_dir()),
         max_inline_chars=max_inline,
         segment_chars=segment_chars,
@@ -916,6 +919,7 @@ class Worker:
             keystore=client.keystore,
             http_client=client.http,
             message_client=client,
+            scheduler_store=client.scheduler_store,
         )
 
     async def stop(self) -> None:
@@ -1117,6 +1121,14 @@ class Worker:
             # Init crashed before warm() — release the startup gate.
             self._warm_done.set()
             return
+
+        # PUF-394: per-agent persistent scheduler engine. Shares the client's
+        # scheduler_store; fires due jobs by injecting a synthetic system turn.
+        from ..agent.scheduler import SchedulerEngine
+
+        scheduler_engine = SchedulerEngine(
+            client.scheduler_store, fire=client.fire_cron_job,
+        )
 
         # Per-agent refresh_ping retired; daemon-level CredentialRefresher is
         # the single writer of ~/.claude/.credentials.json.
@@ -1467,6 +1479,16 @@ class Worker:
             batch: list[dict],
             channel_meta: dict,
         ):
+            # PUF-394: a cron-fired turn finished OK → close its run so the
+            # no-overlap guard clears and the job can fire again.
+            if root_id.startswith("cron-"):
+                try:
+                    await scheduler_engine.record_completion(root_id, "ok")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "agent %s: cron run-close failed for %s: %s",
+                        agent_id, root_id, exc,
+                    )
             Worker._clear_api_error_abandoned_if_recoverable(
                 self.runtime, agent_id, root_id, logger,
             )
@@ -1481,6 +1503,38 @@ class Worker:
                 self.runtime.save(agent_id)
                 try:
                     await asyncio.wait_for(self._stop.wait(), timeout=interval)
+                except asyncio.TimeoutError:
+                    pass
+
+        async def scheduler_loop():
+            # PUF-394: every 30s fire due jobs (catch-up-once on the first
+            # tick), then mirror the job snapshot to the server on change.
+            # Best-effort — a failing tick/sync never wedges the agent.
+            from ..agent import scheduler_ops
+
+            last_synced: str | None = None
+            while not self._stop.is_set():
+                try:
+                    await scheduler_engine.tick()
+                    jobs = await client.scheduler_store.list_jobs()
+                    snapshot = scheduler_ops.server_snapshot(jobs)
+                    payload = json.dumps(snapshot, sort_keys=True)
+                    if payload != last_synced and hasattr(client, "http"):
+                        try:
+                            await client.http.post(
+                                "/agents/me/scheduler", {"jobs": snapshot}
+                            )
+                            last_synced = payload
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug(
+                                "agent %s: scheduler sync failed: %s", agent_id, exc
+                            )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "agent %s: scheduler tick failed: %s", agent_id, exc
+                    )
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=30.0)
                 except asyncio.TimeoutError:
                     pass
 
@@ -1516,6 +1570,7 @@ class Worker:
 
         hb_task = asyncio.ensure_future(heartbeat())
         status_task = asyncio.ensure_future(reporter.run_heartbeat_loop())
+        scheduler_task = asyncio.ensure_future(scheduler_loop())
         try:
             while not self._stop.is_set():
                 try:
@@ -1550,11 +1605,16 @@ class Worker:
             reporter.stop()
             hb_task.cancel()
             status_task.cancel()
-            for task in (hb_task, status_task):
+            scheduler_task.cancel()
+            for task in (hb_task, status_task, scheduler_task):
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):
                     pass
+            try:
+                await client.scheduler_store.close()
+            except Exception:  # noqa: BLE001
+                pass
             self.runtime.status = "stopped"
             self.runtime.save(agent_id)
 

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -1,0 +1,156 @@
+"""PUF-394: SchedulerEngine tick — fire, catch-up-once, no-overlap, completion."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from puffo_agent.agent.scheduler import (
+    SchedulerEngine,
+    is_valid_cron,
+    next_run,
+)
+from puffo_agent.agent.scheduler_store import SchedulerStore
+
+# 2026-07-24 10:00:00 UTC in ms.
+T0 = int(datetime(2026, 7, 24, 10, 0, tzinfo=timezone.utc).timestamp() * 1000)
+HOUR = 3_600_000
+
+
+def test_is_valid_cron():
+    assert is_valid_cron("0 9 * * *")
+    assert is_valid_cron("*/5 * * * *")
+    assert not is_valid_cron("nonsense")
+    assert not is_valid_cron("99 99 * * *")
+
+
+def test_next_run_is_the_next_future_occurrence():
+    # Daily at 09:00 UTC; from 10:00 the next is tomorrow 09:00.
+    got = next_run("0 9 * * *", T0)
+    assert got == int(datetime(2026, 7, 25, 9, 0, tzinfo=timezone.utc).timestamp() * 1000)
+    # Strictly after the base.
+    assert next_run("*/5 * * * *", T0) > T0
+
+
+class _Fires:
+    def __init__(self, *, boom: set[str] | None = None):
+        self.calls: list[tuple[str, str]] = []  # (job_id, envelope_id)
+        self._boom = boom or set()
+
+    async def __call__(self, job: dict, envelope_id: str) -> None:
+        self.calls.append((job["id"], envelope_id))
+        if job["id"] in self._boom:
+            raise RuntimeError("fire failed")
+
+
+async def _store(tmp_path) -> SchedulerStore:
+    s = SchedulerStore(tmp_path / "scheduler.db")
+    await s.open()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_tick_fires_due_job_and_advances(tmp_path):
+    store = await _store(tmp_path)
+    fires = _Fires()
+    engine = SchedulerEngine(store, fires, now_fn=lambda: T0)
+    job = await store.create_job(
+        name="daily", cron_expr="0 9 * * *", prompt="report", channel_id="ch_1",
+        next_run_at=T0 - HOUR,  # due
+    )
+
+    assert await engine.tick() == 1
+    assert fires.calls == [(job["id"], f"cron-{job['id']}-{T0}")]
+    got = await store.get_job(job["id"])
+    assert got["last_run_at"] == T0
+    assert got["next_run_at"] > T0  # rescheduled forward
+    assert await store.has_open_run(job["id"]) is True  # run left open until completion
+
+
+@pytest.mark.asyncio
+async def test_catch_up_once_not_backfill(tmp_path):
+    store = await _store(tmp_path)
+    fires = _Fires()
+    engine = SchedulerEngine(store, fires, now_fn=lambda: T0)
+    # Hourly job that was due 5 hours ago (daemon was down).
+    await store.create_job(
+        name="hourly", cron_expr="0 * * * *", prompt="p", channel_id=None,
+        next_run_at=T0 - 5 * HOUR,
+    )
+    fired = await engine.tick()
+    assert fired == 1  # fires ONCE, not 5×
+    # Next tick: not due (rescheduled to the future) → nothing fires.
+    assert await engine.tick() == 0
+    assert len(fires.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_overlap_skips_when_prior_run_open(tmp_path):
+    store = await _store(tmp_path)
+    fires = _Fires()
+    engine = SchedulerEngine(store, fires, now_fn=lambda: T0)
+    job = await store.create_job(
+        name="slow", cron_expr="* * * * *", prompt="p", channel_id=None,
+        next_run_at=T0 - 60_000,
+    )
+    # Simulate a prior fire still in flight.
+    await store.open_run(job["id"], "cron-prior", started_at=T0 - 60_000)
+
+    assert await engine.tick() == 0  # skipped, not fired
+    assert fires.calls == []
+    got = await store.get_job(job["id"])
+    assert got["last_run_status"] == "skipped"
+    assert got["next_run_at"] > T0  # still rescheduled so it doesn't hot-loop
+
+
+@pytest.mark.asyncio
+async def test_fire_error_marks_run_and_job(tmp_path):
+    store = await _store(tmp_path)
+    job = await store.create_job(
+        name="x", cron_expr="* * * * *", prompt="p", channel_id=None,
+        next_run_at=T0 - 60_000,
+    )
+    fires = _Fires(boom={job["id"]})
+    engine = SchedulerEngine(store, fires, now_fn=lambda: T0)
+
+    await engine.tick()
+    got = await store.get_job(job["id"])
+    assert got["last_run_status"] == "error"
+    assert await store.has_open_run(job["id"]) is False  # run closed on failure
+
+
+@pytest.mark.asyncio
+async def test_record_completion_closes_run_and_stamps_status(tmp_path):
+    store = await _store(tmp_path)
+    fires = _Fires()
+    engine = SchedulerEngine(store, fires, now_fn=lambda: T0)
+    job = await store.create_job(
+        name="x", cron_expr="0 9 * * *", prompt="p", channel_id=None,
+        next_run_at=T0 - HOUR,
+    )
+    await engine.tick()
+    (_, envelope_id) = fires.calls[0]
+
+    await engine.record_completion(envelope_id, "ok")
+    assert await store.has_open_run(job["id"]) is False
+    assert (await store.get_job(job["id"]))["last_run_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_disabled_and_future_jobs_dont_fire(tmp_path):
+    store = await _store(tmp_path)
+    fires = _Fires()
+    engine = SchedulerEngine(store, fires, now_fn=lambda: T0)
+    future = await store.create_job(
+        name="future", cron_expr="0 9 * * *", prompt="p", channel_id=None,
+        next_run_at=T0 + HOUR,
+    )
+    off = await store.create_job(
+        name="off", cron_expr="0 9 * * *", prompt="p", channel_id=None,
+        next_run_at=T0 - HOUR,
+    )
+    await store.update_job(off["id"], enabled=0)
+
+    assert await engine.tick() == 0
+    assert fires.calls == []
+    _ = future

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -117,6 +117,9 @@ async def test_fire_error_marks_run_and_job(tmp_path):
     got = await store.get_job(job["id"])
     assert got["last_run_status"] == "error"
     assert await store.has_open_run(job["id"]) is False  # run closed on failure
+    # record_fire ran BEFORE the failing fire (crash-safety ordering): a crash
+    # mid-fire must leave next_run_at already advanced so the slot can't re-fire.
+    assert got["next_run_at"] > T0
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler_ops.py
+++ b/tests/test_scheduler_ops.py
@@ -1,0 +1,84 @@
+"""PUF-394: scheduler_ops CRUD + validation + formatting."""
+from __future__ import annotations
+
+import pytest
+
+from puffo_agent.agent import scheduler_ops as ops
+from puffo_agent.agent.scheduler_store import SchedulerStore
+
+
+async def _store(tmp_path) -> SchedulerStore:
+    s = SchedulerStore(tmp_path / "scheduler.db")
+    await s.open()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_create_persists_and_confirms(tmp_path):
+    store = await _store(tmp_path)
+    msg = await ops.create_op(
+        store, name="daily-report", cron_expr="0 9 * * *",
+        prompt="post the daily report to #general", channel_id="ch_1",
+    )
+    assert "Created recurring job cronjob_" in msg
+    assert "persists across session/daemon restart" in msg
+    jobs = await store.list_jobs()
+    assert len(jobs) == 1 and jobs[0]["name"] == "daily-report"
+    assert jobs[0]["next_run_at"] > 0
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_bad_cron_and_blank_fields(tmp_path):
+    store = await _store(tmp_path)
+    assert "invalid cron_expr" in await ops.create_op(
+        store, name="x", cron_expr="not a cron", prompt="p", channel_id=None
+    )
+    assert "name is required" in await ops.create_op(
+        store, name="  ", cron_expr="0 9 * * *", prompt="p", channel_id=None
+    )
+    assert "prompt is required" in await ops.create_op(
+        store, name="x", cron_expr="0 9 * * *", prompt="", channel_id=None
+    )
+    assert await store.list_jobs() == []  # nothing persisted on any error
+
+
+@pytest.mark.asyncio
+async def test_list_empty_and_populated(tmp_path):
+    store = await _store(tmp_path)
+    assert await ops.list_op(store) == "No recurring jobs."
+    await ops.create_op(store, name="j1", cron_expr="*/5 * * * *", prompt="p", channel_id="ch_9")
+    listing = await ops.list_op(store)
+    assert "j1" in listing and "*/5 * * * *" in listing and "→ ch_9" in listing
+
+
+@pytest.mark.asyncio
+async def test_update_changes_cron_and_recomputes_next(tmp_path):
+    store = await _store(tmp_path)
+    await ops.create_op(store, name="j", cron_expr="0 9 * * *", prompt="p", channel_id=None)
+    job_id = (await store.list_jobs())[0]["id"]
+    before = (await store.get_job(job_id))["next_run_at"]
+
+    msg = await ops.update_op(store, job_id=job_id, cron_expr="*/1 * * * *", enabled=False)
+    assert "Updated" in msg and "disabled" in msg
+    after = await store.get_job(job_id)
+    assert after["cron_expr"] == "*/1 * * * *"
+    assert after["enabled"] == 0
+    assert after["next_run_at"] != before  # recomputed
+
+
+@pytest.mark.asyncio
+async def test_update_missing_and_bad_cron(tmp_path):
+    store = await _store(tmp_path)
+    assert "no job" in await ops.update_op(store, job_id="cronjob_nope", name="x")
+    await ops.create_op(store, name="j", cron_expr="0 9 * * *", prompt="p", channel_id=None)
+    job_id = (await store.list_jobs())[0]["id"]
+    assert "invalid cron_expr" in await ops.update_op(store, job_id=job_id, cron_expr="bad")
+
+
+@pytest.mark.asyncio
+async def test_delete(tmp_path):
+    store = await _store(tmp_path)
+    await ops.create_op(store, name="j", cron_expr="0 9 * * *", prompt="p", channel_id=None)
+    job_id = (await store.list_jobs())[0]["id"]
+    assert "Deleted recurring job" in await ops.delete_op(store, job_id=job_id)
+    assert "no job" in await ops.delete_op(store, job_id=job_id)

--- a/tests/test_scheduler_store.py
+++ b/tests/test_scheduler_store.py
@@ -1,0 +1,133 @@
+"""PUF-394: SchedulerStore CRUD + due-query + no-overlap run tracking."""
+from __future__ import annotations
+
+import pytest
+
+from puffo_agent.agent.scheduler_store import SchedulerStore
+
+
+async def _fresh(tmp_path) -> SchedulerStore:
+    s = SchedulerStore(tmp_path / "scheduler.db")
+    await s.open()
+    return s
+
+
+async def _mk(store, *, name="daily", cron="0 9 * * *", next_run_at=1000) -> dict:
+    return await store.create_job(
+        name=name, cron_expr=cron, prompt="post the report", channel_id="ch_1",
+        next_run_at=next_run_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_then_get_and_list(tmp_path):
+    store = await _fresh(tmp_path)
+    job = await _mk(store)
+    assert job["id"].startswith("cronjob_")
+    assert job["name"] == "daily"
+    assert job["enabled"] == 1
+    assert job["last_run_at"] is None
+    got = await store.get_job(job["id"])
+    assert got == job
+    assert [j["id"] for j in await store.list_jobs()] == [job["id"]]
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(tmp_path):
+    store = await _fresh(tmp_path)
+    assert await store.get_job("cronjob_nope") is None
+
+
+@pytest.mark.asyncio
+async def test_update_mutable_fields_only(tmp_path):
+    store = await _fresh(tmp_path)
+    job = await _mk(store)
+    updated = await store.update_job(
+        job["id"], cron_expr="*/5 * * * *", enabled=0, name="renamed",
+    )
+    assert updated["cron_expr"] == "*/5 * * * *"
+    assert updated["enabled"] == 0
+    assert updated["name"] == "renamed"
+    assert updated["updated_at"] >= job["updated_at"]
+    # created_at is immutable even if passed.
+    again = await store.update_job(job["id"], created_at=0)
+    assert again["created_at"] == job["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_update_missing_returns_none(tmp_path):
+    store = await _fresh(tmp_path)
+    assert await store.update_job("cronjob_nope", name="x") is None
+
+
+@pytest.mark.asyncio
+async def test_delete(tmp_path):
+    store = await _fresh(tmp_path)
+    job = await _mk(store)
+    assert await store.delete_job(job["id"]) is True
+    assert await store.delete_job(job["id"]) is False
+    assert await store.get_job(job["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_due_jobs_respects_enabled_and_next_run(tmp_path):
+    store = await _fresh(tmp_path)
+    a = await _mk(store, name="past", next_run_at=500)
+    b = await _mk(store, name="future", next_run_at=5000)
+    disabled = await _mk(store, name="off", next_run_at=100)
+    await store.update_job(disabled["id"], enabled=0)
+
+    due = await store.due_jobs(now_ms=1000)
+    assert [j["id"] for j in due] == [a["id"]]  # b is future, disabled excluded
+    _ = b
+
+
+@pytest.mark.asyncio
+async def test_no_overlap_open_run_guard(tmp_path):
+    store = await _fresh(tmp_path)
+    job = await _mk(store)
+    assert await store.has_open_run(job["id"]) is False
+    await store.open_run(job["id"], envelope_id="cron-x-1", started_at=1000)
+    assert await store.has_open_run(job["id"]) is True
+    # Closing the run clears the guard.
+    assert await store.close_run("cron-x-1", status="ok", ended_at=2000) is True
+    assert await store.has_open_run(job["id"]) is False
+    # Second close is a no-op (already closed).
+    assert await store.close_run("cron-x-1", status="ok", ended_at=3000) is False
+
+
+@pytest.mark.asyncio
+async def test_record_fire_advances_next_run(tmp_path):
+    store = await _fresh(tmp_path)
+    job = await _mk(store, next_run_at=1000)
+    await store.record_fire(job["id"], last_run_at=1000, next_run_at=90000)
+    got = await store.get_job(job["id"])
+    assert got["last_run_at"] == 1000
+    assert got["next_run_at"] == 90000
+
+
+@pytest.mark.asyncio
+async def test_set_last_status(tmp_path):
+    store = await _fresh(tmp_path)
+    job = await _mk(store)
+    await store.set_last_status(job["id"], "error")
+    assert (await store.get_job(job["id"]))["last_run_status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_survives_reopen(tmp_path):
+    path = tmp_path / "scheduler.db"
+    s1 = SchedulerStore(path)
+    await s1.open()
+    job = await s1.create_job(
+        name="persist", cron_expr="0 * * * *", prompt="p", channel_id=None,
+        next_run_at=42,
+    )
+    await s1.close()
+    # New store on the same file (models a daemon restart) sees the job.
+    s2 = SchedulerStore(path)
+    await s2.open()
+    got = await s2.get_job(job["id"])
+    assert got is not None and got["next_run_at"] == 42
+    assert got["channel_id"] is None
+    await s2.close()

--- a/tests/test_scheduler_wiring.py
+++ b/tests/test_scheduler_wiring.py
@@ -1,0 +1,101 @@
+"""PUF-394: cron RPC handler integration + wiring source-pins.
+
+The host_mcp_handler cron_* fns are directly testable (they only need a ctx
+carrying a real SchedulerStore). The MCP-tool / RPC-route / Worker-tick glue
+runs only inside a live daemon, so it's source-pinned here (+ py_compile in CI)
+and flagged for runtime QA.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import puffo_agent
+from puffo_agent.agent.scheduler_store import SchedulerStore
+from puffo_agent.agent.status_reporter import _LOCAL_ONLY_ENVELOPE_PREFIXES
+from puffo_agent.portal import host_mcp_handler as h
+
+
+async def _ctx(tmp_path):
+    store = SchedulerStore(tmp_path / "scheduler.db")
+    await store.open()
+    return SimpleNamespace(scheduler_store=store)
+
+
+@pytest.mark.asyncio
+async def test_cron_handlers_crud_through_ctx(tmp_path):
+    ctx = await _ctx(tmp_path)
+    created = await h.cron_create(
+        ctx, name="daily", cron_expr="0 9 * * *", prompt="report", channel_id="ch_1",
+    )
+    assert "Created recurring job cronjob_" in created
+
+    listing = await h.cron_list(ctx)
+    assert "daily" in listing and "0 9 * * *" in listing
+    job_id = (await ctx.scheduler_store.list_jobs())[0]["id"]
+
+    # Omitted update fields are left unchanged (blank → None normalization).
+    updated = await h.cron_update(
+        ctx, job_id=job_id, name="", cron_expr="*/5 * * * *", prompt="",
+        channel_id="", enabled=False,
+    )
+    assert "*/5 * * * *" in updated and "disabled" in updated
+    row = await ctx.scheduler_store.get_job(job_id)
+    assert row["name"] == "daily"  # unchanged (blank name normalized to None)
+    assert row["cron_expr"] == "*/5 * * * *"
+
+    assert "Deleted recurring job" in await h.cron_delete(ctx, job_id=job_id)
+
+
+@pytest.mark.asyncio
+async def test_cron_handler_errors_when_store_missing(tmp_path):
+    ctx = SimpleNamespace(scheduler_store=None)
+    with pytest.raises(RuntimeError):
+        await h.cron_list(ctx)
+
+
+def test_cron_envelope_prefix_is_local_only():
+    # Fired cron turns must skip the server /processing round-trips.
+    assert "cron-" in _LOCAL_ONLY_ENVELOPE_PREFIXES
+
+
+# ── source-pins for the daemon-only glue ─────────────────────────────
+
+
+def _src(rel: str) -> str:
+    return (Path(puffo_agent.__file__).parent / rel).read_text(encoding="utf-8")
+
+
+def test_mcp_tools_registered():
+    src = _src("mcp/puffo_core_tools.py")
+    for tool in ("async def cron_create", "async def cron_list",
+                 "async def cron_update", "async def cron_delete"):
+        assert tool in src
+    # both dispatch branches present (ws-local + harness RPC).
+    assert "cfg.message_client.cron_create" in src
+    assert "cfg.rpc_client.cron_create" in src
+
+
+def test_rpc_routes_registered():
+    src = _src("portal/rpc_service.py")
+    for route in ("cron-create", "cron-list", "cron-update", "cron-delete"):
+        assert route in src
+
+
+def test_worker_wires_engine_tick_and_fire():
+    src = _src("portal/worker.py")
+    assert "SchedulerEngine(" in src
+    assert "scheduler_task = asyncio.ensure_future(scheduler_loop())" in src
+    assert "record_completion(root_id" in src  # cron turn completion hook
+    assert "scheduler_store=scheduler_store" in src  # threaded into the client
+
+
+def test_client_has_fire_and_cron_methods():
+    src = _src("agent/puffo_core_client.py")
+    assert "async def fire_cron_job" in src
+    assert "_admit_thread_message" in src
+    for m in ("async def cron_create", "async def cron_list",
+              "async def cron_update", "async def cron_delete"):
+        assert m in src


### PR DESCRIPTION
## Summary

Persistent per-agent scheduler that survives session drop / daemon restart / worker respawn — the whole point vs the session-local Claude Code SDK `Cron*` tools. SQLite-backed jobs (`croniter` crontab syntax), engine tick with **catch-up-once** on restart + **no-overlap** guard + per-run history, exposed to the agent as 4 persistent MCP tools (`cron_create` / `cron_list` / `cron_update` / `cron_delete`).

Supersedes FB-425 (gives codex + claude-code the same persistent primitive that Karina's session-only Cron tool lost on restart).

**Han-cut scope honored:** no retry/backoff/alerting, no distributed/multi-machine coordination.

**Cross-side sequence:** PR 1 of 3 (this) = agent daemon. PR 2 = puffo-server (jobs table + `POST /v2/agents/me/scheduler` + payload on `/v2/agents/<slug>`). PR 3 = web (agent-profile scheduler panel, read-only).

## Files (11 src + 4 tests)

- `agent/scheduler_store.py` (new) — aiosqlite/WAL `jobs` + `runs` tables, mirrors `message_store.py` idiom. Single writer via daemon event loop.
- `agent/scheduler.py` (new) — `SchedulerEngine` with `tick()` + `record_completion()`. Catch-up-once by computing `next_run_at` from *now* (not the stale slot). No-overlap gate via `has_open_run` before firing.
- `agent/scheduler_ops.py` (new) — shared CRUD/format helpers used by both `message_client` (ws-local) and `rpc_service` (harness) paths.
- `mcp/puffo_core_tools.py` — 4 new tools with per-path dispatch (`message_client` on ws-local, `rpc_client` on harness).
- `mcp/_host_mcp.py`, `portal/host_mcp_handler.py`, `portal/rpc_service.py` — RPC + host-MCP wiring for harness path.
- `portal/worker.py` — tick task, fire via `_admit_thread_message(root_id="cron-…", …)`, `on_turn_success` run-close, signed snapshot POST to `/agents/me/scheduler`.
- `agent/puffo_core_client.py` — ws-local scheduler methods.
- `pyproject.toml` — `croniter` dep.

## Test plan

- [x] Touched suites (`test_scheduler_store` / `_engine` / `_ops` / `_wiring`) → **31 pass** (store 10 / engine 8 / ops 6 / wiring 7).
- [x] Full pytest sweep (excluding pre-existing PySide6 UI files) → **2117 pass / 2 skipped / 0 fail**. Zero regression.
- [ ] **Daemon-live QA** (source-pinned only in my env, needs real daemon): (1) due job fires a turn, (2) MCP tool → RPC round-trip creates a job, (3) restart → catch-up-once fires once + reschedules to next future slot.

## Known limits

- **ws-local idle tick not wired.** The tick loop is on the normal harness `_run` only — cli-local/docker/codex agents (FB-425 target) tick + fire; ws-local-idle firing is a follow-up if wanted. CRUD works either way.
- **State is replace-on-report** (not delta) — right for low-freq scheduler state; simpler idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
