### PR TITLE
Require explicit opt-in for Claude API key auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **Claude Code uses subscription authentication unless API-key mode is
   explicitly enabled.** Ambient `ANTHROPIC_API_KEY` values are ignored for
-  local and Docker CLI agents. A daemon-owned `anthropic.api_key` is passed to
-  Claude Code only when `anthropic.cli_use_api_key: true` is set in
-  `daemon.yml`; both values can also be updated with `puffo-agent config`.
+  local and Docker CLI agents, including per-agent environment and settings
+  overrides. A daemon-owned `anthropic.api_key` is passed to Claude Code only
+  when `anthropic.cli_use_api_key: true` is set. Operators can manage both
+  values with `puffo-agent config --anthropic-api-key KEY` and
+  `--anthropic-cli-use-api-key true|false`. API-key failures now show the
+  correct recovery steps and clear after the next successful turn.
 
 - **Codex Docker agents can write to their mounted workspace reliably.** The
   container is now the effective filesystem sandbox, avoiding unsupported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   explicitly enabled.** Ambient `ANTHROPIC_API_KEY` values are ignored for
   local and Docker CLI agents. A daemon-owned `anthropic.api_key` is passed to
   Claude Code only when `anthropic.cli_use_api_key: true` is set in
-  `daemon.yml`.
+  `daemon.yml`; both values can also be updated with `puffo-agent config`.
 
 - **Codex Docker agents can write to their mounted workspace reliably.** The
   container is now the effective filesystem sandbox, avoiding unsupported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Claude Code uses subscription authentication unless API-key mode is
+  explicitly enabled.** Ambient `ANTHROPIC_API_KEY` values are ignored for
+  local and Docker CLI agents. A daemon-owned `anthropic.api_key` is passed to
+  Claude Code only when `anthropic.cli_use_api_key: true` is set in
+  `daemon.yml`.
+
 - **Codex Docker agents can write to their mounted workspace reliably.** The
   container is now the effective filesystem sandbox, avoiding unsupported
   nested sandboxing, and resumed local and Docker sessions reapply their

--- a/config.example.yml
+++ b/config.example.yml
@@ -17,6 +17,7 @@ default_provider: "anthropic"  # "anthropic" | "openai" | "google"
 
 anthropic:
   api_key: ""                    # https://console.anthropic.com/
+  cli_use_api_key: false          # true = Claude Code uses this key instead of subscription auth
   model:   "claude-sonnet-4-6"   # empty = provider default
 
 openai:

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -134,6 +134,32 @@ def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
     )
 
 
+def format_anthropic_api_key_rejected(
+    agent_id: str, agent_display_name: str = "",
+) -> str:
+    """Bilingual recovery copy for daemon-owned Anthropic API keys."""
+    label = (
+        f"**{agent_display_name}** (`{agent_id}`)"
+        if agent_display_name else f"`{agent_id}`"
+    )
+    return (
+        f"⚠️ {label} — my Anthropic API key was rejected, so I can't "
+        "answer until it is corrected.\n\n"
+        "**On the computer where puffo-agent is running:**\n"
+        "1. Update `anthropic.api_key` in `daemon.yml` (or run "
+        "`puffo-agent config --anthropic-api-key KEY`).\n"
+        "2. Keep `anthropic.cli_use_api_key: true`.\n"
+        "3. Restart puffo-agent, then send me another message.\n\n"
+        f"⚠️ {label} — 我的 Anthropic API key 被拒绝，需要修正后才能"
+        "继续回复。\n\n"
+        "**在运行 puffo-agent 的电脑上：**\n"
+        "1. 修改 `daemon.yml` 中的 `anthropic.api_key`（或运行 "
+        "`puffo-agent config --anthropic-api-key KEY`）。\n"
+        "2. 保持 `anthropic.cli_use_api_key: true`。\n"
+        "3. 重启 puffo-agent，然后再发一条消息。"
+    )
+
+
 def format_codex_oauth_expired(
     agent_id: str, agent_display_name: str = "",
 ) -> str:

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -40,6 +40,7 @@ from ...portal.state import (
     filter_container_mcp_servers,
     read_host_codex_mcp_servers,
     seed_claude_home,
+    strip_claude_api_key_from_settings,
     sync_host_claude_code_auth_view,
     sync_host_codex_auth_view,
     sync_host_codex_skills,
@@ -159,6 +160,7 @@ class DockerCLIAdapter(Adapter):
         puffo_core_server_url: str = "",
         puffo_core_slug: str = "",
         puffo_core_keys_dir: str = "",
+        claude_api_key: str = "",
     ):
         self.agent_id = agent_id
         self.model = model
@@ -206,6 +208,7 @@ class DockerCLIAdapter(Adapter):
         self.puffo_core_server_url = puffo_core_server_url
         self.puffo_core_slug = puffo_core_slug
         self.puffo_core_keys_dir = puffo_core_keys_dir
+        self.claude_api_key = claude_api_key
         self._desired_codex_extras: dict[str, dict] = {}
         self._codex_bearer_env_names: tuple[str, ...] = ()
         self._desired_installed = False
@@ -370,6 +373,7 @@ class DockerCLIAdapter(Adapter):
             build_command=self._build_command,
             # cwd is WORKDIR /workspace inside the container.
             cwd=None,
+            env=self._claude_docker_env(),
             # Host-side write; the workspace bind-mount delivers it
             # to the container's tail loop and ``docker logs``.
             audit=AuditLog(
@@ -388,6 +392,10 @@ class DockerCLIAdapter(Adapter):
         env_overrides: dict[str, str] | None = None,
     ) -> list[str]:
         cmd: list[str] = [getattr(self, "_docker_bin", "docker"), "exec", "-i"]
+        if getattr(self, "claude_api_key", ""):
+            cmd.extend(["-e", "ANTHROPIC_API_KEY"])
+        else:
+            cmd.extend(["-e", "ANTHROPIC_API_KEY="])
         # ``env_overrides`` flows in before the container name so
         # docker treats each ``-e KEY=VALUE`` as an exec flag.
         # SECURITY: values are visible in the process list and in command
@@ -424,6 +432,14 @@ class DockerCLIAdapter(Adapter):
                 )
         cmd.extend(extra_args)
         return cmd
+
+    def _claude_docker_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        env.pop("ANTHROPIC_API_KEY", None)
+        api_key = getattr(self, "claude_api_key", "")
+        if api_key:
+            env["ANTHROPIC_API_KEY"] = api_key
+        return env
 
     def _prepare_mcp_args(self) -> list[str]:
         """Write the per-agent MCP config into the workspace and
@@ -621,6 +637,12 @@ class DockerCLIAdapter(Adapter):
                     "agent %s: seeded per-agent virtual $HOME at %s from %s",
                     self.agent_id, self.agent_home_dir, host_home,
                 )
+            for settings_path in (
+                self.claude_home_src / "settings.json",
+                Path(self.claude_dir) / "settings.json",
+                Path(self.claude_dir) / "settings.local.json",
+            ):
+                strip_claude_api_key_from_settings(settings_path)
             claude_auth_mode = sync_host_claude_code_auth_view(
                 host_home, self.agent_home_dir,
             )
@@ -682,6 +704,7 @@ class DockerCLIAdapter(Adapter):
 
             if (
                 self.harness.name() == "claude-code"
+                and not self.claude_api_key
                 and not (self.agent_home_dir / ".claude" / ".credentials.json").exists()
             ):
                 logger.warning(

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -391,10 +391,14 @@ class DockerCLIAdapter(Adapter):
         extra_args: list[str],
         env_overrides: dict[str, str] | None = None,
     ) -> list[str]:
+        self._strip_claude_api_key_settings()
         cmd: list[str] = [getattr(self, "_docker_bin", "docker"), "exec", "-i"]
         if getattr(self, "claude_api_key", ""):
             cmd.extend(["-e", "ANTHROPIC_API_KEY"])
         else:
+            # docker exec cannot unset a variable. An explicit empty value
+            # prevents the container image from supplying an ambient key;
+            # Claude Code treats the empty value as subscription mode.
             cmd.extend(["-e", "ANTHROPIC_API_KEY="])
         # ``env_overrides`` flows in before the container name so
         # docker treats each ``-e KEY=VALUE`` as an exec flag.
@@ -402,7 +406,10 @@ class DockerCLIAdapter(Adapter):
         # errors. Never pass secrets here; use Docker's name-only ``-e NAME``
         # passthrough, as the Codex bearer-token path does.
         for key, value in (env_overrides or {}).items():
-            if key == "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE":
+            if key in {
+                "ANTHROPIC_API_KEY",
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
+            }:
                 continue
             cmd.extend(["-e", f"{key}={value}"])
         cmd.extend([
@@ -440,6 +447,23 @@ class DockerCLIAdapter(Adapter):
         if api_key:
             env["ANTHROPIC_API_KEY"] = api_key
         return env
+
+    def _strip_claude_api_key_settings(self) -> None:
+        paths: list[Path] = []
+        claude_home_src = getattr(self, "claude_home_src", None)
+        if claude_home_src is not None:
+            paths.extend([
+                Path(claude_home_src) / "settings.json",
+                Path(claude_home_src) / "settings.local.json",
+            ])
+        claude_dir = getattr(self, "claude_dir", None)
+        if claude_dir is not None:
+            paths.extend([
+                Path(claude_dir) / "settings.json",
+                Path(claude_dir) / "settings.local.json",
+            ])
+        for settings_path in paths:
+            strip_claude_api_key_from_settings(settings_path)
 
     def _prepare_mcp_args(self) -> list[str]:
         """Write the per-agent MCP config into the workspace and
@@ -637,12 +661,7 @@ class DockerCLIAdapter(Adapter):
                     "agent %s: seeded per-agent virtual $HOME at %s from %s",
                     self.agent_id, self.agent_home_dir, host_home,
                 )
-            for settings_path in (
-                self.claude_home_src / "settings.json",
-                Path(self.claude_dir) / "settings.json",
-                Path(self.claude_dir) / "settings.local.json",
-            ):
-                strip_claude_api_key_from_settings(settings_path)
+            self._strip_claude_api_key_settings()
             claude_auth_mode = sync_host_claude_code_auth_view(
                 host_home, self.agent_home_dir,
             )

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -793,15 +793,7 @@ class LocalCLIAdapter(Adapter):
         if self._session is not None:
             return self._session
         extra = self._prepare_mcp_args()
-        strip_claude_api_key_from_settings(
-            self.agent_home_dir / ".claude" / "settings.json",
-        )
-        strip_claude_api_key_from_settings(
-            Path(self.claude_dir) / "settings.json",
-        )
-        strip_claude_api_key_from_settings(
-            Path(self.claude_dir) / "settings.local.json",
-        )
+        self._strip_claude_api_key_settings()
         # Register the PreToolUse permission hook before spawning;
         # settings.json is read fresh every spawn so this is
         # idempotent on every worker restart.
@@ -843,6 +835,23 @@ class LocalCLIAdapter(Adapter):
             env_overrides=self.env_overrides,
         )
         return self._session
+
+    def _strip_claude_api_key_settings(self) -> None:
+        paths: list[Path] = []
+        agent_home_dir = getattr(self, "agent_home_dir", None)
+        if agent_home_dir is not None:
+            paths.extend([
+                Path(agent_home_dir) / ".claude" / "settings.json",
+                Path(agent_home_dir) / ".claude" / "settings.local.json",
+            ])
+        claude_dir = getattr(self, "claude_dir", None)
+        if claude_dir is not None:
+            paths.extend([
+                Path(claude_dir) / "settings.json",
+                Path(claude_dir) / "settings.local.json",
+            ])
+        for settings_path in paths:
+            strip_claude_api_key_from_settings(settings_path)
 
     def _macos_credential_env(self) -> dict[str, str]:
         """macOS-only env hardening:
@@ -960,6 +969,7 @@ class LocalCLIAdapter(Adapter):
         extra_args: list[str],
         env_overrides: dict[str, str] | None = None,
     ) -> list[str]:
+        self._strip_claude_api_key_settings()
         # ``env_overrides`` is merged into the subprocess env on the
         # host by ClaudeSession._spawn; the kwarg here is just for
         # symmetry with the docker adapter.

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -35,6 +35,7 @@ from ...portal.state import (
     home_dir,
     read_host_codex_mcp_servers,
     seed_claude_home,
+    strip_claude_api_key_from_settings,
     sync_host_codex_auth_view,
     sync_host_claude_code_auth_view,
     sync_host_enabled_plugins,
@@ -171,6 +172,7 @@ class LocalCLIAdapter(Adapter):
         puffo_core_server_url: str = "",
         puffo_core_slug: str = "",
         puffo_core_keys_dir: str = "",
+        claude_api_key: str = "",
     ):
         self.agent_id = agent_id
         # Adapter-owned variables below take precedence over these overrides.
@@ -195,6 +197,7 @@ class LocalCLIAdapter(Adapter):
         self.puffo_core_server_url = puffo_core_server_url
         self.puffo_core_slug = puffo_core_slug
         self.puffo_core_keys_dir = puffo_core_keys_dir
+        self.claude_api_key = claude_api_key
         self._desired_codex_extras: dict[str, dict] = {}
         self._desired_installed = False
         if harness is None:
@@ -790,6 +793,15 @@ class LocalCLIAdapter(Adapter):
         if self._session is not None:
             return self._session
         extra = self._prepare_mcp_args()
+        strip_claude_api_key_from_settings(
+            self.agent_home_dir / ".claude" / "settings.json",
+        )
+        strip_claude_api_key_from_settings(
+            Path(self.claude_dir) / "settings.json",
+        )
+        strip_claude_api_key_from_settings(
+            Path(self.claude_dir) / "settings.local.json",
+        )
         # Register the PreToolUse permission hook before spawning;
         # settings.json is read fresh every spawn so this is
         # idempotent on every worker restart.
@@ -812,7 +824,10 @@ class LocalCLIAdapter(Adapter):
             },
             **adapter_owned_env,
         }
+        env.pop("ANTHROPIC_API_KEY", None)
         env.pop("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", None)
+        if self.claude_api_key:
+            env["ANTHROPIC_API_KEY"] = self.claude_api_key
         self._session = ClaudeSession(
             agent_id=self.agent_id,
             session_file=self.session_file,

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -208,7 +208,6 @@ def cmd_config(args: argparse.Namespace) -> int:
     else:
         print("creating daemon.yml (optional — defaults only)")
 
-    env_anthropic = os.environ.get("ANTHROPIC_API_KEY", "")
     env_openai = os.environ.get("OPENAI_API_KEY", "")
     env_google = (
         os.environ.get("GEMINI_API_KEY")
@@ -226,10 +225,11 @@ def cmd_config(args: argparse.Namespace) -> int:
 
     cfg.default_provider = prompt("Default AI provider (anthropic|openai|google)", cfg.default_provider or "anthropic")
 
-    anth_key = cfg.anthropic.api_key or env_anthropic
+    anth_key = cfg.anthropic.api_key
     anth_key = prompt("Default Anthropic API key (blank to skip)", anth_key)
     if anth_key:
-        cfg.anthropic = ProviderConfig(api_key=anth_key, model=cfg.anthropic.model or "claude-sonnet-4-6")
+        cfg.anthropic.api_key = anth_key
+        cfg.anthropic.model = cfg.anthropic.model or "claude-sonnet-4-6"
 
     oai_key = cfg.openai.api_key or env_openai
     oai_key = prompt("Default OpenAI API key (blank to skip)", oai_key)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -203,6 +203,21 @@ def cmd_config(args: argparse.Namespace) -> int:
     home_dir().mkdir(parents=True, exist_ok=True)
     cfg = DaemonConfig.load()
 
+    anthropic_api_key = getattr(args, "anthropic_api_key", None)
+    anthropic_cli_use_api_key = getattr(
+        args, "anthropic_cli_use_api_key", None,
+    )
+    if anthropic_api_key is not None or anthropic_cli_use_api_key is not None:
+        if anthropic_api_key is not None:
+            cfg.anthropic.api_key = anthropic_api_key
+        if anthropic_cli_use_api_key is not None:
+            cfg.anthropic.cli_use_api_key = (
+                anthropic_cli_use_api_key == "true"
+            )
+        cfg.save()
+        print(f"wrote {daemon_yml_path()}")
+        return 0
+
     if daemon_yml_path().exists():
         print(f"updating daemon.yml at {daemon_yml_path()}")
     else:
@@ -230,6 +245,14 @@ def cmd_config(args: argparse.Namespace) -> int:
     if anth_key:
         cfg.anthropic.api_key = anth_key
         cfg.anthropic.model = cfg.anthropic.model or "claude-sonnet-4-6"
+    cli_use_api_key = prompt(
+        "Use the Anthropic API key for Claude Code (true|false)",
+        "true" if cfg.anthropic.cli_use_api_key else "false",
+    ).lower()
+    if cli_use_api_key not in {"true", "false"}:
+        print("error: Claude Code API-key mode must be true or false")
+        return 2
+    cfg.anthropic.cli_use_api_key = cli_use_api_key == "true"
 
     oai_key = cfg.openai.api_key or env_openai
     oai_key = prompt("Default OpenAI API key (blank to skip)", oai_key)
@@ -1464,13 +1487,31 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser(
+    config = sub.add_parser(
         "config",
         help=(
             "Optional: set daemon-wide defaults (provider, models, API keys). "
             "The daemon runs fine without this — agents can carry their own keys."
         ),
-    ).set_defaults(func=cmd_config)
+    )
+    config.add_argument(
+        "--anthropic-api-key",
+        metavar="KEY",
+        help=(
+            "Set daemon.yml anthropic.api_key without reading "
+            "ANTHROPIC_API_KEY from the environment; pass an empty value "
+            "to clear it"
+        ),
+    )
+    config.add_argument(
+        "--anthropic-cli-use-api-key",
+        choices=("true", "false"),
+        help=(
+            "Enable or disable passing daemon.yml anthropic.api_key to "
+            "Claude Code"
+        ),
+    )
+    config.set_defaults(func=cmd_config)
     start = sub.add_parser(
         "start",
         help=(

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -46,6 +46,7 @@ from .state import (
     agents_dir,
     archive_flag_path,
     archived_dir,
+    claude_cli_api_key,
     clear_daemon_pid,
     clear_refresh_token_request,
     clear_stop_request,
@@ -65,6 +66,15 @@ from .state import (
 from .worker import Worker
 
 logger = logging.getLogger(__name__)
+
+
+def _uses_claude_api_key(daemon_cfg: DaemonConfig | None, agent_cfg: AgentConfig) -> bool:
+    return (
+        getattr(agent_cfg.runtime, "kind", "cli-local")
+        in {"cli-local", "cli-docker"}
+        and (agent_cfg.runtime.harness or "claude-code") == "claude-code"
+        and bool(claude_cli_api_key(daemon_cfg))
+    )
 
 
 class Daemon:
@@ -349,9 +359,14 @@ class Daemon:
             return self.codex_refresher
         return self.refresher
 
+    def _uses_claude_api_key(self, agent_cfg: AgentConfig) -> bool:
+        return _uses_claude_api_key(self.daemon_cfg, agent_cfg)
+
     def _register_with_refresher(
         self, agent_cfg: AgentConfig, worker: Worker,
     ) -> None:
+        if _uses_claude_api_key(getattr(self, "daemon_cfg", None), agent_cfg):
+            return
         refresher = self._refresher_for(agent_cfg)
         refresher.register_agent(agent_home_dir(agent_cfg.id))
         agent_id = agent_cfg.id
@@ -387,9 +402,13 @@ class Daemon:
         worker._refresh_success_callback = on_refresh_success
 
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
+        if self._uses_claude_api_key(agent_cfg):
+            return None
         return self._refresher_for(agent_cfg).notify_refresh_needed
 
     def _ensure_fresh_for(self, agent_cfg: AgentConfig):
+        if self._uses_claude_api_key(agent_cfg):
+            return None
         return self._refresher_for(agent_cfg).ensure_fresh
 
     def _set_worker_profile_cache(

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -108,6 +108,35 @@ _CLAUDE_HOME_SEED_PATHS = (
 )
 
 
+def strip_claude_api_key_from_settings(path: Path) -> bool:
+    """Remove a persisted ``env.ANTHROPIC_API_KEY`` override.
+
+    Claude Code gives that setting precedence over subscription credentials.
+    Puffo's only API-key opt-in lives in ``daemon.yml``, so agent-scoped
+    settings must not select a separate billing credential.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    env = data.get("env")
+    if not isinstance(env, dict) or "ANTHROPIC_API_KEY" not in env:
+        return False
+    env = dict(env)
+    del env["ANTHROPIC_API_KEY"]
+    if env:
+        data["env"] = env
+    else:
+        data.pop("env", None)
+    try:
+        _atomic_write_json(path, data)
+    except OSError:
+        return False
+    return True
+
+
 def seed_claude_home(host_home: Path, agent_home: Path) -> bool:
     """Seed a per-agent virtual ``$HOME`` from the operator's real
     ``$HOME``. Idempotent — never overwrites an existing file.
@@ -829,6 +858,12 @@ class ProviderConfig:
 
 
 @dataclass
+class AnthropicProviderConfig(ProviderConfig):
+    # Claude Code uses subscription auth unless this explicit opt-in is true.
+    cli_use_api_key: bool = False
+
+
+@dataclass
 class DataServiceConfig:
     """Loopback HTTP service MCP subprocesses use to read each
     agent's ``messages.db``. See ``portal/data_service.py``."""
@@ -863,7 +898,9 @@ class DaemonConfig:
     daemon holds only provider keys + reconcile knobs.
     """
     default_provider: str = "anthropic"
-    anthropic: ProviderConfig = field(default_factory=ProviderConfig)
+    anthropic: AnthropicProviderConfig = field(
+        default_factory=AnthropicProviderConfig,
+    )
     openai: ProviderConfig = field(default_factory=ProviderConfig)
     # Google provider defaults for chat-local/sdk-local runtimes.
     google: ProviderConfig = field(default_factory=ProviderConfig)
@@ -916,7 +953,13 @@ class DaemonConfig:
                 raw.get("catchup_stale_hours", DEFAULT_CATCHUP_STALE_HOURS)
             ),
         )
-        for name in ("anthropic", "openai", "google"):
+        p = raw.get("anthropic") or {}
+        cfg.anthropic = AnthropicProviderConfig(
+            api_key=p.get("api_key", ""),
+            model=p.get("model", ""),
+            cli_use_api_key=p.get("cli_use_api_key") is True,
+        )
+        for name in ("openai", "google"):
             p = raw.get(name) or {}
             setattr(cfg, name, ProviderConfig(
                 api_key=p.get("api_key", ""),
@@ -944,7 +987,6 @@ class DaemonConfig:
             port=int(r.get("port", rs_defaults.port)),
         )
         return cfg
-
     def save(self) -> None:
         path = daemon_yml_path()
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -966,6 +1008,14 @@ class DaemonConfig:
             "rpc_service": asdict(self.rpc_service),
         }
         _atomic_write_yaml(path, data)
+
+
+def claude_cli_api_key(daemon_cfg: DaemonConfig | None) -> str:
+    """Return the daemon-owned Claude CLI key when explicitly enabled."""
+    anthropic = getattr(daemon_cfg, "anthropic", None)
+    if not getattr(anthropic, "cli_use_api_key", False):
+        return ""
+    return getattr(anthropic, "api_key", "")
 
 
 @dataclass
@@ -1486,8 +1536,15 @@ def clear_refresh_token_request() -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Atomic YAML write
+# Atomic config writes
 # ─────────────────────────────────────────────────────────────────────────────
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
 
 
 def _atomic_write_yaml(path: Path, data: Any) -> None:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -987,6 +987,7 @@ class DaemonConfig:
             port=int(r.get("port", rs_defaults.port)),
         )
         return cfg
+
     def save(self) -> None:
         path = daemon_yml_path()
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -48,6 +48,7 @@ from .state import (
     agent_codex_user_dir,
     agent_dir,
     agent_home_dir,
+    claude_cli_api_key,
     cli_session_json_path,
     docker_shared_dir,
     shared_fs_dir,
@@ -89,6 +90,12 @@ def _rebuild_managed_system_prompt(
 logger = logging.getLogger(__name__)
 
 RECONNECT_BACKOFF_SECONDS = 5.0
+
+
+def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
+    if harness_name != "claude-code":
+        return ""
+    return claude_cli_api_key(daemon_cfg)
 
 
 def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
@@ -176,6 +183,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             puffo_core_server_url=agent_cfg.puffo_core.server_url,
             puffo_core_slug=agent_cfg.puffo_core.slug,
             puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
+            claude_api_key=_claude_cli_api_key(daemon_cfg, harness.name()),
         )
         # Env for spawning the puffo_core MCP server; path-typed values are
         # rewritten to container bind-mount paths at config-write time.
@@ -237,6 +245,7 @@ def build_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Adapter:
             puffo_core_server_url=agent_cfg.puffo_core.server_url,
             puffo_core_slug=agent_cfg.puffo_core.slug,
             puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
+            claude_api_key=_claude_cli_api_key(daemon_cfg, harness.name()),
         )
         if agent_cfg.puffo_core.is_configured():
             from ..mcp.config import puffo_core_mcp_env

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -505,6 +505,7 @@ def _handle_suppressed_reply(
     scope: str,
     on_auth_failure: Optional[Callable[[], None]] = None,
     on_auth_failed_enter: Optional[Callable[[], None]] = None,
+    auth_error_message: str | None = None,
 ) -> tuple[bool, float]:
     """Shared landing for a suppressed worker-error leak. Returns
     ``(suppressed, backoff_seconds)``:
@@ -555,7 +556,9 @@ def _handle_suppressed_reply(
                     "agent %s: on_auth_failed_enter callback raised: %s",
                     agent_id, exc,
                 )
-    if scope == "api-error-retry":
+    if is_auth and auth_error_message:
+        runtime.error = auth_error_message
+    elif scope == "api-error-retry":
         if is_auth:
             runtime.error = (
                 "Claude Code sign-in expired. On the computer running "
@@ -660,7 +663,10 @@ class Worker:
             probe_ok = False
         if not probe_ok:
             Worker._reassert_auth_failed_after_failed_probe(
-                self.runtime, agent_id, logger,
+                self.runtime,
+                agent_id,
+                logger,
+                api_key_mode=getattr(self, "_claude_api_key_mode", False),
             )
         self._warm_done.set()
 
@@ -669,6 +675,8 @@ class Worker:
         runtime: "RuntimeState",
         agent_id: str,
         log: logging.Logger,
+        *,
+        api_key_mode: bool = False,
     ) -> None:
         """``on_refresh_success`` eagerly clears ``auth_failed`` before
         the respawn, so a still-broken provider warms up looking healthy.
@@ -678,11 +686,7 @@ class Worker:
         if runtime.health != "ok":
             return
         runtime.health = "auth_failed"
-        runtime.error = (
-            "Claude Code sign-in expired. On the computer running "
-            "puffo-agent, open a terminal and run `claude auth "
-            "login`, then send this agent a message."
-        )
+        runtime.error = Worker._auth_failed_error(api_key_mode)
         runtime.save(agent_id)
         log.warning(
             "agent %s: post-warm health probe failed; reasserted "
@@ -697,10 +701,8 @@ class Worker:
         rt = self.runtime
         was_ok = rt.health != "auth_failed"
         rt.health = "auth_failed"
-        rt.error = (
-            "Claude Code sign-in expired. On the computer running "
-            "puffo-agent, open a terminal and run `claude auth "
-            "login`, then send this agent a message."
+        rt.error = Worker._auth_failed_error(
+            getattr(self, "_claude_api_key_mode", False),
         )
         rt.save(agent_id)
         if self._notify_refresh_needed is not None:
@@ -715,10 +717,12 @@ class Worker:
 
     def _on_auth_failed_enter(self) -> None:
         """Fire the operator DM once per auth_failed episode. The flag
-        re-arms on auth_failed CLEAR (daemon ``on_refresh_success``) and
-        on a failed send, so a later genuine failure re-notifies."""
+        re-arms on OAuth refresh, successful API-key recovery, or a failed
+        send, so a later genuine failure re-notifies."""
         if self._auth_failed_notification_sent:
             return
+        if getattr(self, "_claude_api_key_mode", False):
+            self._api_key_auth_recovery_pending = True
         self._auth_failed_notification_sent = True
         try:
             asyncio.create_task(self._notify_operator_of_auth_failed_oauth())
@@ -731,7 +735,7 @@ class Worker:
             )
 
     async def _notify_operator_of_auth_failed_oauth(self) -> None:
-        """DM the operator the bilingual OAuth-expired recovery copy.
+        """DM the operator the matching bilingual auth recovery copy.
         Re-arms the dedup flag on a transient failure (client not warm,
         or send raised) so the next ENTER retries instead of staying
         silently gated."""
@@ -754,6 +758,7 @@ class Worker:
             )
             return
         from ..agent._invite_strings import (
+            format_anthropic_api_key_rejected,
             format_codex_oauth_expired,
             format_oauth_expired,
         )
@@ -765,7 +770,11 @@ class Worker:
         # the alert is broken. Harness is the cheapest signal we have.
         runtime = getattr(self.agent_cfg, "runtime", None)
         harness = getattr(runtime, "harness", "") if runtime is not None else ""
-        if harness == "codex":
+        if getattr(self, "_claude_api_key_mode", False):
+            text = format_anthropic_api_key_rejected(
+                self.agent_cfg.id, display_name,
+            )
+        elif harness == "codex":
             text = format_codex_oauth_expired(self.agent_cfg.id, display_name)
         else:
             text = format_oauth_expired(self.agent_cfg.id, display_name)
@@ -780,8 +789,22 @@ class Worker:
             )
             return
         logger.info(
-            "agent %s: notified operator @%s of OAuth-expired",
+            "agent %s: notified operator @%s of auth failure",
             self.agent_cfg.id, operator_slug,
+        )
+
+    @staticmethod
+    def _auth_failed_error(api_key_mode: bool) -> str:
+        if api_key_mode:
+            return (
+                "Claude Code API key was rejected. Update anthropic.api_key "
+                "in daemon.yml, keep anthropic.cli_use_api_key enabled, "
+                "restart puffo-agent, then send this agent a message."
+            )
+        return (
+            "Claude Code sign-in expired. On the computer running "
+            "puffo-agent, open a terminal and run `claude auth "
+            "login`, then send this agent a message."
         )
 
     @staticmethod
@@ -803,14 +826,37 @@ class Worker:
         runtime: "RuntimeState",
         agent_id: str,
         log: logging.Logger,
+        *,
+        recover_auth_failed: bool = False,
     ) -> None:
-        """Transition ``in_progress`` → ``ok``; skip any in-turn red."""
-        if runtime.health != "in_progress":
+        """Resolve a successful turn without masking unrelated red states."""
+        recoverable = {"in_progress"}
+        if recover_auth_failed:
+            recoverable.add("auth_failed")
+        if runtime.health not in recoverable:
             return
+        previous_health = runtime.health
         runtime.health = "ok"
         runtime.error = ""
         runtime.save(agent_id)
-        log.info("agent %s: runtime.health in_progress → ok", agent_id)
+        log.info(
+            "agent %s: runtime.health %s → ok", agent_id, previous_health,
+        )
+
+    def _resolve_health_after_success(self, agent_id: str) -> None:
+        recovering_api_key = (
+            getattr(self, "_claude_api_key_mode", False)
+            and getattr(self, "_api_key_auth_recovery_pending", False)
+        )
+        Worker._resolve_health_on_success(
+            self.runtime,
+            agent_id,
+            logger,
+            recover_auth_failed=recovering_api_key,
+        )
+        if recovering_api_key:
+            self._api_key_auth_recovery_pending = False
+            self._auth_failed_notification_sent = False
 
     @staticmethod
     def _fallback_unhandled_error_if_stuck_in_progress(
@@ -856,6 +902,14 @@ class Worker:
         # re-armed on credential refresh-success (daemon
         # on_refresh_success) and on a failed send.
         self._auth_failed_notification_sent = False
+        self._claude_api_key_mode = (
+            agent_cfg.runtime.kind in {RUNTIME_CLI_LOCAL, RUNTIME_CLI_DOCKER}
+            and bool(_claude_cli_api_key(
+                daemon_cfg,
+                agent_cfg.runtime.harness or "claude-code",
+            ))
+        )
+        self._api_key_auth_recovery_pending = False
         self.runtime = RuntimeState(
             status="running",
             started_at=int(time.time()),
@@ -1381,9 +1435,7 @@ class Worker:
                 # AgentAPIError leaves in_progress for next batch's flip.
                 if turn_succeeded:
                     try:
-                        Worker._resolve_health_on_success(
-                            self.runtime, agent_id, logger,
-                        )
+                        self._resolve_health_after_success(agent_id)
                     except Exception as exc:  # noqa: BLE001
                         logger.warning(
                             "agent %s: _resolve_health_on_success failed: %s",
@@ -1418,6 +1470,9 @@ class Worker:
                     scope="fallback",
                     on_auth_failure=self._notify_refresh_needed,
                     on_auth_failed_enter=self._on_auth_failed_enter,
+                    auth_error_message=self._auth_failed_error(
+                        self._claude_api_key_mode,
+                    ),
                 )
                 if suppressed:
                     await asyncio.sleep(backoff)
@@ -1461,6 +1516,9 @@ class Worker:
                     scope="api-error-retry",
                     on_auth_failure=self._notify_refresh_needed,
                     on_auth_failed_enter=self._on_auth_failed_enter,
+                    auth_error_message=self._auth_failed_error(
+                        self._claude_api_key_mode,
+                    ),
                 )
                 if suppressed:
                     # Hottest leak site (FB-88 / FB-159 case-studies).
@@ -1520,9 +1578,7 @@ class Worker:
                 self.runtime, agent_id, root_id, logger,
             )
             # retry-success path bypasses on_message_batch's finally.
-            Worker._resolve_health_on_success(
-                self.runtime, agent_id, logger,
-            )
+            self._resolve_health_after_success(agent_id)
 
         async def heartbeat():
             interval = max(1.0, self.daemon_cfg.runtime_heartbeat_seconds)

--- a/tests/test_claude_api_key_policy.py
+++ b/tests/test_claude_api_key_policy.py
@@ -9,10 +9,16 @@ import pytest
 from _portal_support import isolated_home, write_test_agent
 from puffo_agent.agent.adapters.docker_cli import DockerCLIAdapter
 from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+from puffo_agent.agent.adapters.base import TurnResult
+from puffo_agent.agent._invite_strings import format_anthropic_api_key_rejected
 from puffo_agent.portal import cli, state
 from puffo_agent.portal.daemon import Daemon
-from puffo_agent.portal.state import AgentConfig, DaemonConfig
-from puffo_agent.portal.worker import build_adapter
+from puffo_agent.portal.state import AgentConfig, DaemonConfig, RuntimeState
+from puffo_agent.portal.worker import (
+    Worker,
+    _handle_suppressed_reply,
+    build_adapter,
+)
 
 
 def _local_adapter(tmp_path: Path, *, api_key: str = "") -> LocalCLIAdapter:
@@ -103,6 +109,74 @@ def test_config_command_ignores_ambient_anthropic_api_key(monkeypatch):
     assert DaemonConfig.load().anthropic.api_key == ""
 
 
+def test_config_command_sets_anthropic_cli_api_key_options(capsys):
+    isolated_home()
+
+    assert cli.main([
+        "config",
+        "--anthropic-api-key", "configured-key",
+        "--anthropic-cli-use-api-key", "true",
+    ]) == 0
+
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == "configured-key"
+    assert loaded.anthropic.cli_use_api_key is True
+    assert "configured-key" not in capsys.readouterr().out
+
+    assert cli.main([
+        "config",
+        "--anthropic-api-key", "",
+        "--anthropic-cli-use-api-key", "false",
+    ]) == 0
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == ""
+    assert loaded.anthropic.cli_use_api_key is False
+
+
+def test_config_command_partial_updates_preserve_other_anthropic_field():
+    isolated_home()
+    cfg = DaemonConfig()
+    cfg.anthropic.api_key = "original-key"
+    cfg.anthropic.cli_use_api_key = True
+    cfg.save()
+
+    assert cli.main([
+        "config", "--anthropic-cli-use-api-key", "false",
+    ]) == 0
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == "original-key"
+    assert loaded.anthropic.cli_use_api_key is False
+
+    assert cli.main([
+        "config", "--anthropic-api-key", "replacement-key",
+    ]) == 0
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == "replacement-key"
+    assert loaded.anthropic.cli_use_api_key is False
+
+
+def test_interactive_config_updates_anthropic_cli_api_key(monkeypatch):
+    isolated_home()
+    answers = iter(["", "configured-key", "true", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    assert cli.main(["config"]) == 0
+
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == "configured-key"
+    assert loaded.anthropic.cli_use_api_key is True
+
+
+def test_interactive_config_rejects_invalid_cli_api_key_mode(monkeypatch):
+    isolated_home()
+    answers = iter(["", "", "yes"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    assert cli.main(["config"]) == 2
+
+    assert not state.daemon_yml_path().exists()
+
+
 def test_settings_scrubber_handles_non_object_and_empty_env(tmp_path):
     path = tmp_path / "settings.json"
     path.write_text("[]", encoding="utf-8")
@@ -176,6 +250,36 @@ def test_local_removes_persisted_api_key_settings(tmp_path):
         }
 
 
+def test_local_rescrubs_api_key_settings_before_each_spawn(tmp_path):
+    adapter = _local_adapter(tmp_path)
+    adapter._prepare_mcp_args = lambda: []
+    session = adapter._ensure_session()
+    paths = (
+        adapter.agent_home_dir / ".claude" / "settings.json",
+        adapter.agent_home_dir / ".claude" / "settings.local.json",
+        Path(adapter.claude_dir) / "settings.json",
+        Path(adapter.claude_dir) / "settings.local.json",
+    )
+    for path in paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"env": {"ANTHROPIC_API_KEY": "late-key"}}),
+            encoding="utf-8",
+        )
+
+    session.build_command([], session.env_overrides)
+
+    assert all(json.loads(path.read_text()) == {} for path in paths)
+
+
+def test_local_settings_scrub_tolerates_legacy_adapter_without_paths(tmp_path):
+    adapter = _local_adapter(tmp_path)
+    del adapter.agent_home_dir
+    del adapter.claude_dir
+
+    adapter._strip_claude_api_key_settings()
+
+
 def test_docker_ignores_ambient_api_key(monkeypatch, tmp_path):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
     adapter = _docker_adapter(tmp_path)
@@ -201,6 +305,62 @@ def test_docker_injects_configured_key_without_argv_secret(monkeypatch, tmp_path
     assert command[key_index - 1] == "-e"
     assert "daemon-key" not in command
     assert "ambient-key" not in command
+
+
+@pytest.mark.parametrize("api_key", ["", "daemon-key"])
+def test_docker_env_overrides_cannot_inject_anthropic_api_key(
+    tmp_path, api_key,
+):
+    adapter = _docker_adapter(tmp_path, api_key=api_key)
+    adapter.env_overrides["ANTHROPIC_API_KEY"] = "override-key"
+    adapter._prepare_mcp_args = lambda: []
+
+    session = adapter._ensure_session()
+    command = session.build_command([], session.env_overrides)
+
+    assert "ANTHROPIC_API_KEY=override-key" not in command
+    assert "override-key" not in command
+
+
+def test_docker_preserves_non_secret_env_overrides(tmp_path):
+    adapter = _docker_adapter(tmp_path)
+    adapter.env_overrides["SAFE_VALUE"] = "123"
+    adapter._prepare_mcp_args = lambda: []
+
+    session = adapter._ensure_session()
+    command = session.build_command([], session.env_overrides)
+
+    assert "SAFE_VALUE=123" in command
+
+
+def test_docker_rescrubs_api_key_settings_before_each_spawn(tmp_path):
+    adapter = _docker_adapter(tmp_path)
+    adapter._prepare_mcp_args = lambda: []
+    session = adapter._ensure_session()
+    paths = (
+        adapter.claude_home_src / "settings.json",
+        adapter.claude_home_src / "settings.local.json",
+        Path(adapter.claude_dir) / "settings.json",
+        Path(adapter.claude_dir) / "settings.local.json",
+    )
+    for path in paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"env": {"ANTHROPIC_API_KEY": "late-key"}}),
+            encoding="utf-8",
+        )
+
+    session.build_command([], session.env_overrides)
+
+    assert all(json.loads(path.read_text()) == {} for path in paths)
+
+
+def test_docker_settings_scrub_tolerates_legacy_adapter_without_paths(tmp_path):
+    adapter = _docker_adapter(tmp_path)
+    del adapter.claude_home_src
+    del adapter.claude_dir
+
+    adapter._strip_claude_api_key_settings()
 
 
 @pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])
@@ -265,3 +425,221 @@ def test_daemon_oauth_gate_follows_api_key_policy(api_key, enabled, uses_api_key
     else:
         assert daemon._notify_refresh_for(cfg) is not None
         assert daemon._ensure_fresh_for(cfg) is not None
+
+
+def test_api_key_auth_failure_uses_correct_recovery_and_success_rearms(tmp_path):
+    home = isolated_home()
+    write_test_agent(home, "api-key-recovery")
+    agent_cfg = AgentConfig.load("api-key-recovery")
+    agent_cfg.runtime.kind = "cli-local"
+    agent_cfg.runtime.harness = "claude-code"
+    daemon_cfg = DaemonConfig()
+    daemon_cfg.anthropic.api_key = "configured-key"
+    daemon_cfg.anthropic.cli_use_api_key = True
+    worker = Worker(daemon_cfg, agent_cfg)
+    worker.runtime = RuntimeState(status="running", health="ok")
+    worker._on_auth_failed_enter = lambda: setattr(
+        worker, "_api_key_auth_recovery_pending", True,
+    )
+
+    worker._enter_auth_failed(agent_cfg.id)
+
+    assert worker.runtime.health == "auth_failed"
+    assert "anthropic.api_key" in worker.runtime.error
+    assert "claude auth login" not in worker.runtime.error
+    worker._auth_failed_notification_sent = True
+    worker._resolve_health_after_success(agent_cfg.id)
+    assert worker.runtime.health == "ok"
+    assert worker.runtime.error == ""
+    assert worker._api_key_auth_recovery_pending is False
+    assert worker._auth_failed_notification_sent is False
+
+
+def test_subscription_success_does_not_clear_auth_failed(tmp_path):
+    home = isolated_home()
+    write_test_agent(home, "subscription-sticky")
+    worker = Worker(
+        DaemonConfig(), AgentConfig.load("subscription-sticky"),
+    )
+    worker.runtime = RuntimeState(status="running", health="auth_failed")
+    worker.runtime.error = "sign-in expired"
+
+    worker._resolve_health_after_success("subscription-sticky")
+
+    assert worker.runtime.health == "auth_failed"
+    assert worker.runtime.error == "sign-in expired"
+
+
+def test_non_cli_worker_does_not_use_claude_cli_api_key_recovery():
+    home = isolated_home()
+    write_test_agent(home, "sdk-key-boundary")
+    agent_cfg = AgentConfig.load("sdk-key-boundary")
+    agent_cfg.runtime.kind = "chat-local"
+    agent_cfg.runtime.harness = "claude-code"
+    daemon_cfg = DaemonConfig()
+    daemon_cfg.anthropic.api_key = "configured-key"
+    daemon_cfg.anthropic.cli_use_api_key = True
+
+    worker = Worker(daemon_cfg, agent_cfg)
+
+    assert worker._claude_api_key_mode is False
+
+
+def test_suppressed_api_key_error_uses_api_key_recovery_copy(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runtime = RuntimeState(status="running", health="ok")
+    message = Worker._auth_failed_error(True)
+
+    suppressed, _ = _handle_suppressed_reply(
+        "Invalid API key · Please run /login",
+        runtime,
+        "api-key-agent",
+        scope="fallback",
+        auth_error_message=message,
+    )
+
+    assert suppressed is True
+    assert runtime.health == "auth_failed"
+    assert runtime.error == message
+    assert "claude auth login" not in runtime.error
+
+
+def test_api_key_auth_enter_marks_recovery_pending(monkeypatch):
+    from puffo_agent.portal import worker as worker_module
+
+    class StubWorker:
+        agent_cfg = SimpleNamespace(id="api-key-agent")
+        _auth_failed_notification_sent = False
+        _claude_api_key_mode = True
+        _api_key_auth_recovery_pending = False
+        _on_auth_failed_enter = Worker._on_auth_failed_enter
+
+        async def _notify_operator_of_auth_failed_oauth(self):
+            return None
+
+    def close_task(coro):
+        coro.close()
+
+    monkeypatch.setattr(worker_module.asyncio, "create_task", close_task)
+    worker = StubWorker()
+
+    worker._on_auth_failed_enter()
+
+    assert worker._api_key_auth_recovery_pending is True
+    assert worker._auth_failed_notification_sent is True
+
+
+def test_api_key_auth_failure_copy_is_bilingual():
+    text = format_anthropic_api_key_rejected("agent-1", "Linus")
+    assert "Anthropic API key was rejected" in text
+    assert "Anthropic API key 被拒绝" in text
+    assert "anthropic.api_key" in text
+    assert "anthropic.cli_use_api_key: true" in text
+    assert "claude auth login" not in text
+
+
+@pytest.mark.asyncio
+async def test_api_key_auth_failure_dm_uses_api_key_recovery_copy():
+    home = isolated_home()
+    write_test_agent(home, "api-key-dm")
+    agent_cfg = AgentConfig.load("api-key-dm")
+    agent_cfg.runtime.kind = "cli-local"
+    agent_cfg.runtime.harness = "claude-code"
+    daemon_cfg = DaemonConfig()
+    daemon_cfg.anthropic.api_key = "configured-key"
+    daemon_cfg.anthropic.cli_use_api_key = True
+    worker = Worker(daemon_cfg, agent_cfg)
+
+    class Client:
+        operator_slug = "operator"
+
+        def __init__(self):
+            self.text = ""
+
+        async def _send_dm(self, _slug, text, *, root_id):
+            assert root_id == ""
+            self.text = text
+
+    client = Client()
+    worker._client = client
+
+    await worker._notify_operator_of_auth_failed_oauth()
+
+    assert "Anthropic API key was rejected" in client.text
+    assert "claude auth login" not in client.text
+
+
+@pytest.mark.asyncio
+async def test_worker_success_callbacks_recover_api_key_auth(
+    monkeypatch,
+):
+    from puffo_agent.portal import profile_sync, worker as worker_module
+
+    home = isolated_home()
+    write_test_agent(home, "api-key-callbacks")
+    agent_cfg = AgentConfig.load("api-key-callbacks")
+    agent_cfg.runtime.kind = "cli-local"
+    agent_cfg.runtime.harness = "claude-code"
+    daemon_cfg = DaemonConfig()
+    daemon_cfg.anthropic.api_key = "configured-key"
+    daemon_cfg.anthropic.cli_use_api_key = True
+
+    class Adapter:
+        model = "claude-sonnet-5"
+
+        async def warm(self, _prompt):
+            return None
+
+        async def health_probe(self):
+            return True
+
+        async def run_turn(self, _ctx):
+            return TurnResult(reply="[SILENT]", metadata={})
+
+        def context_limits(self):
+            return None, None
+
+    class Client:
+        async def listen(self, **callbacks):
+            await callbacks["on_message"](
+                "root-1",
+                [{
+                    "envelope_id": "message-1",
+                    "sender_slug": "operator",
+                    "sender_email": "",
+                    "sender_is_agent": False,
+                    "sender_display_name": "Operator",
+                    "text": "hello",
+                    "attachments": [],
+                    "mentions": [],
+                    "sent_at": 1,
+                    "is_dm": True,
+                    "is_visible_to_human": True,
+                }],
+                {"channel_id": "channel-1"},
+            )
+            worker.runtime.health = "auth_failed"
+            worker.runtime.error = "rejected"
+            worker._api_key_auth_recovery_pending = True
+            worker._auth_failed_notification_sent = True
+            await callbacks["on_turn_success"]("root-1", [], {})
+            worker._stop.set()
+
+        async def send_fallback_message(self, *_args, **_kwargs):
+            return None
+
+    async def no_profile_sync(_cfg):
+        return None
+
+    monkeypatch.setattr(worker_module, "build_adapter", lambda *_args: Adapter())
+    monkeypatch.setattr(
+        worker_module, "_build_puffo_core_client", lambda *_args, **_kwargs: Client(),
+    )
+    monkeypatch.setattr(profile_sync, "sync_full_profile", no_profile_sync)
+    worker = Worker(daemon_cfg, agent_cfg)
+
+    await worker._run()
+
+    assert worker.runtime.health == "ok"
+    assert worker._api_key_auth_recovery_pending is False
+    assert worker._auth_failed_notification_sent is False

--- a/tests/test_claude_api_key_policy.py
+++ b/tests/test_claude_api_key_policy.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from _portal_support import isolated_home, write_test_agent
+from puffo_agent.agent.adapters.docker_cli import DockerCLIAdapter
+from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+from puffo_agent.portal import cli, state
+from puffo_agent.portal.daemon import Daemon
+from puffo_agent.portal.state import AgentConfig, DaemonConfig
+from puffo_agent.portal.worker import build_adapter
+
+
+def _local_adapter(tmp_path: Path, *, api_key: str = "") -> LocalCLIAdapter:
+    return LocalCLIAdapter(
+        agent_id="local-key-policy",
+        model="claude-sonnet-5",
+        workspace_dir=str(tmp_path / "workspace"),
+        claude_dir=str(tmp_path / "workspace" / ".claude"),
+        session_file=str(tmp_path / "session.json"),
+        mcp_config_file=str(tmp_path / "mcp.json"),
+        agent_home_dir=str(tmp_path / "agent-home"),
+        claude_api_key=api_key,
+    )
+
+
+def _docker_adapter(tmp_path: Path, *, api_key: str = "") -> DockerCLIAdapter:
+    return DockerCLIAdapter(
+        agent_id="docker-key-policy",
+        model="claude-sonnet-5",
+        image="puffo/agent-runtime:test",
+        workspace_dir=str(tmp_path / "workspace"),
+        claude_dir=str(tmp_path / "workspace" / ".claude"),
+        session_file=str(tmp_path / "session.json"),
+        agent_home_dir=str(tmp_path / "agent-home"),
+        shared_fs_dir=str(tmp_path / "shared"),
+        claude_api_key=api_key,
+    )
+
+
+def test_daemon_anthropic_cli_api_key_opt_in_round_trips(tmp_path, monkeypatch):
+    config_path = tmp_path / "daemon.yml"
+    monkeypatch.setattr(state, "daemon_yml_path", lambda: config_path)
+    cfg = DaemonConfig()
+    assert cfg.anthropic.cli_use_api_key is False
+    cfg.anthropic.api_key = "daemon-key"
+    cfg.anthropic.cli_use_api_key = True
+
+    cfg.save()
+
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == "daemon-key"
+    assert loaded.anthropic.cli_use_api_key is True
+    assert "cli_use_api_key" not in loaded.openai.__dict__
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(None, False), (False, False), ("true", False), (True, True)],
+)
+def test_daemon_cli_api_key_requires_yaml_boolean_true(
+    tmp_path, monkeypatch, raw, expected,
+):
+    config_path = tmp_path / "daemon.yml"
+    monkeypatch.setattr(state, "daemon_yml_path", lambda: config_path)
+    anthropic = {"api_key": "daemon-key"}
+    if raw is not None:
+        anthropic["cli_use_api_key"] = raw
+    config_path.write_text(
+        "anthropic:\n" + "".join(f"  {key}: {json.dumps(value)}\n" for key, value in anthropic.items()),
+        encoding="utf-8",
+    )
+
+    assert DaemonConfig.load().anthropic.cli_use_api_key is expected
+
+
+def test_config_command_preserves_cli_api_key_opt_in(monkeypatch):
+    isolated_home()
+    cfg = DaemonConfig()
+    cfg.anthropic.api_key = "daemon-key"
+    cfg.anthropic.cli_use_api_key = True
+    cfg.save()
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    assert cli.main(["config"]) == 0
+
+    loaded = DaemonConfig.load()
+    assert loaded.anthropic.api_key == "daemon-key"
+    assert loaded.anthropic.cli_use_api_key is True
+
+
+def test_config_command_ignores_ambient_anthropic_api_key(monkeypatch):
+    isolated_home()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    assert cli.main(["config"]) == 0
+
+    assert DaemonConfig.load().anthropic.api_key == ""
+
+
+def test_settings_scrubber_handles_non_object_and_empty_env(tmp_path):
+    path = tmp_path / "settings.json"
+    path.write_text("[]", encoding="utf-8")
+    assert state.strip_claude_api_key_from_settings(path) is False
+    path.write_text(
+        json.dumps({"env": {"ANTHROPIC_API_KEY": "stale-key"}}),
+        encoding="utf-8",
+    )
+
+    assert state.strip_claude_api_key_from_settings(path) is True
+    assert json.loads(path.read_text(encoding="utf-8")) == {}
+
+
+def test_settings_scrubber_reports_write_failure(tmp_path, monkeypatch):
+    path = tmp_path / "settings.json"
+    path.write_text(
+        json.dumps({"env": {"ANTHROPIC_API_KEY": "stale-key"}}),
+        encoding="utf-8",
+    )
+
+    def fail_write(_path, _data):
+        raise OSError("read-only")
+
+    monkeypatch.setattr(state, "_atomic_write_json", fail_write)
+
+    assert state.strip_claude_api_key_from_settings(path) is False
+
+
+def test_local_ignores_ambient_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    adapter = _local_adapter(tmp_path)
+    adapter._prepare_mcp_args = lambda: []
+
+    session = adapter._ensure_session()
+
+    assert "ANTHROPIC_API_KEY" not in session.env
+
+
+def test_local_injects_only_configured_daemon_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    adapter = _local_adapter(tmp_path, api_key="daemon-key")
+    adapter._prepare_mcp_args = lambda: []
+
+    session = adapter._ensure_session()
+
+    assert session.env["ANTHROPIC_API_KEY"] == "daemon-key"
+
+
+def test_local_removes_persisted_api_key_settings(tmp_path):
+    adapter = _local_adapter(tmp_path)
+    adapter._prepare_mcp_args = lambda: []
+    paths = (
+        adapter.agent_home_dir / ".claude" / "settings.json",
+        Path(adapter.claude_dir) / "settings.json",
+        Path(adapter.claude_dir) / "settings.local.json",
+    )
+    for path in paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "env": {"ANTHROPIC_API_KEY": "stale-key", "KEEP": "value"},
+            }),
+            encoding="utf-8",
+        )
+
+    adapter._ensure_session()
+
+    for path in paths:
+        assert json.loads(path.read_text(encoding="utf-8"))["env"] == {
+            "KEEP": "value",
+        }
+
+
+def test_docker_ignores_ambient_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    adapter = _docker_adapter(tmp_path)
+    adapter._prepare_mcp_args = lambda: []
+
+    session = adapter._ensure_session()
+    command = session.build_command([], session.env_overrides)
+
+    assert "ANTHROPIC_API_KEY" not in session.env
+    assert "ANTHROPIC_API_KEY=" in command
+
+
+def test_docker_injects_configured_key_without_argv_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    adapter = _docker_adapter(tmp_path, api_key="daemon-key")
+    adapter._prepare_mcp_args = lambda: []
+
+    session = adapter._ensure_session()
+    command = session.build_command([], session.env_overrides)
+
+    assert session.env["ANTHROPIC_API_KEY"] == "daemon-key"
+    key_index = command.index("ANTHROPIC_API_KEY")
+    assert command[key_index - 1] == "-e"
+    assert "daemon-key" not in command
+    assert "ambient-key" not in command
+
+
+@pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])
+@pytest.mark.parametrize(
+    ("api_key", "enabled", "expected"),
+    [("daemon-key", False, ""), ("", True, ""), ("daemon-key", True, "daemon-key")],
+)
+def test_worker_applies_daemon_key_policy(kind, api_key, enabled, expected):
+    home = isolated_home()
+    write_test_agent(home, "key-policy")
+    cfg = AgentConfig.load("key-policy")
+    cfg.runtime.kind = kind
+    cfg.runtime.provider = "anthropic"
+    cfg.runtime.harness = "claude-code"
+    daemon = DaemonConfig()
+    daemon.anthropic.api_key = api_key
+    daemon.anthropic.cli_use_api_key = enabled
+
+    adapter = build_adapter(daemon, cfg)
+
+    assert adapter.claude_api_key == expected
+
+
+@pytest.mark.parametrize("kind", ["cli-local", "cli-docker"])
+def test_codex_never_receives_anthropic_daemon_key(kind):
+    home = isolated_home()
+    write_test_agent(home, "codex-key-policy")
+    cfg = AgentConfig.load("codex-key-policy")
+    cfg.runtime.kind = kind
+    cfg.runtime.provider = "openai"
+    cfg.runtime.harness = "codex"
+    daemon = DaemonConfig()
+    daemon.anthropic.api_key = "daemon-key"
+    daemon.anthropic.cli_use_api_key = True
+
+    adapter = build_adapter(daemon, cfg)
+
+    assert adapter.claude_api_key == ""
+
+
+@pytest.mark.parametrize(
+    ("api_key", "enabled", "uses_api_key"),
+    [("", True, False), ("daemon-key", False, False), ("daemon-key", True, True)],
+)
+def test_daemon_oauth_gate_follows_api_key_policy(api_key, enabled, uses_api_key):
+    home = isolated_home()
+    write_test_agent(home, "refresh-policy")
+    cfg = AgentConfig.load("refresh-policy")
+    cfg.runtime.kind = "cli-local"
+    cfg.runtime.harness = "claude-code"
+    daemon_cfg = DaemonConfig()
+    daemon_cfg.anthropic.api_key = api_key
+    daemon_cfg.anthropic.cli_use_api_key = enabled
+    daemon = Daemon(daemon_cfg)
+
+    if uses_api_key:
+        assert daemon._notify_refresh_for(cfg) is None
+        assert daemon._ensure_fresh_for(cfg) is None
+        worker = SimpleNamespace()
+        daemon._register_with_refresher(cfg, worker)
+        assert not hasattr(worker, "_refresh_success_callback")
+    else:
+        assert daemon._notify_refresh_for(cfg) is not None
+        assert daemon._ensure_fresh_for(cfg) is not None

--- a/tests/test_context_telemetry_threshold.py
+++ b/tests/test_context_telemetry_threshold.py
@@ -585,10 +585,12 @@ def test_docker_session_receives_overrides(tmp_path, monkeypatch):
     )
     assert runtime["max_context"] == 1_000_000
     command = session.build_command([], session.env_overrides)
-    assert command[:6] == [
+    assert command[:8] == [
         "docker",
         "exec",
         "-i",
+        "-e",
+        "ANTHROPIC_API_KEY=",
         "puffo-ctx-bot",
         "claude",
         "--dangerously-skip-permissions",


### PR DESCRIPTION
## Summary

- ignore ambient `ANTHROPIC_API_KEY` for Claude Code in both `cli-local` and `cli-docker`; subscription authentication remains the default
- add `anthropic.cli_use_api_key` to `daemon.yml` and inject the daemon-owned `anthropic.api_key` only when the key is non-empty and the opt-in is literal YAML `true`
- prevent per-agent `env_overrides` and Claude `settings.json` files from bypassing the policy; settings are scrubbed before every Claude spawn
- skip OAuth refresh gates only in explicit API-key mode, show API-key-specific recovery instructions, and restore healthy state after a successful turn
- extend `puffo-agent config` so operators can update or clear `anthropic.api_key` and independently enable or disable Claude CLI API-key mode

## Configuration

Enable daemon-owned API-key authentication for Claude Code:

```bash
puffo-agent config \
  --anthropic-api-key KEY \
  --anthropic-cli-use-api-key true
```

Return Claude Code to subscription authentication without deleting the stored key:

```bash
puffo-agent config --anthropic-cli-use-api-key false
```

Clear the stored key:

```bash
puffo-agent config --anthropic-api-key ''
```

A daemon restart is required after changing these daemon-level values.

## Validation

- affected suite: 410 passed and 1 expected skip, repeated 3 consecutive times
- full suite: 2421 passed and 2 expected skips
- changed executable lines and branches: 100% covered
- isolated CLI smoke verified combined updates, partial updates, key clearing, and no key leakage in command output
- manual runtime smoke: the daemon started with a deliberately invalid ambient key; Linus (`cli-docker`, Claude Code) received an empty `ANTHROPIC_API_KEY`, completed the turn through subscription auth, and returned to healthy state
- GitHub CI passed on Python 3.11 and 3.12, with CodeQL checks green

One earlier full-suite run hit the existing `test_port_fallback` free-port race because `requested + 1` was occupied. The test passed three isolated reruns and the subsequent full suites passed cleanly.
