### PR TITLE
Use Claude Code autocompact token windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Claude Code auto-compaction now uses the supported token-window CLI flag.**
+  The existing 30%, 50%, and 75% controls are translated to
+  `--autocompact <tokens>` for local and Docker agents instead of relying on
+  `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`. Claude's 100K minimum is enforced, and
+  runtime telemetry reports the effective percentage after that adjustment.
+  The bundled Docker runtime now pins a Claude Code release that supports the
+  flag.
+
 - **Port 63387 is now dedicated to `ws-local` message transport.** The legacy
   Local Bridge HTTP APIs, pairing commands, and browser-facing management
   surface have been removed; externally hosted agents continue to attach over

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -67,14 +67,14 @@ def _puffo_agent_pkg_dir() -> Path:
 # Bump on Dockerfile changes so existing hosts rebuild without manual
 # image-tag pruning. ``_ensure_image`` only builds when the tag is
 # missing locally.
-DEFAULT_IMAGE = "puffo/agent-runtime:v15"
-CONTAINER_LAYOUT_VERSION = "15"
+DEFAULT_IMAGE = "puffo/agent-runtime:v16"
+CONTAINER_LAYOUT_VERSION = "16"
 
 # Pinned Claude Code CLI version baked into the image. Floating would
 # let an upstream release shift the stream-json protocol or
 # ``--permission-mode`` semantics under us; bump deliberately after
 # verification.
-CLAUDE_CODE_NPM_VERSION = "2.1.117"
+CLAUDE_CODE_NPM_VERSION = "2.1.224"
 
 # Pinned Codex CLI version. Keep this aligned with the app-server
 # protocol exercised by ``CodexSession``.
@@ -392,6 +392,8 @@ class DockerCLIAdapter(Adapter):
         # errors. Never pass secrets here; use Docker's name-only ``-e NAME``
         # passthrough, as the Codex bearer-token path does.
         for key, value in (env_overrides or {}).items():
+            if key == "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE":
+                continue
             cmd.extend(["-e", f"{key}={value}"])
         cmd.extend([
             self.container_name,
@@ -399,6 +401,15 @@ class DockerCLIAdapter(Adapter):
         ])
         if self.model:
             cmd.extend(["--model", self.model])
+        from ...portal.control.context_telemetry import claude_autocompact_tokens
+
+        threshold = claude_autocompact_tokens(
+            model=self.model,
+            pct=getattr(self, "auto_compact_threshold_pct", None),
+            env={},
+        )
+        if threshold is not None:
+            cmd.extend(["--autocompact", str(threshold)])
         if self.inference_level:
             if self.inference_level in INFERENCE_LEVELS:
                 cmd.extend(["--effort", self.inference_level])

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -805,9 +805,14 @@ class LocalCLIAdapter(Adapter):
         }
         env = {
             **os.environ,
-            **self.env_overrides,
+            **{
+                key: value
+                for key, value in self.env_overrides.items()
+                if key != "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+            },
             **adapter_owned_env,
         }
+        env.pop("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", None)
         self._session = ClaudeSession(
             agent_id=self.agent_id,
             session_file=self.session_file,
@@ -956,6 +961,14 @@ class LocalCLIAdapter(Adapter):
             cmd.extend(["--permission-mode", self.permission_mode])
         if self.model:
             cmd.extend(["--model", self.model])
+        from ...portal.control.context_telemetry import claude_autocompact_tokens
+
+        threshold = claude_autocompact_tokens(
+            model=self.model,
+            pct=getattr(self, "auto_compact_threshold_pct", None),
+        )
+        if threshold is not None:
+            cmd.extend(["--autocompact", str(threshold)])
         # drops codex-only yaml values
         if self.inference_level:
             if self.inference_level in INFERENCE_LEVELS:

--- a/src/puffo_agent/portal/control/context_telemetry.py
+++ b/src/puffo_agent/portal/control/context_telemetry.py
@@ -8,6 +8,7 @@ import os
 
 MIN_CONTEXT_WINDOW_TOKENS = 100_000
 MAX_CONTEXT_WINDOW_TOKENS = 1_000_000
+MIN_CLAUDE_AUTOCOMPACT_TOKENS = 100_000
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,29 @@ def estimate_compact_threshold_tokens(
     return max(0, int(window * pct / 100))
 
 
+def claude_autocompact_tokens(
+    *,
+    model: str = "",
+    pct: float | None,
+    max_context: int | None = None,
+    env: dict[str, str] | None = None,
+) -> int | None:
+    """Translate the percentage control into Claude Code's token argument."""
+    if pct is None:
+        return None
+    window = (
+        max_context
+        if isinstance(max_context, int)
+        and not isinstance(max_context, bool)
+        and max_context > 0
+        else resolve_context_window(model, env)
+    )
+    threshold = estimate_compact_threshold_tokens(window, pct)
+    if threshold is None:
+        return None
+    return max(MIN_CLAUDE_AUTOCOMPACT_TOKENS, threshold)
+
+
 def compact_threshold_pct(
     window: int | None, threshold: int | None
 ) -> float | None:
@@ -111,6 +135,24 @@ def build_context_runtime(
 ) -> dict:
     """Build context configuration persisted with runtime metadata."""
     overrides = env_overrides or {}
+    configured_pct = parse_threshold_pct(overrides.get(CLAUDE_COMPACT_PCT_KEY))
+    if configured_pct is not None:
+        window = resolve_context_window(model, env)
+        configured_threshold = (
+            claude_autocompact_tokens(
+                pct=configured_pct,
+                max_context=window,
+                env=env,
+            )
+            if window is not None
+            else None
+        )
+        return {
+            "max_context": window,
+            "auto_compact_threshold_pct": compact_threshold_pct(
+                window, configured_threshold
+            ),
+        }
     window = (
         max_context
         if isinstance(max_context, int)
@@ -118,11 +160,8 @@ def build_context_runtime(
         and max_context > 0
         else resolve_context_window(model, env)
     )
-    configured_pct = parse_threshold_pct(overrides.get(CLAUDE_COMPACT_PCT_KEY))
     reported_pct = compact_threshold_pct(window, auto_compact_threshold)
     return {
         "max_context": window,
-        "auto_compact_threshold_pct": (
-            configured_pct if configured_pct is not None else reported_pct
-        ),
+        "auto_compact_threshold_pct": reported_pct,
     }

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -11,6 +11,7 @@ from _portal_support import isolated_home, write_test_agent  # noqa: E402
 
 from puffo_agent.portal.control.context_telemetry import (  # noqa: E402
     build_context_runtime,
+    claude_autocompact_tokens,
     compact_threshold_pct,
     configured_compact_pct,
     estimate_compact_threshold_tokens,
@@ -44,6 +45,34 @@ def test_invalid_claude_threshold_is_ignored(threshold):
 @pytest.mark.parametrize("pct,expected", [(50, 100_000), (30, 60_000), (75, 150_000)])
 def test_pct_override_scales_the_window(pct, expected):
     assert estimate_compact_threshold_tokens(200_000, pct) == expected
+
+
+@pytest.mark.parametrize(
+    ("window", "pct", "expected"),
+    [
+        (200_000, 30, 100_000),
+        (200_000, 50, 100_000),
+        (200_000, 75, 150_000),
+        (1_000_000, 30, 300_000),
+    ],
+)
+def test_claude_autocompact_tokens_enforces_cli_minimum(window, pct, expected):
+    assert claude_autocompact_tokens(
+        max_context=window, pct=pct, env={}
+    ) == expected
+
+
+def test_claude_autocompact_tokens_requires_a_known_window():
+    assert claude_autocompact_tokens(
+        model="claude-future-model", pct=50, env={}
+    ) is None
+
+
+def test_claude_autocompact_tokens_omits_default_without_resolving_model(caplog):
+    assert claude_autocompact_tokens(
+        model="claude-future-model", pct=None, env={}
+    ) is None
+    assert "context window is unknown" not in caplog.text
 
 
 def test_pct_100_estimate_does_not_claim_compaction_is_disabled():
@@ -135,22 +164,38 @@ def test_runtime_reports_active_override():
 
 def test_runtime_configured_override_wins_over_raw_session_default():
     out = build_context_runtime(
+        model="claude-haiku-4-5",
         max_context=200_000,
         auto_compact_threshold=167_000,
         env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "5"},
         env={},
     )
-    assert out["auto_compact_threshold_pct"] == 5.0
+    assert out["auto_compact_threshold_pct"] == 50.0
 
 
 def test_runtime_matching_session_threshold_preserves_override():
     out = build_context_runtime(
+        model="claude-haiku-4-5",
         max_context=200_000,
         auto_compact_threshold=60_000,
         env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
         env={},
     )
-    assert out["auto_compact_threshold_pct"] == 30.0
+    assert out["auto_compact_threshold_pct"] == 50.0
+
+
+def test_runtime_treats_cli_raw_max_as_compact_window_when_configured():
+    out = build_context_runtime(
+        model="claude-fable-5",
+        max_context=300_000,
+        auto_compact_threshold=267_000,
+        env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
+        env={},
+    )
+    assert out == {
+        "max_context": 1_000_000,
+        "auto_compact_threshold_pct": 30.0,
+    }
 
 
 def test_runtime_prefers_session_reported_max_context():
@@ -208,6 +253,30 @@ def test_docker_runtime_info_persists_context_config_with_model(monkeypatch):
         "max_context": 1_000_000,
         "auto_compact_threshold_pct": 30.0,
     }
+
+
+def test_runtime_info_persists_claude_cli_minimum_as_effective_pct(monkeypatch):
+    from types import SimpleNamespace
+
+    from puffo_agent.portal.worker import Worker
+
+    monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
+    worker = Worker.__new__(Worker)
+    worker.agent_cfg = SimpleNamespace(
+        id="ctx-bot",
+        runtime=SimpleNamespace(
+            kind="cli-local",
+            provider="anthropic",
+            harness="claude-code",
+            model="claude-haiku-4-5",
+            inference_level="",
+        ),
+        env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"},
+    )
+    worker.runtime = RuntimeState()
+
+    assert worker._runtime_info()["auto_compact_threshold_pct"] == 50.0
+    assert worker.runtime.auto_compact_threshold_pct == 50.0
 
 
 def test_runtime_info_prefers_adapter_context_window(monkeypatch):
@@ -419,9 +488,10 @@ def test_yaml_int_value_loads_as_string():
     assert isinstance(loaded["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"], str)
 
 
-def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars():
+def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars(monkeypatch):
     from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
 
+    monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "75")
     home = isolated_home()
     write_test_agent(home, "ctx-bot")
     adapter = LocalCLIAdapter(
@@ -437,6 +507,7 @@ def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars():
             "HOME": "/tmp/untrusted-home",
             "USERPROFILE": "/tmp/untrusted-profile",
         },
+        auto_compact_threshold_pct=50,
     )
     assert adapter.context_limits() == (None, None)
     session = adapter._ensure_session()
@@ -451,9 +522,12 @@ def test_overrides_layer_over_os_environ_but_under_adapter_owned_vars():
     assert adapter.context_limits() == (258_400, 193_800)
 
     env = session.env
-    assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "50"
+    assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in env
     assert env["HOME"] == str(adapter.agent_home_dir)
     assert env["USERPROFILE"] == str(adapter.agent_home_dir)
+    assert session.build_command([], session.env_overrides)[-2:] == [
+        "--autocompact", "500000",
+    ]
 
 
 def test_default_band_clears_the_override():
@@ -477,7 +551,7 @@ def test_docker_session_receives_overrides(tmp_path, monkeypatch):
 
     adapter = DockerCLIAdapter(
         agent_id="ctx-bot",
-        model="sonnet",
+        model="claude-sonnet-5",
         image="test",
         workspace_dir=str(tmp_path / "workspace"),
         claude_dir=str(tmp_path / "claude"),
@@ -485,6 +559,7 @@ def test_docker_session_receives_overrides(tmp_path, monkeypatch):
         agent_home_dir=str(tmp_path / "home"),
         shared_fs_dir=str(tmp_path / "shared"),
         env_overrides={"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"},
+        auto_compact_threshold_pct=50,
     )
     adapter._prepare_mcp_args = lambda: []
 
@@ -508,15 +583,18 @@ def test_docker_session_receives_overrides(tmp_path, monkeypatch):
         env_overrides=adapter.env_overrides,
         env={},
     )
-    assert runtime["max_context"] is None
-    assert session.build_command([], session.env_overrides)[:6] == [
+    assert runtime["max_context"] == 1_000_000
+    command = session.build_command([], session.env_overrides)
+    assert command[:6] == [
         "docker",
         "exec",
         "-i",
-        "-e",
-        "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50",
         "puffo-ctx-bot",
+        "claude",
+        "--dangerously-skip-permissions",
     ]
+    assert command[-2:] == ["--autocompact", "500000"]
+    assert all("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in arg for arg in command)
 
 
 @pytest.mark.parametrize(
@@ -647,7 +725,8 @@ async def test_remote_edit_reaches_docker_exec_command():
     adapter._prepare_mcp_args = lambda: []
     session = adapter._ensure_session()
     command = session.build_command([], session.env_overrides)
-    assert command[3:5] == ["-e", "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50"]
+    assert command[-2:] == ["--autocompact", "500000"]
+    assert all("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in arg for arg in command)
 
 
 @pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])

--- a/tests/test_docker_codex.py
+++ b/tests/test_docker_codex.py
@@ -30,7 +30,10 @@ def _adapter(tmp_path: Path, *, harness=None, **overrides) -> DockerCLIAdapter:
 
 
 def test_bundled_image_contains_only_supported_harnesses():
-    assert "@anthropic-ai/claude-code@" in DOCKERFILE
+    assert (
+        f"@anthropic-ai/claude-code@{docker_cli.CLAUDE_CODE_NPM_VERSION}"
+        in DOCKERFILE
+    )
     assert "@openai/codex@" in DOCKERFILE
     assert '"mcp>=1.0,<2"' in DOCKERFILE
     assert '"aiohttp-socks>=0.10"' in DOCKERFILE

--- a/tests/test_ui_context_threshold.py
+++ b/tests/test_ui_context_threshold.py
@@ -194,6 +194,9 @@ def test_threshold_selection_participates_in_dirty_state(qapp, agent_home):
 
 
 def test_threshold_selection_updates_the_preview_immediately(qapp, agent_home):
+    cfg = AgentConfig.load("threshold-ui")
+    cfg.runtime.model = "claude-haiku-4-5"
+    cfg.save()
     RuntimeState(
         max_context=200_000,
         auto_compact_threshold_pct=50,
@@ -205,7 +208,7 @@ def test_threshold_selection_updates_the_preview_immediately(qapp, agent_home):
     qapp.processEvents()
 
     assert "200K window" in view._context_usage.text()
-    assert "~60K (30%)" in view._context_usage.text()
+    assert "~100K (50%)" in view._context_usage.text()
 
 
 def test_switching_from_override_to_default_does_not_reuse_stale_pct(


### PR DESCRIPTION
## What changed

- Translate the existing Claude Code 30%, 50%, and 75% controls into `--autocompact <tokens>` for cli-local and cli-docker.
- Clamp Claude's configured window to its supported 100K-token minimum and report the effective percentage in daemon telemetry.
- Stop forwarding `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` to Claude subprocesses.
- Preserve the model's actual maximum context in telemetry even though Claude reports the custom autocompact window as `rawMaxTokens`.
- Upgrade the bundled Docker runtime to Claude Code 2.1.224 and bump its image/layout version.
- Document the behavior in the Unreleased changelog.

## Why

The legacy percentage environment override is model-dependent: it compacted correctly on some Sonnet models but failed to trigger on Opus and Fable. Current Claude Code exposes a supported token-window CLI option instead. Using that option makes behavior consistent across models while retaining the existing percentage-based operator UI.

## Impact

Operators keep the same percentage controls. Claude Code receives a deterministic absolute token window, values below 100K are safely clamped, and the portal reports the effective threshold rather than the pre-clamp selection.

## Validation

- `pytest -q -p no:warnings` — full suite passed (two existing platform/pending-feature skips).
- Editable-install daemon smoke with cli-local Claude Fable 5 at `--autocompact 100000`: automatic compaction triggered around 68K without crossing 100K or errors.
- Editable-install daemon smoke with cli-local Claude Opus 5 at `--autocompact 100000`: automatic compaction triggered at 66,951 tokens and reduced context to 5,072; the review turn completed healthy.
- Bundled Docker image rebuilt with Claude Code 2.1.224 and accepted `--autocompact 500000`; no running Claude process retained the legacy environment override.
