### PR TITLE
fix(context): address PR 211 review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **Claude context telemetry now treats session-reported limits as authoritative.**
-  Configured compact thresholds are used only until Claude reports the active
-  value, unknown models no longer fall back to an invented 200K window, and a
-  transient context query timeout remains retryable on later turns.
+- **Claude context telemetry no longer invents limits for unknown models.**
+  A transient context query timeout remains retryable on later turns, while
+  configured compact thresholds remain authoritative because Claude's context
+  query reports its raw default even when an environment override is active.
 
 - **Codex host MCP sync now includes portable OAuth credentials.** Codex
   agents use the file-backed MCP OAuth store, and `sync_host_mcp()` copies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Claude context telemetry now treats session-reported limits as authoritative.**
+  Configured compact thresholds are used only until Claude reports the active
+  value, unknown models no longer fall back to an invented 200K window, and a
+  transient context query timeout remains retryable on later turns.
+
 - **Codex host MCP sync now includes portable OAuth credentials.** Codex
   agents use the file-backed MCP OAuth store, and `sync_host_mcp()` copies
   the selected credential into the isolated agent home for both

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -723,7 +723,8 @@ class ClaudeSession:
                 timeout=CONTEXT_USAGE_TIMEOUT_SECONDS,
             )
         except (asyncio.TimeoutError, ConnectionError, RuntimeError) as exc:
-            self._context_usage_supported = False
+            if isinstance(exc, RuntimeError):
+                self._context_usage_supported = False
             logger.debug(
                 "agent %s: Claude context usage unavailable: %s",
                 self.agent_id,
@@ -747,6 +748,9 @@ class ClaudeSession:
     ) -> dict[str, object]:
         assert proc.stdout is not None
         while True:
+            # Queries run only while the turn lock is held and stdout should be
+            # quiet. System status and unrelated control responses are safe to
+            # consume; all other events indicate unexpected stream interleaving.
             line = await proc.stdout.readline()
             if not line:
                 raise ConnectionError("Claude stream closed during context query")
@@ -759,6 +763,11 @@ class ClaudeSession:
                     self._save_session_id(sid)
                 continue
             if event.get("type") != "control_response":
+                logger.warning(
+                    "agent %s: ignoring unexpected %s event during context query",
+                    self.agent_id,
+                    event.get("type"),
+                )
                 continue
             response = event.get("response") or {}
             if not isinstance(response, dict):

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -792,13 +792,16 @@ class LocalCLIAdapter(Adapter):
         # Both HOME (POSIX) and USERPROFILE (Node on Windows) are
         # needed: Claude Code uses Node's os.homedir(). PUFFO_* are
         # consumed by the per-tool-call hook subprocess.
-        env = {
-            **os.environ,
-            **self.env_overrides,
+        adapter_owned_env = {
             "HOME": str(self.agent_home_dir),
             "USERPROFILE": str(self.agent_home_dir),
             **self._permission_hook_env(),
             **self._macos_credential_env(),
+        }
+        env = {
+            **os.environ,
+            **self.env_overrides,
+            **adapter_owned_env,
         }
         self._session = ClaudeSession(
             agent_id=self.agent_id,

--- a/src/puffo_agent/portal/control/context_telemetry.py
+++ b/src/puffo_agent/portal/control/context_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 import logging
 import math
 import os
@@ -25,6 +26,24 @@ _MODEL_WINDOWS: tuple[tuple[str, int], ...] = (
     ("mythos-5", 1_000_000),
     ("haiku-4-5", 200_000),
 )
+
+
+@lru_cache(maxsize=256)
+def _warn_threshold_mismatch(
+    agent_id: str, configured_pct: float, reported_pct: float
+) -> None:
+    logger.warning(
+        "agent %s: Claude session compact threshold %g%% differs from "
+        "configured override %g%%",
+        agent_id or "<unknown>",
+        reported_pct,
+        configured_pct,
+        extra={
+            "agent_id": agent_id,
+            "configured_threshold_pct": configured_pct,
+            "session_threshold_pct": reported_pct,
+        },
+    )
 
 
 def resolve_context_window(
@@ -116,18 +135,7 @@ def build_context_runtime(
         and reported_pct is not None
         and not math.isclose(configured_pct, reported_pct, abs_tol=0.001)
     ):
-        logger.warning(
-            "agent %s: Claude session compact threshold %g%% differs from "
-            "configured override %g%%",
-            agent_id or "<unknown>",
-            reported_pct,
-            configured_pct,
-            extra={
-                "agent_id": agent_id,
-                "configured_threshold_pct": configured_pct,
-                "session_threshold_pct": reported_pct,
-            },
-        )
+        _warn_threshold_mismatch(agent_id, configured_pct, reported_pct)
     return {
         "max_context": window,
         "auto_compact_threshold_pct": (

--- a/src/puffo_agent/portal/control/context_telemetry.py
+++ b/src/puffo_agent/portal/control/context_telemetry.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import os
 
-DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000
 MIN_CONTEXT_WINDOW_TOKENS = 100_000
 MAX_CONTEXT_WINDOW_TOKENS = 1_000_000
 
+logger = logging.getLogger(__name__)
+
 _MODEL_WINDOWS: tuple[tuple[str, int], ...] = (
+    # Legacy explicit extended-window aliases.
     ("[1m]", 1_000_000),
     ("-1m", 1_000_000),
     ("opus-5", 1_000_000),
@@ -20,10 +23,13 @@ _MODEL_WINDOWS: tuple[tuple[str, int], ...] = (
     ("sonnet-4-6", 1_000_000),
     ("fable-5", 1_000_000),
     ("mythos-5", 1_000_000),
+    ("haiku-4-5", 200_000),
 )
 
 
-def resolve_context_window(model: str = "", env: dict[str, str] | None = None) -> int:
+def resolve_context_window(
+    model: str = "", env: dict[str, str] | None = None
+) -> int | None:
     """Resolve Claude Code's effective auto-compact window."""
     src = os.environ if env is None else env
     raw = (src.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") or "").strip()
@@ -41,11 +47,12 @@ def resolve_context_window(model: str = "", env: dict[str, str] | None = None) -
     for needle, window in _MODEL_WINDOWS:
         if needle in low:
             return window
-    return DEFAULT_CONTEXT_WINDOW_TOKENS
+    logger.warning("Claude context window is unknown for model %r", model)
+    return None
 
 
 def parse_threshold_pct(raw: object) -> float | None:
-    """Return the effective override, or None when Claude Code ignores it."""
+    """Parse a syntactically valid Claude auto-compact override."""
     if raw is None:
         return None
     text = str(raw).strip()
@@ -60,15 +67,20 @@ def parse_threshold_pct(raw: object) -> float | None:
     return pct
 
 
-def estimate_compact_threshold_tokens(window: int, pct: float | None) -> int | None:
-    if pct is None:
+def estimate_compact_threshold_tokens(
+    window: int | None, pct: float | None
+) -> int | None:
+    if window is None or pct is None:
         return None
     return max(0, int(window * pct / 100))
 
 
-def compact_threshold_pct(window: int, threshold: int | None) -> float | None:
+def compact_threshold_pct(
+    window: int | None, threshold: int | None
+) -> float | None:
     if (
-        isinstance(threshold, bool)
+        window is None
+        or isinstance(threshold, bool)
         or not isinstance(threshold, int)
         or threshold <= 0
         or threshold > window
@@ -84,6 +96,7 @@ def build_context_runtime(
     auto_compact_threshold: int | None = None,
     env_overrides: dict[str, str] | None = None,
     env: dict[str, str] | None = None,
+    agent_id: str = "",
 ) -> dict:
     """Build context configuration persisted with runtime metadata."""
     overrides = env_overrides or {}
@@ -97,11 +110,27 @@ def build_context_runtime(
     configured_pct = parse_threshold_pct(
         overrides.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")
     )
+    reported_pct = compact_threshold_pct(window, auto_compact_threshold)
+    if (
+        configured_pct is not None
+        and reported_pct is not None
+        and not math.isclose(configured_pct, reported_pct, abs_tol=0.001)
+    ):
+        logger.warning(
+            "agent %s: Claude session compact threshold %g%% differs from "
+            "configured override %g%%",
+            agent_id or "<unknown>",
+            reported_pct,
+            configured_pct,
+            extra={
+                "agent_id": agent_id,
+                "configured_threshold_pct": configured_pct,
+                "session_threshold_pct": reported_pct,
+            },
+        )
     return {
         "max_context": window,
         "auto_compact_threshold_pct": (
-            configured_pct
-            if configured_pct is not None
-            else compact_threshold_pct(window, auto_compact_threshold)
+            reported_pct if reported_pct is not None else configured_pct
         ),
     }

--- a/src/puffo_agent/portal/control/context_telemetry.py
+++ b/src/puffo_agent/portal/control/context_telemetry.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 import logging
 import math
 import os
@@ -26,25 +25,6 @@ _MODEL_WINDOWS: tuple[tuple[str, int], ...] = (
     ("mythos-5", 1_000_000),
     ("haiku-4-5", 200_000),
 )
-
-
-@lru_cache(maxsize=256)
-def _warn_threshold_mismatch(
-    agent_id: str, configured_pct: float, reported_pct: float
-) -> None:
-    logger.warning(
-        "agent %s: Claude session compact threshold %g%% differs from "
-        "configured override %g%%",
-        agent_id or "<unknown>",
-        reported_pct,
-        configured_pct,
-        extra={
-            "agent_id": agent_id,
-            "configured_threshold_pct": configured_pct,
-            "session_threshold_pct": reported_pct,
-        },
-    )
-
 
 def resolve_context_window(
     model: str = "", env: dict[str, str] | None = None
@@ -115,7 +95,6 @@ def build_context_runtime(
     auto_compact_threshold: int | None = None,
     env_overrides: dict[str, str] | None = None,
     env: dict[str, str] | None = None,
-    agent_id: str = "",
 ) -> dict:
     """Build context configuration persisted with runtime metadata."""
     overrides = env_overrides or {}
@@ -130,15 +109,9 @@ def build_context_runtime(
         overrides.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")
     )
     reported_pct = compact_threshold_pct(window, auto_compact_threshold)
-    if (
-        configured_pct is not None
-        and reported_pct is not None
-        and not math.isclose(configured_pct, reported_pct, abs_tol=0.001)
-    ):
-        _warn_threshold_mismatch(agent_id, configured_pct, reported_pct)
     return {
         "max_context": window,
         "auto_compact_threshold_pct": (
-            reported_pct if reported_pct is not None else configured_pct
+            configured_pct if configured_pct is not None else reported_pct
         ),
     }

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -798,6 +798,12 @@ class AgentDetail(QWidget):
             and state.auto_compact_threshold_pct is not None
         ):
             pct = state.auto_compact_threshold_pct
+        if window is None:
+            self._context_usage.setText(
+                "Context limits unavailable. Live usage shows in the web app; "
+                "saving restarts the agent."
+            )
+            return
         threshold = estimate_compact_threshold_tokens(
             window, pct
         )

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -978,7 +978,6 @@ class Worker:
                     max_context=limits[0],
                     auto_compact_threshold=limits[1],
                     env_overrides=self.agent_cfg.env_overrides,
-                    agent_id=self.agent_cfg.id,
                 )
             )
             max_context = int(info["max_context"] or 0)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -978,9 +978,10 @@ class Worker:
                     max_context=limits[0],
                     auto_compact_threshold=limits[1],
                     env_overrides=self.agent_cfg.env_overrides,
+                    agent_id=self.agent_cfg.id,
                 )
             )
-            max_context = int(info["max_context"])
+            max_context = int(info["max_context"] or 0)
             threshold_pct = info["auto_compact_threshold_pct"]
             if (
                 self.runtime.max_context != max_context

--- a/tests/test_cli_session_recovery.py
+++ b/tests/test_cli_session_recovery.py
@@ -298,6 +298,55 @@ def test_context_usage_error_keeps_result_fallback_and_disables_retry(tmp_path):
     assert [frame["type"] for frame in frames] == ["user", "control_request"]
 
 
+def test_context_usage_timeout_remains_retryable(tmp_path, monkeypatch):
+    session = _make_session(tmp_path, audit=False)
+
+    async def timeout(*_args):
+        raise asyncio.TimeoutError
+
+    async def drive():
+        session._proc = _ContextUsageProc({})
+        monkeypatch.setattr(session, "_read_context_usage_response", timeout)
+        assert await session._refresh_context_usage() is None
+        assert await session._refresh_context_usage() is None
+
+    asyncio.run(drive())
+    assert session._context_usage_supported is not False
+
+
+def test_turn_ignores_late_context_control_response(tmp_path, monkeypatch):
+    late_response = {
+        "type": "control_response",
+        "response": {
+            "subtype": "success",
+            "request_id": "ctx_timed_out",
+            "response": {"totalTokens": 42},
+        },
+    }
+    result = {
+        "type": "result",
+        "subtype": "success",
+        "session_id": "sess-1",
+        "result": "still works",
+        "usage": {},
+    }
+    lines = [
+        (json.dumps(late_response) + "\n").encode(),
+        (json.dumps(result) + "\n").encode(),
+    ]
+    session = _make_session(tmp_path, audit=False)
+
+    async def no_refresh():
+        return None
+
+    async def drive():
+        session._proc = _FakeProc(stdout_lines=lines)
+        monkeypatch.setattr(session, "_refresh_context_usage", no_refresh)
+        return await session._one_turn("hi")
+
+    assert asyncio.run(drive()).reply == "still works"
+
+
 def test_context_usage_reader_ignores_unrelated_events(tmp_path):
     session = _make_session(tmp_path, audit=False)
 

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from _bridge_support import isolated_home, write_test_agent  # noqa: E402
 
 from puffo_agent.portal.control.context_telemetry import (  # noqa: E402
+    _warn_threshold_mismatch,
     build_context_runtime,
     compact_threshold_pct,
     estimate_compact_threshold_tokens,
@@ -133,6 +134,7 @@ def test_runtime_reports_active_override():
 
 
 def test_runtime_session_threshold_wins_over_configured_override(caplog):
+    _warn_threshold_mismatch.cache_clear()
     with caplog.at_level("WARNING"):
         out = build_context_runtime(
             max_context=200_000,
@@ -141,9 +143,22 @@ def test_runtime_session_threshold_wins_over_configured_override(caplog):
             env={},
             agent_id="ctx-bot",
         )
+        build_context_runtime(
+            max_context=200_000,
+            auto_compact_threshold=167_000,
+            env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
+            env={},
+            agent_id="ctx-bot",
+        )
     assert out["auto_compact_threshold_pct"] == 83.5
     assert "differs from configured override" in caplog.text
-    record = caplog.records[-1]
+    records = [
+        record
+        for record in caplog.records
+        if "differs from configured override" in record.message
+    ]
+    assert len(records) == 1
+    record = records[0]
     assert record.agent_id == "ctx-bot"
     assert record.configured_threshold_pct == 30.0
     assert record.session_threshold_pct == 83.5

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -10,7 +10,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from _bridge_support import isolated_home, write_test_agent  # noqa: E402
 
 from puffo_agent.portal.control.context_telemetry import (  # noqa: E402
-    _warn_threshold_mismatch,
     build_context_runtime,
     compact_threshold_pct,
     estimate_compact_threshold_tokens,
@@ -133,47 +132,24 @@ def test_runtime_reports_active_override():
     assert out["auto_compact_threshold_pct"] == 50.0
 
 
-def test_runtime_session_threshold_wins_over_configured_override(caplog):
-    _warn_threshold_mismatch.cache_clear()
-    with caplog.at_level("WARNING"):
-        out = build_context_runtime(
-            max_context=200_000,
-            auto_compact_threshold=167_000,
-            env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
-            env={},
-            agent_id="ctx-bot",
-        )
-        build_context_runtime(
-            max_context=200_000,
-            auto_compact_threshold=167_000,
-            env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
-            env={},
-            agent_id="ctx-bot",
-        )
-    assert out["auto_compact_threshold_pct"] == 83.5
-    assert "differs from configured override" in caplog.text
-    records = [
-        record
-        for record in caplog.records
-        if "differs from configured override" in record.message
-    ]
-    assert len(records) == 1
-    record = records[0]
-    assert record.agent_id == "ctx-bot"
-    assert record.configured_threshold_pct == 30.0
-    assert record.session_threshold_pct == 83.5
+def test_runtime_configured_override_wins_over_raw_session_default():
+    out = build_context_runtime(
+        max_context=200_000,
+        auto_compact_threshold=167_000,
+        env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "5"},
+        env={},
+    )
+    assert out["auto_compact_threshold_pct"] == 5.0
 
 
-def test_runtime_matching_session_threshold_does_not_warn(caplog):
-    with caplog.at_level("WARNING"):
-        out = build_context_runtime(
-            max_context=200_000,
-            auto_compact_threshold=60_000,
-            env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
-            env={},
-        )
+def test_runtime_matching_session_threshold_preserves_override():
+    out = build_context_runtime(
+        max_context=200_000,
+        auto_compact_threshold=60_000,
+        env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
+        env={},
+    )
     assert out["auto_compact_threshold_pct"] == 30.0
-    assert "differs from configured override" not in caplog.text
 
 
 def test_runtime_prefers_session_reported_max_context():

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -59,8 +59,14 @@ def test_in_range_pct_parses(raw, expected):
     assert parse_threshold_pct(raw) == expected
 
 
-def test_window_defaults_to_200k():
+def test_haiku_window_resolves_to_200k():
     assert resolve_context_window("claude-haiku-4-5", env={}) == 200_000
+
+
+def test_unknown_model_window_is_not_invented(caplog):
+    with caplog.at_level("WARNING"):
+        assert resolve_context_window("claude-future-model", env={}) is None
+    assert "context window is unknown" in caplog.text
 
 
 def test_window_env_override_wins():
@@ -126,14 +132,33 @@ def test_runtime_reports_active_override():
     assert out["auto_compact_threshold_pct"] == 50.0
 
 
-def test_runtime_override_wins_over_session_default():
-    out = build_context_runtime(
-        max_context=200_000,
-        auto_compact_threshold=167_000,
-        env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
-        env={},
-    )
+def test_runtime_session_threshold_wins_over_configured_override(caplog):
+    with caplog.at_level("WARNING"):
+        out = build_context_runtime(
+            max_context=200_000,
+            auto_compact_threshold=167_000,
+            env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
+            env={},
+            agent_id="ctx-bot",
+        )
+    assert out["auto_compact_threshold_pct"] == 83.5
+    assert "differs from configured override" in caplog.text
+    record = caplog.records[-1]
+    assert record.agent_id == "ctx-bot"
+    assert record.configured_threshold_pct == 30.0
+    assert record.session_threshold_pct == 83.5
+
+
+def test_runtime_matching_session_threshold_does_not_warn(caplog):
+    with caplog.at_level("WARNING"):
+        out = build_context_runtime(
+            max_context=200_000,
+            auto_compact_threshold=60_000,
+            env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
+            env={},
+        )
     assert out["auto_compact_threshold_pct"] == 30.0
+    assert "differs from configured override" not in caplog.text
 
 
 def test_runtime_prefers_session_reported_max_context():
@@ -143,6 +168,14 @@ def test_runtime_prefers_session_reported_max_context():
         env={},
     )
     assert out["max_context"] == 1_000_000
+
+
+def test_runtime_unknown_model_reports_unknown_window():
+    out = build_context_runtime(model="claude-future-model", env={})
+    assert out == {
+        "max_context": None,
+        "auto_compact_threshold_pct": None,
+    }
 
 
 def test_runtime_preserves_valid_100_pct_config():
@@ -211,6 +244,29 @@ def test_runtime_info_prefers_adapter_context_window(monkeypatch):
 
     assert worker._runtime_info()["max_context"] == 1_000_000
     assert worker._runtime_info()["auto_compact_threshold_pct"] == 96.7
+
+
+def test_runtime_info_preserves_unknown_model_window():
+    from types import SimpleNamespace
+
+    from puffo_agent.portal.worker import Worker
+
+    worker = Worker.__new__(Worker)
+    worker.agent_cfg = SimpleNamespace(
+        id="ctx-bot",
+        runtime=SimpleNamespace(
+            kind="cli-local",
+            provider="anthropic",
+            harness="claude-code",
+            model="claude-future-model",
+            inference_level="",
+        ),
+        env_overrides={},
+    )
+    worker.runtime = RuntimeState()
+
+    assert worker._runtime_info()["max_context"] is None
+    assert worker.runtime.max_context == 0
 
 
 def test_codex_runtime_info_omits_claude_context_config():
@@ -337,9 +393,12 @@ def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars():
         session_file=os.path.join(home, "s.json"),
         mcp_config_file=os.path.join(home, "mcp.json"),
         agent_home_dir=os.path.join(home, "agent-home"),
-        env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"},
+        env_overrides={
+            "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+            "HOME": "/tmp/untrusted-home",
+            "USERPROFILE": "/tmp/untrusted-profile",
+        },
     )
-    assert adapter.env_overrides == {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"}
     assert adapter.context_limits() == (None, None)
     session = adapter._ensure_session()
     session._context_usage = {
@@ -348,13 +407,10 @@ def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars():
     }
     assert adapter.context_limits() == (200_000, 167_000)
 
-    env = {
-        **os.environ,
-        **adapter.env_overrides,
-        "HOME": str(adapter.agent_home_dir),
-    }
+    env = session.env
     assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "50"
     assert env["HOME"] == str(adapter.agent_home_dir)
+    assert env["USERPROFILE"] == str(adapter.agent_home_dir)
 
 
 def test_default_band_clears_the_override():
@@ -405,7 +461,7 @@ def test_docker_session_receives_overrides(tmp_path, monkeypatch):
         env_overrides=adapter.env_overrides,
         env={},
     )
-    assert runtime["max_context"] == 200_000
+    assert runtime["max_context"] is None
     assert session.build_command([], session.env_overrides)[:6] == [
         "docker",
         "exec",

--- a/tests/test_ui_context_threshold.py
+++ b/tests/test_ui_context_threshold.py
@@ -50,6 +50,18 @@ def test_preview_is_inert_before_an_agent_is_bound(qapp, agent_home):
     assert view._context_usage.text() == "—"
 
 
+def test_unknown_model_does_not_show_an_invented_window(qapp, agent_home):
+    cfg = AgentConfig.load("threshold-ui")
+    cfg.runtime.model = "claude-future-model"
+    cfg.save()
+    RuntimeState(max_context=0).save("threshold-ui")
+
+    view = agent_detail.AgentDetail()
+    view.bind("threshold-ui")
+
+    assert view._context_usage.text().startswith("Context limits unavailable.")
+
+
 def test_threshold_control_uses_claude_reported_default(qapp, agent_home):
     cfg = AgentConfig.load("threshold-ui")
     cfg.env_overrides = {}


### PR DESCRIPTION
Follow-up to #211. This re-evaluates the four review threads that remained open when that PR was merged.

## What changed

- Returns an unknown context window for unrecognized models instead of inventing a 200K fallback, with explicit UI handling and a warning.
- Keeps context-usage queries retryable after transient timeouts and proves a late control response cannot corrupt the next turn.
- Makes adapter-owned environment precedence structural and tests that HOME/USERPROFILE overrides cannot win.
- Preserves configured compact thresholds as authoritative when present.

## Important protocol finding

Claude Code's `get_context_usage.autoCompactThreshold` is the raw default threshold; it does not incorporate `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`. Therefore the N1 suggestion to prefer that value over the configured override is not correct.

A live Claude Code 2.1.224 test on `linus-7597-cb184a49` proved this: the process environment contained `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=5`, the context query still returned 167K/83.5%, but the next 22K-token turn emitted three `system/compact_boundary` events and took 135 seconds. Runtime/UI must therefore use the valid configured percentage while an override is present, and use the session-reported value only for Default.

## Validation

- Full suite before the protocol correction: 2367 passed, 2 skipped.
- Focused context telemetry, CLI recovery, and desktop UI tests pass after the correction.
- Diff line and branch coverage: 100% before the correction; corrected precedence has direct regression coverage.
- Manual editable-install smoke covered both Default behavior and a 5% override on a resumed session.
