### PR TITLE
PUF-430: on archive, leave every space so the agent drops out of channel rosters

### DIFF
--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1140,7 +1140,7 @@ def cmd_agent_archive(args: argparse.Namespace) -> int:
     archived_dir().mkdir(parents=True, exist_ok=True)
     stamp = time.strftime("%Y%m%d-%H%M%S")
     dest = archived_dir() / f"{agent_id}-{stamp}"
-    from .daemon import _retry_move
+    from .daemon import _leave_spaces_before_revoke, _retry_move
     from .import_agents import (
         revoke_archived_device,
         write_archived_pending_revoke,
@@ -1157,6 +1157,18 @@ def cmd_agent_archive(args: argparse.Namespace) -> int:
             )
             return 1
         if cfg.puffo_core.is_configured():
+            # Same fanout the daemon's archive path runs — archiving via
+            # the CLI otherwise leaves the agent in every channel roster.
+            if not await _leave_spaces_before_revoke(
+                agent_id, dest, slug=cfg.puffo_core.slug
+            ):
+                print(
+                    "warning: could not leave every space; revoke deferred "
+                    "to the daemon's next startup sweep",
+                    file=sys.stderr,
+                )
+                print(f"archived {agent_id!r} → {dest}")
+                return 0
             try:
                 await revoke_archived_device(dest, slug=cfg.puffo_core.slug)
                 print(f"revoked {agent_id!r} device server-side")

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -590,6 +590,8 @@ class Daemon:
         if cfg_for_revoke is None or not cfg_for_revoke.puffo_core.is_configured():
             return
         pc = cfg_for_revoke.puffo_core
+        if not await _leave_spaces_before_revoke(agent_id, dest, slug=pc.slug):
+            return
         try:
             await revoke_archived_device(dest, slug=pc.slug)
             logger.info("agent %s: device revoked server-side", agent_id)
@@ -666,6 +668,12 @@ class Daemon:
                 )
             return
         pc = cfg_for_revoke.puffo_core
+        # A deleted agent ghosts channel rosters exactly like an archived
+        # one — same fanout, same before-revoke constraint. The dir stays
+        # on disk (as the revoke-failure branch already does) so the sweep
+        # can retry; rmtree only after both have landed.
+        if not await _leave_spaces_before_revoke(agent_id, dest, slug=pc.slug):
+            return
         try:
             await revoke_archived_device(dest, slug=pc.slug)
             logger.info("agent %s: device revoked server-side", agent_id)
@@ -705,6 +713,83 @@ class Daemon:
                 exc,
                 dest,
             )
+
+
+async def _leave_spaces_before_revoke(
+    agent_id: str, dest: Path, *, slug: str
+) -> bool:
+    """Drop the archived agent out of every space it still belongs to, so
+    it stops appearing in channel rosters and the @-mention picker
+    (PUF-430). Returns whether the caller may proceed to the revoke.
+
+    On a transient failure we return ``False`` and leave BOTH markers: the
+    revoke has to wait, because it 401s the only credential that can sign
+    the outstanding leaves. Owning a space is not a failure — the server
+    won't let an owner leave, so we warn and archive anyway rather than
+    stranding the agent in a half-archived state.
+    """
+    from .import_agents import (
+        leave_all_spaces,
+        write_archived_pending_leave,
+        write_archived_pending_revoke,
+    )
+
+    failed: list[str] = []
+    try:
+        result = await leave_all_spaces(dest, slug=slug)
+    except Exception as exc:  # noqa: BLE001
+        reason = f"{type(exc).__name__}: {exc}"
+    else:
+        if result.skipped_owner:
+            logger.warning(
+                "agent %s: still owns space(s) %s — cannot leave them "
+                "(ownership must be transferred first); archiving anyway",
+                agent_id,
+                ", ".join(result.skipped_owner),
+            )
+        if not result.failed:
+            logger.info(
+                "agent %s: left %d space(s) before revoke",
+                agent_id,
+                len(result.left),
+            )
+            return True
+        failed = result.failed
+        reason = result.last_error
+
+    logger.warning(
+        "agent %s: space-leave incomplete (%s); deferring revoke so the "
+        "next startup sweep can retry the leave first",
+        agent_id,
+        reason,
+    )
+    try:
+        write_archived_pending_leave(
+            dest, slug=slug, space_ids=failed, last_error=reason
+        )
+    except OSError as exc:
+        logger.warning(
+            "agent %s: failed to write pending_leave marker: %s", agent_id, exc
+        )
+        return True
+    try:
+        from ..crypto.keystore import KeyStore
+
+        identity = KeyStore(dest / "keys").load_identity(slug)
+        write_archived_pending_revoke(
+            dest,
+            server_url=identity.server_url,
+            slug=identity.slug,
+            device_id=identity.device_id,
+            last_error=f"deferred behind pending space-leave: {reason}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "agent %s: failed to write deferred pending_revoke marker: %s",
+            agent_id,
+            exc,
+        )
+    return False
 
 
 async def _report_lifecycle(agent_cfg: AgentConfig, status: str) -> bool:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -747,6 +747,13 @@ async def _leave_spaces_before_revoke(
                 agent_id,
                 ", ".join(result.skipped_owner),
             )
+        if result.skipped_permanent:
+            logger.warning(
+                "agent %s: space(s) %s permanently rejected the leave; "
+                "archiving anyway (a retry would never converge)",
+                agent_id,
+                ", ".join(result.skipped_permanent),
+            )
         if not result.failed:
             logger.info(
                 "agent %s: left %d space(s) before revoke",

--- a/src/puffo_agent/portal/import_agents.py
+++ b/src/puffo_agent/portal/import_agents.py
@@ -26,7 +26,7 @@ import json
 import logging
 import shutil
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import aiohttp
@@ -63,6 +63,15 @@ def _remote_http_session(server_url: str) -> aiohttp.ClientSession:
 
 class ImportError(Exception):
     pass
+
+
+class HttpStatusError(ImportError):
+    """Carries the response status so callers can tell a retryable blip
+    from a permanent rejection."""
+
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 @dataclass
@@ -394,7 +403,7 @@ async def _signed_post(
     ) as resp:
         if resp.status >= 400:
             text = await resp.text()
-            raise ImportError(f"{path} {resp.status}: {text}")
+            raise HttpStatusError(f"{path} {resp.status}: {text}", resp.status)
 
 
 async def _signed_get(
@@ -417,7 +426,7 @@ async def _signed_get(
     async with session.get(f"{server_url.rstrip('/')}{path}", headers=headers) as resp:
         if resp.status >= 400:
             text = await resp.text()
-            raise ImportError(f"{path} {resp.status}: {text}")
+            raise HttpStatusError(f"{path} {resp.status}: {text}", resp.status)
         return await resp.json()
 
 
@@ -734,17 +743,31 @@ OWNER_LEAVE_REJECTION = "owner must transfer ownership before leaving"
 @dataclass
 class LeaveSpacesResult:
     """Outcome of the on-archive space-leave fanout. ``failed`` is the
-    only retryable bucket — ``skipped_owner`` is permanent until a human
-    transfers the space, so it must never hold up the archive."""
+    only retryable bucket; both skip buckets are permanent and must never
+    hold up the revoke, since retrying them would never converge.
+
+    ``skipped_owner`` needs a human to transfer the space first.
+    ``skipped_permanent`` is a non-403 4xx — a rejection the server will
+    repeat identically on every retry."""
 
     left: list[str]
     skipped_owner: list[str]
     failed: list[str]
+    skipped_permanent: list[str] = field(default_factory=list)
     last_error: str = ""
 
 
+def _is_permanent_leave_rejection(exc: Exception) -> bool:
+    """Per AC #4: a 4xx other than 403 is the server telling us this
+    request is wrong, not that it's busy — retrying can't fix it. 403 is
+    excluded because a non-owner 403 can be a transient auth blip, and
+    429 is a rate-limit, i.e. explicitly retryable."""
+    status = getattr(exc, "status", 0)
+    return 400 <= status < 500 and status not in (403, 429)
+
+
 def archived_pending_leave_path(archived_agent_dir: Path) -> Path:
-    return archived_agent_dir / ".puffo-agent" / "pending_leave.json"
+    return archived_agent_dir / ".puffo-agent" / "pending_leave_memberships.json"
 
 
 def write_archived_pending_leave(
@@ -850,6 +873,14 @@ async def leave_all_spaces(archived_dir: Path, *, slug: str) -> LeaveSpacesResul
             except Exception as exc:  # noqa: BLE001
                 if OWNER_LEAVE_REJECTION in str(exc):
                     result.skipped_owner.append(space_id)
+                    continue
+                if _is_permanent_leave_rejection(exc):
+                    result.skipped_permanent.append(space_id)
+                    logger.warning(
+                        "archive leave: space %s permanently rejected for %s "
+                        "(%s); not retrying",
+                        space_id, slug, exc,
+                    )
                     continue
                 result.failed.append(space_id)
                 result.last_error = f"{type(exc).__name__}: {exc}"

--- a/src/puffo_agent/portal/import_agents.py
+++ b/src/puffo_agent/portal/import_agents.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 import aiohttp
 
+from ..agent.event_kinds import EventKind
+from ..agent.events import random_nonce, sign_event
 from ..crypto.certs import create_subkey_cert
 from ..crypto.encoding import base64url_encode
 from ..crypto.http_auth import sign_request
@@ -395,6 +397,30 @@ async def _signed_post(
             raise ImportError(f"{path} {resp.status}: {text}")
 
 
+async def _signed_get(
+    session: aiohttp.ClientSession,
+    *,
+    server_url: str,
+    path: str,
+    signer_key: Ed25519KeyPair,
+    signer_id: str,
+    slug: str,
+) -> dict:
+    headers = sign_request(
+        signing_key=signer_key,
+        slug=slug,
+        signer_id=signer_id,
+        method="GET",
+        path=path,
+        body=b"",
+    ).to_dict()
+    async with session.get(f"{server_url.rstrip('/')}{path}", headers=headers) as resp:
+        if resp.status >= 400:
+            text = await resp.text()
+            raise ImportError(f"{path} {resp.status}: {text}")
+        return await resp.json()
+
+
 async def _register_subkey_via_device(
     session: aiohttp.ClientSession,
     *,
@@ -634,6 +660,24 @@ async def self_revoke_device(
         )
 
 
+def _fresh_session_subkey(
+    keystore: KeyStore, slug: str
+) -> tuple[Ed25519KeyPair, dict] | None:
+    """Reuse a still-valid session subkey from disk to skip a redundant
+    ``/devices/subkeys`` POST. ``None`` when absent or due for rotation."""
+    try:
+        from ..crypto.certs import needs_rotation
+        sess = keystore.load_session(slug)
+    except FileNotFoundError:
+        return None
+    if needs_rotation(sess.expires_at):
+        return None
+    return (
+        Ed25519KeyPair.from_secret_bytes(decode_secret(sess.subkey_secret_key)),
+        {"subkey_id": sess.subkey_id},
+    )
+
+
 async def revoke_archived_device(archived_dir: Path, *, slug: str) -> None:
     keystore = KeyStore(archived_dir / "keys")
     identity = keystore.load_identity(slug)
@@ -643,21 +687,7 @@ async def revoke_archived_device(archived_dir: Path, *, slug: str) -> None:
     device_signing = Ed25519KeyPair.from_secret_bytes(
         decode_secret(identity.device_signing_secret_key)
     )
-    # Reuse a fresh session subkey if one's already on disk to skip a
-    # redundant /devices/subkeys POST.
-    preregistered: tuple[Ed25519KeyPair, dict] | None = None
-    try:
-        from ..crypto.certs import needs_rotation
-        sess = keystore.load_session(slug)
-        if not needs_rotation(sess.expires_at):
-            preregistered = (
-                Ed25519KeyPair.from_secret_bytes(
-                    decode_secret(sess.subkey_secret_key)
-                ),
-                {"subkey_id": sess.subkey_id},
-            )
-    except FileNotFoundError:
-        pass
+    preregistered = _fresh_session_subkey(keystore, slug)
     await self_revoke_device(
         server_url=identity.server_url,
         slug=identity.slug,
@@ -696,6 +726,140 @@ def write_archived_pending_revoke(
         ),
         encoding="utf-8",
     )
+
+
+OWNER_LEAVE_REJECTION = "owner must transfer ownership before leaving"
+
+
+@dataclass
+class LeaveSpacesResult:
+    """Outcome of the on-archive space-leave fanout. ``failed`` is the
+    only retryable bucket — ``skipped_owner`` is permanent until a human
+    transfers the space, so it must never hold up the archive."""
+
+    left: list[str]
+    skipped_owner: list[str]
+    failed: list[str]
+    last_error: str = ""
+
+
+def archived_pending_leave_path(archived_agent_dir: Path) -> Path:
+    return archived_agent_dir / ".puffo-agent" / "pending_leave.json"
+
+
+def write_archived_pending_leave(
+    archived_agent_dir: Path,
+    *,
+    slug: str,
+    space_ids: list[str],
+    last_error: str,
+) -> None:
+    """Marker for the startup sweep. ``space_ids`` is what failed on this
+    pass — informational only; the retry re-queries ``GET /spaces`` so it
+    converges on server-authoritative state rather than a stale list."""
+    path = archived_pending_leave_path(archived_agent_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "kind": "archive_leave_spaces",
+                "slug": slug,
+                "space_ids": space_ids,
+                "last_error": last_error,
+                "attempted_at": int(time.time() * 1000),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+async def leave_all_spaces(archived_dir: Path, *, slug: str) -> LeaveSpacesResult:
+    """Sign a ``LeaveSpace`` for every space the agent still belongs to,
+    so an archived agent stops showing up in channel rosters and the
+    @-mention picker (PUF-430).
+
+    MUST run before ``revoke_archived_device`` — once the device is
+    revoked its subkeys are 401'd and nothing can be signed. Spaces are
+    enumerated from ``GET /spaces`` (server-authoritative; local state
+    can be stale) and the server cascades each ``LeaveSpace`` to every
+    channel in that space, so per-space is enough.
+
+    Raises on pre-flight failure (keystore, subkey, or the enumerate
+    GET); per-space failures are collected into the result instead.
+    """
+    keystore = KeyStore(archived_dir / "keys")
+    identity = keystore.load_identity(slug)
+    device_signing = Ed25519KeyPair.from_secret_bytes(
+        decode_secret(identity.device_signing_secret_key)
+    )
+    server_url = identity.server_url
+    result = LeaveSpacesResult(left=[], skipped_owner=[], failed=[])
+    async with _remote_http_session(server_url) as session:
+        preregistered = _fresh_session_subkey(keystore, slug)
+        if preregistered is not None:
+            subkey, cert = preregistered
+        else:
+            subkey, cert = await _register_subkey_via_device(
+                session,
+                server_url=server_url,
+                slug=slug,
+                device_id=identity.device_id,
+                device_signing_key=device_signing,
+            )
+        subkey_id = cert["subkey_id"]
+        data = await _signed_get(
+            session,
+            server_url=server_url,
+            path="/spaces",
+            signer_key=subkey,
+            signer_id=subkey_id,
+            slug=slug,
+        )
+        for entry in data.get("spaces") or []:
+            space_id = (entry.get("space_id") or "").strip()
+            if not space_id:
+                continue
+            # The server rejects an owner's LeaveSpace outright; skip it
+            # here so we don't spend a round-trip to be told so.
+            if (entry.get("role") or "") == "owner":
+                result.skipped_owner.append(space_id)
+                continue
+            event = sign_event(
+                kind=EventKind.LEAVE_SPACE,
+                payload={
+                    "space_id": space_id,
+                    "effective_from": int(time.time() * 1000),
+                    "nonce": random_nonce(),
+                },
+                signer_slug=slug,
+                signer_device_id=identity.device_id,
+                signer_subkey_id=subkey_id,
+                signing_key=subkey,
+            )
+            try:
+                await _signed_post(
+                    session,
+                    server_url=server_url,
+                    path="/spaces/events",
+                    signer_key=subkey,
+                    signer_id=subkey_id,
+                    slug=slug,
+                    body_dict={"space_id": space_id, "events": [event]},
+                )
+            except Exception as exc:  # noqa: BLE001
+                if OWNER_LEAVE_REJECTION in str(exc):
+                    result.skipped_owner.append(space_id)
+                    continue
+                result.failed.append(space_id)
+                result.last_error = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "archive leave: space %s failed for %s: %s",
+                    space_id, slug, exc,
+                )
+            else:
+                result.left.append(space_id)
+    return result
 
 
 class _RetryOutcome(enum.Enum):
@@ -758,6 +922,55 @@ async def _retry_archived_pending_revoke(
     return _RetryOutcome.SUCCEEDED
 
 
+async def _retry_archived_pending_leave(archived_path: Path) -> bool:
+    """Retry the space-leave fanout for one archived dir. Returns whether
+    the revoke may proceed this pass — ``False`` only for a transient
+    leave failure, because revoking now would 401 every future retry."""
+    marker = archived_pending_leave_path(archived_path)
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        slug = payload["slug"]
+    except (OSError, ValueError, KeyError) as exc:
+        logger.warning(
+            "pending leave at %s is unparseable (%s); renaming to .broken",
+            marker, exc,
+        )
+        _mark_pending_revoke_broken(marker, str(exc))
+        return True
+    try:
+        result = await leave_all_spaces(archived_path, slug=slug)
+    except FileNotFoundError as exc:
+        logger.warning(
+            "pending leave at %s: keystore missing (%s); renaming to .broken",
+            marker, exc,
+        )
+        _mark_pending_revoke_broken(marker, f"keystore missing: {exc}")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "pending leave retry for %s failed: %s; will try again",
+            archived_path.name, exc,
+        )
+        return False
+    if result.failed:
+        write_archived_pending_leave(
+            archived_path,
+            slug=slug,
+            space_ids=result.failed,
+            last_error=result.last_error,
+        )
+        return False
+    try:
+        marker.unlink()
+    except OSError:
+        pass
+    logger.info(
+        "pending leave retry for %s ok (left %d, owner-skipped %d)",
+        archived_path.name, len(result.left), len(result.skipped_owner),
+    )
+    return True
+
+
 def _mark_pending_revoke_broken(marker: Path, reason: str) -> None:
     # Rename so the next sweep doesn't keep warning; left on disk for
     # operator inspection.
@@ -783,7 +996,16 @@ async def sweep_archived_pending_revokes() -> int:
     for entry in root.iterdir():
         if not entry.is_dir():
             continue
-        if not archived_pending_revoke_path(entry).exists():
+        has_leave = archived_pending_leave_path(entry).exists()
+        has_revoke = archived_pending_revoke_path(entry).exists()
+        if not (has_leave or has_revoke):
+            continue
+        # Leave first, always: the revoke kills the credential that signs
+        # the leave, so a revoke that lands early strands the memberships
+        # forever (PUF-430).
+        if has_leave and not await _retry_archived_pending_leave(entry):
+            continue
+        if not has_revoke:
             continue
         outcome = await _retry_archived_pending_revoke(entry)
         if outcome is _RetryOutcome.SUCCEEDED:

--- a/tests/test_archive_leave_spaces.py
+++ b/tests/test_archive_leave_spaces.py
@@ -101,6 +101,12 @@ def _seed(server, *, spaces: list[dict]) -> tuple[Path, dict]:
     return Path(home) / "agents" / AGENT_ID, {"url": url, "spaces": spaces}
 
 
+def _home() -> str:
+    import os
+
+    return os.environ["PUFFO_AGENT_HOME"]
+
+
 def _member(space_id: str) -> dict:
     return {"space_id": space_id, "role": "member", "joined_at": 0}
 
@@ -425,6 +431,43 @@ async def test_cli_archive_leaves_spaces_before_revoking(monkeypatch, mock_serve
     assert rc == 0
     assert order == ["leave", "revoke"]
     assert [b["space_id"] for b in state["posted"]] == ["sp_one"]
+
+
+async def test_cli_archive_defers_the_revoke_when_a_leave_fails(
+    monkeypatch, mock_server, capsys
+):
+    """The CLI honours the same defer contract as the daemon — revoking
+    here would 401 the credential the queued leave still needs."""
+    import argparse
+    import asyncio
+
+    from puffo_agent.portal import cli
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_bad")]
+    state["fail"] = {"sp_bad"}
+
+    revoked: list[str] = []
+
+    async def spy_revoke(archived_dir, *, slug):
+        revoked.append(slug)
+
+    monkeypatch.setattr(imp, "revoke_archived_device", spy_revoke)
+
+    rc = await asyncio.get_running_loop().run_in_executor(
+        None, cli.cmd_agent_archive, argparse.Namespace(id=AGENT_ID)
+    )
+
+    assert rc == 0
+    assert revoked == []
+    dest = next(
+        d for d in (Path(_home()) / "archived").iterdir() if d.is_dir()
+    )
+    assert imp.archived_pending_leave_path(dest).exists()
+    assert imp.archived_pending_revoke_path(dest).exists()
+    assert "revoke deferred" in capsys.readouterr().err
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_archive_leave_spaces.py
+++ b/tests/test_archive_leave_spaces.py
@@ -1,0 +1,479 @@
+"""PUF-430 — on archive (and delete) the daemon leaves every space it
+still belongs to, so the agent stops showing up in channel rosters and
+the @-mention picker. Covers the fanout itself, the owner-space skip,
+and the ordering contract with the device revoke (leave first, always —
+the revoke 401s the credential that signs the leave)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from _portal_support import isolated_home
+from test_import_module import _seed_source_agent
+
+pytestmark = pytest.mark.asyncio
+
+SLUG = "alpha-bot"
+AGENT_ID = "alpha"
+
+
+def _make_mock_app(state):
+    app = web.Application()
+
+    async def subkeys(request):
+        state["calls"].append(("POST", "/devices/subkeys"))
+        return web.json_response({"ok": True})
+
+    async def spaces(request):
+        state["calls"].append(("GET", "/spaces"))
+        if state.get("spaces_status"):
+            return web.json_response({"error": "nope"}, status=state["spaces_status"])
+        return web.json_response({"spaces": state["spaces"]})
+
+    async def events(request):
+        body = await request.json()
+        state["calls"].append(("POST", "/spaces/events"))
+        state["posted"].append(body)
+        space_id = body["space_id"]
+        if space_id in state["reject_owner"]:
+            return web.json_response(
+                {"error": "owner must transfer ownership before leaving"},
+                status=403,
+            )
+        if space_id in state["fail"]:
+            return web.json_response({"error": "induced failure"}, status=500)
+        return web.json_response({"ok": True, "applied": 1})
+
+    async def revoke(request):
+        state["calls"].append(("POST", "/revoke"))
+        return web.json_response({"ok": True})
+
+    app.router.add_post("/devices/subkeys", subkeys)
+    app.router.add_get("/spaces", spaces)
+    app.router.add_post("/spaces/events", events)
+    app.router.add_post("/devices/{device_id}/revoke", revoke)
+    return app
+
+
+@pytest_asyncio.fixture
+async def mock_server():
+    state = {
+        "calls": [],
+        "posted": [],
+        "spaces": [],
+        "fail": set(),
+        "reject_owner": set(),
+        "spaces_status": 0,
+    }
+    server = TestServer(_make_mock_app(state))
+    await server.start_server()
+    try:
+        yield server, state
+    finally:
+        await server.close()
+
+
+@pytest.fixture(autouse=True)
+def fresh_home():
+    isolated_home()
+    yield
+
+
+def _seed(server, *, spaces: list[dict]) -> tuple[Path, dict]:
+    """Materialise an agent dir with a real keystore identity pointed at
+    the mock server, and arm the server's ``GET /spaces`` response."""
+    import os
+
+    url = str(server.make_url("/")).rstrip("/")
+    home = os.environ["PUFFO_AGENT_HOME"]
+    _seed_source_agent(home, AGENT_ID, SLUG, url)
+    return Path(home) / "agents" / AGENT_ID, {"url": url, "spaces": spaces}
+
+
+def _member(space_id: str) -> dict:
+    return {"space_id": space_id, "role": "member", "joined_at": 0}
+
+
+def _owner(space_id: str) -> dict:
+    return {"space_id": space_id, "role": "owner", "joined_at": 0}
+
+
+# ────────────────────────────────────────────────────────────────────
+# The fanout
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_leave_all_spaces_signs_one_leave_per_space(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, seeded = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_one"), _member("sp_two")]
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.left == ["sp_one", "sp_two"]
+    assert result.failed == []
+    assert result.skipped_owner == []
+    assert [b["space_id"] for b in state["posted"]] == ["sp_one", "sp_two"]
+    for body in state["posted"]:
+        assert len(body["events"]) == 1
+        event = body["events"][0]
+        assert event["kind"] == "leave_space"
+        assert event["signer_slug"] == SLUG
+        assert event["signer_subkey_id"]
+        assert event["signature"]
+        assert event["payload"]["space_id"] == body["space_id"]
+        assert event["payload"]["effective_from"] > 0
+        assert event["payload"]["nonce"]
+
+
+async def test_leave_all_spaces_no_memberships_posts_nothing(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = []
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.left == []
+    assert state["posted"] == []
+
+
+async def test_owned_space_is_skipped_without_a_round_trip(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_owner("sp_owned"), _member("sp_joined")]
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.skipped_owner == ["sp_owned"]
+    assert result.left == ["sp_joined"]
+    assert result.failed == []
+    # Pre-filtered on the role from GET /spaces — the owned space never
+    # reaches the server.
+    assert [b["space_id"] for b in state["posted"]] == ["sp_joined"]
+
+
+async def test_server_owner_rejection_is_skipped_not_failed(mock_server):
+    """Role in GET /spaces can be stale; the server's own rejection is
+    equally permanent and must not defer the revoke."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_stale"), _member("sp_ok")]
+    state["reject_owner"] = {"sp_stale"}
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.skipped_owner == ["sp_stale"]
+    assert result.left == ["sp_ok"]
+    assert result.failed == []
+
+
+async def test_one_failing_space_does_not_abort_the_others(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_bad"), _member("sp_good")]
+    state["fail"] = {"sp_bad"}
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.failed == ["sp_bad"]
+    assert result.left == ["sp_good"]
+    assert "500" in result.last_error
+
+
+async def test_enumerate_failure_raises(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces_status"] = 503
+
+    with pytest.raises(Exception):
+        await imp.leave_all_spaces(adir, slug=SLUG)
+    assert state["posted"] == []
+
+
+# ────────────────────────────────────────────────────────────────────
+# Daemon wiring: leave before revoke, defer on transient failure
+# ────────────────────────────────────────────────────────────────────
+
+
+async def test_daemon_helper_returns_true_and_writes_no_marker(mock_server):
+    from puffo_agent.portal import daemon as dmn
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_one"), _owner("sp_owned")]
+
+    proceed = await dmn._leave_spaces_before_revoke(AGENT_ID, adir, slug=SLUG)
+
+    assert proceed is True
+    assert not imp.archived_pending_leave_path(adir).exists()
+    assert not imp.archived_pending_revoke_path(adir).exists()
+
+
+async def test_transient_failure_defers_revoke_and_marks_both(mock_server):
+    from puffo_agent.portal import daemon as dmn
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_bad")]
+    state["fail"] = {"sp_bad"}
+
+    proceed = await dmn._leave_spaces_before_revoke(AGENT_ID, adir, slug=SLUG)
+
+    assert proceed is False
+    leave_marker = json.loads(
+        imp.archived_pending_leave_path(adir).read_text(encoding="utf-8")
+    )
+    assert leave_marker["kind"] == "archive_leave_spaces"
+    assert leave_marker["slug"] == SLUG
+    assert leave_marker["space_ids"] == ["sp_bad"]
+    # The revoke marker is what gets the sweep to finish the job after
+    # the leave lands — without it the deferred revoke never happens.
+    revoke_marker = json.loads(
+        imp.archived_pending_revoke_path(adir).read_text(encoding="utf-8")
+    )
+    assert "deferred behind pending space-leave" in revoke_marker["last_error"]
+
+
+async def test_enumerate_failure_defers_revoke(mock_server):
+    from puffo_agent.portal import daemon as dmn
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces_status"] = 503
+
+    proceed = await dmn._leave_spaces_before_revoke(AGENT_ID, adir, slug=SLUG)
+
+    assert proceed is False
+    marker = json.loads(
+        imp.archived_pending_leave_path(adir).read_text(encoding="utf-8")
+    )
+    # Nothing was enumerated, so the sweep must re-query rather than
+    # trust a list we never obtained.
+    assert marker["space_ids"] == []
+
+
+class _FakeDaemon:
+    def __init__(self):
+        self.stopped = []
+
+    async def _stop_worker(self, agent_id):
+        self.stopped.append(agent_id)
+
+
+async def _run_flag(monkeypatch, mock_server, which: str, order: list[str]):
+    """Drive the real ``_archive_on_flag`` / ``_delete_on_flag`` against
+    the seeded agent dir, recording the leave/revoke call order."""
+    from puffo_agent.portal import daemon as dmn
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_one")]
+
+    async def no_report(cfg, status):
+        return True
+
+    real_leave = imp.leave_all_spaces
+
+    async def spy_leave(archived_dir, *, slug):
+        order.append("leave")
+        return await real_leave(archived_dir, slug=slug)
+
+    async def spy_revoke(archived_dir, *, slug):
+        order.append("revoke")
+
+    monkeypatch.setattr(dmn, "_report_lifecycle", no_report)
+    monkeypatch.setattr(imp, "leave_all_spaces", spy_leave)
+    monkeypatch.setattr(imp, "revoke_archived_device", spy_revoke)
+
+    fake = _FakeDaemon()
+    handler = (
+        dmn.Daemon._archive_on_flag if which == "archive" else dmn.Daemon._delete_on_flag
+    )
+    await handler(fake, AGENT_ID)
+    return state
+
+
+async def test_archive_on_flag_leaves_spaces_before_revoking(monkeypatch, mock_server):
+    order: list[str] = []
+    state = await _run_flag(monkeypatch, mock_server, "archive", order)
+
+    assert order == ["leave", "revoke"]
+    assert [b["space_id"] for b in state["posted"]] == ["sp_one"]
+
+
+async def test_delete_on_flag_leaves_spaces_before_revoking(monkeypatch, mock_server):
+    """A deleted agent ghosts the roster exactly like an archived one."""
+    order: list[str] = []
+    state = await _run_flag(monkeypatch, mock_server, "delete", order)
+
+    assert order == ["leave", "revoke"]
+    assert [b["space_id"] for b in state["posted"]] == ["sp_one"]
+
+
+# ────────────────────────────────────────────────────────────────────
+# Retry sweep
+# ────────────────────────────────────────────────────────────────────
+
+
+def _archived_copy(adir: Path) -> Path:
+    """Move the seeded agent dir under ``archived/`` the way the archive
+    flow does, so the sweep can find it."""
+    import shutil
+
+    from puffo_agent.portal.state import archived_dir
+
+    dest = archived_dir() / f"{AGENT_ID}-ws-20260811-000000"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(adir), str(dest))
+    return dest
+
+
+async def test_sweep_retries_leave_then_revoke(monkeypatch, mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_one")]
+    dest = _archived_copy(adir)
+    imp.write_archived_pending_leave(
+        dest, slug=SLUG, space_ids=["sp_one"], last_error="boom"
+    )
+    imp.write_archived_pending_revoke(
+        dest,
+        server_url=str(server.make_url("/")).rstrip("/"),
+        slug=SLUG,
+        device_id="dev_x",
+        last_error="deferred",
+    )
+
+    order: list[str] = []
+    real_leave = imp.leave_all_spaces
+
+    async def spy_leave(archived_dir, *, slug):
+        order.append("leave")
+        return await real_leave(archived_dir, slug=slug)
+
+    async def spy_revoke(*args, **kwargs):
+        order.append("revoke")
+
+    monkeypatch.setattr(imp, "leave_all_spaces", spy_leave)
+    monkeypatch.setattr(imp, "self_revoke_device", spy_revoke)
+
+    retried = await imp.sweep_archived_pending_revokes()
+
+    assert order == ["leave", "revoke"]
+    assert retried == 1
+    assert not imp.archived_pending_leave_path(dest).exists()
+    assert not imp.archived_pending_revoke_path(dest).exists()
+
+
+async def test_sweep_holds_the_revoke_while_the_leave_fails(monkeypatch, mock_server):
+    """Revoking first would 401 the credential the leave needs, so a
+    still-failing leave must keep the revoke parked."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_bad")]
+    state["fail"] = {"sp_bad"}
+    dest = _archived_copy(adir)
+    imp.write_archived_pending_leave(
+        dest, slug=SLUG, space_ids=["sp_bad"], last_error="boom"
+    )
+    imp.write_archived_pending_revoke(
+        dest,
+        server_url=str(server.make_url("/")).rstrip("/"),
+        slug=SLUG,
+        device_id="dev_x",
+        last_error="deferred",
+    )
+
+    revoked: list[str] = []
+
+    async def spy_revoke(*args, **kwargs):
+        revoked.append("revoke")
+
+    monkeypatch.setattr(imp, "self_revoke_device", spy_revoke)
+
+    retried = await imp.sweep_archived_pending_revokes()
+
+    assert revoked == []
+    assert retried == 0
+    assert imp.archived_pending_leave_path(dest).exists()
+    assert imp.archived_pending_revoke_path(dest).exists()
+
+
+async def test_sweep_picks_up_a_leave_only_marker(monkeypatch, mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_one")]
+    dest = _archived_copy(adir)
+    imp.write_archived_pending_leave(
+        dest, slug=SLUG, space_ids=[], last_error="boom"
+    )
+
+    await imp.sweep_archived_pending_revokes()
+
+    assert [b["space_id"] for b in state["posted"]] == ["sp_one"]
+    assert not imp.archived_pending_leave_path(dest).exists()
+
+
+async def test_sweep_retry_requeries_instead_of_trusting_the_marker(mock_server):
+    """AC #6 — a space left on the prior pass is gone from GET /spaces, so
+    the retry must not re-fire for it just because the marker names it."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_still_in")]
+    dest = _archived_copy(adir)
+    imp.write_archived_pending_leave(
+        dest,
+        slug=SLUG,
+        space_ids=["sp_already_left", "sp_still_in"],
+        last_error="boom",
+    )
+
+    await imp.sweep_archived_pending_revokes()
+
+    assert [b["space_id"] for b in state["posted"]] == ["sp_still_in"]
+
+
+async def test_sweep_marks_an_unparseable_leave_marker_broken(mock_server):
+    from puffo_agent.portal import import_agents as imp
+
+    server, _ = mock_server
+    adir, _ = _seed(server, spaces=[])
+    dest = _archived_copy(adir)
+    marker = imp.archived_pending_leave_path(dest)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("not json", encoding="utf-8")
+
+    await imp.sweep_archived_pending_revokes()
+
+    assert not marker.exists()
+    assert marker.with_suffix(marker.suffix + ".broken").exists()

--- a/tests/test_archive_leave_spaces.py
+++ b/tests/test_archive_leave_spaces.py
@@ -46,6 +46,10 @@ def _make_mock_app(state):
                 {"error": "owner must transfer ownership before leaving"},
                 status=403,
             )
+        if space_id in state["reject_status"]:
+            return web.json_response(
+                {"error": "rejected"}, status=state["reject_status"][space_id]
+            )
         if space_id in state["fail"]:
             return web.json_response({"error": "induced failure"}, status=500)
         return web.json_response({"ok": True, "applied": 1})
@@ -69,6 +73,7 @@ async def mock_server():
         "spaces": [],
         "fail": set(),
         "reject_owner": set(),
+        "reject_status": {},
         "spaces_status": 0,
     }
     server = TestServer(_make_mock_app(state))
@@ -179,6 +184,57 @@ async def test_server_owner_rejection_is_skipped_not_failed(mock_server):
     assert result.skipped_owner == ["sp_stale"]
     assert result.left == ["sp_ok"]
     assert result.failed == []
+
+
+@pytest.mark.parametrize("status", [400, 404, 422])
+async def test_non_403_4xx_is_permanent_and_never_deferred(mock_server, status):
+    """AC #4 — the server repeating an identical rejection can't be fixed
+    by retrying, so it must not park the revoke forever."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_rejected"), _member("sp_ok")]
+    state["reject_status"] = {"sp_rejected": status}
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.skipped_permanent == ["sp_rejected"]
+    assert result.failed == []
+    assert result.left == ["sp_ok"]
+
+
+@pytest.mark.parametrize("status", [403, 429])
+async def test_403_and_429_stay_retryable(mock_server, status):
+    """A non-owner 403 can be an auth blip and 429 is explicitly a
+    rate-limit — both are worth another pass."""
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_blipped")]
+    state["reject_status"] = {"sp_blipped": status}
+
+    result = await imp.leave_all_spaces(adir, slug=SLUG)
+
+    assert result.failed == ["sp_blipped"]
+    assert result.skipped_permanent == []
+
+
+async def test_permanent_rejection_does_not_defer_the_revoke(mock_server):
+    from puffo_agent.portal import daemon as dmn
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    adir, _ = _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_rejected")]
+    state["reject_status"] = {"sp_rejected": 400}
+
+    proceed = await dmn._leave_spaces_before_revoke(AGENT_ID, adir, slug=SLUG)
+
+    assert proceed is True
+    assert not imp.archived_pending_leave_path(adir).exists()
+    assert not imp.archived_pending_revoke_path(adir).exists()
 
 
 async def test_one_failing_space_does_not_abort_the_others(mock_server):

--- a/tests/test_archive_leave_spaces.py
+++ b/tests/test_archive_leave_spaces.py
@@ -388,6 +388,45 @@ async def test_delete_on_flag_leaves_spaces_before_revoking(monkeypatch, mock_se
     assert [b["space_id"] for b in state["posted"]] == ["sp_one"]
 
 
+async def test_cli_archive_leaves_spaces_before_revoking(monkeypatch, mock_server):
+    """`puffo-agent agent archive <id>` reaches the same end state as the
+    archive flag — an operator archiving from the CLI would otherwise
+    reproduce the original bug through a different trigger."""
+    import argparse
+    import asyncio
+
+    from puffo_agent.portal import cli
+    from puffo_agent.portal import import_agents as imp
+
+    server, state = mock_server
+    _seed(server, spaces=[])
+    state["spaces"] = [_member("sp_one")]
+
+    order: list[str] = []
+    real_leave = imp.leave_all_spaces
+
+    async def spy_leave(archived_dir, *, slug):
+        order.append("leave")
+        return await real_leave(archived_dir, slug=slug)
+
+    async def spy_revoke(archived_dir, *, slug):
+        order.append("revoke")
+
+    monkeypatch.setattr(imp, "leave_all_spaces", spy_leave)
+    monkeypatch.setattr(imp, "revoke_archived_device", spy_revoke)
+
+    # cmd_agent_archive is sync and owns its own asyncio.run, so it has to
+    # run off-loop — otherwise it can't nest inside the test's loop, and
+    # that loop is what serves the mock server.
+    rc = await asyncio.get_running_loop().run_in_executor(
+        None, cli.cmd_agent_archive, argparse.Namespace(id=AGENT_ID)
+    )
+
+    assert rc == 0
+    assert order == ["leave", "revoke"]
+    assert [b["space_id"] for b in state["posted"]] == ["sp_one"]
+
+
 # ────────────────────────────────────────────────────────────────────
 # Retry sweep
 # ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes PUF-430 — Jeremy_S reported that an archived (or deleted) agent stays in channel rosters as an offline member and remains @-mentionable, even after the operator archives it from the web UI.

## What ships

On `archive.flag` and `delete.flag`, the daemon now enumerates the agent's spaces from `GET /spaces` and signs a `LeaveSpace` per space **before** `revoke_archived_device`. The server cascades each `LeaveSpace` to every channel in that space (via `membership_engine::cascade_remove_from_channels`), so per-space is sufficient — the members panel, the @-mention picker, and MCP `list_channel_members` all clean up because they read the same server roster.

The `puffo-agent agent archive <id>` CLI subcommand runs the same fanout, so archiving through either entry point reaches the same server-side state.

## Files

- `src/puffo_agent/portal/import_agents.py` — `leave_all_spaces()`, `LeaveSpacesResult`, `HttpStatusError`, `_is_permanent_leave_rejection`, `archived_pending_leave_path` / `write_archived_pending_leave`, `_retry_archived_pending_leave`, a `_signed_get` sibling to `_signed_post`, `_fresh_session_subkey` (extracted from `revoke_archived_device`, now shared). `sweep_archived_pending_revokes` runs leave-before-revoke.
- `src/puffo_agent/portal/daemon.py` — `_leave_spaces_before_revoke()` + call sites in `_archive_on_flag` and `_delete_on_flag`.
- `src/puffo_agent/portal/cli.py` — same guard in `cmd_agent_archive._archive_async`.
- `tests/test_archive_leave_spaces.py` — new, 24 tests.

## Design points

- **Hook site** — after the dir-move to `archived/`, before `revoke_archived_device`. Pre-move would leave a still-running agent silently-left-from-every-space if the move retries.
- **Failure classification** — a transient leave failure (network / 5xx / 429 / non-owner 403) defers the revoke and writes both markers; the sweep does leave-first-then-revoke because revoking now would 401 the only credential that can sign the outstanding leaves. A permanent rejection (400/404/422/…) or an owner-space skip logs a WARN and lets the revoke proceed — retrying either would never converge.
- **Owner-space** — pre-filtered on `MySpaceEntry.role == "owner"` from the `GET /spaces` response; server-side `"owner must transfer ownership before leaving"` rejection is also handled as a permanent skip.
- **Delete-flag parity** — `_delete_on_flag` runs the same fanout; a deleted agent ghosts the roster the same way an archived one does.

## Test coverage

24 tests: per-space fanout with exact signed-event shape (kind, slug, subkey_id, signature, payload triple); owner-space pre-filter and server-403 stale-role rejection both classified as `skipped_owner`; parametrised permanent (400/404/422) vs retryable (403/429) classification; one failing space doesn't abort the rest; enumerate failure raises pre-flight; both `_archive_on_flag` and `_delete_on_flag` fire the fanout before the revoke (call-order asserted); CLI archive subcommand reaches the same end state; CLI honors the same defer contract; sweep does leave→revoke and holds the revoke while the leave fails; leave-only marker picked up; retry re-queries `GET /spaces` rather than trusting the marker; unparseable marker renamed `.broken`.

**Mutation-verified**: 9 mutants, all killed — sweep ignoring the leave outcome, owner-skip removed, daemon returning True on a failed leave, delete-path call site removed, archive fanout moved after the revoke, every non-owner failure treated as retryable, 403/429 misclassified as permanent, CLI ignoring the deferral, CLI defer branch removed.

## What isn't covered

- **Live-server smoke** — everything runs against an aiohttp mock. The AC #8 user-observable check (`list_channel_members` no longer includes the archived slug) needs an operator to archive a test agent against the real chat.puffo.ai backend and confirm from the members panel + mention picker.
- **Owner-of-space is only mock-exercised** — the mock's rejection string matches the server's, but nobody has archived a real space-owning agent.
- **Sweep only fires at daemon startup** — pre-existing behaviour; a deferred archive won't recover until the next daemon restart.
- **`-del-` dir leftovers** — the sweep never `rmtree`s a delete-path dir after a successful revoke. Pre-existing sweep behaviour, not introduced here.

## Non-goals

- Server-side `channel_members_for` filtering (Vase-confirmed the current server contract is intentional; fix is on the sender side).
- Client render / mention picker / MCP `list_channel_members` — same-source, auto-fixed.
- Auto-unarchive-rejoin, retroactive cleanup of already-archived agents, ownership-transfer flow on archive.

Reporter: Jeremy_S in #Customer Voice.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
