### PR TITLE
fix(cloud): report runtime telemetry after reconnect

### DIFF
--- a/docs/FAT-CLOUD-ARCHITECTURE.md
+++ b/docs/FAT-CLOUD-ARCHITECTURE.md
@@ -217,18 +217,20 @@ keys and does crypto locally; fat-cloud holds nothing and lets the server do it.
 
 `StatusReporter` uses signed HTTP for native agents and
 `CloudBridgeClient.send_status` for keyless agents. Both paths report
-`idle` / `busy` / `error`, the current message, bounded error text,
-effective runtime metadata, and runtime health. The bridge sends a fresh
+`idle` / `busy` / `error`, the current message, bounded error text, and
+effective runtime metadata. The bridge sends a fresh
 snapshot after every successful connection or reconnect, on state
 transitions, and on the periodic heartbeat.
 
 The server folds bridge status frames into the same `agent_status` row
 and WebSocket notification used by signed heartbeats. Processing
-start/end updates preserve the latest runtime and health snapshot.
+start/end updates preserve the latest runtime snapshot.
 
 This status path is **[BUILT]**. Full daemon log collection, retention,
 and operator access remain a separate observability feature;
 `error_text` is not a replacement for an audit-log channel.
+
+Cloud runtime health remains AIM-owned and does not cross this bridge.
 
 #### Historical gap (resolved)
 

--- a/docs/FAT-CLOUD-ARCHITECTURE.md
+++ b/docs/FAT-CLOUD-ARCHITECTURE.md
@@ -213,7 +213,24 @@ keys and does crypto locally; fat-cloud holds nothing and lets the server do it.
 > `agent/bridge_client.py`. Net: a large deletion, a small addition — the exact
 > spirit of the cited figure, quantified from what actually exists.
 
-### Observability rides the deleted transport (SWAP-needs-new-frame)
+### Observability crosses the keyless bridge
+
+`StatusReporter` uses signed HTTP for native agents and
+`CloudBridgeClient.send_status` for keyless agents. Both paths report
+`idle` / `busy` / `error`, the current message, bounded error text,
+effective runtime metadata, and runtime health. The bridge sends a fresh
+snapshot after every successful connection or reconnect, on state
+transitions, and on the periodic heartbeat.
+
+The server folds bridge status frames into the same `agent_status` row
+and WebSocket notification used by signed heartbeats. Processing
+start/end updates preserve the latest runtime and health snapshot.
+
+This status path is **[BUILT]**. Full daemon log collection, retention,
+and operator access remain a separate observability feature;
+`error_text` is not a replacement for an audit-log channel.
+
+#### Historical gap (resolved)
 
 One module falsifies the tidy "everything above the seam is unchanged" claim: the
 desktop `StatusReporter` (`src/puffo_agent/agent/status_reporter.py:32`) reports the
@@ -592,13 +609,13 @@ The author ran this checklist against the finished doc:
         missing from the bridge" (`bridge.rs:76`/`:82`, commit `6725d46`), Overview ADD
         bucket, Phase-3 row (re-scoped to token-HTTP), and delta-table rows — **[BUILT:
         server]**.
-      - **G3** (status observability omitted) → "Observability rides the deleted
-        transport" (**SWAP-needs-new-frame**), the lifecycle-diagram observability note,
-        and a delta-table row (`status_reporter.py:32`).
+      - **G3** (status observability omitted) → "Observability crosses the keyless
+        bridge" (**BUILT**), the lifecycle-diagram observability note, and a delta-table
+        row (`status_reporter.py:32`).
       - **G4** (delta-table completeness overclaimed) → completeness claim scoped to the
         message surface + new KEEP/disposition rows + "Capabilities beyond the message
         surface".
-      - **MISSING-GAP #1 status** → G3 (SWAP-needs-new-frame). **#2 OAuth refresh** →
+      - **MISSING-GAP #1 status** → G3 (BUILT). **#2 OAuth refresh** →
         DROP-BY-DESIGN (LiteLLM VK; `claude-code`-OAuth caveat). **#3 local message
         store** → KEEP (`fetch_pending` = cold-start backfill on top of `messages.db`).
         **#4 model catalog** → KEEP-with-reconcile (LiteLLM VK model set). **#5 workspace

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -517,7 +517,6 @@ class CloudBridgeClient:
         current_message_id: Optional[str] = None,
         error_text: Optional[str] = None,
         runtime: Optional[dict[str, Any]] = None,
-        health: Optional[str] = None,
     ) -> None:
         """Report runtime status over the bridge — the keyless equivalent of the
         signed ``POST /agents/me/heartbeat`` + processing-run status flips. A
@@ -540,8 +539,6 @@ class CloudBridgeClient:
                 for key in allowed
                 if key in runtime
             }
-        if health is not None:
-            frame["health"] = str(health)[:128]
         await ws.send_json(frame)
 
     def _discard_waiter(

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -20,7 +20,7 @@ import contextlib
 import json
 import logging
 import uuid
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
 import aiohttp
 
@@ -75,6 +75,12 @@ class CloudBridgeClient:
         # in the spec — only one in-flight at a time).
         self._ack_result_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
         self._spaces_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+        self._connected_callbacks: list[Callable[[], Awaitable[None]]] = []
+
+    def add_connected_callback(
+        self, callback: Callable[[], Awaitable[None]],
+    ) -> None:
+        self._connected_callbacks.append(callback)
 
     async def connect(self) -> None:
         self._session = aiohttp.ClientSession(
@@ -122,6 +128,11 @@ class CloudBridgeClient:
         # Start the heartbeat only after a clean handshake so no failure
         # path leaves a live heartbeat task behind.
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        for callback in tuple(self._connected_callbacks):
+            try:
+                await callback()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("cloud bridge: connected callback failed: %s", exc)
 
     async def frames(self) -> AsyncIterator[dict]:
         # Yields message / pending_delivered / uncorrelated error.
@@ -505,6 +516,8 @@ class CloudBridgeClient:
         *,
         current_message_id: Optional[str] = None,
         error_text: Optional[str] = None,
+        runtime: Optional[dict[str, Any]] = None,
+        health: Optional[str] = None,
     ) -> None:
         """Report runtime status over the bridge — the keyless equivalent of the
         signed ``POST /agents/me/heartbeat`` + processing-run status flips. A
@@ -513,11 +526,22 @@ class CloudBridgeClient:
         WS broadcast, so the operator's status dot + Log are identical.
         Fire-and-forget (no reply frame)."""
         ws = await self._require_ws()
+        if status not in {"idle", "busy", "error"}:
+            raise ValueError(f"invalid agent status: {status}")
         frame: dict[str, Any] = {"type": "status", "status": status}
-        if current_message_id is not None:
-            frame["current_message_id"] = current_message_id
+        if status == "busy" and current_message_id is not None:
+            frame["current_message_id"] = current_message_id[:1024]
         if error_text is not None:
-            frame["error_text"] = error_text
+            frame["error_text"] = error_text[:1024]
+        if runtime is not None:
+            allowed = ("kind", "provider", "harness", "model", "inference_level")
+            frame["runtime"] = {
+                key: str(runtime.get(key, ""))[:256]
+                for key in allowed
+                if key in runtime
+            }
+        if health is not None:
+            frame["health"] = str(health)[:128]
         await ws.send_json(frame)
 
     def _discard_waiter(

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -109,7 +109,6 @@ class StatusReporter:
                 current_message_id=current_message_id,
                 error_text=error_text,
                 runtime=self._runtime_payload(),
-                health=self._health_payload(),
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("keyless status emit (%s) failed (%s)", status, exc)

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -108,9 +108,39 @@ class StatusReporter:
                 status,
                 current_message_id=current_message_id,
                 error_text=error_text,
+                runtime=self._runtime_payload(),
+                health=self._health_payload(),
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("keyless status emit (%s) failed (%s)", status, exc)
+
+    def _runtime_payload(self) -> dict[str, str] | None:
+        if self._runtime_provider is None:
+            return None
+        try:
+            runtime = self._runtime_provider()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("runtime_provider raised (%s)", exc)
+            return None
+        allowed = ("kind", "provider", "harness", "model", "inference_level")
+        return {
+            key: str(runtime.get(key, ""))[:256]
+            for key in allowed
+            if key in runtime
+        }
+
+    def _health_payload(self) -> str | None:
+        if self._runtime_health_provider is None:
+            return None
+        try:
+            return str(self._runtime_health_provider())[:128]
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("runtime_health_provider raised (%s)", exc)
+            return None
+
+    async def report_current_status(self) -> None:
+        """Best-effort status refresh used after bridge reconnects."""
+        await self._send_heartbeat()
 
     async def begin_turn(self, message_id: str) -> str:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
@@ -299,10 +329,9 @@ class StatusReporter:
                 except Exception as exc:  # noqa: BLE001
                     logger.debug("runtime_provider raised (%s)", exc)
         if self._runtime_health_provider is not None:
-            try:
-                body["health"] = self._runtime_health_provider()
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("runtime_health_provider raised (%s)", exc)
+            health = self._health_payload()
+            if health is not None:
+                body["health"] = health
         try:
             await self._http.post("/agents/me/heartbeat", body)
         except HttpError as exc:

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -128,15 +128,6 @@ class StatusReporter:
             if key in runtime
         }
 
-    def _health_payload(self) -> str | None:
-        if self._runtime_health_provider is None:
-            return None
-        try:
-            return str(self._runtime_health_provider())[:128]
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("runtime_health_provider raised (%s)", exc)
-            return None
-
     async def report_current_status(self) -> None:
         """Best-effort status refresh used after bridge reconnects."""
         await self._send_heartbeat()
@@ -328,9 +319,10 @@ class StatusReporter:
                 except Exception as exc:  # noqa: BLE001
                     logger.debug("runtime_provider raised (%s)", exc)
         if self._runtime_health_provider is not None:
-            health = self._health_payload()
-            if health is not None:
-                body["health"] = health
+            try:
+                body["health"] = self._runtime_health_provider()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("runtime_health_provider raised (%s)", exc)
         try:
             await self._http.post("/agents/me/heartbeat", body)
         except HttpError as exc:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1117,7 +1117,9 @@ class Worker:
         bridge = getattr(client, "_bridge", None)
         reporter = StatusReporter(
             client.http,
-            runtime_health_provider=lambda: self.runtime.health,
+            runtime_health_provider=(
+                None if bridge is not None else lambda: self.runtime.health
+            ),
             runtime_provider=self._runtime_info,
             status_sender=bridge.send_status if bridge is not None else None,
         )
@@ -1490,27 +1492,6 @@ class Worker:
                     asyncio.ensure_future(
                         get_reporter().emit(agent_id, "error", {"error": turn_error})
                     )
-                # AgentAPIError leaves in_progress for next batch's flip.
-                if turn_succeeded:
-                    try:
-                        Worker._resolve_health_on_success(
-                            self.runtime, agent_id, logger,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "agent %s: _resolve_health_on_success failed: %s",
-                            agent_id, exc,
-                        )
-                elif not turn_will_retry:
-                    try:
-                        Worker._fallback_unhandled_error_if_stuck_in_progress(
-                            self.runtime, agent_id, turn_error, logger,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "agent %s: in_progress backstop failed: %s",
-                            agent_id, exc,
-                        )
                 if run_id is not None and first_post_id:
                     # Build the batch payload: first row reuses the
                     # /start run_id (server UPDATEs its row); the
@@ -1533,6 +1514,27 @@ class Worker:
                             "error_text": turn_error,
                         })
                     await reporter.end_turn_batch(runs)
+                # AgentAPIError leaves in_progress for next batch's flip.
+                if turn_succeeded:
+                    try:
+                        Worker._resolve_health_on_success(
+                            self.runtime, agent_id, logger,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent %s: _resolve_health_on_success failed: %s",
+                            agent_id, exc,
+                        )
+                elif not turn_will_retry:
+                    try:
+                        Worker._fallback_unhandled_error_if_stuck_in_progress(
+                            self.runtime, agent_id, turn_error, logger,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent %s: in_progress backstop failed: %s",
+                            agent_id, exc,
+                        )
                 # Clear turn context so post-turn background work
                 # doesn't inherit a stale channel/root. Hook
                 # fails-open when the file is absent.

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -23,9 +23,12 @@ from ..agent.adapters import Adapter
 from ..agent.core import AgentAPIError, PuffoAgent
 from ..agent.status_reporter import StatusReporter
 from .runtime_matrix import (
+    HARNESS_PROVIDERS,
     RUNTIME_CLI_DOCKER,
     RUNTIME_CLI_LOCAL,
     RUNTIME_WS_LOCAL,
+    resolve_effective_harness,
+    resolve_effective_provider,
 )
 from .ws_local.hub import AttachPoint
 from ..agent.shared_content import (
@@ -1088,16 +1091,39 @@ class Worker:
         self.runtime.save(self.agent_cfg.id)
 
     def _runtime_info(self) -> dict[str, str]:
-        """Heartbeat payload: the agent's runtime, so the operator's portal can
-        show + pre-select the live model. An edit restarts the worker, so the
-        next instance reports the updated values."""
         rt = self.agent_cfg.runtime
+        kind = rt.kind or "chat-local"
+        if kind == RUNTIME_WS_LOCAL:
+            return {"kind": kind, "provider": "", "harness": "", "model": ""}
+        provider = rt.provider
+        if not provider and kind in (RUNTIME_CLI_LOCAL, RUNTIME_CLI_DOCKER) and rt.harness:
+            supported = HARNESS_PROVIDERS.get(rt.harness, frozenset())
+            if len(supported) == 1:
+                provider = next(iter(supported))
+        if not provider and kind == "chat-local":
+            provider = self.daemon_cfg.default_provider
+        provider = resolve_effective_provider(kind, provider)
+        harness = resolve_effective_harness(kind, provider, rt.harness)
+        provider_cfg = getattr(self.daemon_cfg, provider, None)
+        model = rt.model or getattr(provider_cfg, "model", "")
         return {
-            "kind": rt.kind,
-            "provider": rt.provider,
-            "harness": rt.harness,
-            "model": rt.model,
+            "kind": kind,
+            "provider": provider,
+            "harness": harness,
+            "model": model,
         }
+
+    def _build_status_reporter(self, client) -> StatusReporter:
+        bridge = getattr(client, "_bridge", None)
+        reporter = StatusReporter(
+            client.http,
+            runtime_health_provider=lambda: self.runtime.health,
+            runtime_provider=self._runtime_info,
+            status_sender=bridge.send_status if bridge is not None else None,
+        )
+        if bridge is not None:
+            bridge.add_connected_callback(reporter.report_current_status)
+        return reporter
 
     async def _run_ws_local(self) -> None:
         """ws-local agents run no harness consumer. Build the client,
@@ -1113,19 +1139,7 @@ class Worker:
                 self.agent_cfg, agent_id, daemon_cfg=self.daemon_cfg,
             )
             self._client = client
-            reporter = StatusReporter(
-                client.http,
-                runtime_health_provider=lambda: self.runtime.health,
-                runtime_provider=self._runtime_info,
-                # Keyless bridge agents can't sign the HTTP status routes — report
-                # status over the (already token-authed) bridge WS instead. None
-                # on native agents, so they keep the signed HTTP path unchanged.
-                status_sender=(
-                    client._bridge.send_status
-                    if getattr(client, "_bridge", None) is not None
-                    else None
-                ),
-            )
+            reporter = self._build_status_reporter(client)
             point = AttachPoint(
                 slug=self.agent_cfg.puffo_core.slug,
                 agent_id=agent_id,
@@ -1476,6 +1490,27 @@ class Worker:
                     asyncio.ensure_future(
                         get_reporter().emit(agent_id, "error", {"error": turn_error})
                     )
+                # AgentAPIError leaves in_progress for next batch's flip.
+                if turn_succeeded:
+                    try:
+                        Worker._resolve_health_on_success(
+                            self.runtime, agent_id, logger,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent %s: _resolve_health_on_success failed: %s",
+                            agent_id, exc,
+                        )
+                elif not turn_will_retry:
+                    try:
+                        Worker._fallback_unhandled_error_if_stuck_in_progress(
+                            self.runtime, agent_id, turn_error, logger,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "agent %s: in_progress backstop failed: %s",
+                            agent_id, exc,
+                        )
                 if run_id is not None and first_post_id:
                     # Build the batch payload: first row reuses the
                     # /start run_id (server UPDATEs its row); the
@@ -1498,27 +1533,6 @@ class Worker:
                             "error_text": turn_error,
                         })
                     await reporter.end_turn_batch(runs)
-                # AgentAPIError leaves in_progress for next batch's flip.
-                if turn_succeeded:
-                    try:
-                        Worker._resolve_health_on_success(
-                            self.runtime, agent_id, logger,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "agent %s: _resolve_health_on_success failed: %s",
-                            agent_id, exc,
-                        )
-                elif not turn_will_retry:
-                    try:
-                        Worker._fallback_unhandled_error_if_stuck_in_progress(
-                            self.runtime, agent_id, turn_error, logger,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "agent %s: in_progress backstop failed: %s",
-                            agent_id, exc,
-                        )
                 # Clear turn context so post-turn background work
                 # doesn't inherit a stale channel/root. Hook
                 # fails-open when the file is absent.
@@ -1663,18 +1677,7 @@ class Worker:
         # back to a no-op when the client has no http client (tests).
         # Lazy provider so each heartbeat reads live runtime.health.
         reporter = (
-            StatusReporter(
-                client.http,
-                runtime_health_provider=lambda: self.runtime.health,
-                runtime_provider=self._runtime_info,
-                # Keyless bridge agents report status over the bridge WS (they
-                # can't sign the HTTP routes); None on native agents.
-                status_sender=(
-                    client._bridge.send_status
-                    if getattr(client, "_bridge", None) is not None
-                    else None
-                ),
-            )
+            self._build_status_reporter(client)
             if hasattr(client, "http")
             else None
         )

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -202,7 +202,7 @@ async def test_heartbeat_frame_reaches_server(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_status_frame_carries_bounded_runtime_and_health():
+async def test_status_frame_carries_bounded_runtime():
     bridge_app = _MockBridgeApp()
     async with TestClient(TestServer(_build_app(bridge_app))) as client:
         url = str(client.make_url("")).rstrip("/")
@@ -220,7 +220,6 @@ async def test_status_frame_carries_bounded_runtime_and_health():
                     "model": "gpt-5",
                     "secret": "drop-me",
                 },
-                health="in_progress",
             )
             await asyncio.sleep(0)
         finally:
@@ -236,7 +235,6 @@ async def test_status_frame_carries_bounded_runtime_and_health():
         "harness": "codex",
         "model": "gpt-5",
     }
-    assert sent["health"] == "in_progress"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -41,6 +41,7 @@ class _MockBridgeApp:
         self.error_on_send: dict | None = None
         self.recv_send: list[dict] = []
         self.recv_heartbeats: list[dict] = []
+        self.recv_statuses: list[dict] = []
         self.token_seen: str | None = None
         self.heartbeat_received = asyncio.Event()
 
@@ -59,6 +60,8 @@ class _MockBridgeApp:
             if kind == "heartbeat":
                 self.recv_heartbeats.append(frame)
                 self.heartbeat_received.set()
+            elif kind == "status":
+                self.recv_statuses.append(frame)
             elif kind == "send":
                 self.recv_send.append(frame)
                 if self.error_on_send is not None:
@@ -196,6 +199,101 @@ async def test_heartbeat_frame_reaches_server(monkeypatch):
         finally:
             await c.close()
     assert bridge_app.recv_heartbeats[0] == {"type": "heartbeat"}
+
+
+@pytest.mark.asyncio
+async def test_status_frame_carries_bounded_runtime_and_health():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            await c.send_status(
+                "busy",
+                current_message_id="m" * 1100,
+                error_text="e" * 1100,
+                runtime={
+                    "kind": "cli-local",
+                    "provider": "openai",
+                    "harness": "codex",
+                    "model": "gpt-5",
+                    "secret": "drop-me",
+                },
+                health="in_progress",
+            )
+            await asyncio.sleep(0)
+        finally:
+            await c.close()
+
+    sent = bridge_app.recv_statuses[0]
+    assert sent["status"] == "busy"
+    assert len(sent["current_message_id"]) == 1024
+    assert len(sent["error_text"]) == 1024
+    assert sent["runtime"] == {
+        "kind": "cli-local",
+        "provider": "openai",
+        "harness": "codex",
+        "model": "gpt-5",
+    }
+    assert sent["health"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_status_rejects_invalid_state_and_clears_non_busy_message_id():
+    bridge_app = _MockBridgeApp()
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        await c.connect()
+        try:
+            with pytest.raises(ValueError, match="invalid agent status"):
+                await c.send_status("starting")
+            await c.send_status("error", current_message_id="must-not-send")
+            await asyncio.sleep(0)
+        finally:
+            await c.close()
+
+    assert "current_message_id" not in bridge_app.recv_statuses[0]
+
+
+@pytest.mark.asyncio
+async def test_connected_callback_runs_after_every_reconnect():
+    bridge_app = _MockBridgeApp()
+    calls = 0
+
+    async def on_connected():
+        nonlocal calls
+        calls += 1
+
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        c.add_connected_callback(on_connected)
+        await c.connect()
+        await c.close()
+        await c.connect()
+        await c.close()
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_connected_callback_failure_does_not_break_bridge():
+    bridge_app = _MockBridgeApp()
+
+    async def broken():
+        raise RuntimeError("telemetry unavailable")
+
+    async with TestClient(TestServer(_build_app(bridge_app))) as client:
+        url = str(client.make_url("")).rstrip("/")
+        c = CloudBridgeClient(url, "sbx", "slug")
+        c.add_connected_callback(broken)
+        await c.connect()
+        try:
+            await c.send_fetch_pending()
+        finally:
+            await c.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_cloud_status_telemetry.py
+++ b/tests/test_cloud_status_telemetry.py
@@ -94,7 +94,6 @@ async def test_worker_registers_reconnect_status_callback():
             ),
         ),
     )
-    worker.runtime.health = "ok"
     bridge = Bridge()
     client = SimpleNamespace(
         http=SimpleNamespace(keyless=True),
@@ -116,6 +115,5 @@ async def test_worker_registers_reconnect_status_callback():
                 "harness": "codex",
                 "model": "gpt-5.4",
             },
-            "health": "ok",
         },
     )]

--- a/tests/test_cloud_status_telemetry.py
+++ b/tests/test_cloud_status_telemetry.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    ProviderConfig,
+    RuntimeConfig,
+)
+from puffo_agent.portal.worker import Worker
+
+
+def test_runtime_info_reports_effective_codex_defaults():
+    daemon = DaemonConfig(openai=ProviderConfig(model="gpt-5.4"))
+    agent = AgentConfig(
+        id="cloud-agent",
+        runtime=RuntimeConfig(
+            kind="cli-local",
+            provider="",
+            harness="codex",
+            model="",
+        ),
+    )
+
+    worker = Worker(daemon, agent)
+
+    assert worker._runtime_info() == {
+        "kind": "cli-local",
+        "provider": "openai",
+        "harness": "codex",
+        "model": "gpt-5.4",
+    }
+
+
+def test_runtime_info_uses_chat_provider_and_model_defaults():
+    daemon = DaemonConfig(
+        default_provider="openai",
+        openai=ProviderConfig(model="gpt-4.1"),
+    )
+    agent = AgentConfig(
+        id="cloud-agent",
+        runtime=RuntimeConfig(kind="chat-local"),
+    )
+
+    worker = Worker(daemon, agent)
+
+    assert worker._runtime_info() == {
+        "kind": "chat-local",
+        "provider": "openai",
+        "harness": "",
+        "model": "gpt-4.1",
+    }
+
+
+def test_runtime_info_does_not_invent_ws_local_provider():
+    worker = Worker(
+        DaemonConfig(),
+        AgentConfig(
+            id="wallet-agent",
+            runtime=RuntimeConfig(kind="ws-local"),
+        ),
+    )
+
+    assert worker._runtime_info() == {
+        "kind": "ws-local",
+        "provider": "",
+        "harness": "",
+        "model": "",
+    }
+
+
+@pytest.mark.asyncio
+async def test_worker_registers_reconnect_status_callback():
+    callbacks = []
+    sent = []
+
+    class Bridge:
+        async def send_status(self, status, **kwargs):
+            sent.append((status, kwargs))
+
+        def add_connected_callback(self, callback):
+            callbacks.append(callback)
+
+    worker = Worker(
+        DaemonConfig(openai=ProviderConfig(model="gpt-5.4")),
+        AgentConfig(
+            id="cloud-agent",
+            runtime=RuntimeConfig(
+                kind="cli-local",
+                harness="codex",
+            ),
+        ),
+    )
+    worker.runtime.health = "ok"
+    bridge = Bridge()
+    client = SimpleNamespace(
+        http=SimpleNamespace(keyless=True),
+        _bridge=bridge,
+    )
+
+    reporter = worker._build_status_reporter(client)
+
+    assert callbacks == [reporter.report_current_status]
+    await callbacks[0]()
+    assert sent == [(
+        "idle",
+        {
+            "current_message_id": None,
+            "error_text": None,
+            "runtime": {
+                "kind": "cli-local",
+                "provider": "openai",
+                "harness": "codex",
+                "model": "gpt-5.4",
+            },
+            "health": "ok",
+        },
+    )]

--- a/tests/test_runtime_health_in_progress.py
+++ b/tests/test_runtime_health_in_progress.py
@@ -263,7 +263,10 @@ def test_chain_non_api_error_swallow_falls_back_to_unhandled_error(
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_carries_both_status_and_health():
+async def test_heartbeat_carries_both_status_and_health(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.store.current_machine_id", lambda: None,
+    )
     from puffo_agent.agent.status_reporter import StatusReporter
     mock_http = AsyncMock()
     mock_http.keyless = False  # AsyncMock auto-truthies attrs; pin native so the heartbeat isn't skipped
@@ -287,7 +290,10 @@ async def test_heartbeat_carries_both_status_and_health():
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_without_provider_omits_health_field():
+async def test_heartbeat_without_provider_omits_health_field(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.store.current_machine_id", lambda: None,
+    )
     """Back-compat: when constructed without a provider (no-op /
     tests), heartbeat carries the legacy single-stream shape."""
     from puffo_agent.agent.status_reporter import StatusReporter
@@ -303,7 +309,10 @@ async def test_heartbeat_without_provider_omits_health_field():
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_provider_exception_does_not_break_heartbeat():
+async def test_heartbeat_provider_exception_does_not_break_heartbeat(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.store.current_machine_id", lambda: None,
+    )
     from puffo_agent.agent.status_reporter import StatusReporter
     mock_http = AsyncMock()
     mock_http.keyless = False  # AsyncMock auto-truthies attrs; pin native so the heartbeat isn't skipped

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -565,14 +565,12 @@ class _CaptureSender:
         current_message_id=None,
         error_text=None,
         runtime=None,
-        health=None,
     ):
         self.calls.append({
             "status": status,
             "current_message_id": current_message_id,
             "error_text": error_text,
             "runtime": runtime,
-            "health": health,
         })
         if self._boom:
             raise RuntimeError("bridge ws closed")
@@ -592,7 +590,6 @@ async def test_keyless_begin_turn_emits_busy_over_bridge():
         "current_message_id": "msg_42",
         "error_text": None,
         "runtime": None,
-        "health": None,
     }]
     assert rep._current_status == "busy"
 
@@ -654,7 +651,7 @@ async def test_keyless_report_error_emits_over_bridge():
 
 
 @pytest.mark.asyncio
-async def test_keyless_status_includes_runtime_and_health():
+async def test_keyless_status_includes_runtime():
     http = _ExplodingKeylessHttp()
     sender = _CaptureSender()
     rep = StatusReporter(
@@ -668,7 +665,6 @@ async def test_keyless_status_includes_runtime_and_health():
             "model": "gpt-5",
             "secret": "must-not-cross-the-wire",
         },
-        runtime_health_provider=lambda: "ok",
     )
 
     await rep.report_current_status()
@@ -683,7 +679,6 @@ async def test_keyless_status_includes_runtime_and_health():
             "harness": "codex",
             "model": "gpt-5",
         },
-        "health": "ok",
     }]
 
 
@@ -698,13 +693,11 @@ async def test_keyless_status_survives_telemetry_provider_errors():
         heartbeat_interval_s=999,
         status_sender=sender,
         runtime_provider=broken,
-        runtime_health_provider=broken,
     )
 
     await rep.report_current_status()
 
     assert sender.calls[0]["runtime"] is None
-    assert sender.calls[0]["health"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -159,7 +159,10 @@ async def test_report_error_flips_status_red():
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_loop_sends_immediately_then_on_interval():
+async def test_heartbeat_loop_sends_immediately_then_on_interval(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.store.current_machine_id", lambda: None,
+    )
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=10.0)
 
@@ -176,7 +179,10 @@ async def test_heartbeat_loop_sends_immediately_then_on_interval():
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_busy_carries_current_message_id():
+async def test_heartbeat_busy_carries_current_message_id(monkeypatch):
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.store.current_machine_id", lambda: None,
+    )
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=10.0)
     rep._current_status = "busy"
@@ -546,14 +552,28 @@ async def test_reporter_keyless_defaults_false_without_attr():
 
 
 class _CaptureSender:
-    """Fake bridge status sink; records every (status, mid, err) emitted."""
+    """Fake bridge status sink."""
 
     def __init__(self, *, boom: bool = False) -> None:
-        self.calls: list[tuple[str, str | None, str | None]] = []
+        self.calls: list[dict] = []
         self._boom = boom
 
-    async def __call__(self, status, *, current_message_id=None, error_text=None):
-        self.calls.append((status, current_message_id, error_text))
+    async def __call__(
+        self,
+        status,
+        *,
+        current_message_id=None,
+        error_text=None,
+        runtime=None,
+        health=None,
+    ):
+        self.calls.append({
+            "status": status,
+            "current_message_id": current_message_id,
+            "error_text": error_text,
+            "runtime": runtime,
+            "health": health,
+        })
         if self._boom:
             raise RuntimeError("bridge ws closed")
 
@@ -567,7 +587,13 @@ async def test_keyless_begin_turn_emits_busy_over_bridge():
     run_id = await rep.begin_turn("msg_42")
     assert run_id.startswith("run_")
     assert http.calls == []  # never touched the signed wire
-    assert sender.calls == [("busy", "msg_42", None)]
+    assert sender.calls == [{
+        "status": "busy",
+        "current_message_id": "msg_42",
+        "error_text": None,
+        "runtime": None,
+        "health": None,
+    }]
     assert rep._current_status == "busy"
 
 
@@ -578,11 +604,13 @@ async def test_keyless_end_turn_emits_idle_and_error_over_bridge():
     rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
 
     await rep.end_turn("msg_5", "run_x", succeeded=True)
-    assert sender.calls == [("idle", None, None)]
+    assert sender.calls[0]["status"] == "idle"
+    assert sender.calls[0]["current_message_id"] is None
 
     sender.calls.clear()
     await rep.end_turn("msg_6", "run_y", succeeded=False, error_text="boom")
-    assert sender.calls == [("error", None, "boom")]
+    assert sender.calls[0]["status"] == "error"
+    assert sender.calls[0]["error_text"] == "boom"
     assert http.calls == []
 
 
@@ -595,7 +623,7 @@ async def test_keyless_end_turn_batch_emits_over_bridge():
     await rep.end_turn_batch([
         {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
     ])
-    assert sender.calls == [("idle", None, None)]
+    assert sender.calls[0]["status"] == "idle"
     assert http.calls == []
 
 
@@ -609,7 +637,8 @@ async def test_keyless_send_heartbeat_emits_current_status_over_bridge():
 
     await rep._send_heartbeat()
     assert http.calls == []
-    assert sender.calls == [("busy", "msg_z", None)]
+    assert sender.calls[0]["status"] == "busy"
+    assert sender.calls[0]["current_message_id"] == "msg_z"
 
 
 @pytest.mark.asyncio
@@ -619,8 +648,63 @@ async def test_keyless_report_error_emits_over_bridge():
     rep = StatusReporter(http, heartbeat_interval_s=999, status_sender=sender)
 
     await rep.report_error("fatal")
-    assert sender.calls == [("error", None, "fatal")]
+    assert sender.calls[0]["status"] == "error"
+    assert sender.calls[0]["error_text"] == "fatal"
     assert rep._current_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_keyless_status_includes_runtime_and_health():
+    http = _ExplodingKeylessHttp()
+    sender = _CaptureSender()
+    rep = StatusReporter(
+        http,
+        heartbeat_interval_s=999,
+        status_sender=sender,
+        runtime_provider=lambda: {
+            "kind": "cli-local",
+            "provider": "openai",
+            "harness": "codex",
+            "model": "gpt-5",
+            "secret": "must-not-cross-the-wire",
+        },
+        runtime_health_provider=lambda: "ok",
+    )
+
+    await rep.report_current_status()
+
+    assert sender.calls == [{
+        "status": "idle",
+        "current_message_id": None,
+        "error_text": None,
+        "runtime": {
+            "kind": "cli-local",
+            "provider": "openai",
+            "harness": "codex",
+            "model": "gpt-5",
+        },
+        "health": "ok",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_keyless_status_survives_telemetry_provider_errors():
+    def broken():
+        raise RuntimeError("not ready")
+
+    sender = _CaptureSender()
+    rep = StatusReporter(
+        _ExplodingKeylessHttp(),
+        heartbeat_interval_s=999,
+        status_sender=sender,
+        runtime_provider=broken,
+        runtime_health_provider=broken,
+    )
+
+    await rep.report_current_status()
+
+    assert sender.calls[0]["runtime"] is None
+    assert sender.calls[0]["health"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- send effective runtime metadata over the keyless cloud bridge
- report current idle/busy/error status immediately after every initial connection and reconnect
- isolate machine-dependent status tests and add bridge/runtime coverage
- keep cloud runtime health AIM-owned and off the puffo-server bridge

## Compatibility
Unknown JSON fields are ignored by older servers. Runtime persistence requires puffo-ai/puffo-server#245.

## Tests
- 81 focused status/bridge/runtime tests passed
- 79 bridge/message-flow/worker regression tests passed

Existing aiosqlite event-loop-close and unclosed aiohttp-session warnings remain in the regression suite.