### PR TITLE
PUF-395: add desired_subagents to agent-create API

### DIFF
--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -196,7 +196,11 @@ async def _create_agent_command(
         return {"ok": False, "error": exc.reason}
     except ControlError as exc:
         return {"ok": False, "error": str(exc)}
-    return {"ok": True, "agent_slug": result["agent_id"]}
+    return {
+        "ok": True,
+        "agent_slug": result["agent_id"],
+        "subagents": result.get("subagents", []),
+    }
 
 
 async def post_usage_snapshot(machine, base: str) -> bool:

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -24,6 +24,7 @@ from ..state import (
     derive_role_short,
     is_valid_agent_id,
 )
+from ..subagent_provision import validate_desired_subagents, write_subagents
 from .certs import CertError, verify_device_cert, verify_identity_cert, verify_slug_binding
 
 logger = logging.getLogger(__name__)
@@ -176,6 +177,15 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
         isinstance(value, str) and value for value in desired_mcps
     ):
         raise ProvisionError("desired_mcps must be a list of non-empty template-id strings")
+    # Sub-agents arrive as inline .md rather than template ids, so they're
+    # validated here — pre-finalize, before any identity is materialized —
+    # and written at create time by write_agent_from_context.
+    try:
+        desired_subagents = validate_desired_subagents(
+            payload.get("desired_subagents"), harness=runtime.harness,
+        )
+    except ValueError as exc:
+        raise ProvisionError(f"desired_subagents: {exc}")
     return {
         "agent_id": slug,
         "display_name": display_name,
@@ -191,6 +201,7 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
         "runtime": runtime,
         "desired_skills": list(desired_skills),
         "desired_mcps": list(desired_mcps),
+        "desired_subagents": desired_subagents,
         "bundle": bundle,
     }
 
@@ -223,7 +234,7 @@ def write_agent_from_context(context: dict) -> dict:
         raise ProvisionError(f"agent directory {target} already exists")
     try:
         target.mkdir(parents=True, exist_ok=False)
-        AgentConfig(
+        cfg = AgentConfig(
             id=agent_id,
             state="running",
             display_name=context["display_name"],
@@ -242,14 +253,22 @@ def write_agent_from_context(context: dict) -> dict:
             desired_skills=context["desired_skills"],
             desired_mcps=context["desired_mcps"],
             created_at=int(time.time()),
-        ).save()
+        )
+        cfg.save()
         (target / "memory").mkdir(exist_ok=True)
         (target / "profile.md").write_text(context["profile_text"], encoding="utf-8")
+        subagents = write_subagents(
+            cfg.resolve_claude_dir(), context.get("desired_subagents") or [],
+        )
         _write_keystore(context)
     except Exception:
         shutil.rmtree(target, ignore_errors=True)
         raise
-    return {"agent_id": agent_id, "agent_dir": str(target)}
+    return {
+        "agent_id": agent_id,
+        "agent_dir": str(target),
+        "subagents": subagents,
+    }
 
 
 async def provision_agent_from_bundle(

--- a/src/puffo_agent/portal/subagent_provision.py
+++ b/src/puffo_agent/portal/subagent_provision.py
@@ -1,0 +1,124 @@
+"""PUF-395: create-time provisioning of claude-code sub-agents.
+
+A sub-agent is a markdown expert-context (YAML frontmatter — name / description /
+tools / model — plus a system-prompt body) the claude-code harness auto-loads
+from ``<workspace>/.claude/agents/<name>.md`` at Task-tool spawn. Unlike skills
+and MCPs (operator-picked template ids the daemon fetches from the catalog at
+worker spawn), a sub-agent's ``.md`` arrives inline in the create request — same
+trust tier as the ``profile.md`` / ``avatarBytes`` already there — so it is
+validated and written at create time. claude-code only; codex has no sub-agent
+surface and a non-empty list on a codex create is a hard error.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+import yaml
+
+# kebab-case, mirroring the skill-id charset: the name becomes the
+# ``<name>.md`` filename, so this also blocks path-escape.
+_SUBAGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+def sha256_hex(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _frontmatter_name(content: str) -> str | None:
+    """The ``name`` from a leading ``---`` YAML frontmatter block, or None if
+    there is no parseable block or no string ``name`` in it."""
+    text = content.lstrip()
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)  # ['', '<frontmatter>', '<body>']
+    if len(parts) < 3:
+        return None
+    try:
+        meta = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(meta, dict):
+        return None
+    name = meta.get("name")
+    return name if isinstance(name, str) else None
+
+
+def validate_desired_subagents(raw: object, *, harness: str) -> list[dict]:
+    """Validate a create request's ``desired_subagents`` and return a
+    normalized ``[{name, content}]`` list.
+
+    Raises ``ValueError`` (message enumerates every problem) on failure so the
+    caller can surface a single 400. Rules:
+
+    - codex harness + non-empty → rejected (no sub-agent surface)
+    - each item is ``{name: str, content: str}`` with a kebab-case name
+    - content has parseable YAML frontmatter whose ``name`` matches the item
+    - no duplicate names in the request
+    """
+    if raw is None:
+        raw = []
+    if not isinstance(raw, list):
+        raise ValueError("must be a list of {name, content} objects")
+    if not raw:
+        return []
+    if harness == "codex":
+        raise ValueError("subagents not supported on codex harness")
+
+    errors: list[str] = []
+    normalized: list[dict] = []
+    seen: set[str] = set()
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            errors.append(f"subagent[{i}]: must be an object with name + content")
+            continue
+        name = item.get("name")
+        content = item.get("content")
+        if not isinstance(name, str) or not name:
+            errors.append(f"subagent[{i}]: missing non-empty 'name'")
+            continue
+        if not isinstance(content, str) or not content.strip():
+            errors.append(f"subagent {name!r}: missing non-empty 'content'")
+            continue
+        if not _SUBAGENT_NAME_RE.match(name):
+            errors.append(
+                f"subagent {name!r}: name must be kebab-case [a-z0-9-], <=64 chars"
+            )
+            continue
+        if name in seen:
+            errors.append(f"subagent {name!r}: duplicate name in request")
+            continue
+        seen.add(name)
+        fm_name = _frontmatter_name(content)
+        if fm_name is None:
+            errors.append(
+                f"subagent {name!r}: content has no parseable YAML frontmatter 'name'"
+            )
+            continue
+        if fm_name != name:
+            errors.append(
+                f"subagent {name!r}: frontmatter name {fm_name!r} does not match "
+                "request name"
+            )
+            continue
+        normalized.append({"name": name, "content": content})
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return normalized
+
+
+def write_subagents(claude_dir: Path, subagents: list[dict]) -> list[dict]:
+    """Write each normalized ``{name, content}`` to
+    ``<claude_dir>/agents/<name>.md`` (dir created on demand) and return the
+    materialized ``[{name, sha256}]`` for byte-faithful client verification."""
+    written: list[dict] = []
+    if not subagents:
+        return written
+    agents_dir = claude_dir / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    for sa in subagents:
+        (agents_dir / f"{sa['name']}.md").write_text(sa["content"], encoding="utf-8")
+        written.append({"name": sa["name"], "sha256": sha256_hex(sa["content"])})
+    return written

--- a/src/puffo_agent/portal/subagent_provision.py
+++ b/src/puffo_agent/portal/subagent_provision.py
@@ -119,6 +119,15 @@ def write_subagents(claude_dir: Path, subagents: list[dict]) -> list[dict]:
     agents_dir = claude_dir / "agents"
     agents_dir.mkdir(parents=True, exist_ok=True)
     for sa in subagents:
-        (agents_dir / f"{sa['name']}.md").write_text(sa["content"], encoding="utf-8")
-        written.append({"name": sa["name"], "sha256": sha256_hex(sa["content"])})
+        path = agents_dir / f"{sa['name']}.md"
+        # Never write through a pre-existing symlink — a planted link could
+        # escape the workspace. The create path uses a fresh dir so this can't
+        # trigger there, but the helper must not assume its caller does.
+        if path.is_symlink():
+            raise ValueError(f"subagent {sa['name']!r}: refusing to write through a symlink")
+        # write_bytes (not write_text) so the on-disk file is byte-identical to
+        # the sha256 we report — no newline translation on any platform.
+        data = sa["content"].encode("utf-8")
+        path.write_bytes(data)
+        written.append({"name": sa["name"], "sha256": hashlib.sha256(data).hexdigest()})
     return written

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -151,7 +151,10 @@ async def test_create_delegates_to_control_provisioner(home, monkeypatch):
         server_url="https://relay.example",
         paired_root_pubkey="operator-key",
     )
-    assert result == {"ok": True, "agent_slug": "helper-1"}
+    # PUF-395: the response now carries the sub-agents written at create time
+    # so the caller can show what landed. Absent from the stub's return value
+    # → empty list, not a missing key: the field is part of the contract.
+    assert result == {"ok": True, "agent_slug": "helper-1", "subagents": []}
     assert seen["operator_key"] == "operator-key"
     assert seen["params"]["puffo_core"]["server_url"] == "https://relay.example"
 

--- a/tests/test_subagent_provision.py
+++ b/tests/test_subagent_provision.py
@@ -1,0 +1,237 @@
+"""PUF-395: create-time sub-agent provisioning — inline .md validation +
+write, plus the write path through ``_write_agent_from_context``.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.portal.subagent_provision import (
+    sha256_hex,
+    validate_desired_subagents,
+    write_subagents,
+    _frontmatter_name,
+)
+
+
+def _md(name: str, *, body: str = "You review code.") -> str:
+    return (
+        f"---\nname: {name}\ndescription: A {name}.\ntools: Read, Grep\n"
+        f"model: sonnet\n---\n\n{body}\n"
+    )
+
+
+# ── _frontmatter_name ────────────────────────────────────────────────
+
+def test_frontmatter_name_extracts():
+    assert _frontmatter_name(_md("code-reviewer")) == "code-reviewer"
+
+
+def test_frontmatter_name_tolerates_leading_whitespace():
+    assert _frontmatter_name("\n\n" + _md("tdd-guide")) == "tdd-guide"
+
+
+def test_frontmatter_name_none_without_fence():
+    # Body-only content (no frontmatter) — claude-code wouldn't load it.
+    assert _frontmatter_name("You are a reviewer, no frontmatter here.") is None
+
+
+def test_frontmatter_name_none_on_unterminated_block():
+    assert _frontmatter_name("---\nname: x\nno closing fence") is None
+
+
+def test_frontmatter_name_none_on_bad_yaml():
+    assert _frontmatter_name("---\nname: : : broken\n---\nbody") is None
+
+
+def test_frontmatter_name_none_when_name_missing():
+    assert _frontmatter_name("---\ndescription: no name\n---\nbody") is None
+
+
+# ── validate_desired_subagents ───────────────────────────────────────
+
+def test_validate_none_and_empty_are_empty():
+    assert validate_desired_subagents(None, harness="claude-code") == []
+    assert validate_desired_subagents([], harness="claude-code") == []
+
+
+def test_validate_happy_single():
+    got = validate_desired_subagents(
+        [{"name": "code-reviewer", "content": _md("code-reviewer")}],
+        harness="claude-code",
+    )
+    assert got == [{"name": "code-reviewer", "content": _md("code-reviewer")}]
+
+
+def test_validate_happy_multiple():
+    items = [
+        {"name": "code-reviewer", "content": _md("code-reviewer")},
+        {"name": "tdd-guide", "content": _md("tdd-guide")},
+    ]
+    assert validate_desired_subagents(items, harness="claude-code") == items
+
+
+def test_validate_codex_nonempty_rejected():
+    # AC #6 — hard error, not silent-drop.
+    with pytest.raises(ValueError, match="codex"):
+        validate_desired_subagents(
+            [{"name": "code-reviewer", "content": _md("code-reviewer")}],
+            harness="codex",
+        )
+
+
+def test_validate_codex_empty_ok():
+    # AC #7 — empty/omitted on codex flows normally.
+    assert validate_desired_subagents([], harness="codex") == []
+    assert validate_desired_subagents(None, harness="codex") == []
+
+
+def test_validate_non_list_rejected():
+    with pytest.raises(ValueError, match="list"):
+        validate_desired_subagents({"name": "x"}, harness="claude-code")
+
+
+def test_validate_name_mismatch_rejected():
+    # AC #10 — frontmatter name must match the request name.
+    with pytest.raises(ValueError, match="does not match"):
+        validate_desired_subagents(
+            [{"name": "code-reviewer", "content": _md("security-reviewer")}],
+            harness="claude-code",
+        )
+
+
+def test_validate_missing_frontmatter_rejected():
+    # AC #10 — parse failure.
+    with pytest.raises(ValueError, match="frontmatter"):
+        validate_desired_subagents(
+            [{"name": "code-reviewer", "content": "body only, no frontmatter"}],
+            harness="claude-code",
+        )
+
+
+def test_validate_duplicate_names_rejected():
+    # AC #11.
+    with pytest.raises(ValueError, match="duplicate"):
+        validate_desired_subagents(
+            [
+                {"name": "code-reviewer", "content": _md("code-reviewer")},
+                {"name": "code-reviewer", "content": _md("code-reviewer", body="dup")},
+            ],
+            harness="claude-code",
+        )
+
+
+def test_validate_bad_name_charset_rejected():
+    with pytest.raises(ValueError, match="kebab-case"):
+        validate_desired_subagents(
+            [{"name": "../evil", "content": _md("../evil")}],
+            harness="claude-code",
+        )
+
+
+def test_validate_missing_content_rejected():
+    with pytest.raises(ValueError, match="content"):
+        validate_desired_subagents(
+            [{"name": "code-reviewer"}], harness="claude-code",
+        )
+
+
+def test_validate_collects_all_errors():
+    # AC #2 — every failure surfaced together, not just the first.
+    with pytest.raises(ValueError) as exc:
+        validate_desired_subagents(
+            [
+                {"name": "ok-one", "content": _md("ok-one")},
+                {"name": "bad-name-mismatch", "content": _md("other")},
+                {"name": "no-fm", "content": "nope"},
+            ],
+            harness="claude-code",
+        )
+    msg = str(exc.value)
+    assert "bad-name-mismatch" in msg and "no-fm" in msg
+
+
+# ── write_subagents ──────────────────────────────────────────────────
+
+def test_write_subagents_creates_dir_on_demand(tmp_path):
+    # AC #12 — .claude/agents created if absent.
+    claude_dir = tmp_path / ".claude"
+    assert not (claude_dir / "agents").exists()
+    content = _md("code-reviewer")
+    written = write_subagents(claude_dir, [{"name": "code-reviewer", "content": content}])
+    md = claude_dir / "agents" / "code-reviewer.md"
+    assert md.read_text(encoding="utf-8") == content
+    assert written == [
+        {"name": "code-reviewer", "sha256": hashlib.sha256(content.encode()).hexdigest()},
+    ]
+
+
+def test_write_subagents_empty_is_noop(tmp_path):
+    claude_dir = tmp_path / ".claude"
+    assert write_subagents(claude_dir, []) == []
+    assert not (claude_dir / "agents").exists()
+
+
+def test_sha256_hex_matches_stdlib():
+    assert sha256_hex("hello") == hashlib.sha256(b"hello").hexdigest()
+
+
+# ── write path through _write_agent_from_context ─────────────────────
+
+def _ctx(agent_id: str, subagents: list[dict]) -> dict:
+    from puffo_agent.portal.state import RuntimeConfig
+    return {
+        "agent_id": agent_id,
+        "display_name": "Reviewer Bot",
+        "avatar_url": "",
+        "role": "reviewer",
+        "role_short": "rev",
+        "profile_text": "# Role\n\nYou review.\n",
+        "server_url": "https://api.puffo.ai",
+        "slug": f"{agent_id}-slug",
+        "device_id": "dev-1",
+        "space_id": "sp_1",
+        "operator_slug": "op-1",
+        "runtime": RuntimeConfig(kind="cli-local", provider="anthropic", harness="claude-code"),
+        "desired_skills": [],
+        "desired_mcps": [],
+        "desired_subagents": subagents,
+        "bundle": {
+            "root_secret_key": "rsk",
+            "device_signing_secret_key": "dssk",
+            "kem_secret_key": "ksk",
+            "identity_cert": {"cert": "id"},
+            "slug_binding": {"binding": "sb"},
+        },
+    }
+
+
+def test_write_agent_from_context_lands_subagents(tmp_path, monkeypatch):
+    # AC #3 + #5 — .md written under <workspace>/.claude/agents, response
+    # carries {name, sha256}.
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.portal.api.handlers import _write_agent_from_context
+    from puffo_agent.portal.state import agent_dir
+
+    content = _md("code-reviewer")
+    result = _write_agent_from_context(
+        _ctx("rev-bot", [{"name": "code-reviewer", "content": content}]),
+    )
+    md = agent_dir("rev-bot") / "workspace" / ".claude" / "agents" / "code-reviewer.md"
+    assert md.read_text(encoding="utf-8") == content
+    assert result["subagents"] == [
+        {"name": "code-reviewer", "sha256": hashlib.sha256(content.encode()).hexdigest()},
+    ]
+
+
+def test_write_agent_from_context_no_subagents(tmp_path, monkeypatch):
+    # AC #8 — no desired_subagents → no .claude/agents dir, empty response list.
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.portal.api.handlers import _write_agent_from_context
+    from puffo_agent.portal.state import agent_dir
+
+    result = _write_agent_from_context(_ctx("plain-bot", []))
+    assert result["subagents"] == []
+    assert not (agent_dir("plain-bot") / "workspace" / ".claude" / "agents").exists()

--- a/tests/test_subagent_provision.py
+++ b/tests/test_subagent_provision.py
@@ -1,5 +1,5 @@
 """PUF-395: create-time sub-agent provisioning — inline .md validation +
-write, plus the write path through ``_write_agent_from_context``.
+write, plus the write path through ``write_agent_from_context``.
 """
 from __future__ import annotations
 
@@ -214,7 +214,7 @@ def test_sha256_hex_matches_stdlib():
     assert sha256_hex("hello") == hashlib.sha256(b"hello").hexdigest()
 
 
-# ── write path through _write_agent_from_context ─────────────────────
+# ── write path through write_agent_from_context ──────────────────────
 
 def _ctx(agent_id: str, subagents: list[dict]) -> dict:
     from puffo_agent.portal.state import RuntimeConfig
@@ -248,11 +248,11 @@ def test_write_agent_from_context_lands_subagents(tmp_path, monkeypatch):
     # AC #3 + #5 — .md written under <workspace>/.claude/agents, response
     # carries {name, sha256}.
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    from puffo_agent.portal.api.handlers import _write_agent_from_context
+    from puffo_agent.portal.control.provision import write_agent_from_context
     from puffo_agent.portal.state import agent_dir
 
     content = _md("code-reviewer")
-    result = _write_agent_from_context(
+    result = write_agent_from_context(
         _ctx("rev-bot", [{"name": "code-reviewer", "content": content}]),
     )
     md = agent_dir("rev-bot") / "workspace" / ".claude" / "agents" / "code-reviewer.md"
@@ -267,16 +267,19 @@ def test_write_agent_from_context_prunes_on_subagent_write_failure(tmp_path, mon
     # the half-built agent dir (shutil.rmtree) rather than leaving it for the
     # reconcile loop. The new subagent write is a fresh IO surface; pin it.
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    from puffo_agent.portal import subagent_provision
-    from puffo_agent.portal.api.handlers import _write_agent_from_context
+    from puffo_agent.portal.control import provision as provision_mod
+    from puffo_agent.portal.control.provision import write_agent_from_context
     from puffo_agent.portal.state import agent_dir
 
     def _boom(claude_dir, subagents):
         raise OSError("disk full")
 
-    monkeypatch.setattr(subagent_provision, "write_subagents", _boom)
+    # Patch where it's used, not where it's defined: provision.py binds the
+    # symbol at import (``from ..subagent_provision import write_subagents``),
+    # so patching the source module leaves the bound reference untouched.
+    monkeypatch.setattr(provision_mod, "write_subagents", _boom)
     with pytest.raises(OSError):
-        _write_agent_from_context(
+        write_agent_from_context(
             _ctx("doomed-bot", [{"name": "code-reviewer", "content": _md("code-reviewer")}]),
         )
     assert not agent_dir("doomed-bot").exists()  # half-built dir pruned
@@ -285,9 +288,9 @@ def test_write_agent_from_context_prunes_on_subagent_write_failure(tmp_path, mon
 def test_write_agent_from_context_no_subagents(tmp_path, monkeypatch):
     # AC #8 — no desired_subagents → no .claude/agents dir, empty response list.
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    from puffo_agent.portal.api.handlers import _write_agent_from_context
+    from puffo_agent.portal.control.provision import write_agent_from_context
     from puffo_agent.portal.state import agent_dir
 
-    result = _write_agent_from_context(_ctx("plain-bot", []))
+    result = write_agent_from_context(_ctx("plain-bot", []))
     assert result["subagents"] == []
     assert not (agent_dir("plain-bot") / "workspace" / ".claude" / "agents").exists()

--- a/tests/test_subagent_provision.py
+++ b/tests/test_subagent_provision.py
@@ -131,6 +131,20 @@ def test_validate_bad_name_charset_rejected():
         )
 
 
+def test_validate_lax_frontmatter_with_valid_name_passes():
+    # Intake: "daemon does NOT interpret semantics — harness owns them." A
+    # valid name is the only structural guard; garbage tools/model pass through
+    # and are caught (if at all) at claude-code load time. Source-pin the laxity.
+    content = (
+        "---\nname: loose-agent\ntools: not-a-list-lol\nmodel: 42\n"
+        "description:\n---\n\nbody\n"
+    )
+    got = validate_desired_subagents(
+        [{"name": "loose-agent", "content": content}], harness="claude-code",
+    )
+    assert got == [{"name": "loose-agent", "content": content}]
+
+
 def test_validate_missing_content_rejected():
     with pytest.raises(ValueError, match="content"):
         validate_desired_subagents(
@@ -172,6 +186,28 @@ def test_write_subagents_empty_is_noop(tmp_path):
     claude_dir = tmp_path / ".claude"
     assert write_subagents(claude_dir, []) == []
     assert not (claude_dir / "agents").exists()
+
+
+def test_write_subagents_byte_faithful_across_newlines(tmp_path):
+    # sha256 contract: the on-disk file must be byte-identical to the reported
+    # sha256 regardless of newline style (write_bytes, no translation).
+    content = "---\r\nname: crlf-agent\r\n---\r\n\r\nbody\r\nline2\n"
+    written = write_subagents(tmp_path / ".claude", [{"name": "crlf-agent", "content": content}])
+    on_disk = (tmp_path / ".claude" / "agents" / "crlf-agent.md").read_bytes()
+    assert on_disk == content.encode("utf-8")  # CRLF preserved verbatim
+    assert written[0]["sha256"] == hashlib.sha256(on_disk).hexdigest()
+
+
+def test_write_subagents_refuses_symlink(tmp_path):
+    # Safe-by-construction: a pre-existing symlink at the target is refused,
+    # never followed (would let a planted link escape the workspace).
+    agents_dir = tmp_path / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    (agents_dir / "code-reviewer.md").symlink_to(outside)
+    with pytest.raises(ValueError, match="symlink"):
+        write_subagents(tmp_path / ".claude", [{"name": "code-reviewer", "content": _md("code-reviewer")}])
+    assert not outside.exists()  # nothing written through the link
 
 
 def test_sha256_hex_matches_stdlib():
@@ -224,6 +260,26 @@ def test_write_agent_from_context_lands_subagents(tmp_path, monkeypatch):
     assert result["subagents"] == [
         {"name": "code-reviewer", "sha256": hashlib.sha256(content.encode()).hexdigest()},
     ]
+
+
+def test_write_agent_from_context_prunes_on_subagent_write_failure(tmp_path, monkeypatch):
+    # AC #4 partial-failure path: a disk-write failure AFTER validation prunes
+    # the half-built agent dir (shutil.rmtree) rather than leaving it for the
+    # reconcile loop. The new subagent write is a fresh IO surface; pin it.
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.portal import subagent_provision
+    from puffo_agent.portal.api.handlers import _write_agent_from_context
+    from puffo_agent.portal.state import agent_dir
+
+    def _boom(claude_dir, subagents):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(subagent_provision, "write_subagents", _boom)
+    with pytest.raises(OSError):
+        _write_agent_from_context(
+            _ctx("doomed-bot", [{"name": "code-reviewer", "content": _md("code-reviewer")}]),
+        )
+    assert not agent_dir("doomed-bot").exists()  # half-built dir pruned
 
 
 def test_write_agent_from_context_no_subagents(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Adds `desired_subagents: [{name, content}]` to the agent-create API (`createAgent` + `createAgentOnMachine`), parallel to the shipped `desired_skills` / `desired_mcps`. Inline `.md` payload — same trust tier as `profile.md` / `avatarBytes` already in the request — validated at bundle-verify time and written to `<workspace>/.claude/agents/<name>.md` at write-time. Response returns `{subagents: [{name, sha256}]}` for byte-faithful client verification.

## Design
- **New module** `subagent_provision.py` (124 LOC): pure `validate_desired_subagents` → normalized list, `write_subagents(claude_dir, items)` → materialized `{name, sha256}` list.
- **Two wiring points** (both existing paths converge here):
  - `_verify_agent_bundle` — pre-materialize validation, so a bad payload fails 400 with nothing materialized.
  - `_write_agent_from_context` — writes .md files under `cfg.resolve_claude_dir()/agents/`, alongside `profile.md` + `memory/`.
- **Codex hard-400 on non-empty** (`"subagents not supported on codex harness"`) — not silent-drop, that's the bug this fixes.
- **kebab-case name regex** `^[a-z0-9][a-z0-9-]{0,63}$` blocks path escape (`../evil`) at validation time.
- **Frontmatter `name` must match request `name`** (parse failure or mismatch → 400 with actionable message).
- **Multi-error surfacing** — one 400 enumerates every bad item, not the first-failure-shortcut.

## No server change
Verified `puffo-server` relays the create envelope opaquely: `submit_command` on `/v2/machines/<machine_id>/commands` takes `envelope: Value` with a 256 KiB cap and passes through. `desired_subagents` reaches the daemon intact.

## Test plan
- [x] `pytest tests/test_subagent_provision.py` — 23 tests: happy single + multi, codex hard-400 (non-empty) + normal (empty), validation → 400 for bad/missing frontmatter + name-mismatch + kebab-case violation (incl. `../evil`) + dup names + missing content + non-list, multi-error surfacing, dir-create-on-demand, no-regression (no field → no dir).
- [x] Full suite (`--ignore=test_ui_mcp_scanner.py --ignore=test_ui_views.py`): **2192 passed, 3 skipped, 0 failed**. Zero regression.
- [ ] E2E daemon smoke (source-pinned only): create a claude-code agent with 1-2 real subagents via the web → server → daemon chain; verify `.md` lands under `workspace/.claude/agents/` byte-faithful + response `sha256s` match.

## Related
- Linear: [PUF-125](https://linear.app/puffo-ai/issue/PUF-125)
- Shared-dir: `/home/hanchen/.puffo-agent/shared/PUF-395.md`
- Supersedes FB-425 (Karina codex `CronCreate` gap surface: subagent primitive replaces need for session-only `CronCreate`).