### PR TITLE
Fix Codex sandboxing in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Codex Docker agents can write to their mounted workspace reliably.** The
+  container is now the effective filesystem sandbox, avoiding unsupported
+  nested sandboxing, and resumed local and Docker sessions reapply their
+  working directory and permission policy instead of falling back to
+  read-only access.
+
 - **Claude context telemetry no longer invents limits for unknown models.**
   A transient context query timeout remains retryable on later turns, while
   configured compact thresholds remain authoritative because Claude's context

--- a/src/puffo_agent/agent/adapters/codex_session.py
+++ b/src/puffo_agent/agent/adapters/codex_session.py
@@ -264,8 +264,9 @@ class CodexSession:
         self._conversation_id: str = self._load_conversation_id()
         self._model_context_window: int | None = self._load_model_context_window()
         self._compact_config_pending = False
-        # thread/start params aren't re-sent on resume; a sandbox change would
-        # silently keep the old policy. Drop the thread, next start re-applies.
+        # A sandbox change must start a fresh thread. Although resume re-applies
+        # our current policy, retaining a thread created under a different
+        # policy would make the persisted session state misleading.
         if self._conversation_id:
             persisted_sandbox = self._load_persisted_sandbox()
             persisted_model = self._load_persisted_model()
@@ -793,11 +794,21 @@ class CodexSession:
                 self.agent_id, exc,
             )
 
-        # 2. Start or resume the conversation/thread.
+        # 2. Start or resume the conversation/thread. App Server processes can
+        # be short-lived, so resume must re-apply these settings; otherwise a
+        # newly spawned server falls back to read-only / on-request defaults.
+        thread_settings: dict[str, Any] = {
+            "cwd": self._effective_thread_cwd or os.getcwd(),
+            "approvalPolicy": (
+                "never" if self.permission_mode == "bypassPermissions" else "untrusted"
+            ),
+            "sandbox": self.sandbox,
+        }
         if self._conversation_id:
             try:
                 resume_params: dict[str, Any] = {
                     "threadId": self._conversation_id,
+                    **thread_settings,
                 }
                 config = self._thread_config()
                 if config:
@@ -832,13 +843,7 @@ class CodexSession:
         # ``approvalPolicy: "never"`` = auto-approve everything (confusing name;
         # verified live). Sandbox default stays open: cli-local runs as the
         # operator's UID, the real boundary is cli-docker's container.
-        new_conv_params: dict[str, Any] = {
-            "cwd": self._effective_thread_cwd or os.getcwd(),
-            "approvalPolicy": (
-                "never" if self.permission_mode == "bypassPermissions" else "untrusted"
-            ),
-            "sandbox": self.sandbox,
-        }
+        new_conv_params = thread_settings
         if self.model:
             new_conv_params["model"] = self.model
         config = self._thread_config()

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -68,6 +68,7 @@ def _puffo_agent_pkg_dir() -> Path:
 # image-tag pruning. ``_ensure_image`` only builds when the tag is
 # missing locally.
 DEFAULT_IMAGE = "puffo/agent-runtime:v16"
+CONTAINER_CODEX_SANDBOX = "danger-full-access"
 CONTAINER_LAYOUT_VERSION = "16"
 
 # Pinned Claude Code CLI version baked into the image. Floating would
@@ -146,7 +147,6 @@ class DockerCLIAdapter(Adapter):
         shared_fs_dir: str,
         owner_username: str = "",
         permission_mode: str = "bypassPermissions",
-        sandbox: str = "danger-full-access",
         inference_level: str = "",
         auto_compact_threshold_pct: float | None = None,
         task_timeout_seconds: float = 1800.0,
@@ -177,7 +177,9 @@ class DockerCLIAdapter(Adapter):
         self.shared_fs_dir = Path(shared_fs_dir)
         self.owner_username = owner_username
         self.permission_mode = permission_mode
-        self.sandbox = sandbox
+        # Docker is the filesystem boundary. A second bubblewrap sandbox
+        # cannot create user namespaces under Docker's default seccomp policy.
+        self.sandbox = CONTAINER_CODEX_SANDBOX
         self.inference_level = inference_level
         self.auto_compact_threshold_pct = auto_compact_threshold_pct
         self.task_timeout_seconds = task_timeout_seconds

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -987,7 +987,12 @@ def cmd_agent_runtime(args: argparse.Namespace) -> int:
         print(f"  allowed_tools:    {cfg.runtime.allowed_tools or '[]'}")
         print(f"  docker_image:     {cfg.runtime.docker_image or '(bundled default)'}")
         print(f"  permission_mode:  {cfg.runtime.permission_mode}  (cli-local only)")
-        print(f"  sandbox:          {cfg.runtime.sandbox}  (codex only)")
+        sandbox = (
+            "Docker container"
+            if cfg.runtime.kind == "cli-docker" and cfg.runtime.harness == "codex"
+            else cfg.runtime.sandbox
+        )
+        print(f"  sandbox:          {sandbox}  (codex only)")
         print(f"  max_turns:        {cfg.runtime.max_turns}  (sdk-local only)")
         return 0
 
@@ -1646,7 +1651,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--sandbox",
         choices=["read-only", "workspace-write", "danger-full-access"],
         help=(
-            "codex: file-system policy. Note "
+            "cli-local codex: file-system policy. cli-docker always uses "
+            "its container as the sandbox. Note "
             "``workspace-write`` is silently downgraded to read-only "
             "on Windows; use ``danger-full-access`` there."
         ),

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -844,6 +844,8 @@ class AgentDetail(QWidget):
                 "never" if cfg.runtime.permission_mode == "bypassPermissions"
                 else "untrusted"
             )
+            if cfg.runtime.kind == "cli-docker":
+                return f"sandbox: Docker container · approve: {policy}"
             return f"sandbox: {cfg.runtime.sandbox} · approve: {policy}"
         return f"permission: {cfg.runtime.permission_mode}"
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -162,7 +162,6 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             agent_home_dir=str(agent_home_dir(agent_cfg.id)),
             shared_fs_dir=str(shared_fs_dir()),
             permission_mode=agent_cfg.runtime.permission_mode,
-            sandbox=agent_cfg.runtime.sandbox,
             inference_level=agent_cfg.runtime.inference_level,
             auto_compact_threshold_pct=configured_compact_pct(
                 harness.name(), agent_cfg.env_overrides,

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -519,6 +519,9 @@ absorb_initialize()
 msg = r()
 assert msg["method"] == "thread/resume", f"expected thread/resume, got {msg['method']}"
 assert msg["params"]["threadId"] == "conv_42"
+assert msg["params"]["cwd"] == EXPECTED_CWD
+assert msg["params"]["approvalPolicy"] == "never"
+assert msg["params"]["sandbox"] == "danger-full-access"
 assert msg["params"]["config"] == {"model_auto_compact_token_limit": 193800}
 w({"jsonrpc": "2.0", "id": msg["id"],
    "result": {"thread": {"id": "conv_42"}}})
@@ -539,7 +542,10 @@ while True:
 
 
 def test_resume_existing_conversation(tmp_path):
-    fake = _write_fake(tmp_path, RESUME_SCRIPT)
+    fake = _write_fake(
+        tmp_path,
+        f'EXPECTED_CWD = {str(tmp_path)!r}\n' + RESUME_SCRIPT,
+    )
     session_file = tmp_path / "codex_session.json"
     session_file.write_text(json.dumps({
         "conversation_id": "conv_42",

--- a/tests/test_docker_codex.py
+++ b/tests/test_docker_codex.py
@@ -155,7 +155,6 @@ def test_codex_session_runs_app_server_inside_container(tmp_path):
         tmp_path,
         harness=CodexHarness(),
         permission_mode="bypassPermissions",
-        sandbox="workspace-write",
         task_timeout_seconds=321,
     )
     session = adapter._ensure_codex_session()
@@ -166,9 +165,26 @@ def test_codex_session_runs_app_server_inside_container(tmp_path):
     ]
     assert session.cwd is None
     assert session.thread_cwd == "/workspace"
-    assert session.sandbox == "workspace-write"
+    assert session.sandbox == "danger-full-access"
     assert session.task_timeout_seconds == 321
     assert session.model == "gpt-5.4"
+
+
+def test_codex_session_replaces_persisted_nested_sandbox(tmp_path):
+    adapter = _adapter(tmp_path, harness=CodexHarness())
+    adapter.codex_home.mkdir(parents=True)
+    (adapter.codex_home / "codex_session.json").write_text(
+        json.dumps({
+            "conversation_id": "nested-sandbox-thread",
+            "sandbox": "workspace-write",
+        }),
+        encoding="utf-8",
+    )
+
+    session = adapter._ensure_codex_session()
+
+    assert session.sandbox == "danger-full-access"
+    assert session._conversation_id == ""
 
 
 def test_resolved_docker_path_is_used_for_harness_commands(tmp_path):
@@ -279,5 +295,5 @@ def test_worker_uses_openai_defaults_and_forwards_desired_content(monkeypatch, t
     assert captured["model"] == "gpt-default"
     assert captured["desired_skills"] == ["review"]
     assert captured["desired_mcps"] == ["github"]
-    assert captured["sandbox"] == "workspace-write"
+    assert "sandbox" not in captured
     assert captured["task_timeout_seconds"] == 456

--- a/tests/test_ui_context_threshold.py
+++ b/tests/test_ui_context_threshold.py
@@ -8,6 +8,7 @@ import pytest
 from PySide6.QtWidgets import QApplication
 
 from _portal_support import write_test_agent
+from puffo_agent.portal import cli
 from puffo_agent.portal.state import AgentConfig, RuntimeState
 from puffo_agent.portal.ui.widgets import agent_detail
 
@@ -89,6 +90,42 @@ def test_threshold_control_applies_to_cli_docker_claude(qapp, agent_home):
     qapp.processEvents()
 
     assert view._autocompact.isEnabled()
+
+
+def test_cli_docker_codex_reports_container_as_sandbox(qapp, agent_home):
+    cfg = AgentConfig.load("threshold-ui")
+    cfg.runtime.kind = "cli-docker"
+    cfg.runtime.provider = "openai"
+    cfg.runtime.harness = "codex"
+    cfg.runtime.sandbox = "workspace-write"
+    cfg.save()
+
+    view = agent_detail.AgentDetail()
+    view.bind("threshold-ui")
+
+    assert view._access.text() == "sandbox: Docker container · approve: never"
+
+
+@pytest.mark.parametrize(
+    ("runtime_kind", "expected"),
+    [
+        ("cli-docker", "Docker container"),
+        ("cli-local", "workspace-write"),
+    ],
+)
+def test_runtime_cli_reports_effective_codex_sandbox(
+    agent_home, capsys, runtime_kind, expected,
+):
+    cfg = AgentConfig.load("threshold-ui")
+    cfg.runtime.kind = runtime_kind
+    cfg.runtime.provider = "openai"
+    cfg.runtime.harness = "codex"
+    cfg.runtime.sandbox = "workspace-write"
+    cfg.save()
+
+    assert cli.main(["agent", "runtime", "threshold-ui"]) == 0
+
+    assert f"sandbox:          {expected}" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- treat the Docker container as the Codex filesystem sandbox, avoiding unsupported nested bubblewrap namespaces
- reapply cwd, approval policy, and sandbox when resuming Codex threads after app-server restarts
- report the effective Docker isolation boundary in CLI and desktop runtime details

## Validation

- affected tests passed three consecutive runs
- new executable line and branch diff coverage: 100%
- full suite: 2378 passed, 2 skipped
- CLI load smoke passed
- manual Puffpuff smoke passed across daemon restart, thread resume, and workspace write