### PR TITLE
chore(release): prepare 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-08-10
+
 ### Added
 
 - **Codex agents now report and control their live context window.** Local and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.1.6"
+version = "1.2.0"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- bump the package version from 1.1.6 to 1.2.0
- roll the current Unreleased changelog into the dated 1.2.0 section
- prepare the user-facing release notes in English and Chinese

## Release notes — English

Puffo Agent 1.2.0 is out:

- Codex can now run in Docker while continuing to use host login, skills, and MCP servers.
- Claude Code and Codex context usage is now visible in the UI. The UI also lets you manage when automatic compaction starts.
- Docker is more reliable. Puffo Agent can find Docker Desktop automatically, and temporary failures no longer cause containers to be removed or rebuilt by mistake.
- Codex agents can sync MCP login credentials from the host, so each agent does not need a separate login.
- Claude Code uses subscription login by default. To use an API key, explicitly enable it with `puffo-agent config --anthropic-cli-use-api-key true`.
- The legacy Local Bridge has been removed. Agent Portal and `ws-local` are not affected.

## Release notes — 中文

Puffo Agent 1.2.0 发布了：

- Codex 现在可以在 Docker 中运行，并继续使用主机上的登录、skills 和 MCP。
- Claude Code 和 Codex 的上下文使用量会显示在 UI 中。你还可以通过 UI 管理自动压缩的触发阈值。
- Docker 更稳定。Puffo Agent 能自动找到 Docker Desktop，临时故障也不会再误删或重建容器。
- Codex agent 可以同步主机上的 MCP 登录信息，不需要每个 agent 单独登录。
- Claude Code 默认使用订阅登录。如需使用 API key，可以运行 `puffo-agent config --anthropic-cli-use-api-key true` 明确开启。
- 旧的 Local Bridge 已移除。Agent Portal 和 `ws-local` 不受影响。

## Validation

- `python -m build` — wheel and sdist built successfully for 1.2.0
- `python -m pytest -p no:warnings -k 'not test_save_rejects_oversized_utf8_fields'` — 2411 passed, 11 skipped, 2 deselected
- `git diff --check` — passed

The deselected parametrized test is blocked before its test body on Windows with pytest 9 because its generated node ID makes `PYTEST_CURRENT_TEST` exceed the Windows 32,767-character environment-variable limit. The other parameter passes locally; GitHub's Linux CI remains the release gate.