### PR TITLE
PUF-431: make the web Refresh button a full refresh (session + prompt + host_sync)

### DIFF
--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -80,8 +80,12 @@ def _apply_refresh(agent_slug: str, params: dict) -> dict:
         }
     harness = params.get("harness")
     model = params.get("model")
-    host_sync = bool(params.get("host_sync", False))
-    session = bool(params.get("session", False))
+    # PUF-431: the web's Refresh button sends no params, and a user who
+    # hits Refresh wants everything current from disk — session dropped,
+    # profile.md + memory reloaded, MCP + skills re-synced. Callers that
+    # want a narrower refresh pass the flags explicitly.
+    host_sync = bool(params.get("host_sync", True))
+    session = bool(params.get("session", True))
     if (harness is None) != (model is None):
         return {
             "ok": False,

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -476,3 +476,132 @@ async def test_concurrent_identical_env_edits_are_idempotent(home):
     assert AgentConfig.load("scout").env_overrides == {
         "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
     }
+
+
+# ── PUF-431: the web "Refresh" button is a full refresh ─────────────
+#
+# The button sends the control-ws ``refresh`` op with NO params
+# (client/web AgentsPane.tsx:380 → portal-store runCommand), so these
+# defaults are the whole user-visible contract.
+
+
+def _cli_local_agent(home, agent_id: str = "scout"):
+    from puffo_agent.portal.state import refresh_agent_flag_path
+
+    write_test_agent(home, agent_id)
+    cfg = AgentConfig.load(agent_id)
+    cfg.runtime.kind = "cli-local"
+    cfg.save()
+    return cfg.resolve_workspace_dir(), refresh_agent_flag_path
+
+
+def _flags(workspace):
+    from puffo_agent.portal.state import (
+        refresh_agent_flag_path,
+        refresh_host_sync_flag_path,
+        refresh_model_flag_path,
+        refresh_session_flag_path,
+    )
+
+    return {
+        "agent": refresh_agent_flag_path(workspace).exists(),
+        "host_sync": refresh_host_sync_flag_path(workspace).exists(),
+        "session": refresh_session_flag_path(workspace).exists(),
+        "model": refresh_model_flag_path(workspace).exists(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_refresh_with_no_params_fires_all_three_flags(home):
+    """AC #1/#4 — a paramless refresh (what the web sends) drops the
+    session, reloads profile.md + memory, and re-syncs host MCP/skills."""
+    from puffo_agent.portal.state import restart_flag_path
+
+    workspace, _ = _cli_local_agent(home)
+
+    res = await execute_command("refresh", "scout", {})
+
+    assert res["ok"] is True
+    assert sorted(res["touched"]) == [
+        "refresh_agent",
+        "refresh_host_sync",
+        "refresh_session",
+    ]
+    flags = _flags(workspace)
+    assert flags["agent"] and flags["host_sync"] and flags["session"]
+    assert not flags["model"]
+    # The worker keeps running: no restart.flag means the reconciler
+    # never stops it, so the refresh lands at the next turn start.
+    assert not restart_flag_path("scout").exists()
+    assert AgentConfig.load("scout").state == "running"
+
+
+@pytest.mark.asyncio
+async def test_refresh_still_honors_an_explicitly_narrow_request(home):
+    """Defaults changed, the parameter contract didn't — a caller that
+    wants prompt-only still gets prompt-only."""
+    workspace, _ = _cli_local_agent(home)
+
+    res = await execute_command(
+        "refresh", "scout", {"session": False, "host_sync": False}
+    )
+
+    assert res["ok"] is True
+    assert res["touched"] == ["refresh_agent"]
+    flags = _flags(workspace)
+    assert flags["agent"]
+    assert not flags["session"]
+    assert not flags["host_sync"]
+
+
+@pytest.mark.asyncio
+async def test_harness_swap_is_unaffected_by_the_new_defaults(home):
+    """The harness/model branch writes refresh_model alone and never
+    consulted session/host_sync — flipping their defaults must not leak
+    into it."""
+    workspace, _ = _cli_local_agent(home)
+
+    res = await execute_command(
+        "refresh", "scout", {"harness": "codex", "model": "gpt-5.1-codex-max"}
+    )
+
+    assert res["ok"] is True
+    assert res["touched"] == ["refresh_model"]
+    flags = _flags(workspace)
+    assert flags["model"]
+    assert not (flags["agent"] or flags["session"] or flags["host_sync"])
+
+
+@pytest.mark.asyncio
+async def test_cli_docker_host_sync_guard_not_tripped_by_defaults(home):
+    """The cli-docker guard rejects host_sync without a session drop.
+    The new defaults set both, so a docker agent's Refresh still works —
+    a session-only default would have broken it."""
+    write_test_agent(home, "dock")
+    cfg = AgentConfig.load("dock")
+    cfg.runtime.kind = "cli-docker"
+    cfg.save()
+
+    res = await execute_command("refresh", "dock", {})
+
+    assert res["ok"] is True
+    assert sorted(res["touched"]) == [
+        "refresh_agent",
+        "refresh_host_sync",
+        "refresh_session",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_still_rejects_a_non_cli_runtime(home):
+    """Unchanged guard — ws-local has no daemon-owned worker to refresh
+    (an external tool brings its own engine)."""
+    write_test_agent(home, "external")
+    cfg = AgentConfig.load("external")
+    cfg.runtime.kind = "ws-local"
+    cfg.save()
+
+    res = await execute_command("refresh", "external", {})
+
+    assert res["ok"] is False
+    assert "cli-local" in res["error"]


### PR DESCRIPTION
Fixes PUF-431 — Jeremy_S reported that the web "Restart" button doesn't refresh the session (the profile.md reload happens, but the conversation history is preserved). Vase directed the fix at the daemon side: repurpose the button as a full refresh.

## The change

Two default booleans in the control-ws `refresh` op handler:

```
- host_sync = bool(params.get("host_sync", False))
- session   = bool(params.get("session", False))
+ host_sync = bool(params.get("host_sync", True))
+ session   = bool(params.get("session", True))
```

The web's Restart button already sends the `refresh` op with no params (`client/web/src/ui/components/agent/AgentsPane.tsx:388` → `portal-store.ts:842-855`), so this is the whole user-visible contract for the button. The parameter contract is preserved: any caller that wants a narrower refresh passes `{session: False, host_sync: False}` explicitly and gets prompt-only.

## What did NOT need changing

Spec-time model was that the web Restart writes `restart.flag` and the daemon `_stop_worker`s. On `origin/main` (verified via `git show origin/main:<path>`), neither is true:

- The web sends the `refresh` op verbatim, not `restart`.
- `execute_command` has no `restart` op at all (would return `unsupported op`).
- The only `restart.flag` writer is the daemon's own credential-recovery path at `daemon.py:454`; no web path touches it.

So AC #1 ("does NOT write `restart.flag`; does NOT `_stop_worker`") and AC #3 ("preserve the `restart.flag` path for internal callers") needed zero code — they were already true. The real gap was two defaults.

## Tests

5 new tests in `tests/test_control_client.py`:

- paramless refresh (what the web sends) → all three flags present, `restart.flag` absent, agent state stays `running`
- explicit `{session: False, host_sync: False}` still yields `refresh_agent` alone
- harness/model swap writes `refresh_model` only — new defaults don't leak into it
- `cli-docker` + defaults clears the existing host_sync guard (that guard rejects host_sync without a session drop, so a session-only default would have broken docker agents)
- `ws-local` still rejected

**Mutation-verified**: 4 mutants, all killed — session default reverted, host_sync default reverted, explicit params ignored, defaults leaking into the harness/model branch.

Full suite: 3092 / 0 failures / 0 errors / 1 skip (Windows-only), exit 0. Baseline `origin/main` is 3087 → Δ +5.

## Coupled release

This is the daemon half of a two-lane change (AC #11). The client/web lane (button label "Restart" → "Refresh", tooltip update, confirmation dialog) is Yasushi's. Preferred rollout is daemon-first: until the web lane lands, users get the new full-refresh behavior under the pre-change "Restart" label with no dialog. Marked acceptable at the intake level.

## What isn't covered

- **No live web → daemon smoke** — tests drive `execute_command` directly (where the decrypted web command lands), but nobody has clicked the real button against a real daemon.
- **Cloud agents are a different path** — `AgentsPane.tsx:455` maps their Restart to `runCloudLifecycle(slug, "resume")`, never reaches this code. If cloud-agent Refresh should follow the new semantics, that's an unscoped follow-up.
- **MCP `refresh()` tool defaults unchanged** (explicit non-goal) — the agent-facing tool at `puffo_core_server.py:129` keeps `host_sync=False, session=False`. The two `refresh` surfaces now have different no-args behavior: agent calling own refresh → prompt-only (unchanged); user pressing the web button → full refresh. Defensible (different caller expectations); noting so anyone updating docs cross-references both.

## Non-goals

- Web lane (label / tooltip / confirmation dialog) — Yasushi.
- MCP `refresh()` tool defaults — different caller, different reasonable default.
- Pause/Resume semantics — that's the migration path for users who wanted the old worker-respawn behavior.
- CLI `agent refresh` — CLI has no `restart` today.

Reporter: Jeremy_S in #Customer Voice.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
