### PR TITLE
Add Codex context telemetry and compaction controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Codex agents now report and control their live context window.** Local and
+  Docker workers persist the model-reported maximum and selected compact point,
+  attach current usage to completed-turn events, and translate per-agent
+  compact percentages into Codex app-server session limits. The default follows
+  Codex's model-derived limit, while 75%, 50%, or 30% overrides are available.
+
 - **Per-agent Claude Code auto-compaction controls and context telemetry.**
   Operators can select Claude's session-reported default or an earlier 75%,
   50%, or 30% threshold for local and Docker CLI agents. The desktop and web

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -83,6 +83,11 @@ TURN_TIMEOUT_SECONDS = 1800.0
 # Reacts fast in a small fleet, absorbs single transient hiccups.
 CODEX_THREAD_WEDGED_THRESHOLD = 2
 
+# Codex reports the usable 95% window while its default compaction point is
+# 90% of the underlying model window.
+CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95
+CODEX_AUTO_COMPACT_CONTEXT_WINDOW_PERCENT = 90
+
 # Tuple shape so a future "thread is dead" surface adds one line.
 _CODEX_THREAD_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"agent thread limit reached", re.IGNORECASE),
@@ -186,6 +191,7 @@ class _PendingTurn:
     # value standing when this turn's first request completed.
     input_tokens: int = 0
     output_tokens: int = 0
+    context_tokens: int = 0
     _in_base: int | None = None
     _out_base: int | None = None
     # ``turn/completed`` resolves this; ``turn/failed`` rejects it.
@@ -224,6 +230,7 @@ class CodexSession:
         permission_mode: str = "bypassPermissions",
         sandbox: str = "danger-full-access",
         model: str = "",
+        auto_compact_threshold_pct: float | None = None,
         task_timeout_seconds: float = TURN_TIMEOUT_SECONDS,
         audit: Optional[AuditLog] = None,
     ):
@@ -242,6 +249,7 @@ class CodexSession:
         # Codex's thread/start takes ``model`` as a required-ish
         # parameter; empty string means "let codex pick its default".
         self.model = model
+        self.auto_compact_threshold_pct = auto_compact_threshold_pct
         # Per-agent turn wall-clock budget; raised via agent.yml for long tasks.
         self.task_timeout_seconds = task_timeout_seconds
         self.audit = audit
@@ -254,11 +262,22 @@ class CodexSession:
         self._active_turn: _PendingTurn | None = None
         self._lock = asyncio.Lock()
         self._conversation_id: str = self._load_conversation_id()
+        self._model_context_window: int | None = self._load_model_context_window()
         # thread/start params aren't re-sent on resume; a sandbox change would
         # silently keep the old policy. Drop the thread, next start re-applies.
         if self._conversation_id:
             persisted_sandbox = self._load_persisted_sandbox()
-            if persisted_sandbox != self.sandbox:
+            persisted_model = self._load_persisted_model()
+            if persisted_model is not None and persisted_model != self.model:
+                logger.info(
+                    "agent %s: codex model changed (%s → %s); starting a "
+                    "fresh thread",
+                    self.agent_id, persisted_model or "<default>",
+                    self.model or "<default>",
+                )
+                self._conversation_id = ""
+                self._model_context_window = None
+            elif persisted_sandbox != self.sandbox:
                 logger.info(
                     "agent %s: codex sandbox changed (%s → %s); starting a "
                     "fresh thread so the new policy applies",
@@ -282,6 +301,27 @@ class CodexSession:
         # Resets on next success; hits THRESHOLD → rotate (drop the
         # persisted conversation id; next _ensure_running starts fresh).
         self._consecutive_thread_failures: int = 0
+
+    def context_limits(self) -> tuple[int | None, int | None]:
+        window = self._model_context_window
+        pct = self.auto_compact_threshold_pct
+        if window is None:
+            return None, None
+        if pct is not None:
+            return window, int(window * pct / 100)
+        threshold = (
+            window * CODEX_AUTO_COMPACT_CONTEXT_WINDOW_PERCENT
+            // CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT
+        )
+        return window, threshold
+
+    def _thread_config(self) -> dict[str, int]:
+        if self.auto_compact_threshold_pct is None:
+            return {}
+        _, threshold = self.context_limits()
+        if threshold is None:
+            return {}
+        return {"model_auto_compact_token_limit": threshold}
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -439,6 +479,7 @@ class CodexSession:
                 "harness": "codex",
                 "conversation_id": self._conversation_id,
                 "send_message_targets": turn.send_message_targets,
+                "context_tokens": turn.context_tokens,
             },
         )
 
@@ -618,6 +659,27 @@ class CodexSession:
             return ""
         return str(data.get("thread_cwd") or "")
 
+    def _load_persisted_model(self) -> str | None:
+        try:
+            data = json.loads(self.session_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        if "model" not in data:
+            return None
+        return str(data.get("model") or "")
+
+    def _load_model_context_window(self) -> int | None:
+        try:
+            data = json.loads(self.session_file.read_text(encoding="utf-8"))
+            if "model" in data and str(data.get("model") or "") != self.model:
+                return None
+            value = data.get("model_context_window")
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                return value
+        except (OSError, ValueError):
+            pass
+        return None
+
     def _save_conversation_id(self, cid: str) -> None:
         try:
             self.session_file.parent.mkdir(parents=True, exist_ok=True)
@@ -626,6 +688,8 @@ class CodexSession:
                     "conversation_id": cid,
                     "sandbox": self.sandbox,
                     "thread_cwd": self._effective_thread_cwd,
+                    "model": self.model,
+                    "model_context_window": self._model_context_window,
                 }),
                 encoding="utf-8",
             )
@@ -729,10 +793,16 @@ class CodexSession:
         # 2. Start or resume the conversation/thread.
         if self._conversation_id:
             try:
+                resume_params: dict[str, Any] = {
+                    "threadId": self._conversation_id,
+                }
+                config = self._thread_config()
+                if config:
+                    resume_params["config"] = config
                 await self._send_raw_request(
                     self._reserve_id(),
                     METHOD_RESUME_CONVERSATION,
-                    {"threadId": self._conversation_id},
+                    resume_params,
                 )
                 logger.info(
                     "agent %s: resumed codex thread %s",
@@ -766,6 +836,9 @@ class CodexSession:
         }
         if self.model:
             new_conv_params["model"] = self.model
+        config = self._thread_config()
+        if config:
+            new_conv_params["config"] = config
 
         result = await self._send_raw_request(
             self._reserve_id(),
@@ -1094,12 +1167,30 @@ class CodexSession:
             get_reporter().record_codex_rate_limits((params or {}).get("rateLimits"))
             return
 
-        if m.startswith("thread/tokenusage/updated") and turn is not None:
+        if m.startswith("thread/tokenusage/updated"):
             # codex reports per-turn tokens here (not turn/completed); ``last``
             # refreshes during the turn, final value stands at turn/completed.
             tu = (params or {}).get("tokenUsage") or {}
+            model_context_window = tu.get("modelContextWindow")
+            if (
+                isinstance(model_context_window, int)
+                and not isinstance(model_context_window, bool)
+                and model_context_window > 0
+                and model_context_window != self._model_context_window
+            ):
+                self._model_context_window = model_context_window
+                self._save_conversation_id(self._conversation_id)
+            if turn is None:
+                return
             last = tu.get("last") or {}
             total = tu.get("total") or {}
+            context_tokens = last.get("totalTokens")
+            if (
+                isinstance(context_tokens, int)
+                and not isinstance(context_tokens, bool)
+                and context_tokens > 0
+            ):
+                turn.context_tokens = context_tokens
             try:
                 # ``last`` is a single request; sum the whole turn via the
                 # thread total's delta. Input excludes the re-sent cached read.

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -263,6 +263,7 @@ class CodexSession:
         self._lock = asyncio.Lock()
         self._conversation_id: str = self._load_conversation_id()
         self._model_context_window: int | None = self._load_model_context_window()
+        self._compact_config_pending = False
         # thread/start params aren't re-sent on resume; a sandbox change would
         # silently keep the old policy. Drop the thread, next start re-applies.
         if self._conversation_id:
@@ -335,6 +336,8 @@ class CodexSession:
     async def run_turn(self, user_message: str, system_prompt: str) -> TurnResult:
         """Send one turn; wait for ``turn/completed``."""
         async with self._lock:
+            if self._compact_config_pending:
+                await self._teardown_locked()
             await self._ensure_running(system_prompt)
             # Defence-in-depth: a non-empty cid is ``_ensure_running``'s
             # contract; never send ``threadId=""`` (a silent wedge) if
@@ -814,6 +817,8 @@ class CodexSession:
                         resume=True,
                         session_id=self._conversation_id,
                     )
+                if config:
+                    self._compact_config_pending = False
                 return
             except Exception as exc:
                 logger.warning(
@@ -863,7 +868,8 @@ class CodexSession:
                 resume=False,
                 session_id=self._conversation_id,
             )
-
+        if config:
+            self._compact_config_pending = False
 
     async def _teardown_locked(self) -> None:
         for pending in self._pending.values():
@@ -1180,6 +1186,8 @@ class CodexSession:
             ):
                 self._model_context_window = model_context_window
                 self._save_conversation_id(self._conversation_id)
+                if self.auto_compact_threshold_pct is not None:
+                    self._compact_config_pending = True
             if turn is None:
                 return
             last = tu.get("last") or {}

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -148,6 +148,7 @@ class DockerCLIAdapter(Adapter):
         permission_mode: str = "bypassPermissions",
         sandbox: str = "danger-full-access",
         inference_level: str = "",
+        auto_compact_threshold_pct: float | None = None,
         task_timeout_seconds: float = 1800.0,
         harness=None,
         memory_limit: str = "",
@@ -178,6 +179,7 @@ class DockerCLIAdapter(Adapter):
         self.permission_mode = permission_mode
         self.sandbox = sandbox
         self.inference_level = inference_level
+        self.auto_compact_threshold_pct = auto_compact_threshold_pct
         self.task_timeout_seconds = task_timeout_seconds
         # Optional cgroup caps. ``--memory`` is a hard ceiling that
         # OOM-kills processes in this container only; ``--memory-
@@ -227,6 +229,8 @@ class DockerCLIAdapter(Adapter):
         return await session.run_turn(user_message, ctx.system_prompt)
 
     def context_limits(self) -> tuple[int | None, int | None]:
+        if self._codex_session is not None:
+            return self._codex_session.context_limits()
         if self._session is None:
             return None, None
         return self._session.context_limits()
@@ -345,6 +349,7 @@ class DockerCLIAdapter(Adapter):
             permission_mode=self.permission_mode,
             sandbox=self.sandbox,
             model=self.model,
+            auto_compact_threshold_pct=self.auto_compact_threshold_pct,
             task_timeout_seconds=self.task_timeout_seconds,
             audit=AuditLog(
                 Path(self.workspace_dir) / ".puffo-agent" / "audit.log",

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -162,6 +162,7 @@ class LocalCLIAdapter(Adapter):
         permission_mode: str = "default",
         sandbox: str = "danger-full-access",
         inference_level: str = "",
+        auto_compact_threshold_pct: float | None = None,
         task_timeout_seconds: float = 1800.0,
         harness=None,
         desired_skills: list[str] | None = None,
@@ -187,6 +188,7 @@ class LocalCLIAdapter(Adapter):
         self.permission_mode = _sanitise_permission_mode(permission_mode, agent_id)
         self.sandbox = _sanitise_sandbox(sandbox, agent_id)
         self.inference_level = inference_level
+        self.auto_compact_threshold_pct = auto_compact_threshold_pct
         self.task_timeout_seconds = task_timeout_seconds
         self.desired_skills = list(desired_skills or [])
         self.desired_mcps = list(desired_mcps or [])
@@ -230,6 +232,8 @@ class LocalCLIAdapter(Adapter):
         return await session.run_turn(user_message, ctx.system_prompt)
 
     def context_limits(self) -> tuple[int | None, int | None]:
+        if self._codex_session is not None:
+            return self._codex_session.context_limits()
         if self._session is None:
             return None, None
         return self._session.context_limits()
@@ -466,6 +470,7 @@ class LocalCLIAdapter(Adapter):
             permission_mode=self.permission_mode,
             sandbox=self.sandbox,
             model=self.model,
+            auto_compact_threshold_pct=self.auto_compact_threshold_pct,
             task_timeout_seconds=self.task_timeout_seconds,
             audit=codex_audit,
         )

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -305,11 +305,28 @@ async def execute_command(
             if not result.ok:
                 return {"ok": False, "error": f"runtime: {result.error}"}
         if "env_overrides" in params:
+            from .context_telemetry import (
+                CLAUDE_COMPACT_PCT_KEY,
+                CODEX_COMPACT_PCT_KEY,
+            )
             from ..state import merge_env_overrides
 
+            updates = params.get("env_overrides")
+            if (
+                cfg.runtime.harness == "codex"
+                and isinstance(updates, dict)
+                and CLAUDE_COMPACT_PCT_KEY in updates
+                and CODEX_COMPACT_PCT_KEY not in updates
+            ):
+                updates = dict(updates)
+                updates[CODEX_COMPACT_PCT_KEY] = updates.pop(
+                    CLAUDE_COMPACT_PCT_KEY
+                )
+                if CLAUDE_COMPACT_PCT_KEY in cfg.env_overrides:
+                    updates[CLAUDE_COMPACT_PCT_KEY] = ""
             try:
                 merged = merge_env_overrides(
-                    cfg.env_overrides, params.get("env_overrides")
+                    cfg.env_overrides, updates
                 )
             except ValueError as exc:
                 return {"ok": False, "error": str(exc)}

--- a/src/puffo_agent/portal/control/context_telemetry.py
+++ b/src/puffo_agent/portal/control/context_telemetry.py
@@ -1,4 +1,4 @@
-"""Claude Code context limits and auto-compact configuration."""
+"""Harness context limits and auto-compact configuration."""
 
 from __future__ import annotations
 
@@ -10,6 +10,19 @@ MIN_CONTEXT_WINDOW_TOKENS = 100_000
 MAX_CONTEXT_WINDOW_TOKENS = 1_000_000
 
 logger = logging.getLogger(__name__)
+
+CLAUDE_COMPACT_PCT_KEY = "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+CODEX_COMPACT_PCT_KEY = "CODEX_AUTOCOMPACT_PCT_OVERRIDE"
+
+
+def compact_pct_key(harness: str) -> str:
+    return CODEX_COMPACT_PCT_KEY if harness == "codex" else CLAUDE_COMPACT_PCT_KEY
+
+
+def configured_compact_pct(
+    harness: str, env_overrides: dict[str, str] | None,
+) -> float | None:
+    return parse_threshold_pct((env_overrides or {}).get(compact_pct_key(harness)))
 
 _MODEL_WINDOWS: tuple[tuple[str, int], ...] = (
     # Legacy explicit extended-window aliases.
@@ -105,9 +118,7 @@ def build_context_runtime(
         and max_context > 0
         else resolve_context_window(model, env)
     )
-    configured_pct = parse_threshold_pct(
-        overrides.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")
-    )
+    configured_pct = parse_threshold_pct(overrides.get(CLAUDE_COMPACT_PCT_KEY))
     reported_pct = compact_threshold_pct(window, auto_compact_threshold)
     return {
         "max_context": window,

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1067,7 +1067,10 @@ class RuntimeConfig:
 MAX_ROLE_SHORT_LEN = 32
 
 # Prevent remote edits from rewriting process identity or credentials.
-ENV_OVERRIDE_WHITELIST = frozenset({"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"})
+ENV_OVERRIDE_WHITELIST = frozenset({
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
+    "CODEX_AUTOCOMPACT_PCT_OVERRIDE",
+})
 
 
 def validate_env_overrides(raw: object) -> dict[str, str]:
@@ -1096,8 +1099,7 @@ def validate_env_overrides(raw: object) -> dict[str, str]:
             ) from None
         if not (0 < pct <= 100):
             raise ValueError(
-                f"{key} must be >0 and <=100 (claude-code ignores anything "
-                f"else); got {text!r}"
+                f"{key} must be >0 and <=100; got {text!r}"
             )
         text = str(int(pct)) if pct.is_integer() else str(pct)
         out[key] = text

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -703,16 +703,17 @@ class AgentDetail(QWidget):
         self._populate_effort_combo(harness, self._effort.currentData() or "")
         if self._cfg is not None:
             self._access.setText(self._access_summary(harness, self._cfg))
+            self._populate_autocompact(self._cfg, harness=harness)
         self._update_autocompact_enabled()
 
     def _update_autocompact_enabled(self, *_args) -> None:
         applies = (
             self._runtime_kind.currentText() in {"cli-local", "cli-docker"}
-            and self._harness.currentText() == "claude-code"
+            and self._harness.currentText() in {"claude-code", "codex"}
         )
         self._autocompact.setEnabled(applies)
         self._context_usage.setEnabled(applies)
-        reason = "" if applies else "Auto-compact thresholds apply only to Claude Code."
+        reason = "" if applies else "Auto-compact thresholds require Claude Code or Codex."
         self._autocompact.setToolTip(
             "Compact the agent's context earlier; saving restarts the agent."
             if applies else reason
@@ -736,10 +737,13 @@ class AgentDetail(QWidget):
         self._effort.setCurrentIndex(idx if idx >= 0 else 0)
         self._effort.blockSignals(False)
 
-    def _populate_autocompact(self, cfg: AgentConfig) -> None:
-        from ...control.context_telemetry import parse_threshold_pct
+    def _populate_autocompact(
+        self, cfg: AgentConfig, *, harness: str | None = None,
+    ) -> None:
+        from ...control.context_telemetry import compact_pct_key, parse_threshold_pct
 
-        raw = cfg.env_overrides.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "")
+        active_harness = harness or cfg.runtime.harness
+        raw = cfg.env_overrides.get(compact_pct_key(active_harness), "")
         configured_pct = parse_threshold_pct(raw)
         wanted = (
             ""
@@ -768,32 +772,41 @@ class AgentDetail(QWidget):
             return
         from ...control.context_telemetry import (
             build_context_runtime,
+            compact_pct_key,
             estimate_compact_threshold_tokens,
             parse_threshold_pct,
         )
 
         cfg = self._cfg
         state = RuntimeState.load(cfg.id)
-        live_window = state.max_context if state and state.max_context > 0 else None
-        selected_pct = parse_threshold_pct(self._autocompact.currentData())
-        runtime = build_context_runtime(
-            model=cfg.runtime.model,
-            max_context=live_window,
-            env_overrides={
-                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": (
-                    self._autocompact.currentData() or ""
-                )
-            },
-            env={} if cfg.runtime.kind == "cli-docker" else None,
+        harness = self._harness.currentText()
+        same_harness = harness == cfg.runtime.harness
+        live_window = (
+            state.max_context
+            if same_harness and state and state.max_context > 0
+            else None
         )
-        window = runtime["max_context"]
-        pct = runtime["auto_compact_threshold_pct"]
+        selected_pct = parse_threshold_pct(self._autocompact.currentData())
+        key = compact_pct_key(harness)
+        if harness == "codex":
+            window = live_window
+            pct = selected_pct
+        else:
+            runtime = build_context_runtime(
+                model=cfg.runtime.model,
+                max_context=live_window,
+                env_overrides={key: self._autocompact.currentData() or ""},
+                env={} if cfg.runtime.kind == "cli-docker" else None,
+            )
+            window = runtime["max_context"]
+            pct = runtime["auto_compact_threshold_pct"]
         configured_pct = parse_threshold_pct(
-            cfg.env_overrides.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")
+            cfg.env_overrides.get(key)
         )
         if (
             pct is None
             and configured_pct is None
+            and same_harness
             and state is not None
             and state.auto_compact_threshold_pct is not None
         ):
@@ -861,7 +874,7 @@ class AgentDetail(QWidget):
             cfg.runtime.kind,
             cfg.runtime.harness,
             cfg.runtime.model,
-            cfg.env_overrides.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", ""),
+            tuple(sorted(cfg.env_overrides.items())),
         )
 
         runtime_kind = self._runtime_kind.currentText()
@@ -900,10 +913,12 @@ class AgentDetail(QWidget):
         cfg.runtime.model = model
         cfg.runtime.inference_level = self._effort.currentData() or ""
         pct = self._autocompact.currentData() or ""
+        from ...control.context_telemetry import compact_pct_key
+        compact_key = compact_pct_key(harness)
         try:
             cfg.env_overrides = merge_env_overrides(
                 cfg.env_overrides,
-                {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": pct},
+                {compact_key: pct},
             )
         except ValueError as exc:
             QMessageBox.warning(self, "Save", str(exc))
@@ -918,7 +933,7 @@ class AgentDetail(QWidget):
             cfg.runtime.kind,
             cfg.runtime.harness,
             cfg.runtime.model,
-            pct,
+            tuple(sorted(cfg.env_overrides.items())),
         )
         if current_context_config != previous_context_config:
             state = RuntimeState.load(cfg.id)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -136,6 +136,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
     if kind == "cli-docker":
         from ..agent.adapters.docker_cli import DockerCLIAdapter
         from ..agent.harness import build_harness
+        from .control.context_telemetry import configured_compact_pct
         harness = build_harness(agent_cfg.runtime.harness)
         if harness.name() == "codex":
             model = agent_cfg.runtime.model or daemon_cfg.openai.model or ""
@@ -163,6 +164,9 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             permission_mode=agent_cfg.runtime.permission_mode,
             sandbox=agent_cfg.runtime.sandbox,
             inference_level=agent_cfg.runtime.inference_level,
+            auto_compact_threshold_pct=configured_compact_pct(
+                harness.name(), agent_cfg.env_overrides,
+            ),
             task_timeout_seconds=agent_cfg.runtime.task_timeout_seconds,
             harness=harness,
             memory_limit=memory_limit,
@@ -200,6 +204,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
 
     if kind == "cli-local":
         from ..agent.adapters.local_cli import LocalCLIAdapter
+        from .control.context_telemetry import configured_compact_pct
         # The legacy permission-proxy DM flow has not been ported to
         # puffo-core; the hook fail-opens when PUFFO_OPERATOR_USERNAME
         # is unset, so cli-local works without supervised approvals.
@@ -222,6 +227,9 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             permission_mode=agent_cfg.runtime.permission_mode,
             sandbox=agent_cfg.runtime.sandbox,
             inference_level=agent_cfg.runtime.inference_level,
+            auto_compact_threshold_pct=configured_compact_pct(
+                harness.name(), agent_cfg.env_overrides,
+            ),
             task_timeout_seconds=agent_cfg.runtime.task_timeout_seconds,
             harness=harness,
             desired_skills=agent_cfg.desired_skills,
@@ -980,15 +988,39 @@ class Worker:
                     env_overrides=self.agent_cfg.env_overrides,
                 )
             )
+        elif rt.harness == "codex":
+            from .control.context_telemetry import (
+                compact_threshold_pct,
+                configured_compact_pct,
+            )
+
+            adapter = getattr(self, "_adapter", None)
+            limits = adapter.context_limits() if adapter is not None else (None, None)
+            configured_pct = configured_compact_pct(
+                "codex", getattr(self.agent_cfg, "env_overrides", {}),
+            )
+            info.update({
+                "max_context": limits[0],
+                "auto_compact_threshold_pct": (
+                    configured_pct
+                    if configured_pct is not None
+                    else compact_threshold_pct(limits[0], limits[1])
+                ),
+            })
+        if rt.harness in {"claude-code", "codex"}:
             max_context = int(info["max_context"] or 0)
             threshold_pct = info["auto_compact_threshold_pct"]
+            runtime_state = getattr(self, "runtime", None)
             if (
-                self.runtime.max_context != max_context
-                or self.runtime.auto_compact_threshold_pct != threshold_pct
+                runtime_state is not None
+                and (
+                    runtime_state.max_context != max_context
+                    or runtime_state.auto_compact_threshold_pct != threshold_pct
+                )
             ):
-                self.runtime.max_context = max_context
-                self.runtime.auto_compact_threshold_pct = threshold_pct
-                self.runtime.save(self.agent_cfg.id)
+                runtime_state.max_context = max_context
+                runtime_state.auto_compact_threshold_pct = threshold_pct
+                runtime_state.save(self.agent_cfg.id)
         return info
 
     async def _run_ws_local(self) -> None:

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -422,6 +422,48 @@ while True:
     asyncio.run(_run())
 
 
+def test_first_context_window_reloads_session_before_next_turn(tmp_path):
+    fake = _write_fake(tmp_path, '''\
+absorb_initialize()
+msg = r()
+if msg["method"] == "thread/start":
+    assert "config" not in msg["params"]
+    w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "c1"}}})
+    while sys.stdin.readline():
+        pass
+else:
+    assert msg["method"] == "thread/resume"
+    assert msg["params"]["config"] == {"model_auto_compact_token_limit": 193800}
+    w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "c1"}}})
+    msg = r()
+    w({"jsonrpc": "2.0", "id": msg["id"], "result": None})
+    w({"jsonrpc": "2.0", "method": "turn/completed", "params": {"turn": {"status": "completed"}}})
+    while sys.stdin.readline():
+        pass
+''')
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+        auto_compact_threshold_pct=75,
+    )
+
+    async def _run():
+        await cs.warm("system prompt")
+        await cs._handle_notification(
+            "thread/tokenUsage/updated",
+            {"tokenUsage": {"modelContextWindow": 258400}},
+        )
+        result = await cs.run_turn("hi", "system prompt")
+        await cs.aclose()
+        return result
+
+    result = asyncio.run(_run())
+    assert result.metadata["conversation_id"] == "c1"
+    assert cs._compact_config_pending is False
+
+
 def test_token_usage_sums_multi_request_turn(tmp_path):
     """A turn with several model requests reports the whole turn's usage (the
     thread total's delta), not just the last request."""
@@ -967,14 +1009,15 @@ while True:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_load_conversation_id_failsoft_on_corrupt_json(tmp_path):
-    """Corrupt session JSON loads as ``""`` — the signal
-    ``_ensure_running`` keys on to recover."""
+def test_persisted_session_loaders_failsoft_on_corrupt_json(tmp_path):
     session_file = tmp_path / "codex_session.json"
     session_file.write_text("not-valid-json{", encoding="utf-8")
     cs = CodexSession.__new__(CodexSession)
     cs.session_file = session_file
     assert cs._load_conversation_id() == ""
+    assert cs._load_persisted_thread_cwd() == ""
+    assert cs._load_persisted_model() is None
+    assert cs._load_model_context_window() is None
 
 
 def test_ensure_running_with_empty_cid_and_alive_proc_respawns(tmp_path):
@@ -1075,6 +1118,7 @@ def test_run_turn_raises_when_cid_stays_empty(tmp_path):
     cs._lock = asyncio.Lock()
     cs._next_id = 1
     cs._active_turn = None
+    cs._compact_config_pending = False
     cs.current_instructions = None
 
     async def _stub_ensure_running(_system_prompt):

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -291,7 +291,8 @@ turn_id = msg["id"]
 
 w({"jsonrpc": "2.0", "method": "thread/tokenUsage/updated",
    "params": {"threadId": "c1", "turnId": "u1", "tokenUsage": {
-       "last": {"inputTokens": 76544, "cachedInputTokens": 74624, "outputTokens": 21},
+       "last": {"totalTokens": 76565, "inputTokens": 76544, "cachedInputTokens": 74624, "outputTokens": 21},
+       "modelContextWindow": 258400,
    }}})
 
 w({"jsonrpc": "2.0", "id": turn_id, "result": None})
@@ -318,6 +319,107 @@ while True:
     result = asyncio.run(_run())
     assert result.input_tokens == 76544 - 74624  # cached history excluded
     assert result.output_tokens == 21
+    assert result.metadata["context_tokens"] == 76565
+    assert cs.context_limits() == (258400, 244800)
+    assert cs._thread_config() == {}
+    persisted = json.loads((tmp_path / "codex_session.json").read_text())
+    assert persisted["model_context_window"] == 258400
+
+
+def test_configured_compact_pct_uses_persisted_model_window(tmp_path):
+    session_file = tmp_path / "codex_session.json"
+    session_file.write_text(json.dumps({
+        "conversation_id": "c1",
+        "sandbox": "danger-full-access",
+        "thread_cwd": str(tmp_path),
+        "model_context_window": 258400,
+    }))
+
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=session_file,
+        argv=["unused"],
+        cwd=str(tmp_path),
+        auto_compact_threshold_pct=75,
+    )
+
+    assert cs.context_limits() == (258400, 193800)
+    assert cs._thread_config() == {"model_auto_compact_token_limit": 193800}
+
+
+@pytest.mark.parametrize("window", [None, 0, -1, True, "258400"])
+def test_invalid_context_window_notification_is_ignored(tmp_path, window):
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=["unused"],
+    )
+
+    asyncio.run(cs._handle_notification(
+        "thread/tokenUsage/updated",
+        {"tokenUsage": {"modelContextWindow": window}},
+    ))
+
+    assert cs.context_limits() == (None, None)
+
+
+def test_context_window_updates_without_an_active_turn(tmp_path):
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "codex_session.json",
+        argv=["unused"],
+    )
+
+    asyncio.run(cs._handle_notification(
+        "thread/tokenUsage/updated",
+        {"tokenUsage": {"modelContextWindow": 258400}},
+    ))
+
+    assert cs.context_limits() == (258400, 244800)
+
+
+def test_missing_persisted_model_is_backward_compatible(tmp_path):
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=tmp_path / "missing.json",
+        argv=["unused"],
+    )
+
+    assert cs._load_persisted_model() is None
+
+
+def test_new_thread_receives_configured_compact_limit(tmp_path):
+    fake = _write_fake(tmp_path, '''\
+absorb_initialize()
+msg = r()
+assert msg["method"] == "thread/start"
+assert msg["params"]["config"] == {"model_auto_compact_token_limit": 193800}
+w({"jsonrpc": "2.0", "id": msg["id"], "result": {"thread": {"id": "c1"}}})
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+''')
+    session_file = tmp_path / "codex_session.json"
+    session_file.write_text(json.dumps({
+        "conversation_id": "",
+        "sandbox": "danger-full-access",
+        "model": "",
+        "model_context_window": 258400,
+    }))
+    cs = CodexSession(
+        agent_id="alice-test-0001",
+        session_file=session_file,
+        argv=_argv_for(fake),
+        cwd=str(tmp_path),
+        auto_compact_threshold_pct=75,
+    )
+
+    async def _run():
+        await cs.warm("system prompt")
+        await cs.aclose()
+
+    asyncio.run(_run())
 
 
 def test_token_usage_sums_multi_request_turn(tmp_path):
@@ -332,11 +434,11 @@ turn_id = msg["id"]
 
 w({"jsonrpc": "2.0", "method": "thread/tokenUsage/updated",
    "params": {"tokenUsage": {
-       "last": {"inputTokens": 1005, "cachedInputTokens": 1000, "outputTokens": 100},
+       "last": {"totalTokens": 1105, "inputTokens": 1005, "cachedInputTokens": 1000, "outputTokens": 100},
        "total": {"inputTokens": 5005, "cachedInputTokens": 5000, "outputTokens": 100}}}})
 w({"jsonrpc": "2.0", "method": "thread/tokenUsage/updated",
    "params": {"tokenUsage": {
-       "last": {"inputTokens": 1008, "cachedInputTokens": 1000, "outputTokens": 110},
+       "last": {"totalTokens": 1118, "inputTokens": 1008, "cachedInputTokens": 1000, "outputTokens": 110},
        "total": {"inputTokens": 6013, "cachedInputTokens": 6000, "outputTokens": 210}}}})
 
 w({"jsonrpc": "2.0", "id": turn_id, "result": None})
@@ -360,6 +462,7 @@ while True:
         return result
 
     result = asyncio.run(_run())
+    assert result.metadata["context_tokens"] == 1118
     assert result.output_tokens == 210  # 100 + 110, not just the last request's 110
     assert result.input_tokens == 13    # cumulative non-cached, not just the last
 
@@ -374,6 +477,7 @@ absorb_initialize()
 msg = r()
 assert msg["method"] == "thread/resume", f"expected thread/resume, got {msg['method']}"
 assert msg["params"]["threadId"] == "conv_42"
+assert msg["params"]["config"] == {"model_auto_compact_token_limit": 193800}
 w({"jsonrpc": "2.0", "id": msg["id"],
    "result": {"thread": {"id": "conv_42"}}})
 
@@ -399,6 +503,7 @@ def test_resume_existing_conversation(tmp_path):
         "conversation_id": "conv_42",
         "sandbox": "danger-full-access",
         "thread_cwd": str(tmp_path),
+        "model_context_window": 258400,
     }))
 
     cs = CodexSession(
@@ -406,6 +511,7 @@ def test_resume_existing_conversation(tmp_path):
         session_file=session_file,
         argv=_argv_for(fake),
         cwd=str(tmp_path),
+        auto_compact_threshold_pct=75,
     )
 
     async def _run():
@@ -1221,6 +1327,25 @@ def test_codex_same_sandbox_keeps_persisted_thread(tmp_path):
         agent_id="a", session_file=sf, argv=["x"], sandbox="workspace-write",
     )
     assert cs._conversation_id == "old_thread"  # unchanged → resume
+
+
+def test_codex_model_change_resets_thread_and_stale_context_window(tmp_path):
+    sf = tmp_path / "codex_session.json"
+    sf.write_text(json.dumps({
+        "conversation_id": "old_thread",
+        "sandbox": "danger-full-access",
+        "model": "gpt-old",
+        "model_context_window": 258_400,
+    }), encoding="utf-8")
+
+    cs = CodexSession(
+        agent_id="a", session_file=sf, argv=["x"], model="gpt-new",
+        auto_compact_threshold_pct=75,
+    )
+
+    assert cs._conversation_id == ""
+    assert cs.context_limits() == (None, None)
+    assert cs._thread_config() == {}
 
 
 def test_codex_legacy_session_file_treated_as_full_access(tmp_path):

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -650,14 +650,15 @@ async def test_remote_edit_reaches_docker_exec_command():
     assert command[3:5] == ["-e", "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50"]
 
 
-def test_build_local_codex_adapter_receives_compact_pct():
+@pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])
+def test_build_codex_adapter_receives_compact_pct(kind):
     from puffo_agent.portal.state import DaemonConfig
     from puffo_agent.portal.worker import build_adapter
 
     home = isolated_home()
     write_test_agent(home, "ctx-bot")
     cfg = AgentConfig.load("ctx-bot")
-    cfg.runtime.kind = "cli-local"
+    cfg.runtime.kind = kind
     cfg.runtime.provider = "openai"
     cfg.runtime.harness = "codex"
     cfg.env_overrides = {"CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75"}

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -12,6 +12,7 @@ from _bridge_support import isolated_home, write_test_agent  # noqa: E402
 from puffo_agent.portal.control.context_telemetry import (  # noqa: E402
     build_context_runtime,
     compact_threshold_pct,
+    configured_compact_pct,
     estimate_compact_threshold_tokens,
     parse_threshold_pct,
     resolve_context_window,
@@ -260,13 +261,14 @@ def test_runtime_info_preserves_unknown_model_window():
     assert worker.runtime.max_context == 0
 
 
-def test_codex_runtime_info_omits_claude_context_config():
+def test_codex_runtime_info_persists_app_server_context_window():
     from types import SimpleNamespace
 
     from puffo_agent.portal.worker import Worker
 
     worker = Worker.__new__(Worker)
     worker.agent_cfg = SimpleNamespace(
+        id="ctx-bot",
         runtime=SimpleNamespace(
             kind="cli-docker",
             provider="openai",
@@ -276,6 +278,8 @@ def test_codex_runtime_info_omits_claude_context_config():
         ),
         env_overrides={},
     )
+    worker._adapter = SimpleNamespace(context_limits=lambda: (258_400, 244_800))
+    worker.runtime = RuntimeState()
 
     assert worker._runtime_info() == {
         "kind": "cli-docker",
@@ -283,13 +287,57 @@ def test_codex_runtime_info_omits_claude_context_config():
         "harness": "codex",
         "model": "gpt-5.4",
         "inference_level": "high",
+        "max_context": 258_400,
+        "auto_compact_threshold_pct": 94.737,
     }
+    assert worker.runtime.max_context == 258_400
+
+
+def test_codex_runtime_reports_configured_compact_pct():
+    from types import SimpleNamespace
+
+    from puffo_agent.portal.worker import Worker
+
+    worker = Worker.__new__(Worker)
+    worker.agent_cfg = SimpleNamespace(
+        id="ctx-bot",
+        runtime=SimpleNamespace(
+            kind="cli-local",
+            provider="openai",
+            harness="codex",
+            model="gpt-5.4",
+            inference_level="high",
+        ),
+        env_overrides={"CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75"},
+    )
+    worker._adapter = SimpleNamespace(context_limits=lambda: (258_400, 193_800))
+    worker.runtime = RuntimeState()
+
+    out = worker._runtime_info()
+
+    assert out["max_context"] == 258_400
+    assert out["auto_compact_threshold_pct"] == 75
 
 
 def test_validate_accepts_whitelisted_key():
     assert validate_env_overrides(
         {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"}
     ) == {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"}
+
+
+def test_validate_accepts_codex_threshold_key():
+    assert validate_env_overrides(
+        {"CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75"}
+    ) == {"CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75"}
+
+
+def test_configured_threshold_is_harness_specific():
+    overrides = {
+        "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30",
+        "CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75",
+    }
+    assert configured_compact_pct("claude-code", overrides) == 30
+    assert configured_compact_pct("codex", overrides) == 75
 
 
 def test_validate_rejects_unknown_key():
@@ -397,6 +445,10 @@ def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars():
         "autoCompactThreshold": 167_000,
     }
     assert adapter.context_limits() == (200_000, 167_000)
+    adapter._codex_session = type("CodexLimits", (), {
+        "context_limits": lambda self: (258_400, 193_800),
+    })()
+    assert adapter.context_limits() == (258_400, 193_800)
 
     env = session.env
     assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "50"
@@ -443,6 +495,10 @@ def test_docker_session_receives_overrides(tmp_path, monkeypatch):
         "autoCompactThreshold": 967_000,
     }
     assert adapter.context_limits() == (1_000_000, 967_000)
+    adapter._codex_session = type("CodexLimits", (), {
+        "context_limits": lambda self: (258_400, 193_800),
+    })()
+    assert adapter.context_limits() == (258_400, 193_800)
     assert session.env_overrides == {
         "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"
     }
@@ -592,3 +648,20 @@ async def test_remote_edit_reaches_docker_exec_command():
     session = adapter._ensure_session()
     command = session.build_command([], session.env_overrides)
     assert command[3:5] == ["-e", "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50"]
+
+
+def test_build_local_codex_adapter_receives_compact_pct():
+    from puffo_agent.portal.state import DaemonConfig
+    from puffo_agent.portal.worker import build_adapter
+
+    home = isolated_home()
+    write_test_agent(home, "ctx-bot")
+    cfg = AgentConfig.load("ctx-bot")
+    cfg.runtime.kind = "cli-local"
+    cfg.runtime.provider = "openai"
+    cfg.runtime.harness = "codex"
+    cfg.env_overrides = {"CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75"}
+
+    adapter = build_adapter(DaemonConfig(), cfg)
+
+    assert adapter.auto_compact_threshold_pct == 75

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -339,6 +339,47 @@ async def test_edit_sets_env_override_threshold(home):
 
 
 @pytest.mark.asyncio
+async def test_edit_maps_legacy_threshold_key_to_codex(home):
+    write_test_agent(home, "scout")
+    cfg = AgentConfig.load("scout")
+    cfg.runtime.harness = "codex"
+    cfg.env_overrides = {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"}
+    cfg.save()
+
+    res = await execute_command(
+        "edit", "scout",
+        {"env_overrides": {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"}},
+    )
+
+    assert res["ok"] is True
+    assert AgentConfig.load("scout").env_overrides == {
+        "CODEX_AUTOCOMPACT_PCT_OVERRIDE": "30",
+    }
+
+
+@pytest.mark.asyncio
+async def test_edit_prefers_explicit_codex_threshold_key(home):
+    write_test_agent(home, "scout")
+    cfg = AgentConfig.load("scout")
+    cfg.runtime.harness = "codex"
+    cfg.save()
+
+    res = await execute_command(
+        "edit", "scout",
+        {"env_overrides": {
+            "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+            "CODEX_AUTOCOMPACT_PCT_OVERRIDE": "30",
+        }},
+    )
+
+    assert res["ok"] is True
+    assert AgentConfig.load("scout").env_overrides == {
+        "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+        "CODEX_AUTOCOMPACT_PCT_OVERRIDE": "30",
+    }
+
+
+@pytest.mark.asyncio
 async def test_edit_rejects_non_whitelisted_env_key(home):
     write_test_agent(home, "scout")
     res = await execute_command(

--- a/tests/test_ui_context_threshold.py
+++ b/tests/test_ui_context_threshold.py
@@ -93,7 +93,7 @@ def test_threshold_control_applies_to_cli_docker_claude(qapp, agent_home):
 
 @pytest.mark.parametrize(
     ("runtime_kind", "harness"),
-    [("cli-local", "codex"), ("ws-local", "claude-code")],
+    [("ws-local", "claude-code"), ("ws-local", "codex")],
 )
 def test_threshold_control_disables_when_not_applicable(
     qapp, agent_home, runtime_kind, harness
@@ -106,7 +106,39 @@ def test_threshold_control_disables_when_not_applicable(
     qapp.processEvents()
 
     assert not view._autocompact.isEnabled()
-    assert "only to Claude Code" in view._autocompact.toolTip()
+    assert "require Claude Code or Codex" in view._autocompact.toolTip()
+
+
+def test_threshold_control_applies_to_codex(qapp, agent_home):
+    cfg = AgentConfig.load("threshold-ui")
+    cfg.runtime.harness = "codex"
+    cfg.runtime.provider = "openai"
+    cfg.env_overrides = {"CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75"}
+    cfg.save()
+    RuntimeState(max_context=258_400, auto_compact_threshold_pct=75).save(
+        "threshold-ui"
+    )
+    view = agent_detail.AgentDetail()
+    view.bind("threshold-ui")
+
+    assert view._autocompact.isEnabled()
+    assert view._autocompact.currentData() == "75"
+    assert "258K window" in view._context_usage.text()
+    assert "~193K (75%)" in view._context_usage.text()
+
+
+def test_codex_save_uses_codex_override_key(qapp, agent_home):
+    view = agent_detail.AgentDetail()
+    view.bind("threshold-ui")
+    view._harness.setCurrentText("codex")
+    view._autocompact.setCurrentIndex(view._autocompact.findData("75"))
+
+    view._on_save()
+
+    assert AgentConfig.load("threshold-ui").env_overrides == {
+        "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+        "CODEX_AUTOCOMPACT_PCT_OVERRIDE": "75",
+    }
 
 
 def test_threshold_selection_participates_in_dirty_state(qapp, agent_home):


### PR DESCRIPTION
## What changed

- report Codex `modelContextWindow` through persistent runtime metadata and current usage through `turn_complete`
- support per-agent Codex compact thresholds for both `cli-local` and `cli-docker`
- pass configured token limits through Codex app-server `thread/start` and `thread/resume`
- automatically resume the same Codex thread with its compact limit after a new session first reports its model context window
- show Codex context limits and compact controls in the local portal UI
- translate the legacy remote compact-setting key for Codex agents

## Why

Claude Code agents already exposed context telemetry and configurable compaction. Codex agents lacked the same runtime metadata and control path, so operators could not see their context usage or tune when compaction occurred.

## Validation

- `pytest -p no:warnings`: 2387 passed, 2 expected platform/feature skips
- focused telemetry, adapter, lifecycle, control, and UI tests passed repeatedly
- diff line and branch coverage: 100%
- `cli-local` smoke: Gates reported a 258400-token window and triggered real Codex compaction with an override
- `cli-docker` smoke: Gates reported 258400 and Linus reported 200000; both reported configured thresholds and triggered real auto-compaction at an 8% test setting
- restored both smoke agents to 75% after validation
