### PR TITLE
Correct Agent Foundation prerelease to 2.0.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [1.3.0a1] — 2026-08-11
+## [2.0.0a1] — 2026-08-11
 
 > Pre-release published to TestPyPI for staging validation only. It is not the
-> stable `1.3.0` release.
+> stable `2.0.0` release. It supersedes the incorrectly numbered,
+> TestPyPI-only `1.3.0a1` artifact; no stable `1.3.0` was published.
 
 ### Added
 
@@ -4396,8 +4397,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v1.3.0a1...HEAD
-[1.3.0a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v1.3.0a1
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.0a1...HEAD
+[2.0.0a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a1
 [1.2.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v1.2.0
 [0.10.0a2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.10.0a2
 [0.10.0a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.10.0a1

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ pip install puffo-agent
 pip install puffo-agent==1.2.0
 ```
 
-The Agent Foundation `1.3.0a1` candidate is for staging validation and is
+The Agent Foundation `2.0.0a1` candidate is for staging validation and is
 published to TestPyPI only. See
-[`docs/RELEASE-CANDIDATE-1.3.0a1.md`](docs/RELEASE-CANDIDATE-1.3.0a1.md) for
+[`docs/RELEASE-CANDIDATE-2.0.0a1.md`](docs/RELEASE-CANDIDATE-2.0.0a1.md) for
 the install command, test scope, and stable-release TODOs.
 
 Both paths install the `puffo-agent` console script. The CLI's

--- a/docs/RELEASE-CANDIDATE-2.0.0a1.md
+++ b/docs/RELEASE-CANDIDATE-2.0.0a1.md
@@ -1,8 +1,11 @@
-# Agent Foundation 1.3 Test Release
+# Agent Foundation 2.0 Test Release
 
-- **Candidate:** `puffo-agent==1.3.0a1`
+- **Candidate:** `puffo-agent==2.0.0a1`
 - **Status:** staging and TestPyPI validation only
 - **Stable release:** not authorized by this merge
+
+This candidate supersedes the incorrectly numbered TestPyPI-only `1.3.0a1`
+artifact. No stable `1.3.0` package was published.
 
 This document freezes the release decisions and evidence expected after the
 Agent Foundation integration branch merges. It is intentionally narrower than
@@ -11,8 +14,8 @@ the complete product roadmap.
 ## Decisions
 
 1. Merge the Agent Foundation implementation to `main`, but publish it first as
-   `1.3.0a1` through the manual TestPyPI workflow. Do not create a stable GitHub
-   release or publish `1.3.0` to production PyPI yet.
+   `2.0.0a1` through the manual TestPyPI workflow. Do not create a stable GitHub
+   release or publish `2.0.0` to production PyPI yet.
 2. Validate the candidate against staging. A green merge CI run is necessary
    but is not evidence of live Server, harness, or upgrade compatibility.
 3. Channel encryption policy and plaintext-channel behavior are owned by Han's
@@ -26,7 +29,7 @@ the complete product roadmap.
 6. No more broad refactoring, feature additions, or test-suite expansion belongs
    in this candidate. Fix only failures that block the acceptance cases below.
 
-## TODO Before Stable 1.3.0
+## TODO Before Stable 2.0.0
 
 - Forward-port the Windows Claude Code shim-spawn behavior from
   [PR #224](https://github.com/puffo-ai/puffo-agent/pull/224) to the new Claude
@@ -41,7 +44,7 @@ the complete product roadmap.
   validate candidate templates in staging, and define migration for existing
   pinned cloud Agents before calling cloud Agent support generally available.
 - Add stable-release evidence and change the package version, changelog, and
-  README from `1.3.0a1` to `1.3.0` only after the gates above close.
+  README from `2.0.0a1` to `2.0.0` only after the gates above close.
 
 The following product work remains deferred rather than release-blocking:
 keyless invitation approval, complete keyless DM trust management, Runtime
@@ -53,12 +56,12 @@ ACP, and plaintext DMs.
 Run the smallest set that exercises the integrated behavior on the final
 candidate SHA:
 
-1. Install `1.3.0a1` from TestPyPI in a clean environment and confirm the CLI
+1. Install `2.0.0a1` from TestPyPI in a clean environment and confirm the CLI
    starts:
 
    ```bash
    pip install --index-url https://test.pypi.org/simple/ \
-     --extra-index-url https://pypi.org/simple/ puffo-agent==1.3.0a1
+     --extra-index-url https://pypi.org/simple/ puffo-agent==2.0.0a1
    puffo-agent --help
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "1.3.0a1"
+version = "2.0.0a1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "1.3.0a1"
+version = "2.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Corrects the Agent Foundation prerelease from `1.3.0a1` to `2.0.0a1` because the runtime consolidation contains intentional compatibility breaks.

- updates package and lock metadata
- renames the release-candidate decision/TODO/test document
- updates README and changelog references
- records that the TestPyPI-only `1.3.0a1` artifact was incorrectly numbered and is superseded

No runtime behavior changes. Channel encryption remains outside this release scope in #212.

## Verification

- targeted pre-commit checks
- built sdist and wheel
- installed wheel in a clean Python 3.11 environment
- `puffo-agent version` reports `2.0.0a1`
- wheel METADATA reports `Version: 2.0.0a1`