### PR TITLE
fix(bridge+crypto): fresh TLS context per connection — survive E2B per-sandbox proxy-CA rotation (PUF-192)

### DIFF
--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -19,6 +19,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import ssl
 import uuid
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
@@ -30,6 +31,23 @@ logger = logging.getLogger(__name__)
 # Module constant (not class attribute) so tests can monkeypatch a
 # short interval. Server recv-timeout is 90s.
 _HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+def _fresh_tls_context() -> ssl.SSLContext:
+    """A fresh default TLS trust context, rebuilt on every (re)connect.
+
+    aiohttp caches its default verified ``SSLContext`` at import time (the
+    module-level ``connector._SSL_CONTEXT_VERIFIED`` singleton) and reuses it for
+    the whole process. E2B's egress proxy TLS-intercepts the relay host to inject
+    ``x-sandbox-token`` and installs its ``E2B Proxy CA`` into the sandbox system
+    trust store at boot (~boot + 2s). If the daemon imports aiohttp *before* that
+    CA lands — a boot-time race — the cached context never picks it up and every
+    connection to the intercepted relay loops on ``CERTIFICATE_VERIFY_FAILED``
+    until the process is restarted. Building the context here re-reads the system
+    trust store on each call, so a lost boot race self-heals on the next connect.
+    See PUF-192.
+    """
+    return ssl.create_default_context()
 
 
 class BridgeError(Exception):
@@ -97,6 +115,7 @@ class CloudBridgeClient:
             try:
                 self._ws = await self._session.ws_connect(
                     self._url, headers=headers, heartbeat=None,
+                    ssl=_fresh_tls_context(),
                 )
             except aiohttp.WSServerHandshakeError as exc:
                 raise BridgeError(
@@ -252,6 +271,7 @@ class CloudBridgeClient:
             ) as session:
                 async with session.post(
                     url, data=data, headers=headers,
+                    ssl=_fresh_tls_context(),
                 ) as resp:
                     body = await resp.read()
                     if resp.status // 100 != 2:
@@ -287,7 +307,9 @@ class CloudBridgeClient:
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=300),
             ) as session:
-                async with session.get(url, headers=headers) as resp:
+                async with session.get(
+                    url, headers=headers, ssl=_fresh_tls_context(),
+                ) as resp:
                     if resp.status != 200:
                         logger.warning(
                             "cloud bridge: blob download failed "
@@ -324,6 +346,7 @@ class CloudBridgeClient:
             ) as session:
                 async with session.request(
                     method, url, headers=headers, json=json_body,
+                    ssl=_fresh_tls_context(),
                 ) as resp:
                     body = await resp.read()
                     if not body:

--- a/src/puffo_agent/crypto/http_session.py
+++ b/src/puffo_agent/crypto/http_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ssl
 from urllib.parse import urlsplit
 from urllib.request import getproxies, proxy_bypass
 
@@ -33,9 +34,19 @@ def create_remote_http_session(
     if timeout is not None:
         kwargs["timeout"] = timeout
 
+    # Fresh TLS trust per session (PUF-192). aiohttp caches its default verified
+    # SSLContext at import (a process-wide singleton). E2B's egress proxy
+    # TLS-intercepts the relay and (re)generates its per-sandbox proxy CA on a
+    # cold restore, so a reused cached context can't verify the intercepted cert
+    # and every request to the relay fails until the process restarts. Building
+    # the context here means a session recreated after a CA change picks the new
+    # CA up — the same fix bridge_client applies at the WS.
+    ssl_ctx = ssl.create_default_context()
+
     proxy_url = _env_proxy_for_url(base_url)
     if proxy_url and _is_socks_proxy(proxy_url):
-        connector = ProxyConnector.from_url(proxy_url)
+        connector = ProxyConnector.from_url(proxy_url, ssl=ssl_ctx)
         return aiohttp.ClientSession(connector=connector, trust_env=False, **kwargs)
 
-    return aiohttp.ClientSession(trust_env=True, **kwargs)
+    connector = aiohttp.TCPConnector(ssl=ssl_ctx)
+    return aiohttp.ClientSession(connector=connector, trust_env=True, **kwargs)

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -528,3 +528,39 @@ async def test_f3_send_list_spaces_timeout_discards_waiter_then_next_resolves():
             await consumer
         except (asyncio.CancelledError, Exception):
             pass
+
+
+def test_fresh_tls_context_is_rebuilt_per_call_not_cached():
+    """PUF-192: the helper must return a NEW verifying SSLContext each call,
+    never a reused singleton — that's what lets a reconnect pick up E2B's
+    proxy CA if it landed after the process (and aiohttp's cached default
+    context) was created."""
+    import ssl as _ssl
+
+    a = bridge_client_mod._fresh_tls_context()
+    b = bridge_client_mod._fresh_tls_context()
+    assert isinstance(a, _ssl.SSLContext)
+    assert a is not b, "must be rebuilt per call, not a cached singleton"
+    assert a.verify_mode == _ssl.CERT_REQUIRED, "must be a verifying default context"
+
+
+@pytest.mark.asyncio
+async def test_connect_passes_a_fresh_tls_context_to_ws_connect(monkeypatch):
+    """PUF-192: connect() must hand ws_connect an explicit per-connect
+    SSLContext, bypassing aiohttp's import-time cached default so a boot-time
+    E2B-proxy-CA race self-heals on the next reconnect."""
+    import ssl as _ssl
+
+    captured: dict = {}
+
+    async def _capture_ws_connect(self, *a, **k):
+        captured["ssl"] = k.get("ssl")
+        raise OSError("stop-after-capture")  # we only need the kwarg
+
+    monkeypatch.setattr(aiohttp.ClientSession, "ws_connect", _capture_ws_connect)
+    c = CloudBridgeClient("http://127.0.0.1:1", "sbx", "slug")
+    with pytest.raises(OSError):
+        await c.connect()
+    assert isinstance(captured["ssl"], _ssl.SSLContext), (
+        "connect() must pass a fresh SSLContext to ws_connect (PUF-192)"
+    )

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -527,3 +527,27 @@ class TestHttpClientKeylessEgress(AioHTTPTestCase):
                 assert "x-puffo-signature" in self.captured_headers
         finally:
             await client.close()
+
+
+def test_create_remote_http_session_uses_a_fresh_verifying_tls_context():
+    """PUF-192: the remote session must carry a fresh, verifying SSLContext
+    (not aiohttp's import-time cached default singleton), rebuilt per call — so a
+    session recreated after E2B (re)generates its per-sandbox proxy CA on a cold
+    restore picks the new CA up instead of looping on CERTIFICATE_VERIFY_FAILED."""
+    import ssl as _ssl
+
+    from puffo_agent.crypto.http_session import create_remote_http_session
+
+    async def _check():
+        s1 = create_remote_http_session("https://relay.example/relay")
+        s2 = create_remote_http_session("https://relay.example/relay")
+        try:
+            c1, c2 = s1.connector._ssl, s2.connector._ssl
+            assert isinstance(c1, _ssl.SSLContext)
+            assert c1.verify_mode == _ssl.CERT_REQUIRED
+            assert c1 is not c2, "must be a fresh context per call, not cached"
+        finally:
+            await s1.close()
+            await s2.close()
+
+    asyncio.run(_check())


### PR DESCRIPTION
## The bug (PUF-192)
Cloud agents silently drop DMs: connections to the relay loop on `CERTIFICATE_VERIFY_FAILED`, never recover, until the **process** is restarted (`resume` does not clear it).

**Mechanism (measured, corrected from the first draft):**
- E2B's egress proxy TLS-intercepts the relay host to inject `x-sandbox-token`, presenting a **per-sandbox** `E2B Proxy CA` installed into the sandbox system trust store.
- aiohttp builds its default verified `SSLContext` **once at import** (the process-wide singleton `connector._SSL_CONTEXT_VERIFIED`) and reuses it forever.
- E2B **regenerates that per-sandbox CA on a cold restore** (not on a warm resume — verified). When a cold restore preserves the daemon (thawed with its stale cached context) but rewrites the CA to a **different** value, the cached snapshot can no longer verify the intercepted relay → fail forever.

It is therefore neither purely a boot race nor "every resume" — it's **cached-snapshot-vs-current-CA divergence**, triggered whenever E2B rotates the per-sandbox CA under a surviving process.

**Evidence (staging):** three agents, three **distinct** CA fingerprints (per-sandbox). A quick pause/resume left the CA byte-identical (`sha 28a4771c…`, mtime unchanged) — warm resume does **not** rotate. But `kimi-26`'s `e2b-ca.crt` mtime = its resume time (a cold restore that rewrote it), while its daemon's cached context did not update → the exact failure. A fresh Python process in the same sandbox verifies fine, confirming the store is current and only the cached context is stale.

## The fix
Build `ssl.create_default_context()` **per connection** so every (re)connect re-reads the current trust store — a rotated CA self-heals on the next attempt. Two files, all relay-bound aiohttp connections:
- **`bridge_client.py`** — `_fresh_tls_context()` passed to the WS `ws_connect` and the three keyless blob/REST calls.
- **`crypto/http_session.py`** — `create_remote_http_session()` now attaches a fresh context via `TCPConnector` (and the SOCKS `ProxyConnector`). *(Reviewer catch: this feeds `crypto/http_client.py` (`/devices/subkeys`), `portal/control/client.py`, and `import_agents.py` — the signed-crypto/subkey path to the relay, which would otherwise stay broken after the WS was fixed.)*

Interception + the E2B CA are correct and unchanged — this only stops relying on aiohttp's import-time cached context.

## Rejected alternative (recorded as *insufficient*)
"Gate the first connect until the CA file exists" addresses **boot** only and does **nothing** for CA rotation on a later cold restore. The per-connect rebuild is what covers both.

## Tests
Existing **21 http_client + 17 bridge** pass unchanged. **+3** new: bridge `_fresh_tls_context` distinct-per-call; `connect()` passes an `SSLContext` to `ws_connect`; `create_remote_http_session` carries a fresh verifying context per call.

## Deployment note (what actually gates this helping)
- Base is **`fleet/cloud-agent-agent-all`** — ships only when that branch lands (does **not** conflict with #208; verified it doesn't touch these files).
- Sandboxes run a **frozen `puffo_agent 1.0.7` from site-packages**, so merging changes nothing for running agents until a **package release + E2B template rebuild**.
- **Already-wedged agents need `POST /agents/{id}/up`** (a full process restart) — `resume` restores the same dead context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)