### PR TITLE
fix(deps): pin mcp>=1.0,<2 — 2.x dropped mcp.server.fastmcp (greens fleet CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "aiohttp-socks>=0.10",
     "aiosqlite>=0.20",
     "cryptography>=43.0",
-    "mcp>=1.0",
+    "mcp>=1.0,<2",  # mcp 2.x moved FastMCP out of `mcp.server.fastmcp` (now the standalone `fastmcp` pkg); our MCP servers import the 1.x path
     # Pillow stays in the BASE install (not an extra): the inbound-image
     # dimension guard (_downscale_oversized_image) runs on the shared
     # PuffoCoreClient delivery path for EVERY runtime kind — including the


### PR DESCRIPTION
## Problem
`fleet` CI is red: pytest aborts collection with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` in 6 MCP test modules. Cause: `mcp>=1.0` resolves to a **2.x** release that moved `FastMCP` out of `mcp.server.fastmcp` into the standalone `fastmcp` package. Our servers (`puffo_core_server`, `lifecycle_tools`, `memory_tools`, `puffo_core_tools`) import the 1.x path (`from mcp.server.fastmcp import FastMCP`).

## Fix
Pin `mcp>=1.0,<2` — the **same pin already in #208**, extracted as a tiny standalone change so isolated fixes (e.g. #213) can merge green without waiting on the large #208 tree. Local `mcp 1.27.2` satisfies `<2` and has `mcp.server.fastmcp`.

One-line dependency pin, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)