### PR TITLE
PUF-349: reset recovery state on external rotation + split UNCHANGED from FAILED in refresh_broken streak

### DIFF
--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1015,6 +1015,7 @@ class CredentialRefresher:
                 continue
             if rotated:
                 self._sync_views()
+                self._note_recovery("keychain poll")
                 self._fire_refresh_success()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -216,6 +216,15 @@ def _disk_expires_in_seconds(host_home: Path) -> Optional[int]:
     return int(ms / 1000 - time.time())
 
 
+def _is_fresh(expires_in: int | None) -> bool:
+    """One definition of "this credential doesn't need rotating yet".
+
+    ``None`` (no credential, or an unreadable one) is not fresh — the
+    absence of an expiry is not evidence of a valid token.
+    """
+    return expires_in is not None and expires_in > REFRESH_SAFETY_MARGIN_SECONDS
+
+
 class RefreshOutcome(enum.Enum):
     """Result of a single backend refresh attempt."""
     REFRESHED = "refreshed"
@@ -918,7 +927,7 @@ class CredentialRefresher:
         fires — N concurrent callers see "another caller already
         refreshed" and skip the backend invocation."""
         expires = self.expires_in_seconds()
-        if expires is not None and expires > REFRESH_SAFETY_MARGIN_SECONDS:
+        if _is_fresh(expires):
             self._sync_views()
             return True
         await self._refresh_now(expires_in=expires, by_agent=False)
@@ -1136,8 +1145,7 @@ class CredentialRefresher:
         UNCHANGED at or below the margin means we asked for a rotation we
         genuinely needed and did not get one.
         """
-        expires_in = self.expires_in_seconds()
-        return expires_in is not None and expires_in > REFRESH_SAFETY_MARGIN_SECONDS
+        return _is_fresh(self.expires_in_seconds())
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
         if outcome is RefreshOutcome.REFRESHED:

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -854,7 +854,12 @@ class CredentialRefresher:
         self._agent_homes: set[Path] = set()
         self._on_refresh_success: list[Callable[[], None]] = []
         self._lock = asyncio.Lock()
-        self._consecutive_non_success = 0
+        # Split deliberately: only the failure streak may flip
+        # refresh_broken. A benign UNCHANGED (token still fresh) is not
+        # evidence of breakage, and counting it as such re-flagged agents
+        # moments after a recovery.
+        self._consecutive_failed = 0
+        self._consecutive_unchanged = 0
         self._rate_limit_retry_task: asyncio.Task | None = None
         # Last host-credential fingerprint, for spotting an external
         # rotation (operator re-login) on copy-mode hosts with no symlink
@@ -1034,6 +1039,7 @@ class CredentialRefresher:
                 "— syncing agents + firing refresh-success",
             )
             self._sync_views()
+            self._note_recovery("external rotation")
             self._fire_refresh_success()
 
     def _record_cred_fingerprint(self) -> None:
@@ -1099,21 +1105,51 @@ class CredentialRefresher:
         if outcome is RefreshOutcome.REFRESHED:
             self._fire_refresh_success()
 
+    def _note_recovery(self, source: str) -> None:
+        """Single definition of "we now have a working credential", so
+        every recovery path resets the same state. Both callers reach it:
+        a probe-driven REFRESHED and an externally-detected rotation.
+        Keeping this in one place is the fix for the two paths having
+        drifted apart."""
+        if self._consecutive_failed > 0:
+            logger.info(
+                "credential refresh recovered via %s after %d failed "
+                "tick(s) — clearing refresh_broken health on "
+                "registered agents",
+                source, self._consecutive_failed,
+            )
+        # Always clear: a daemon restart resets the in-memory counter
+        # to 0 while leaving on-disk ``refresh_broken`` from the
+        # previous instance — without the unconditional call those
+        # agents stay stuck. _clear_refresh_broken is idempotent.
+        self._clear_refresh_broken()
+        self._consecutive_failed = 0
+        self._consecutive_unchanged = 0
+
+    def _credential_is_fresh(self) -> bool:
+        """Whether the credential we hold right now is comfortably valid.
+
+        This is what separates a benign UNCHANGED from a concerning one.
+        The poll only refreshes at or below the safety margin, so an
+        UNCHANGED with plenty of life left means the refresh was
+        redundant (agent-triggered, or a rotation that just landed). An
+        UNCHANGED at or below the margin means we asked for a rotation we
+        genuinely needed and did not get one.
+        """
+        expires_in = self.expires_in_seconds()
+        return expires_in is not None and expires_in > REFRESH_SAFETY_MARGIN_SECONDS
+
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
         if outcome is RefreshOutcome.REFRESHED:
-            if self._consecutive_non_success > 0:
-                logger.info(
-                    "credential refresh recovered after %d non-success "
-                    "tick(s) — clearing refresh_broken health on "
-                    "registered agents",
-                    self._consecutive_non_success,
-                )
-            # Always clear: a daemon restart resets the in-memory counter
-            # to 0 while leaving on-disk ``refresh_broken`` from the
-            # previous instance — without the unconditional call those
-            # agents stay stuck. _clear_refresh_broken is idempotent.
-            self._clear_refresh_broken()
-            self._consecutive_non_success = 0
+            self._note_recovery("refresh probe")
+            return
+        if outcome is RefreshOutcome.UNCHANGED and self._credential_is_fresh():
+            self._consecutive_unchanged += 1
+            logger.debug(
+                "credential refresh unchanged with a fresh token "
+                "(%d in a row) — not counted toward refresh_broken",
+                self._consecutive_unchanged,
+            )
             return
         if outcome is RefreshOutcome.AUTH_FAILED:
             # Skip the 2-tick refresh_broken streak: Anthropic revoked
@@ -1123,8 +1159,8 @@ class CredentialRefresher:
             # operator.
             self._flip_auth_failed()
             return
-        self._consecutive_non_success += 1
-        if self._consecutive_non_success >= REFRESH_BROKEN_THRESHOLD:
+        self._consecutive_failed += 1
+        if self._consecutive_failed >= REFRESH_BROKEN_THRESHOLD:
             self._flip_refresh_broken(outcome)
         if outcome is RefreshOutcome.RATE_LIMITED:
             self._schedule_rate_limit_retry()
@@ -1163,7 +1199,7 @@ class CredentialRefresher:
         from .state import RuntimeState
         logger.warning(
             "flipping refresh_broken after %d consecutive %s outcome(s)",
-            self._consecutive_non_success, outcome.value,
+            self._consecutive_failed, outcome.value,
         )
         msg = (
             "Claude Code sign-in couldn't be refreshed. On the computer "

--- a/tests/test_credential_refresh_ensure_fresh.py
+++ b/tests/test_credential_refresh_ensure_fresh.py
@@ -232,14 +232,14 @@ def test_classify_failed_refresh_prefers_auth_failed_over_rate_limit():
 
 
 def test_propagate_auth_failed_does_not_bump_streak(tmp_path):
-    """AUTH_FAILED skips the consecutive_non_success streak so a later
-    RATE_LIMITED / FAILED outcome starts fresh at 1, not N+1."""
+    """AUTH_FAILED skips the failure streak so a later RATE_LIMITED /
+    FAILED outcome starts fresh at 1, not N+1."""
     _write_creds(tmp_path, expires_in_seconds=7200)
     r = CredentialRefresher(host_home=tmp_path)
-    r._consecutive_non_success = 0
+    r._consecutive_failed = 0
 
     r._propagate_outcome(RefreshOutcome.AUTH_FAILED)
-    assert r._consecutive_non_success == 0
+    assert r._consecutive_failed == 0
 
     r._propagate_outcome(RefreshOutcome.FAILED)
-    assert r._consecutive_non_success == 1
+    assert r._consecutive_failed == 1

--- a/tests/test_credential_refresh_recovery_reset.py
+++ b/tests/test_credential_refresh_recovery_reset.py
@@ -15,11 +15,13 @@ import json
 import time
 from pathlib import Path
 
+from puffo_agent.portal import credential_refresh
 from puffo_agent.portal.credential_refresh import (
     REFRESH_BROKEN_THRESHOLD,
     REFRESH_SAFETY_MARGIN_SECONDS,
     CredentialRefresher,
     RefreshOutcome,
+    _is_fresh,
 )
 
 
@@ -166,6 +168,54 @@ def test_benign_unchanged_does_not_clear_an_existing_break(tmp_path, monkeypatch
     r._propagate_outcome(RefreshOutcome.UNCHANGED)
 
     assert RuntimeState.load(aid).health == "refresh_broken"
+
+
+# ── the freshness predicate itself ─────────────────────────────────
+
+
+def test_already_expired_credential_is_not_fresh():
+    # Intent, not accident: a negative remaining lifetime has to fail the
+    # check. `> MARGIN` gets this right today, but nothing pinned it, so a
+    # future rewrite to `abs(...)` or `!= 0` would pass every other test.
+    assert _is_fresh(-1) is False
+    assert _is_fresh(-REFRESH_SAFETY_MARGIN_SECONDS * 10) is False
+
+
+def test_margin_boundary_is_exclusive():
+    assert _is_fresh(REFRESH_SAFETY_MARGIN_SECONDS) is False
+    assert _is_fresh(REFRESH_SAFETY_MARGIN_SECONDS + 1) is True
+
+
+def test_no_credential_is_not_fresh():
+    assert _is_fresh(None) is False
+
+
+def test_ensure_fresh_and_the_outcome_check_share_one_predicate(monkeypatch):
+    # Drift guard (Solution's QA nit). ensure_fresh() short-circuits on the
+    # same "comfortably valid" question that _credential_is_fresh answers.
+    # They were separate expressions; if they drift, a credential can be
+    # fresh enough to skip refreshing but stale enough to count UNCHANGED
+    # as a failure — the exact conflation PUF-349 removed. Both now route
+    # through _is_fresh, and this fails if either stops doing so.
+    seen: list[int | None] = []
+    real = credential_refresh._is_fresh
+
+    def spy(expires_in):
+        seen.append(expires_in)
+        return real(expires_in)
+
+    monkeypatch.setattr(credential_refresh, "_is_fresh", spy)
+
+    import asyncio
+    from pathlib import Path as _P
+
+    r = CredentialRefresher(host_home=_P("/nonexistent-host-home"))
+    asyncio.run(r.ensure_fresh())
+    assert seen, "ensure_fresh() no longer consults _is_fresh"
+
+    seen.clear()
+    r._credential_is_fresh()
+    assert seen, "_credential_is_fresh() no longer consults _is_fresh"
 
 
 # ── the reported trace, end to end ─────────────────────────────────

--- a/tests/test_credential_refresh_recovery_reset.py
+++ b/tests/test_credential_refresh_recovery_reset.py
@@ -113,6 +113,74 @@ def test_unchanged_fingerprint_does_not_reset(tmp_path, monkeypatch):
     assert r._consecutive_failed == 1
 
 
+def test_every_refresh_success_site_also_notes_recovery():
+    """The sweep I owed the first commit (Solution caught the miss).
+
+    There are three places that declare "we have a working credential
+    again". Two of them going through _note_recovery is not the fix —
+    the whole point is that no path can declare recovery without
+    resetting the state that recovery invalidates. Source-level because
+    the third site (KeychainBackend poll) is macOS-only and never
+    executes on CI or on the operator's host, so a behavioural test
+    would pass here while the path stayed broken.
+    """
+    import inspect
+
+    src = inspect.getsource(credential_refresh.CredentialRefresher)
+    fire = [
+        line for line in src.splitlines()
+        if "self._fire_refresh_success()" in line
+    ]
+    assert len(fire) == 3, (
+        f"call-site count changed ({len(fire)}); re-check the sweep"
+    )
+    notes = src.count("self._note_recovery(")
+    assert notes >= 3, (
+        "a _fire_refresh_success() site is not paired with _note_recovery()"
+    )
+
+
+def test_keychain_rotation_loop_resets_state(tmp_path, monkeypatch):
+    # The macOS path, driven directly: one poll reporting a rotation has
+    # to leave the same clean state the file-fingerprint path leaves.
+    import asyncio
+    from puffo_agent.portal.state import RuntimeState
+
+    r, aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    _break_it(r)
+    assert RuntimeState.load(aid).health == "refresh_broken"
+
+    monkeypatch.setattr(
+        credential_refresh, "REFRESH_POLL_SECONDS", 0, raising=False,
+    )
+    polls = {"n": 0}
+
+    async def fake_poll():
+        polls["n"] += 1
+        return True
+
+    monkeypatch.setattr(
+        r.backend, "poll_external_rotation", fake_poll, raising=False,
+    )
+
+    async def drive():
+        stop = asyncio.Event()
+        task = asyncio.create_task(r._external_rotation_loop(stop))
+        await asyncio.sleep(0.05)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2)
+
+    monkeypatch.setattr(
+        "puffo_agent.macos.keychain.KEYCHAIN_POLL_INTERVAL_SECONDS",
+        0.01, raising=False,
+    )
+    asyncio.run(drive())
+
+    assert polls["n"] >= 1, "the loop never polled; test drove nothing"
+    assert r._consecutive_failed == 0
+    assert RuntimeState.load(aid).health == "ok"
+
+
 # ── gap 2: UNCHANGED is only trouble when the token is not fresh ───
 
 

--- a/tests/test_credential_refresh_recovery_reset.py
+++ b/tests/test_credential_refresh_recovery_reset.py
@@ -1,0 +1,212 @@
+"""PUF-349: recovery must leave clean state, and a benign UNCHANGED
+must not be read as a failure.
+
+Two gaps, one observed symptom. ``_detect_external_rotation`` fired
+refresh-success but left ``_consecutive_failed`` and the on-disk
+``refresh_broken`` flag alone — only the probe-driven REFRESHED path
+reset those. And the streak counter treated UNCHANGED like FAILED, even
+though UNCHANGED with a fresh token means "nothing needed doing".
+Together: operator re-login recovered the daemon, then the next benign
+probe re-flagged every agent as broken.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from puffo_agent.portal.credential_refresh import (
+    REFRESH_BROKEN_THRESHOLD,
+    REFRESH_SAFETY_MARGIN_SECONDS,
+    CredentialRefresher,
+    RefreshOutcome,
+)
+
+
+def _write_creds(host_home: Path, *, expires_in_seconds: int) -> Path:
+    creds_path = host_home / ".claude" / ".credentials.json"
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    creds_path.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat01-test",
+            "refreshToken": "sk-ant-ort01-test",
+            "expiresAt": int((time.time() + expires_in_seconds) * 1000),
+            "scopes": ["user:inference"],
+        }
+    }))
+    return creds_path
+
+
+def _refresher(tmp_path: Path, monkeypatch, *, expires_in_seconds: int,
+               agent_id: str = "agent-puf349"):
+    from puffo_agent.portal.state import RuntimeState, agent_home_dir
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    _write_creds(tmp_path / "host", expires_in_seconds=expires_in_seconds)
+    RuntimeState(status="running", started_at=int(time.time())).save(agent_id)
+
+    r = CredentialRefresher(host_home=tmp_path / "host")
+    r.register_agent(agent_home_dir(agent_id))
+    return r, agent_id
+
+
+def _break_it(r) -> None:
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.FAILED)
+
+
+# ── gap 1: external-rotation recovery resets the same state ────────
+
+
+def test_external_rotation_resets_the_failure_counter(tmp_path, monkeypatch):
+    r, _aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: (2, 11))
+    r._last_cred_fingerprint = (1, 10)
+    r._consecutive_failed = 1
+
+    r._detect_external_rotation()
+
+    assert r._consecutive_failed == 0
+
+
+def test_external_rotation_clears_refresh_broken_on_disk(tmp_path, monkeypatch):
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    _break_it(r)
+    assert RuntimeState.load(aid).health == "refresh_broken"
+
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: (2, 11))
+    r._last_cred_fingerprint = (1, 10)
+    r._detect_external_rotation()
+
+    rs = RuntimeState.load(aid)
+    assert rs.health == "ok"
+    assert rs.error == ""
+
+
+def test_external_rotation_still_fires_refresh_success(tmp_path, monkeypatch):
+    # The reset must be additive: the daemon's restart-auth_failed-agents
+    # callback still has to run.
+    r, _aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    fired: list[int] = []
+    r.register_on_refresh_success(lambda: fired.append(1))
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: (2, 11))
+    r._last_cred_fingerprint = (1, 10)
+
+    r._detect_external_rotation()
+
+    assert fired == [1]
+
+
+def test_unchanged_fingerprint_does_not_reset(tmp_path, monkeypatch):
+    # No rotation → no recovery. A quiet tick must not clear a real
+    # failure streak.
+    r, _aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: (1, 10))
+    r._last_cred_fingerprint = (1, 10)
+    r._consecutive_failed = 1
+
+    r._detect_external_rotation()
+
+    assert r._consecutive_failed == 1
+
+
+# ── gap 2: UNCHANGED is only trouble when the token is not fresh ───
+
+
+def test_unchanged_with_fresh_token_does_not_count_toward_broken(
+    tmp_path, monkeypatch,
+):
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+
+    for _ in range(REFRESH_BROKEN_THRESHOLD * 3):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert r._consecutive_failed == 0
+    assert r._consecutive_unchanged == REFRESH_BROKEN_THRESHOLD * 3
+    assert RuntimeState.load(aid).health != "refresh_broken"
+
+
+def test_unchanged_with_expiring_token_still_flips_broken(tmp_path, monkeypatch):
+    # Detection must not be lost. This is the FileBackend case that logs
+    # "claude may not be rewriting credentials.json ... operator may need
+    # `claude /login`" — a refresh we needed and didn't get.
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _refresher(
+        tmp_path, monkeypatch,
+        expires_in_seconds=REFRESH_SAFETY_MARGIN_SECONDS - 60,
+    )
+
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert r._consecutive_failed == REFRESH_BROKEN_THRESHOLD
+    assert RuntimeState.load(aid).health == "refresh_broken"
+
+
+def test_missing_credential_counts_unchanged_as_trouble(tmp_path, monkeypatch):
+    # expires_in_seconds() returns None with no host file at all. That is
+    # not a fresh token, so it must not take the benign branch.
+    r, _aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    (tmp_path / "host" / ".claude" / ".credentials.json").unlink()
+
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert r._consecutive_failed == 1
+
+
+def test_benign_unchanged_does_not_clear_an_existing_break(tmp_path, monkeypatch):
+    # Not counting toward the streak is not the same as proving recovery.
+    # Only a REFRESHED or a detected rotation clears the flag.
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    _break_it(r)
+
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert RuntimeState.load(aid).health == "refresh_broken"
+
+
+# ── the reported trace, end to end ─────────────────────────────────
+
+
+def test_relogin_then_benign_probe_does_not_reflag(tmp_path, monkeypatch):
+    """The 2026-07-02 08:41:31–08:41:36 sequence.
+
+    Agents were refresh_broken; the operator re-logged in; five seconds
+    later an already-pending probe returned UNCHANGED because the token
+    it found was the fresh one. Before the fix the counter — never reset
+    by the rotation path — crossed the threshold again immediately.
+    """
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    _break_it(r)
+    assert RuntimeState.load(aid).health == "refresh_broken"
+
+    # Operator re-login lands.
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: (2, 11))
+    r._last_cred_fingerprint = (1, 10)
+    r._detect_external_rotation()
+    assert RuntimeState.load(aid).health == "ok"
+
+    # The probe that was already in flight reports back.
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+
+    assert RuntimeState.load(aid).health == "ok"
+    assert r._consecutive_failed == 0
+
+
+def test_genuine_failure_after_recovery_still_flags(tmp_path, monkeypatch):
+    # The counter resets, it doesn't become sticky-clean.
+    from puffo_agent.portal.state import RuntimeState
+    r, aid = _refresher(tmp_path, monkeypatch, expires_in_seconds=3600)
+    monkeypatch.setattr(r.backend, "fingerprint", lambda: (2, 11))
+    r._last_cred_fingerprint = (1, 10)
+    r._detect_external_rotation()
+
+    for _ in range(REFRESH_BROKEN_THRESHOLD):
+        r._propagate_outcome(RefreshOutcome.FAILED)
+
+    assert RuntimeState.load(aid).health == "refresh_broken"

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -316,11 +316,15 @@ def _make_agent_runtime(home_root: Path, agent_id: str) -> Path:
 
 def _make_refresher_with_agent(
     tmp_path: Path, monkeypatch, *, agent_id: str = "agent-puf265",
+    expires_in_seconds: int = 3600,
 ) -> tuple[CredentialRefresher, str]:
     from puffo_agent.portal.state import agent_home_dir
 
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    _write_creds(tmp_path / "host", expires_in_seconds=3600)
+    # PUF-349: 3600s is above REFRESH_SAFETY_MARGIN_SECONDS, so UNCHANGED
+    # reads as benign here. Tests that need UNCHANGED to count as trouble
+    # pass an expiry at or below the margin.
+    _write_creds(tmp_path / "host", expires_in_seconds=expires_in_seconds)
     _make_agent_runtime(tmp_path, agent_id)
 
     r = CredentialRefresher(host_home=tmp_path / "host")
@@ -330,34 +334,28 @@ def _make_refresher_with_agent(
 
 def test_propagate_outcome_refreshed_resets_counter(tmp_path, monkeypatch):
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    r._consecutive_non_success = 1
+    r._consecutive_failed = 1
     r._propagate_outcome(RefreshOutcome.REFRESHED)
-    assert r._consecutive_non_success == 0
-
-
-def test_propagate_outcome_unchanged_increments_counter(tmp_path, monkeypatch):
-    r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
-    assert r._consecutive_non_success == 1
+    assert r._consecutive_failed == 0
 
 
 def test_propagate_outcome_failed_increments_counter(tmp_path, monkeypatch):
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
     r._propagate_outcome(RefreshOutcome.FAILED)
-    assert r._consecutive_non_success == 1
+    assert r._consecutive_failed == 1
 
 
 def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch, caplog):
     from puffo_agent.portal.state import RuntimeState
     import logging
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.FAILED)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health != "refresh_broken"
     assert REFRESH_BROKEN_THRESHOLD == 2
     with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.credential_refresh"):
-        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+        r._propagate_outcome(RefreshOutcome.FAILED)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health == "refresh_broken"
@@ -365,7 +363,7 @@ def test_refresh_broken_flips_after_threshold_consecutive(tmp_path, monkeypatch,
     assert "claude auth login" in rs.error
     # Outcome-class debug stays in the daemon log, not in runtime.error.
     assert any(
-        "flipping refresh_broken" in rec.getMessage() and "unchanged" in rec.getMessage()
+        "flipping refresh_broken" in rec.getMessage() and "failed" in rec.getMessage()
         for rec in caplog.records
     )
 
@@ -374,14 +372,14 @@ def test_refresh_broken_clears_on_next_refreshed(tmp_path, monkeypatch):
     from puffo_agent.portal.state import RuntimeState
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
     for _ in range(REFRESH_BROKEN_THRESHOLD):
-        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+        r._propagate_outcome(RefreshOutcome.FAILED)
     assert RuntimeState.load(aid).health == "refresh_broken"
     r._propagate_outcome(RefreshOutcome.REFRESHED)
     rs = RuntimeState.load(aid)
     assert rs is not None
     assert rs.health == "ok"
     assert rs.error == ""
-    assert r._consecutive_non_success == 0
+    assert r._consecutive_failed == 0
 
 
 def test_refresh_broken_cleared_after_daemon_restart(tmp_path, monkeypatch):
@@ -391,7 +389,7 @@ def test_refresh_broken_cleared_after_daemon_restart(tmp_path, monkeypatch):
     rs.health = "refresh_broken"
     rs.error = "left over from previous daemon"
     rs.save(aid)
-    assert r._consecutive_non_success == 0
+    assert r._consecutive_failed == 0
     r._propagate_outcome(RefreshOutcome.REFRESHED)
     rs = RuntimeState.load(aid)
     assert rs.health == "ok"
@@ -511,7 +509,7 @@ def test_refresh_broken_flips_all_registered_agents(tmp_path, monkeypatch):
     r.register_agent(agent_home_dir("agent-beta"))
 
     for _ in range(REFRESH_BROKEN_THRESHOLD):
-        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+        r._propagate_outcome(RefreshOutcome.FAILED)
 
     assert RuntimeState.load("agent-alpha").health == "refresh_broken"
     assert RuntimeState.load("agent-beta").health == "refresh_broken"
@@ -520,8 +518,8 @@ def test_refresh_broken_flips_all_registered_agents(tmp_path, monkeypatch):
 def test_refresh_broken_flip_is_idempotent_past_threshold(tmp_path, monkeypatch):
     from puffo_agent.portal.state import RuntimeState
     r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.FAILED)
+    r._propagate_outcome(RefreshOutcome.FAILED)
     rs_after_flip = RuntimeState.load(aid)
     assert rs_after_flip.health == "refresh_broken"
     initial_error = rs_after_flip.error
@@ -529,7 +527,7 @@ def test_refresh_broken_flip_is_idempotent_past_threshold(tmp_path, monkeypatch)
     # already-refresh_broken agent's disk state must not be re-written
     # (avoids log spam + redundant disk writes once flipped).
     r._propagate_outcome(RefreshOutcome.FAILED)
-    r._propagate_outcome(RefreshOutcome.UNCHANGED)
+    r._propagate_outcome(RefreshOutcome.FAILED)
     r._propagate_outcome(RefreshOutcome.FAILED)
     rs_later = RuntimeState.load(aid)
     assert rs_later.health == "refresh_broken"
@@ -537,7 +535,7 @@ def test_refresh_broken_flip_is_idempotent_past_threshold(tmp_path, monkeypatch)
     # inner-loop guard `health == "refresh_broken": continue` blocked
     # the re-write.
     assert rs_later.error == initial_error
-    assert r._consecutive_non_success == 5
+    assert r._consecutive_failed == 5
 
 
 def test_refresh_broken_does_not_touch_unregistered_agents(tmp_path, monkeypatch):
@@ -553,7 +551,7 @@ def test_refresh_broken_does_not_touch_unregistered_agents(tmp_path, monkeypatch
     r.unregister_agent(agent_home_dir("agent-leaves"))
 
     for _ in range(REFRESH_BROKEN_THRESHOLD):
-        r._propagate_outcome(RefreshOutcome.UNCHANGED)
+        r._propagate_outcome(RefreshOutcome.FAILED)
 
     assert RuntimeState.load("agent-stays").health == "refresh_broken"
     assert RuntimeState.load("agent-leaves").health != "refresh_broken"
@@ -579,7 +577,13 @@ def test_refreshed_outcome_does_not_lift_unrelated_health_to_ok(
 def test_refresh_broken_streak_mixes_unchanged_and_failed(tmp_path, monkeypatch, caplog):
     from puffo_agent.portal.state import RuntimeState
     import logging
-    r, aid = _make_refresher_with_agent(tmp_path, monkeypatch)
+    # PUF-349: the mixed streak only holds when UNCHANGED means trouble,
+    # i.e. the credential is at or below the safety margin and a refresh
+    # we needed didn't land. A fresh-token UNCHANGED no longer joins the
+    # streak — test_unchanged_with_fresh_token_does_not_flip pins that.
+    r, aid = _make_refresher_with_agent(
+        tmp_path, monkeypatch, expires_in_seconds=60,
+    )
     with caplog.at_level(logging.WARNING, logger="puffo_agent.portal.credential_refresh"):
         r._propagate_outcome(RefreshOutcome.UNCHANGED)
         r._propagate_outcome(RefreshOutcome.FAILED)
@@ -708,9 +712,9 @@ def test_filebackend_rate_limit_pattern_matches_in_stdout_too(tmp_path, monkeypa
 def test_propagate_outcome_rate_limited_counts_toward_streak(tmp_path, monkeypatch):
     r, _aid = _make_refresher_with_agent(tmp_path, monkeypatch)
     r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
-    assert r._consecutive_non_success == 1
+    assert r._consecutive_failed == 1
     r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
-    assert r._consecutive_non_success >= REFRESH_BROKEN_THRESHOLD
+    assert r._consecutive_failed >= REFRESH_BROKEN_THRESHOLD
 
 
 def test_propagate_outcome_rate_limited_schedules_fast_retry(tmp_path, monkeypatch):
@@ -785,7 +789,7 @@ def test_propagate_outcome_rate_limited_does_not_crash_without_event_loop(
     r._propagate_outcome(RefreshOutcome.RATE_LIMITED)
     assert r._rate_limit_retry_task is None
     # Streak counter still advanced.
-    assert r._consecutive_non_success == 1
+    assert r._consecutive_failed == 1
 
 
 # ── model_not_found fallback latch ──────────────────────────────────────


### PR DESCRIPTION
**Ticket**: PUF-349 (Linear [PUF-18](https://linear.app/puffo-ai/issue/PUF-18)) — puffo-agent credential-refresh state-integrity gaps surfaced by Cal 2026-07-02 during operator auth-outage diagnosis.

**Two bugs, one merged fix** (`src/puffo_agent/portal/credential_refresh.py`):

1. **Recovery-path asymmetry** — `_detect_external_rotation()` fired `_fire_refresh_success()` on operator re-login but never reset `_consecutive_non_success` or cleared `refresh_broken`. Only probe-driven `_propagate_outcome(REFRESHED)` did.
2. **UNCHANGED conflated with FAILED** — `_consecutive_non_success` counted benign UNCHANGED (token still fresh) the same as genuine FAILED. A refresh-success-then-in-flight-UNCHANGED-probe sequence would re-flag `refresh_broken` seconds after recovery.

Empirical trace (2026-07-02 08:41:31–08:41:36 local): operator re-login → refresh-success fired → 5s later pending probe returned UNCHANGED → counter hit 8 → `refresh_broken` re-flagged post-recovery.

## Design shape (per operator directive)

Operator picked **(a) minimal-diff** at intake (msg_0343d120). During build, Cal expanded to **(a) + (c) counter-split + `_note_recovery` structural convergence** based on substrate analysis: pure (a) would silently drop the FileBackend UNCHANGED-as-ERROR case (which logs `claude /login` guidance — a real signal that a blanket 'UNCHANGED is benign' would suppress). The credential's own remaining lifetime discriminates benign vs concerning UNCHANGED (poll only refreshes at-or-below safety margin → fresh-remaining UNCHANGED = redundant refresh, at-margin UNCHANGED = failed rotation).

Operator accepted the expansion per **msg_52d9a111** (2026-08-10 23:25 UTC): "1，既然做了我就一起看" — reviewing the whole shape together.

## What's in the diff

- `_note_recovery(source)` helper — single definition of "we have a working credential again", called from three recovery sites: `_propagate_outcome(REFRESHED)`, `_detect_external_rotation()` (file-fingerprint path), and `_external_rotation_loop` (Keychain macOS-only path). No path can announce recovery without resetting the state that announcement invalidates.
- `_is_fresh(expires_in)` module-level helper — one predicate for "credential doesn't need rotating yet" shared by `ensure_fresh()` and `_credential_is_fresh()`. Drift-guard test spies on `_is_fresh` and asserts both callsites hit it.
- Split `_consecutive_non_success` → `_consecutive_failed` + `_consecutive_unchanged`. Only `_consecutive_failed` flips `refresh_broken`.
- 6 existing tests that used UNCHANGED as arbitrary non-success carrier swapped to FAILED (semantics preserving; subject was flip-mechanism/threshold/fan-out). 1 kept (`test_refresh_broken_streak_mixes_unchanged_and_failed`) with credential fixture adjusted to `expires_in_seconds=60` because UNCHANGED-in-mixed-streak only holds when token is at-margin. 1 deleted (`test_propagate_outcome_unchanged_increments_counter`) — pinned the exact bug being fixed.
- **14 new pinning tests** in `tests/test_credential_refresh_recovery_reset.py` covering: recovery-path symmetry, counter-split behavior, benign vs concerning UNCHANGED discrimination, invariant guards (recovery doesn't clear existing break, real failure after recovery still flags), the exact intake-trace reproducer, drift-guard, boundary values for `_is_fresh`, and source-level assertion counting `_fire_refresh_success` sites paired with `_note_recovery` (guards platform-conditional macOS code CI can't execute).

## Verification

- **Test count**: baseline `origin/main` `431bb77` = 2422 passed / 2 skipped. Branch `7da8028` = **2437 passed / 2 skipped** (+15 net = 14 new + 1 delete + 2 for source-level & Keychain-driver tests; matches Cal's arithmetic).
- **Reverse-verify (behavior-red)**: reverting src per commit produced 6 behavior-red tests on baseline (2 external-rotation, 1 intake-trace reproducer, 3 counter-split AttributeError-weaker); +2 more on Keychain-fold revert (source-level assertion + driver test).
- **QA base commits**: `958df0d` (initial), `abbe605` (drift-guard + boundaries fold), `7da8028` (Keychain-loop symmetry fold). All three passed Solution QA.

**QA verdict thread**: msg_ac902e7d in #Development Team. Final verdict msg_e5267d83.

**Impact**: no user-observable behavior change. Fixes internal health-flag correctness after operator re-login. P3.
