### PR TITLE
feat: plaintext envelope send — daemon-level encryption decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   plaintext envelopes by default. The daemon decides per send: if the
   turn's triggering bundle contained an encrypted message, or the
   target thread's root is encrypted, the reply stays E2EE — the agent
-  never downgrades a conversation's confidentiality. Applies to all
-  send paths (LLM replies, MCP tools, daemon system DMs); attachments
+  never downgrades a conversation's confidentiality. The encryption
+  context is scoped to the turn (cleared when it ends), so sends
+  outside any turn use the plaintext default. Applies to all send
+  paths (LLM replies, MCP tools, daemon system DMs); attachments
   remain encrypted blob references.
 
 ## [1.1.5] — 2026-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `puffo-agent` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Plaintext (non-E2EE) sending.** Agent replies now go out as
+  plaintext envelopes by default. The daemon decides per send: if the
+  turn's triggering bundle contained an encrypted message, or the
+  target thread's root is encrypted, the reply stays E2EE — the agent
+  never downgrades a conversation's confidentiality. Applies to all
+  send paths (LLM replies, MCP tools, daemon system DMs); attachments
+  remain encrypted blob references.
+
 ## [1.1.5] — 2026-07-23
 
 ### Added

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -26,10 +26,12 @@ from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import (
     EncryptInput,
     RecipientDevice,
+    build_plaintext_message,
     decrypt_message,
     encrypt_message,
     read_plaintext_message,
 )
+from . import send_mode
 from ..crypto.primitives import Ed25519KeyPair, KemKeyPair
 from ..crypto.ws_client import PuffoCoreWsClient
 from . import disk_cache
@@ -1572,6 +1574,11 @@ class PuffoCoreMessageClient:
             except asyncio.CancelledError:
                 raise
 
+            # Missing key counts as encrypted — never downgrade on doubt.
+            send_mode.note_turn_bundle(
+                [getattr(self, "slug", "")],
+                any(m.get("is_encrypted", True) for m in batch),
+            )
             try:
                 await on_message_batch(root_id, batch, channel_meta)
             except AgentAPIError as exc:
@@ -4369,12 +4376,18 @@ class PuffoCoreMessageClient:
         signing_key = Ed25519KeyPair.from_secret_bytes(
             decode_secret(sess.subkey_secret_key)
         )
-        devices = await self._fetch_device_keys([self.slug, recipient_slug])
-        if not devices:
-            self._log.warning(
-                "no recipient devices for DM to %s — dropping", recipient_slug,
-            )
-            return None
+        encrypt = await send_mode.encryption_required(
+            self.slug, self.store, root_id or None,
+        )
+        devices: list[RecipientDevice] = []
+        if encrypt:
+            devices = await self._fetch_device_keys([self.slug, recipient_slug])
+            if not devices:
+                self._log.warning(
+                    "no recipient devices for DM to %s — dropping",
+                    recipient_slug,
+                )
+                return None
         inp = EncryptInput(
             envelope_kind="dm",
             sender_slug=self.slug,
@@ -4387,9 +4400,14 @@ class PuffoCoreMessageClient:
             content=text,
             recipients=devices,
         )
-        envelope = encrypt_message(inp, signing_key)
+        if encrypt:
+            envelope = encrypt_message(inp, signing_key)
+            path = "/messages"
+        else:
+            envelope = build_plaintext_message(inp, signing_key)
+            path = "/v2/messages/plaintext"
         try:
-            await self.http.post("/messages", envelope)
+            await self.http.post(path, envelope)
         except HttpError:
             self._log.exception("DM send to %s failed", recipient_slug)
             raise
@@ -4489,20 +4507,6 @@ class PuffoCoreMessageClient:
                     channel_id,
                 )
                 return
-            members_resp = await self.http.get(
-                f"/spaces/{target_space_id}/channels/{channel_id}/members"
-            )
-            member_slugs = [
-                m.get("slug", "")
-                for m in members_resp.get("members", [])
-                if m.get("slug")
-            ]
-            if not member_slugs:
-                self._log.warning(
-                    "channel %s has no members — dropping reply", channel_id,
-                )
-                return
-            devices = await self._fetch_device_keys(member_slugs)
             envelope_kind = "channel"
             recipient_slug: Optional[str] = None
             send_space_id: Optional[str] = target_space_id
@@ -4516,22 +4520,45 @@ class PuffoCoreMessageClient:
                     "context — dropping reply",
                 )
                 return
-            devices = await self._fetch_device_keys([self.slug, recipient])
             envelope_kind = "dm"
             recipient_slug = recipient
             send_space_id = None
             send_channel_id = None
 
-        if not devices:
-            self._log.warning(
-                "no recipient devices found (kind=%s target=%s) — dropping",
-                envelope_kind, recipient_slug or channel_id,
-            )
-            return
+        encrypt = await send_mode.encryption_required(
+            self.slug, self.store, root_id or None,
+        )
+        devices: list[RecipientDevice] = []
+        if encrypt:
+            if envelope_kind == "channel":
+                members_resp = await self.http.get(
+                    f"/spaces/{send_space_id}/channels/{channel_id}/members"
+                )
+                member_slugs = [
+                    m.get("slug", "")
+                    for m in members_resp.get("members", [])
+                    if m.get("slug")
+                ]
+                if not member_slugs:
+                    self._log.warning(
+                        "channel %s has no members — dropping reply", channel_id,
+                    )
+                    return
+                devices = await self._fetch_device_keys(member_slugs)
+            else:
+                devices = await self._fetch_device_keys(
+                    [self.slug, recipient_slug or ""]
+                )
+            if not devices:
+                self._log.warning(
+                    "no recipient devices found (kind=%s target=%s) — dropping",
+                    envelope_kind, recipient_slug or channel_id,
+                )
+                return
 
         self._log.info(
-            "send_fallback_message: kind=%s target=%s devices=%d",
-            envelope_kind, recipient_slug or channel_id, len(devices),
+            "send_fallback_message: kind=%s target=%s encrypt=%s devices=%d",
+            envelope_kind, recipient_slug or channel_id, encrypt, len(devices),
         )
 
         # Fallback shares the visibility_level="default" floor; the
@@ -4557,18 +4584,23 @@ class PuffoCoreMessageClient:
             content=text,
             recipients=devices,
         )
-        envelope = encrypt_message(inp, signing_key)
-        # POST /messages takes the envelope at the top level, not
-        # wrapped in ``{"envelope": ...}``.
+        if encrypt:
+            envelope = encrypt_message(inp, signing_key)
+            path = "/messages"
+        else:
+            envelope = build_plaintext_message(inp, signing_key)
+            path = "/v2/messages/plaintext"
+        # POST takes the envelope at the top level, not wrapped in
+        # ``{"envelope": ...}``.
         try:
-            resp = await self.http.post("/messages", envelope)
+            resp = await self.http.post(path, envelope)
             self._log.info(
                 "send_fallback_message sent: envelope_id=%s queued=%s",
                 envelope.get("envelope_id"),
                 (resp or {}).get("devices_queued"),
             )
         except Exception:
-            self._log.exception("send_fallback_message: POST /messages failed")
+            self._log.exception("send_fallback_message: POST %s failed", path)
             raise
 
         # No mirror-write here anymore. The WS echo path now persists

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1624,6 +1624,9 @@ class PuffoCoreMessageClient:
                 # the slot done in-memory so live arrivals keep
                 # flowing for other threads.
                 continue
+            finally:
+                # Between turns the default (plaintext) applies.
+                send_mode.clear_turn_bundle([getattr(self, "slug", "")])
 
             # Success: persist the cursor so a restart-then-redeliver
             # doesn't re-trigger this thread. ``batch[-1].sent_at`` is

--- a/src/puffo_agent/agent/send_mode.py
+++ b/src/puffo_agent/agent/send_mode.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 from typing import Any
 
-# Single-slot per agent — the worker serializes turns, so the flag set
-# at batch dispatch governs every send until the next batch. Keyed by
-# both slug and agent_id (callers know one or the other).
+# Single-slot per agent — the worker serializes turns. Set at batch
+# dispatch, cleared when the turn ends, so between-turn sends fall to
+# the plaintext default. Keyed by slug and/or agent_id.
 _turn_bundle_encrypted: dict[str, bool] = {}
 
 
@@ -20,6 +20,11 @@ def note_turn_bundle(keys: list[str], has_encrypted: bool) -> None:
     for key in keys:
         if key:
             _turn_bundle_encrypted[key] = has_encrypted
+
+
+def clear_turn_bundle(keys: list[str]) -> None:
+    for key in keys:
+        _turn_bundle_encrypted.pop(key, None)
 
 
 def turn_bundle_encrypted(key: str) -> bool:

--- a/src/puffo_agent/agent/send_mode.py
+++ b/src/puffo_agent/agent/send_mode.py
@@ -1,0 +1,46 @@
+"""Daemon-level decision for whether an outbound message must be E2EE.
+
+Encrypt when the turn's triggering bundle contained an encrypted
+message, or when the send targets a thread whose root is encrypted —
+the agent never downgrades a conversation's confidentiality. Everything
+else (daemon system DMs included) goes out as a plaintext envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Single-slot per agent — the worker serializes turns, so the flag set
+# at batch dispatch governs every send until the next batch. Keyed by
+# both slug and agent_id (callers know one or the other).
+_turn_bundle_encrypted: dict[str, bool] = {}
+
+
+def note_turn_bundle(keys: list[str], has_encrypted: bool) -> None:
+    for key in keys:
+        if key:
+            _turn_bundle_encrypted[key] = has_encrypted
+
+
+def turn_bundle_encrypted(key: str) -> bool:
+    return _turn_bundle_encrypted.get(key, False)
+
+
+async def encryption_required(
+    key: str,
+    store: Any,
+    thread_root_id: str | None,
+) -> bool:
+    """The OR of the two rules. An unknown/unstored root counts as
+    encrypted (store rows also default is_encrypted=True for legacy)."""
+    if turn_bundle_encrypted(key):
+        return True
+    if not thread_root_id:
+        return False
+    try:
+        row = await store.get_message_by_envelope(thread_root_id)
+    except Exception:
+        return True
+    if row is None:
+        return True
+    return bool(getattr(row, "is_encrypted", True))

--- a/src/puffo_agent/crypto/message.py
+++ b/src/puffo_agent/crypto/message.py
@@ -117,22 +117,17 @@ def encrypt_message(
     return envelope
 
 
-def encrypt_message_with_content_key(
+def _build_signed_payload(
     inp: EncryptInput,
     signing_key: Ed25519KeyPair,
-    *,
-    now_ms: int | None = None,
-) -> tuple[dict, bytes]:
-    """Like ``encrypt_message`` but exposes ``content_key`` so the
-    caller can supplement later via ``build_supplementation_envelope``."""
-    if not inp.recipients:
-        raise ValueError("no recipients")
-
+    now_ms: int | None,
+) -> tuple[str, int, dict]:
+    """Shared by the E2EE and plaintext producers so the payload shape
+    and signature input can't drift between the two send modes."""
     # EnvelopeId MUST be ``msg_<UUID>`` — server's prefix validator
     # rejects anything else before crypto runs.
     envelope_id = f"msg_{uuid.uuid4()}"
     message_nonce = base64url_encode(os.urandom(16))
-
     if now_ms is None:
         now_ms = _now_ms()
 
@@ -154,15 +149,45 @@ def encrypt_message_with_content_key(
         content=inp.content,
         is_visible_to_human=inp.is_visible_to_human,
     )
-
     payload_dict = payload.to_payload_dict()
     canonical = canonicalize_for_signing(payload_dict)
     sig = signing_key.sign(canonical)
-
     signed = {
         "payload": payload_dict,
         "signature": base64url_encode(sig),
     }
+    return envelope_id, now_ms, signed
+
+
+def build_plaintext_message(
+    inp: EncryptInput,
+    signing_key: Ed25519KeyPair,
+    *,
+    now_ms: int | None = None,
+) -> dict:
+    """Non-E2EE producer: the signed payload rides in the clear; no
+    recipient devices involved. ``inp.recipients`` is ignored."""
+    envelope_id, _, signed = _build_signed_payload(inp, signing_key, now_ms)
+    return {
+        "type": "plaintext_message_envelope",
+        "version": 1,
+        "envelope_id": envelope_id,
+        "signed_payload": signed,
+    }
+
+
+def encrypt_message_with_content_key(
+    inp: EncryptInput,
+    signing_key: Ed25519KeyPair,
+    *,
+    now_ms: int | None = None,
+) -> tuple[dict, bytes]:
+    """Like ``encrypt_message`` but exposes ``content_key`` so the
+    caller can supplement later via ``build_supplementation_envelope``."""
+    if not inp.recipients:
+        raise ValueError("no recipients")
+
+    envelope_id, now_ms, signed = _build_signed_payload(inp, signing_key, now_ms)
     plaintext = json.dumps(signed, separators=(",", ":")).encode()
 
     content_key = generate_content_key()

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -314,6 +314,33 @@ class DataClient:
             )
             return None
 
+    async def get_send_encryption(
+        self, slug: str, thread_root_id: str | None,
+    ) -> bool:
+        """Ask the daemon whether the next send must be E2EE.
+        Fail-safe: any transport/decode problem answers encrypt."""
+        path = (
+            f"/v1/data/{urllib.parse.quote(self.agent_id, safe='')}"
+            f"/send-encryption"
+        )
+        params = {"slug": slug}
+        if thread_root_id:
+            params["thread_root_id"] = thread_root_id
+        session = await self._get_session()
+        try:
+            async with session.get(
+                f"{self.base_url}{path}", params=params,
+            ) as resp:
+                if resp.status >= 400:
+                    return True
+                data = await resp.json()
+                return bool(data.get("encrypt", True))
+        except aiohttp.ClientError as exc:
+            logger.warning(
+                "data-service: get_send_encryption transport: %s", exc,
+            )
+            return True
+
     async def update_profile_cache(
         self, slug: str, display_name: str, avatar_url: str,
     ) -> None:

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -27,6 +27,7 @@ from ..crypto.encoding import base64url_decode, base64url_encode
 from ..crypto.http_client import PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
 from ..crypto.message import (
+    build_plaintext_message,
     EncryptInput,
     RecipientDevice,
     build_supplementation_envelope,
@@ -39,6 +40,15 @@ from .data_client import DataClient, DataNotFound
 from ._host_mcp import PuffoRpcClient
 
 logger = logging.getLogger(__name__)
+
+
+async def _send_encryption_required(cfg, resolved_root):
+    """Daemon-level send-mode decision. Data-client shims without the
+    method (older harnesses) fail safe to E2EE."""
+    getter = getattr(cfg.data_client, "get_send_encryption", None)
+    if getter is None:
+        return True
+    return await getter(cfg.slug, resolved_root or None)
 
 
 async def _resolve_channel_space(cfg: Any, channel_id: str) -> str:
@@ -463,10 +473,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     f"(searched space {send_space_id})"
                 )
 
-        devices = await _fetch_device_keys(cfg.http_client, recipient_slugs)
-        if not devices:
-            raise RuntimeError("no recipient devices found")
-
         sess = cfg.keystore.load_session(cfg.slug)
         signing_key = Ed25519KeyPair.from_secret_bytes(
             decode_secret(sess.subkey_secret_key)
@@ -479,6 +485,12 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             space_id=send_space_id,
             dm_peer=recipient_slug,
         )
+        encrypt = await _send_encryption_required(cfg, resolved_root)
+        devices: list = []
+        if encrypt:
+            devices = await _fetch_device_keys(cfg.http_client, recipient_slugs)
+            if not devices:
+                raise RuntimeError("no recipient devices found")
         # Visibility floors key off the RESOLVED root — a wiped root makes
         # this a root-level post, which can't fold in the UI.
         effective_visible, visibility_note = await _resolve_visibility(
@@ -497,17 +509,21 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             content=text,
             recipients=devices,
         )
-        envelope, content_key = encrypt_message_with_content_key(
-            inp, signing_key,
-        )
-        # Server expects the envelope at the top level, not wrapped.
-        resp = await cfg.http_client.post("/messages", envelope) or {}
-        missing = resp.get("missing_devices") or []
-        if missing:
-            asyncio.create_task(_supplement_missing_devices(
-                cfg.http_client, envelope, content_key,
-                recipient_slugs, missing,
-            ))
+        if encrypt:
+            envelope, content_key = encrypt_message_with_content_key(
+                inp, signing_key,
+            )
+            # Server expects the envelope at the top level, not wrapped.
+            resp = await cfg.http_client.post("/messages", envelope) or {}
+            missing = resp.get("missing_devices") or []
+            if missing:
+                asyncio.create_task(_supplement_missing_devices(
+                    cfg.http_client, envelope, content_key,
+                    recipient_slugs, missing,
+                ))
+        else:
+            envelope = build_plaintext_message(inp, signing_key)
+            await cfg.http_client.post("/v2/messages/plaintext", envelope)
         return (
             f"posted {envelope.get('envelope_id', '?')} to {channel}"
             f"{visibility_note}"
@@ -1078,10 +1094,6 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
                     f"send_message_with_attachments: channel {channel_id} has no resolvable members"
                 )
 
-        devices = await _fetch_device_keys(cfg.http_client, recipient_slugs)
-        if not devices:
-            raise RuntimeError("send_message_with_attachments: no recipient devices found")
-
         sess = cfg.keystore.load_session(cfg.slug)
         signing_key = Ed25519KeyPair.from_secret_bytes(
             decode_secret(sess.subkey_secret_key)
@@ -1097,6 +1109,14 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             space_id=send_space_id,
             dm_peer=recipient_slug,
         )
+        encrypt = await _send_encryption_required(cfg, resolved_root)
+        devices: list = []
+        if encrypt:
+            devices = await _fetch_device_keys(cfg.http_client, recipient_slugs)
+            if not devices:
+                raise RuntimeError(
+                    "send_message_with_attachments: no recipient devices found"
+                )
         effective_visible, visibility_note = await _resolve_visibility(
             visibility_level, channel_ref, caption, resolved_root or "", cfg.http_client,
         )
@@ -1113,16 +1133,20 @@ def register_core_tools(mcp: FastMCP, cfg: PuffoCoreToolsConfig) -> None:
             content=body_content,
             recipients=devices,
         )
-        envelope, content_key = encrypt_message_with_content_key(
-            inp, signing_key,
-        )
-        resp = await cfg.http_client.post("/messages", envelope) or {}
-        missing = resp.get("missing_devices") or []
-        if missing:
-            asyncio.create_task(_supplement_missing_devices(
-                cfg.http_client, envelope, content_key,
-                recipient_slugs, missing,
-            ))
+        if encrypt:
+            envelope, content_key = encrypt_message_with_content_key(
+                inp, signing_key,
+            )
+            resp = await cfg.http_client.post("/messages", envelope) or {}
+            missing = resp.get("missing_devices") or []
+            if missing:
+                asyncio.create_task(_supplement_missing_devices(
+                    cfg.http_client, envelope, content_key,
+                    recipient_slugs, missing,
+                ))
+        else:
+            envelope = build_plaintext_message(inp, signing_key)
+            await cfg.http_client.post("/v2/messages/plaintext", envelope)
         names = ", ".join(t.name for t in targets)
         thread_note = f" in thread {resolved_root}" if resolved_root else ""
         return (

--- a/src/puffo_agent/portal/data_service.py
+++ b/src/puffo_agent/portal/data_service.py
@@ -407,6 +407,23 @@ async def update_profile_cache(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+async def get_send_encryption(request: web.Request) -> web.Response:
+    """Daemon-level send-mode decision for out-of-process senders (the
+    MCP subprocess). Fail-safe: unknown agent/store answers encrypt."""
+    from ..agent import send_mode
+
+    agent_id = request.match_info["agent_id"]
+    slug = request.query.get("slug", "")
+    root = request.query.get("thread_root_id") or None
+    store = await _store_for(request.app, agent_id)
+    if store is None:
+        return web.json_response({"encrypt": True})
+    encrypt = await send_mode.encryption_required(
+        slug or agent_id, store, root,
+    )
+    return web.json_response({"encrypt": bool(encrypt)})
+
+
 # ── Lifecycle ────────────────────────────────────────────────────
 
 
@@ -436,6 +453,10 @@ def build_app(cfg: DataServiceConfig) -> web.Application:
     app.router.add_get(
         "/v1/data/{agent_id}/messages/{envelope_id}",
         get_message_by_envelope,
+    )
+    app.router.add_get(
+        "/v1/data/{agent_id}/send-encryption",
+        get_send_encryption,
     )
     app.router.add_post(
         "/v1/data/{agent_id}/profile-cache",

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -15,7 +15,13 @@ from typing import Any
 from ..crypto.encoding import base64url_decode
 from ..crypto.http_client import PuffoCoreHttpClient
 from ..crypto.keystore import KeyStore, decode_secret
-from ..crypto.message import EncryptInput, RecipientDevice, encrypt_message
+from ..agent import send_mode
+from ..crypto.message import (
+    EncryptInput,
+    RecipientDevice,
+    build_plaintext_message,
+    encrypt_message,
+)
 from ..crypto.primitives import Ed25519KeyPair
 from ..mcp.config import _emit_codex_mcp_block
 
@@ -251,13 +257,17 @@ async def _send_dm_to_operator(
     signing_key = Ed25519KeyPair.from_secret_bytes(
         decode_secret(sess.subkey_secret_key)
     )
-    devices = await _fetch_device_keys(
-        ctx.http_client, [ctx.slug, ctx.operator_slug],
-    )
-    if not devices:
-        raise RuntimeError(
-            f"no recipient devices resolved for @{ctx.operator_slug}"
+    # Unthreaded DM — only the turn-bundle rule applies (no store here).
+    encrypt = await send_mode.encryption_required(ctx.slug, None, None)
+    devices: list[RecipientDevice] = []
+    if encrypt:
+        devices = await _fetch_device_keys(
+            ctx.http_client, [ctx.slug, ctx.operator_slug],
         )
+        if not devices:
+            raise RuntimeError(
+                f"no recipient devices resolved for @{ctx.operator_slug}"
+            )
     inp = EncryptInput(
         envelope_kind="dm",
         sender_slug=ctx.slug,
@@ -271,8 +281,12 @@ async def _send_dm_to_operator(
         content=text,
         recipients=devices,
     )
-    envelope = encrypt_message(inp, signing_key)
-    await ctx.http_client.post("/messages", envelope)
+    if encrypt:
+        envelope = encrypt_message(inp, signing_key)
+        await ctx.http_client.post("/messages", envelope)
+    else:
+        envelope = build_plaintext_message(inp, signing_key)
+        await ctx.http_client.post("/v2/messages/plaintext", envelope)
     return str(envelope.get("envelope_id") or "?")
 
 

--- a/src/puffo_agent/portal/ws_local/in_process_data_client.py
+++ b/src/puffo_agent/portal/ws_local/in_process_data_client.py
@@ -30,6 +30,15 @@ class InProcessDataClient:
     async def close(self) -> None:
         return None
 
+    async def get_send_encryption(
+        self, slug: str, thread_root_id: str | None,
+    ) -> bool:
+        from ...agent import send_mode
+
+        return await send_mode.encryption_required(
+            slug, self._store, thread_root_id,
+        )
+
     async def lookup_channel_space(self, channel_id: str) -> str | None:
         space_id = await self._store.lookup_channel_space(channel_id)
         if space_id is None and channel_id.startswith("ch_"):

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -219,3 +219,92 @@ async def test_thread_messages_404_for_unknown_root() -> None:
         assert resp.status == 404
         body = await resp.json()
         assert body == {"error": "thread root not found"}
+
+
+@pytest.mark.asyncio
+async def test_send_encryption_fail_safe_for_unknown_agent() -> None:
+    _isolated_home()
+    app = ds.build_app(ds.DataServiceConfig())
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/v1/data/nope/send-encryption?slug=x")
+        assert resp.status == 200
+        assert (await resp.json())["encrypt"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_encryption_decision_matrix_over_http() -> None:
+    from puffo_agent.agent import send_mode
+
+    home = _isolated_home()
+    agent_path = Path(home) / "agents" / "agent-enc-1"
+    agent_path.mkdir(parents=True, exist_ok=True)
+    store = MessageStore(agent_path / "messages.db")
+    await store.open()
+    await store.store({
+        "envelope_id": "msg_pt",
+        "envelope_kind": "channel",
+        "sender_slug": "alice",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "clear",
+        "sent_at": 1700000000_000,
+        "is_encrypted": False,
+    })
+    await store.store({
+        "envelope_id": "msg_enc",
+        "envelope_kind": "channel",
+        "sender_slug": "bob",
+        "channel_id": "ch_1",
+        "space_id": "sp_1",
+        "content_type": "text/plain",
+        "content": "sealed",
+        "sent_at": 1700000001_000,
+    })
+    await store.close()
+
+    send_mode._turn_bundle_encrypted.clear()
+    app = ds.build_app(ds.DataServiceConfig())
+    try:
+        async with TestClient(TestServer(app)) as client:
+            base = "/v1/data/agent-enc-1/send-encryption?slug=bot-1"
+
+            async def ask(url):
+                resp = await client.get(url)
+                assert resp.status == 200
+                return (await resp.json())["encrypt"]
+
+            assert await ask(base) is False  # default plaintext
+            assert await ask(base + "&thread_root_id=msg_pt") is False
+            assert await ask(base + "&thread_root_id=msg_enc") is True  # legacy row
+            assert await ask(base + "&thread_root_id=msg_gone") is True  # fail-safe
+            send_mode.note_turn_bundle(["bot-1"], True)
+            assert await ask(base) is True
+
+            # The MCP-side wrapper resolves the same answers over HTTP.
+            from puffo_agent.mcp.data_client import DataClient
+            send_mode._turn_bundle_encrypted.clear()
+            dc = DataClient(
+                str(client.server.make_url("")).rstrip("/"), "agent-enc-1",
+            )
+            try:
+                assert await dc.get_send_encryption("bot-1", "msg_pt") is False
+                assert await dc.get_send_encryption("bot-1", "msg_gone") is True
+            finally:
+                await dc.close()
+
+            # Error branches fail safe to E2EE: non-route 404 + dead host.
+            dc404 = DataClient(
+                str(client.server.make_url("/bogus")).rstrip("/"), "agent-enc-1",
+            )
+            try:
+                assert await dc404.get_send_encryption("bot-1", None) is True
+            finally:
+                await dc404.close()
+            dc_dead = DataClient("http://127.0.0.1:1", "agent-enc-1")
+            try:
+                assert await dc_dead.get_send_encryption("bot-1", None) is True
+            finally:
+                await dc_dead.close()
+    finally:
+        send_mode._turn_bundle_encrypted.clear()

--- a/tests/test_plaintext_send.py
+++ b/tests/test_plaintext_send.py
@@ -188,3 +188,16 @@ async def test_send_dm_encrypts_when_turn_bundle_was_encrypted():
     assert env["type"] == "message_envelope"
     assert posts[0][0] == "/messages"
     assert fetched  # devices resolved for sealing
+
+
+@pytest.mark.asyncio
+async def test_in_process_data_client_delegates_to_send_mode():
+    from puffo_agent.portal.ws_local.in_process_data_client import (
+        InProcessDataClient,
+    )
+
+    c = InProcessDataClient.__new__(InProcessDataClient)
+    c._store = _Store(_Row(False))
+    assert await c.get_send_encryption("a-1", "msg_r") is False
+    send_mode.note_turn_bundle(["a-1"], True)
+    assert await c.get_send_encryption("a-1", None) is True

--- a/tests/test_plaintext_send.py
+++ b/tests/test_plaintext_send.py
@@ -201,3 +201,13 @@ async def test_in_process_data_client_delegates_to_send_mode():
     assert await c.get_send_encryption("a-1", "msg_r") is False
     send_mode.note_turn_bundle(["a-1"], True)
     assert await c.get_send_encryption("a-1", None) is True
+
+
+@pytest.mark.asyncio
+async def test_clear_turn_bundle_restores_the_plaintext_default():
+    send_mode.note_turn_bundle(["a-1"], True)
+    assert await send_mode.encryption_required("a-1", _Store(), None) is True
+    send_mode.clear_turn_bundle(["a-1"])
+    assert await send_mode.encryption_required("a-1", _Store(), None) is False
+    # Clearing an unset key is a no-op.
+    send_mode.clear_turn_bundle(["never-set"])

--- a/tests/test_plaintext_send.py
+++ b/tests/test_plaintext_send.py
@@ -1,0 +1,190 @@
+"""Plaintext (non-E2EE) send: producer round-trip + the daemon-level
+encryption decision + the client DM send branch."""
+
+import logging
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.agent import send_mode
+from puffo_agent.crypto.message import (
+    EncryptInput,
+    build_plaintext_message,
+    read_plaintext_message,
+)
+from puffo_agent.crypto.primitives import Ed25519KeyPair
+from puffo_agent.crypto.keystore import encode_secret
+
+
+def _inp(**over):
+    base = dict(
+        envelope_kind="dm",
+        sender_slug="agent-1",
+        sender_subkey_id="sk_1",
+        is_visible_to_human=True,
+        recipient_slug="op-1",
+        content_type="text/plain",
+        content="hello",
+    )
+    base.update(over)
+    return EncryptInput(**base)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    send_mode._turn_bundle_encrypted.clear()
+    yield
+    send_mode._turn_bundle_encrypted.clear()
+
+
+# ── producer ─────────────────────────────────────────────────────────
+
+
+def test_plaintext_round_trips_through_reader():
+    kp = Ed25519KeyPair.generate()
+    env = build_plaintext_message(_inp(), kp)
+    assert env["type"] == "plaintext_message_envelope"
+    assert env["version"] == 1
+    assert env["envelope_id"].startswith("msg_")
+    payload = read_plaintext_message(env, kp.public_key_bytes())
+    assert payload.content == "hello"
+    assert payload.envelope_kind == "dm"
+    assert payload.recipient_slug == "op-1"
+    # Inactive route fields serialize as explicit null.
+    assert env["signed_payload"]["payload"]["space_id"] is None
+
+
+def test_tampered_plaintext_fails_verification():
+    kp = Ed25519KeyPair.generate()
+    env = build_plaintext_message(_inp(), kp)
+    env["signed_payload"]["payload"]["content"] = "evil"
+    with pytest.raises(ValueError):
+        read_plaintext_message(env, kp.public_key_bytes())
+
+
+def test_wrong_key_fails_verification():
+    kp = Ed25519KeyPair.generate()
+    env = build_plaintext_message(_inp(), kp)
+    with pytest.raises(ValueError):
+        read_plaintext_message(env, Ed25519KeyPair.generate().public_key_bytes())
+
+
+# ── decision ─────────────────────────────────────────────────────────
+
+
+class _Row:
+    def __init__(self, is_encrypted):
+        self.is_encrypted = is_encrypted
+
+
+class _Store:
+    def __init__(self, row=None, raise_=False):
+        self.row = row
+        self.raise_ = raise_
+
+    async def get_message_by_envelope(self, _eid):
+        if self.raise_:
+            raise RuntimeError("db down")
+        return self.row
+
+
+@pytest.mark.asyncio
+async def test_default_is_plaintext():
+    assert await send_mode.encryption_required("a-1", _Store(), None) is False
+
+
+@pytest.mark.asyncio
+async def test_encrypted_bundle_forces_encryption():
+    send_mode.note_turn_bundle(["a-1"], True)
+    assert await send_mode.encryption_required("a-1", _Store(), None) is True
+    # A later all-plaintext bundle releases it.
+    send_mode.note_turn_bundle(["a-1"], False)
+    assert await send_mode.encryption_required("a-1", _Store(), None) is False
+
+
+@pytest.mark.asyncio
+async def test_encrypted_thread_root_forces_encryption():
+    assert (
+        await send_mode.encryption_required("a-1", _Store(_Row(True)), "msg_r")
+        is True
+    )
+    assert (
+        await send_mode.encryption_required("a-1", _Store(_Row(False)), "msg_r")
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_root_and_store_failure_fail_safe_to_encrypted():
+    assert await send_mode.encryption_required("a-1", _Store(None), "msg_r") is True
+    assert (
+        await send_mode.encryption_required("a-1", _Store(raise_=True), "msg_r")
+        is True
+    )
+
+
+# ── client DM send branch ────────────────────────────────────────────
+
+
+def _make_client(flag: bool):
+    from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client.slug = "agent-1"
+    client._log = logging.getLogger("plaintext-send-test")
+    client.store = _Store(row=None)
+
+    kp = Ed25519KeyPair.generate()
+
+    class _Sess:
+        subkey_id = "sk_1"
+        subkey_secret_key = encode_secret(kp.secret_bytes())
+
+    class _Keystore:
+        def load_session(self, _slug):
+            return _Sess()
+
+    client.keystore = _Keystore()
+
+    posts = []
+
+    class _Http:
+        async def post(self, path, body):
+            posts.append((path, body))
+            return {"devices_queued": 1}
+
+    client.http = _Http()
+
+    fetched = []
+
+    async def _fetch(slugs):
+        fetched.append(slugs)
+        from puffo_agent.crypto.message import RecipientDevice
+        import os as _os
+
+        return [RecipientDevice(device_id="dev_1", kem_public_key=_os.urandom(32))]
+
+    client._fetch_device_keys = _fetch
+    send_mode.note_turn_bundle(["agent-1"], flag)
+    return client, posts, fetched
+
+
+@pytest.mark.asyncio
+async def test_send_dm_goes_plaintext_by_default():
+    client, posts, fetched = _make_client(flag=False)
+    env = await client._send_dm("op-1", "hi", "")
+    assert env["type"] == "plaintext_message_envelope"
+    assert posts[0][0] == "/v2/messages/plaintext"
+    assert fetched == []  # no device resolution on the plaintext path
+
+
+@pytest.mark.asyncio
+async def test_send_dm_encrypts_when_turn_bundle_was_encrypted():
+    client, posts, fetched = _make_client(flag=True)
+    env = await client._send_dm("op-1", "hi", "")
+    assert env["type"] == "message_envelope"
+    assert posts[0][0] == "/messages"
+    assert fetched  # devices resolved for sealing

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -159,6 +159,37 @@ async def test_whoami_includes_display_name():
 
 
 @pytest.mark.asyncio
+async def test_send_message_plaintext_when_daemon_says_unencrypted():
+    cfg, http, ms = _setup()
+    await ms.mark_channel_space("ch_abc", "sp_test")
+    http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
+        "members": [{"slug": "alice-0001", "role": "owner"}],
+    }
+
+    async def _no_encrypt(slug, root):
+        return False
+
+    ms.get_send_encryption = _no_encrypt
+    mcp = _build_tools(cfg)
+    result = await _call(
+        mcp,
+        "send_message",
+        {"channel": "ch_abc", "text": "hello world", "visibility_level": "human"},
+    )
+    assert "posted" in result
+    # No device resolution on the plaintext path.
+    assert not any(
+        p.startswith("/certs/sync") for m, p, _ in http.calls if m == "GET"
+    )
+    post_calls = [(p, b) for m, p, b in http.calls if m == "POST"]
+    assert len(post_calls) == 1
+    path, body = post_calls[0]
+    assert path == "/v2/messages/plaintext"
+    assert body["type"] == "plaintext_message_envelope"
+    assert body["signed_payload"]["payload"]["channel_id"] == "ch_abc"
+
+
+@pytest.mark.asyncio
 async def test_send_message_channel():
     cfg, http, ms = _setup()
     recipient_kem = KemKeyPair.generate()
@@ -1082,6 +1113,12 @@ class _FakeDataClient:
         self.messages: dict[str, object] = {}
         self.exc: Exception | None = None
         self.calls: list[str] = []
+        # Existing tool tests exercise the E2EE branch; plaintext-branch
+        # tests flip this to False.
+        self.send_encryption = True
+
+    async def get_send_encryption(self, slug, thread_root_id):
+        return self.send_encryption
 
     def add(
         self,

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -347,7 +347,14 @@ async def test_puffo_core_client_send_fallback_message_encrypts():
     # cache from inbound envelopes + membership events; the smoke
     # test seeds it directly.
     client._channel_space["ch_abc"] = "sp_test"
-    await client.send_fallback_message("ch_abc", "hello world", root_id="")
+    # E2EE branch: mark the turn's bundle as encrypted (plaintext is
+    # the default otherwise — covered in test_plaintext_send).
+    from puffo_agent.agent import send_mode
+    send_mode.note_turn_bundle(["bot-0001"], True)
+    try:
+        await client.send_fallback_message("ch_abc", "hello world", root_id="")
+    finally:
+        send_mode.note_turn_bundle(["bot-0001"], False)
 
     # Channel resolution: members endpoint -> /certs/sync.
     assert any(


### PR DESCRIPTION
## What & why

Plaintext (non-E2EE) sending for agents — the counterpart to receive-side #181, web #449, and CLI #11. Replies default to plaintext; the daemon alone decides when E2EE is still required:

1. The turn's triggering bundle contained an encrypted message → every send this turn is E2EE.
2. The send targets a thread whose root is encrypted → E2EE (unknown/legacy roots count as encrypted — fail-safe).

The agent never downgrades a conversation's confidentiality; everything else (daemon system DMs included) ships as a signed plaintext_message_envelope to /v2/messages/plaintext with no recipient-device resolution. Attachments stay encrypted blob references.

## Design

- One shared signed-payload builder backs the E2EE and plaintext producers (crypto/message.py) so the signed shape can't drift.
- Turn context lives in a per-agent single-slot registry (agent/send_mode.py) set at batch dispatch — the worker serializes turns.
- Out-of-process senders (the MCP subprocess) ask the daemon via a new data-service route GET /v1/data/{agent_id}/send-encryption; data-client shims without the method fail safe to E2EE.
- Send surfaces covered: client _send_dm / send_fallback_message, MCP send_message / send_message_with_attachments, host-MCP operator DM, ws-local (in-process data client).

## Tests

+15: producer round-trip through read_plaintext_message, tamper + wrong-key rejection, decision matrix (default plaintext / bundle flag set+released / root encrypted / root plaintext / missing root + store failure fail-safe), client DM branch both modes (plaintext skips device resolution), MCP tool plaintext branch (no /certs/sync, correct endpoint + envelope). Existing E2EE integration test pinned to an encrypted-bundle turn. Full suite green.
