### PR TITLE
fix(cli): rotate the CLI session when the agent's model changes (PUF-159)

### DIFF
--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -192,6 +192,7 @@ class ClaudeSession:
         env: Optional[dict[str, str]] = None,
         audit: Optional["AuditLog"] = None,
         extra_args: Optional[list[str]] = None,
+        model: str = "",
     ):
         """
         ``build_command(extra_args, env_overrides)`` returns the full
@@ -203,6 +204,15 @@ class ClaudeSession:
 
         ``audit`` is optional; when set, each turn appends structured
         events for operators to tail.
+
+        ``model`` scopes the persisted session to the model that
+        produced it: a transcript born under one model must not be
+        ``--resume``d under another. Cross-family replay injects the
+        old model's thinking blocks into the new provider's API — a
+        kimi-born session resumed under an Anthropic model makes
+        claude-code send ``clear_thinking_20251015`` without thinking
+        enabled, and every turn 400s until the session rotates
+        (PUF-159). Empty = legacy behavior (no scoping).
         """
         self.agent_id = agent_id
         self.session_file = session_file
@@ -210,6 +220,7 @@ class ClaudeSession:
         self.cwd = cwd
         self.env = env
         self.audit = audit
+        self.model = (model or "").strip()
         # Extra claude CLI flags re-applied on every spawn (typically
         # --mcp-config / --permission-prompt-tool).
         self.extra_args = list(extra_args or [])
@@ -412,11 +423,27 @@ class ClaudeSession:
             data = json.loads(self.session_file.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             return ""
+        stored_model = (data.get("model") or "").strip()
+        if self.model and stored_model and stored_model != self.model:
+            # Model changed since this transcript was recorded — resuming
+            # it would replay the old model's thinking blocks into the new
+            # provider (PUF-159). Rotate: drop the file, start fresh.
+            logger.info(
+                "agent %s: model changed %s -> %s; rotating CLI session %s",
+                self.agent_id,
+                stored_model,
+                self.model,
+                (data.get("session_id") or "")[:8],
+            )
+            self._clear_session_file()
+            return ""
         return (data.get("session_id") or "").strip()
 
     def _save_session_id(self, sid: str) -> None:
         self._session_id = sid
         data = {"session_id": sid, "updated_at": int(time.time())}
+        if self.model:
+            data["model"] = self.model
         self.session_file.parent.mkdir(parents=True, exist_ok=True)
         tmp = self.session_file.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -424,6 +451,9 @@ class ClaudeSession:
 
     def _clear_session_id(self) -> None:
         self._session_id = ""
+        self._clear_session_file()
+
+    def _clear_session_file(self) -> None:
         try:
             self.session_file.unlink()
         except OSError:

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -697,6 +697,7 @@ class DockerCLIAdapter(Adapter):
                 self.agent_id,
             ),
             extra_args=extra,
+            model=self.model,
         )
         return self._session
 

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -805,6 +805,7 @@ class LocalCLIAdapter(Adapter):
                 self.agent_id,
             ),
             extra_args=extra,
+            model=self.model,
         )
         return self._session
 

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -798,3 +798,79 @@ def test_drain_swallows_readline_error_and_hands_off_to_main_loop(tmp_path):
     out = asyncio.run(drive())
     assert out.metadata.get("stream_error") == "readline_limit"
     assert out.reply == ""
+
+
+# ── Session rotation on model change (PUF-159) ───────────────────────────────
+#
+# A transcript born under one model must not be --resume'd under another:
+# cross-family replay injects the old model's thinking blocks into the new
+# provider's API (a kimi-born session resumed under an Anthropic model makes
+# claude-code send clear_thinking_20251015 without thinking enabled → 400 on
+# every turn until the session rotates).
+
+
+def _write_session_file(tmp_path: Path, sid: str, model: str | None) -> Path:
+    data: dict = {"session_id": sid, "updated_at": 1}
+    if model is not None:
+        data["model"] = model
+    f = tmp_path / "session.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    return f
+
+
+def _make_model_session(tmp_path: Path, model: str) -> ClaudeSession:
+    return ClaudeSession(
+        agent_id="test-agent",
+        session_file=tmp_path / "session.json",
+        build_command=lambda args: ["true"],
+        cwd=str(tmp_path),
+        env={},
+        audit=None,
+        model=model,
+    )
+
+
+def test_session_rotates_when_model_changed(tmp_path, caplog):
+    _write_session_file(tmp_path, "sess-kimi", "kimi-k3")
+    with caplog.at_level(logging.INFO):
+        session = _make_model_session(tmp_path, "claude-opus-4-7")
+    assert session._session_id == ""  # fresh session, no --resume
+    assert not (tmp_path / "session.json").exists()  # stale file dropped
+    assert "rotating CLI session" in caplog.text
+
+
+def test_session_kept_when_model_unchanged(tmp_path):
+    _write_session_file(tmp_path, "sess-opus", "claude-opus-4-7")
+    session = _make_model_session(tmp_path, "claude-opus-4-7")
+    assert session._session_id == "sess-opus"
+    assert (tmp_path / "session.json").exists()
+
+
+def test_legacy_session_file_without_model_is_kept(tmp_path):
+    # Pre-PUF-159 files carry no model — keep them (one gratuitous reset per
+    # fleet on upgrade would be worse); the model lands on the next save.
+    _write_session_file(tmp_path, "sess-legacy", None)
+    session = _make_model_session(tmp_path, "claude-opus-4-7")
+    assert session._session_id == "sess-legacy"
+
+
+def test_session_kept_when_no_model_configured(tmp_path):
+    # model="" (legacy caller) → scoping disabled entirely.
+    _write_session_file(tmp_path, "sess-any", "kimi-k3")
+    session = _make_model_session(tmp_path, "")
+    assert session._session_id == "sess-any"
+
+
+def test_save_records_model(tmp_path):
+    session = _make_model_session(tmp_path, "claude-opus-4-7")
+    session._save_session_id("sess-new")
+    data = json.loads((tmp_path / "session.json").read_text(encoding="utf-8"))
+    assert data["session_id"] == "sess-new"
+    assert data["model"] == "claude-opus-4-7"
+
+
+def test_save_omits_model_when_unset(tmp_path):
+    session = _make_model_session(tmp_path, "")
+    session._save_session_id("sess-new")
+    data = json.loads((tmp_path / "session.json").read_text(encoding="utf-8"))
+    assert "model" not in data


### PR DESCRIPTION
## Problem
The cli-local / cli-docker adapters persist **one claude-code session per agent** (`cli_session.json`) and resume it across model changes. A session transcript born under one model, resumed under another, replays the old model's thinking blocks into the new provider's API. Concretely (staging cloud agent `alice-5911-5038c04f`): a kimi-born session resumed under sonnet/opus makes claude-code 2.1.212 attach `clear_thinking_20251015` without `thinking` enabled — real Anthropic rejects **every** turn (`invalid_request_error`), the worker retries 3×, abandons the thread (`api_error_abandoned`), and the agent posts Error. OpenRouter's compat endpoint ignores the field, which is why kimi→kimi switches never tripped it.

Proven by live repro in the sandbox: fresh session + opus on the same VK/gateway → works; daemon-style resume (`CLAUDE_CONFIG_DIR` + workspace cwd + `--resume`) → the exact 400. VK scope, gateway config, and CLI version all ruled out (identical between working and failing sandboxes).

Closes PUF-159.

## Fix
`ClaudeSession` records the **model** that produced the session alongside its id. On load, a mismatch between the stored and current model drops the file and starts a fresh session (logged: `model changed X -> Y; rotating CLI session`). `local_cli` and `docker_cli` thread `self.model` in.

Back-compat is deliberate: legacy `cli_session.json` files without a `model` key are kept (no gratuitous fleet-wide session reset on upgrade — the model lands on the next save), and callers that pass no model get today's behavior unchanged.

Not covered (follow-up candidates): the hermes/gemini session path in `docker_cli` writes its own session file and could grow the same scoping; cross-provider switches also need a harness/template rebuild (tracked separately).

## Tests
6 new: rotate on change, keep on match, legacy-file compat, no-model compat, model recorded on save, omitted when unset. Full suite 2181 passed / 2 skipped (`test_host_credentials` failures pre-exist on clean main — verified by stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)