### PR TITLE
Restart Docker Claude after OAuth rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Docker Claude workers now reload rotated OAuth credentials.** After the
+  daemon refreshes the shared Claude credential, it restarts affected
+  `cli-docker` Claude Code workers so long-running processes stop using the
+  revoked access token cached at session startup.
+
 - **Claude context telemetry no longer invents limits for unknown models.**
   A transient context query timeout remains retryable on later turns, while
   configured compact thresholds remain authoritative because Claude's context

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -366,17 +366,24 @@ class Daemon:
             # Re-arm the auth_failed DM dedup so a re-expiry this
             # session re-notifies the operator.
             worker._auth_failed_notification_sent = False
-            if was_auth_failed:
-                # The running adapter session still holds the stale
-                # credential; a restart re-links the fresh cred and
-                # redelivers the stalled batch (cursor wasn't advanced).
+            restart_docker_claude = (
+                (getattr(agent_cfg.runtime, "harness", "") or "claude-code")
+                == "claude-code"
+                and getattr(agent_cfg.runtime, "kind", "") == "cli-docker"
+            )
+            if was_auth_failed or restart_docker_claude:
                 try:
                     flag = restart_flag_path(agent_id)
                     flag.parent.mkdir(parents=True, exist_ok=True)
                     flag.write_text("")
+                    reason = (
+                        "credential recovered"
+                        if was_auth_failed
+                        else "credential rotated for cli-docker"
+                    )
                     logger.info(
-                        "agent %s: credential recovered — requesting restart "
-                        "to pick up the new credential", agent_id,
+                        "agent %s: %s — requesting restart to pick up the "
+                        "new credential", agent_id, reason,
                     )
                 except OSError as exc:
                     logger.warning(

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -104,7 +104,10 @@ async def test_first_tick_establishes_baseline_without_firing(tmp_path):
 # ── daemon: restart auth_failed agents on recovery ─────────────────
 
 
-def _daemon_harness(monkeypatch, tmp_path, health: str):
+def _daemon_harness(
+    monkeypatch, tmp_path, health: str, *, kind: str = "cli-local",
+    harness: str = "claude-code",
+):
     from puffo_agent.portal import daemon as daemon_module
     from puffo_agent.portal.state import RuntimeState
 
@@ -125,7 +128,10 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
         id = "t-agent"
 
         class runtime:
-            harness = "claude-code"
+            pass
+
+        runtime.kind = kind
+        runtime.harness = harness
 
         class puffo_core:
             slug = "alice-0001"
@@ -140,9 +146,7 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
         refresher = _StubRefresher()
         codex_refresher = _StubRefresher()
 
-        def _refresher_for(self, _cfg):
-            return self.refresher
-
+        _refresher_for = daemon_module.Daemon._refresher_for
         _register_with_refresher = daemon_module.Daemon._register_with_refresher
 
     d = _StubDaemon()
@@ -163,6 +167,40 @@ def test_on_refresh_success_no_restart_when_healthy(tmp_path, monkeypatch):
     d, w, flag = _daemon_harness(monkeypatch, tmp_path, "ok")
     d.refresher.callback()
     assert not flag.exists()    # nothing to recover → no restart
+
+
+def test_on_refresh_success_restarts_healthy_docker_claude(tmp_path, monkeypatch):
+    d, _w, flag = _daemon_harness(
+        monkeypatch, tmp_path, "ok", kind="cli-docker",
+    )
+
+    d.refresher.callback()
+
+    assert flag.exists()
+
+
+def test_on_refresh_success_does_not_restart_healthy_docker_codex(
+    tmp_path, monkeypatch,
+):
+    d, _w, flag = _daemon_harness(
+        monkeypatch, tmp_path, "ok", kind="cli-docker", harness="codex",
+    )
+
+    d.codex_refresher.callback()
+
+    assert not flag.exists()
+
+
+def test_docker_claude_refresh_restart_is_idempotent(tmp_path, monkeypatch):
+    d, _w, flag = _daemon_harness(
+        monkeypatch, tmp_path, "ok", kind="cli-docker",
+    )
+
+    d.refresher.callback()
+    d.refresher.callback()
+
+    assert flag.exists()
+    assert flag.read_text() == ""
 
 
 # ── new message while auth_failed wakes the refresher ──────────────

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -911,15 +913,26 @@ def test_probe_uses_default_model_after_latch_persists_across_calls(
     assert "--model" not in spawned_argvs[1]
 
 
-def test_refresh_probe_model_honors_env_var_override(monkeypatch):
-    # Reload the module with the env var set so the module-level
-    # constant picks it up. Verifies the operator escape hatch works.
-    import importlib
-    monkeypatch.setenv("PUFFO_AGENT_REFRESH_MODEL", "claude-sonnet-4-6-fake")
-    reloaded = importlib.reload(credential_refresh)
-    try:
-        assert reloaded.REFRESH_PROBE_MODEL == "claude-sonnet-4-6-fake"
-    finally:
-        # Restore the original module state for downstream tests.
-        monkeypatch.delenv("PUFFO_AGENT_REFRESH_MODEL", raising=False)
-        importlib.reload(credential_refresh)
+def test_refresh_probe_model_honors_env_var_override():
+    repo_src = str(Path(__file__).resolve().parents[1] / "src")
+    env = {
+        **os.environ,
+        "PUFFO_AGENT_REFRESH_MODEL": "claude-sonnet-4-6-fake",
+        "PYTHONPATH": os.pathsep.join(
+            path for path in (repo_src, os.environ.get("PYTHONPATH")) if path
+        ),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from puffo_agent.portal.credential_refresh import "
+            "REFRESH_PROBE_MODEL; print(REFRESH_PROBE_MODEL)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.stdout.strip() == "claude-sonnet-4-6-fake"


### PR DESCRIPTION
## Summary

- restart healthy `cli-docker` Claude Code workers after the daemon rotates their shared OAuth credential
- leave `cli-local` workers and Docker Codex workers unchanged
- add recovery, isolation, and idempotency coverage
- document the fix in the Unreleased changelog

## Root cause

The refreshed credential was correctly written to the host credential file and visible through Linus's Docker bind mount. However, the already-running Claude Code process continued using the access token it had cached at startup. Once rotation revoked that token, the process failed even though the credential file contained the new token. The daemon previously restarted a worker only when it was already marked `auth_failed` at refresh time.

## Impact

Docker Claude workers now restart after a real credential rotation and resume with the fresh mounted credential. Repeated callbacks remain idempotent, and other runtime/harness combinations do not restart.

## Validation

- Linus Docker smoke test: message processed to `result/success`, `turn_complete` reported, health returned to `ok`, and no OAuth-revoked error occurred
- focused credential tests passed
- full suite passed (2 expected skips)
- changed-line branch coverage: 100%
- `git diff --check` passed
