### PR TITLE
fix(skills): one skill-id rule, and make it newline-tight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Skill ids ending in a newline are no longer accepted.** The daemon
+  validated ids with Python's `$`, which also matches immediately before
+  a trailing newline, so a name like `my-skill\n` passed on its way to
+  `.claude/skills/` while the server's own constraint rejected it. The
+  gap was reachable — `install_skill` takes its name from an
+  agent-supplied tool call. The anchor is now `\Z`, matching the server.
+  The two copies of the rule, in the desired-skill installer and the MCP
+  host tools, were also folded into one shared constant so they can't
+  drift apart again.
+
 ## [1.1.6] — 2026-07-28
 
 ### Changed

--- a/src/puffo_agent/agent/adapters/desired_install.py
+++ b/src/puffo_agent/agent/adapters/desired_install.py
@@ -19,15 +19,12 @@ from pathlib import Path
 from typing import Any
 
 from ...crypto.http_client import HttpError, PuffoCoreHttpClient
+from ...skill_ids import SKILL_ID_RE
 from ..shared_content import _strip_puffo_mcp_prefix_for_codex
 
 logger = logging.getLogger(__name__)
 
 
-# Skill ids that pass the host_tools regex; tightens the picker
-# wire to the same charset the on-disk installer accepts so a
-# malformed id can't escape into a stray directory write.
-_SKILL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _MCP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 
 
@@ -106,7 +103,7 @@ def _write_skill_to_dir(
 ) -> str:
     """Idempotent write of a SKILL.md + provenance marker to ``skill_dir``.
     Returns ``"installed"`` / ``"already-present"`` / ``"invalid"``."""
-    if not _SKILL_ID_RE.match(template_id):
+    if not SKILL_ID_RE.match(template_id):
         logger.warning("desired skill %r: invalid id — skipping", template_id)
         return "invalid"
     if not body or not body.strip():

--- a/src/puffo_agent/mcp/host_tools.py
+++ b/src/puffo_agent/mcp/host_tools.py
@@ -19,8 +19,8 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from ..skill_ids import SKILL_ID_RE
 
-_SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 
 # Provenance markers dropped inside every skill directory. Claude
 # Code only executes ``SKILL.md``, so siblings are inert unless
@@ -169,7 +169,7 @@ def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
 
 
 def _install_skill(workspace: Path, name: str, content: str) -> Path:
-    if not _SKILL_NAME_RE.match(name or ""):
+    if not SKILL_ID_RE.match(name or ""):
         raise RuntimeError(
             f"invalid skill name {name!r}: must be lowercase letters, "
             "digits, and hyphens (max 64 chars, can't start with a hyphen)"
@@ -186,7 +186,7 @@ def _install_skill(workspace: Path, name: str, content: str) -> Path:
 
 
 def _uninstall_skill(workspace: Path, name: str) -> Path:
-    if not _SKILL_NAME_RE.match(name or ""):
+    if not SKILL_ID_RE.match(name or ""):
         raise RuntimeError(f"invalid skill name {name!r}")
     dst = _workspace_skills_dir(workspace) / name
     if not dst.is_dir():

--- a/src/puffo_agent/skill_ids.py
+++ b/src/puffo_agent/skill_ids.py
@@ -1,14 +1,11 @@
 """Shared skill-id rule — single definition, imported everywhere.
 
-Also spelled as a ``CHECK`` constraint on ``skill_templates`` in puffo-server
-migration 038. That copy can't import this one and can't be edited either
-(sqlx checksums applied migrations), so the two are kept in step by hand.
+Also a ``CHECK`` on ``skill_templates`` in puffo-server migration 038, which
+can't import this and can't be edited (sqlx checksums applied migrations).
 """
 
 import re
 
-# Both the catalog id and the ``.claude/skills/<id>/`` folder name, so a
-# malformed id can't escape into a stray directory write. ``\Z`` not ``$``:
-# Python's ``$`` also matches before a trailing newline, so ``"ok-id\n"``
-# would pass here and be rejected by the SQL copy.
+# ``\Z`` not ``$``: Python's ``$`` also matches before a trailing newline, so
+# ``"ok-id\n"`` would pass here and be rejected by the SQL copy.
 SKILL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}\Z")

--- a/src/puffo_agent/skill_ids.py
+++ b/src/puffo_agent/skill_ids.py
@@ -1,0 +1,14 @@
+"""Shared skill-id rule — single definition, imported everywhere.
+
+Also spelled as a ``CHECK`` constraint on ``skill_templates`` in puffo-server
+migration 038. That copy can't import this one and can't be edited either
+(sqlx checksums applied migrations), so the two are kept in step by hand.
+"""
+
+import re
+
+# Both the catalog id and the ``.claude/skills/<id>/`` folder name, so a
+# malformed id can't escape into a stray directory write. ``\Z`` not ``$``:
+# Python's ``$`` also matches before a trailing newline, so ``"ok-id\n"``
+# would pass here and be rejected by the SQL copy.
+SKILL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}\Z")

--- a/tests/test_skill_ids.py
+++ b/tests/test_skill_ids.py
@@ -51,6 +51,6 @@ def test_the_end_anchor_is_newline_tight():
 
 
 def test_pattern_matches_the_sql_check_verbatim():
-    """Migration 038 can't import this, and sqlx checksums forbid editing it —
-    so pin the charset here and fail loudly if either side drifts."""
-    assert SKILL_ID_RE.pattern == r"^[a-z0-9][a-z0-9-]{0,63}\Z"
+    assert SKILL_ID_RE.pattern == r"^[a-z0-9][a-z0-9-]{0,63}\Z", (
+        "charset drifted from the CHECK in puffo-server migration 038"
+    )

--- a/tests/test_skill_ids.py
+++ b/tests/test_skill_ids.py
@@ -1,0 +1,56 @@
+import pytest
+
+from puffo_agent.agent.adapters import desired_install
+from puffo_agent.mcp import host_tools
+from puffo_agent.skill_ids import SKILL_ID_RE
+
+
+def test_both_call_sites_share_one_object():
+    assert host_tools.SKILL_ID_RE is SKILL_ID_RE
+    assert desired_install.SKILL_ID_RE is SKILL_ID_RE
+
+
+@pytest.mark.parametrize(
+    "ok",
+    [
+        "interview-me",
+        "planning-and-task-breakdown",
+        "continuous-learning-v2",
+        "benchmark",
+        "a",
+        "0",
+        "a" * 64,
+    ],
+)
+def test_accepts_catalog_ids(ok):
+    assert SKILL_ID_RE.match(ok)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "-leading-hyphen",
+        "WithCaps",
+        "under_score",
+        "with.dot",
+        "with space",
+        "../etc/passwd",
+        "a" * 65,
+        "ok-id\n",
+        "ok\nevil",
+    ],
+)
+def test_rejects_everything_else(bad):
+    assert not SKILL_ID_RE.match(bad)
+
+
+def test_the_end_anchor_is_newline_tight():
+    """``$`` would accept this; the SQL CHECK in migration 038 does not."""
+    assert not SKILL_ID_RE.match("interview-me\n")
+
+
+def test_pattern_matches_the_sql_check_verbatim():
+    """Migration 038 can't import this, and sqlx checksums forbid editing it —
+    so pin the charset here and fail loudly if either side drifts."""
+    assert SKILL_ID_RE.pattern == r"^[a-z0-9][a-z0-9-]{0,63}\Z"


### PR DESCRIPTION
The skill-id charset was written out three times: `_SKILL_ID_RE` in `agent/adapters/desired_install.py`, `_SKILL_NAME_RE` in `mcp/host_tools.py`, and a `CHECK (id ~ …)` on `skill_templates` in puffo-server migration 038. Nothing kept them in step.

The two Python copies now import `puffo_agent.skill_ids.SKILL_ID_RE`, sitting alongside `limits.py` with the same "single definition, imported everywhere" shape.

## The third copy stays where it is

Migration 038 can't import Python, and it can't be edited either — sqlx stores a checksum per applied migration in `_sqlx_migrations` and refuses to start when one drifts, so touching it would break every deployed database. The module docstring says so, and a test pins the pattern string to fail loudly if either side moves.

## Unifying them surfaced a real divergence

Python's `$` also matches immediately before a trailing newline. Postgres's `~` does not:

```
'ok-id'    → python True   postgres t
'ok-id\n'  → python True   postgres f      ← the gap
```

So `"ok-id\n"` passed the daemon's check and would be rejected by the catalog's. That's reachable, not theoretical: `install_skill` in `host_tools.py` takes its name from an agent-supplied MCP tool call, and the name becomes a directory under `.claude/skills/`. Anchored with `\Z` instead of `$`, which is exactly the SQL semantics.

The pattern string now reads `^[a-z0-9][a-z0-9-]{0,63}\Z` rather than `…$` — semantically identical to the SQL, textually one character off from it, and the comment says why.

## Tests

New `tests/test_skill_ids.py`:

- both call sites resolve to the same compiled object (this is what stops them re-forking)
- accepts real catalog ids — `interview-me`, `planning-and-task-breakdown`, `continuous-learning-v2` — plus the boundaries `a`, `0`, 64 chars
- rejects empty, leading hyphen, caps, underscore, dot, space, `../etc/passwd`, 65 chars, `ok-id\n`, `ok\nevil`
- a dedicated newline-tightness case, so a future revert to `$` fails with a message naming migration 038
- the pattern-string pin

The existing rejection tests at both call sites (`test_agent_install.py::test_install_skill_rejects_invalid_names`, `test_local_cli_desired_install.py::test_write_desired_skill_rejects_invalid_id`) already prove the shared constant is wired through correctly, and still pass unchanged.

`PYTHONPATH=src python -m pytest`: no failures — only the pre-existing platform skips (symlinks / posix permission bits unavailable on this host).

## Follow-up, not here

`server/src/v2/skill_templates/types.rs` documents the id as "Matches the daemon's `_SKILL_NAME_RE`" — that name no longer exists. One-line fix, different repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyvHzX7gbRitsFXC3YQtcW
