### PR TITLE
chore(release): prepare 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.6] — 2026-07-28
+
 ### Changed
 
 - **`role_short` is now single-source-derived from `role` (PUF-401).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.1.5"
+version = "1.1.6"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Preps the **1.1.6** release.

- `pyproject.toml`: `version` 1.1.5 → 1.1.6
- `CHANGELOG.md`: roll the `[Unreleased]` entries into a dated `## [1.1.6] — 2026-07-28` section

### Shipping in 1.1.6

**Changed**
- `role_short` is now single-source-derived from `role` (PUF-401) — chip label always derived on every write path; explicit `role_short`/`--role-short` deprecated (accepted-but-ignored + warn); daemon-startup backfill repairs stale on-disk values (#205).
- Default agent task timeout raised 600s → 1800s / 30 min (PUF-399) (#204).

**Added**
- Plaintext (non-E2EE) sending by default, with per-send E2EE preservation when the turn/thread is encrypted.

**Fixed**
- Cap `mcp` below 2.0 — the 2.x SDK dropped bundled `mcp.server.fastmcp` (#205).

After merge: create the GitHub Release `v1.1.6` off `main` to fire the PyPI publish workflow (per the release-puffo-agent flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)