### PR TITLE
feat(send): channel is_encrypted drives the outbound channel format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Channel sends follow the channel's format policy.** The channel's
+  `is_encrypted` field alone decides sealed vs signed-plaintext for channel
+  sends; DMs stay encrypted and the agent cannot choose the format. The
+  policy is cached (disk + memory), kept live by `channel_update` frames,
+  and a `CHANNEL_FORMAT_MISMATCH` rejection refreshes the policy once and
+  resends in the channel's current format. (#212)
+
 ## [2.0.0] - 2026-08-23
 
 > Stable Agent Foundation 2.0 release, promoted from `2.0.0a25` without

--- a/src/puffo_agent/agent/channel_format.py
+++ b/src/puffo_agent/agent/channel_format.py
@@ -1,0 +1,22 @@
+"""Channel format policy: channels.is_encrypted drives the outbound format.
+
+Fail-safe: an unknown or missing policy answers encrypted.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ..crypto.http_client import HttpError
+
+CHANNEL_FORMAT_MISMATCH = "CHANNEL_FORMAT_MISMATCH"
+
+
+def is_channel_format_mismatch(exc: Exception) -> bool:
+    if not isinstance(exc, HttpError) or exc.status != 400:
+        return False
+    try:
+        body = json.loads(exc.body or "{}")
+    except (TypeError, ValueError):
+        return False
+    return isinstance(body, dict) and body.get("error") == CHANNEL_FORMAT_MISMATCH

--- a/src/puffo_agent/agent/client_setup.py
+++ b/src/puffo_agent/agent/client_setup.py
@@ -99,6 +99,7 @@ def _cache_state() -> dict[str, Any]:
         "_warm_task": None,
         "_space_name_cache": {},
         "_channel_name_cache": {},
+        "_channel_encrypted": {},
         "_space_members": {},
     }
 

--- a/src/puffo_agent/agent/directory_cache.py
+++ b/src/puffo_agent/agent/directory_cache.py
@@ -173,6 +173,7 @@ async def warm_channels_for_space(
     store: Any,
     channel_spaces: dict[str, str],
     channel_names: dict[str, str],
+    channel_policies: dict[str, bool] | None = None,
 ) -> None:
     try:
         response = await http.get(f"/spaces/{space_id}/channels")
@@ -184,9 +185,13 @@ async def warm_channels_for_space(
         if not channel_id:
             continue
         channel_spaces.setdefault(channel_id, space_id)
+        # Missing/legacy policy fails safe to encrypted.
+        is_encrypted = channel.get("is_encrypted") is not False
+        if channel_policies is not None:
+            channel_policies[channel_id] = is_encrypted
         if name:
             channel_names.setdefault(channel_id, name)
-            disk_cache.persist_channel(channel_id, name, space_id)
+            disk_cache.persist_channel(channel_id, name, space_id, is_encrypted)
         try:
             await store.mark_channel_space(channel_id, space_id)
         except Exception:

--- a/src/puffo_agent/agent/disk_cache.py
+++ b/src/puffo_agent/agent/disk_cache.py
@@ -79,18 +79,31 @@ def persist_space(space_id: str, name: str) -> None:
         logger.debug("persist_space(%s) failed: %s", space_id, exc)
 
 
-def persist_channel(channel_id: str, name: str, space_id: str = "") -> None:
+def persist_channel(
+    channel_id: str,
+    name: str,
+    space_id: str = "",
+    is_encrypted: bool | None = None,
+) -> None:
     if not channel_id or not name:
         return
     try:
+        payload = {
+            "channel_id": channel_id,
+            "name": name,
+            "space_id": space_id,
+            "fetched_at": int(time.time()),
+        }
+        if is_encrypted is None:
+            # Preserve a previously persisted policy.
+            existing = (load_channel(channel_id) or {}).get("is_encrypted")
+            if isinstance(existing, bool):
+                payload["is_encrypted"] = existing
+        else:
+            payload["is_encrypted"] = bool(is_encrypted)
         _atomic_write_json(
             _cache_root() / "channels" / f"{_safe(channel_id)}.json",
-            {
-                "channel_id": channel_id,
-                "name": name,
-                "space_id": space_id,
-                "fetched_at": int(time.time()),
-            },
+            payload,
         )
     except OSError as exc:
         logger.debug("persist_channel(%s) failed: %s", channel_id, exc)

--- a/src/puffo_agent/agent/membership_events.py
+++ b/src/puffo_agent/agent/membership_events.py
@@ -71,6 +71,7 @@ async def evict_space_caches(
     space_members: dict[str, dict[str, str]],
     store: Any,
     log: Log,
+    channel_policies: dict[str, bool] | None = None,
 ) -> None:
     if not space_id:
         return
@@ -79,6 +80,8 @@ async def evict_space_caches(
     ]:
         channel_spaces.pop(channel_id, None)
         channel_names.pop(channel_id, None)
+        if channel_policies is not None:
+            channel_policies.pop(channel_id, None)
     space_names.pop(space_id, None)
     space_members.pop(space_id, None)
     try:
@@ -98,11 +101,14 @@ async def evict_channel_caches(
     channel_names: dict[str, str],
     store: Any,
     log: Log,
+    channel_policies: dict[str, bool] | None = None,
 ) -> None:
     if not channel_id:
         return
     channel_spaces.pop(channel_id, None)
     channel_names.pop(channel_id, None)
+    if channel_policies is not None:
+        channel_policies.pop(channel_id, None)
     try:
         await store.unmark_channel_space(channel_id)
     except Exception:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -943,6 +943,12 @@ class PuffoCoreMessageClient:
             self._channel_name_cache[channel_id] = name.strip()
         policy = update.get("is_encrypted")
         if isinstance(policy, bool):
+            if self._channel_encrypted.get(channel_id) != policy:
+                logger.info(
+                    "channel %s policy -> %s",
+                    channel_id,
+                    "encrypted" if policy else "plaintext",
+                )
             self._channel_encrypted[channel_id] = policy
             cache_name = (
                 self._channel_name_cache.get(channel_id)

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -279,6 +279,7 @@ class PuffoCoreMessageClient:
         self._ws.on_message = receipt_handler.handle
         self._ws.on_event = self._handle_event
         self._ws.on_space_membership_changed = self._handle_space_membership_changed
+        self._ws.on_channel_update = self._handle_channel_update
         # Re-warms caches on every (re)connect, first connect included.
         self._ws.on_connect = self._on_ws_connect
         await self.store.open()
@@ -558,6 +559,7 @@ class PuffoCoreMessageClient:
             space_members=self._space_members,
             store=self.store,
             log=self._log,
+            channel_policies=self._channel_encrypted,
         )
 
     async def _evict_channel_caches(self, channel_id: str) -> None:
@@ -567,6 +569,7 @@ class PuffoCoreMessageClient:
             channel_names=self._channel_name_cache,
             store=self.store,
             log=self._log,
+            channel_policies=self._channel_encrypted,
         )
 
     async def _dm_operator_membership_change(self, text: str) -> None:
@@ -891,7 +894,67 @@ class PuffoCoreMessageClient:
             store=self.store,
             channel_spaces=self._channel_space,
             channel_names=self._channel_name_cache,
+            channel_policies=self._channel_encrypted,
         )
+
+    def channel_policy(self, channel_id: str) -> bool:
+        """is_encrypted for a channel; unknown fails safe to encrypted."""
+        if not channel_id:
+            return True
+        cached = self._channel_encrypted.get(channel_id)
+        if isinstance(cached, bool):
+            return cached
+        persisted = (disk_cache.load_channel(channel_id) or {}).get("is_encrypted")
+        return persisted is not False
+
+    async def ensure_channel_policy(self, channel_id: str, space_id: str = "") -> bool:
+        if channel_id in self._channel_encrypted:
+            return self._channel_encrypted[channel_id]
+        persisted = (disk_cache.load_channel(channel_id) or {}).get("is_encrypted")
+        if isinstance(persisted, bool):
+            self._channel_encrypted[channel_id] = persisted
+            return persisted
+        space = space_id or self._channel_space.get(channel_id) or ""
+        if space:
+            await self._warm_channels_for_space(space)
+        return self.channel_policy(channel_id)
+
+    async def refresh_channel_policy(self, channel_id: str) -> bool:
+        """Server re-read, bypassing caches (post-CHANNEL_FORMAT_MISMATCH)."""
+        space_id = self._channel_space.get(channel_id) or ""
+        if not space_id:
+            try:
+                space_id = await self.store.lookup_channel_space(channel_id) or ""
+            except Exception:
+                space_id = ""
+        if space_id:
+            await self._warm_channels_for_space(space_id)
+        return self.channel_policy(channel_id)
+
+    async def _handle_channel_update(self, update: dict) -> None:
+        channel_id = update.get("channel_id")
+        if not isinstance(channel_id, str) or not channel_id:
+            return
+        space_id = update.get("space_id")
+        if isinstance(space_id, str) and space_id:
+            self._channel_space[channel_id] = space_id
+        name = update.get("name")
+        if isinstance(name, str) and name.strip():
+            self._channel_name_cache[channel_id] = name.strip()
+        policy = update.get("is_encrypted")
+        if isinstance(policy, bool):
+            self._channel_encrypted[channel_id] = policy
+            cache_name = (
+                self._channel_name_cache.get(channel_id)
+                or (disk_cache.load_channel(channel_id) or {}).get("name")
+                or channel_id
+            )
+            disk_cache.persist_channel(
+                channel_id,
+                cache_name,
+                self._channel_space.get(channel_id) or "",
+                policy,
+            )
 
     async def _bulk_fetch_profiles(self, slugs: list[str]) -> None:
         await bulk_fetch_profiles(

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -26,10 +26,12 @@ from ..crypto.http_client import HttpError
 from ..crypto.keystore import decode_secret
 from ..crypto.message import (
     EncryptInput,
+    build_plaintext_message,
     build_supplementation_envelope,
     encrypt_message_with_content_key,
 )
 from ..crypto.primitives import Ed25519KeyPair
+from .channel_format import is_channel_format_mismatch
 from .held_context import build_held_context_output
 from .message_projection import CONTEXT_VERSION
 from .send_models import SemanticSendRequest, SendResult
@@ -186,6 +188,7 @@ class SendCoordinator:
         active_turn_source: ActiveTurnBoundarySource | Any | None = None,
         held_recovery_source: HeldRecoverySource | Any | None = None,
         provider_session_id: str | None = None,
+        channel_policy_source: Any | None = None,
     ) -> None:
         self.slug = slug
         self.keystore = keystore
@@ -197,6 +200,9 @@ class SendCoordinator:
         self.active_turn_source = active_turn_source
         self.held_recovery_source = held_recovery_source
         self.provider_session_id = provider_session_id
+        # ensure_channel_policy/refresh_channel_policy provider (the message
+        # client). None -> always encrypt (keyless never routes through here).
+        self.channel_policy_source = channel_policy_source
         self._channel_locks: dict[tuple[str, str], asyncio.Lock] = {}
         self._held_lock = asyncio.Lock()
         self._held_evidence: dict[tuple[str, str, str, str], _HeldEvidence] = {}
@@ -871,6 +877,7 @@ class SendCoordinator:
         )
         if isinstance(boundary, dict):
             return boundary
+        encrypt = await self._channel_encrypt_policy(channel_id, space_id)
         try:
             resolved = await self._resolve_route_and_content(
                 request,
@@ -878,27 +885,59 @@ class SendCoordinator:
                 channel_id=channel_id,
                 dm_peer=None,
                 materialized=boundary.materialized,
+                encrypt=encrypt,
             )
         except Exception as exc:
             return failed_result(str(exc), kind="validation")
 
-        envelope, content_key = encrypt_message_with_content_key(
-            resolved["input"],
-            resolved["signing_key"],
-        )
         freshness = {
             "context_baseline_seq": boundary.baseline,
             "seen_seq": boundary.seen_seq,
             "mode": "send_anyway" if request.send_anyway else "require_current",
         }
-        body = {"envelope": envelope, "freshness": freshness}
         visible_draft_basis = await self._visible_draft_basis(
             space_id,
             channel_id,
             str(resolved.get("root_id") or request.root_id or ""),
         )
-        response = await self._post_channel_exact(body)
-        result = self._validate_channel_response(response, envelope, freshness)
+        for attempt in (0, 1):
+            if encrypt:
+                envelope, content_key = encrypt_message_with_content_key(
+                    resolved["input"],
+                    resolved["signing_key"],
+                )
+            else:
+                envelope = build_plaintext_message(
+                    resolved["input"], resolved["signing_key"]
+                )
+                content_key = b""
+            body = {"envelope": envelope, "freshness": freshness}
+            response = await self._post_channel_exact(body)
+            result = self._validate_channel_response(response, envelope, freshness)
+            if (
+                attempt == 0
+                and result.state == "failed"
+                and result.error_kind == "channel_format_mismatch"
+            ):
+                refreshed = await self._refresh_channel_encrypt_policy(
+                    channel_id, encrypt
+                )
+                if refreshed == encrypt:
+                    break
+                encrypt = refreshed
+                try:
+                    resolved = await self._resolve_route_and_content(
+                        request,
+                        space_id=space_id,
+                        channel_id=channel_id,
+                        dm_peer=None,
+                        materialized=boundary.materialized,
+                        encrypt=encrypt,
+                    )
+                except Exception as exc:
+                    return failed_result(str(exc), kind="validation")
+                continue
+            break
         return await self._finish_channel_send(
             request,
             space_id,
@@ -1048,6 +1087,28 @@ class SendCoordinator:
             f"context-independent draft, or leave it unsent.{resolved['note']}"
         )
 
+    async def _channel_encrypt_policy(self, channel_id: str, space_id: str) -> bool:
+        source = self.channel_policy_source
+        if source is None:
+            return True
+        try:
+            return bool(await source.ensure_channel_policy(channel_id, space_id))
+        except Exception:
+            logger.exception("channel policy lookup failed; defaulting to encrypted")
+            return True
+
+    async def _refresh_channel_encrypt_policy(
+        self, channel_id: str, current: bool
+    ) -> bool:
+        source = self.channel_policy_source
+        if source is None:
+            return current
+        try:
+            return bool(await source.refresh_channel_policy(channel_id))
+        except Exception:
+            logger.exception("channel policy refresh failed")
+            return current
+
     async def _post_channel_exact(self, body: dict[str, Any]) -> Any:
         # The same object is deliberately reused after an uncertain outcome; the
         # signed client serializes it deterministically with json.dumps.
@@ -1055,6 +1116,13 @@ class SendCoordinator:
             try:
                 return await self.http_client.post(CHANNEL_SEND_PATH, body)
             except HttpError as exc:
+                if is_channel_format_mismatch(exc):
+                    return SendResult(
+                        state="failed",
+                        error=http_error_detail(exc.body),
+                        error_kind="channel_format_mismatch",
+                        status=exc.status,
+                    )
                 kind = (
                     "deployment"
                     if exc.status in (404, 405)
@@ -1211,6 +1279,7 @@ class SendCoordinator:
         channel_id: str | None,
         dm_peer: str | None,
         materialized: Sequence[tuple[str, bytes]] | None = None,
+        encrypt: bool = True,
     ) -> dict[str, Any]:
         from ..mcp.puffo_core_tools import (
             _fetch_device_keys,
@@ -1263,10 +1332,13 @@ class SendCoordinator:
             for device in (*peer_devices, *self_devices):
                 merged.setdefault(device.device_id, device)
             devices = list(merged.values())
-        else:
+        elif encrypt:
             devices = await _fetch_device_keys(self.http_client, recipient_slugs)
             if not devices:
                 raise RuntimeError("no recipient devices found")
+        else:
+            # Plaintext channel send: no per-device key wrap.
+            devices = []
         visible, visibility_note = await resolve_visibility(
             request.visibility_level,
             destination,

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -1289,7 +1289,12 @@ class SendCoordinator:
 
         destination = request.destination.strip()
         if channel_id is not None:
-            recipient_slugs = await self._channel_recipient_slugs(space_id, channel_id)
+            # Members feed device wraps + supplementation: encrypted only.
+            recipient_slugs = (
+                await self._channel_recipient_slugs(space_id, channel_id)
+                if encrypt
+                else []
+            )
             kind = "channel"
         else:
             recipient_slugs = [self.slug, dm_peer]

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -933,6 +933,7 @@ class SendCoordinator:
                         dm_peer=None,
                         materialized=boundary.materialized,
                         encrypt=encrypt,
+                        prepared=resolved["prepared_attachments"],
                     )
                 except Exception as exc:
                     return failed_result(str(exc), kind="validation")
@@ -1271,58 +1272,27 @@ class SendCoordinator:
             raise RuntimeError(f"channel {channel_id} has no resolvable members")
         return recipient_slugs
 
-    async def _resolve_route_and_content(
-        self,
-        request: SemanticSendRequest,
-        *,
-        space_id: str | None,
-        channel_id: str | None,
-        dm_peer: str | None,
-        materialized: Sequence[tuple[str, bytes]] | None = None,
-        encrypt: bool = True,
-    ) -> dict[str, Any]:
-        from ..mcp.puffo_core_tools import (
-            _fetch_device_keys,
-            _resolve_outgoing_root,
-        )
-        from ._visibility import resolve_visibility
-
-        destination = request.destination.strip()
+    async def _resolve_send_recipients(
+        self, *, space_id: str | None, channel_id: str | None,
+        dm_peer: str | None, encrypt: bool
+    ) -> tuple[list[str], str]:
         if channel_id is not None:
             # Members feed device wraps + supplementation: encrypted only.
-            recipient_slugs = (
-                await self._channel_recipient_slugs(space_id, channel_id)
-                if encrypt
-                else []
-            )
-            kind = "channel"
-        else:
-            recipient_slugs = [self.slug, dm_peer]
-            kind = "dm"
+            if not encrypt:
+                return [], "channel"
+            slugs = await self._channel_recipient_slugs(space_id, channel_id)
+            return slugs, "channel"
+        return [self.slug, dm_peer], "dm"
 
-        root, root_note = await _resolve_outgoing_root(
-            request.root_id,
-            self.data_client,
-            self_slug=self.slug,
-            channel_id=channel_id,
-            space_id=space_id,
-            dm_peer=dm_peer,
-        )
-        attachments, attachment_note = await self._prepare_attachments(
-            request, materialized
-        )
-        content: Any
-        content_type: str
-        visible_text = request.caption if request.attachment_paths else request.text
-        if request.attachment_paths:
-            content = {
-                "text": request.caption,
-                "attachments": [m.to_dict() for m in attachments],
-            }
-            content_type = ATTACHMENT_CONTENT_TYPE
-        else:
-            content = request.text
-            content_type = "text/plain"
+    async def _resolve_send_devices(
+        self,
+        kind: str,
+        dm_peer: str | None,
+        recipient_slugs: list[str],
+        encrypt: bool,
+    ) -> list[Any]:
+        from ..mcp.puffo_core_tools import _fetch_device_keys
+
         if kind == "dm":
             # Fetch the peer alone: a combined [self, peer] fetch cannot
             # tell "peer unreachable" from "reachable" once the sender's
@@ -1336,14 +1306,66 @@ class SendCoordinator:
             merged: dict[str, Any] = {}
             for device in (*peer_devices, *self_devices):
                 merged.setdefault(device.device_id, device)
-            devices = list(merged.values())
-        elif encrypt:
+            return list(merged.values())
+        if encrypt:
             devices = await _fetch_device_keys(self.http_client, recipient_slugs)
             if not devices:
                 raise RuntimeError("no recipient devices found")
+            return devices
+        # Plaintext channel send: no per-device key wrap.
+        return []
+
+    async def _resolve_route_and_content(
+        self,
+        request: SemanticSendRequest,
+        *,
+        space_id: str | None,
+        channel_id: str | None,
+        dm_peer: str | None,
+        materialized: Sequence[tuple[str, bytes]] | None = None,
+        encrypt: bool = True,
+        prepared: tuple[list[AttachmentMeta], str] | None = None,
+    ) -> dict[str, Any]:
+        from ..mcp.puffo_core_tools import _resolve_outgoing_root
+        from ._visibility import resolve_visibility
+
+        destination = request.destination.strip()
+        recipient_slugs, kind = await self._resolve_send_recipients(
+            space_id=space_id,
+            channel_id=channel_id,
+            dm_peer=dm_peer,
+            encrypt=encrypt,
+        )
+
+        root, root_note = await _resolve_outgoing_root(
+            request.root_id,
+            self.data_client,
+            self_slug=self.slug,
+            channel_id=channel_id,
+            space_id=space_id,
+            dm_peer=dm_peer,
+        )
+        # Format retry reuses the already-uploaded blobs.
+        attachments, attachment_note = (
+            prepared
+            if prepared is not None
+            else await self._prepare_attachments(request, materialized)
+        )
+        content: Any
+        content_type: str
+        visible_text = request.caption if request.attachment_paths else request.text
+        if request.attachment_paths:
+            content = {
+                "text": request.caption,
+                "attachments": [m.to_dict() for m in attachments],
+            }
+            content_type = ATTACHMENT_CONTENT_TYPE
         else:
-            # Plaintext channel send: no per-device key wrap.
-            devices = []
+            content = request.text
+            content_type = "text/plain"
+        devices = await self._resolve_send_devices(
+            kind, dm_peer, recipient_slugs, encrypt
+        )
         visible, visibility_note = await resolve_visibility(
             request.visibility_level,
             destination,
@@ -1375,6 +1397,7 @@ class SendCoordinator:
             "recipient_slugs": recipient_slugs,
             "root_id": root or "",
             "note": f"{visibility_note}{root_note}{attachment_note}",
+            "prepared_attachments": (attachments, attachment_note),
         }
 
     async def _prepare_attachments(

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -82,6 +82,7 @@ class PuffoCoreWsClient:
         self.on_event: EventHandler | None = None
         self.on_cert_update: CertHandler | None = None
         self.on_space_membership_changed: SpaceMembershipHandler | None = None
+        self.on_channel_update: Callable[[dict], Coroutine[Any, Any, None]] | None = None
         # Fires after every (re)connect handshake, before catch-up.
         self.on_connect: Callable[[], Coroutine[Any, Any, None]] | None = None
         self._catchup_lock = asyncio.Lock()
@@ -323,6 +324,13 @@ class PuffoCoreWsClient:
                     await self.on_space_membership_changed(space_id)
                 except Exception:
                     logger.exception("on_space_membership_changed callback failed")
+
+        elif msg_type == "channel_update":
+            if self.on_channel_update:
+                try:
+                    await self.on_channel_update(msg)
+                except Exception:
+                    logger.exception("on_channel_update callback failed")
 
     async def _listen_loop(self) -> None:
         async for raw in self._ws:

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -740,6 +740,7 @@ class StandardWorkerRun:
                 client.store, global_runtime.active
             ),
             held_recovery_source=global_runtime.held_recovery_source,
+            channel_policy_source=client,
         )
         global_runtime.coordinator = coordinator
         global_runtime.send_delegate = TrackingSendDelegate(

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -349,6 +349,7 @@ def _make_owned_runtime(point: AttachPoint, bridge, holder: dict[str, WsLocalSes
         baseline_source=BaselineAdapter(client.store),
         active_turn_source=ActiveBoundaryAdapter(client.store, runtime.active),
         held_recovery_source=runtime.held_recovery_source,
+        channel_policy_source=client,
     )
     runtime.coordinator = coordinator
     runtime.send_delegate = TrackingSendDelegate(coordinator, runtime.attempts, runtime)

--- a/tests/test_channel_cache_selfheal.py
+++ b/tests/test_channel_cache_selfheal.py
@@ -67,6 +67,7 @@ async def test_warm_caches_only_server_returned_channels(monkeypatch):
     client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
     client._channel_space = {}
     client._channel_name_cache = {}
+    client._channel_encrypted = {}
     client.http = MagicMock()
     # Server returns ONLY the member channel (it is membership-filtered).
     client.http.get = AsyncMock(

--- a/tests/test_channel_format_policy.py
+++ b/tests/test_channel_format_policy.py
@@ -183,6 +183,42 @@ async def test_format_mismatch_refreshes_and_resends_in_the_other_format():
 
 
 @pytest.mark.asyncio
+async def test_format_mismatch_retry_uploads_attachments_once(tmp_path):
+    policy = _Policy(False, refreshed=True)
+    coordinator, http = await _policy_fixture(policy)
+    coordinator.workspace = str(tmp_path)
+    (tmp_path / "a.txt").write_bytes(b"hello file")
+
+    original_post = http.post
+    state = {"failed": False}
+
+    async def post(path, body=None):
+        if path == CHANNEL_SEND_PATH and not state["failed"]:
+            state["failed"] = True
+            http.calls.append(("POST", path, body))
+            raise HttpError(400, MISMATCH_BODY)
+        return await original_post(path, body)
+
+    http.post = post
+    result = await coordinator.send(
+        SemanticSendRequest(
+            destination="ch_a",
+            caption="see file",
+            attachment_paths=("a.txt",),
+        )
+    )
+    assert result["state"] == "sent"
+    uploads = [
+        c for c in http.calls if c[0] == "POST_BYTES" and c[1] == "/blobs/upload"
+    ]
+    assert len(uploads) == 1
+    # Both attempts reference the same uploaded blob.
+    first, second = _channel_posts(http)
+    assert first[2]["envelope"]["type"] == "plaintext_message_envelope"
+    assert second[2]["envelope"]["type"] == "message_envelope"
+
+
+@pytest.mark.asyncio
 async def test_format_mismatch_with_unchanged_policy_fails_once():
     policy = _Policy(False, refreshed=False)
     coordinator, http = await _policy_fixture(policy)

--- a/tests/test_channel_format_policy.py
+++ b/tests/test_channel_format_policy.py
@@ -1,0 +1,343 @@
+"""channels.is_encrypted drives the outbound channel format."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from puffo_agent.agent import disk_cache
+from puffo_agent.agent.channel_format import is_channel_format_mismatch
+from puffo_agent.agent.send_coordinator import (
+    CHANNEL_SEND_PATH,
+    SemanticSendRequest,
+    SendCoordinator,
+)
+from puffo_agent.crypto.http_client import HttpError
+from puffo_agent.mcp.data_client import DataNotFound
+
+from .test_puffo_core_tools import _setup
+from .test_send_coordinator import Freshness
+
+MISMATCH_BODY = json.dumps(
+    {"error": "CHANNEL_FORMAT_MISMATCH", "message": "channel is plaintext"}
+)
+
+
+def test_is_channel_format_mismatch_matches_only_the_contract():
+    assert is_channel_format_mismatch(HttpError(400, MISMATCH_BODY))
+    assert not is_channel_format_mismatch(HttpError(400, '{"error": "OTHER"}'))
+    assert not is_channel_format_mismatch(HttpError(409, MISMATCH_BODY))
+    assert not is_channel_format_mismatch(HttpError(400, "not json"))
+    assert not is_channel_format_mismatch(RuntimeError("nope"))
+
+
+def test_disk_cache_round_trips_and_preserves_policy(tmp_path, monkeypatch):
+    monkeypatch.setattr(disk_cache, "_cache_root", lambda: tmp_path)
+    disk_cache.persist_channel("ch_1", "general", "sp_1", False)
+    assert disk_cache.load_channel("ch_1")["is_encrypted"] is False
+    # A policy-less rewrite preserves the persisted value.
+    disk_cache.persist_channel("ch_1", "general-renamed", "sp_1")
+    assert disk_cache.load_channel("ch_1")["is_encrypted"] is False
+    # Legacy rows without the field fail safe (no key present).
+    disk_cache.persist_channel("ch_2", "general", "sp_1")
+    assert "is_encrypted" not in disk_cache.load_channel("ch_2")
+
+
+class _Policy:
+    def __init__(self, initial: bool, refreshed: bool | None = None):
+        self.value = initial
+        self.refreshed = refreshed
+        self.ensures: list[tuple[str, str]] = []
+        self.refreshes: list[str] = []
+
+    async def ensure_channel_policy(self, channel_id, space_id=""):
+        self.ensures.append((channel_id, space_id))
+        return self.value
+
+    async def refresh_channel_policy(self, channel_id):
+        self.refreshes.append(channel_id)
+        if self.refreshed is not None:
+            self.value = self.refreshed
+        return self.value
+
+
+async def _policy_fixture(policy):
+    cfg, http, _store = _setup()
+
+    class Data:
+        async def lookup_channel_space(self, channel_id):
+            return {"ch_a": "sp_1"}.get(channel_id)
+
+        async def get_message_by_envelope(self, _envelope_id):
+            raise DataNotFound("not found")
+
+    from puffo_agent.crypto.encoding import base64url_encode
+    from puffo_agent.crypto.primitives import KemKeyPair
+
+    device = KemKeyPair.generate()
+    http.responses["/spaces/sp_1/channels/ch_a/members"] = {
+        "members": [{"slug": "alice-1"}],
+    }
+    http.responses["/certs/sync?slugs=alice-1"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "cert": {
+                "device_id": "dev_a",
+                "kem_public_key": base64url_encode(device.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
+    }
+    freshness = Freshness(0, None)
+    coordinator = SendCoordinator(
+        slug=cfg.slug,
+        keystore=cfg.keystore,
+        http_client=http,
+        data_client=Data(),
+        baseline_source=freshness,
+        active_turn_source=freshness,
+        channel_policy_source=policy,
+    )
+    return coordinator, http
+
+
+def _channel_posts(http):
+    return [c for c in http.calls if c[0] == "POST" and c[1] == CHANNEL_SEND_PATH]
+
+
+@pytest.mark.asyncio
+async def test_encrypted_channel_sends_a_sealed_envelope():
+    coordinator, http = await _policy_fixture(_Policy(True))
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "sent"
+    (post,) = _channel_posts(http)
+    envelope = post[2]["envelope"]
+    assert envelope["type"] == "message_envelope"
+    assert envelope["recipients"]
+
+
+@pytest.mark.asyncio
+async def test_plaintext_channel_sends_a_plaintext_envelope():
+    coordinator, http = await _policy_fixture(_Policy(False))
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "sent"
+    (post,) = _channel_posts(http)
+    envelope = post[2]["envelope"]
+    assert envelope["type"] == "plaintext_message_envelope"
+    assert "signed_payload" in envelope
+    # No device fetch on the plaintext path.
+    assert not any("/certs/sync" in c[1] for c in http.calls if c[0] == "GET")
+
+
+@pytest.mark.asyncio
+async def test_format_mismatch_refreshes_and_resends_in_the_other_format():
+    policy = _Policy(False, refreshed=True)
+    coordinator, http = await _policy_fixture(policy)
+
+    original_post = http.post
+    state = {"failed": False}
+
+    async def post(path, body=None):
+        if path == CHANNEL_SEND_PATH and not state["failed"]:
+            state["failed"] = True
+            http.calls.append(("POST", path, body))
+            raise HttpError(400, MISMATCH_BODY)
+        return await original_post(path, body)
+
+    http.post = post
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "sent"
+    assert policy.refreshes == ["ch_a"]
+    first, second = _channel_posts(http)
+    assert first[2]["envelope"]["type"] == "plaintext_message_envelope"
+    assert second[2]["envelope"]["type"] == "message_envelope"
+
+
+@pytest.mark.asyncio
+async def test_format_mismatch_with_unchanged_policy_fails_once():
+    policy = _Policy(False, refreshed=False)
+    coordinator, http = await _policy_fixture(policy)
+
+    original_post = http.post
+
+    async def post(path, body=None):
+        if path == CHANNEL_SEND_PATH:
+            http.calls.append(("POST", path, body))
+            raise HttpError(400, MISMATCH_BODY)
+        return await original_post(path, body)
+
+    http.post = post
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "failed"
+    assert result["error_kind"] == "channel_format_mismatch"
+    assert policy.refreshes == ["ch_a"]
+    assert len(_channel_posts(http)) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_policy_source_stays_encrypted():
+    coordinator, http = await _policy_fixture(None)
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "sent"
+    (post,) = _channel_posts(http)
+    assert post[2]["envelope"]["type"] == "message_envelope"
+
+
+# ── client-side policy cache ─────────────────────────────────────────
+
+from unittest.mock import AsyncMock, MagicMock
+
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+
+
+def _bare_client():
+    client = PuffoCoreMessageClient.__new__(PuffoCoreMessageClient)
+    client._channel_space = {}
+    client._channel_name_cache = {}
+    client._channel_encrypted = {}
+    client.http = MagicMock()
+    client.store = MagicMock()
+    client.store.mark_channel_space = AsyncMock()
+    client.store.lookup_channel_space = AsyncMock(return_value=None)
+    client._log = MagicMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_warm_caches_channel_policy(monkeypatch, tmp_path):
+    monkeypatch.setattr(disk_cache, "_cache_root", lambda: tmp_path)
+    client = _bare_client()
+    client.http.get = AsyncMock(return_value={"channels": [
+        {"channel_id": "ch_p", "name": "open", "is_encrypted": False},
+        {"channel_id": "ch_e", "name": "sealed", "is_encrypted": True},
+        {"channel_id": "ch_legacy", "name": "old"},
+    ]})
+    await client._warm_channels_for_space("sp_1")
+    assert client._channel_encrypted == {
+        "ch_p": False,
+        "ch_e": True,
+        "ch_legacy": True,  # missing field fails safe
+    }
+    assert disk_cache.load_channel("ch_p")["is_encrypted"] is False
+    assert client.channel_policy("ch_p") is False
+    assert client.channel_policy("ch_unknown") is True
+
+
+@pytest.mark.asyncio
+async def test_channel_update_frame_updates_caches(monkeypatch, tmp_path):
+    monkeypatch.setattr(disk_cache, "_cache_root", lambda: tmp_path)
+    client = _bare_client()
+    await client._handle_channel_update({
+        "type": "channel_update",
+        "channel_id": "ch_p",
+        "space_id": "sp_1",
+        "is_encrypted": False,
+    })
+    assert client._channel_encrypted["ch_p"] is False
+    assert disk_cache.load_channel("ch_p")["is_encrypted"] is False
+    # A policy-less update (e.g. rename) leaves the policy alone.
+    await client._handle_channel_update({
+        "type": "channel_update",
+        "channel_id": "ch_p",
+        "space_id": "sp_1",
+        "name": "renamed",
+    })
+    assert client._channel_encrypted["ch_p"] is False
+    assert client._channel_name_cache["ch_p"] == "renamed"
+
+
+@pytest.mark.asyncio
+async def test_ensure_channel_policy_reads_disk_then_warms(monkeypatch, tmp_path):
+    monkeypatch.setattr(disk_cache, "_cache_root", lambda: tmp_path)
+    client = _bare_client()
+    disk_cache.persist_channel("ch_disk", "general", "sp_1", False)
+    assert await client.ensure_channel_policy("ch_disk") is False
+    assert client._channel_encrypted["ch_disk"] is False
+
+    # Unknown everywhere -> warm the space, then adopt the fetched policy.
+    client.http.get = AsyncMock(return_value={"channels": [
+        {"channel_id": "ch_new", "name": "fresh", "is_encrypted": False},
+    ]})
+    assert await client.ensure_channel_policy("ch_new", "sp_1") is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_channel_policy_rewarnms_from_the_server(monkeypatch, tmp_path):
+    monkeypatch.setattr(disk_cache, "_cache_root", lambda: tmp_path)
+    client = _bare_client()
+    client._channel_space["ch_p"] = "sp_1"
+    client._channel_encrypted["ch_p"] = False
+    client.http.get = AsyncMock(return_value={"channels": [
+        {"channel_id": "ch_p", "name": "open", "is_encrypted": True},
+    ]})
+    assert await client.refresh_channel_policy("ch_p") is True
+    assert client._channel_encrypted["ch_p"] is True
+
+
+@pytest.mark.asyncio
+async def test_eviction_clears_the_policy_cache():
+    from puffo_agent.agent.membership_events import (
+        evict_channel_caches,
+        evict_space_caches,
+    )
+
+    client = _bare_client()
+    client._channel_space.update({"ch_a": "sp_1", "ch_b": "sp_1"})
+    client._channel_encrypted.update({"ch_a": False, "ch_b": True})
+    client.store.unmark_channel_space = AsyncMock()
+    await evict_channel_caches(
+        channel_id="ch_a",
+        channel_spaces=client._channel_space,
+        channel_names=client._channel_name_cache,
+        store=client.store,
+        log=client._log,
+        channel_policies=client._channel_encrypted,
+    )
+    assert "ch_a" not in client._channel_encrypted
+    await evict_space_caches(
+        space_id="sp_1",
+        channel_spaces=client._channel_space,
+        channel_names=client._channel_name_cache,
+        space_names={},
+        space_members={},
+        store=client.store,
+        log=client._log,
+        channel_policies=client._channel_encrypted,
+    )
+    assert client._channel_encrypted == {}
+
+
+@pytest.mark.asyncio
+async def test_ws_channel_update_frame_dispatches():
+    from puffo_agent.crypto.ws_client import PuffoCoreWsClient
+
+    client = PuffoCoreWsClient.__new__(PuffoCoreWsClient)
+    client.on_message = None
+    client.on_event = None
+    client.on_cert_update = None
+    client.on_space_membership_changed = None
+    client.on_connect = None
+    seen: list[dict] = []
+
+    async def handler(update):
+        seen.append(update)
+
+    client.on_channel_update = handler
+    await client._handle_frame(json.dumps({
+        "type": "channel_update",
+        "channel_id": "ch_p",
+        "space_id": "sp_1",
+        "is_encrypted": False,
+    }))
+    assert seen and seen[0]["channel_id"] == "ch_p"

--- a/tests/test_channel_format_policy.py
+++ b/tests/test_channel_format_policy.py
@@ -130,8 +130,30 @@ async def test_plaintext_channel_sends_a_plaintext_envelope():
     envelope = post[2]["envelope"]
     assert envelope["type"] == "plaintext_message_envelope"
     assert "signed_payload" in envelope
-    # No device fetch on the plaintext path.
+    # No device or member fetch on the plaintext path.
     assert not any("/certs/sync" in c[1] for c in http.calls if c[0] == "GET")
+    assert not any("/members" in c[1] for c in http.calls if c[0] == "GET")
+
+
+@pytest.mark.asyncio
+async def test_plaintext_channel_send_survives_an_empty_member_list():
+    coordinator, http = await _policy_fixture(_Policy(False))
+    http.responses["/spaces/sp_1/channels/ch_a/members"] = {"members": []}
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "sent"
+
+
+@pytest.mark.asyncio
+async def test_encrypted_channel_send_still_requires_members():
+    coordinator, http = await _policy_fixture(_Policy(True))
+    http.responses["/spaces/sp_1/channels/ch_a/members"] = {"members": []}
+    result = await coordinator.send(
+        SemanticSendRequest(destination="ch_a", text="hello")
+    )
+    assert result["state"] == "failed"
+    assert "no resolvable members" in result["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_channel_intro_nudge.py
+++ b/tests/test_channel_intro_nudge.py
@@ -55,6 +55,7 @@ def _make_client(store: MessageStore) -> PuffoCoreMessageClient:
     # /channels response so the immediately-following
     # ``_resolve_channel_name`` inside the intro nudge becomes a hit.
     client._channel_name_cache = {}
+    client._channel_encrypted = {}
     # Read by ``_maybe_announce_membership_change`` on the OTHER-signer
     # accept_channel_invite path; empty so the predicate bails cleanly.
     client._channel_space = {}

--- a/tests/test_channel_membership_system_message.py
+++ b/tests/test_channel_membership_system_message.py
@@ -36,6 +36,7 @@ async def _client(tmp_path):
     client._channel_space = {"channel": "space"}
     client._space_name_cache = {}
     client._channel_name_cache = {}
+    client._channel_encrypted = {}
     client._processed_membership_event_ids = set()
     client._inviter_by_invitation_event_id = {}
 

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -52,6 +52,7 @@ def _make_client(
     client._channel_space = {}
     client._space_name_cache = {}
     client._channel_name_cache = {}
+    client._channel_encrypted = {}
     client._space_members = {}
     client._processed_invite_ids = set()
     client._pending_invite_dms = {}

--- a/tests/test_resolve_name_perf.py
+++ b/tests/test_resolve_name_perf.py
@@ -38,6 +38,7 @@ def _bare_client(http: _FakeHttp) -> PuffoCoreMessageClient:
     client.http = http  # type: ignore[assignment]
     client._space_name_cache = {}
     client._channel_name_cache = {}
+    client._channel_encrypted = {}
     return client
 
 


### PR DESCRIPTION
## What

Reimplements this PR's original 1.2.0-era format rules on the 2.0.0 architecture (branch replaced wholesale; old history superseded), against puffo-server's coordinated plaintext support (server PR #321, merged):

1. **Channel sends follow `channels.is_encrypted`** — encrypted → sealed envelope (unchanged); plaintext → signed plaintext envelope through the **same** `/v2/agent-runtime/messages:send` freshness pipeline (require_current / held / send_anyway all apply to plaintext channels). Plaintext sends skip device-key resolution entirely.
2. **DMs stay E2EE** — the DM path is untouched; the agent cannot choose a format.
3. **`CHANNEL_FORMAT_MISMATCH` recovery** — on the server's mismatch error the coordinator re-reads the channel policy from the server, updates the cache, and resends **once** in the other format; an unchanged policy surfaces the failure (`error_kind: channel_format_mismatch`).

**Policy cache** (`PuffoCoreMessageClient`): in-memory `_channel_encrypted` populated by space warms (the channel list now carries `is_encrypted`), persisted in `disk_cache` (policy preserved across policy-less rewrites), updated live by the new `channel_update` WS frame, evicted alongside the other channel caches. Unknown/missing/legacy always fails safe to **encrypted**. The coordinator takes the client as an optional `channel_policy_source`; without one (keyless MCP fallback) it stays always-encrypted — keyless channel sends already route through the bridge where the **server** picks the format.

Not needed anymore from the original plan: the old `send_mode` rules (turn-bundle / thread-root) were already deleted upstream in the 2.0.0 release, and synthetic system-message rows keep the store's fail-safe `is_encrypted=True` default.

## Tests

13 new (`test_channel_format_policy.py`): mismatch detector contract, disk-cache policy round-trip + preservation, sealed/plaintext format selection off the policy, mismatch → refresh → cross-format resend, mismatch with unchanged policy fails once, missing-policy-source default, warm/WS-update/ensure/refresh/eviction cache behavior, WS `channel_update` dispatch. Existing manual-construction fixtures updated for the new cache attr. Full suite: **0 failures** (2 pre-existing environment skips).

Depends on a puffo-server deployment carrying #321 (already on server main).

## Staging validation (2026-08-24)

Live smoke against chat-staging with a dedicated staging daemon: plaintext channels send/receive plaintext, encrypted channels stay sealed, and an encrypted→plaintext flip reached the agent via the `channel_update` frame before its next send — first attempt already used the new format, no mismatch retry needed. Policy changes now log one INFO line.
