### PR TITLE
(Reopen) PUF-420 (agent): spawn claude by resolved path, and wrap Windows shims

### DIFF
--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -43,7 +43,13 @@ from ...portal.state import (
     sync_host_plugins,
     sync_host_skills,
 )
-from ..cli_bin import resolve_claude_bin, resolve_codex_bin, resolve_hermes_bin
+from ..cli_bin import (
+    CLAUDE_BIN_MISSING,
+    resolve_claude_bin,
+    resolve_codex_bin,
+    resolve_hermes_bin,
+    spawn_argv,
+)
 from .base import Adapter, TurnContext, TurnResult
 from .cli_session import AuditLog, ClaudeSession
 from .codex_session import CodexSession
@@ -974,7 +980,15 @@ class LocalCLIAdapter(Adapter):
         # host by ClaudeSession._spawn; the kwarg here is just for
         # symmetry with the docker adapter.
         del env_overrides
-        cmd = ["claude"]
+        # PUF-420. Bare ``["claude"]`` relies on the OS resolving the name at
+        # spawn time. execvp does; CreateProcess does not, so on Windows an
+        # npm-installed CLI died with WinError 2 even though the shell could
+        # find it. The resolver was already being called in _verify and its
+        # answer thrown away — this uses it, the way the codex adapter does.
+        claude_bin = resolve_claude_bin()
+        if claude_bin is None:
+            raise RuntimeError(CLAUDE_BIN_MISSING)
+        cmd = spawn_argv(claude_bin)
         # --dangerously-skip-permissions bypasses BOTH the per-tool prompt AND
         # the per-project trust dialog; stream-json has no UI for the dialog,
         # and an untrusted cwd silently drops --mcp-config servers. Non-bypass
@@ -1044,12 +1058,7 @@ class LocalCLIAdapter(Adapter):
             self._verified = True
             return
         if resolve_claude_bin() is None:
-            raise RuntimeError(
-                "claude binary not found. Tried $PUFFO_CLAUDE_BIN, "
-                "$PATH, and known bundle paths. Install the Claude "
-                "Code CLI (`npm install -g @anthropic-ai/claude-code`) "
-                "or set ``PUFFO_CLAUDE_BIN=/abs/path/to/claude``."
-            )
+            raise RuntimeError(CLAUDE_BIN_MISSING)
         # Seed the per-agent virtual $HOME on first use (settings,
         # .claude.json). Credentials handled separately below.
         host_home = Path.home()

--- a/src/puffo_agent/agent/adapters/local_cli.py
+++ b/src/puffo_agent/agent/adapters/local_cli.py
@@ -985,10 +985,14 @@ class LocalCLIAdapter(Adapter):
         # npm-installed CLI died with WinError 2 even though the shell could
         # find it. The resolver was already being called in _verify and its
         # answer thrown away — this uses it, the way the codex adapter does.
+        # A miss falls back to the bare name rather than raising: _verify()
+        # runs ahead of every spawn path and already fails with
+        # CLAUDE_BIN_MISSING, so raising here only moved that error onto
+        # callers that never spawn — argv-shape tests, which legitimately
+        # run without the CLI installed. Falling back keeps their behaviour
+        # exactly as it was before this change.
         claude_bin = resolve_claude_bin()
-        if claude_bin is None:
-            raise RuntimeError(CLAUDE_BIN_MISSING)
-        cmd = spawn_argv(claude_bin)
+        cmd = spawn_argv(claude_bin) if claude_bin else ["claude"]
         # --dangerously-skip-permissions bypasses BOTH the per-tool prompt AND
         # the per-project trust dialog; stream-json has no UI for the dialog,
         # and an untrusted cwd silently drops --mcp-config servers. Non-bypass

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -113,6 +113,66 @@ def _is_executable_file(path: Path) -> bool:
     return path.is_file() and os.access(path, os.X_OK)
 
 
+# PUF-420. Windows spawn, in preference order: a real .exe costs nothing to
+# launch, .cmd/.bat need cmd.exe, .ps1 needs powershell and is the slowest
+# and the most likely to be blocked by execution policy.
+_WINDOWS_SPAWN_EXTS = (".exe", ".cmd", ".bat", ".ps1")
+
+
+def windows_runnable(binary: str) -> str:
+    """Map a resolved path to one Windows can actually start.
+
+    ``npm install -g`` drops three files next to each other: ``claude.cmd``,
+    ``claude.ps1``, and an extensionless ``claude`` shell script. Only the
+    first two can be started on Windows, but ``shutil.which`` can hand back
+    the extensionless one, and ``CreateProcess`` fails on it with
+    ``WinError 2`` — the same error as "not found at all", which is what
+    made this hard to read from the traceback.
+
+    Non-Windows, or an already-runnable suffix, is returned untouched.
+    """
+    if sys.platform != "win32":
+        return binary
+    p = Path(binary)
+    if p.suffix.lower() in _WINDOWS_SPAWN_EXTS:
+        return binary
+    for ext in _WINDOWS_SPAWN_EXTS:
+        sibling = p.with_name(p.name + ext)
+        if sibling.is_file():
+            return str(sibling)
+    return binary
+
+
+def spawn_argv(binary: str) -> list[str]:
+    """argv head for launching ``binary`` via ``create_subprocess_exec``.
+
+    POSIX passes through. On Windows a script shim can't be argv[0] — it
+    isn't a PE image — so it goes to its interpreter instead. Callers append
+    their own arguments to the returned list; everything after the shim path
+    is forwarded by both interpreters unchanged.
+    """
+    resolved = windows_runnable(binary)
+    if sys.platform != "win32":
+        return [resolved]
+    ext = Path(resolved).suffix.lower()
+    if ext in (".cmd", ".bat"):
+        return ["cmd.exe", "/c", resolved]
+    if ext == ".ps1":
+        return ["powershell.exe", "-NoProfile", "-NonInteractive", "-File", resolved]
+    return [resolved]
+
+
+CLAUDE_BIN_MISSING = (
+    "claude binary not found. Tried $PUFFO_CLAUDE_BIN, $PATH, and known "
+    "bundle paths. Install the Claude Code CLI "
+    "(`npm install -g @anthropic-ai/claude-code`) or set "
+    "``PUFFO_CLAUDE_BIN=/abs/path/to/claude``. On Windows the npm install "
+    "writes claude.cmd and claude.ps1 (no .exe) into %APPDATA%\\npm — point "
+    "PUFFO_CLAUDE_BIN at the .cmd if PATH lookup is failing under the "
+    "daemon's narrower environment."
+)
+
+
 def _first_executable(paths: list[Path]) -> str | None:
     for cand in paths:
         if _is_executable_file(cand):
@@ -253,10 +313,17 @@ def _claude_bundle_paths() -> list[Path]:
             "~/Applications/Claude.app/Contents/Resources/claude",
         )
     if sys.platform == "win32":
+        # npm-global shims last, and .exe before .cmd before .ps1 — see
+        # _WINDOWS_SPAWN_EXTS. These matter when the daemon starts with a
+        # narrower PATH than the operator's interactive shell, which is the
+        # case PUF-420 was reported from.
         return _expand(
             r"%LOCALAPPDATA%\Programs\claude\claude.exe",
             r"%LOCALAPPDATA%\Programs\Claude\claude.exe",
             r"%PROGRAMFILES%\Claude\claude.exe",
+            r"%APPDATA%\npm\claude.exe",
+            r"%APPDATA%\npm\claude.cmd",
+            r"%APPDATA%\npm\claude.ps1",
         )
     return _expand(
         "/opt/Claude/claude",

--- a/tests/test_cli_local_mcp_trust.py
+++ b/tests/test_cli_local_mcp_trust.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -77,7 +78,11 @@ def test_command_shape_matches_cli_docker_for_bypass():
     # is irrelevant here).
     adapter = _make_adapter("bypassPermissions")
     cmd = adapter._build_command(extra_args=["--verbose"])
-    assert cmd[0] == "claude"
+    # PUF-420: argv[0] is now the resolver's absolute path rather than the
+    # bare name — bare names don't resolve under Windows CreateProcess. The
+    # shape assertions below are what this test is actually for; the old
+    # ``== "claude"`` pinned the defect by accident.
+    assert Path(cmd[0]).name.startswith("claude")
     assert cmd[1] == "--dangerously-skip-permissions"
     # --model + value sit right after the bypass flag.
     assert cmd[2] == "--model"

--- a/tests/test_windows_claude_spawn.py
+++ b/tests/test_windows_claude_spawn.py
@@ -1,0 +1,183 @@
+"""PUF-420: the claude adapter spawned a bare ``["claude"]``.
+
+On POSIX ``execvp`` searches PATH and it works. On Windows
+``CreateProcess`` does not, and an npm-installed CLI — which ships
+``claude.cmd`` / ``claude.ps1`` and no ``.exe`` — failed with WinError 2
+even though the shell resolved ``claude`` fine. The resolver was already
+being called in ``_verify``; its answer was discarded.
+
+There is no Windows CI, so the platform is faked. That is a real limit:
+these pin argv construction, not that CreateProcess accepts the result.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.agent import cli_bin
+from puffo_agent.agent.cli_bin import spawn_argv, windows_runnable
+
+
+@pytest.fixture
+def win(monkeypatch):
+    monkeypatch.setattr(cli_bin.sys, "platform", "win32")
+
+
+@pytest.fixture
+def posix(monkeypatch):
+    monkeypatch.setattr(cli_bin.sys, "platform", "linux")
+
+
+def test_posix_passes_the_path_through(posix):
+    assert spawn_argv("/usr/local/bin/claude") == ["/usr/local/bin/claude"]
+
+
+def test_posix_never_wraps_even_for_a_cmd_suffix(posix):
+    # A file literally named ``claude.cmd`` on Linux is still just a file.
+    assert spawn_argv("/opt/claude.cmd") == ["/opt/claude.cmd"]
+
+
+def test_exe_is_argv0_directly(win):
+    assert spawn_argv(r"C:\Programs\claude\claude.exe") == [
+        r"C:\Programs\claude\claude.exe"
+    ]
+
+
+@pytest.mark.parametrize("ext", [".cmd", ".bat"])
+def test_cmd_shims_go_through_cmd_exe(win, ext):
+    target = rf"C:\Users\j\AppData\Roaming\npm\claude{ext}"
+    assert spawn_argv(target) == ["cmd.exe", "/c", target]
+
+
+def test_ps1_goes_through_powershell_non_interactive(win):
+    target = r"C:\Users\j\AppData\Roaming\npm\claude.ps1"
+    assert spawn_argv(target) == [
+        "powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-File",
+        target,
+    ]
+
+
+def test_suffix_matching_is_case_insensitive(win):
+    assert spawn_argv(r"C:\npm\claude.CMD")[:2] == ["cmd.exe", "/c"]
+
+
+# The npm layout: three files side by side, only two of them startable.
+def _npm_layout(tmp_path: Path, *exts: str) -> Path:
+    (tmp_path / "claude").write_text("#!/bin/sh\n", encoding="utf-8")
+    for ext in exts:
+        (tmp_path / f"claude{ext}").write_text("shim", encoding="utf-8")
+    return tmp_path / "claude"
+
+
+def test_extensionless_npm_script_is_upgraded_to_the_cmd_shim(win, tmp_path):
+    # This is Jeremy's exact failure: shutil.which can hand back the
+    # extensionless shell script, which CreateProcess rejects with the same
+    # WinError 2 that "missing entirely" produces.
+    bare = _npm_layout(tmp_path, ".cmd", ".ps1")
+    assert windows_runnable(str(bare)) == str(tmp_path / "claude.cmd")
+    assert spawn_argv(str(bare)) == ["cmd.exe", "/c", str(tmp_path / "claude.cmd")]
+
+
+def test_exe_wins_over_cmd_and_ps1(win, tmp_path):
+    bare = _npm_layout(tmp_path, ".exe", ".cmd", ".ps1")
+    assert windows_runnable(str(bare)) == str(tmp_path / "claude.exe")
+
+
+def test_cmd_wins_over_ps1(win, tmp_path):
+    bare = _npm_layout(tmp_path, ".cmd", ".ps1")
+    assert windows_runnable(str(bare)) == str(tmp_path / "claude.cmd")
+
+
+def test_ps1_only_still_resolves(win, tmp_path):
+    bare = _npm_layout(tmp_path, ".ps1")
+    assert windows_runnable(str(bare)) == str(tmp_path / "claude.ps1")
+
+
+def test_no_sibling_shim_leaves_the_path_alone(win, tmp_path):
+    bare = _npm_layout(tmp_path)
+    assert windows_runnable(str(bare)) == str(bare)
+
+
+def test_windows_bundle_paths_cover_the_npm_global_shims(win):
+    # Compared as whole strings, not Path.name: these are Windows paths and
+    # the test host is POSIX, so backslashes aren't separators here and
+    # %APPDATA% stays unexpanded.
+    names = [str(p).lower() for p in cli_bin._claude_bundle_paths()]
+    assert any(n.endswith(r"npm\claude.cmd") for n in names)
+    assert any(n.endswith(r"npm\claude.ps1") for n in names)
+
+    def first(suffix: str) -> int:
+        return next(i for i, n in enumerate(names) if n.endswith(suffix))
+
+    # .exe before .cmd before .ps1 — _first_executable takes the first hit.
+    assert first(r"npm\claude.exe") < first(r"npm\claude.cmd")
+    assert first(r"npm\claude.cmd") < first(r"npm\claude.ps1")
+
+
+def test_missing_binary_message_names_the_windows_shim_case():
+    msg = cli_bin.CLAUDE_BIN_MISSING
+    assert "PUFFO_CLAUDE_BIN" in msg
+    assert "claude.cmd" in msg
+    # The raw failure is WinError 2, which reads as "not installed" and sent
+    # the reporter down the wrong path. The message has to say otherwise.
+    assert "npm" in msg
+
+
+class TestBuildCommandUsesTheResolver:
+    """The bug itself: argv[0] must come from the resolver, not a bare name."""
+
+    def _adapter(self):
+        from puffo_agent.agent.adapters.local_cli import LocalCLIAdapter
+
+        return LocalCLIAdapter.__new__(LocalCLIAdapter)
+
+    def _configure(self, adapter, tmp_path):
+        adapter.permission_mode = "bypassPermissions"
+        adapter.model = ""
+        adapter.inference_level = ""
+        adapter.auto_compact_threshold_pct = None
+        adapter.mcp_config_file = tmp_path / "mcp.json"
+        adapter.session_file = tmp_path / "session.json"
+        adapter.workspace_dir = str(tmp_path)
+        return adapter
+
+    def test_argv0_is_the_resolved_absolute_path(self, monkeypatch, tmp_path):
+        from puffo_agent.agent.adapters import local_cli
+
+        monkeypatch.setattr(local_cli, "resolve_claude_bin", lambda: "/opt/bin/claude")
+        monkeypatch.setattr(local_cli, "spawn_argv", lambda b: [b])
+        adapter = self._configure(self._adapter(), tmp_path)
+        cmd = local_cli.LocalCLIAdapter._build_command(adapter, [])
+        assert cmd[0] == "/opt/bin/claude"
+        assert cmd[0] != "claude"
+
+    def test_windows_shim_wrapper_keeps_every_following_argument(
+        self, monkeypatch, tmp_path
+    ):
+        from puffo_agent.agent.adapters import local_cli
+
+        shim = r"C:\npm\claude.cmd"
+        monkeypatch.setattr(local_cli, "resolve_claude_bin", lambda: shim)
+        monkeypatch.setattr(
+            local_cli, "spawn_argv", lambda b: ["cmd.exe", "/c", b]
+        )
+        adapter = self._configure(self._adapter(), tmp_path)
+        cmd = local_cli.LocalCLIAdapter._build_command(adapter, ["--extra", "x"])
+        assert cmd[:3] == ["cmd.exe", "/c", shim]
+        # Wrapping must not eat the adapter's own flags.
+        assert "--dangerously-skip-permissions" in cmd
+        assert cmd[-2:] == ["--extra", "x"]
+
+    def test_resolver_miss_raises_the_friendly_error_not_winerror(
+        self, monkeypatch, tmp_path
+    ):
+        from puffo_agent.agent.adapters import local_cli
+
+        monkeypatch.setattr(local_cli, "resolve_claude_bin", lambda: None)
+        adapter = self._configure(self._adapter(), tmp_path)
+        with pytest.raises(RuntimeError, match="PUFFO_CLAUDE_BIN"):
+            local_cli.LocalCLIAdapter._build_command(adapter, [])

--- a/tests/test_windows_claude_spawn.py
+++ b/tests/test_windows_claude_spawn.py
@@ -19,6 +19,14 @@ from puffo_agent.agent import cli_bin
 from puffo_agent.agent.cli_bin import spawn_argv, windows_runnable
 
 
+class _StubHarness:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
 @pytest.fixture
 def win(monkeypatch):
     monkeypatch.setattr(cli_bin.sys, "platform", "win32")
@@ -172,12 +180,26 @@ class TestBuildCommandUsesTheResolver:
         assert "--dangerously-skip-permissions" in cmd
         assert cmd[-2:] == ["--extra", "x"]
 
-    def test_resolver_miss_raises_the_friendly_error_not_winerror(
-        self, monkeypatch, tmp_path
-    ):
+    def test_resolver_miss_falls_back_to_the_bare_name(self, monkeypatch, tmp_path):
+        # _build_command must not raise on a miss. Every spawn path calls
+        # _verify() first, which is where CLAUDE_BIN_MISSING belongs; raising
+        # here as well broke argv-shape tests that never spawn and so have no
+        # reason to need the CLI present. Bare name = exactly the old
+        # behaviour, so a machine without claude is no worse off than before.
         from puffo_agent.agent.adapters import local_cli
 
         monkeypatch.setattr(local_cli, "resolve_claude_bin", lambda: None)
         adapter = self._configure(self._adapter(), tmp_path)
+        cmd = local_cli.LocalCLIAdapter._build_command(adapter, ["--verbose"])
+        assert cmd[0] == "claude"
+        assert "--dangerously-skip-permissions" in cmd
+
+    def test_verify_is_where_the_friendly_error_comes_from(self, monkeypatch):
+        from puffo_agent.agent.adapters import local_cli
+
+        monkeypatch.setattr(local_cli, "resolve_claude_bin", lambda: None)
+        adapter = self._adapter()
+        adapter._verified = False
+        adapter.harness = _StubHarness("claude-code")
         with pytest.raises(RuntimeError, match="PUFFO_CLAUDE_BIN"):
-            local_cli.LocalCLIAdapter._build_command(adapter, [])
+            local_cli.LocalCLIAdapter._verify(adapter)


### PR DESCRIPTION
Closes PUF-420. An agent on Windows died on its first turn with WinError 2. Reporter's manual patch (Jeremy) confirmed the fix direction.

## Problem

`local_cli.py:952` built argv as bare `["claude"]`. On POSIX, `execvp` searches PATH so this worked; on Windows, `CreateProcess` does not, so an npm-installed CLI (`claude.cmd`/`claude.ps1`/extensionless `claude` shell script, no `.exe`) failed with WinError 2 — the same error code as "not installed at all", which sent the traceback down the wrong path.

The resolver was already in the codebase: `_verify` on line 1021 called `resolve_claude_bin()` and used it only as an existence gate, discarding the path. The codex adapter three hundred lines earlier does the right thing.

## Fix

Two helpers in `cli_bin.py` so the next adapter inherits rather than repeats:

- **`spawn_argv(binary)`** — on Windows, routes `.cmd`/`.bat` through `cmd.exe /c` and `.ps1` through `powershell -NoProfile -NonInteractive -File`. A shim can't be argv[0]; it isn't a PE image. Preference order: `.exe` > `.cmd` > `.bat` > `.ps1`. POSIX passes through unchanged.
- **`windows_runnable(binary)`** — upgrades an extensionless resolution to a sibling shim. `shutil.which` can legitimately return the npm-installed shell script; CreateProcess rejects it with the same WinError 2 as "not found". This is the failure mode that made the original traceback so hard to read.

`_claude_bundle_paths()` gains the `%APPDATA%\npm\claude.{exe,cmd,ps1}` shims for narrow-PATH daemon start. Error message is rewritten to explicitly name the Windows shim case.

## One existing test modified

`test_cli_local_mcp_trust.py::test_command_shape_matches_cli_docker_for_bypass` asserted `cmd[0] == "claude"` — that check was incidentally pinning the bug while testing flag ordering. Changed to `Path(cmd[0]).name.startswith("claude")` to preserve the actual intent. Comment explains why.

## Tests

`test_windows_claude_spawn.py` — 16 new test cases (17 with parametrization) covering:

- POSIX pass-through (including a `.cmd`-named file on Linux stays a file)
- Windows `.exe` direct
- Windows `.cmd`/`.bat` wrapped via cmd.exe
- Windows `.ps1` wrapped via powershell
- Extensionless resolution → sibling shim upgrade
- `_build_command` uses resolver's path, not bare name
- Windows shim wrapping preserves following arguments

Baseline-anchored: **suite `2349 = 2332 baseline + 17`** on freshly-baselined `origin/main`.

## Real limits (Cal + Solution both agree)

1. **No Windows CI.** `sys.platform` is monkey-patched. Tests pin argv construction, NOT that CreateProcess actually accepts the result. The only real proof is a Windows run. Jeremy's manual patch on his machine ships the same argv shape and worked — closest thing we have.
2. **Reverse-verification weaker than usual.** Stashing the source causes `ImportError` at collection (helpers missing), not behavior-red assertions. Proves "this API is required," not "argv is correctly assembled."

## Recommend: Vase asks Jeremy to run this on his real Windows machine before merging.

The reporter has the only real-Windows testing environment; every automated check we have is on Linux.

## Not done

Intake option (b) — wrap the codex adapter similarly. Codex is currently working (uses resolved path); intake flagged as follow-up. Fold as separate PR if needed.

Linear: PUF-273. Ticket: PUF-420.