### PR TITLE
PUF-399: bump default task_timeout_seconds 600s → 1800s (30 min)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Default agent task timeout raised 600s → 1800s (30 min) (PUF-399).**
+  `runtime.task_timeout_seconds` — the per-agent per-turn wall-clock
+  budget — now defaults to 30 minutes so long-running projects aren't
+  cut off at 10 min. Operators can still override it per-agent in
+  `agent.yml`; only the default changed.
+
 ### Added
 
 - **Plaintext (non-E2EE) sending.** Agent replies now go out as

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -78,7 +78,7 @@ REQUEST_TIMEOUT_SECONDS = 60.0
 
 # Default per-turn wall-clock budget; defensive against an App Server
 # that ACKs but never streams.
-TURN_TIMEOUT_SECONDS = 600.0
+TURN_TIMEOUT_SECONDS = 1800.0
 
 # Reacts fast in a small fleet, absorbs single transient hiccups.
 CODEX_THREAD_WEDGED_THRESHOLD = 2

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -162,7 +162,7 @@ class LocalCLIAdapter(Adapter):
         permission_mode: str = "default",
         sandbox: str = "danger-full-access",
         inference_level: str = "",
-        task_timeout_seconds: float = 600.0,
+        task_timeout_seconds: float = 1800.0,
         harness=None,
         desired_skills: list[str] | None = None,
         desired_mcps: list[str] | None = None,

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1024,9 +1024,9 @@ class RuntimeConfig:
     sandbox: str = "danger-full-access"
     # "" = harness default; codex → config.toml, claude-code → --effort
     inference_level: str = ""
-    # codex (cli-local) per-turn wall-clock budget in seconds; raise for
-    # agents running long reasoning/complex tasks.
-    task_timeout_seconds: float = 600.0
+    # codex (cli-local) per-turn wall-clock budget in seconds (default 30 min);
+    # raise it for agents running even longer reasoning/complex tasks.
+    task_timeout_seconds: float = 1800.0
     # Agent engine (CLI kinds only): ``claude-code`` (stream-json + resume +
     # puffo MCP), ``hermes`` (one-shot ``hermes chat -q``), ``gemini-cli``
     # (declared, unimplemented). Hermes OAuth bills to Anthropic
@@ -1127,7 +1127,7 @@ class AgentConfig:
                 permission_mode=rt.get("permission_mode", "bypassPermissions"),
                 sandbox=rt.get("sandbox", "danger-full-access"),
                 inference_level=rt.get("inference_level", ""),
-                task_timeout_seconds=float(rt.get("task_timeout_seconds", 600.0)),
+                task_timeout_seconds=float(rt.get("task_timeout_seconds", 1800.0)),
                 harness=harness,
                 max_turns=int(rt.get("max_turns", 10)),
             ),

--- a/tests/test_codex_thread_rotation.py
+++ b/tests/test_codex_thread_rotation.py
@@ -384,7 +384,7 @@ def test_looks_like_codex_thread_limit_helper():
 # _propagate_turn_outcome at the success / turn_failed sites. Uses the
 # same fake-codex-app-server pattern as test_codex_session.py so the
 # wire shape matches what real codex emits. Timeout coverage is
-# omitted because TURN_TIMEOUT_SECONDS = 600s makes the wire-level
+# omitted because TURN_TIMEOUT_SECONDS = 1800s makes the wire-level
 # path impractical to exercise; the bookkeeping for the timeout outcome
 # is fully covered by the direct ``_propagate_turn_outcome(outcome=
 # "timeout")`` tests above.

--- a/tests/test_task_timeout_knob.py
+++ b/tests/test_task_timeout_knob.py
@@ -1,5 +1,5 @@
 """RuntimeConfig.task_timeout_seconds round-trips through agent.yml,
-defaults to 600s, and reaches the CodexSession."""
+defaults to 1800s (30 min), and reaches the CodexSession."""
 
 from __future__ import annotations
 
@@ -14,9 +14,9 @@ def home(tmp_path, monkeypatch) -> Path:
     return tmp_path
 
 
-def test_default_is_600():
+def test_default_is_1800():
     from puffo_agent.portal.state import RuntimeConfig
-    assert RuntimeConfig().task_timeout_seconds == 600.0
+    assert RuntimeConfig().task_timeout_seconds == 1800.0
 
 
 def test_round_trips(home):
@@ -24,13 +24,13 @@ def test_round_trips(home):
     cfg = AgentConfig(
         id="codex-slow",
         display_name="codex-slow",
-        runtime=RuntimeConfig(kind="cli-local", harness="codex", task_timeout_seconds=1800.0),
+        runtime=RuntimeConfig(kind="cli-local", harness="codex", task_timeout_seconds=900.0),
     )
     cfg.save()
-    assert AgentConfig.load("codex-slow").runtime.task_timeout_seconds == 1800.0
+    assert AgentConfig.load("codex-slow").runtime.task_timeout_seconds == 900.0
 
 
-def test_legacy_yml_without_field_defaults_600(home):
+def test_legacy_yml_without_field_defaults_1800(home):
     from puffo_agent.portal.state import AgentConfig, agent_yml_path
     aid = "legacy-codex"
     yml = agent_yml_path(aid)
@@ -50,7 +50,7 @@ def test_legacy_yml_without_field_defaults_600(home):
         "triggers: {on_mention: true, on_dm: true}\n",
         encoding="utf-8",
     )
-    assert AgentConfig.load(aid).runtime.task_timeout_seconds == 600.0
+    assert AgentConfig.load(aid).runtime.task_timeout_seconds == 1800.0
 
 
 def test_codex_session_stores_timeout():

--- a/tests/test_task_timeout_knob.py
+++ b/tests/test_task_timeout_knob.py
@@ -64,6 +64,16 @@ def test_codex_session_stores_timeout():
     assert s.task_timeout_seconds == 42.0
 
 
+def test_codex_session_defaults_to_1800():
+    from puffo_agent.agent.adapters.codex_session import CodexSession
+    s = CodexSession(
+        agent_id="a",
+        session_file=Path("/tmp/nonexistent-codex-session.json"),
+        argv=["codex", "app-server"],
+    )
+    assert s.task_timeout_seconds == 1800.0
+
+
 def test_local_cli_adapter_plumbs_timeout_to_codex_session(tmp_path, monkeypatch):
     from puffo_agent.agent.adapters import local_cli as lc
     from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter


### PR DESCRIPTION
Raises the per-agent task-turn wall-clock budget default from 600s (10 min) to 1800s (30 min), unblocking Sam's dogfood feedback that "绝大部分项目无法完成" — most real projects hit the previous 10-min ceiling.

## Substance

- `RuntimeConfig.task_timeout_seconds` default: `600.0 → 1800.0` in 4 aligned spots:
  - `src/puffo_agent/portal/state.py:1029` — `RuntimeConfig` dataclass default (authoritative)
  - `src/puffo_agent/portal/state.py:1130` — config-read fallback (authoritative)
  - `src/puffo_agent/agent/adapters/codex_session.py:81` — `TURN_TIMEOUT_SECONDS` module constant
  - `src/puffo_agent/agent/adapters/local_cli.py:165` — LocalCLIAdapter constructor default
- Operator override untouched — any explicit `task_timeout_seconds` in `agent.yml` still round-trips (test covers 900s)
- CHANGELOG entry added

## Terminology note (Solution + Equation confirmed)

Vase's directive "session timeout" (user-facing term) maps to internal `task_timeout_seconds` (per-agent per-turn wall-clock budget) — the only per-agent task-duration knob in the codebase. This is NOT the HTTP client / model API / daemon session lifecycle timeouts (those stay untouched per intake OOS).

## Tests

- `tests/test_task_timeout_knob.py` — 7 tests pass, all default/legacy-yml assertions updated to 1800 + round-trip retained via non-default 900

## Solution QA — pass

- 4 aligned bumps confirmed via `grep task_timeout_seconds` (all four spots now 1800.0)
- `pytest tests/test_task_timeout_knob.py` **7/7 pass** locally
- Full timeout-related sweep for stale 600 references: unrelated 600s (CORS max-age, CLI --wait-timeout, HTTP query default, heartbeat, credential-refresh margin, model-catalog TTL) all correctly left alone
- Operator override non-regression covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)