### PR TITLE
PUF-401: single-source role_short derived from role + startup backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   paths (LLM replies, MCP tools, daemon system DMs); attachments
   remain encrypted blob references.
 
+### Fixed
+
+- **Cap `mcp` below 2.0.** The 2.x SDK dropped the bundled
+  `mcp.server.fastmcp`; pin `mcp>=1.0,<2` until the tool servers move
+  to the standalone `fastmcp` package.
+
 ## [1.1.5] — 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`role_short` is now single-source-derived from `role` (PUF-401).**
+  The chip label is always derived from the `<short>: <description>`
+  role on every write path (bridge, CLI, provision, control-WS, agent
+  detail) instead of being stored independently, so it can no longer
+  orphan a stale value. Explicit `role_short` / `--role-short` is
+  deprecated: still accepted for backward compatibility but ignored,
+  with a warning when the supplied value differs from the derived one.
+  A daemon-startup backfill repairs a stale on-disk `role_short` before
+  the first server sync, so a restart fixes the chip instead of pushing
+  the stale value back.
+
 - **Default agent task timeout raised 600s → 1800s (30 min) (PUF-399).**
   `runtime.task_timeout_seconds` — the per-agent per-turn wall-clock
   budget — now defaults to 30 minutes so long-running projects aren't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Relay TLS trust bundle for hosts with an empty OpenSSL cert store.
     "certifi>=2024.2.2",
     "cryptography>=43.0",
-    "mcp>=1.0",
+    "mcp>=1.0,<2",
     # Pillow: dimension-check + downscale inbound image attachments so
     # an oversized image can't poison the agent's claude session.
     "pillow>=10.0",

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -600,10 +600,6 @@ async def update_profile(request: web.Request) -> web.Response:
         return _bad(
             f"role_short must be at most {MAX_ROLE_SHORT_LEN} characters",
         )
-    # role_short is single-source-derived from role (PUF-401). An explicit
-    # role_short is still accepted for backward compat but ignored; warn when
-    # the supplied value would actually differ from the derived one so a
-    # deprecated caller learns the value was dropped (never silently).
     if isinstance(new_role_short, str) and isinstance(new_role, str):
         _derived = _derive_role_short(new_role)
         if new_role_short.strip() and new_role_short.strip() != _derived:
@@ -647,8 +643,6 @@ async def update_profile(request: web.Request) -> web.Response:
         profile_patch["avatar_url"] = new_avatar_url
     if isinstance(new_role, str):
         profile_patch["role"] = new_role
-        # role_short is single-source-derived from role (PUF-401); push the
-        # derived chip so the server stores the single-source value.
         profile_patch["role_short"] = _derive_role_short(new_role)
 
     new_profile_summary = payload.get("profile_summary")
@@ -669,8 +663,6 @@ async def update_profile(request: web.Request) -> web.Response:
         cfg.avatar_url = new_avatar_url
     if isinstance(new_role, str):
         cfg.role = new_role
-        # role_short is single-source-derived from role (PUF-401); any
-        # explicit role_short on the wire is accepted but ignored.
         cfg.role_short = _derive_role_short(new_role)
     cfg.save()
     if isinstance(new_role, str):
@@ -726,8 +718,7 @@ async def update_profile(request: web.Request) -> web.Response:
 
 
 def _derive_role_short(role: str) -> str:
-    """Thin wrapper over :func:`state.derive_role_short` — the single
-    canonical implementation (PUF-401). Kept for existing call-sites."""
+    """Thin wrapper over the canonical :func:`state.derive_role_short`."""
     return derive_role_short(role)
 
 
@@ -1521,8 +1512,6 @@ def _verify_agent_bundle(payload: dict, paired_root_pubkey_b64: str) -> dict:
         raise ProvisionError(f"role_short must be at most {MAX_ROLE_SHORT_LEN} characters")
     if not role and role_short_raw:
         raise ProvisionError("role_short cannot be set without role")
-    # role_short is single-source-derived from role (PUF-401); role_short_raw
-    # is still accepted on the wire (validated above) but ignored.
     role_short = _derive_role_short(role) if role else ""
     if isinstance(role_short_raw, str) and role_short_raw.strip() and role_short_raw.strip() != role_short:
         logger.warning(

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -35,6 +35,7 @@ from ..state import (
     agent_yml_path,
     archive_flag_path,
     delete_flag_path,
+    derive_role_short,
     discover_agents,
     is_valid_agent_id,
     refresh_agent_flag_path,
@@ -634,8 +635,9 @@ async def update_profile(request: web.Request) -> web.Response:
         profile_patch["avatar_url"] = new_avatar_url
     if isinstance(new_role, str):
         profile_patch["role"] = new_role
-    if isinstance(new_role_short, str):
-        profile_patch["role_short"] = new_role_short
+        # role_short is single-source-derived from role (PUF-401); push the
+        # derived chip so the server stores the single-source value.
+        profile_patch["role_short"] = _derive_role_short(new_role)
 
     new_profile_summary = payload.get("profile_summary")
     stripped_summary: str | None = None
@@ -655,10 +657,9 @@ async def update_profile(request: web.Request) -> web.Response:
         cfg.avatar_url = new_avatar_url
     if isinstance(new_role, str):
         cfg.role = new_role
-        if not isinstance(new_role_short, str):
-            cfg.role_short = _derive_role_short(new_role)
-    if isinstance(new_role_short, str):
-        cfg.role_short = new_role_short
+        # role_short is single-source-derived from role (PUF-401); any
+        # explicit role_short on the wire is accepted but ignored.
+        cfg.role_short = _derive_role_short(new_role)
     cfg.save()
     if isinstance(new_role, str):
         _update_profile_role(cfg, new_role)
@@ -713,24 +714,9 @@ async def update_profile(request: web.Request) -> web.Response:
 
 
 def _derive_role_short(role: str) -> str:
-    """Local mirror of puffo-server's ``derive_role_short``: pull a
-    short chip label out of a ``<short>: <description>``-shaped role
-    string. Returns ``""`` for any shape the server would also
-    reject (no colon, empty prefix, whitespace in prefix, empty
-    suffix, prefix > ``MAX_ROLE_SHORT_LEN``). Kept in sync with
-    ``profiles::derive_role_short`` in puffo-server."""
-    if ":" not in role:
-        return ""
-    colon_pos = role.index(":")
-    candidate = role[:colon_pos].strip()
-    rest = role[colon_pos + 1:].strip()
-    if not candidate or not rest:
-        return ""
-    if len(candidate) > MAX_ROLE_SHORT_LEN:
-        return ""
-    if any(ch.isspace() for ch in candidate):
-        return ""
-    return candidate
+    """Thin wrapper over :func:`state.derive_role_short` — the single
+    canonical implementation (PUF-401). Kept for existing call-sites."""
+    return derive_role_short(role)
 
 
 def _update_profile_summary(cfg: AgentConfig, new_summary: str) -> None:
@@ -1523,11 +1509,9 @@ def _verify_agent_bundle(payload: dict, paired_root_pubkey_b64: str) -> dict:
         raise ProvisionError(f"role_short must be at most {MAX_ROLE_SHORT_LEN} characters")
     if not role and role_short_raw:
         raise ProvisionError("role_short cannot be set without role")
-    role_short = (
-        role_short_raw.strip() if isinstance(role_short_raw, str)
-        else _derive_role_short(role) if role
-        else ""
-    )
+    # role_short is single-source-derived from role (PUF-401); role_short_raw
+    # is still accepted on the wire (validated above) but ignored.
+    role_short = _derive_role_short(role) if role else ""
     profile_text = payload.get("profile")
     if not isinstance(profile_text, str) or not profile_text.strip():
         raise ProvisionError("profile (markdown body) is required")

--- a/src/puffo_agent/portal/api/handlers.py
+++ b/src/puffo_agent/portal/api/handlers.py
@@ -600,6 +600,18 @@ async def update_profile(request: web.Request) -> web.Response:
         return _bad(
             f"role_short must be at most {MAX_ROLE_SHORT_LEN} characters",
         )
+    # role_short is single-source-derived from role (PUF-401). An explicit
+    # role_short is still accepted for backward compat but ignored; warn when
+    # the supplied value would actually differ from the derived one so a
+    # deprecated caller learns the value was dropped (never silently).
+    if isinstance(new_role_short, str) and isinstance(new_role, str):
+        _derived = _derive_role_short(new_role)
+        if new_role_short.strip() and new_role_short.strip() != _derived:
+            logger.warning(
+                "bridge: 'role_short' is deprecated (PUF-401); ignoring "
+                "provided %r, using role-derived %r for agent=%s",
+                new_role_short, _derived, agent_id,
+            )
 
     avatar_bytes: bytes | None = None
     if avatar_b64 is not None:
@@ -1512,6 +1524,12 @@ def _verify_agent_bundle(payload: dict, paired_root_pubkey_b64: str) -> dict:
     # role_short is single-source-derived from role (PUF-401); role_short_raw
     # is still accepted on the wire (validated above) but ignored.
     role_short = _derive_role_short(role) if role else ""
+    if isinstance(role_short_raw, str) and role_short_raw.strip() and role_short_raw.strip() != role_short:
+        logger.warning(
+            "provision: 'role_short' is deprecated (PUF-401); ignoring "
+            "provided %r, using role-derived %r for agent=%s",
+            role_short_raw, role_short, agent_id,
+        )
     profile_text = payload.get("profile")
     if not isinstance(profile_text, str) or not profile_text.strip():
         raise ProvisionError("profile (markdown body) is required")

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -449,8 +449,7 @@ def _resolve_api_key_for_create(
 
 
 def _derive_role_short_cli(role: str) -> str:
-    """Thin wrapper over :func:`state.derive_role_short` — the single
-    canonical implementation (PUF-401). Kept for existing call-sites."""
+    """Thin wrapper over the canonical :func:`state.derive_role_short`."""
     return derive_role_short(role)
 
 
@@ -487,8 +486,6 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     if role_short_raw and len(role_short_raw) > 32:
         print("error: --role-short must be at most 32 characters", file=sys.stderr)
         return 2
-    # role_short is single-source-derived from role (PUF-401); --role-short
-    # is still accepted on the CLI (validated above) but ignored.
     role_short = _derive_role_short_cli(role) if role else ""
     if role_short_raw and role_short_raw != role_short:
         print(
@@ -956,9 +953,6 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
     if role_short_arg is not None and len(role_short_arg) > 32:
         print("error: --role-short must be at most 32 characters", file=sys.stderr)
         return 2
-    # role_short is single-source-derived from role (PUF-401); --role-short is
-    # accepted but ignored. Warn when the supplied value would differ from the
-    # authoritative derived one so it's never dropped silently.
     if role_short_arg is not None and role_short_arg.strip():
         _authoritative = _derive_role_short_cli(
             role_arg if isinstance(role_arg, str) else cfg.role
@@ -981,8 +975,6 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
     if isinstance(role_arg, str):
         cfg.role = role_arg
         patch["role"] = role_arg
-        # role_short is single-source-derived from role (PUF-401);
-        # --role-short is accepted but ignored (derive wins).
         cfg.role_short = _derive_role_short_cli(role_arg)
         patch["role_short"] = cfg.role_short
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -490,6 +490,12 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     # role_short is single-source-derived from role (PUF-401); --role-short
     # is still accepted on the CLI (validated above) but ignored.
     role_short = _derive_role_short_cli(role) if role else ""
+    if role_short_raw and role_short_raw != role_short:
+        print(
+            f"warning: --role-short is deprecated (PUF-401); ignoring "
+            f"{role_short_raw!r}, using role-derived {role_short!r}",
+            file=sys.stderr,
+        )
 
     target.mkdir(parents=True)
 
@@ -950,6 +956,19 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
     if role_short_arg is not None and len(role_short_arg) > 32:
         print("error: --role-short must be at most 32 characters", file=sys.stderr)
         return 2
+    # role_short is single-source-derived from role (PUF-401); --role-short is
+    # accepted but ignored. Warn when the supplied value would differ from the
+    # authoritative derived one so it's never dropped silently.
+    if role_short_arg is not None and role_short_arg.strip():
+        _authoritative = _derive_role_short_cli(
+            role_arg if isinstance(role_arg, str) else cfg.role
+        )
+        if role_short_arg.strip() != _authoritative:
+            print(
+                f"warning: --role-short is deprecated (PUF-401); ignoring "
+                f"{role_short_arg!r}, using role-derived {_authoritative!r}",
+                file=sys.stderr,
+            )
 
     # Build the wire patch + apply locally in lock-step. agent.yml
     # writes happen first so a server-side hiccup doesn't lose what
@@ -986,9 +1005,7 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
     if "role" in patch:
         print(f"  role:         {cfg.role!r}")
     if "role_short" in patch:
-        print(f"  role_short:   {cfg.role_short!r}  (explicit)")
-    elif "role" in patch:
-        print(f"  role_short:   {cfg.role_short!r}  (server-derived)")
+        print(f"  role_short:   {cfg.role_short!r}  (derived from role)")
     return 0
 
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -37,6 +37,7 @@ from .state import (
     clear_daemon_pid,
     clear_stop_request,
     daemon_yml_path,
+    derive_role_short,
     daemon_pid_path,
     discover_agents,
     docker_shared_dir,
@@ -448,21 +449,9 @@ def _resolve_api_key_for_create(
 
 
 def _derive_role_short_cli(role: str) -> str:
-    """Local mirror of ``profiles::derive_role_short`` (server) +
-    ``_derive_role_short`` (bridge). Keeps the chip label in
-    agent.yml consistent with what the server stores when the
-    daemon syncs on first connect. See server-side validators for
-    the canonical contract."""
-    if ":" not in role:
-        return ""
-    head, tail = role.split(":", 1)
-    candidate = head.strip()
-    rest = tail.strip()
-    if not candidate or not rest or len(candidate) > 32:
-        return ""
-    if any(ch.isspace() for ch in candidate):
-        return ""
-    return candidate
+    """Thin wrapper over :func:`state.derive_role_short` — the single
+    canonical implementation (PUF-401). Kept for existing call-sites."""
+    return derive_role_short(role)
 
 
 def cmd_agent_create(args: argparse.Namespace) -> int:
@@ -498,7 +487,9 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     if role_short_raw and len(role_short_raw) > 32:
         print("error: --role-short must be at most 32 characters", file=sys.stderr)
         return 2
-    role_short = role_short_raw or (_derive_role_short_cli(role) if role else "")
+    # role_short is single-source-derived from role (PUF-401); --role-short
+    # is still accepted on the CLI (validated above) but ignored.
+    role_short = _derive_role_short_cli(role) if role else ""
 
     target.mkdir(parents=True)
 
@@ -971,14 +962,10 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
     if isinstance(role_arg, str):
         cfg.role = role_arg
         patch["role"] = role_arg
-        # Mirror the server-side derive locally so agent.yml stays
-        # in sync with what the server stores unless the caller
-        # explicitly overrides ``role_short`` below.
-        if not isinstance(role_short_arg, str):
-            cfg.role_short = _derive_role_short_cli(role_arg)
-    if isinstance(role_short_arg, str):
-        cfg.role_short = role_short_arg
-        patch["role_short"] = role_short_arg
+        # role_short is single-source-derived from role (PUF-401);
+        # --role-short is accepted but ignored (derive wins).
+        cfg.role_short = _derive_role_short_cli(role_arg)
+        patch["role_short"] = cfg.role_short
 
     cfg.save()
 

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -18,6 +18,7 @@ from ..state import (
     agent_yml_path,
     archive_flag_path,
     archived_dir,
+    derive_role_short,
     discover_agents,
     refresh_agent_flag_path,
     refresh_host_sync_flag_path,
@@ -268,6 +269,10 @@ async def execute_command(
         if isinstance(params.get("role"), str):
             cfg.role = params["role"]
             patch["role"] = params["role"]
+            # role_short is single-source-derived from role (PUF-401);
+            # keep it in lock-step so it never orphans on this write path.
+            cfg.role_short = derive_role_short(params["role"])
+            patch["role_short"] = cfg.role_short
             prompt_changed = True
         # avatar_url points to a blob the operator already uploaded; sync it to
         # the server identity (avatars are public, so no gating needed).

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -269,8 +269,6 @@ async def execute_command(
         if isinstance(params.get("role"), str):
             cfg.role = params["role"]
             patch["role"] = params["role"]
-            # role_short is single-source-derived from role (PUF-401);
-            # keep it in lock-step so it never orphans on this write path.
             cfg.role_short = derive_role_short(params["role"])
             patch["role_short"] = cfg.role_short
             prompt_changed = True

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -124,12 +124,8 @@ async def sync_full_profile(cfg: AgentConfig) -> None:
     ``# Soul`` section extracted from profile.md. Soul is omitted
     when profile.md is missing OR has no soul-like heading — the
     server's stored value is preserved rather than clobbered."""
-    # PUF-401 backfill: role_short is single-source-derived from role.
-    # An offline hand-edit or a legacy orphaned role-write can leave a
-    # stale role_short on disk; correct + persist it BEFORE syncing so a
-    # restart repairs the chip instead of reverting the server to the
-    # stale value. Idempotent: no write (no thrash) when they already
-    # match, and left untouched when role is empty.
+    # Repair a stale on-disk role_short BEFORE syncing, so a restart fixes
+    # the chip instead of pushing the stale value back to the server.
     if cfg.role:
         derived = derive_role_short(cfg.role)
         if cfg.role_short != derived:

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -10,7 +10,7 @@ import logging
 import time
 from typing import Any
 
-from .state import AgentConfig
+from .state import AgentConfig, derive_role_short
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +124,17 @@ async def sync_full_profile(cfg: AgentConfig) -> None:
     ``# Soul`` section extracted from profile.md. Soul is omitted
     when profile.md is missing OR has no soul-like heading — the
     server's stored value is preserved rather than clobbered."""
+    # PUF-401 backfill: role_short is single-source-derived from role.
+    # An offline hand-edit or a legacy orphaned role-write can leave a
+    # stale role_short on disk; correct + persist it BEFORE syncing so a
+    # restart repairs the chip instead of reverting the server to the
+    # stale value. Idempotent: no write (no thrash) when they already
+    # match, and left untouched when role is empty.
+    if cfg.role:
+        derived = derive_role_short(cfg.role)
+        if cfg.role_short != derived:
+            cfg.role_short = derived
+            cfg.save()
     patch: dict[str, Any] = {
         "display_name": cfg.display_name,
         "role": cfg.role,

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1042,13 +1042,9 @@ MAX_ROLE_SHORT_LEN = 32
 
 
 def derive_role_short(role: str) -> str:
-    """Canonical mirror of puffo-server's ``profiles::derive_role_short``:
-    pull a short chip label out of a ``<short>: <description>``-shaped role
-    string. Returns ``""`` for any shape the server would also reject (no
-    colon, empty prefix, whitespace in the prefix, empty suffix, prefix
-    longer than ``MAX_ROLE_SHORT_LEN``). ``role_short`` is single-source
-    derived from ``role`` (PUF-401); this is the one implementation — the
-    bridge and CLI wrappers delegate here."""
+    """Canonical mirror of puffo-server's ``derive_role_short``: the chip
+    label from a ``<short>: <description>`` role, or ``""`` for any shape the
+    server rejects. The single source — bridge/CLI wrappers delegate here."""
     if ":" not in role:
         return ""
     colon_pos = role.index(":")

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1038,6 +1038,31 @@ class RuntimeConfig:
     max_turns: int = 10
 
 
+MAX_ROLE_SHORT_LEN = 32
+
+
+def derive_role_short(role: str) -> str:
+    """Canonical mirror of puffo-server's ``profiles::derive_role_short``:
+    pull a short chip label out of a ``<short>: <description>``-shaped role
+    string. Returns ``""`` for any shape the server would also reject (no
+    colon, empty prefix, whitespace in the prefix, empty suffix, prefix
+    longer than ``MAX_ROLE_SHORT_LEN``). ``role_short`` is single-source
+    derived from ``role`` (PUF-401); this is the one implementation — the
+    bridge and CLI wrappers delegate here."""
+    if ":" not in role:
+        return ""
+    colon_pos = role.index(":")
+    candidate = role[:colon_pos].strip()
+    rest = role[colon_pos + 1:].strip()
+    if not candidate or not rest:
+        return ""
+    if len(candidate) > MAX_ROLE_SHORT_LEN:
+        return ""
+    if any(ch.isspace() for ch in candidate):
+        return ""
+    return candidate
+
+
 @dataclass
 class AgentConfig:
     """Contents of ~/.puffo-agent/agents/<id>/agent.yml.

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -757,8 +757,6 @@ class AgentDetail(QWidget):
 
         cfg.display_name = self._display_name.text().strip() or cfg.display_name
         cfg.role = role
-        # role_short is single-source-derived from role (PUF-401); the
-        # role_short field is accepted but ignored (derive wins).
         cfg.role_short = derive_role_short(role)
         cfg.runtime.kind = runtime_kind
         cfg.runtime.provider = provider

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -49,7 +49,7 @@ from ...runtime_matrix import (
     harness_applies,
     validate_triple,
 )
-from ...state import AgentConfig
+from ...state import AgentConfig, derive_role_short
 from ..names import resolve_display_name
 from .avatar import initial_pixmap
 
@@ -757,7 +757,9 @@ class AgentDetail(QWidget):
 
         cfg.display_name = self._display_name.text().strip() or cfg.display_name
         cfg.role = role
-        cfg.role_short = role_short
+        # role_short is single-source-derived from role (PUF-401); the
+        # role_short field is accepted but ignored (derive wins).
+        cfg.role_short = derive_role_short(role)
         cfg.runtime.kind = runtime_kind
         cfg.runtime.provider = provider
         cfg.runtime.harness = harness

--- a/tests/test_role_short_sync.py
+++ b/tests/test_role_short_sync.py
@@ -1,0 +1,241 @@
+"""PUF-401: role_short is single-source-derived from role.
+
+Covers the canonical ``derive_role_short`` (state.py), the thin
+bridge/CLI wrappers delegating to it, the control-WS role-write path
+that used to orphan role_short, and the daemon-startup backfill that
+repairs a stale role_short instead of reverting the server to it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from _bridge_support import isolated_home, write_test_agent  # noqa: E402
+
+from puffo_agent.portal.api.handlers import _derive_role_short  # noqa: E402
+from puffo_agent.portal.cli import _derive_role_short_cli  # noqa: E402
+from puffo_agent.portal.control.client import execute_command  # noqa: E402
+from puffo_agent.portal.profile_sync import sync_full_profile  # noqa: E402
+from puffo_agent.portal.state import AgentConfig, derive_role_short  # noqa: E402
+
+
+# ─── canonical derive_role_short (single source) ──────────────────
+
+
+def test_derive_role_short_edge_cases():
+    assert derive_role_short("coder: main puffo-core coder") == "coder"
+    assert derive_role_short("reviewer: code review specialist") == "reviewer"
+    # trailing whitespace before the colon is tolerated
+    assert derive_role_short("coder :  desc") == "coder"
+    # no colon → empty
+    assert derive_role_short("just a description") == ""
+    assert derive_role_short("") == ""
+    # empty prefix / empty suffix → empty
+    assert derive_role_short(": missing prefix") == ""
+    assert derive_role_short("only-prefix:") == ""
+    assert derive_role_short("only-prefix:   ") == ""
+    # whitespace inside the prefix → not a clean chip label
+    assert derive_role_short("two words: desc") == ""
+    # overlong prefix (>32 chars) → empty
+    assert derive_role_short("a" * 33 + ": x") == ""
+    # exactly 32 is accepted
+    assert derive_role_short("a" * 32 + ": x") == "a" * 32
+
+
+def test_wrappers_delegate_to_canonical():
+    """The bridge + CLI helpers must be thin wrappers — identical output
+    to the one canonical implementation for every shape."""
+    cases = [
+        "coder: main coder",
+        "plain text no colon",
+        ": empty-prefix",
+        "trailing:",
+        "two words: nope",
+        "a" * 33 + ": overlong",
+        "coder :  desc",
+        "",
+    ]
+    for c in cases:
+        assert _derive_role_short(c) == derive_role_short(c), c
+        assert _derive_role_short_cli(c) == derive_role_short(c), c
+
+
+# ─── control-WS role-write path no longer orphans role_short ───────
+
+
+@pytest.fixture()
+def home():
+    return isolated_home()
+
+
+@pytest.mark.asyncio
+async def test_control_edit_role_sets_derived_role_short(home, monkeypatch):
+    write_test_agent(home, "scout")
+
+    posted: dict = {}
+
+    async def _fake_sync(cfg, patch):
+        posted.update(patch)
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.api.handlers._sync_agent_profile", _fake_sync
+    )
+
+    res = await execute_command(
+        "edit", "scout", {"role": "CPO: chief product officer"}
+    )
+    assert res["ok"] is True
+
+    cfg = AgentConfig.load("scout")
+    assert cfg.role == "CPO: chief product officer"
+    # role_short is derived, not orphaned to the pre-edit value
+    assert cfg.role_short == "CPO"
+    # and the derived chip rides the server patch
+    assert posted["role"] == "CPO: chief product officer"
+    assert posted["role_short"] == "CPO"
+
+
+@pytest.mark.asyncio
+async def test_control_edit_role_without_colon_clears_chip(home, monkeypatch):
+    write_test_agent(home, "scout")
+    monkeypatch.setattr(
+        "puffo_agent.portal.api.handlers._sync_agent_profile",
+        _noop_sync,
+    )
+    res = await execute_command("edit", "scout", {"role": "researcher"})
+    assert res["ok"] is True
+    cfg = AgentConfig.load("scout")
+    assert cfg.role == "researcher"
+    assert cfg.role_short == ""
+
+
+async def _noop_sync(cfg, patch):
+    return None
+
+
+# ─── daemon-startup backfill (the load-bearing no-revert fix) ──────
+
+
+def _write_agent_with_roles(home: str, agent_id: str, role: str, role_short: str):
+    write_test_agent(home, agent_id)
+    cfg = AgentConfig.load(agent_id)
+    cfg.role = role
+    cfg.role_short = role_short
+    cfg.save()
+    return cfg
+
+
+class _FakeHttp:
+    posted: list[dict] = []
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def patch(self, path, body):
+        _FakeHttp.posted.append(body)
+        return {}
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_startup_backfill_repairs_stale_role_short(monkeypatch):
+    home = isolated_home()
+    # Stale on-disk orphan: role updated to a CPO role but role_short
+    # still carries a previous "Receptionist" chip.
+    _write_agent_with_roles(
+        home, "chip-bot", "CPO: chief product officer", "Receptionist"
+    )
+    _FakeHttp.posted = []
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient", _FakeHttp
+    )
+
+    cfg = AgentConfig.load("chip-bot")
+    await sync_full_profile(cfg)
+
+    # persisted to agent.yml
+    reloaded = AgentConfig.load("chip-bot")
+    assert reloaded.role_short == "CPO"
+    # corrected value synced to the server, not the stale one
+    assert _FakeHttp.posted[-1]["role_short"] == "CPO"
+    # role itself untouched
+    assert reloaded.role == "CPO: chief product officer"
+
+
+@pytest.mark.asyncio
+async def test_startup_backfill_idempotent(monkeypatch):
+    home = isolated_home()
+    _write_agent_with_roles(
+        home, "chip-bot", "CPO: chief product officer", "CPO"
+    )
+    _FakeHttp.posted = []
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient", _FakeHttp
+    )
+
+    cfg = AgentConfig.load("chip-bot")
+    mtime_before = os.path.getmtime(
+        os.path.join(home, "agents", "chip-bot", "agent.yml")
+    )
+    await sync_full_profile(cfg)
+    mtime_after = os.path.getmtime(
+        os.path.join(home, "agents", "chip-bot", "agent.yml")
+    )
+    # already matched → no rewrite (no thrash)
+    assert mtime_before == mtime_after
+    assert AgentConfig.load("chip-bot").role_short == "CPO"
+
+
+@pytest.mark.asyncio
+async def test_startup_backfill_skips_empty_role(monkeypatch):
+    home = isolated_home()
+    # role empty, role_short empty → nothing to derive, no write
+    write_test_agent(home, "blank-bot")
+    _FakeHttp.posted = []
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient", _FakeHttp
+    )
+    cfg = AgentConfig.load("blank-bot")
+    await sync_full_profile(cfg)
+    reloaded = AgentConfig.load("blank-bot")
+    assert reloaded.role == ""
+    assert reloaded.role_short == ""
+
+
+@pytest.mark.asyncio
+async def test_startup_backfill_preserves_behavior_fields(monkeypatch):
+    """Non-regression: the backfill touches only role_short — soul /
+    profile.md long role / triggers / runtime are unchanged."""
+    home = isolated_home()
+    _write_agent_with_roles(
+        home, "chip-bot", "CPO: chief product officer", "stale"
+    )
+    profile_path = AgentConfig.load("chip-bot").resolve_profile_path()
+    profile_path.write_text(
+        "# chip-bot\n\n# Soul\n\nI lead product.\n", encoding="utf-8"
+    )
+    before_triggers = AgentConfig.load("chip-bot").triggers
+    before_runtime_kind = AgentConfig.load("chip-bot").runtime.kind
+
+    _FakeHttp.posted = []
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.PuffoCoreHttpClient", _FakeHttp
+    )
+    cfg = AgentConfig.load("chip-bot")
+    await sync_full_profile(cfg)
+
+    reloaded = AgentConfig.load("chip-bot")
+    assert reloaded.role_short == "CPO"
+    # behavior fields intact
+    assert reloaded.triggers == before_triggers
+    assert reloaded.runtime.kind == before_runtime_kind
+    # soul section still in profile.md; synced body unchanged
+    assert profile_path.read_text(encoding="utf-8").count("# Soul") == 1
+    assert _FakeHttp.posted[-1]["soul"] == "I lead product."

--- a/tests/test_role_short_sync.py
+++ b/tests/test_role_short_sync.py
@@ -339,3 +339,30 @@ def test_cli_agent_profile_warns_on_explicit_role_short(
     assert "BOGUS" in err
     # derive still wins on disk
     assert AgentConfig.load("chip-bot").role_short == "coder"
+
+
+def test_cli_agent_create_warns_on_explicit_role_short(monkeypatch, capsys):
+    isolated_home()
+    monkeypatch.setattr(
+        "puffo_agent.portal.cli._resolve_api_key_for_create", lambda **k: ""
+    )
+    args = argparse.Namespace(
+        id="chip-bot",
+        runtime="chat-local",
+        provider=None,
+        api_key=None,
+        model=None,
+        role="coder: main puffo-core coder",
+        role_short="BOGUS",
+        display_name=None,
+        no_mention=False,
+        no_dm=False,
+        profile=None,
+    )
+    from puffo_agent.portal.cli import cmd_agent_create
+
+    assert cmd_agent_create(args) == 0
+    err = capsys.readouterr().err
+    assert "deprecated (PUF-401)" in err
+    assert "BOGUS" in err
+    assert AgentConfig.load("chip-bot").role_short == "coder"

--- a/tests/test_role_short_sync.py
+++ b/tests/test_role_short_sync.py
@@ -1,10 +1,4 @@
-"""PUF-401: role_short is single-source-derived from role.
-
-Covers the canonical ``derive_role_short`` (state.py), the thin
-bridge/CLI wrappers delegating to it, the control-WS role-write path
-that used to orphan role_short, and the daemon-startup backfill that
-repairs a stale role_short instead of reverting the server to it.
-"""
+"""role_short is single-source-derived from role, on every write path."""
 
 from __future__ import annotations
 
@@ -254,12 +248,7 @@ async def test_startup_backfill_preserves_behavior_fields(monkeypatch):
     assert _FakeHttp.posted[-1]["soul"] == "I lead product."
 
 
-# ─── deprecated explicit-override → accept-but-warn (PUF-401) ──────
-# The bridge PATCH and the CLI `agent profile` are the two live
-# override surfaces; both now derive authoritatively and log a
-# deprecation warning when a differing explicit role_short is dropped
-# (never silently). Provision + `agent create` share this exact
-# derive-and-warn logic.
+# ─── deprecated explicit-override → accept-but-warn ───────────────
 
 
 _HOST = {"Host": "127.0.0.1:63387"}

--- a/tests/test_role_short_sync.py
+++ b/tests/test_role_short_sync.py
@@ -8,6 +8,8 @@ repairs a stale role_short instead of reverting the server to it.
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
 import sys
 
@@ -15,7 +17,18 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from _bridge_support import isolated_home, write_test_agent  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+from _bridge_support import (  # noqa: E402
+    isolated_home,
+    make_user,
+    pair_request_body,
+    signed_headers,
+    write_test_agent,
+)
+from puffo_agent.crypto.encoding import base64url_encode  # noqa: E402
+from puffo_agent.portal.api.server import build_app  # noqa: E402
+from puffo_agent.portal.state import DaemonConfig  # noqa: E402
 
 from puffo_agent.portal.api.handlers import _derive_role_short  # noqa: E402
 from puffo_agent.portal.cli import _derive_role_short_cli  # noqa: E402
@@ -239,3 +252,90 @@ async def test_startup_backfill_preserves_behavior_fields(monkeypatch):
     # soul section still in profile.md; synced body unchanged
     assert profile_path.read_text(encoding="utf-8").count("# Soul") == 1
     assert _FakeHttp.posted[-1]["soul"] == "I lead product."
+
+
+# ─── deprecated explicit-override → accept-but-warn (PUF-401) ──────
+# The bridge PATCH and the CLI `agent profile` are the two live
+# override surfaces; both now derive authoritatively and log a
+# deprecation warning when a differing explicit role_short is dropped
+# (never silently). Provision + `agent create` share this exact
+# derive-and-warn logic.
+
+
+_HOST = {"Host": "127.0.0.1:63387"}
+
+
+@pytest.mark.asyncio
+async def test_bridge_update_profile_warns_on_explicit_role_short(
+    monkeypatch, caplog
+):
+    home = isolated_home()
+    user = make_user()
+    write_test_agent(
+        home,
+        "chip-bot",
+        owner_root_pubkey=base64url_encode(user.root_key.public_key_bytes()),
+    )
+
+    async def _noop_sync(cfg, patch):
+        return None
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.api.handlers._sync_agent_profile", _noop_sync
+    )
+
+    app = build_app(DaemonConfig().bridge)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        body = pair_request_body(user)
+        h = signed_headers(user, "POST", "/v1/pair", body)
+        h.update(_HOST)
+        assert (await c.post("/v1/pair", data=body, headers=h)).status == 200
+
+        payload = json.dumps(
+            {"role": "coder: main puffo-core coder", "role_short": "BOGUS"}
+        ).encode("utf-8")
+        h = signed_headers(
+            user, "PATCH", "/v1/agents/chip-bot/profile", payload
+        )
+        h.update(_HOST)
+        h["content-type"] = "application/json"
+        with caplog.at_level("WARNING"):
+            r = await c.patch(
+                "/v1/agents/chip-bot/profile", data=payload, headers=h
+            )
+        assert r.status == 200, await r.text()
+        # derived value wins over the explicit override
+        assert (await r.json())["role_short"] == "coder"
+    # the drop is announced, not silent
+    assert "deprecated (PUF-401)" in caplog.text
+    assert "BOGUS" in caplog.text
+
+
+def test_cli_agent_profile_warns_on_explicit_role_short(
+    monkeypatch, capsys
+):
+    home = isolated_home()
+    write_test_agent(home, "chip-bot")
+
+    async def _noop_sync(cfg, patch):
+        return None
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.profile_sync.sync_agent_profile", _noop_sync
+    )
+
+    args = argparse.Namespace(
+        id="chip-bot",
+        role="coder: main puffo-core coder",
+        role_short="BOGUS",
+        display_name=None,
+    )
+    from puffo_agent.portal.cli import cmd_agent_profile
+
+    assert cmd_agent_profile(args) == 0
+    err = capsys.readouterr().err
+    assert "deprecated (PUF-401)" in err
+    assert "BOGUS" in err
+    # derive still wins on disk
+    assert AgentConfig.load("chip-bot").role_short == "coder"


### PR DESCRIPTION
Fixes the daemon-side `role_short` orphan: `agent.yml:role_short` was never updated on `role` write paths, so long-form role updates left the chip stale. On daemon restart, the stale value was synced to the server → UI reverted the display after every restart.

## Root cause

- `control/client.py:269` updated `role` + patched it, but left `role_short` untouched
- Startup sync then re-pushed the stale `role_short` to the server
- Verified on live agents (e.g. Equation's `agent.yml`: long-form `CPO: …` correct, short still `Receptionist`)

## Fix (Option A — single-source)

- `state.derive_role_short(role: str) -> str` — the one canonical implementation, mirroring puffo-server's `derive_role_short`
- Existing dup helpers (`handlers._derive_role_short`, `cli._derive_role_short_cli`) now delegate to the canonical impl
- Wired into every `role`-write site (control-WS, bridge PATCH, CLI create/profile, provision, desktop agent_detail) so no path can orphan again
- **Startup backfill** in `profile_sync`: before syncing, if `cfg.role_short != derive(cfg.role)` (and `role` non-empty), update + persist + sync the corrected value — repairs pre-existing orphans without a manual edit. Idempotent when they already match.
- Explicit `--role-short` / bridge `role_short` param **deprecated, not removed** — validation preserved; incoming values get a `deprecated (PUF-401)` warning and are dropped in favor of the derived value

## Tests

- `tests/test_role_short_sync.py` — 10 tests locally green:
  - derive edge cases (colon / no-colon / empty-prefix / empty-suffix / whitespace-in-prefix / exactly-32 / over-32)
  - wrapper delegation identity
  - control-WS role edit derives + role-without-colon clears chip
  - startup backfill: repairs stale, idempotent, skips empty role, preserves other fields
  - deprecation warning fires on explicit role_short override (bridge + CLI)

## Solution QA — pass

- `pytest tests/test_role_short_sync.py` **10/10 pass** locally (Python 3.14, PYTHONPATH src)
- All `role_short =` and `patch["role_short"]` write sites verified to route through the derive helper (grep swept)
- Startup backfill correctly runs BEFORE the sync PATCH so the corrected value hits the server, not the stale one
- Non-regression: soul / profile.md / triggers / runtime untouched (backfill only sets `role_short`)
- Deprecation path is accept-and-warn, not silent-drop — existing clients still see their explicit value ignored but with a visible log

🤖 Generated with [Claude Code](https://claude.com/claude-code)