### PR TITLE
Agent Foundation 2.0: restore runtime compatibility and approval flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a2] — 2026-08-12
+
+> Pre-release candidate for staging validation only. It is not the stable
+> `2.0.0` release and supersedes the TestPyPI-only `2.0.0a1` candidate.
+
+### Added
+
+- **Keyless Agents can durably ask their operator about foreign DMs and space
+  invitations.** Approval decisions survive restart and replay through the
+  bridge without giving the model transport credentials.
+
+- **Every Agent workspace exposes the Puffo-home collaboration directory as
+  `shared/`.** Existing Agents are repaired during daemon reconciliation,
+  Docker retains `.shared` as a compatibility alias, and existing conflicting
+  files are preserved rather than overwritten.
+
+### Fixed
+
+- **Restored Agent Foundation compatibility needed for staging.** Docker Codex,
+  Windows Claude shim launch handling, legacy daemon stop requests, Global
+  Inbox status lifecycle, local Runtime Event status, telemetry privacy, and
+  optional context baselines now follow the post-`2.0.0a1` contracts.
+
+- **Shared-workspace attachments retain the workspace escape boundary.** The
+  managed `shared/` target is accepted explicitly while unrelated symlink
+  escapes remain rejected.
+
 ## [2.0.0a1] — 2026-08-11
 
 > Pre-release published to TestPyPI for staging validation only. It is not the
@@ -4397,7 +4424,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.0a1...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.0a2...HEAD
+[2.0.0a2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a2
 [2.0.0a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a1
 [1.2.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v1.2.0
 [0.10.0a2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v0.10.0a2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a3] — 2026-08-12
+
+> Staging-only prompt candidate for manual conversation validation.
+
+### Changed
+
+- **Agent communication now follows concise standing guidance.** Concrete
+  Inbox work defaults to a useful response or clarification, multi-Agent work
+  uses lightweight claims, thread routing is explicit, and the former
+  four-outcome `decide-response` skill is no longer installed.
+
 ## [2.0.0a2] — 2026-08-12
 
 > Pre-release candidate for staging validation only. It is not the stable

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ entirely on disk:
     ├── messages.db              # message, Inbox, turn, reminder state
     ├── runtime_events.db        # bounded Runtime event outbox
     ├── runtime.json             # heartbeat / status (daemon-managed)
-    └── workspace/.puffo/inbox/  # decrypted incoming attachments
+    └── workspace/
+        ├── shared -> ../../../shared/ # cross-Agent files on this Puffo home
+        └── .puffo/inbox/              # decrypted incoming attachments
 ```
 
 ### 3.2 Network proxies

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ pip install puffo-agent
 pip install puffo-agent==1.2.0
 ```
 
-The Agent Foundation `2.0.0a1` candidate is for staging validation and is
+The Agent Foundation `2.0.0a2` candidate is for staging validation and is
 published to TestPyPI only. See
-[`docs/RELEASE-CANDIDATE-2.0.0a1.md`](docs/RELEASE-CANDIDATE-2.0.0a1.md) for
+[`docs/RELEASE-CANDIDATE-2.0.0a2.md`](docs/RELEASE-CANDIDATE-2.0.0a2.md) for
 the install command, test scope, and stable-release TODOs.
 
 Both paths install the `puffo-agent` console script. The CLI's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,6 +220,7 @@ Default state is rooted at `~/.puffo-agent/` (overridable with
       imports/
         index.md
     workspace/
+      shared -> ../../../shared/ # same host-wide directory for every Agent
       .puffo/inbox/          # materialized inbound attachments
       .puffo-agent/          # current turn and refresh flags
 ```

--- a/docs/RELEASE-CANDIDATE-2.0.0a1.md
+++ b/docs/RELEASE-CANDIDATE-2.0.0a1.md
@@ -11,6 +11,9 @@ This document freezes the release decisions and evidence expected after the
 Agent Foundation integration branch merges. It is intentionally narrower than
 the complete product roadmap.
 
+The ordered implementation and release backlog is tracked in
+[`roadmap/agent-foundation/STABLE-2.0-READINESS.md`](../roadmap/agent-foundation/STABLE-2.0-READINESS.md).
+
 ## Decisions
 
 1. Merge the Agent Foundation implementation to `main`, but publish it first as

--- a/docs/RELEASE-CANDIDATE-2.0.0a2.md
+++ b/docs/RELEASE-CANDIDATE-2.0.0a2.md
@@ -1,0 +1,90 @@
+# Agent Foundation 2.0 Test Release
+
+- **Candidate:** `puffo-agent==2.0.0a2`
+- **Status:** staging and TestPyPI validation only
+- **Stable release:** not authorized by this merge
+
+This candidate supersedes the TestPyPI-only `2.0.0a1` candidate. The earlier
+candidate and its audit remain historical evidence; `a2` contains the
+compatibility and authorization fixes found during that validation.
+
+The ordered implementation and release backlog is tracked in
+[`roadmap/agent-foundation/STABLE-2.0-READINESS.md`](../roadmap/agent-foundation/STABLE-2.0-READINESS.md).
+
+## Candidate Delta
+
+- Restores Docker Codex and Windows Claude shim support on the Driver runtime.
+- Restores daemon stop, status, telemetry, and optional context-baseline
+  compatibility for existing installations.
+- Adds durable operator authorization for keyless foreign DMs and space
+  invitations.
+- Exposes one host-wide collaboration directory as `shared/` inside every
+  private Agent workspace while preserving existing conflicting content.
+
+## Decisions
+
+1. Publish `2.0.0a2` only through the manual TestPyPI workflow. Do not create a
+   stable GitHub release or publish `2.0.0` to production PyPI yet.
+2. Validate the exact candidate commit against staging. Green CI is necessary
+   but is not evidence of live Server, harness, Windows, or upgrade behavior.
+3. Channel encryption and plaintext-channel policy remain outside this
+   candidate.
+4. Server/local Agent release and AIM/E2B template promotion remain separate
+   tracks with explicit immutable commit pins.
+5. Runtime execution content remains local. Only fixed-vocabulary Runtime Event
+   metadata may be uploaded.
+6. Limit further candidate changes to acceptance blockers and their narrow
+   boundary tests.
+
+## TODO Before Stable 2.0.0
+
+- Run a real Windows Claude Code turn through an npm shim.
+- Validate keyless invitation and foreign-DM approval/rejection, including
+  restart and replay, against the real staging bridge.
+- Verify the required Puffo Server changes are merged and deployed, then audit
+  staging Runtime Event privacy.
+- Inventory production runtime configurations and explicitly migrate, pin, or
+  retire every active Docker Codex and legacy direct-runtime Agent.
+- Pin and validate AIM/E2B templates from the immutable candidate commit.
+- Record upgrade, harness, coordination, recovery, multi-target Inbox, restart,
+  and privacy evidence against one final candidate SHA.
+- Only after those gates close, update package metadata from `2.0.0a2` to
+  `2.0.0`, tag it, and run the production publishing workflow.
+
+Runtime Event UI, encrypted remote runtime-output streaming, reactions,
+Hermes, Gemini, ACP, and plaintext DMs remain separate product work.
+
+## Staging Acceptance
+
+1. Clean-install the candidate from TestPyPI and confirm the CLI starts:
+
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ puffo-agent==2.0.0a2
+   puffo-agent --help
+   ```
+
+2. Upgrade a copied `1.2.0` state directory. Confirm configuration, profile,
+   memory, workspace, keys, message history, supported session references, and
+   the managed `workspace/shared` link remain usable.
+3. Run one real Claude Code turn and one real Codex app-server turn, including
+   Puffo MCP discovery and an explicit send.
+4. Run the three coordination cases on fresh channels: `1,2,3,4,5`; the fourth
+   Agent repeats `1`; and five Agents each take five turns without duplicates
+   or abandoned progress.
+5. Exercise held-draft recovery through revise, wait with a reminder, silence,
+   and the rare explicit send-anyway decision.
+6. Deliver pending messages across multiple spaces and targets in one Inbox
+   turn and verify routing to the intended channel, thread, or DM.
+7. Restart during pending Inbox, reminder, keyless DM approval, and invitation
+   approval work; verify persistence without duplicate side effects.
+8. Inspect staging Runtime Events and logs. Assistant output, reasoning, message
+   content, tool payloads, credentials, and Inbox bodies must remain local.
+
+Browser validation is the final product smoke after CLI and runtime acceptance;
+it is not the primary debugging harness.
+
+## Publishing
+
+Run `.github/workflows/publish-testpypi.yml` manually from the final merged SHA.
+Do not publish a GitHub Release for this candidate.

--- a/docs/agent-foundation-2.0-compatibility-matrix.md
+++ b/docs/agent-foundation-2.0-compatibility-matrix.md
@@ -25,8 +25,9 @@ repairs, and bounded acceptance evidence.
 |---|---|
 | Agent diagnosis snapshot | `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89` |
 | Server diagnosis snapshot | `393a1af6f54b9f44e0711437bd787ce0f093e80b` |
-| Agent repaired head | `8641a89` (`feat/agent-foundation-stable-readiness`) |
+| Agent repaired head | `df635e9` (`feat/agent-foundation-stable-readiness`) |
 | Server repaired head | `ae0f238` (`feat/keyless-agent-authorization`) |
+| Web product-validation snapshot | `bc5db876` (`origin/main`, local compatibility worktree) |
 | Integration commit audited | `0d9f44d` "Integrate Agent Foundation across native and keyless cloud runtimes (#225)" |
 | Findings source | `puffo-agent-staging-findings` snapshot 2026-08-11; staging Server `sha-7ad4698b959a`; package `puffo-agent==2.0.0a1` |
 
@@ -42,8 +43,29 @@ diagnosis blocks refer to the recorded diagnosis snapshots.
 | F002 busy / activity strip | Restored | Global Inbox turns open and close the legacy Server status lifecycle. Real Web acceptance showed `Processing` during work and `Idle` after completion for all five Agents. Daemon-local membership/reminder envelopes no longer call message-processing endpoints for nonexistent message IDs. |
 | F003 Docker Codex | Restored with residual live-provider risk | `cli-docker + openai + codex` is admitted and wired through the Driver transport, isolated home, image, cleanup, and persisted-session paths. The bounded Docker smoke did not execute a live provider turn because the local Agent Core data/RPC dependency was unavailable. |
 | F004 stop upgrade | Restored | Current daemon accepts both legacy timestamp-only and PID-scoped JSON stop sentinels; current CLI waits on the exact daemon PID. Focused old/new compatibility and bounded shutdown tests pass. |
-| F005 logs / telemetry | Restored at Agent contracts | Safe Driver lifecycle/tool events and Codex/Claude token/context telemetry are projected without raw reasoning. Runtime-event recovery was proven for 5/5 Agents. The current local Web session could not verify the local Profile Log body because it was not paired to the Python daemon and correctly disabled device-local Log/Files tabs. |
+| F005 logs / telemetry | Restored | A currently paired Python daemon delivered encrypted `turn_start`, bounded `assistant_text`, tool labels, and `turn_complete` to the current Web. Profile Log rendered the safe rows and nonzero Codex tokens (`14405` input / `599` output) while avatar and chat activity state returned to Idle. |
 | F006 Activity / Files | Intentionally deferred | These surfaces did not have a complete pre-2.0 contract and remain product work. |
+
+### Current local product evidence (2026-08-11)
+
+- The legacy Python CLI created a device code from the real Agent home. Current
+  Web `origin/main` opened `/link-machine`, approved **Agent Foundation
+  Compatibility**, and the waiting CLI completed with the expected operator.
+  The running daemon then established its control WebSocket and enabled the
+  encrypted `agent.status` reverse channel. No old browser-to-daemon HTTP
+  bridge was restored.
+- A real channel turn showed `Processing` on the avatar and the chat activity
+  strip, returned to `Idle`, and populated Profile Log with `Working`, safe
+  tool labels, bounded assistant summaries, `Done`, and nonzero Codex token
+  usage. Raw tool arguments, provider frames, and hidden reasoning were not
+  exposed.
+- In fresh channel `ch_08f31122-fad7-4f64-8f08-6b415b37a556`, all five Agent
+  stores had no `channel_context_state` row immediately after membership, so
+  all five baselines read as `None`. After each Agent's first successful
+  coordinated introduction, the persisted values became one authoritative
+  empty boundary (`0`) and four positive established boundaries
+  (`2569`-`2572`). The Web showed five introductions exactly once and all five
+  Agents settled to `Idle`.
 
 ### Cross-cutting reconnect recovery
 
@@ -410,7 +432,7 @@ Agent.
 
 ## F005 — Agent Profile Log loses Driver detail and Codex telemetry
 
-**Classification: `restored at Agent contracts`**
+**Classification: `restored`**
 
 Resolution: Agent merge `5bec939` restores safe Driver-to-legacy projection and
 token/context telemetry; follow-up commit `d5ddb2b` records the compatibility
@@ -463,19 +485,24 @@ render `in token: 0, out token: 0`, and context telemetry is absent.
 - History: `git show 0d9f44d^:src/puffo_agent/agent/adapters/codex_session.py`
   (`tokenUsage` `last`/`total` delta math at lines ~1182-1215) and
   pre-integration `core.py` `current_context` handling.
+- Current Web `bc5db876` consumes decrypted machine messages in
+  `use-realtime.ts`, stores safe rows in `agent-status-history.ts`, and renders
+  them through `AgentStatusHistory.tsx`.
+- A paired real Codex turn rendered `Working`, `read_inbox`, `send_message`,
+  bounded assistant summaries, terminal `Done`, and `14405/599` token usage.
 
-### Unknowns
+### Residuals
 
-- Whether every observed `0/0` row came from Codex or a separate Claude Code
-  runtime issue also exists (source-level cause proven here is Codex-specific).
-- Which safe activity details the future Profile Log should expose; this must
-  not be conflated with publishing raw chain-of-thought or provider-native
-  payloads.
+- The Profile Log is a per-device live history. Events emitted while the
+  device is disconnected are intentionally best-effort and are not replayed as
+  a durable cross-device audit log.
+- Future presentation changes must not be conflated with publishing raw
+  chain-of-thought, tool arguments, or provider-native payloads.
 
 ### Repository owner
 
 Agent (driver telemetry + legacy projection); Web owns the consuming Profile
-Log contract (not re-inspected).
+Log contract, inspected and exercised at `bc5db876`.
 
 ### Bounded acceptance criteria
 
@@ -504,10 +531,10 @@ testing rather than removing an established pipeline.
 
 ### Current source behavior
 
-Agent source does not feed these surfaces. Web-side evidence (attributed to
-F006, not re-inspected): Activity is a view over the current Web message cache
-(`ProfilePanels.tsx:1333-1340`) and Files renders the static placeholder text
-(`ProfilePanels.tsx:1188-1191`).
+Agent source does not feed these surfaces. Current Web inspection confirms
+Activity is a view over the current Web message cache and Files renders the
+static `No files yet · Coming soon` placeholder. Pairing a current Python
+daemon enables the tab but does not create a file index.
 
 ### User-visible impact
 
@@ -541,10 +568,11 @@ Within the bounded evidence inventory, F001-F005 are restored and F006 remains
 intentionally deferred. Acceptance found the additional stale Runtime-session
 projection failure documented above; it is fixed at Server `ae0f238`.
 
-The legacy Python `machine link` command still emits a `/link-machine` URL while
-the current Web exposes the newer `/agents/pair` flow. This is a separate
-unresolved compatibility finding, not part of F001-F006 and not silently
-classified as restored here.
+The legacy Python `machine link` command and current Web `/link-machine` route
+were exercised together successfully. The earlier claim that current Web only
+exposed `/agents/pair` came from a Web worktree 211 commits behind
+`origin/main`; it is superseded and must not motivate restoration of the
+deprecated local HTTP bridge.
 
 The extended behavioral acceptance prompt asking five Agents to count five
 times stopped after `11/25`. Its Inbox slice was complete and untruncated, and
@@ -683,6 +711,6 @@ History (`git show <commit>:<path>` verified for each):
 ## Confirmed evidence vs unknowns
 
 Each entry separates confirmed source/history evidence from explicitly stated
-unknowns. The resolution table adds the later focused tests and local product
-acceptance. It does not claim a paired-device Profile Log UI test or a live
-Docker provider turn where those environments were unavailable.
+unknowns. The resolution table adds focused tests and local product acceptance,
+including a paired-device Profile Log UI test. It still does not claim a live
+Docker provider turn where that environment was unavailable.

--- a/docs/agent-foundation-2.0-compatibility-matrix.md
+++ b/docs/agent-foundation-2.0-compatibility-matrix.md
@@ -1,0 +1,622 @@
+# Agent Foundation 2.0 Compatibility Matrix
+
+Source-grounded inventory of pre-2.0 Web-visible contracts affected by the
+Agent Foundation 2.0 migration, with classifications, exact evidence, ownership,
+and bounded acceptance criteria for later work.
+
+## Purpose and method
+
+- Frozen goal: `loop-engineering/runtime/agent-foundation-2.0/goal.md`
+  (referenced, not modified).
+- Findings F001-F006:
+  `/Users/glimmer/Desktop/projects/puffo.ai/slock-agent/research/puffo-agent-staging-findings/`.
+- Current-source behavior was re-checked against the **Agent worktree** at the
+  recorded HEAD and the **bounded Server contract** at the recorded Server HEAD.
+  Web-side claims are attributed to the frozen findings, not re-inspected here.
+- Git history was used only to recover specific pre-2.0 contracts (stop sentinel,
+  `cli-docker + codex` admission/adapter/image/tests, status lifecycle wiring,
+  telemetry projection, baseline fallback introduction).
+- Classifications are restricted to: `restored`, `intentionally deferred`,
+  `not a regression`, `missing`.
+
+## Snapshot used by this matrix
+
+| Surface | Snapshot |
+|---|---|
+| Agent worktree | `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89` (matches canonical `puffo-agent-stable-readiness`) |
+| Server worktree | `393a1af6f54b9f44e0711437bd787ce0f093e80b` (`puffo-server-keyless-agent-auth`) |
+| Integration commit audited | `0d9f44d` "Integrate Agent Foundation across native and keyless cloud runtimes (#225)" |
+| Findings source | `puffo-agent-staging-findings` snapshot 2026-08-11; staging Server `sha-7ad4698b959a`; package `puffo-agent==2.0.0a1` |
+
+All Agent path citations below are relative to the Agent worktree root; Server
+citations are under `server/` in the Server worktree. Line numbers are from the
+recorded HEADs.
+
+---
+
+## F001 — New-member introduction stalls at the visibility boundary
+
+**Classification: `missing`**
+
+### Frozen compatibility contract
+
+`context_baseline_seq` distinguished three states end to end:
+- `None` (omitted) — no authoritative visible-history baseline established;
+- `0` — an authoritative empty-channel baseline;
+- a positive value — history through that sequence predates the Agent's context.
+
+The 2026-07-26 design intent was to send JSON `null` for
+`context_baseline_seq` in the new-member/no-visible-history case and let the
+Server lazily establish the numeric baseline inside a successful coordinated
+send. Freshness fields are daemon-owned; the model never supplies them.
+
+### Current source behavior
+
+- Agent storage for the baseline exists but has **no production writer**:
+  `src/puffo_agent/agent/inbox_store.py:1024-1061` defines
+  `get_context_baseline`/`set_context_baseline` over the `channel_context_state`
+  table. Production call sites for `set_context_baseline` do not exist; the only
+  callers are tests (`tests/test_message_store.py:1142-1143`,
+  `tests/test_global_inbox_runtime.py:1035,1106`).
+- The send path collapses the missing value to `0`:
+  `src/puffo_agent/agent/send_coordinator.py:869-871`
+  (`baseline = await self._baseline(...); if baseline is None: baseline = 0`).
+- The request body always carries a numeric value:
+  `src/puffo_agent/agent/send_coordinator.py:669-679`
+  (`"context_baseline_seq": boundary.baseline` inside `freshness`).
+- The Server DTO makes the field mandatory and has no `None` representation:
+  `server/src/v2/agent_runtime_messages.rs:27-31`
+  (`pub context_baseline_seq: i64`), validated non-negative at
+  `server/src/v2/agent_runtime_messages.rs:81-85`.
+- The Server send decision computes
+  `effective_seen_seq = seen_seq.max(context_baseline_seq)` and returns `Held`
+  when it is below the committed boundary:
+  `server/src/messages.rs:872-912` (reject-ahead branches at 828-871).
+- The intro nudge producer exists: `enqueue_channel_intro_nudge` at
+  `src/puffo_agent/agent/membership_actions.py:178-235` emits
+  `intro-prompt-<channel_id>`. Its wired baseline source reads only the
+  unwritten store table (`BaselineAdapter` at
+  `src/puffo_agent/agent/global_inbox_types.py:221-228` → `get_context_baseline`).
+- Response validation echoes the numeric baseline back from the Server
+  (sent and held shapes) at
+  `src/puffo_agent/agent/send_response_validation.py:138-150,158-186`, so the
+  `None` distinction is equally absent from the response side.
+
+### User-visible impact
+
+Only the first newly added Agent introduces itself immediately. Later new
+Agents' introduction sends are held against a channel message they cannot read
+until another visible channel message arrives and unblocks recovery (staging
+timeline in F001).
+
+### Confirmed evidence
+
+- Current-source citations above (Agent + Server).
+- History: integration commit `0d9f44d` introduced the `None -> 0` fallback in
+  the audited lineage. Parallel historical branch commit `2e50c31` contains the
+  same fallback and its focused test, but is not an ancestor of the audited
+  HEAD and is supporting evidence only.
+- Staging runtime log and per-Agent stores (attributed to F001; not re-run here).
+
+### Unknowns
+
+- The Server's omitted-baseline branch is not implemented in current source.
+  The frozen contract assigns lazy establishment to the Server send
+  transaction, not to membership or attach processing.
+- With encrypted history, `null` plus `seen_seq == 0` cannot distinguish an old
+  inaccessible channel head from a newly arrived visible message that has not
+  reached the local store yet. That bounded first-send race is an explicit
+  residual of the privacy-preserving design; later sends use the established
+  numeric baseline and normal freshness coordination.
+- Visibility scoping for baseline establishment (identity vs device vs locally
+  decryptable deliveries).
+- Two observations attached to F001 await independent classification:
+  (1) an intro Inbox row can be marked `processed` even when the required
+  outbound introduction was not committed; (2) a delayed recovery response can
+  expose coordination internals (held send / unavailable synchronization
+  boundary) to channel users.
+
+### Repository owner
+
+Agent (`send_coordinator`, `inbox_store`, `membership_actions`,
+`global_inbox_types`) **and** Server (`agent_runtime_messages`, `messages`).
+
+### Bounded acceptance criteria
+
+1. `None`, `0`, and positive baseline values are preserved through local state,
+   the Agent request, Server decision/response, and retry/replay; `None` is
+   never coerced to `0`.
+2. The Server lazily establishes a usable boundary without pretending the Agent
+   saw pre-membership ciphertext.
+3. Multiple Agents joining a channel with existing history each introduce
+   themselves once without a follow-up human message.
+4. A genuinely newer visible message still participates in freshness
+   coordination (can hold a stale draft).
+5. Restarting the daemon does not duplicate or abandon an outstanding intro.
+
+---
+
+## F002 — Agent busy status and chat activity strip are missing
+
+**Classification: `missing`**
+
+### Old contract
+
+The pre-integration Worker wired the Server status lifecycle into the message
+turn: `reporter.begin_turn(first_post_id)` before the batch and
+`reporter.end_turn_batch(runs)` in `finally`
+(`0d9f44d^:src/puffo_agent/portal/worker.py:1367,1434`). The Server stores
+`agent_status` (`idle`/`busy`/`error` + `current_message_id`) and
+`message_processing_runs`, which the chat UI renders as avatar busy state and
+the activity strip.
+
+### Current source behavior
+
+- The Global Inbox turn path never calls the lifecycle:
+  `src/puffo_agent/portal/worker_run.py:430-452` (`_execute_global_turn`) calls
+  `context.puffo.handle_global_inbox_turn(planned)` with no
+  `StatusReporter` involvement; `worker_run.py:588-625` builds the reporter and
+  starts only its heartbeat loop.
+- The only production callers of `begin_turn`/`end_turn_batch` are the WS-local
+  session path (`src/puffo_agent/portal/ws_local/session.py:276,296,324-325`),
+  not the Global Inbox path.
+- The reporter's own contract still says the message handler must call the
+  lifecycle: `src/puffo_agent/agent/status_reporter.py:32-37`.
+- The legacy control-plane `agent.status` frame still fires from
+  `src/puffo_agent/agent/core.py:380-404` (`turn_start`/`turn_complete`) via
+  `src/puffo_agent/portal/control/reporter.py` (encrypted control WS), but that
+  is a separate channel from the Server-backed status/run contract.
+
+### User-visible impact
+
+During real Global Inbox turns, Agent avatars do not show busy state and the
+chat activity strip does not describe who is working on what. Web renders these
+surfaces from Server-backed `agent_status_update` /
+`message_processing_run_update` events, which the Agent never emits because no
+processing run is opened (Web claim attributed to F002; not re-inspected).
+
+### Confirmed evidence
+
+- Current citations above (Agent).
+- Server status/run contract: `server/src/agent_status.rs:63-68`
+  (status + `current_message_id`), `server/src/agent_status.rs:370-409`
+  (busy+run upsert), `server/src/agent_status.rs:538` (`get_message_processing_runs`).
+- History: pre-integration `worker.py:1367,1434` wiring (verified with
+  `git show 0d9f44d^:src/puffo_agent/portal/worker.py`).
+
+### Unknowns
+
+- Exact commit deployed by staging Web was not verified; a separate deployed-Web
+  regression has not been ruled out (attributed to F002).
+
+### Repository owner
+
+Agent (status lifecycle wiring in the Global Inbox composition root); Server
+owns the status/run storage and broadcast contract.
+
+### Bounded acceptance criteria
+
+1. A normal Global Inbox turn produces a busy status with the source message ID
+   and one active processing run.
+2. Avatar and activity strip appear during the turn and settle on success,
+   failure, cancellation, and daemon shutdown.
+3. Retry and held-reconsideration turns do not leave orphaned or duplicate
+   active runs.
+4. Synthetic local notices may show the Agent busy but must not invent a
+   processing run for a nonexistent message.
+5. Legacy control-plane activity and the chat integration status path have
+   explicit, non-conflicting ownership.
+
+---
+
+## F003 — `cli-docker + codex` support regressed in 2.0.0a1
+
+**Classification: `missing`**
+
+### Old contract
+
+Before integration, the runtime matrix accepted the `cli-docker` runtime with
+provider `openai` and harness `codex`:
+- `HARNESSES_FOR_RUNTIME[cli-docker] = {claude-code, codex}` and
+  `DEFAULT_DOCKER_HARNESS_FOR_PROVIDER[openai] = codex`
+  (`0d9f44d^:src/puffo_agent/portal/runtime_matrix.py`).
+- `DockerCLIAdapter` ran a Codex app-server inside the per-agent container with
+  isolated home, sanitized credentials, MCP config, and skills preparation.
+- The bundled Docker image baked `@openai/codex@__CODEX_VERSION__`
+  (`0d9f44d^:src/puffo_agent/agent/adapters/docker_cli.py:106-108`).
+- `tests/test_docker_codex.py` covered the image dependency, isolated home,
+  credential view, MCP config, app-server command, persisted sessions, and
+  Docker binary selection.
+
+### Current source behavior
+
+- The runtime matrix rejects the combination:
+  `src/puffo_agent/portal/runtime_matrix.py:204-211` admits only `claude-code`
+  on `cli-docker` and tells the operator to set `runtime.kind` to `cli-local`.
+- `DockerCLIAdapter` is Claude Code-only: it rejects any non-`claude-code`
+  harness (`src/puffo_agent/agent/adapters/docker_cli.py:183-189`) and the
+  Dockerfile installs only `@anthropic-ai/claude-code`
+  (`src/puffo_agent/agent/adapters/docker_cli.py:103`).
+- Integration commit `0d9f44d` deleted `src/puffo_agent/agent/adapters/codex_session.py`
+  (1452 lines) and `tests/test_codex_session.py`, `tests/test_codex_session_audit.py`,
+  `tests/test_docker_codex.py`; the commit message states "validate_triple now
+  admits only claude-code on cli-docker".
+
+### User-visible impact
+
+An Agent persisted with `cli-docker + openai + codex` no longer starts after
+upgrade. The validation error is explicit, but silently changing to `cli-local`
+changes the execution and isolation model and is not an equivalent migration.
+
+### Confirmed evidence
+
+- Current citations above.
+- History: `git show 0d9f44d --name-status` (deleted `codex_session.py` +
+  three test files) and `git show 0d9f44d^:.../runtime_matrix.py` /
+  `.../docker_cli.py` (pre-integration acceptance + image contents).
+
+### Unknowns
+
+- Han's complete Docker/Codex workload has not been reproduced on his host.
+  This is not needed to prove the admission regression, but is required before a
+  restored implementation can be claimed compatible with the new Global Inbox
+  and runtime-event contracts.
+
+### Repository owner
+
+Agent.
+
+### Bounded acceptance criteria
+
+1. An Agent persisted as `cli-docker + openai + codex` loads without manual
+   configuration edits.
+2. Codex app-server runs inside the Agent's container with isolated, sanitized
+   credentials and container-reachable MCP configuration.
+3. The runtime satisfies the same Inbox admission, send, reminder, status, and
+   runtime-event contracts as `cli-local + codex`.
+4. Upgrade from an existing Docker Codex Agent preserves its workspace and
+   documented session state.
+5. `start`, `stop`, restart, auth failure, and container cleanup are exercised
+   on at least one real Docker host.
+
+---
+
+## F004 — `puffo-agent stop` does not exit normally after upgrade
+
+**Classification: `missing`**
+
+### Old contract
+
+The pre-integration `.stop_requested` sentinel was a timestamp-only file, and
+the daemon treated the mere existence of the file as a stop request
+(`0d9f44d^:src/puffo_agent/portal/state.py:1502-1506`,
+`write_stop_request` writes `str(int(time.time()))`).
+
+### Current source behavior
+
+- The sentinel is now PID-scoped JSON: `write_stop_request` writes
+  `{"pid": ..., "created_at": ...}` (`src/puffo_agent/portal/state.py:1145-1156`;
+  CLI writes it at `src/puffo_agent/portal/cli.py:344`).
+- The daemon accepts only a JSON payload whose PID matches the running daemon:
+  `read_stop_request_pid` (`src/puffo_agent/portal/state.py:1128-1138`) parses
+  only JSON and explicitly treats timestamp-only sentinels as stale (returns
+  `None`); `stop_requested_for(pid)` requires an exact PID match
+  (`src/puffo_agent/portal/state.py:1141-1142`).
+
+### User-visible impact
+
+A stop request written by an older CLI is rejected by the new daemon, so
+`puffo-agent stop` can fail to shut the new daemon down in a mixed-version
+upgrade. Compatibility matrix of the wire formats:
+- `2.0.0a1` CLI → `0.12.2` daemon: compatible (old daemon checks existence).
+- `0.12.2` CLI → `2.0.0a1` daemon: incompatible (new daemon rejects the
+  timestamp payload).
+- `2.0.0a1` CLI → `2.0.0a1` daemon (same home): compatible.
+
+### Confirmed evidence
+
+- Current `state.py:1128-1156` and `cli.py:344`.
+- History: `git show 0d9f44d^:src/puffo_agent/portal/state.py` (timestamp-only
+  writer), `git log -S 'read_stop_request_pid'` shows the JSON format was
+  introduced by `0d9f44d`.
+- Finding's isolated check: `legacy_timestamp_accepted=False`,
+  `pid_json_accepted=True` (attributed to F004; executable-level, not re-run).
+
+### Unknowns
+
+- Han's exact executable/daemon/`PUFFO_AGENT_HOME` pairing on the reported host
+  is unverified; this cross-version cause is confirmed but does not alone prove
+  his full report.
+- Secondary shutdown-latency risk (new CLI waits 60s; daemon checks the sentinel
+  only between reconcile iterations, and one reconcile can wait up to 120s for a
+  Worker warm) is a confirmed architectural possibility but is not tied to the
+  report.
+
+### Repository owner
+
+Agent.
+
+### Bounded acceptance criteria
+
+1. The supported upgrade path can stop a daemon started by the previous release,
+   regardless of which supported CLI version writes the request.
+2. CLI and daemon identify version, executable, PID, and Agent home in
+   diagnostics without exposing credentials.
+3. A stop request interrupts or observes long Worker warm operations instead of
+   waiting for a full warm timeout before shutdown begins.
+4. Docker and provider subprocess cleanup remain bounded and report which phase
+   delayed exit.
+5. The command distinguishes "request not recognized", "shutdown in progress",
+   and "cleanup timed out".
+
+---
+
+## F005 — Agent Profile Log loses Driver detail and Codex telemetry
+
+**Classification: `missing`**
+
+### Old contract
+
+The Web Profile Log consumed decrypted legacy `agent.status` events
+(`turn_start`, `assistant_text`, `tool_use`, `turn_complete`) and rendered
+`Thinking`/`Using`/`Sending` rows and `turn_complete.payload.tokens`. The old
+`codex_session.py` processed the `last` and `total` sections of
+`thread/tokenUsage/updated`, calculated per-turn input/output deltas, and
+retained current-context usage; the old `core.py` added `current_context` to
+`turn_complete` when present.
+
+### Current source behavior
+
+- The 2.0 core emits only the outer legacy boundaries and drops `current_context`:
+  `src/puffo_agent/agent/core.py:380-404` emits `turn_start` and
+  `turn_complete` (with `tokens` only). The pre-integration
+  `turn_complete_payload` additionally included `current_context`
+  (`0d9f44d^:src/puffo_agent/agent/core.py:325-330`).
+- The Codex Driver maps only cumulative context totals and drops per-turn token
+  deltas: `src/puffo_agent/agent/harness/codex_driver.py:643-659`
+  (`thread/tokenUsage/updated` → `ContextStatus` with `totalTokens` +
+  `modelContextWindow`); its terminal event carries only `outcome`
+  (`codex_driver.py:827-831`).
+- `src/puffo_agent/agent/harness/runtime_manager.py:800-812` copies token fields
+  onto `TurnResult` only if the terminal event contains them, otherwise both
+  default to `0` — hence Codex `0/0`.
+- Claude Code still supplies terminal tokens:
+  `src/puffo_agent/agent/harness/claude_code_driver.py:618-627`
+  (`input_tokens`/`output_tokens` from `usage`).
+- The old Claude session path still projects rich events into the legacy
+  reporter (`src/puffo_agent/agent/adapters/cli_session.py:1351-1372`,
+  `assistant_text`/`tool_use`), which explains the execution-path difference.
+- Normalized Driver events are not projected into the legacy `agent.status`
+  reporter, and the Runtime Event projector publishes a metadata-only
+  vocabulary (no raw frames/chain-of-thought); the Web does not consume Runtime
+  Events for the Profile Log (Web claim attributed to F005).
+
+### User-visible impact
+
+Agent Profile Log shows coarse `Working`/`Done` rows, Codex completion rows
+render `in token: 0, out token: 0`, and context telemetry is absent.
+
+### Confirmed evidence
+
+- Current citations above (Agent).
+- History: `git show 0d9f44d^:src/puffo_agent/agent/adapters/codex_session.py`
+  (`tokenUsage` `last`/`total` delta math at lines ~1182-1215) and
+  pre-integration `core.py` `current_context` handling.
+
+### Unknowns
+
+- Whether every observed `0/0` row came from Codex or a separate Claude Code
+  runtime issue also exists (source-level cause proven here is Codex-specific).
+- Which safe activity details the future Profile Log should expose; this must
+  not be conflated with publishing raw chain-of-thought or provider-native
+  payloads.
+
+### Repository owner
+
+Agent (driver telemetry + legacy projection); Web owns the consuming Profile
+Log contract (not re-inspected).
+
+### Bounded acceptance criteria
+
+1. Codex and Claude Code both preserve terminal token telemetry when supplied
+   by their native protocols.
+2. Context usage reaches the Profile surface through one documented contract.
+3. A Driver turn exposes safe lifecycle/tool progress without publishing
+   private reasoning or provider-native payloads.
+4. The Web consumes the chosen authoritative stream; compatibility behavior is
+   explicit while the legacy path remains supported.
+5. Profile Log, avatar status, and chat activity strip agree on turn start,
+   terminal state, failure, cancellation, and reconnect.
+
+---
+
+## F006 — Agent Profile Activity and Files are incomplete projections
+
+**Classification: `intentionally deferred`**
+
+### Old contract
+
+No complete pre-2.0 contract existed for these surfaces. Git history shows the
+Activity cache view and the Files `Coming soon` placeholder predate the Agent
+Foundation integration; Agent 2.0 exposed their incompleteness during release
+testing rather than removing an established pipeline.
+
+### Current source behavior
+
+Agent source does not feed these surfaces. Web-side evidence (attributed to
+F006, not re-inspected): Activity is a view over the current Web message cache
+(`ProfilePanels.tsx:1333-1340`) and Files renders the static placeholder text
+(`ProfilePanels.tsx:1188-1191`).
+
+### User-visible impact
+
+Profile Activity is incomplete and changes with the loaded browser history;
+Files never lists shared files or images.
+
+### Classification rationale
+
+Intentionally deferred: F006 predates 2.0, has no complete legacy interface for
+the Agent to restore, and is product backlog per the frozen goal ("F006
+Activity/Files is product backlog, not compatibility work").
+
+### Repository owner
+
+Web / product (not Agent).
+
+### Bounded acceptance criteria
+
+None defined in this workstream (product design decisions pending). Candidate
+acceptance shape is recorded in F006: durable paginated Activity source with
+explicit scope; Files at minimum listing accessible attachments the Agent
+shared, with originating conversation/message; private local workspace files
+never exposed merely because a viewer can open a Profile; empty states
+distinguish `no results`, `not loaded`, `not supported`, `not authorized`.
+
+---
+
+## Additional evidence-backed pre-2.0 Web-visible contracts
+
+Within the bounded evidence inventory (the six findings plus the named contract
+areas: Global Inbox/status-run ownership, encrypted `agent.status` projection,
+Codex/Claude normalized events and token/context mapping, Docker/Codex
+admission and adapters, stop sentinel read/write/shutdown, and baseline storage,
+request construction, response validation, and held/replay/retry behavior), no
+further confirmed lost pre-2.0 Web-visible contract was found beyond F001-F005.
+
+Two observations attached to F001 remain **unclassified unknowns** (recorded
+under F001): an intro Inbox row can be marked `processed` without a committed
+outbound introduction, and delayed recovery can surface coordination internals
+to channel users. No unsupported additional contract is presented as confirmed.
+
+---
+
+## Downstream slice definitions
+
+These bounds the two later independent work slices. Normalized Harness Driver
+events remain the single internal source of truth; both slices must preserve
+that invariant.
+
+### Slice 1 — Agent-only legacy status/processing and safe projection (observability)
+
+- Project normalized Driver events into the legacy encrypted `agent.status`
+  stream for the Profile Log: safe `assistant_text`/`tool_use` activity and
+  terminal `turn_complete` with token counts.
+- Codex per-turn input/output token telemetry must be restored from
+  `thread/tokenUsage/updated` (the `last`/`total` delta pattern that
+  `codex_session.py` implemented pre-integration) and surfaced through
+  `TurnResult` into `turn_complete`.
+- Claude Code terminal `input_tokens`/`output_tokens` (already present in
+  `claude_code_driver.py:618-627`) must be preserved.
+- Context usage reaches the Profile surface through one documented contract.
+- No raw chain-of-thought, native frames, or provider-native payloads may be
+  projected (metadata-only vocabulary is retained).
+- Implicated files (Agent): `src/puffo_agent/agent/harness/codex_driver.py`,
+  `src/puffo_agent/agent/harness/claude_code_driver.py`,
+  `src/puffo_agent/agent/harness/runtime_manager.py`,
+  `src/puffo_agent/agent/harness/local_runtime.py`,
+  `src/puffo_agent/agent/core.py` (legacy `turn_complete` emission),
+  `src/puffo_agent/agent/adapters/cli_session.py` (existing projection pattern),
+  `src/puffo_agent/portal/control/reporter.py`.
+
+### Slice 2 — Coordinated Agent/Server optional-baseline wire contract
+
+- Preserve `None` (no authoritative baseline), `0` (authoritative empty
+  baseline), and positive values (history through that sequence is
+  pre-context) through every hop:
+  - local state: `src/puffo_agent/agent/inbox_store.py` (`channel_context_state`);
+  - Agent request: `src/puffo_agent/agent/send_coordinator.py:869-871,669-679`
+    (remove the `None -> 0` coercion);
+  - Agent response validation: `src/puffo_agent/agent/send_response_validation.py`
+    (sent/held freshness echo must preserve the distinction);
+  - Server DTO/validation: `server/src/v2/agent_runtime_messages.rs:27-31,73-96`
+    (make `context_baseline_seq` optional);
+  - Server decision: `server/src/messages.rs:828-912` (define the `None` branch
+    instead of treating it as `0`).
+- Lazy establishment: the Server establishes a usable boundary for a new member
+  without pretending the Agent saw pre-membership ciphertext.
+- Replay/retry keep the same baseline meaning across retries.
+- Multiple Agents joining an existing-history channel each introduce themselves
+  once without a follow-up human message; genuinely newer visible messages still
+  participate in freshness coordination.
+- After a successful first coordinated send, persist the Server-established
+  numeric baseline through `BaselineAdapter` so later sends and daemon restarts
+  use normal freshness coordination. Membership/attach processing emits the
+  intro notice only and does not inspect or manufacture an encrypted-history
+  boundary.
+- Implicated files: Agent `send_coordinator.py`, `inbox_store.py`,
+  `global_inbox_types.py`, `send_response_validation.py`;
+  Server `agent_runtime_messages.rs`, `messages.rs`.
+
+### Overlapping state owners, wire files, and the coordination rule
+
+The slices feed the same composition root but have separable ownership when the
+file bounds below are enforced:
+
+- Slice 1 owns `portal/worker_run.py`, Harness Driver/runtime files,
+  `harness/local_runtime.py`, and `agent/core.py`.
+- Slice 2 owns `send_coordinator.py`, `send_response_validation.py`,
+  `global_inbox_types.py`, `inbox_store.py`, and the bounded Server freshness
+  files.
+- Neither slice should restructure `global_inbox_runtime.py`. If source
+  inspection proves that file unavoidable, serialize only that integration
+  edit after the independent implementations are complete.
+- F002 status-lifecycle wiring is part of Slice 1 and must not be implemented in
+  a third branch.
+
+**Coordination rule:** Server baseline work and Agent observability may proceed
+in parallel because their files do not overlap. Agent baseline work follows the
+frozen Server wire contract and may also proceed independently of observability
+while the ownership bounds above are respected. Serialize only an unavoidable
+shared composition-root edit. This keeps normalized Driver events authoritative
+without blocking unrelated compatibility restoration.
+
+---
+
+## Source evidence index
+
+Agent (at `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89`):
+
+- `src/puffo_agent/portal/runtime_matrix.py:204-211` (F003 current rejection)
+- `src/puffo_agent/agent/adapters/docker_cli.py:103,183-189` (F003 Claude-only)
+- `src/puffo_agent/portal/state.py:1128-1156` (F004 JSON sentinel)
+- `src/puffo_agent/portal/cli.py:344` (F004 CLI write)
+- `src/puffo_agent/portal/worker_run.py:430-452,588-625` (F002 no lifecycle)
+- `src/puffo_agent/portal/ws_local/session.py:276,324-325` (F002 sole callers)
+- `src/puffo_agent/agent/status_reporter.py:32-37` (F002 lifecycle contract)
+- `src/puffo_agent/agent/core.py:380-404` (F002/F005 legacy emission)
+- `src/puffo_agent/agent/inbox_store.py:1024-1061` (F001 storage)
+- `src/puffo_agent/agent/send_coordinator.py:669-679,869-871` (F001 coercion + request)
+- `src/puffo_agent/agent/send_response_validation.py:138-186` (F001 response echo)
+- `src/puffo_agent/agent/membership_actions.py:178-235` (F001 intro nudge)
+- `src/puffo_agent/agent/global_inbox_types.py:221-228` (F001 baseline adapter)
+- `src/puffo_agent/agent/harness/codex_driver.py:643-659,827-831` (F005)
+- `src/puffo_agent/agent/harness/claude_code_driver.py:618-627` (F005)
+- `src/puffo_agent/agent/harness/runtime_manager.py:800-812` (F005)
+- `src/puffo_agent/agent/adapters/cli_session.py:1351-1372` (F005 projection)
+
+Server (at `393a1af6f54b9f44e0711437bd787ce0f093e80b`):
+
+- `server/src/v2/agent_runtime_messages.rs:27-31,73-96` (F001 DTO/validation)
+- `server/src/messages.rs:828-912` (F001 send decision / held)
+- `server/src/agent_status.rs:63-68,370-409,538` (F002 status/run contract)
+
+History (`git show <commit>:<path>` verified for each):
+
+- `0d9f44d^:src/puffo_agent/portal/worker.py:1367,1434` (F002 old lifecycle)
+- `0d9f44d^:src/puffo_agent/portal/runtime_matrix.py` (F003 old matrix)
+- `0d9f44d^:src/puffo_agent/agent/adapters/docker_cli.py:106-108` (F003 old image)
+- `0d9f44d` name-status (F003 deleted `codex_session.py` + test files; F004
+  `-S 'read_stop_request_pid'`)
+- `0d9f44d^:src/puffo_agent/portal/state.py:1502-1506` (F004 old sentinel)
+- `0d9f44d^:src/puffo_agent/agent/adapters/codex_session.py:1182-1215` (F005 old tokens)
+- `0d9f44d^:src/puffo_agent/agent/core.py:325-330` (F005 old `current_context`)
+- `0d9f44d` blame/history for the current-lineage F001 `None -> 0` fallback;
+  parallel non-ancestor `2e50c31` is supporting evidence only
+
+## Confirmed evidence vs unknowns
+
+Each entry separates confirmed source/history evidence (citations verified
+against the recorded HEADs above) from explicitly stated unknowns. Claims about
+staging observation, the installed wheel, and the Web consumer are attributed to
+the frozen findings (F001-F006) and were not re-run or re-inspected in this
+documentation run.

--- a/docs/agent-foundation-2.0-compatibility-matrix.md
+++ b/docs/agent-foundation-2.0-compatibility-matrix.md
@@ -1,8 +1,8 @@
 # Agent Foundation 2.0 Compatibility Matrix
 
 Source-grounded inventory of pre-2.0 Web-visible contracts affected by the
-Agent Foundation 2.0 migration, with classifications, exact evidence, ownership,
-and bounded acceptance criteria for later work.
+Agent Foundation 2.0 migration, their original failure evidence, implemented
+repairs, and bounded acceptance evidence.
 
 ## Purpose and method
 
@@ -10,9 +10,9 @@ and bounded acceptance criteria for later work.
   (referenced, not modified).
 - Findings F001-F006:
   `/Users/glimmer/Desktop/projects/puffo.ai/slock-agent/research/puffo-agent-staging-findings/`.
-- Current-source behavior was re-checked against the **Agent worktree** at the
-  recorded HEAD and the **bounded Server contract** at the recorded Server HEAD.
-  Web-side claims are attributed to the frozen findings, not re-inspected here.
+- The detailed pre-repair source blocks remain frozen at the diagnosis snapshots
+  so the failure mechanism stays auditable. Resolution claims are pinned
+  separately to the current Agent and Server heads below.
 - Git history was used only to recover specific pre-2.0 contracts (stop sentinel,
   `cli-docker + codex` admission/adapter/image/tests, status lifecycle wiring,
   telemetry projection, baseline fallback introduction).
@@ -23,20 +23,63 @@ and bounded acceptance criteria for later work.
 
 | Surface | Snapshot |
 |---|---|
-| Agent worktree | `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89` (matches canonical `puffo-agent-stable-readiness`) |
-| Server worktree | `393a1af6f54b9f44e0711437bd787ce0f093e80b` (`puffo-server-keyless-agent-auth`) |
+| Agent diagnosis snapshot | `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89` |
+| Server diagnosis snapshot | `393a1af6f54b9f44e0711437bd787ce0f093e80b` |
+| Agent repaired head | `8641a89` (`feat/agent-foundation-stable-readiness`) |
+| Server repaired head | `ae0f238` (`feat/keyless-agent-authorization`) |
 | Integration commit audited | `0d9f44d` "Integrate Agent Foundation across native and keyless cloud runtimes (#225)" |
 | Findings source | `puffo-agent-staging-findings` snapshot 2026-08-11; staging Server `sha-7ad4698b959a`; package `puffo-agent==2.0.0a1` |
 
 All Agent path citations below are relative to the Agent worktree root; Server
-citations are under `server/` in the Server worktree. Line numbers are from the
-recorded HEADs.
+citations are under `server/` in the Server worktree. Line numbers in the
+diagnosis blocks refer to the recorded diagnosis snapshots.
+
+## Resolution status
+
+| Finding | Status | Bounded evidence |
+|---|---|---|
+| F001 introduction / baseline | Restored | Missing local row remains `None`; JSON `null`, authoritative `0`, and positive sequence values stay distinct. Server establishes a numeric baseline only inside the first successful coordinated send. Five Agents joining both empty-history and pre-history channels each introduced themselves once. |
+| F002 busy / activity strip | Restored | Global Inbox turns open and close the legacy Server status lifecycle. Real Web acceptance showed `Processing` during work and `Idle` after completion for all five Agents. Daemon-local membership/reminder envelopes no longer call message-processing endpoints for nonexistent message IDs. |
+| F003 Docker Codex | Restored with residual live-provider risk | `cli-docker + openai + codex` is admitted and wired through the Driver transport, isolated home, image, cleanup, and persisted-session paths. The bounded Docker smoke did not execute a live provider turn because the local Agent Core data/RPC dependency was unavailable. |
+| F004 stop upgrade | Restored | Current daemon accepts both legacy timestamp-only and PID-scoped JSON stop sentinels; current CLI waits on the exact daemon PID. Focused old/new compatibility and bounded shutdown tests pass. |
+| F005 logs / telemetry | Restored at Agent contracts | Safe Driver lifecycle/tool events and Codex/Claude token/context telemetry are projected without raw reasoning. Runtime-event recovery was proven for 5/5 Agents. The current local Web session could not verify the local Profile Log body because it was not paired to the Python daemon and correctly disabled device-local Log/Files tabs. |
+| F006 Activity / Files | Intentionally deferred | These surfaces did not have a complete pre-2.0 contract and remain product work. |
+
+### Cross-cutting reconnect recovery
+
+Product acceptance exposed a separate compatibility failure: three Agents had
+old `agent_runtime_state` rows left `running` after an earlier Runtime session
+disappeared. Every event from their replacement session was rejected with
+`409 invalid_turn_transition`, leaving Profile/runtime projection data stale.
+
+Server commit `ae0f238` allows a `turn.started` from a different `session_ref`
+to atomically replace an incomplete active turn. A second turn in the same
+session remains invalid, reused turn references remain invalid, and late events
+from the replaced session are fenced. No schema change or backfill is needed;
+existing installations recover lazily on their next real turn.
+
+Evidence:
+
+- 14 focused Runtime Events tests pass, including replacement-session recovery
+  and rejection of a late event from the old session.
+- The unchanged local database contained three independently reproduced stale
+  projections. A fresh five-Agent channel produced three explicit
+  `runtime_event_session_takeover` transitions, Runtime Events for all 5/5
+  Agents, five introductions, and five terminal `succeeded` projections.
+- The same real browser run showed all five avatar states return to `Idle`; no
+  runtime-event `409` remained after takeover.
 
 ---
 
 ## F001 — New-member introduction stalls at the visibility boundary
 
-**Classification: `missing`**
+**Classification: `restored`**
+
+Resolution: Agent merge `1f980ea` and Server merge `b1acd07` restore the
+optional baseline contract. Missing local state is represented by no row and
+serializes as JSON `null`; `0` remains an authoritative empty boundary. The
+Server returns the established numeric value, which the daemon persists for
+later sends and restarts. Membership/attach does not inspect encrypted history.
 
 ### Frozen compatibility contract
 
@@ -50,7 +93,7 @@ The 2026-07-26 design intent was to send JSON `null` for
 Server lazily establish the numeric baseline inside a successful coordinated
 send. Freshness fields are daemon-owned; the model never supplies them.
 
-### Current source behavior
+### Pre-repair source behavior (frozen diagnosis)
 
 - Agent storage for the baseline exists but has **no production writer**:
   `src/puffo_agent/agent/inbox_store.py:1024-1061` defines
@@ -138,7 +181,12 @@ Agent (`send_coordinator`, `inbox_store`, `membership_actions`,
 
 ## F002 — Agent busy status and chat activity strip are missing
 
-**Classification: `missing`**
+**Classification: `restored`**
+
+Resolution: Agent merge `8472281` restores the Global Inbox status lifecycle;
+commit `8641a89` classifies membership, intro, and reminder envelopes as local
+synthetic work so they update Agent busy state without inventing a processing
+run for a nonexistent server message.
 
 ### Old contract
 
@@ -150,7 +198,7 @@ turn: `reporter.begin_turn(first_post_id)` before the batch and
 `message_processing_runs`, which the chat UI renders as avatar busy state and
 the activity strip.
 
-### Current source behavior
+### Pre-repair source behavior (frozen diagnosis)
 
 - The Global Inbox turn path never calls the lifecycle:
   `src/puffo_agent/portal/worker_run.py:430-452` (`_execute_global_turn`) calls
@@ -211,7 +259,12 @@ owns the status/run storage and broadcast contract.
 
 ## F003 — `cli-docker + codex` support regressed in 2.0.0a1
 
-**Classification: `missing`**
+**Classification: `restored`**
+
+Resolution: Agent merge `8fc5c43` restores the Docker Codex admission,
+preparation, Driver transport, isolated runtime home, cleanup, and persisted
+session compatibility paths. The real-provider-turn residual is recorded in
+the status table rather than hidden by the passing bounded smoke.
 
 ### Old contract
 
@@ -228,7 +281,7 @@ provider `openai` and harness `codex`:
   credential view, MCP config, app-server command, persisted sessions, and
   Docker binary selection.
 
-### Current source behavior
+### Pre-repair source behavior (frozen diagnosis)
 
 - The runtime matrix rejects the combination:
   `src/puffo_agent/portal/runtime_matrix.py:204-211` admits only `claude-code`
@@ -283,7 +336,11 @@ Agent.
 
 ## F004 — `puffo-agent stop` does not exit normally after upgrade
 
-**Classification: `missing`**
+**Classification: `restored`**
+
+Resolution: Agent merge `f65e9ee` restores legacy sentinel parsing and exact
+PID-scoped shutdown behavior; follow-up commit `0609961` records the accepted
+upgrade contract and evidence.
 
 ### Old contract
 
@@ -292,7 +349,7 @@ the daemon treated the mere existence of the file as a stop request
 (`0d9f44d^:src/puffo_agent/portal/state.py:1502-1506`,
 `write_stop_request` writes `str(int(time.time()))`).
 
-### Current source behavior
+### Pre-repair source behavior (frozen diagnosis)
 
 - The sentinel is now PID-scoped JSON: `write_stop_request` writes
   `{"pid": ..., "created_at": ...}` (`src/puffo_agent/portal/state.py:1145-1156`;
@@ -353,7 +410,11 @@ Agent.
 
 ## F005 — Agent Profile Log loses Driver detail and Codex telemetry
 
-**Classification: `missing`**
+**Classification: `restored at Agent contracts`**
+
+Resolution: Agent merge `5bec939` restores safe Driver-to-legacy projection and
+token/context telemetry; follow-up commit `d5ddb2b` records the compatibility
+evidence. Raw provider frames and private chain-of-thought remain excluded.
 
 ### Old contract
 
@@ -365,7 +426,7 @@ The Web Profile Log consumed decrypted legacy `agent.status` events
 retained current-context usage; the old `core.py` added `current_context` to
 `turn_complete` when present.
 
-### Current source behavior
+### Pre-repair source behavior (frozen diagnosis)
 
 - The 2.0 core emits only the outer legacy boundaries and drops `current_context`:
   `src/puffo_agent/agent/core.py:380-404` emits `turn_start` and
@@ -476,25 +537,29 @@ distinguish `no results`, `not loaded`, `not supported`, `not authorized`.
 
 ## Additional evidence-backed pre-2.0 Web-visible contracts
 
-Within the bounded evidence inventory (the six findings plus the named contract
-areas: Global Inbox/status-run ownership, encrypted `agent.status` projection,
-Codex/Claude normalized events and token/context mapping, Docker/Codex
-admission and adapters, stop sentinel read/write/shutdown, and baseline storage,
-request construction, response validation, and held/replay/retry behavior), no
-further confirmed lost pre-2.0 Web-visible contract was found beyond F001-F005.
+Within the bounded evidence inventory, F001-F005 are restored and F006 remains
+intentionally deferred. Acceptance found the additional stale Runtime-session
+projection failure documented above; it is fixed at Server `ae0f238`.
 
-Two observations attached to F001 remain **unclassified unknowns** (recorded
-under F001): an intro Inbox row can be marked `processed` without a committed
-outbound introduction, and delayed recovery can surface coordination internals
-to channel users. No unsupported additional contract is presented as confirmed.
+The legacy Python `machine link` command still emits a `/link-machine` URL while
+the current Web exposes the newer `/agents/pair` flow. This is a separate
+unresolved compatibility finding, not part of F001-F006 and not silently
+classified as restored here.
+
+The extended behavioral acceptance prompt asking five Agents to count five
+times stopped after `11/25`. Its Inbox slice was complete and untruncated, and
+the deciding Agent returned `[SILENT]` despite an open repeated obligation.
+Ordinary counting (`1,2,3,4,5`) and the fourth-is-one variant (`1,2,3,1,5`)
+passed. This remains a model-behavior residual rather than evidence that the
+baseline, status, or Runtime Events compatibility contracts are broken.
 
 ---
 
-## Downstream slice definitions
+## Historical implementation slices (completed)
 
-These bounds the two later independent work slices. Normalized Harness Driver
-events remain the single internal source of truth; both slices must preserve
-that invariant.
+These were the ownership bounds used while restoring the contracts. They are
+retained as implementation history. Normalized Harness Driver events remain the
+single internal source of truth.
 
 ### Slice 1 — Agent-only legacy status/processing and safe projection (observability)
 
@@ -574,7 +639,8 @@ without blocking unrelated compatibility restoration.
 
 ## Source evidence index
 
-Agent (at `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89`):
+Pre-repair Agent diagnosis (at
+`dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89`):
 
 - `src/puffo_agent/portal/runtime_matrix.py:204-211` (F003 current rejection)
 - `src/puffo_agent/agent/adapters/docker_cli.py:103,183-189` (F003 Claude-only)
@@ -594,7 +660,8 @@ Agent (at `dd5f4ef517decaa814ffb9bc27b7c2d2b53efc89`):
 - `src/puffo_agent/agent/harness/runtime_manager.py:800-812` (F005)
 - `src/puffo_agent/agent/adapters/cli_session.py:1351-1372` (F005 projection)
 
-Server (at `393a1af6f54b9f44e0711437bd787ce0f093e80b`):
+Pre-repair Server diagnosis (at
+`393a1af6f54b9f44e0711437bd787ce0f093e80b`):
 
 - `server/src/v2/agent_runtime_messages.rs:27-31,73-96` (F001 DTO/validation)
 - `server/src/messages.rs:828-912` (F001 send decision / held)
@@ -615,8 +682,7 @@ History (`git show <commit>:<path>` verified for each):
 
 ## Confirmed evidence vs unknowns
 
-Each entry separates confirmed source/history evidence (citations verified
-against the recorded HEADs above) from explicitly stated unknowns. Claims about
-staging observation, the installed wheel, and the Web consumer are attributed to
-the frozen findings (F001-F006) and were not re-run or re-inspected in this
-documentation run.
+Each entry separates confirmed source/history evidence from explicitly stated
+unknowns. The resolution table adds the later focused tests and local product
+acceptance. It does not claim a paired-device Profile Log UI test or a live
+Docker provider turn where those environments were unavailable.

--- a/docs/puffo-agent-architecture.md
+++ b/docs/puffo-agent-architecture.md
@@ -131,6 +131,7 @@ Memory tools are split between `mcp/memory_tools.py` and
     runtime.json
     memory/
     workspace/
+      shared -> ../../../shared/
 ```
 
 | Artifact | Owner |
@@ -141,6 +142,7 @@ Memory tools are split between `mcp/memory_tools.py` and
 | `runtime_events.db` | Bounded local outbox and resumable local Driver session references. |
 | `runtime.json` | Daemon health and status projection for CLI/UI. |
 | `memory/` | Bounded briefing, notes, recollection, imports, and Git history. |
+| `workspace/shared/` | Managed link to the Puffo-home cross-Agent collaboration directory. |
 | `workspace/.puffo/inbox/` | Materialized inbound attachments. |
 
 Native Agents use `keys/`. Keyless bridge Agents use a scoped token and do not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a1"
+version = "2.0.0a2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a2"
+version = "2.0.0a3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/roadmap/agent-foundation/STABLE-2.0-READINESS.md
+++ b/roadmap/agent-foundation/STABLE-2.0-READINESS.md
@@ -4,6 +4,12 @@ This is the execution backlog for moving `puffo-agent==2.0.0a1` toward a
 stable `2.0.0` release. The release contract and acceptance cases remain in
 [`docs/RELEASE-CANDIDATE-2.0.0a1.md`](../../docs/RELEASE-CANDIDATE-2.0.0a1.md).
 
+The reviewed, source-grounded inventory of every item below against the frozen
+Agent source and local git evidence is in
+[`roadmap/agent-foundation/STABLE-2.0-SOURCE-AUDIT.md`](STABLE-2.0-SOURCE-AUDIT.md).
+Treat that audit as authoritative for classifications and evidence; this table
+tracks status and evidence links.
+
 The goal is readiness evidence and the smallest required fixes. This branch is
 not a new feature integration branch.
 
@@ -47,9 +53,14 @@ evidence.
 
 - Channel encryption and plaintext-channel policy are owned by Han's Agent PR
   #212 and must not be duplicated here.
-- Keyless invitation approval, complete keyless DM trust management, Runtime
-  Event UI, encrypted remote runtime-output streaming, reactions, Hermes,
-  Gemini, ACP, and plaintext DMs remain separate product work.
+- Keyless invitation/DM **operator authorization** is in scope for this
+  workstream as a bounded requirement from the current goal: when an
+  invitation or DM action is not already operator-authorized, the Agent routes
+  a clear authorization request to its configured operator. See the
+  [source audit](STABLE-2.0-SOURCE-AUDIT.md) for the exact missing behavior
+  boundary. The broader keyless DM trust-management surface, Runtime Event UI,
+  encrypted remote runtime-output streaming, reactions, Hermes, Gemini, ACP,
+  and plaintext DMs remain separate product work.
 - Broad refactoring and test-suite expansion are not readiness work. Add only
   tests that guard a changed boundary or a release acceptance failure.
 

--- a/roadmap/agent-foundation/STABLE-2.0-READINESS.md
+++ b/roadmap/agent-foundation/STABLE-2.0-READINESS.md
@@ -13,16 +13,17 @@ tracks status and evidence links.
 The goal is readiness evidence and the smallest required fixes. This branch is
 not a new feature integration branch.
 
-## Missing Work
+## Remaining Work
 
-| ID | Gap | Owner / repository | Stable blocker | Completion evidence |
-|---|---|---|---|---|
-| A1 | The new Claude Driver launches the resolved executable directly and does not yet carry the Windows npm shim handling from Agent PR #224. | Puffo Agent | Yes | Forward-port the command normalization at the Driver boundary, keep tests limited to command construction, and complete one real Windows Claude turn. |
-| S1 | Server PR #273 is still open. The metadata-only Runtime Event contract is therefore not deployed with the Agent candidate. | Puffo Server | Yes | PR merged, staging deployed, and a real Agent run confirms that only fixed-vocabulary metadata reaches the Server. |
-| O1 | Production `agent_status.runtime` has not been inventoried for active Docker Codex or retired direct-runtime configurations. | Release operations | Yes | Inventory recorded and every active runtime class has an explicit migration, pin, or retirement decision. No Docker Agent silently moves to the host boundary. |
-| C1 | AIM/E2B templates are not yet pinned and promoted from an immutable Agent commit for each supported harness. | Cloud Agent / AIM | Yes for cloud GA | Candidate templates pass staging, existing cloud Agent pins have a migration plan, and promotion records the exact Agent commit. |
-| V1 | The final candidate SHA does not yet have one consolidated staging evidence record for upgrade, real harness, coordination, recovery, multi-target Inbox, restart, and privacy behavior. | Puffo Agent + staging | Yes | All acceptance cases in the release contract are recorded against one immutable candidate SHA. |
-| R1 | Stable package metadata and publishing remain intentionally disabled. | Puffo Agent release | Yes | Only after A1, S1, O1, C1, and V1 close: set `2.0.0`, update changelog and README, tag `v2.0.0`, and run the production workflow. |
+| ID | Status | Remaining gap | Owner / repository | Stable blocker | Completion evidence |
+|---|---|---|---|---|---|
+| A1 | Local code complete at `8a56124` | Real Windows execution is not locally verified. | Puffo Agent + Windows QA | Yes | Run one real Windows Claude turn through an npm shim and record the immutable Agent commit. |
+| K1 | Local Agent and Server feature work complete at `ea83bc2` / `393a1af` | Real keyless bridge acceptance is not locally verified. | Puffo Agent + Puffo Server + staging | Yes for keyless GA | Exercise external invitation approval/rejection and foreign-DM allow/block through the real bridge, including restart/replay, against immutable candidate SHAs. |
+| S1 | External evidence pending | Runtime Event Server merge/deploy state and staging privacy behavior must be reverified. | Puffo Server | Yes | Server change merged and deployed, and a real Agent run confirms that only fixed-vocabulary metadata reaches the Server. |
+| O1 | External evidence pending | Production `agent_status.runtime` has not been inventoried for active Docker Codex or retired direct-runtime configurations. | Release operations | Yes | Inventory recorded and every active runtime class has an explicit migration, pin, or retirement decision. No Docker Agent silently moves to the host boundary. |
+| C1 | External evidence pending | AIM/E2B templates are not yet pinned and promoted from an immutable Agent commit for each supported harness. | Cloud Agent / AIM | Yes for cloud GA | Candidate templates pass staging, existing cloud Agent pins have a migration plan, and promotion records the exact Agent commit. |
+| V1 | External evidence pending | The final candidate SHA does not yet have one consolidated staging evidence record for upgrade, real harness, coordination, recovery, multi-target Inbox, restart, and privacy behavior. | Puffo Agent + staging | Yes | All acceptance cases in the release contract are recorded against one immutable candidate SHA. |
+| R1 | Intentionally deferred | Stable package metadata and publishing remain disabled. | Puffo Agent release | Yes | Only after A1, K1, S1, O1, C1, and V1 close: set `2.0.0`, update changelog and README, tag `v2.0.0`, and run the production workflow. |
 
 ## Evidence Already Available
 
@@ -31,15 +32,16 @@ not a new feature integration branch.
   version and a fresh install check.
 - Agent Foundation and its release correction are on `main` through Agent PRs
   #225 and #229.
-- Agent PR #224 documents the confirmed Windows failure and the old Adapter
-  fix, but remains open because the implementation must target the new Driver.
+- Agent PR #224 documents the historical Windows failure and old Adapter fix;
+  the new Driver forward-port is now present locally at `8a56124`.
 
 These facts reduce repeated discovery work; they do not replace final staging
 evidence.
 
 ## Execution Order
 
-1. **Agent code:** complete A1 as an isolated Driver-boundary change.
+1. **Platform evidence:** complete the real-Windows A1 turn and real-bridge K1
+   invitation/DM scenarios against immutable Agent and Server commits.
 2. **Server dependency:** merge and deploy S1 before privacy acceptance.
 3. **Release inventory:** complete O1 before choosing migration defaults.
 4. **Candidate validation:** run V1 on the exact Agent and Server candidate
@@ -53,11 +55,10 @@ evidence.
 
 - Channel encryption and plaintext-channel policy are owned by Han's Agent PR
   #212 and must not be duplicated here.
-- Keyless invitation/DM **operator authorization** is in scope for this
-  workstream as a bounded requirement from the current goal: when an
-  invitation or DM action is not already operator-authorized, the Agent routes
-  a clear authorization request to its configured operator. See the
-  [source audit](STABLE-2.0-SOURCE-AUDIT.md) for the exact missing behavior
+- Keyless invitation/DM **operator authorization** was the bounded K1
+  requirement for this workstream and is locally implemented; real bridge
+  acceptance remains in the table above. See the
+  [source audit](STABLE-2.0-SOURCE-AUDIT.md) for the original missing behavior
   boundary. The broader keyless DM trust-management surface, Runtime Event UI,
   encrypted remote runtime-output streaming, reactions, Hermes, Gemini, ACP,
   and plaintext DMs remain separate product work.

--- a/roadmap/agent-foundation/STABLE-2.0-READINESS.md
+++ b/roadmap/agent-foundation/STABLE-2.0-READINESS.md
@@ -1,8 +1,8 @@
 # Agent Foundation 2.0 Stable Readiness
 
-This is the execution backlog for moving `puffo-agent==2.0.0a1` toward a
+This is the execution backlog for moving `puffo-agent==2.0.0a2` toward a
 stable `2.0.0` release. The release contract and acceptance cases remain in
-[`docs/RELEASE-CANDIDATE-2.0.0a1.md`](../../docs/RELEASE-CANDIDATE-2.0.0a1.md).
+[`docs/RELEASE-CANDIDATE-2.0.0a2.md`](../../docs/RELEASE-CANDIDATE-2.0.0a2.md).
 
 The reviewed, source-grounded inventory of every item below against the frozen
 Agent source and local git evidence is in

--- a/roadmap/agent-foundation/STABLE-2.0-READINESS.md
+++ b/roadmap/agent-foundation/STABLE-2.0-READINESS.md
@@ -1,0 +1,64 @@
+# Agent Foundation 2.0 Stable Readiness
+
+This is the execution backlog for moving `puffo-agent==2.0.0a1` toward a
+stable `2.0.0` release. The release contract and acceptance cases remain in
+[`docs/RELEASE-CANDIDATE-2.0.0a1.md`](../../docs/RELEASE-CANDIDATE-2.0.0a1.md).
+
+The goal is readiness evidence and the smallest required fixes. This branch is
+not a new feature integration branch.
+
+## Missing Work
+
+| ID | Gap | Owner / repository | Stable blocker | Completion evidence |
+|---|---|---|---|---|
+| A1 | The new Claude Driver launches the resolved executable directly and does not yet carry the Windows npm shim handling from Agent PR #224. | Puffo Agent | Yes | Forward-port the command normalization at the Driver boundary, keep tests limited to command construction, and complete one real Windows Claude turn. |
+| S1 | Server PR #273 is still open. The metadata-only Runtime Event contract is therefore not deployed with the Agent candidate. | Puffo Server | Yes | PR merged, staging deployed, and a real Agent run confirms that only fixed-vocabulary metadata reaches the Server. |
+| O1 | Production `agent_status.runtime` has not been inventoried for active Docker Codex or retired direct-runtime configurations. | Release operations | Yes | Inventory recorded and every active runtime class has an explicit migration, pin, or retirement decision. No Docker Agent silently moves to the host boundary. |
+| C1 | AIM/E2B templates are not yet pinned and promoted from an immutable Agent commit for each supported harness. | Cloud Agent / AIM | Yes for cloud GA | Candidate templates pass staging, existing cloud Agent pins have a migration plan, and promotion records the exact Agent commit. |
+| V1 | The final candidate SHA does not yet have one consolidated staging evidence record for upgrade, real harness, coordination, recovery, multi-target Inbox, restart, and privacy behavior. | Puffo Agent + staging | Yes | All acceptance cases in the release contract are recorded against one immutable candidate SHA. |
+| R1 | Stable package metadata and publishing remain intentionally disabled. | Puffo Agent release | Yes | Only after A1, S1, O1, C1, and V1 close: set `2.0.0`, update changelog and README, tag `v2.0.0`, and run the production workflow. |
+
+## Evidence Already Available
+
+- `2.0.0a1` was built and clean-installed from TestPyPI from the merged
+  candidate commit. Any code change after that commit requires a new candidate
+  version and a fresh install check.
+- Agent Foundation and its release correction are on `main` through Agent PRs
+  #225 and #229.
+- Agent PR #224 documents the confirmed Windows failure and the old Adapter
+  fix, but remains open because the implementation must target the new Driver.
+
+These facts reduce repeated discovery work; they do not replace final staging
+evidence.
+
+## Execution Order
+
+1. **Agent code:** complete A1 as an isolated Driver-boundary change.
+2. **Server dependency:** merge and deploy S1 before privacy acceptance.
+3. **Release inventory:** complete O1 before choosing migration defaults.
+4. **Candidate validation:** run V1 on the exact Agent and Server candidate
+   commits. Use CLI/runtime tests for diagnosis and one browser smoke at the
+   end.
+5. **Cloud track:** complete C1 before calling cloud Agent support generally
+   available.
+6. **Stable release:** perform R1 only after every applicable gate is closed.
+
+## Explicitly Out Of Scope
+
+- Channel encryption and plaintext-channel policy are owned by Han's Agent PR
+  #212 and must not be duplicated here.
+- Keyless invitation approval, complete keyless DM trust management, Runtime
+  Event UI, encrypted remote runtime-output streaming, reactions, Hermes,
+  Gemini, ACP, and plaintext DMs remain separate product work.
+- Broad refactoring and test-suite expansion are not readiness work. Add only
+  tests that guard a changed boundary or a release acceptance failure.
+
+## Branch Discipline
+
+- Keep one commit or review unit per gap; do not mix Agent code, release
+  operations, and cloud-template work.
+- Treat the release contract as canonical. Update this backlog with status and
+  evidence links rather than copying new acceptance rules into multiple files.
+- Preserve existing `1.2.0` user state during upgrade: configuration, profile,
+  memory, workspace, keys, message history, and supported session references.
+- Do not publish stable artifacts from this branch.

--- a/roadmap/agent-foundation/STABLE-2.0-SOURCE-AUDIT.md
+++ b/roadmap/agent-foundation/STABLE-2.0-SOURCE-AUDIT.md
@@ -1,0 +1,386 @@
+# Agent Foundation 2.0 Stable-Readiness Source Audit
+
+Reviewed, source-grounded inventory for Agent Foundation 2.0 stable readiness.
+This is a documentation audit, not an implementation pass.
+
+## Method and provenance
+
+- **Frozen source base (immutable):** `b3669377d0978f3b4cdf02647f170522a32ed05e`
+  ("docs: organize Agent Foundation 2.0 readiness", 2026-08-11). The worktree
+  `HEAD` equals this SHA and was clean at audit start (`git status --short`
+  empty). All path/symbol evidence below was read from this commit unless a
+  different immutable commit is named.
+- **Newer scope authority:** the current workstream goal at
+  `loop-engineering/runtime/agent-foundation-2.0/goal.md` is treated as newer
+  authority than the older backlog wording in
+  `roadmap/agent-foundation/STABLE-2.0-READINESS.md` and
+  `docs/RELEASE-CANDIDATE-2.0.0a1.md`. The goal's completion conditions and
+  user-consensus item 6 bring keyless invitation/DM **operator authorization**
+  into this workstream (see [Authority reconciliation](#authority-reconciliation)).
+  The goal file itself is **external to the git worktree** (it lives in the
+  main checkout under `loop-engineering/`, which is not a tracked repository
+  path), so it is quoted as authority but is not a worktree-resolvable local
+  path.
+- **Vocabulary (closed):** every inventory row has exactly one primary
+  classification: `confirmed local Agent gap`, `external dependency/evidence
+  gate`, `already satisfied`, `stale/inaccurate wording`, or `not a blocker for
+  this branch`. Where an item spans local and external concerns, the
+  classification answers whether **this branch** has a confirmed
+  code/documentation obligation; the other concern is described in the row's
+  "local action / external evidence" field.
+- **Evidence discipline:** remote PR state, production inventory, cloud
+  promotion, staging scenarios, package publishing, and real-Windows execution
+  that are not provable from this repository are explicitly marked
+  `not locally verified`. The old backlog's assertion is never cited as proof
+  of itself, and mutable branch names are only used alongside immutable commit
+  facts.
+
+## Canonical inventory
+
+| ID | Backlog item | Primary classification | Local action / external evidence |
+|---|---|---|---|
+| A1 | New Claude Driver launches the resolved executable directly; no Windows npm-shim handling | `confirmed local Agent gap` | Driver-boundary command normalization + focused construction tests are local work; one real-Windows Claude turn remains `not locally verified`. |
+| S1 | Metadata-only Runtime Event contract not yet deployed with the Agent candidate (Server PR #273 open) | `external dependency/evidence gate` | Agent-side vocabulary/outbox/uploader is committed and locally satisfied; Server PR merge/deploy + staging are `not locally verified`. |
+| O1 | Production `agent_status.runtime` not inventoried for active Docker Codex / retired direct-runtime configs | `external dependency/evidence gate` | Status-reporting code that feeds `agent_status.runtime` is local; querying/mutating production inventory is `not locally verified`. |
+| C1 | AIM/E2B templates not pinned and promoted from an immutable Agent commit | `external dependency/evidence gate` | Cloud harness code exists locally; no template pin/promotion machinery or records exist in this repo and none may be invented here. |
+| V1 | No consolidated staging evidence record against one immutable candidate SHA | `external dependency/evidence gate` | Release-contract acceptance set is documented locally; staging execution evidence is `not locally verified`. |
+| R1 | Stable package metadata and publishing remain intentionally disabled | `not a blocker for this branch` | Local metadata is already at `2.0.0a1`; publishing is external and forbidden in this run. |
+| K1 | Newer requirement: keyless invitation/DM operator authorization | `confirmed local Agent gap` | Identity/operator, invitation, DM-gate, and keyless-transport contracts exist; the operator-request/decision route for the keyless transport is missing (see below). |
+
+## A1 — Windows Claude Driver command launch
+
+### Current Driver boundary (frozen base)
+
+- `src/puffo_agent/agent/harness/claude_code_driver.py::ClaudeCodeCliDriver.open`
+  (line 103) builds the launch argv at lines 110–120:
+
+  ```python
+  args = [
+      spec.executable or "claude",
+      *spec.launch_args,
+      "-p", "--input-format", "stream-json", "--output-format",
+      "stream-json", "--replay-user-messages", "--verbose",
+  ]
+  ```
+
+  and launches it **directly** via `asyncio.create_subprocess_exec(*args, ...)`
+  at `claude_code_driver.py:137`. There is no platform-normalization step
+  between `spec.executable` and the subprocess argv. A repository-wide search
+  for `win32`/`windows`/`.cmd`/`powershell`/`shim` in
+  `src/puffo_agent/agent/harness/` and `tests/test_harness_driver.py` returns
+  nothing.
+- `RuntimeSpec.executable` (`src/puffo_agent/agent/harness/driver.py:102`)
+  carries the resolved binary path. It is populated by
+  `LocalRuntime._prepare_claude_spec` (`src/puffo_agent/agent/harness/local_runtime.py:402`)
+  from `resolve_claude_bin()` (`cli_bin.py:59`) and stored at
+  `local_runtime.py:476`.
+- `src/puffo_agent/agent/cli_bin.py` at the frozen base exposes
+  `resolve_claude_bin` (line 59) but **not** `spawn_argv` / `windows_runnable`
+  (`git show b3669377:src/puffo_agent/agent/cli_bin.py` has no such symbols).
+- Current focused tests: `tests/test_harness_driver.py` drives
+  `ClaudeCodeCliDriver` through a `process_factory` double; the only argv
+  assertion is `assert "--replay-user-messages" in captured_args`
+  (`test_harness_driver.py:1343`). `tests/test_local_runtime_migration.py:91`
+  asserts `prepared.spec.executable == "/opt/bin/claude"`. No test pins the
+  executable head or any Windows shim behavior for the Driver.
+
+### Immutable git evidence (Windows shim work)
+
+- `1f64930ef1a4bc5ff09f415dec072f4d93a708fb` ("PUF-420 (agent): spawn claude
+  by resolved path, and wrap Windows shims") and
+  `9ffae53567fdd827c9087a52f26477a4296eb469` ("PUF-420: fall back to the bare
+  name instead of raising in _build_command") are **not ancestors** of the
+  frozen base (`git merge-base --is-ancestor` fails for both). They exist on
+  the remote branch `origin/puf-420-windows-claude-spawn` (branch tip
+  `9ffae53`). The base therefore does **not** contain the fix.
+- On that branch, commit `1f64930` adds `windows_runnable()` and `spawn_argv()`
+  to `src/puffo_agent/agent/cli_bin.py` (`.cmd`/`.bat` → `cmd.exe /c`,
+  `.ps1` → `powershell -NoProfile -NonInteractive -File`, `.exe` passes
+  through) and uses them in the **old** `adapters/local_cli.py::_build_command`
+  via `cmd = spawn_argv(claude_bin) if claude_bin else ["claude"]`
+  (`local_cli.py:995` on the branch). The old adapter file
+  `adapters/local_cli.py` does not exist at the frozen base (the path moved to
+  `agent/harness/`), so the shim helpers must be forward-ported to the **new**
+  Driver boundary, not copied onto a dead adapter.
+- `9ffae53` adds `tests/test_windows_claude_spawn.py` (17 argv-construction
+  tests) and pins the resolver-miss fallback to the bare name. The commit
+  message states the evidence limit verbatim: *"sys.platform is monkeypatched
+  since there is no Windows CI: these pin argv construction, NOT that
+  CreateProcess accepts the result. A real Windows run is still the only proof
+  of the fix."*
+
+### Smallest confirmed change
+
+Normalize `RuntimeSpec.executable` at the Driver command-launch boundary before
+the `asyncio.create_subprocess_exec(*args)` call — i.e. route the resolved
+executable through a Windows-runnable/spawn-argv normalization (the behavior
+`windows_runnable` + `spawn_argv` provide on the PUF-420 branch) so `.cmd` /
+`.bat` / `.ps1` shims are launched through their interpreter, `.exe` passes
+through, and POSIX is unchanged — plus focused command-construction tests.
+This is the smallest change that restores the confirmed shim behavior at the
+new boundary; no broader refactor is prescribed.
+
+### Real-Windows evidence limitation
+
+Mocked/platform-monkeypatched argv tests (the PUF-420 pattern) pin argv
+construction only. They cannot replace one real Windows Claude turn. The
+frozen base has no Windows CI, and this repo cannot produce real-Windows
+execution evidence, so real-Windows acceptance remains `not locally verified`
+and external.
+
+## K1 — Keyless invitation / DM operator authorization
+
+The newer goal requires: when an invitation or DM action is not already
+operator-authorized, the Agent should route a clear authorization request to
+its configured operator rather than silently accepting, silently rejecting, or
+treating an external party as the operator. The trace below follows the
+identity/operator, invitation, DM-gate, and keyless-transport contracts.
+
+### Identity / operator contracts
+
+- `operator_slug` is configured at provision/portal time and threaded into the
+  client: `src/puffo_agent/agent/client_setup.py` (fields at lines 26, 111–129),
+  `src/puffo_agent/portal/state.py:468`, and
+  `src/puffo_agent/portal/control/provision.py:91–104`; consumed by
+  `PuffoCoreMessageClient.__init__` (`src/puffo_agent/agent/puffo_core_client.py:157–180`).
+- Operator root-key identity comes from the identity cert:
+  `parse_operator_pubkey` (`src/puffo_agent/agent/client_support.py:33–48`)
+  reads `declared_operator_public_key`; `PuffoCoreMessageClient.listen` caches
+  `self._operator_root_pubkey` from it (`puffo_core_client.py:272–281`).
+- `inviter_is_operator` (`src/puffo_agent/agent/membership_events.py:483–504`)
+  accepts an inviter **only** if the inviter's slug equals `operator_slug` or
+  the inviter's fetched root public key equals `operator_root_pubkey`. An
+  external inviter is never promoted to operator. This invariant is preserved
+  by any future work and is not changed by this audit.
+
+### Native invitation flow (signed transport)
+
+- `invite_poll_loop` (`membership_events.py:17–35`) drives
+  `poll_pending_invites` (`membership_events.py:300–336`,
+  `http.get("/invites?direction=received")`), which calls `process_invite`
+  (`membership_events.py:347–420`). `process_invite` auto-accepts only when
+  `inviter_is_operator` is true or the space auto-accept flag is set; otherwise
+  it calls `notify_operator_of_invite`.
+- `PuffoCoreMessageClient._notify_operator_of_invite`
+  (`puffo_core_client.py:1714–1787`) DMs the configured operator a permission
+  prompt and records the prompt in `_pending_invite_dms` keyed by envelope id.
+  The operator's reply is consumed by `operator_control_gate`
+  (`src/puffo_agent/agent/ingress_policy.py:120–177`) via
+  `_apply_invite_replies` / `resolve_invite_targets`
+  (`src/puffo_agent/agent/membership_actions.py:591–641`). Reply routing is
+  pinned by `tests/test_invite_reply_routing.py`.
+
+### Keyless skipped invite-poll boundary
+
+- `listen_bridge` (`src/puffo_agent/agent/bridge_transport.py:62–104`)
+  "Deliberately does NOT start `_invite_poll_loop` / `_warm_member_caches` —
+  they drive signed HTTP endpoints that can't work keyless" (lines 73–76).
+- `PuffoCoreMessageClient.listen` (`puffo_core_client.py:258–314`) returns
+  through `_listen_bridge()` whenever `_bridge` is set (lines 268–270); the
+  invite poll task is only created on the native WS branch (line 290). The
+  bridge frame dispatch (`dispatch_bridge_frame`, `bridge_transport.py:107+`)
+  handles `message`, `pending_delivered`, `runtime_command`, `added_to_space`,
+  and `error` — no invite frames. Consequence: a keyless agent never learns of,
+  and never asks the operator about, a pending invitation; `_pending_invite_dms`
+  is never populated keyless.
+
+### Shared foreign-DM gating
+
+- `foreign_dm_gate` (`src/puffo_agent/agent/ingress_policy.py:180–253`) is the
+  one Agent-owned DM approval gate used by both transports
+  (`_bridge_gate_verdict`, `bridge_transport.py:485–523`, applies it at line 514).
+  For the keyless transport (`signed_http_available` returns False for bridge
+  clients, `ingress_policy.py:68–78`), a foreign DM from a non-trusted sender
+  with an `operator_slug` configured is held with disposition
+  `FOREIGN_DM_GATED` and logged as *"keyless transport cannot send the operator
+  approval prompt … holding the DM gated rather than delivering it unapproved"*
+  (`ingress_policy.py:221–241`). The prompt is **never sent** to the operator.
+- Durable gated receipt behavior: `store_bridge_payload`
+  (`bridge_transport.py:398–435`) commits the verdict via `_commit_bridge_verdict`
+  (`bridge_transport.py:526–569`); `_redelivery_ack`
+  (`bridge_transport.py:438–448`) returns `False` for `FOREIGN_DM_GATED` rows,
+  so a held DM is never acked and stays queued server-side until the operator
+  answers. Pinned by `tests/test_bridge_ingress_policy.py`:
+  `test_foreign_dm_over_bridge_is_gated_not_eligible` (line 159),
+  `test_legacy_seqless_bridge_frames_carry_verdict_into_storage` (line 178,
+  which shows `store.promote_gated_receipt` can release such a row).
+- Native release path exists but is keyless-inaccessible: `promote_gated_receipt`
+  is called in product code only by the signed WS path
+  `src/puffo_agent/agent/inbound_receipts.py:54`, and the approval reply
+  handler `maybe_handle_dm_approval_reply` (`src/puffo_agent/agent/dm_gate.py:104–186`)
+  requires `_pending_dm_approvals` (never populated keyless), signed
+  `/allowlists` / `/blocklists` POSTs, and `client._ws` for draining
+  (`dm_gate.py:189–228`). None of that exists on the keyless transport.
+
+### Available keyless transport operations
+
+- `CloudBridgeClient` (`src/puffo_agent/agent/bridge_client.py:71+`) exposes
+  `send_send` (500), `send_fetch_pending` (550), `send_status` (558),
+  `send_ack` (608), `send_list_spaces` (621), plus status/wake/blob operations.
+- A keyless plaintext DM **can** be sent: `send_bridge_fallback_dm`
+  (`src/puffo_agent/agent/outbound_messages.py:154–173`) uses
+  `bridge.send_send(plaintext, recipient_slug, …)`. Today it is wired only to
+  the fallback DM reply to `_last_dm_sender`
+  (`puffo_core_client.py:1884–1899`) — not to any authorization request.
+- An operator's DM over the bridge **is** intercepted: `operator_control_gate`
+  keys on `payload.sender_slug == client.operator_slug`
+  (`ingress_policy.py:135–139`); pinned by
+  `tests/test_bridge_ingress_policy.py::test_operator_control_reply_over_bridge_is_consumed_not_delivered`
+  (line 126).
+
+### Missing behavior boundary
+
+The exact missing boundary is the absent **keyless-capable operator-request /
+decision route**: a keyless agent has (a) no invite poll, so it never requests
+a decision about an unauthorized invitation; (b) no operator approval prompt
+for a gated foreign DM, so it holds the DM without asking; and (c) no keyless
+apply path (`_pending_dm_approvals` / signed allowlist-blocklist / `_ws` drain
+are all native-only), so even an operator reply over the bridge has no pending
+state or keyless side effect to act on. The piece the goal calls for is a route
+that, on the keyless transport, sends a decision request to the configured
+operator through an operation the bridge already supports (e.g. `send_send`)
+and applies the operator's answer through the durable gated-receipt lane
+(`promote_gated_receipt`/`tombstone_gated_dms_from`) plus the keyless local
+contact state, while the server-side blocklist/allowlist writes remain
+native-only. Two invariants hold for any such design: an external inviter or
+sender is **never** promoted to operator (`membership_events.py:483–504`), and
+no channel-encryption or plaintext policy is designed, duplicated, or
+reclassified here (Han's scope, per
+`docs/RELEASE-CANDIDATE-2.0.0a1.md` decisions and this audit's out-of-scope).
+
+## S1 — Runtime Event contract
+
+- Locally committed and satisfied on the Agent side: fixed-vocabulary schema
+  `src/puffo_agent/agent/runtime_events.py` (`RUNTIME_EVENT_TYPES` lines 14–20,
+  `validate_runtime_event` lines 96–149), allowlist-only projection
+  (`RuntimeEventProjector`, lines 220–306), durable outbox and serial uploader
+  (`RuntimeEventOutbox`, `RuntimeEventUploader` in
+  `src/puffo_agent/agent/runtime_event_outbox.py`), wiring in
+  `src/puffo_agent/portal/worker_run.py`. Vocabulary/privacy pinned by
+  `tests/test_runtime_events.py` (e.g. `test_schema_has_exact_v1_envelope_and_metadata_only_types`,
+  line 31) and `tests/test_runtime_event_outbox.py`.
+- The backlog's S1 blocker is Server PR #273 merge/deploy status
+  (`docs/RELEASE-CANDIDATE-2.0.0a1.md:40–42`). The Server is a separate
+  repository; its PR state, deployment, and staging behavior are `not locally
+  verified`. Staging behavior and "only fixed-vocabulary metadata reaches the
+  Server" remain external evidence, not derivable from local unit tests.
+
+## O1 — Production `agent_status.runtime` inventory
+
+- Repository-local: the status reporter feeds the server's `agent_status`
+  `runtime` field — `src/puffo_agent/agent/status_reporter.py::_runtime_payload`
+  (line 116) allows only `kind/provider/harness/model/inference_level`; the
+  keyless bridge `send_status` folds into the same `agent_status` row
+  (`src/puffo_agent/agent/bridge_client.py:569`); `runtime_provider` is wired at
+  `src/puffo_agent/portal/worker.py:1217`.
+- The actual **production** inventory of active Docker-Codex and retired
+  direct-runtime configurations requires querying production, which is
+  `not locally verified` and out of scope for this run. No repository
+  configuration or migration code proves what is active in production.
+
+## C1 — AIM/E2B template pinning
+
+- Repository-local: cloud harness support exists — E2B egress/token references
+  in `src/puffo_agent/agent/bridge_client.py` (5, 43–44),
+  `src/puffo_agent/crypto/http_client.py` (39, 231),
+  `src/puffo_agent/crypto/http_session.py` (39), `src/puffo_agent/mcp/config.py`
+  (390), `src/puffo_agent/mcp/puffo_core_tools.py` (196), and the historical
+  note `roadmap/cloud-agent/FAT-E2B-INTEGRATION.md`.
+- No immutable template pin, staging promotion record, or migration plan exists
+  anywhere in this repository, and none may be invented here. Those remain
+  external evidence gates (`not locally verified`).
+
+## V1 — Consolidated candidate staging evidence
+
+- The required acceptance set is documented in
+  `docs/RELEASE-CANDIDATE-2.0.0a1.md:57–93` (install, upgrade of `1.2.0`
+  state, one real Claude and one real Codex turn, three coordination cases, one
+  held draft through context recovery, multi-target Inbox delivery, restart
+  during pending work, staging Runtime-Event privacy inspection).
+- No consolidated evidence record for these cases against one immutable
+  candidate SHA is committed at the frozen base. `docs/integration-tests/python-agent-message-runtime-system-e2e-20260728.md`
+  is an earlier integration record, not the candidate acceptance set. Local unit
+  tests (e.g. `tests/test_global_inbox_runtime.py`,
+  `tests/test_global_inbox_runtime_held_and_reminders.py`) exercise components
+  but are **not** staging proof and are not presented as such.
+
+## R1 — Stable metadata and publishing
+
+- Local state at the frozen base already satisfies "intentionally disabled":
+  `pyproject.toml:14` is `version = "2.0.0a1"`; `README.md:76–79` describes the
+  TestPyPI-only candidate and links the release-candidate doc; `CHANGELOG.md`
+  has a `[2.0.0a1]` entry dated 2026-08-11; the newest local tag is `v1.2.0`
+  (no `v2.0.0` tag); `.github/workflows/publish-pypi.yml:48–66` rejects any
+  non-stable version and requires a matching `vX.Y.Z` tag, so a stable publish
+  is currently impossible and publishing is an external action in any case.
+- R1's prerequisite ordering (A1 → S1 → O1 → C1 → V1 before R1) is a release
+  policy, not a local code obligation. This branch has no confirmed
+  code/documentation obligation for R1, hence `not a blocker for this branch`;
+  stable publication remains `not locally verified` and forbidden in this run.
+
+## Authority reconciliation
+
+The older backlog (`roadmap/agent-foundation/STABLE-2.0-READINESS.md`,
+"Explicitly Out Of Scope") and the release candidate
+(`docs/RELEASE-CANDIDATE-2.0.0a1.md:52–55`) classify *"keyless invitation
+approval, complete keyless DM trust management"* as separate product work. The
+current goal (`loop-engineering/runtime/agent-foundation-2.0/goal.md`,
+user-consensus item 6 and completion conditions) is newer authority and brings
+a **bounded operator-authorization requirement** into this workstream: when an
+invitation or DM action is not already operator-authorized, the Agent routes a
+clear authorization request to its configured operator instead of silently
+accepting, silently rejecting, or treating the external party as the operator.
+
+This audit replaces the stale classification for that bounded requirement only.
+It remains out of scope here (and for any implementation) that: the **broad**
+keyless DM trust-management surface and Runtime Event UI stay separate product
+work; and Han-owned channel encryption / plaintext-channel policy
+(`docs/RELEASE-CANDIDATE-2.0.0a1.md:24–26`, decisions item 3) is neither
+designed, duplicated, nor reclassified by this inventory or by the K1
+recommendation. `roadmap/agent-foundation/STABLE-2.0-READINESS.md` is updated
+in this run to link this audit and reflect this reconciliation; no release gate
+is added or removed.
+
+## Ordered recommendation
+
+The source traces confirm both premises of the task, so the first two future
+implementation units are, in order:
+
+1. **Windows Claude Driver shim normalization** (A1): route
+   `RuntimeSpec.executable` through the Windows shim/spawn normalization at the
+   Driver command-launch boundary in
+   `src/puffo_agent/agent/harness/claude_code_driver.py::open`
+   (and the executable source in
+   `src/puffo_agent/agent/harness/local_runtime.py` / `cli_bin.py`), with
+   focused command-construction tests modeled on the PUF-420
+   `tests/test_windows_claude_spawn.py` pattern. Real-Windows acceptance stays
+   an external evidence gate.
+2. **Keyless invitation/DM operator authorization** (K1): add the
+   keyless-capable operator-request/decision route described under
+   [Missing behavior boundary](#missing-behavior-boundary), grounded in the
+   existing contracts — identity/operator (`client_support.py`,
+   `membership_events.py::inviter_is_operator`), bridge ingress
+   (`bridge_transport.py`, `ingress_policy.py::foreign_dm_gate`),
+   membership/DM authorization (`membership_actions.py`, `dm_gate.py`,
+   `message_store.py::promote_gated_receipt`), and the keyless transport
+   (`bridge_client.py::send_send`, `outbound_messages.py::send_bridge_fallback_dm`).
+
+Likely non-overlapping boundaries: Driver/CLI launch normalization (A1) versus
+identity, bridge ingress, and membership/DM authorization (K1), each with its
+own focused tests. No implementation, test design beyond the observed
+boundaries, deployment step, or encryption/plaintext policy is specified here.
+
+### External evidence work (out of scope for any execution in this run)
+
+Keep separate from local code work; none of these actions occur in this run:
+
+- **S1** — merge and deploy puffo-server PR #273; staging confirmation that only
+  fixed-vocabulary metadata reaches the Server.
+- **O1** — query production `agent_status.runtime`; record migration, pin, or
+  retirement decisions for every active runtime class.
+- **C1** — AIM/E2B template pinning and promotion from an immutable Agent
+  commit; staging validation; existing-cloud-Agent migration plan.
+- **V1** — run the release-contract acceptance cases against one immutable
+  candidate SHA and record the evidence.
+- **R1** — package build/publish/tag/release, and the version/README/changelog
+  change to `2.0.0`, only after the applicable gates close.

--- a/roadmap/agent-foundation/STABLE-2.0-SOURCE-AUDIT.md
+++ b/roadmap/agent-foundation/STABLE-2.0-SOURCE-AUDIT.md
@@ -3,6 +3,24 @@
 Reviewed, source-grounded inventory for Agent Foundation 2.0 stable readiness.
 This is a documentation audit, not an implementation pass.
 
+## Post-audit implementation status (2026-08-11)
+
+This section records work completed after the frozen audit base. It does not
+rewrite the source evidence or classifications below.
+
+- **A1 local implementation complete:** Agent merge commit `8a56124` routes
+  the Claude Driver executable through `normalize_launch_argv`, including npm
+  `.cmd`/`.bat`, PowerShell `.ps1`, direct `.exe`, and `%APPDATA%\npm`
+  discovery. Focused construction tests pass. One real Windows Claude turn is
+  still external and `not locally verified`.
+- **K1 local implementation complete:** Agent merge commit `ea83bc2` provides
+  resumable keyless foreign-DM and invitation operator authorization, bridge
+  polling/control routing, fail-closed persistence, and durable ACK ordering.
+  The companion Server feature branch is at `393a1af` and provides self-scoped
+  invitation listing and serialized decisions. Agent focused checks and the
+  full Python suite pass; a real Agent-to-Server bridge scenario remains
+  external and `not locally verified`.
+
 ## Method and provenance
 
 - **Frozen source base (immutable):** `b3669377d0978f3b4cdf02647f170522a32ed05e`

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -46,7 +46,7 @@ from ...portal.state import (
     sync_host_mcp_servers,
     sync_host_skills,
 )
-from ...portal.workspace_layout import ensure_workspace_shared_link
+from ...portal.workspace_layout import prepare_workspace_shared_access
 from .base import Adapter, TurnContext, TurnResult
 from ..context_controller import (
     ContextCapabilities,
@@ -72,7 +72,7 @@ def _puffo_agent_pkg_dir() -> Path:
 # image-tag pruning. ``_ensure_image`` only builds when the tag is
 # missing locally.
 DEFAULT_IMAGE = "puffo/agent-runtime:v19"
-CONTAINER_LAYOUT_VERSION = "20"
+CONTAINER_LAYOUT_VERSION = "21"
 
 # Pinned Claude Code CLI version baked into the image. Floating would
 # let an upstream release shift the stream-json protocol or
@@ -743,8 +743,8 @@ class DockerCLIAdapter(Adapter):
         )
 
     async def _start_container(self) -> None:
-        agent_claude_json = self._prepare_container_mounts()
-        command = self._container_run_command(agent_claude_json)
+        agent_claude_json, shared_status = self._prepare_container_mounts()
+        command = self._container_run_command(agent_claude_json, shared_status)
         self._add_optional_container_args(command)
         command.append(self.image)
         rc, _, stderr = await _run_cmd(command, check=False)
@@ -754,17 +754,22 @@ class DockerCLIAdapter(Adapter):
                 f"{stderr.decode('utf-8', errors='replace').strip()[:500]}"
             )
 
-    def _prepare_container_mounts(self) -> Path:
-        ensure_workspace_shared_link(Path(self.workspace_dir), self.shared_fs_dir)
+    def _prepare_container_mounts(self) -> tuple[Path, str]:
+        shared_status = prepare_workspace_shared_access(
+            Path(self.workspace_dir),
+            self.shared_fs_dir,
+            mounted=True,
+        )
         self.agent_home_dir.mkdir(parents=True, exist_ok=True)
         (self.agent_home_dir / ".claude").mkdir(parents=True, exist_ok=True)
         agent_claude_json = self.agent_home_dir / ".claude.json"
         agent_claude_json.touch(exist_ok=True)
-        return agent_claude_json
+        return agent_claude_json, shared_status
 
     def _container_run_command(
         self,
         agent_claude_json: Path,
+        shared_status: str,
     ) -> list[str]:
         return [
             self._docker_bin,
@@ -782,8 +787,11 @@ class DockerCLIAdapter(Adapter):
             # container's ephemeral fs and is lost on restart.
             "-v",
             f"{agent_claude_json}:/home/agent/.claude.json",
-            "-v",
-            f"{self.shared_fs_dir}:/workspace/shared",
+            *(
+                ["-v", f"{self.shared_fs_dir}:/workspace/shared"]
+                if shared_status == "mounted"
+                else []
+            ),
             # Compatibility for existing sessions and user-authored paths.
             "-v",
             f"{self.shared_fs_dir}:/workspace/.shared",

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -70,14 +70,19 @@ def _puffo_agent_pkg_dir() -> Path:
 # Bump on Dockerfile changes so existing hosts rebuild without manual
 # image-tag pruning. ``_ensure_image`` only builds when the tag is
 # missing locally.
-DEFAULT_IMAGE = "puffo/agent-runtime:v18"
-CONTAINER_LAYOUT_VERSION = "18"
+DEFAULT_IMAGE = "puffo/agent-runtime:v19"
+CONTAINER_LAYOUT_VERSION = "19"
 
 # Pinned Claude Code CLI version baked into the image. Floating would
 # let an upstream release shift the stream-json protocol or
 # ``--permission-mode`` semantics under us; bump deliberately after
 # verification.
 CLAUDE_CODE_NPM_VERSION = "2.1.224"
+
+# Pinned Codex CLI version baked into the same image. The Driver talks
+# ``codex app-server`` JSON-RPC, whose frame shapes move between
+# releases, so the version is pinned and only bumped after verification.
+CODEX_NPM_VERSION = "0.147.0"
 
 DOCKER_COMMAND_TIMEOUT_SECONDS = 60.0
 DOCKER_BUILD_TIMEOUT_SECONDS = 900.0
@@ -102,6 +107,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
 
 RUN npm install -g @anthropic-ai/claude-code@__CLAUDE_CODE_VERSION__
 
+RUN npm install -g @openai/codex@__CODEX_CODE_VERSION__
+
 # Puffo MCP tools server deps. ``--break-system-packages`` is
 # required on Debian bookworm (PEP 668); acceptable since the
 # container is single-purpose and disposable. ``uv`` ships ``uvx``
@@ -124,6 +131,9 @@ CMD ["sh", "-c", "set -eu; mkdir -p /workspace/.puffo-agent; touch /workspace/.p
 """.replace(
     "__CLAUDE_CODE_VERSION__",
     CLAUDE_CODE_NPM_VERSION,
+).replace(
+    "__CODEX_CODE_VERSION__",
+    CODEX_NPM_VERSION,
 )
 
 
@@ -521,22 +531,7 @@ class DockerCLIAdapter(Adapter):
         the container doesn't exist, or ``None`` when Docker could not
         answer the probe.
         """
-        rc, out, _ = await _run_cmd(
-            [
-                self._docker_bin,
-                "container",
-                "ls",
-                "--all",
-                "--filter",
-                f"name=^/{self.container_name}$",
-                "--format",
-                "{{.State}}",
-            ],
-            check=False,
-        )
-        if rc != 0:
-            return None
-        return out.decode("utf-8", errors="replace").strip()
+        return await container_state(self._docker_bin, self.container_name)
 
     async def _install_desired(self) -> None:
         """Install container-compatible desired assets once per instance."""
@@ -742,57 +737,9 @@ class DockerCLIAdapter(Adapter):
         layout_marker.write_text(CONTAINER_LAYOUT_VERSION + "\n", encoding="utf-8")
 
     async def _ensure_image(self) -> None:
-        if await _image_exists_locally(self._docker_bin, self.image):
-            return
-        if self.image != DEFAULT_IMAGE:
-            raise RuntimeError(
-                f"docker image {self.image!r} not found locally. "
-                f"pull it (`docker pull {self.image}`) or clear "
-                "runtime.docker_image to use the bundled default."
-            )
-        # Daemon-wide lock — concurrent ``docker build -t <tag>``
-        # races in BuildKit's exporter and the loser crashes with
-        # "image already exists". First wins; others wait and re-check.
-        async with _BUILD_LOCK:
-            if await _image_exists_locally(self._docker_bin, self.image):
-                logger.info(
-                    "agent %s: image %s was built by another worker "
-                    "during our wait — skipping rebuild",
-                    self.agent_id,
-                    self.image,
-                )
-                return
-            logger.info(
-                "agent %s: building docker image %s (first use — this may take a few minutes)",
-                self.agent_id,
-                self.image,
-            )
-            await self._build_image()
-
-    async def _build_image(self) -> None:
-        from ..._proc import no_window_kwargs
-
-        proc = await asyncio.create_subprocess_exec(
-            self._docker_bin,
-            "build",
-            "-t",
-            self.image,
-            "-",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            **no_window_kwargs(),
+        await ensure_docker_image(
+            self._docker_bin, self.image, agent_id=self.agent_id
         )
-        stdout, _ = await _communicate_with_timeout(
-            proc,
-            input_data=DOCKERFILE.encode(),
-            timeout_seconds=DOCKER_BUILD_TIMEOUT_SECONDS,
-            operation="docker build",
-        )
-        if proc.returncode != 0:
-            tail = stdout.decode("utf-8", errors="replace")[-1500:]
-            raise RuntimeError(f"docker build failed:\n{tail}")
-        logger.info("agent %s: docker image %s built", self.agent_id, self.image)
 
     async def _start_container(self) -> None:
         agent_claude_json = self._prepare_container_mounts()
@@ -868,6 +815,90 @@ class DockerCLIAdapter(Adapter):
 # (right after an image-tag bump every cli-docker worker would
 # otherwise race BuildKit's exporter).
 _BUILD_LOCK = asyncio.Lock()
+
+
+async def container_state(docker_bin: str, container_name: str) -> str | None:
+    """Docker-reported container State.Status (``running``, ``exited``,
+    ``paused``, ``created``, ``dead``), ``""`` when the container doesn't
+    exist, or ``None`` when Docker could not answer the probe.
+    """
+    rc, out, _ = await _run_cmd(
+        [
+            docker_bin,
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            f"name=^/{container_name}$",
+            "--format",
+            "{{.State}}",
+        ],
+        check=False,
+    )
+    if rc != 0:
+        return None
+    return out.decode("utf-8", errors="replace").strip()
+
+
+async def ensure_docker_image(docker_bin: str, image: str, *, agent_id: str = "") -> None:
+    """Build the bundled image when ``image`` is missing locally.
+
+    Shared by the Claude Docker adapter and the Docker Codex runtime
+    owner. A non-default image must already exist (the operator pulled
+    or built it); only ``DEFAULT_IMAGE`` is ever built here.
+    """
+    if await _image_exists_locally(docker_bin, image):
+        return
+    if image != DEFAULT_IMAGE:
+        raise RuntimeError(
+            f"docker image {image!r} not found locally. "
+            f"pull it (`docker pull {image}`) or clear "
+            "runtime.docker_image to use the bundled default."
+        )
+    # Daemon-wide lock — concurrent ``docker build -t <tag>``
+    # races in BuildKit's exporter and the loser crashes with
+    # "image already exists". First wins; others wait and re-check.
+    async with _BUILD_LOCK:
+        if await _image_exists_locally(docker_bin, image):
+            logger.info(
+                "agent %s: image %s was built by another worker "
+                "during our wait — skipping rebuild",
+                agent_id,
+                image,
+            )
+            return
+        logger.info(
+            "agent %s: building docker image %s (first use — this may take a few minutes)",
+            agent_id,
+            image,
+        )
+        await _build_image(docker_bin, image, agent_id)
+
+
+async def _build_image(docker_bin: str, image: str, agent_id: str) -> None:
+    from ..._proc import no_window_kwargs
+
+    proc = await asyncio.create_subprocess_exec(
+        docker_bin,
+        "build",
+        "-t",
+        image,
+        "-",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        **no_window_kwargs(),
+    )
+    stdout, _ = await _communicate_with_timeout(
+        proc,
+        input_data=DOCKERFILE.encode(),
+        timeout_seconds=DOCKER_BUILD_TIMEOUT_SECONDS,
+        operation="docker build",
+    )
+    if proc.returncode != 0:
+        tail = stdout.decode("utf-8", errors="replace")[-1500:]
+        raise RuntimeError(f"docker build failed:\n{tail}")
+    logger.info("agent %s: docker image %s built", agent_id, image)
 
 
 def _probe_result(returncode: int) -> bool | None:

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -10,9 +10,9 @@ settings — seeded once from the operator's real ``~/.claude``). A private
 credential view is refreshed from the host before the per-agent Claude home
 is mounted into the container.
 
-A second bind-mount exposes ``~/.puffo-agent/shared/`` at
-``/workspace/.shared`` so all agents on this host can cooperate at
-the filesystem level.
+A second bind-mount exposes the Puffo-home ``shared/`` directory at
+``/workspace/shared`` so all agents on this host can cooperate at the
+filesystem level. ``/workspace/.shared`` remains as a compatibility alias.
 
 Lifecycle:
   - container: one per agent (``puffo-<id>``), started lazily,
@@ -46,6 +46,7 @@ from ...portal.state import (
     sync_host_mcp_servers,
     sync_host_skills,
 )
+from ...portal.workspace_layout import ensure_workspace_shared_link
 from .base import Adapter, TurnContext, TurnResult
 from ..context_controller import (
     ContextCapabilities,
@@ -71,7 +72,7 @@ def _puffo_agent_pkg_dir() -> Path:
 # image-tag pruning. ``_ensure_image`` only builds when the tag is
 # missing locally.
 DEFAULT_IMAGE = "puffo/agent-runtime:v19"
-CONTAINER_LAYOUT_VERSION = "19"
+CONTAINER_LAYOUT_VERSION = "20"
 
 # Pinned Claude Code CLI version baked into the image. Floating would
 # let an upstream release shift the stream-json protocol or
@@ -754,12 +755,11 @@ class DockerCLIAdapter(Adapter):
             )
 
     def _prepare_container_mounts(self) -> Path:
-        Path(self.workspace_dir).mkdir(parents=True, exist_ok=True)
+        ensure_workspace_shared_link(Path(self.workspace_dir), self.shared_fs_dir)
         self.agent_home_dir.mkdir(parents=True, exist_ok=True)
         (self.agent_home_dir / ".claude").mkdir(parents=True, exist_ok=True)
         agent_claude_json = self.agent_home_dir / ".claude.json"
         agent_claude_json.touch(exist_ok=True)
-        self.shared_fs_dir.mkdir(parents=True, exist_ok=True)
         return agent_claude_json
 
     def _container_run_command(
@@ -782,6 +782,9 @@ class DockerCLIAdapter(Adapter):
             # container's ephemeral fs and is lost on restart.
             "-v",
             f"{agent_claude_json}:/home/agent/.claude.json",
+            "-v",
+            f"{self.shared_fs_dir}:/workspace/shared",
+            # Compatibility for existing sessions and user-authored paths.
             "-v",
             f"{self.shared_fs_dir}:/workspace/.shared",
             "-v",

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -507,6 +507,7 @@ class CloudBridgeClient:
         reply_to_id: Optional[str] = None,
         thread_root_id: Optional[str] = None,
         attachments: Optional[list[dict]] = None,
+        client_ref: Optional[str] = None,
         timeout: float = 30.0,
     ) -> dict:
         # Pass EITHER recipient_slug (DM) OR space_id+channel_id
@@ -520,8 +521,18 @@ class CloudBridgeClient:
         # size_bytes? }); blobs were already uploaded keyless via
         # ``upload_blob``. Added only when non-empty so a plain send
         # stays byte-shape-identical to the pre-attachment frame.
+        # ``client_ref`` is the correlation id: a caller-supplied
+        # non-empty string is used verbatim for both the outbound frame
+        # and the waiter (the resumable approval flow sends a stable
+        # prompt ref), otherwise the existing ``r_<random>`` is generated.
+        # An empty / whitespace-only / non-string caller value fails before
+        # a frame is sent.
+        if client_ref is not None:
+            if not isinstance(client_ref, str) or not client_ref.strip():
+                raise ValueError(f"invalid client_ref: {client_ref!r}")
         ws = await self._require_ws()
-        client_ref = f"r_{uuid.uuid4().hex[:12]}"
+        if client_ref is None:
+            client_ref = f"r_{uuid.uuid4().hex[:12]}"
         frame: dict[str, Any] = {
             "type": "send",
             "plaintext": plaintext,

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -91,10 +91,14 @@ class CloudBridgeClient:
         self._heartbeat_task: asyncio.Task | None = None
         # client_ref → Future for ack correlation (one ack per send).
         self._send_acks: dict[str, asyncio.Future] = {}
-        # FIFO of futures awaiting ack_result / spaces (no client_ref
-        # in the spec — only one in-flight at a time).
+        # FIFO of futures awaiting ack_result / spaces / invites (no
+        # client_ref in the spec — only one in-flight at a time).
         self._ack_result_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
         self._spaces_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+        self._invites_waiters: asyncio.Queue[asyncio.Future] = asyncio.Queue()
+        # client_ref → Future for decide_invitation_result correlation
+        # (one result per decision send).
+        self._decide_waiters: dict[str, asyncio.Future] = {}
         self._connected_callbacks: list[Callable[[], Awaitable[None]]] = []
 
     def add_connected_callback(
@@ -182,52 +186,94 @@ class CloudBridgeClient:
                 )
                 continue
             kind = frame.get("type", "")
-            if kind == "ping":
-                # Server keepalive — no reply per spec §5.1.
+            if self._route_frame(kind, frame):
                 continue
-            if kind == "ack":
-                client_ref = frame.get("client_ref")
-                if client_ref and client_ref in self._send_acks:
-                    fut = self._send_acks.pop(client_ref)
-                    if not fut.done():
-                        fut.set_result(frame)
-                    continue
-                # Unsolicited ack (e.g. server-side resend / lost
-                # correlation) — surface it for diagnostics.
-                logger.debug(
-                    "cloud bridge: ack with unknown client_ref=%r",
-                    client_ref,
-                )
-                continue
-            if kind == "ack_result":
-                if not self._ack_result_waiters.empty():
-                    fut = self._ack_result_waiters.get_nowait()
-                    if not fut.done():
-                        fut.set_result(frame)
-                    continue
-                logger.debug("cloud bridge: ack_result with no waiter")
-                continue
-            if kind == "spaces":
-                if not self._spaces_waiters.empty():
-                    fut = self._spaces_waiters.get_nowait()
-                    if not fut.done():
-                        fut.set_result(frame)
-                    continue
-                logger.debug("cloud bridge: spaces with no waiter")
-                continue
-            if kind == "error" and frame.get("client_ref"):
-                # An error correlated to a send — route to that future
-                # as an exception.
-                client_ref = frame["client_ref"]
-                if client_ref in self._send_acks:
-                    fut = self._send_acks.pop(client_ref)
-                    if not fut.done():
-                        fut.set_exception(BridgeError(
-                            frame.get("code", "ERROR"),
-                            frame.get("message", ""),
-                        ))
-                    continue
             yield frame
+
+    def _route_frame(self, kind: str, frame: dict) -> bool:
+        """Route a correlated response/error frame to its waiter future.
+
+        Returns ``True`` when the frame was consumed by a waiter (or is a
+        swallowed keepalive / uncorrelated diagnostic), so ``frames()``
+        yields only message / pending_delivered / uncorrelated error
+        frames. Sync (no awaits) so it can't interleave with a concurrent
+        ``send_*`` popping or finally-cleaning the same waiter maps.
+        """
+        if kind == "ping":
+            # Server keepalive — no reply per spec §5.1.
+            return True
+        if kind == "ack":
+            client_ref = frame.get("client_ref")
+            if client_ref and client_ref in self._send_acks:
+                fut = self._send_acks.pop(client_ref)
+                if not fut.done():
+                    fut.set_result(frame)
+                return True
+            # Unsolicited ack (e.g. server-side resend / lost
+            # correlation) — surface it for diagnostics.
+            logger.debug(
+                "cloud bridge: ack with unknown client_ref=%r",
+                client_ref,
+            )
+            return True
+        if kind == "ack_result":
+            if not self._ack_result_waiters.empty():
+                fut = self._ack_result_waiters.get_nowait()
+                if not fut.done():
+                    fut.set_result(frame)
+                return True
+            logger.debug("cloud bridge: ack_result with no waiter")
+            return True
+        if kind == "spaces":
+            if not self._spaces_waiters.empty():
+                fut = self._spaces_waiters.get_nowait()
+                if not fut.done():
+                    fut.set_result(frame)
+                return True
+            logger.debug("cloud bridge: spaces with no waiter")
+            return True
+        if kind == "invites":
+            if not self._invites_waiters.empty():
+                fut = self._invites_waiters.get_nowait()
+                if not fut.done():
+                    fut.set_result(frame)
+                return True
+            logger.debug("cloud bridge: invites with no waiter")
+            return True
+        if kind == "decide_invitation_result":
+            client_ref = frame.get("client_ref")
+            if client_ref and client_ref in self._decide_waiters:
+                fut = self._decide_waiters.pop(client_ref)
+                if not fut.done():
+                    fut.set_result(frame)
+                return True
+            logger.debug(
+                "cloud bridge: decide_invitation_result with unknown "
+                "client_ref=%r",
+                client_ref,
+            )
+            return True
+        if kind == "error" and frame.get("client_ref"):
+            # An error correlated to a send — route to that future
+            # as an exception.
+            client_ref = frame["client_ref"]
+            if client_ref in self._send_acks:
+                fut = self._send_acks.pop(client_ref)
+                if not fut.done():
+                    fut.set_exception(BridgeError(
+                        frame.get("code", "ERROR"),
+                        frame.get("message", ""),
+                    ))
+                return True
+            if client_ref in self._decide_waiters:
+                fut = self._decide_waiters.pop(client_ref)
+                if not fut.done():
+                    fut.set_exception(BridgeError(
+                        frame.get("code", "ERROR"),
+                        frame.get("message", ""),
+                    ))
+                return True
+        return False
 
     async def _heartbeat_loop(self) -> None:
         while self._ws is not None and not self._ws.closed:
@@ -640,6 +686,64 @@ class CloudBridgeClient:
             self._discard_waiter(self._spaces_waiters, fut)
             raise
 
+    async def send_list_invites(self, *, timeout: float = 30.0) -> dict:
+        """Read this agent's authoritative pending invitations.
+
+        Sends exactly ``{"type": "list_invites"}`` and returns the
+        correlated ``invites`` frame (uncorrelated FIFO — the spec has
+        no ``client_ref`` for this request, so one in-flight at a time).
+        Shares the ``send_list_spaces`` send-before-wait, timeout,
+        cancellation, and ``BridgeClosed`` conventions.
+        """
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        await self._invites_waiters.put(fut)
+        await ws.send_json({"type": "list_invites"})
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._discard_waiter(self._invites_waiters, fut)
+            raise
+
+    async def send_decide_invitation(
+        self,
+        *,
+        invitation_event_id: str,
+        decision: str,
+        client_ref: str,
+        timeout: float = 30.0,
+    ) -> dict:
+        """Submit the authenticated bridge Agent's invitation decision.
+
+        The frame carries exactly ``type``, ``client_ref``,
+        ``invitation_event_id``, and ``decision`` (``accept`` /
+        ``reject``) — no Agent slug, no signed payload, per the keyless
+        contract. ``client_ref`` is required and caller-supplied so the
+        resumable flow can retry with a stable ref. Returns the
+        correlated ``decide_invitation_result`` frame; a correlated
+        ``error`` frame raises ``BridgeError``; a timed-out or cancelled
+        waiter is removed so the next result is never misdelivered.
+        """
+        if not isinstance(invitation_event_id, str) or not invitation_event_id:
+            raise ValueError("invitation_event_id must be a non-empty string")
+        if decision not in {"accept", "reject"}:
+            raise ValueError(f"invalid decision: {decision!r}")
+        if not isinstance(client_ref, str) or not client_ref.strip():
+            raise ValueError(f"invalid client_ref: {client_ref!r}")
+        ws = await self._require_ws()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._decide_waiters[client_ref] = fut
+        await ws.send_json({
+            "type": "decide_invitation",
+            "client_ref": client_ref,
+            "invitation_event_id": invitation_event_id,
+            "decision": decision,
+        })
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        finally:
+            self._decide_waiters.pop(client_ref, None)
+
     async def close(self) -> None:
         if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
@@ -667,3 +771,11 @@ class CloudBridgeClient:
             fut = self._spaces_waiters.get_nowait()
             if not fut.done():
                 fut.set_exception(BridgeClosed("WS closed"))
+        while not self._invites_waiters.empty():
+            fut = self._invites_waiters.get_nowait()
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        for fut in list(self._decide_waiters.values()):
+            if not fut.done():
+                fut.set_exception(BridgeClosed("WS closed"))
+        self._decide_waiters.clear()

--- a/src/puffo_agent/agent/bridge_transport.py
+++ b/src/puffo_agent/agent/bridge_transport.py
@@ -21,11 +21,20 @@ runs them in the native order (blocked → self echo → operator control →
 foreign DM → stale → eligible) and only maps each verdict onto the bridge's
 own storage lane.
 
-Known keyless DM gaps: outbound allowlisting on self-echo needs a signed
-``POST /allowlists`` this transport cannot make, and the foreign-DM operator
-approval flow also depends on signed prompt/allowlist/blocklist operations.
-With ``auto_accept_dm=false`` and an operator configured, an untrusted inbound
-DM therefore remains safely gated until a keyless approval control plane exists.
+Known keyless DM gaps: outbound allowlisting on self-echo still needs a
+signed ``POST /allowlists`` this transport cannot make, so an approved
+foreign DM is admitted via local ``ContactCache`` state only. The foreign-DM
+operator approval prompt itself is a plain bridge ``send_send`` DM, and the
+same local contact state records the decision; there is no signed approval
+control plane involved.
+
+Keyless invitations: each real keyless bridge client constructs exactly one
+durable ``KeylessInvitationFlow``. ``listen_bridge`` owns one
+connection-scoped poller that reads the Server's authoritative pending list
+with ``send_list_invites``, reconciles it into the durable flow, and resumes
+any persisted prompt/decision work. The configured operator is prompted only
+through ``send_send``; exact threaded ``y``/``yes``/``n``/``no`` replies are
+consumed as tracked work, and no signed HTTP invitation route is used.
 """
 
 from __future__ import annotations
@@ -43,7 +52,10 @@ from ..limits import (
     MAX_INBOUND_ATTACHMENT_TOTAL_BYTES,
 )
 from . import disk_cache
-from .client_support import DM_GATE_PROMPT_PLACEHOLDER
+from .client_support import (
+    DM_GATE_PROMPT_PLACEHOLDER,
+    INVITE_PROMPT_PLACEHOLDER,
+)
 from .inbound_attachments import (
     downscale_oversized_image,
     is_safe_path_component,
@@ -63,8 +75,12 @@ from .keyless_dm_approval_flow import (
     record_gated_dm,
     resume_pending_approvals,
 )
+from .membership_events import invite_poll_loop
 from .message_context import MENTION_RE, maybe_redact_long_text
 from .message_store import ReceiptDisposition, ReceiptWriteStatus
+
+KEYLESS_DM_REPLY_REASON = "handled keyless dm approval reply"
+KEYLESS_INVITATION_REPLY_REASON = "handled keyless invitation reply"
 
 
 async def listen_bridge(client) -> None:
@@ -78,7 +94,13 @@ async def listen_bridge(client) -> None:
     is scheduled. A fresh ``connect()`` drives ``send_fetch_pending()``
     once so a cold sandbox drains its server-side queue.
 
-    Deliberately does NOT start ``_invite_poll_loop`` /
+    Owns exactly one keyless invitation poller per connection: armed when
+    the first ``pending_delivered`` marker proves the frame pump is live
+    enough to resolve correlated replies, and cancelled and awaited in the
+    connection's ``finally`` so a reconnect creates one fresh poller and
+    never leaks or duplicates background work.
+
+    Deliberately does NOT start the native ``_invite_poll_loop`` /
     ``_warm_member_caches`` — they drive signed HTTP endpoints that
     can't work keyless. Current Server message frames pre-seed sender identity;
     other uncached directory entries degrade to their stable slugs.
@@ -94,9 +116,13 @@ async def listen_bridge(client) -> None:
                 await bridge.connect()
                 backoff = INITIAL_BACKOFF
                 await bridge.send_fetch_pending()
+                client._keyless_invite_poll_task = None
                 async for frame in bridge.frames():
+                    if frame.get("type") == "pending_delivered":
+                        _arm_keyless_invite_poller(client)
                     await client._dispatch_bridge_frame(frame)
             finally:
+                await _stop_keyless_invite_poller(client)
                 await bridge.close()
         except asyncio.CancelledError:
             raise
@@ -110,6 +136,77 @@ async def listen_bridge(client) -> None:
             )
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, MAX_BACKOFF)
+
+
+def _arm_keyless_invite_poller(client) -> None:
+    """Start the connection-owned keyless invitation poller exactly once.
+
+    Called when a ``pending_delivered`` marker establishes that ``frames()``
+    is actively dispatching and can resolve correlated replies. Repeated
+    markers (or a poller that already finished) never spawn a duplicate; the
+    per-connection ``finally`` cancels and awaits it before reconnect.
+    """
+    if getattr(client, "_keyless_invitation_flow", None) is None:
+        return
+    task = getattr(client, "_keyless_invite_poll_task", None)
+    if task is not None and not task.done():
+        return
+    client._keyless_invite_poll_task = asyncio.create_task(
+        keyless_invite_poll_loop(client)
+    )
+
+
+async def _stop_keyless_invite_poller(client) -> None:
+    """Cancel and await the current connection's invitation poller, then
+    clear its ownership slot so the next connect creates one fresh task."""
+    task = getattr(client, "_keyless_invite_poll_task", None)
+    if task is None:
+        return
+    client._keyless_invite_poll_task = None
+    if task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001 - cleanup only
+        pass
+
+
+async def keyless_invite_poll_loop(client) -> None:
+    """The connection-owned keyless invitation poller (fast-then-steady).
+
+    Reuses the native cadence helper: a 2-second initial delay, then 10
+    seconds during the first five minutes and 30 seconds after. Every poll
+    reads the Server's authoritative pending invites, reconciles them into
+    the durable flow, and resumes any persisted prompt/decision work.
+    """
+    flow = getattr(client, "_keyless_invitation_flow", None)
+    if flow is None:
+        return
+    await invite_poll_loop(
+        poll_invites=lambda: poll_keyless_invites(client, flow),
+        next_interval=client._next_invite_poll_interval,
+        sleep=asyncio.sleep,
+    )
+
+
+async def poll_keyless_invites(client, flow) -> None:
+    """One authoritative keyless invitation poll round.
+
+    Fail-soft: a poll failure is logged and retried on the next cadence; it
+    must never escape the poller and kill bridge delivery.
+    """
+    try:
+        invites = await client._bridge.send_list_invites()
+        await flow.reconcile(invites)
+        await flow.resume()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - a poll failure must not stop delivery
+        client._log.warning(
+            "keyless_invitation: poll failed (%s); retrying on next cadence",
+            exc,
+        )
 
 
 async def dispatch_bridge_frame(
@@ -431,6 +528,8 @@ async def store_bridge_payload(
         stored = await client.store.get_message_by_envelope(payload.envelope_id)
         if stored is not None:
             _reschedule_keyless_gated_record(client, payload, stored)
+            if _reschedule_sequence_less_control_reply(client, payload, stored):
+                return False
             return _redelivery_ack(stored)
     row = await _bridge_storage_row(client, payload)
     try:
@@ -468,6 +567,61 @@ def _redelivery_ack(stored) -> bool:
     if stored.receipt_disposition is ReceiptDisposition.FOREIGN_DM_GATED:
         return False
     return True
+
+
+def _reschedule_sequence_less_control_reply(client, payload, stored) -> bool:
+    """Resume a deferred keyless control reply from its terminal receipt.
+
+    Sequence-less compatibility deliveries bypass receipt classification on
+    redelivery. Re-run only the matching durable control handler while its
+    decision is still pending; otherwise the terminal receipt may be ACKed.
+    """
+    row = {"thread_root_id": stored.thread_root_id or payload.thread_root_id or ""}
+    if stored.receipt_reason == KEYLESS_DM_REPLY_REASON:
+        pending = getattr(client, "_pending_dm_approvals", None) or {}
+        thread_root_id = row["thread_root_id"]
+        text = str(payload.content) if payload.content else ""
+        if not is_keyless_operator_approval_reply(
+            pending,
+            thread_root_id=thread_root_id,
+            text=text,
+        ):
+            return False
+        _track_bridge_task(
+            client,
+            asyncio.create_task(
+                _finish_keyless_dm_operator_reply(
+                    client,
+                    thread_root_id=thread_root_id,
+                    text=text,
+                    envelope_id=payload.envelope_id,
+                )
+            ),
+        )
+        return True
+    if stored.receipt_reason == KEYLESS_INVITATION_REPLY_REASON:
+        flow = getattr(client, "_keyless_invitation_flow", None)
+        thread_root_id = row["thread_root_id"]
+        text = str(payload.content) if payload.content else ""
+        if flow is None or not flow.is_operator_reply(
+            thread_root_id=thread_root_id,
+            text=text,
+        ):
+            return False
+        _track_bridge_task(
+            client,
+            asyncio.create_task(
+                _finish_keyless_invitation_reply(
+                    client,
+                    flow,
+                    thread_root_id=thread_root_id,
+                    text=text,
+                    envelope_id=payload.envelope_id,
+                )
+            ),
+        )
+        return True
+    return False
 
 
 def _reschedule_keyless_gated_record(client, payload, stored) -> None:
@@ -554,6 +708,11 @@ async def _bridge_gate_verdict(client, payload, row) -> GateVerdict | None:
             # plaintext the gate is holding. Same redaction the native lane
             # applies, keyed on the durable prompt envelope id here.
             content = DM_GATE_PROMPT_PLACEHOLDER
+        elif _is_keyless_invite_prompt_echo(client, payload.envelope_id):
+            # The echo of the agent's own invitation prompt is operator
+            # control, not model context; store a short placeholder instead
+            # of the operator-visible invitation wording.
+            content = INVITE_PROMPT_PLACEHOLDER
         return GateVerdict(
             gate="self_echo",
             disposition=ReceiptDisposition.TERMINAL,
@@ -569,6 +728,9 @@ async def _bridge_gate_verdict(client, payload, row) -> GateVerdict | None:
     if verdict is not None:
         return verdict
     verdict = await _keyless_operator_reply_gate(client, payload, row)
+    if verdict is not None:
+        return verdict
+    verdict = await _keyless_invitation_reply_gate(client, payload, row)
     if verdict is not None:
         return verdict
     verdict = await foreign_dm_gate(client, payload, _bridge_raw_text(payload))
@@ -614,18 +776,105 @@ async def _keyless_operator_reply_gate(client, payload, row) -> GateVerdict | No
     _track_bridge_task(
         client,
         asyncio.create_task(
-            maybe_handle_operator_reply(
+            _finish_keyless_dm_operator_reply(
                 client,
                 thread_root_id=thread_root_id,
                 text=text,
+                envelope_id=payload.envelope_id,
             )
         ),
     )
     return GateVerdict(
         gate="operator_control",
         disposition=ReceiptDisposition.TERMINAL,
-        reason="handled keyless dm approval reply",
+        reason=KEYLESS_DM_REPLY_REASON,
+        defer_ack=True,
     )
+
+
+async def _finish_keyless_dm_operator_reply(
+    client, *, thread_root_id: str, text: str, envelope_id: str,
+) -> None:
+    """ACK an operator reply only after its approval decision is durable."""
+    durable = await maybe_handle_operator_reply(
+        client,
+        thread_root_id=thread_root_id,
+        text=text,
+    )
+    if durable:
+        await ack_bridge_envelope(client, [envelope_id])
+
+
+def _is_keyless_invite_prompt_echo(client, envelope_id: str) -> bool:
+    """Whether ``envelope_id`` is the agent's own durable invitation prompt.
+
+    The server echoes the prompt back to its sender; that self-echo is
+    operator control and must be stored as a short placeholder, not
+    delivered to model context.
+    """
+    flow = getattr(client, "_keyless_invitation_flow", None)
+    if flow is None:
+        return False
+    return flow.is_prompt_envelope(envelope_id)
+
+
+async def _keyless_invitation_reply_gate(client, payload, row) -> GateVerdict | None:
+    """Consume an exact threaded keyless invitation decision reply.
+
+    Recognition is synchronous against the durable flow's in-memory mirror,
+    so it runs on the frame-pump stack without awaiting anything
+    response-waiting; the locked ``handle_operator_reply`` — which can call
+    ``send_decide_invitation`` and block on correlation — is scheduled as a
+    tracked task the pump keeps feeding. Any other operator control (invite /
+    leave / permission / signed DM approval) has already been decided by
+    ``operator_control_gate`` before this runs.
+    """
+    flow = getattr(client, "_keyless_invitation_flow", None)
+    if flow is None:
+        return None
+    if not (
+        payload.envelope_kind == "dm"
+        and payload.sender_slug == client.operator_slug
+    ):
+        return None
+    # A fast operator reply can arrive before the prompt self-echo has been
+    # persisted locally. The operator identity plus a durable prompt-id match
+    # is sufficient to authenticate this control reference, so retain the raw
+    # wire root as a fallback instead of silently losing the reply.
+    thread_root_id = row["thread_root_id"] or payload.thread_root_id or ""
+    text = str(payload.content) if payload.content else ""
+    if not flow.is_operator_reply(thread_root_id=thread_root_id, text=text):
+        return None
+    _track_bridge_task(
+        client,
+        asyncio.create_task(
+            _finish_keyless_invitation_reply(
+                client,
+                flow,
+                thread_root_id=thread_root_id,
+                text=text,
+                envelope_id=payload.envelope_id,
+            )
+        ),
+    )
+    return GateVerdict(
+        gate="operator_control",
+        disposition=ReceiptDisposition.TERMINAL,
+        reason=KEYLESS_INVITATION_REPLY_REASON,
+        defer_ack=True,
+    )
+
+
+async def _finish_keyless_invitation_reply(
+    client, flow, *, thread_root_id: str, text: str, envelope_id: str,
+) -> None:
+    """ACK an operator reply only after its invitation decision is durable."""
+    durable = await flow.handle_operator_reply(
+        thread_root_id=thread_root_id,
+        text=text,
+    )
+    if durable:
+        await ack_bridge_envelope(client, [envelope_id])
 
 
 async def _commit_bridge_verdict(
@@ -687,7 +936,7 @@ async def _commit_bridge_verdict(
         }
     ):
         runtime.notify_delivery()
-    return result.acknowledge
+    return result.acknowledge and not verdict.defer_ack
 
 
 def _bridge_raw_text(payload) -> str:

--- a/src/puffo_agent/agent/bridge_transport.py
+++ b/src/puffo_agent/agent/bridge_transport.py
@@ -43,6 +43,7 @@ from ..limits import (
     MAX_INBOUND_ATTACHMENT_TOTAL_BYTES,
 )
 from . import disk_cache
+from .client_support import DM_GATE_PROMPT_PLACEHOLDER
 from .inbound_attachments import (
     downscale_oversized_image,
     is_safe_path_component,
@@ -54,6 +55,13 @@ from .ingress_policy import (
     blocked_gate,
     foreign_dm_gate,
     operator_control_gate,
+)
+from .keyless_dm_approval_flow import (
+    is_keyless_operator_approval_reply,
+    is_keyless_prompt_envelope,
+    maybe_handle_operator_reply,
+    record_gated_dm,
+    resume_pending_approvals,
 )
 from .message_context import MENTION_RE, maybe_redact_long_text
 from .message_store import ReceiptDisposition, ReceiptWriteStatus
@@ -124,6 +132,14 @@ async def dispatch_bridge_frame(
         client._log.info(
             "bridge backfill complete: pending_delivered (count=%s)",
             frame.get("count"),
+        )
+        # Reconnect replay: resend missing approval prompts, resume local
+        # receipt transitions, and ACK completed envelopes. It is
+        # response-waiting, so it runs as a tracked task now that the frame
+        # pump is live — never from ``connect()`` or a connected callback.
+        _track_bridge_task(
+            client,
+            asyncio.create_task(resume_pending_approvals(client)),
         )
         # Seed the channel→space map for every channel we're already a
         # member of, so a proactive post to a pre-existing channel works
@@ -414,6 +430,7 @@ async def store_bridge_payload(
     if server_seq is None:
         stored = await client.store.get_message_by_envelope(payload.envelope_id)
         if stored is not None:
+            _reschedule_keyless_gated_record(client, payload, stored)
             return _redelivery_ack(stored)
     row = await _bridge_storage_row(client, payload)
     try:
@@ -430,6 +447,11 @@ async def store_bridge_payload(
         )
         return False
     if verdict is not None:
+        if verdict.disposition is ReceiptDisposition.FOREIGN_DM_GATED:
+            # A held receipt must already contain the same model-facing
+            # context an admitted DM would expose. Approval may happen after
+            # a restart, when the original bridge frame is no longer present.
+            await _populate_bridge_prompt_content(client, payload, row)
         return await _commit_bridge_verdict(client, payload, row, server_seq, verdict)
     await _populate_bridge_prompt_content(client, payload, row)
     return await _persist_eligible_bridge_payload(client, payload, row, server_seq)
@@ -446,6 +468,30 @@ def _redelivery_ack(stored) -> bool:
     if stored.receipt_disposition is ReceiptDisposition.FOREIGN_DM_GATED:
         return False
     return True
+
+
+def _reschedule_keyless_gated_record(client, payload, stored) -> None:
+    """Re-schedule durable recording for a redelivered gated envelope.
+
+    The compatibility lane answers a redelivery before any gate runs, so the
+    durable record must be re-scheduled here when it is missing — the first
+    attempt may have crashed or failed to persist. Without it the held
+    receipt would look ACKable to ``_redelivery_ack`` while carrying no
+    resumable approval state. Idempotent when the record already exists.
+    """
+    if stored.receipt_disposition is not ReceiptDisposition.FOREIGN_DM_GATED:
+        return
+    _track_bridge_task(
+        client,
+        asyncio.create_task(
+            record_gated_dm(
+                client,
+                envelope_id=payload.envelope_id,
+                sender_slug=payload.sender_slug,
+                server_seq=None,
+            )
+        ),
+    )
 
 
 async def _bridge_storage_row(client, payload: MessagePayload) -> dict[str, Any]:
@@ -498,10 +544,21 @@ async def _bridge_gate_verdict(client, payload, row) -> GateVerdict | None:
     if verdict is not None:
         return verdict
     if payload.sender_slug == client.slug:
+        content = None
+        if is_keyless_prompt_envelope(
+            getattr(client, "_pending_dm_approvals", None) or {},
+            envelope_id=payload.envelope_id,
+        ):
+            # The echo of the agent's own keyless approval prompt quotes the
+            # withheld stranger's body; storing it verbatim would leak the
+            # plaintext the gate is holding. Same redaction the native lane
+            # applies, keyed on the durable prompt envelope id here.
+            content = DM_GATE_PROMPT_PLACEHOLDER
         return GateVerdict(
             gate="self_echo",
             disposition=ReceiptDisposition.TERMINAL,
             reason="keyless bridge client echo",
+            content=content,
         )
     verdict = await operator_control_gate(
         client,
@@ -509,6 +566,9 @@ async def _bridge_gate_verdict(client, payload, row) -> GateVerdict | None:
         thread_root_id=row["thread_root_id"] or "",
         text=str(payload.content) if payload.content else "",
     )
+    if verdict is not None:
+        return verdict
+    verdict = await _keyless_operator_reply_gate(client, payload, row)
     if verdict is not None:
         return verdict
     verdict = await foreign_dm_gate(client, payload, _bridge_raw_text(payload))
@@ -521,6 +581,51 @@ async def _bridge_gate_verdict(client, payload, row) -> GateVerdict | None:
             reason="keyless bridge stale history",
         )
     return None
+
+
+async def _keyless_operator_reply_gate(client, payload, row) -> GateVerdict | None:
+    """Consume a keyless operator's exact threaded approval reply.
+
+    Recognition is synchronous against validated durable records only, so it
+    runs on the frame-pump stack without awaiting anything response-waiting;
+    ``maybe_handle_operator_reply`` — which calls bridge ``send_ack`` and can
+    block — is scheduled as a tracked task the pump keeps feeding. Any other
+    operator control (invite / leave / permission / signed DM approval) has
+    already been decided by ``operator_control_gate`` before this runs.
+    """
+    if not (
+        payload.envelope_kind == "dm"
+        and payload.sender_slug == client.operator_slug
+    ):
+        return None
+    # A fast operator reply can arrive before the prompt self-echo has been
+    # persisted locally. The operator identity plus a durable prompt-id match
+    # is sufficient to authenticate this control reference, so retain the raw
+    # wire root as a fallback instead of silently losing the reply.
+    thread_root_id = row["thread_root_id"] or payload.thread_root_id or ""
+    text = str(payload.content) if payload.content else ""
+    pending = getattr(client, "_pending_dm_approvals", None) or {}
+    if not is_keyless_operator_approval_reply(
+        pending,
+        thread_root_id=thread_root_id,
+        text=text,
+    ):
+        return None
+    _track_bridge_task(
+        client,
+        asyncio.create_task(
+            maybe_handle_operator_reply(
+                client,
+                thread_root_id=thread_root_id,
+                text=text,
+            )
+        ),
+    )
+    return GateVerdict(
+        gate="operator_control",
+        disposition=ReceiptDisposition.TERMINAL,
+        reason="handled keyless dm approval reply",
+    )
 
 
 async def _commit_bridge_verdict(
@@ -543,18 +648,34 @@ async def _commit_bridge_verdict(
         # lane must still persist the verdict: a plain ``store()`` drops it,
         # leaving a gated DM unpromotable and a terminal row invisible to prior
         # context.
-        local = await client.store.store_local_receipt(
+        result = await client.store.store_local_receipt(
             row,
             disposition=verdict.disposition,
             reason=verdict.reason,
         )
-        return local.acknowledge
-    result = await client.store.store_receipt(
-        row,
-        server_seq=server_seq,
-        disposition=verdict.disposition,
-        reason=verdict.reason,
-    )
+    else:
+        result = await client.store.store_receipt(
+            row,
+            server_seq=server_seq,
+            disposition=verdict.disposition,
+            reason=verdict.reason,
+        )
+    if (
+        verdict.disposition is ReceiptDisposition.FOREIGN_DM_GATED
+        and result.status
+        in {ReceiptWriteStatus.COMMITTED, ReceiptWriteStatus.IDEMPOTENT}
+    ):
+        _track_bridge_task(
+            client,
+            asyncio.create_task(
+                record_gated_dm(
+                    client,
+                    envelope_id=payload.envelope_id,
+                    sender_slug=payload.sender_slug,
+                    server_seq=server_seq,
+                )
+            ),
+        )
     runtime = getattr(client, "global_runtime", None)
     if (
         runtime is not None

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -120,6 +120,54 @@ def _first_executable(paths: list[Path]) -> str | None:
     return None
 
 
+# ── Windows shim launch normalization ────────────────────────────────
+
+
+def normalize_launch_argv(executable: str) -> list[str]:
+    """Return the argv prefix that launches ``executable`` on this host.
+
+    POSIX passes the executable through unchanged. Windows maps an
+    extensionless path to an existing ``.exe`` / ``.cmd`` / ``.bat`` /
+    ``.ps1`` sibling and wraps the interpreter-backed shims so a direct
+    ``asyncio.create_subprocess_exec`` can run them: ``.cmd`` / ``.bat``
+    through ``cmd.exe /c``, ``.ps1`` through ``powershell.exe``. Every
+    returned element is a single argv entry, so paths containing spaces
+    survive intact.
+    """
+    if sys.platform != "win32":
+        return [executable]
+    resolved = _windows_launch_path(executable)
+    lower = resolved.lower()
+    if lower.endswith((".cmd", ".bat")):
+        return ["cmd.exe", "/c", resolved]
+    if lower.endswith(".ps1"):
+        return [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            resolved,
+        ]
+    return [resolved]
+
+
+def _windows_launch_path(executable: str) -> str:
+    """Prefer an existing sibling for an extensionless Windows executable.
+
+    Order: ``.exe``, ``.cmd``, ``.bat``, ``.ps1``. A path that already
+    carries an extension — or whose sibling set has no match — is used
+    as-is (the resolver-miss fallback launches the bare name directly).
+    """
+    path = Path(executable).expanduser()
+    if path.suffix:
+        return str(path)
+    for suffix in (".exe", ".cmd", ".bat", ".ps1"):
+        candidate = path.with_suffix(suffix)
+        if candidate.is_file():
+            return str(candidate)
+    return str(path)
+
+
 # ── Real-PATH reconstruction (broader than the daemon's process PATH) ──
 
 
@@ -244,9 +292,10 @@ def _codex_bundle_paths() -> list[Path]:
 
 
 def _claude_bundle_paths() -> list[Path]:
-    # Anthropic doesn't currently ship a desktop app that bundles the
-    # ``claude`` CLI the way Codex.app does; defensive paths cover
-    # the case where they start to.
+    # The standard Windows install is the npm-global shim set under
+    # ``%APPDATA%\npm``; Anthropic doesn't currently ship a desktop app
+    # that bundles the ``claude`` CLI the way Codex.app does, so the
+    # app-root paths are defensive coverage.
     if sys.platform == "darwin":
         return _expand(
             "/Applications/Claude.app/Contents/Resources/claude",
@@ -254,6 +303,9 @@ def _claude_bundle_paths() -> list[Path]:
         )
     if sys.platform == "win32":
         return _expand(
+            r"%APPDATA%\npm\claude.exe",
+            r"%APPDATA%\npm\claude.cmd",
+            r"%APPDATA%\npm\claude.ps1",
             r"%LOCALAPPDATA%\Programs\claude\claude.exe",
             r"%LOCALAPPDATA%\Programs\Claude\claude.exe",
             r"%PROGRAMFILES%\Claude\claude.exe",

--- a/src/puffo_agent/agent/client_setup.py
+++ b/src/puffo_agent/agent/client_setup.py
@@ -11,6 +11,7 @@ from ..limits import (
     MAX_INLINE_MESSAGE_CHARS,
     MESSAGE_SEGMENT_CHARS,
 )
+from ..portal.state import agent_dir
 from .client_support import AgentLogger, DeviceKeyCache
 from .contact_cache import ContactCache
 from .dm_approvals import load_pending_dm_approvals
@@ -80,6 +81,7 @@ def _membership_state(slug: str) -> dict[str, Any]:
         "_pending_leave_dms": {},
         "_gate_left_spaces": set(),
         "_pending_dm_approvals": load_pending_dm_approvals(slug),
+        "_keyless_dm_approval_lock": asyncio.Lock(),
         "_pending_command_permissions": {},
         "_timed_out_command_permissions": {},
     }
@@ -97,6 +99,31 @@ def _cache_state() -> dict[str, Any]:
         "_channel_name_cache": {},
         "_space_members": {},
     }
+
+
+def _keyless_contact_state_path(slug: str) -> Any:
+    """Per-Agent local contact state for a keyless transport.
+
+    A keyless agent can never hydrate the signed ``/allowlists`` and
+    ``/blocklists`` routes, so its ``ContactCache`` answers (and persists)
+    a small per-Agent JSON allow/block set instead. Signed clients never
+    pass a path and keep today's server-hydration / in-memory behavior.
+    """
+    return agent_dir(slug) / ".puffo-agent" / "keyless_contacts.json"
+
+
+def _contacts(
+    http_client: Any,
+    log: Any,
+    *,
+    slug: str,
+) -> ContactCache:
+    keyless = bool(getattr(http_client, "keyless", False))
+    return ContactCache(
+        http_client,
+        log,
+        local_state_path=_keyless_contact_state_path(slug) if keyless else None,
+    )
 
 
 def initial_client_state(
@@ -143,5 +170,5 @@ def initial_client_state(
     state["_log"] = AgentLogger(
         logging.getLogger("puffo_agent.agent.puffo_core_client"), {"agent": slug}
     )
-    state["_contacts"] = ContactCache(http_client, state["_log"])
+    state["_contacts"] = _contacts(http_client, state["_log"], slug=slug)
     return state

--- a/src/puffo_agent/agent/client_setup.py
+++ b/src/puffo_agent/agent/client_setup.py
@@ -65,6 +65,9 @@ def _transport_state(*, http_client: Any, bridge_client: Any) -> dict[str, Any]:
         "global_runtime": None,
         "_legacy_dm_peer": "",
         "_last_dm_sender": "",
+        # The connection-owned keyless invitation poller (see
+        # ``bridge_transport.listen_bridge``); one fresh task per connect.
+        "_keyless_invite_poll_task": None,
     }
 
 
@@ -126,6 +129,50 @@ def _contacts(
     )
 
 
+def _bridge_invite_prompt_send(bridge: Any, operator_slug: str):
+    """The durable flow's DM-prompt lane over a real bridge transport.
+
+    A keyless bridge prompt is a plain ``send_send`` DM to the configured
+    operator — never a signed HTTP route. The returned correlated ack is the
+    flow's prompt identity, which the operator's threaded reply echoes back.
+    """
+
+    async def send(prompt: str, *, client_ref: str) -> dict:
+        return await bridge.send_send(
+            plaintext=prompt,
+            recipient_slug=operator_slug,
+            client_ref=client_ref,
+        )
+
+    return send
+
+
+def _keyless_invitation_flow(
+    *,
+    slug: str,
+    bridge_client: Any,
+    operator_slug: str,
+    auto_accept_space_invitations: bool,
+):
+    """Build exactly one invitation flow for a real keyless bridge client.
+
+    Native clients keep no flow and never touch the signed HTTP invitation
+    path. The flow loads its durable per-Agent invitation state here, so a
+    reconnect resumes the same records instead of minting a second flow.
+    """
+    if bridge_client is None:
+        return None
+    from .keyless_invitation_flow import KeylessInvitationFlow
+
+    return KeylessInvitationFlow(
+        slug=slug,
+        bridge=bridge_client,
+        operator_slug=operator_slug,
+        send_dm=_bridge_invite_prompt_send(bridge_client, operator_slug),
+        auto_accept_space_invitations=auto_accept_space_invitations,
+    )
+
+
 def initial_client_state(
     *,
     agent_id: str = "",
@@ -171,4 +218,10 @@ def initial_client_state(
         logging.getLogger("puffo_agent.agent.puffo_core_client"), {"agent": slug}
     )
     state["_contacts"] = _contacts(http_client, state["_log"], slug=slug)
+    state["_keyless_invitation_flow"] = _keyless_invitation_flow(
+        slug=slug,
+        bridge_client=bridge_client,
+        operator_slug=operator_slug,
+        auto_accept_space_invitations=auto_accept_space_invitations,
+    )
     return state

--- a/src/puffo_agent/agent/client_support.py
+++ b/src/puffo_agent/agent/client_support.py
@@ -22,6 +22,12 @@ DM_GATE_PROMPT_PLACEHOLDER = (
     "[foreign-DM approval prompt — held message withheld from context]"
 )
 
+# Stored in place of the agent's own keyless invitation prompt when the
+# server echoes it back. The echo is an operator-control artifact, not
+# model context; storing the operator-visible prompt verbatim would let the
+# agent "hear itself" ask to accept an invite it is waiting to decide.
+INVITE_PROMPT_PLACEHOLDER = "[invitation prompt — operator decision pending]"
+
 
 class AgentLogger(logging.LoggerAdapter):
     """Prefix daemon logs with the active agent slug."""

--- a/src/puffo_agent/agent/contact_cache.py
+++ b/src/puffo_agent/agent/contact_cache.py
@@ -2,11 +2,19 @@
 from puffo-server. Per-agent - the server scopes both lists to the
 authenticated identity. Single read/write point for every allow/block
 decision - never hit /allowlists + /blocklists ad hoc.
+
+A keyless transport can never hydrate those signed lists, so a cache given
+an optional per-agent local-state path serves (and atomically persists) a
+small JSON allow/block set instead. Signed caches and keyless caches without
+a path keep today's server/in-memory behavior unchanged.
 """
 
 from __future__ import annotations
 
+import json
+import os
 import time
+from pathlib import Path
 from typing import Any
 
 
@@ -31,6 +39,7 @@ class ContactCache:
         *,
         ttl: float = 300.0,
         miss_refresh_interval: float = 15.0,
+        local_state_path: str | os.PathLike[str] | None = None,
     ):
         self._http = http_client
         self._log = log
@@ -43,6 +52,12 @@ class ContactCache:
         # True once a server read has actually landed. Distinguishes "the
         # server says these are blocked" from "we have never been told".
         self._hydrated = False
+        # Keyless-only per-Agent local persistence. ``None`` (the default)
+        # keeps every caller's behavior exactly as it was.
+        self._local_state_path = (
+            Path(local_state_path) if local_state_path is not None else None
+        )
+        self._local_state_loaded = False
 
     @property
     def _keyless(self) -> bool:
@@ -89,6 +104,59 @@ class ContactCache:
             return float("inf")
         return time.monotonic() - self._fetched_at
 
+    def _ensure_local_state(self) -> None:
+        """Load the keyless local allow/block set once, if this cache owns it.
+
+        A keyless transport cannot hydrate from the signed server lists, so a
+        cache handed a per-agent path answers from the small JSON set that
+        ``note_allowed`` / ``note_blocked`` persist. Signed caches and keyless
+        caches without a path never read the file and never write one.
+        """
+        if self._local_state_loaded or self._local_state_path is None:
+            return
+        self._local_state_loaded = True
+        if not self._keyless:
+            return
+        path = self._local_state_path
+        if not path.exists():
+            return
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            self._log.warning(
+                "contact_cache: keyless local state %s unreadable (%s); "
+                "starting empty",
+                path,
+                exc,
+            )
+            return
+        if isinstance(raw, dict):
+            allow = raw.get("allow")
+            block = raw.get("block")
+            if isinstance(allow, list):
+                self._allow = {str(entry) for entry in allow if entry} - {""}
+            if isinstance(block, list):
+                self._block = {str(entry) for entry in block if entry} - {""}
+        # The sets stay mutually exclusive even if a hand-edited file breaks
+        # the invariant; an explicit block wins over an allow.
+        self._allow -= self._block
+
+    def _persist_local_state(self) -> None:
+        """Atomically write the keyless local allow/block sets, if owned."""
+        if self._local_state_path is None or not self._keyless:
+            return
+        path = self._local_state_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(
+                {"allow": sorted(self._allow), "block": sorted(self._block)},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+
     async def _maybe_refresh(self, *, on_miss: bool) -> None:
         age = self._age()
         if age >= self._ttl:
@@ -99,6 +167,7 @@ class ContactCache:
     async def is_allowed(self, slug: str) -> bool:
         if not slug:
             return False
+        self._ensure_local_state()
         await self._maybe_refresh(on_miss=slug not in self._allow)
         return slug in self._allow
 
@@ -115,6 +184,7 @@ class ContactCache:
         """
         if not slug:
             return False
+        self._ensure_local_state()
         await self._maybe_refresh(on_miss=False)
         if not self._hydrated and not self._keyless:
             raise BlocklistUnavailable(
@@ -123,13 +193,36 @@ class ContactCache:
         return slug in self._block
 
     def note_allowed(self, slug: str) -> None:
-        if slug:
+        if not slug:
+            return
+        self._ensure_local_state()
+        changed = False
+        if self._keyless and slug in self._block:
+            # The allow/block sets stay mutually exclusive; an explicit allow
+            # cancels a block the operator is reversing.
+            self._block.discard(slug)
+            changed = True
+        if slug not in self._allow:
             self._allow.add(slug)
+            changed = True
+        if changed:
+            self._persist_local_state()
 
     def note_blocked(self, slug: str, blocked: bool) -> None:
         if not slug:
             return
+        self._ensure_local_state()
         if blocked:
-            self._block.add(slug)
-        else:
+            changed = False
+            if self._keyless and slug in self._allow:
+                # Mutual exclusion, mirrored from ``note_allowed``.
+                self._allow.discard(slug)
+                changed = True
+            if slug not in self._block:
+                self._block.add(slug)
+                changed = True
+            if changed:
+                self._persist_local_state()
+        elif slug in self._block:
             self._block.discard(slug)
+            self._persist_local_state()

--- a/src/puffo_agent/agent/contact_cache.py
+++ b/src/puffo_agent/agent/contact_cache.py
@@ -157,6 +157,21 @@ class ContactCache:
         )
         os.replace(tmp, path)
 
+    def _persist_or_rollback(self, allow_before: set[str], block_before: set[str]) -> None:
+        """Persist keyless state, restoring the pre-mutation sets on failure.
+
+        The mutation has already been applied in memory; if the durable write
+        raises, the sets are rolled back and the error re-raised so the caller
+        can retry as a full mutation. Memory must never run ahead of disk, or
+        a retry would see "no change" and skip persistence entirely.
+        """
+        try:
+            self._persist_local_state()
+        except OSError:
+            self._allow = allow_before
+            self._block = block_before
+            raise
+
     async def _maybe_refresh(self, *, on_miss: bool) -> None:
         age = self._age()
         if age >= self._ttl:
@@ -196,8 +211,12 @@ class ContactCache:
         if not slug:
             return
         self._ensure_local_state()
+        keyless = self._keyless
+        if keyless:
+            allow_before = set(self._allow)
+            block_before = set(self._block)
         changed = False
-        if self._keyless and slug in self._block:
+        if keyless and slug in self._block:
             # The allow/block sets stay mutually exclusive; an explicit allow
             # cancels a block the operator is reversing.
             self._block.discard(slug)
@@ -205,24 +224,29 @@ class ContactCache:
         if slug not in self._allow:
             self._allow.add(slug)
             changed = True
-        if changed:
-            self._persist_local_state()
+        if changed and keyless:
+            self._persist_or_rollback(allow_before, block_before)
 
     def note_blocked(self, slug: str, blocked: bool) -> None:
         if not slug:
             return
         self._ensure_local_state()
+        keyless = self._keyless
+        if keyless:
+            allow_before = set(self._allow)
+            block_before = set(self._block)
         if blocked:
             changed = False
-            if self._keyless and slug in self._allow:
+            if keyless and slug in self._allow:
                 # Mutual exclusion, mirrored from ``note_allowed``.
                 self._allow.discard(slug)
                 changed = True
             if slug not in self._block:
                 self._block.add(slug)
                 changed = True
-            if changed:
-                self._persist_local_state()
+            if changed and keyless:
+                self._persist_or_rollback(allow_before, block_before)
         elif slug in self._block:
             self._block.discard(slug)
-            self._persist_local_state()
+            if keyless:
+                self._persist_or_rollback(allow_before, block_before)

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -390,16 +390,24 @@ class PuffoAgent:
         )
         result = await self.adapter.run_turn(ctx)
 
+        turn_complete_payload = {
+            "tokens": {
+                "input": result.input_tokens,
+                "output": result.output_tokens,
+            }
+        }
+        context_tokens = result.metadata.get("context_tokens")
+        if (
+            isinstance(context_tokens, int)
+            and not isinstance(context_tokens, bool)
+            and context_tokens > 0
+        ):
+            turn_complete_payload["current_context"] = context_tokens
         asyncio.ensure_future(
             get_reporter().emit(
                 self.agent_id,
                 "turn_complete",
-                {
-                    "tokens": {
-                        "input": result.input_tokens,
-                        "output": result.output_tokens,
-                    }
-                },
+                turn_complete_payload,
             )
         )
 

--- a/src/puffo_agent/agent/dm_approvals.py
+++ b/src/puffo_agent/agent/dm_approvals.py
@@ -5,12 +5,113 @@ from __future__ import annotations
 import json
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from ..portal.state import agent_dir
 
 logger = logging.getLogger(__name__)
+
+# Marker distinguishing a keyless resumable approval record from a legacy
+# native prompt record inside the same flat JSON file.
+KEYLESS_APPROVAL_KIND = "keyless_dm_approval"
+
+# The exact operator decisions a keyless record may carry. "pending" means
+# no exact answer has been received yet.
+DM_APPROVAL_DECISIONS = frozenset({"pending", "approved", "denied"})
+
+# Completion phases: a record opens ``pending`` and moves to ``applied`` once
+# the allow/block mutation and denial tombstone have been committed.
+DM_APPROVAL_PHASES = frozenset({"pending", "applied"})
+
+
+@dataclass(frozen=True)
+class KeylessDmApproval:
+    """Resumable keyless DM approval, keyed by the held foreign envelope.
+
+    The bridge orchestration needs one durable record per held DM so a
+    restart can still correlate the operator's reply to the exact envelope.
+    ``envelope_id`` is both the JSON key and a validated field; ``server_seq``
+    and the prompt envelope/thread ids are genuinely optional (the keyless
+    lane can be sequence-less and a prompt may have no envelope/thread).
+    ``decision`` is the exact operator answer and ``phase`` its completion
+    stage — both restricted to the vocabularies above.
+    """
+
+    envelope_id: str
+    sender_slug: str
+    operator_slug: str
+    server_seq: int | None
+    prompt_client_ref: str
+    prompt_envelope_id: str | None
+    prompt_thread_id: str | None
+    decision: str
+    phase: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": KEYLESS_APPROVAL_KIND,
+            "envelope_id": self.envelope_id,
+            "sender_slug": self.sender_slug,
+            "operator_slug": self.operator_slug,
+            "server_seq": self.server_seq,
+            "prompt_client_ref": self.prompt_client_ref,
+            "prompt_envelope_id": self.prompt_envelope_id,
+            "prompt_thread_id": self.prompt_thread_id,
+            "decision": self.decision,
+            "phase": self.phase,
+        }
+
+
+def parse_keyless_approval(value: Any) -> KeylessDmApproval | None:
+    """Validate one keyless record's exact shape; ``None`` when malformed.
+
+    Every field is type-checked and the decision/phase vocabulary enforced,
+    so a corrupt or hand-edited record can never silently resurface as
+    approval state. ``server_seq`` and the prompt thread/envelope ids are
+    genuinely optional; the rest are required.
+    """
+    if not isinstance(value, dict) or value.get("kind") != KEYLESS_APPROVAL_KIND:
+        return None
+    envelope_id = value.get("envelope_id")
+    sender_slug = value.get("sender_slug")
+    operator_slug = value.get("operator_slug")
+    prompt_client_ref = value.get("prompt_client_ref")
+    if not isinstance(envelope_id, str) or not envelope_id:
+        return None
+    if not isinstance(sender_slug, str) or not sender_slug:
+        return None
+    if not isinstance(operator_slug, str):
+        return None
+    server_seq = value.get("server_seq")
+    if server_seq is not None and (
+        isinstance(server_seq, bool) or not isinstance(server_seq, int)
+    ):
+        return None
+    if not isinstance(prompt_client_ref, str) or not prompt_client_ref:
+        return None
+    prompt_envelope_id = value.get("prompt_envelope_id")
+    if prompt_envelope_id is not None and not isinstance(prompt_envelope_id, str):
+        return None
+    prompt_thread_id = value.get("prompt_thread_id")
+    if prompt_thread_id is not None and not isinstance(prompt_thread_id, str):
+        return None
+    decision = value.get("decision")
+    phase = value.get("phase")
+    if decision not in DM_APPROVAL_DECISIONS or phase not in DM_APPROVAL_PHASES:
+        return None
+    return KeylessDmApproval(
+        envelope_id=envelope_id,
+        sender_slug=sender_slug,
+        operator_slug=operator_slug,
+        server_seq=server_seq,
+        prompt_client_ref=prompt_client_ref,
+        prompt_envelope_id=prompt_envelope_id,
+        prompt_thread_id=prompt_thread_id,
+        decision=decision,
+        phase=phase,
+    )
 
 
 def _pending_dir(slug: str) -> Path:
@@ -22,6 +123,10 @@ def pending_dm_approvals_path(slug: str) -> Path:
 
 
 def load_pending_dm_approvals(slug: str) -> dict[str, dict[str, Any]]:
+    """Load legacy native prompt records plus valid keyless records from one
+    flat file. Malformed keyless records are skipped (never resurfaced as
+    approval state); legacy native dictionary records pass through unchanged.
+    """
     path = pending_dm_approvals_path(slug)
     if not path.exists():
         return {}
@@ -36,11 +141,23 @@ def load_pending_dm_approvals(slug: str) -> dict[str, dict[str, Any]]:
         return {}
     if not isinstance(raw, dict):
         return {}
-    return {
-        key: value
-        for key, value in raw.items()
-        if isinstance(value, dict)
-    }
+    loaded: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if not isinstance(value, dict):
+            continue
+        if value.get("kind") == KEYLESS_APPROVAL_KIND:
+            parsed = parse_keyless_approval(value)
+            if parsed is None or parsed.envelope_id != key:
+                logger.warning(
+                    "pending_dm_approvals: skipping malformed keyless "
+                    "record %s",
+                    key,
+                )
+                continue
+            loaded[key] = parsed.to_dict()
+        else:
+            loaded[key] = value
+    return loaded
 
 
 def save_pending_dm_approvals(

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -16,7 +16,7 @@ import uuid
 from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Sequence
+from typing import Any, Awaitable, Callable, Protocol, Sequence
 
 from .context_controller import (
     AdmissionCandidate,
@@ -56,7 +56,7 @@ DEGRADED_RECOVERY_MAX_SECONDS = 300.0
 
 from .global_inbox_held import HeldRecoverySource
 from .global_inbox_send import TrackingSendDelegate
-from .global_inbox_admission import InboxAdmissionMixin
+from .global_inbox_admission import InboxAdmissionMixin, InboxReadContext
 from .global_inbox_types import (
     ActiveBoundaryAdapter,
     ActiveExactUnion,
@@ -96,6 +96,7 @@ __all__ = [
     "SendAttemptState",
     "TrackingSendDelegate",
     "ToolResultAdmission",
+    "TurnStatusLifecycle",
     "await_listener_with_runtime",
     "conservative_token_estimate",
     "format_stored_message",
@@ -105,6 +106,27 @@ __all__ = [
 
 TurnRunner = Callable[[PlannedTurn], Awaitable[Any]]
 UnfitPolicy = Callable[..., bool | Awaitable[bool]]
+
+
+class TurnStatusLifecycle(Protocol):
+    """Optional worker-owned mirror of the active Global Inbox turn.
+
+    The runtime owns only the durable turn lifecycle; it notifies this
+    callback with immutable active-union snapshots so the worker can drive
+    Server processing-row status without moving status policy in here.
+    """
+
+    async def on_turn_active(self, message_ids: tuple[str, ...]) -> None:
+        """Report that the active union is (or has grown to) ``message_ids``."""
+
+    async def on_turn_terminal(
+        self,
+        *,
+        message_ids: tuple[str, ...],
+        succeeded: bool,
+        error_text: str | None,
+    ) -> None:
+        """Settle the exact active union in one terminal status batch."""
 
 
 class GlobalInboxRuntime(InboxAdmissionMixin):
@@ -133,6 +155,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         notice_delivery: InboxNoticeDelivery | None = None,
         runtime_event_outbox: Any | None = None,
         reminder_scheduler: ReminderScheduler | None = None,
+        status_lifecycle: TurnStatusLifecycle | None = None,
     ) -> None:
         self.store = store
         self.adapter = adapter
@@ -179,6 +202,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             store=store,
             notify=self.notify,
         )
+        self.status_lifecycle = status_lifecycle
         self.send_delegate: TrackingSendDelegate | None = None
         self.held_recovery_source = HeldRecoverySource(
             self,
@@ -700,6 +724,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         self.active.routes[:] = list(planned.routes)
         if self.coordinator is not None:
             self.coordinator.provider_session_id = event.provider_session_id
+        await self._notify_status_active()
         log_runtime_event(
             logger,
             "turn.admitted",
@@ -725,6 +750,98 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                 notice_generation=planned.notice_generation,
                 outcome="admitted",
             )
+
+    async def _notify_status_active(self) -> None:
+        """Expose the exact active union to the worker's status lifecycle.
+
+        Telemetry-only: a reporter failure must never break admission or
+        processing-state decisions, so the callback is shielded here.
+        """
+        if self.status_lifecycle is None or not self.active.message_ids:
+            return
+        try:
+            await self.status_lifecycle.on_turn_active(
+                tuple(self.active.message_ids)
+            )
+        except Exception:
+            logger.warning(
+                "agent %s: status lifecycle admission notify failed",
+                self.agent_id,
+                exc_info=True,
+            )
+
+    async def _notify_status_terminal(
+        self,
+        *,
+        terminal: bool,
+        succeeded: bool,
+        error_text: str | None,
+    ) -> None:
+        """Settle the exact active union before ``_finalize_process`` clears it.
+
+        Only a terminal turn settles status; the batch is built from the same
+        immutable snapshot the durable requeue/process just used.
+        """
+        if self.status_lifecycle is None or not terminal:
+            return
+        try:
+            await self.status_lifecycle.on_turn_terminal(
+                message_ids=tuple(self.active.message_ids),
+                succeeded=succeeded,
+                error_text=error_text,
+            )
+        except Exception:
+            logger.warning(
+                "agent %s: status lifecycle terminal notify failed",
+                self.agent_id,
+                exc_info=True,
+            )
+
+    async def _admit_inbox_read(
+        self,
+        context: InboxReadContext,
+        event: ProviderAdmissionEvent,
+        fired: list[bool],
+    ) -> None:
+        """Admit a mid-turn Inbox read, then expose the grown active union.
+
+        The durable admission and its processing-state decisions stay in the
+        implementation trait; this override only mirrors the post-admission
+        union into the worker's status lifecycle.
+        """
+        await super()._admit_inbox_read(context, event, fired)
+        await self._notify_status_active()
+
+    async def _admit_held_recovery(
+        self,
+        event: ProviderAdmissionEvent,
+        *,
+        fired: list[bool],
+        correlation_key: str,
+        active_turn_id: str,
+        provider_session_id: str,
+        evidence: Any,
+        evidence_key: tuple[str, str, str, str, int, str],
+        displayed_ids: tuple[str, ...],
+        space_id: str,
+        channel_id: str,
+        latest_seq: int,
+    ) -> None:
+        """Admit a held-send recovery, then expose the grown active union."""
+        await super()._admit_held_recovery(
+            event,
+            fired=fired,
+            correlation_key=correlation_key,
+            active_turn_id=active_turn_id,
+            provider_session_id=provider_session_id,
+            evidence=evidence,
+            evidence_key=evidence_key,
+            displayed_ids=displayed_ids,
+            space_id=space_id,
+            channel_id=channel_id,
+            latest_seq=latest_seq,
+        )
+        await self._notify_status_active()
 
     def _write_current_turn(self, planned: PlannedTurn) -> None:
         path = self.current_turn_path
@@ -1099,21 +1216,26 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                 or any(item.is_encrypted for item in planned.items),
             )
             terminal = False
+            terminal_succeeded = False
+            terminal_error: str | None = None
             try:
                 await self._invoke_turn_with_retries(planned)
                 if self.active.turn_id == planned.turn_id:
                     await self._mark_active_processed(planned, process_started)
                     terminal = True
+                    terminal_succeeded = True
                 else:
                     self._degrade("provider returned without correlated admission")
             except asyncio.CancelledError:
                 await self._requeue_active_turn(planned, process_started, "cancelled")
                 terminal = True
+                terminal_error = "global inbox turn cancelled before completion"
                 raise
             except Exception as exc:
                 terminal = await self._requeue_active_turn(
                     planned, process_started, "provider_error"
                 )
+                terminal_error = f"{type(exc).__name__}: {exc}"
                 diagnostic = (
                     "turn failed and was requeued"
                     if terminal
@@ -1135,6 +1257,11 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                     outcome="requeued" if terminal else "degraded",
                 )
             finally:
+                await self._notify_status_terminal(
+                    terminal=terminal,
+                    succeeded=terminal_succeeded,
+                    error_text=terminal_error,
+                )
                 self._finalize_process(planned, terminal)
             await self._wake_remaining_pending()
             return True

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -116,12 +116,15 @@ class TurnStatusLifecycle(Protocol):
     Server processing-row status without moving status policy in here.
     """
 
-    async def on_turn_active(self, message_ids: tuple[str, ...]) -> None:
+    async def on_turn_active(
+        self, *, turn_id: str, message_ids: tuple[str, ...]
+    ) -> None:
         """Report that the active union is (or has grown to) ``message_ids``."""
 
     async def on_turn_terminal(
         self,
         *,
+        turn_id: str,
         message_ids: tuple[str, ...],
         succeeded: bool,
         error_text: str | None,
@@ -382,6 +385,12 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                 mode="startup_orphan_recovery",
                 message_count=len(run.message_ids),
                 outcome="requeued",
+            )
+            await self._settle_recovered_status(
+                turn_id=run.turn_id,
+                message_ids=tuple(run.message_ids),
+                succeeded=False,
+                error_text="orphaned durable turn requeued at startup",
             )
             recovered += 1
         return recovered
@@ -757,11 +766,16 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         Telemetry-only: a reporter failure must never break admission or
         processing-state decisions, so the callback is shielded here.
         """
-        if self.status_lifecycle is None or not self.active.message_ids:
+        if (
+            self.status_lifecycle is None
+            or not self.active.turn_id
+            or not self.active.message_ids
+        ):
             return
         try:
             await self.status_lifecycle.on_turn_active(
-                tuple(self.active.message_ids)
+                turn_id=self.active.turn_id,
+                message_ids=tuple(self.active.message_ids),
             )
         except Exception:
             logger.warning(
@@ -782,10 +796,11 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         Only a terminal turn settles status; the batch is built from the same
         immutable snapshot the durable requeue/process just used.
         """
-        if self.status_lifecycle is None or not terminal:
+        if self.status_lifecycle is None or not terminal or not self.active.turn_id:
             return
         try:
             await self.status_lifecycle.on_turn_terminal(
+                turn_id=self.active.turn_id,
                 message_ids=tuple(self.active.message_ids),
                 succeeded=succeeded,
                 error_text=error_text,
@@ -793,6 +808,42 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         except Exception:
             logger.warning(
                 "agent %s: status lifecycle terminal notify failed",
+                self.agent_id,
+                exc_info=True,
+            )
+
+    async def _settle_recovered_status(
+        self,
+        *,
+        turn_id: str,
+        message_ids: tuple[str, ...],
+        succeeded: bool,
+        error_text: str | None,
+    ) -> None:
+        """Reconstruct and settle a processing run after process restart."""
+        if self.status_lifecycle is None or not turn_id or not message_ids:
+            return
+        try:
+            await self.status_lifecycle.on_turn_active(
+                turn_id=turn_id,
+                message_ids=message_ids,
+            )
+        except Exception:
+            logger.warning(
+                "agent %s: recovered status lifecycle admission failed",
+                self.agent_id,
+                exc_info=True,
+            )
+        try:
+            await self.status_lifecycle.on_turn_terminal(
+                turn_id=turn_id,
+                message_ids=message_ids,
+                succeeded=succeeded,
+                error_text=error_text,
+            )
+        except Exception:
+            logger.warning(
+                "agent %s: recovered status lifecycle terminal notify failed",
                 self.agent_id,
                 exc_info=True,
             )
@@ -1499,6 +1550,20 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         )
         self.health = RuntimeHealth(state, diagnostic)
         self._defer_requeued_recovery = defer_requeued_recovery and requeued
+        if activated:
+            await self._notify_status_terminal(
+                terminal=True,
+                succeeded=False,
+                error_text=diagnostic,
+            )
+        elif run is not None:
+            succeeded = run.state == ProcessingState.PROCESSED.value
+            await self._settle_recovered_status(
+                turn_id=run.turn_id,
+                message_ids=tuple(run.message_ids),
+                succeeded=succeeded,
+                error_text=None if succeeded else diagnostic,
+            )
         self._clear_terminal_turn()
         if requeued:
             self.notify()
@@ -1624,6 +1689,11 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             duration_ms=int((time.monotonic() - recovery_started) * 1000),
         )
         self.health = RuntimeHealth()
+        await self._notify_status_terminal(
+            terminal=True,
+            succeeded=True,
+            error_text=None,
+        )
         self._clear_terminal_turn()
         return True
 
@@ -1649,6 +1719,11 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             error_category="cancelled",
         )
         self.health = RuntimeHealth("degraded", "crash resume cancelled and requeued")
+        await self._notify_status_terminal(
+            terminal=True,
+            succeeded=False,
+            error_text="crash resume cancelled and requeued",
+        )
         self._clear_terminal_turn()
         self.notify()
 
@@ -1701,6 +1776,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                 diagnostic="crash join identity, route, or target mismatch",
             )
         self._activate_recovery(planned, durable_ids, run.provider_session_id)
+        await self._notify_status_active()
         from . import send_mode
 
         # A resumed turn establishes the same send-mode facts ``process_once``

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -44,7 +44,7 @@ from .message_store import (
 from ._logging import log_runtime_event
 from .message_projection import CONTEXT_VERSION, format_message_group
 from .reminder_scheduler import ReminderScheduler
-from .shared_content import INBOX_RESPONSE_DECISION_CUE
+from .shared_content import INBOX_TURN_CUE
 
 logger = logging.getLogger(__name__)
 
@@ -499,7 +499,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             "<global_inbox_notice>\n"
             + summary
             + "\n</global_inbox_notice>\n"
-            + INBOX_RESPONSE_DECISION_CUE
+            + INBOX_TURN_CUE
         )
         log_runtime_event(
             logger,

--- a/src/puffo_agent/agent/global_inbox_types.py
+++ b/src/puffo_agent/agent/global_inbox_types.py
@@ -227,6 +227,11 @@ class BaselineAdapter:
     ) -> int | None:
         return await self.store.get_context_baseline(space_id, channel_id)
 
+    async def set_context_baseline_seq(
+        self, space_id: str, channel_id: str, context_baseline_seq: int
+    ) -> None:
+        await self.store.set_context_baseline(space_id, channel_id, context_baseline_seq)
+
 
 class ActiveBoundaryAdapter:
     """Inject the active turn id into the authoritative store query."""

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -616,13 +616,20 @@ class ClaudeCodeCliDriver(Driver):
             )
             return
         usage = frame.get("usage") or {}
+        input_tokens = int(usage.get("input_tokens") or 0) + int(
+            usage.get("cache_creation_input_tokens") or 0
+        )
+        context_tokens = input_tokens + int(
+            usage.get("cache_read_input_tokens") or 0
+        )
         await self._emit(
             HarnessEventType.TURN_COMPLETED,
             turn_ref=self._active,
             data={
                 "outcome": "failed" if subtype not in {"success", ""} else "succeeded",
-                "input_tokens": int(usage.get("input_tokens") or 0),
+                "input_tokens": input_tokens,
                 "output_tokens": int(usage.get("output_tokens") or 0),
+                "context_tokens": context_tokens,
             },
             native_payload=frame,
         )

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timezone
 from typing import Any
 
+from ..cli_bin import normalize_launch_argv
 from .driver import (
     CancelCapability,
     CompactCapability,
@@ -108,7 +109,7 @@ class ClaudeCodeCliDriver(Driver):
         if self._closed:
             self._prepare_reopen()
         args = [
-            spec.executable or "claude",
+            *normalize_launch_argv(spec.executable or "claude"),
             *spec.launch_args,
             "-p",
             "--input-format",

--- a/src/puffo_agent/agent/harness/codex_driver.py
+++ b/src/puffo_agent/agent/harness/codex_driver.py
@@ -218,6 +218,11 @@ class CodexAppServerDriver(Driver):
         self._fallback_block_id: str | None = None
         self._fallback_block_counter = 0
         self._closed = False
+        # Turn-scoped token accounting: the baseline freezes on the first
+        # observed thread totals and the latest derived values stand at
+        # turn/completed. Cleared on every terminal, start-failure, and close.
+        self._usage_baseline: tuple[int, int] | None = None
+        self._usage_latest: dict[str, int] = {}
 
     async def open(
         self, spec: RuntimeSpec, resume: SessionRef | None = None
@@ -338,6 +343,10 @@ class CodexAppServerDriver(Driver):
     async def start_turn(self, input: TurnInput):
         if self._active.value:
             raise RuntimeError("one turn is already active")
+        # Clear the previous turn before issuing turn/start. The reader may
+        # receive this turn's first tokenUsage notification immediately after
+        # the response future resolves, before this coroutine resumes.
+        self._reset_usage()
         local = TurnRef(f"turn_{uuid.uuid4().hex}")
         self._active = local
         params: dict[str, Any] = {
@@ -350,11 +359,13 @@ class CodexAppServerDriver(Driver):
             result = await self._request("turn/start", params)
         except BaseException:
             self._active = TurnRef("")
+            self._reset_usage()
             raise
         turn = result.get("turn", result) if isinstance(result, dict) else {}
         native = str(turn.get("id") or turn.get("turnId") or "")
         if not native:
             self._active = TurnRef("")
+            self._reset_usage()
             raise RuntimeError("Codex turn/start omitted native turn id")
         self._active_native_turn_id = native
         return TurnStarted(local, native)
@@ -457,6 +468,7 @@ class CodexAppServerDriver(Driver):
         self._permission_requests.clear()
         self._open_output_blocks.clear()
         self._fallback_block_id = None
+        self._reset_usage()
         self._context = ContextStatus(stale=True)
         await self._events.put(None)
 
@@ -470,6 +482,7 @@ class CodexAppServerDriver(Driver):
         self._permission_requests.clear()
         self._open_output_blocks.clear()
         self._fallback_block_id = None
+        self._reset_usage()
         self._context = ContextStatus(stale=True)
 
     def _fail_pending_requests(self, message: str) -> None:
@@ -649,6 +662,7 @@ class CodexAppServerDriver(Driver):
                 context_window=_integer(usage.get("modelContextWindow")),
                 stale=False,
             )
+            self._update_usage(usage)
             await self._emit(
                 HarnessEventType.CONTEXT_UPDATED,
                 turn_ref=self._active,
@@ -824,10 +838,13 @@ class CodexAppServerDriver(Driver):
             if "fail" in status
             else "succeeded"
         )
+        data: dict[str, Any] = {"outcome": outcome}
+        if self._usage_latest:
+            data.update(self._usage_latest)
         await self._emit(
             HarnessEventType.TURN_COMPLETED,
             turn_ref=self._active,
-            data={"outcome": outcome},
+            data=data,
             native_payload=frame,
         )
         # Permission requests are scoped to the sole active turn. Once that
@@ -835,6 +852,53 @@ class CodexAppServerDriver(Driver):
         # retain no unreachable request payloads in the long-lived Driver.
         self._permission_requests.clear()
         self._active, self._active_native_turn_id = TurnRef(""), ""
+        self._reset_usage()
+
+    def _update_usage(self, usage: dict[str, Any]) -> None:
+        """Restore the historical per-turn ``last``/``total`` token semantics.
+
+        ``last`` is the latest single request; ``total`` is the whole thread.
+        The turn's input/output are non-negative deltas from the first observed
+        thread totals, with re-sent cached input excluded, and context comes
+        from ``last.totalTokens``. The final values stand at turn/completed.
+        """
+        last = usage.get("last")
+        total = usage.get("total")
+        if not isinstance(last, dict) or not isinstance(total, dict):
+            return
+        context_tokens = last.get("totalTokens")
+        if (
+            isinstance(context_tokens, int)
+            and not isinstance(context_tokens, bool)
+            and context_tokens > 0
+        ):
+            self._usage_latest["context_tokens"] = context_tokens
+        try:
+            cum_out = int(total.get("outputTokens") or 0)
+            cum_in = max(
+                0,
+                int(total.get("inputTokens") or 0)
+                - int(total.get("cachedInputTokens") or 0),
+            )
+            if self._usage_baseline is None:
+                last_in = max(
+                    0,
+                    int(last.get("inputTokens") or 0)
+                    - int(last.get("cachedInputTokens") or 0),
+                )
+                self._usage_baseline = (
+                    cum_out - int(last.get("outputTokens") or 0),
+                    cum_in - last_in,
+                )
+            out_base, in_base = self._usage_baseline
+            self._usage_latest["output_tokens"] = max(0, cum_out - out_base)
+            self._usage_latest["input_tokens"] = max(0, cum_in - in_base)
+        except (TypeError, ValueError):
+            return
+
+    def _reset_usage(self) -> None:
+        self._usage_baseline = None
+        self._usage_latest = {}
 
     async def _emit(
         self,

--- a/src/puffo_agent/agent/harness/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/docker_runtime.py
@@ -1,0 +1,548 @@
+"""Prepare and own the per-agent Docker Codex runtime.
+
+Runs the pinned Codex CLI's ``codex app-server`` inside the per-Agent
+container through a bounded ``docker exec -i`` transport consumed by
+:class:`~puffo_agent.agent.harness.codex_driver.CodexAppServerDriver`.
+The container is the sandbox, so codex runs with
+``danger-full-access`` and the Driver auto-approves permissions.
+
+Isolation: the agent's Codex home (``CODEX_HOME``), auth view, config,
+skills, and MCPs are synchronized host-side and bind-mounted at the
+container's ``/home/agent/.codex``. The operator's ``~/.codex`` is
+never mounted; bearer/API values cross only as named ``-e`` variables,
+never as argv literals. The owner starts the container on prepare and
+stops it with a bounded ``docker stop -t 5`` after the Driver closes —
+never ``rm -f`` on a live runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..._proc import no_window_kwargs
+from ...mcp.config import puffo_core_mcp_env, write_codex_mcp_config
+from ...portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    agent_codex_user_dir,
+    agent_dir,
+    agent_home_dir,
+    read_host_codex_mcp_servers,
+    shared_fs_dir,
+    sync_host_codex_auth_view,
+    sync_host_codex_skills,
+)
+from ..adapters.desired_install import run_spawn_install
+from ..adapters.docker_cli import (
+    DEFAULT_IMAGE,
+    _puffo_agent_pkg_dir,
+    _run_cmd,
+    container_state,
+    ensure_docker_image,
+    CONTAINER_LAYOUT_VERSION,
+)
+from ..cli_bin import resolve_docker_bin
+from .driver import RuntimeSpec
+from .local_runtime import (
+    PreparedLocalRuntime,
+    _read_json_object,
+    build_codex_gateway_provider,
+    compute_session_fingerprint,
+)
+from ...portal.host_assets import filter_container_mcp_servers
+
+logger = logging.getLogger(__name__)
+
+# Container-local paths for the codex process, its auth/config home, and
+# the puffo-core MCP's per-agent state (keystore + memory). ``agent_home``
+# host dir is bind-mounted at CODEX_CONTAINER_STATE_DIR, exactly like the
+# Claude Docker runtime.
+CODEX_CONTAINER_CODEX_HOME = "/home/agent/.codex"
+CODEX_CONTAINER_STATE_DIR = "/home/agent/.puffo-agent-state"
+# The container is the filesystem boundary. A second bubblewrap sandbox
+# cannot create user namespaces under Docker's default seccomp policy, so
+# codex always runs fully open inside the container.
+CODEX_CONTAINER_SANDBOX = "danger-full-access"
+
+# Distinct from DockerCLIAdapter's plain layout marker: the extra ":codex"
+# suffix forces a container rebuild when an agent flips between the Claude
+# and Codex Docker harnesses (mount layouts differ), while a layout-version
+# bump still rebuilds both.
+_CODEX_LAYOUT_MARKER = f"{CONTAINER_LAYOUT_VERSION}:codex"
+
+_DOCKER_LAYOUT_MARKER = ".docker-layout"
+
+
+def _sanitise_permission_mode(mode: str, agent_id: str) -> str:
+    if mode in {"bypassPermissions"}:
+        return mode
+    if mode:
+        logger.warning(
+            "agent %s: permission_mode %r is not supported; using "
+            "'bypassPermissions'",
+            agent_id,
+            mode,
+        )
+    return "bypassPermissions"
+
+
+class DockerCodexPreparer:
+    """Prepare, start, and clean up one per-agent Docker Codex runtime.
+
+    Implements the same :class:`RuntimePreparer` contract as
+    :class:`LocalRuntimePreparer` so the durable Runtime Manager assembly
+    in ``local_runtime.build_local_runtime_adapter`` is shared unchanged.
+    The composition boundary additionally wires ``process_factory`` into
+    ``CodexAppServerDriver`` and ``aclose`` as the bounded container stop.
+    """
+
+    harness_name = "codex"
+
+    def __init__(self, daemon_cfg: DaemonConfig, agent_cfg: AgentConfig):
+        self.daemon_cfg = daemon_cfg
+        self.agent_cfg = agent_cfg
+        self.agent_id = agent_cfg.id
+        self.workspace_dir = agent_cfg.resolve_workspace_dir()
+        self.claude_dir = agent_cfg.resolve_claude_dir()
+        self.agent_home = agent_home_dir(self.agent_id)
+        self.codex_home = agent_codex_user_dir(self.agent_id)
+        self.shared_fs_dir = shared_fs_dir()
+        self.image = agent_cfg.runtime.docker_image or DEFAULT_IMAGE
+        self.container_name = f"puffo-{self.agent_id}"
+        self.permission_mode = _sanitise_permission_mode(
+            agent_cfg.runtime.permission_mode, self.agent_id
+        )
+        self.model = agent_cfg.runtime.model or daemon_cfg.openai.model or ""
+        self.memory_limit = (
+            agent_cfg.runtime.docker_memory_limit or daemon_cfg.docker_memory_limit
+        )
+        self.memory_reservation = (
+            agent_cfg.runtime.docker_memory_reservation
+            or daemon_cfg.docker_memory_reservation
+        )
+        self._docker_bin = "docker"
+        self._desired_codex_extras: dict[str, dict] = {}
+        self._desired_installed = False
+        self._container_stopped = False
+
+    async def prepare(
+        self,
+        *,
+        system_prompt: str,
+        persisted_native_session_id: str = "",
+        persisted_session_fingerprint: str = "",
+    ) -> PreparedLocalRuntime:
+        spec = await self.refresh_spec(system_prompt)
+        session_fingerprint = self.session_fingerprint(spec)
+        legacy_path = self._legacy_session_path()
+        legacy_id = self._load_legacy_session_id(legacy_path)
+        discarded_persisted_session = bool(
+            persisted_native_session_id
+            and persisted_session_fingerprint != session_fingerprint
+        )
+        if persisted_native_session_id and not discarded_persisted_session:
+            native_session_id = persisted_native_session_id
+            source = "runtime_event_outbox"
+        elif legacy_id:
+            native_session_id = legacy_id
+            source = "legacy_session_file"
+        else:
+            native_session_id = ""
+            source = (
+                "fresh_incompatible_persisted_session"
+                if discarded_persisted_session
+                else "fresh"
+            )
+        if discarded_persisted_session:
+            logger.info(
+                "agent %s: starting a fresh codex session because the durable "
+                "session fingerprint is missing or incompatible",
+                self.agent_id,
+            )
+        await self.ensure_container()
+        return PreparedLocalRuntime(
+            harness_name=self.harness_name,
+            spec=spec,
+            native_session_id=native_session_id,
+            migration_source=source,
+            legacy_session_path=legacy_path,
+            preparer=self,
+            session_fingerprint=session_fingerprint,
+            discarded_persisted_session=discarded_persisted_session,
+        )
+
+    def session_fingerprint(self, spec: RuntimeSpec) -> str:
+        """Fingerprint only inputs that make a native session incompatible."""
+        from ...portal.runtime_matrix import resolve_effective_provider
+
+        return compute_session_fingerprint(
+            agent_cfg=self.agent_cfg,
+            harness_name=self.harness_name,
+            provider=resolve_effective_provider(
+                "cli-docker", self.agent_cfg.runtime.provider
+            ),
+            spec=spec,
+        )
+
+    async def refresh_spec(self, system_prompt: str) -> RuntimeSpec:
+        self.workspace_dir.mkdir(parents=True, exist_ok=True)
+        self.codex_home.mkdir(parents=True, exist_ok=True)
+        agents_md = self.codex_home / "AGENTS.md"
+        if not agents_md.exists():
+            agents_md.write_text("", encoding="utf-8")
+        await self._install_desired_once()
+        return self._prepare_codex_spec(system_prompt)
+
+    async def _install_desired_once(self) -> None:
+        if self._desired_installed:
+            return
+        self._desired_installed = True
+        extras = await run_spawn_install(
+            agent_id=self.agent_id,
+            agent_home=self.agent_home,
+            workspace_dir=self.workspace_dir,
+            harness_name=self.harness_name,
+            desired_skills=self.agent_cfg.desired_skills,
+            desired_mcps=self.agent_cfg.desired_mcps,
+            server_url=self.agent_cfg.puffo_core.server_url,
+            slug=self.agent_cfg.puffo_core.slug,
+            keys_dir=str(agent_dir(self.agent_id) / "keys"),
+            containerized=True,
+        )
+        if extras:
+            self._desired_codex_extras = extras
+
+    def _codex_gateway_provider(self) -> dict[str, str] | None:
+        return build_codex_gateway_provider(
+            model=self.model,
+            llm_base_url=self.agent_cfg.runtime.llm_base_url,
+            api_key=self.agent_cfg.runtime.api_key,
+        )
+
+    def _container_puffo_mcp_env(self) -> dict[str, str] | None:
+        pc = self.agent_cfg.puffo_core
+        if not pc.is_configured():
+            return None
+        env = puffo_core_mcp_env(
+            slug=pc.slug,
+            device_id=pc.device_id,
+            server_url=pc.server_url,
+            space_id=pc.space_id,
+            keystore_dir=f"{CODEX_CONTAINER_STATE_DIR}/keys",
+            workspace="/workspace",
+            agent_id=self.agent_id,
+            data_service_url=(
+                f"http://host.docker.internal:{self.daemon_cfg.data_service.port}"
+            ),
+            rpc_url=f"http://host.docker.internal:{self.daemon_cfg.rpc_service.port}",
+            runtime_kind="cli-docker",
+            harness=self.harness_name,
+            memory_dir=f"{CODEX_CONTAINER_STATE_DIR}/memory",
+            transport=pc.transport,
+        )
+        env["CODEX_HOME"] = CODEX_CONTAINER_CODEX_HOME
+        env["PYTHONPATH"] = "/opt/puffoagent-pkg"
+        return env
+
+    def _prepare_codex_spec(self, system_prompt: str) -> RuntimeSpec:
+        host_home = Path.home()
+        host_mcps = read_host_codex_mcp_servers(host_home)
+        reachable_mcps, unreachable = filter_container_mcp_servers(host_mcps)
+        for name, command in unreachable:
+            logger.warning(
+                "agent %s: host codex MCP %r has host-local path %r that won't "
+                "resolve inside the container — SKIPPED (not injected). "
+                "Install the binary in the image or bind-mount it, then "
+                "re-sync, to make this MCP available.",
+                self.agent_id,
+                name,
+                command,
+            )
+        extras = dict(self._desired_codex_extras)
+        extras.update(reachable_mcps)
+        gateway = self._codex_gateway_provider()
+        config_kwargs: dict[str, Any] = {
+            "extra_servers": extras,
+            "inference_level": self.agent_cfg.runtime.inference_level,
+            "provider": gateway,
+        }
+        puffo_env = self._container_puffo_mcp_env()
+        if puffo_env:
+            config_kwargs.update({
+                "command": "python3",
+                "args": ["-m", "puffo_agent.mcp.puffo_core_server"],
+                "env": puffo_env,
+            })
+        else:
+            logger.warning(
+                "agent %s: cli-docker codex MCP tools unavailable — "
+                "puffo_core is not configured. populate `puffo_core:` in "
+                "agent.yml so send_message / list_channels_in_all_spaces / "
+                "etc. show up under codex's tool surface.",
+                self.agent_id,
+            )
+        write_codex_mcp_config(self.codex_home / "config.toml", **config_kwargs)
+
+        # Only codex-relevant values; never the operator's env wholesale.
+        environment: dict[str, str] = {
+            "HOME": "/home/agent",
+            "CODEX_HOME": CODEX_CONTAINER_CODEX_HOME,
+        }
+        if gateway:
+            environment["OPENAI_API_KEY"] = self.agent_cfg.runtime.api_key
+        else:
+            auth_mode = sync_host_codex_auth_view(host_home, self.codex_home)
+            if auth_mode == "no-host-file":
+                raise RuntimeError(
+                    f"agent {self.agent_id!r}: codex needs auth; run "
+                    "`codex login` on the host or configure "
+                    "runtime.llm_base_url and runtime.api_key"
+                )
+            logger.info(
+                "agent %s: refreshed Codex credential view (%s)",
+                self.agent_id,
+                auth_mode,
+            )
+        skill_count = sync_host_codex_skills(host_home, self.codex_home)
+        if skill_count:
+            logger.info(
+                "agent %s: synced %d host codex skill(s) into %s",
+                self.agent_id,
+                skill_count,
+                self.codex_home,
+            )
+
+        from ...portal.control.context_telemetry import configured_compact_pct
+
+        compact_pct = configured_compact_pct(
+            "codex", self.agent_cfg.env_overrides
+        )
+        return RuntimeSpec(
+            workspace_dir="/workspace",
+            model=self.model,
+            system_prompt=system_prompt,
+            environment=environment,
+            permission_mode=self.permission_mode,
+            sandbox=CODEX_CONTAINER_SANDBOX,
+            task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
+            auto_compact_threshold_pct=compact_pct,
+        )
+
+    def _legacy_session_path(self) -> Path:
+        return self.codex_home / "codex_session.json"
+
+    def _load_legacy_session_id(self, path: Path) -> str:
+        document = _read_json_object(path)
+        persisted_sandbox = str(
+            document.get("sandbox") or "danger-full-access"
+        )
+        if persisted_sandbox != CODEX_CONTAINER_SANDBOX:
+            logger.info(
+                "agent %s: not importing legacy Docker Codex session because "
+                "sandbox changed from %s to %s",
+                self.agent_id,
+                persisted_sandbox,
+                CODEX_CONTAINER_SANDBOX,
+            )
+            return ""
+        return str(document.get("conversation_id") or "").strip()
+
+    # ── Container lifecycle ────────────────────────────────────────────
+
+    async def ensure_container(self) -> None:
+        """Start the per-agent container, recreating it when the layout
+        marker is stale (image tag bump or a harness flip)."""
+        self._require_docker()
+        state = await container_state(self._docker_bin, self.container_name)
+        if state is None:
+            raise RuntimeError(
+                f"could not inspect Docker container {self.container_name!r}; "
+                "refusing to create or replace it while Docker is unavailable"
+            )
+        layout_current = await self._layout_is_current()
+        if state != "" and not layout_current:
+            logger.warning(
+                "agent %s: recreating Docker Codex container %r "
+                "(layout=%s)",
+                self.agent_id,
+                self.container_name,
+                layout_current,
+            )
+            if state == "running":
+                # A live prior container must be stopped through the owned
+                # bounded lifecycle before removal. A failed stop aborts the
+                # replacement instead of falling through to forced removal.
+                await _run_cmd(
+                    [self._docker_bin, "stop", "-t", "5", self.container_name],
+                )
+            await _run_cmd(
+                [self._docker_bin, "rm", self.container_name],
+            )
+            state = ""
+        if state == "running":
+            logger.info(
+                "agent %s: reusing running Docker Codex container %r",
+                self.agent_id,
+                self.container_name,
+            )
+        elif state in ("exited", "created", "dead"):
+            logger.info(
+                "agent %s: starting existing container %r (was %s)",
+                self.agent_id,
+                self.container_name,
+                state,
+            )
+            await _run_cmd([self._docker_bin, "start", self.container_name])
+        elif state == "paused":
+            logger.info(
+                "agent %s: unpausing container %r",
+                self.agent_id,
+                self.container_name,
+            )
+            await _run_cmd([self._docker_bin, "unpause", self.container_name])
+        elif state == "":
+            await ensure_docker_image(
+                self._docker_bin, self.image, agent_id=self.agent_id
+            )
+            await self._start_container()
+        else:
+            raise RuntimeError(
+                f"Docker container {self.container_name!r} is in transient "
+                f"state {state!r}; refusing to replace it"
+            )
+        self._write_layout_marker()
+
+    def _require_docker(self) -> None:
+        docker_bin = resolve_docker_bin()
+        if docker_bin is None:
+            raise RuntimeError(
+                "docker binary not found. Tried $PUFFO_DOCKER_BIN, $PATH, "
+                "the persistent user PATH, and known Docker Desktop install "
+                "locations. Install Docker Desktop (Windows/macOS) or "
+                "docker-ce (Linux) to use runtime kind 'cli-docker'."
+            )
+        self._docker_bin = docker_bin
+
+    async def _layout_is_current(self) -> bool:
+        marker = self.agent_home / _DOCKER_LAYOUT_MARKER
+        try:
+            return marker.read_text(encoding="utf-8").strip() == _CODEX_LAYOUT_MARKER
+        except OSError:
+            return False
+
+    def _write_layout_marker(self) -> None:
+        marker = self.agent_home / _DOCKER_LAYOUT_MARKER
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.write_text(_CODEX_LAYOUT_MARKER + "\n", encoding="utf-8")
+        except OSError:
+            pass
+
+    async def _start_container(self) -> None:
+        self.workspace_dir.mkdir(parents=True, exist_ok=True)
+        self.codex_home.mkdir(parents=True, exist_ok=True)
+        self.agent_home.mkdir(parents=True, exist_ok=True)
+        self.shared_fs_dir.mkdir(parents=True, exist_ok=True)
+        command = [
+            self._docker_bin,
+            "run",
+            "-d",
+            "--name",
+            self.container_name,
+            "-e",
+            f"PUFFO_AGENT_ID={self.agent_id}",
+            "-v",
+            f"{self.workspace_dir}:/workspace",
+            # Agent-scoped Codex home only — never the operator's ~/.codex.
+            "-v",
+            f"{self.codex_home}:{CODEX_CONTAINER_CODEX_HOME}",
+            # Per-agent keystore + memory for the puffo-core MCP.
+            "-v",
+            f"{self.agent_home}:{CODEX_CONTAINER_STATE_DIR}",
+            "-v",
+            f"{self.shared_fs_dir}:/workspace/.shared",
+            "-v",
+            f"{_puffo_agent_pkg_dir()}:/opt/puffoagent-pkg:ro",
+            "--init",
+        ]
+        if self.memory_limit:
+            command.extend(["--memory", self.memory_limit])
+        if self.memory_reservation:
+            command.extend(["--memory-reservation", self.memory_reservation])
+        command.append(self.image)
+        rc, _, stderr = await _run_cmd(command, check=False)
+        if rc != 0:
+            raise RuntimeError(
+                f"docker run failed for {self.container_name}: "
+                f"{stderr.decode('utf-8', errors='replace').strip()[:500]}"
+            )
+
+    # ── Driver transport ───────────────────────────────────────────────
+
+    async def _exec_process(self, spec: RuntimeSpec) -> asyncio.subprocess.Process:
+        """Spawn the bounded ``docker exec -i`` transport for the Driver.
+
+        Only codex-relevant values are forwarded with explicit ``-e`` flags.
+        The bearer/API key crosses by name (value read from the subprocess
+        environment), never as an argv literal.
+        """
+        command = [self._docker_bin, "exec", "-i"]
+        for key, value in spec.environment.items():
+            if key == "OPENAI_API_KEY":
+                command.extend(["-e", key])
+            else:
+                command.extend(["-e", f"{key}={value}"])
+        command.extend([self.container_name, "codex", "app-server"])
+        env = dict(os.environ)
+        api_key = spec.environment.get("OPENAI_API_KEY")
+        if api_key:
+            env["OPENAI_API_KEY"] = api_key
+        return await asyncio.create_subprocess_exec(
+            *command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            # One provider frame can carry a large tool result; the default
+            # 64 KiB stream limit would terminate the reader mid-session.
+            limit=16 * 1024 * 1024,
+            **no_window_kwargs(),
+        )
+
+    @property
+    def process_factory(self) -> Callable[[RuntimeSpec], Any]:
+        """Driver-compatible transport factory: ``docker exec -i`` spawn.
+
+        Exposes the bounded exec transport so the composition boundary can
+        inject it into ``CodexAppServerDriver`` without reaching into a
+        private method. The Driver awaits the returned coroutine.
+        """
+        return self._exec_process
+
+    # ── Bounded shutdown ───────────────────────────────────────────────
+
+    async def aclose(self) -> None:
+        """Stop the container once the Driver transport has terminated."""
+        if self._container_stopped:
+            return
+        self._container_stopped = True
+        # ``docker stop`` (not ``rm -f``) preserves the container's fs —
+        # codex home, sessions, config — so the next start resumes cleanly.
+        # ``-t 5`` bounds the SIGTERM grace inside Worker.stop's 30s budget.
+        await _run_cmd(
+            [self._docker_bin, "stop", "-t", "5", self.container_name],
+            check=False,
+        )
+
+
+__all__ = [
+    "DockerCodexPreparer",
+    "CODEX_CONTAINER_CODEX_HOME",
+    "CODEX_CONTAINER_STATE_DIR",
+    "CODEX_CONTAINER_SANDBOX",
+]

--- a/src/puffo_agent/agent/harness/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/docker_runtime.py
@@ -37,7 +37,7 @@ from ...portal.state import (
     sync_host_codex_auth_view,
     sync_host_codex_skills,
 )
-from ...portal.workspace_layout import ensure_workspace_shared_link
+from ...portal.workspace_layout import prepare_workspace_shared_access
 from ..adapters.desired_install import run_spawn_install
 from ..adapters.docker_cli import (
     DEFAULT_IMAGE,
@@ -446,7 +446,11 @@ class DockerCodexPreparer:
             pass
 
     async def _start_container(self) -> None:
-        ensure_workspace_shared_link(self.workspace_dir, self.shared_fs_dir)
+        shared_status = prepare_workspace_shared_access(
+            self.workspace_dir,
+            self.shared_fs_dir,
+            mounted=True,
+        )
         self.codex_home.mkdir(parents=True, exist_ok=True)
         self.agent_home.mkdir(parents=True, exist_ok=True)
         command = [
@@ -465,8 +469,11 @@ class DockerCodexPreparer:
             # Per-agent keystore + memory for the puffo-core MCP.
             "-v",
             f"{self.agent_home}:{CODEX_CONTAINER_STATE_DIR}",
-            "-v",
-            f"{self.shared_fs_dir}:/workspace/shared",
+            *(
+                ["-v", f"{self.shared_fs_dir}:/workspace/shared"]
+                if shared_status == "mounted"
+                else []
+            ),
             # Compatibility for existing sessions and user-authored paths.
             "-v",
             f"{self.shared_fs_dir}:/workspace/.shared",

--- a/src/puffo_agent/agent/harness/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/docker_runtime.py
@@ -37,6 +37,7 @@ from ...portal.state import (
     sync_host_codex_auth_view,
     sync_host_codex_skills,
 )
+from ...portal.workspace_layout import ensure_workspace_shared_link
 from ..adapters.desired_install import run_spawn_install
 from ..adapters.docker_cli import (
     DEFAULT_IMAGE,
@@ -235,6 +236,7 @@ class DockerCodexPreparer:
             space_id=pc.space_id,
             keystore_dir=f"{CODEX_CONTAINER_STATE_DIR}/keys",
             workspace="/workspace",
+            shared_workspace="/workspace/shared",
             agent_id=self.agent_id,
             data_service_url=(
                 f"http://host.docker.internal:{self.daemon_cfg.data_service.port}"
@@ -444,10 +446,9 @@ class DockerCodexPreparer:
             pass
 
     async def _start_container(self) -> None:
-        self.workspace_dir.mkdir(parents=True, exist_ok=True)
+        ensure_workspace_shared_link(self.workspace_dir, self.shared_fs_dir)
         self.codex_home.mkdir(parents=True, exist_ok=True)
         self.agent_home.mkdir(parents=True, exist_ok=True)
-        self.shared_fs_dir.mkdir(parents=True, exist_ok=True)
         command = [
             self._docker_bin,
             "run",
@@ -464,6 +465,9 @@ class DockerCodexPreparer:
             # Per-agent keystore + memory for the puffo-core MCP.
             "-v",
             f"{self.agent_home}:{CODEX_CONTAINER_STATE_DIR}",
+            "-v",
+            f"{self.shared_fs_dir}:/workspace/shared",
+            # Compatibility for existing sessions and user-authored paths.
             "-v",
             f"{self.shared_fs_dir}:/workspace/.shared",
             "-v",

--- a/src/puffo_agent/agent/harness/local_runtime.py
+++ b/src/puffo_agent/agent/harness/local_runtime.py
@@ -9,6 +9,7 @@ those responsibilities belong to :mod:`codex_driver`,
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -48,7 +49,11 @@ from ...portal.runtime_matrix import (
     resolve_effective_harness,
     resolve_effective_provider,
 )
-from ..adapters.base import anthropic_base_url_env
+from ..adapters.base import (
+    STATUS_PREVIEW_CHARS,
+    anthropic_base_url_env,
+    is_silent,
+)
 from ..adapters.desired_install import run_spawn_install
 from ..cli_bin import resolve_claude_bin, resolve_codex_bin
 from ..runtime_event_outbox import (
@@ -58,7 +63,13 @@ from ..runtime_event_outbox import (
 from ..runtime_events import RuntimeEventProjector, TrustedScope
 from ..shared_content import MEMORY_SECTION_HEADER
 from . import UnsupportedDriver, build_driver
-from .driver import HarnessEvent, RuntimeSpec, SessionRef, TurnRef
+from .driver import (
+    HarnessEvent,
+    HarnessEventType,
+    RuntimeSpec,
+    SessionRef,
+    TurnRef,
+)
 from .runtime_manager import RuntimeManager, RuntimeManagerAdapter
 
 logger = logging.getLogger(__name__)
@@ -643,6 +654,93 @@ class LocalRuntimePreparer:
         )
 
 
+def _event_kind(event: HarnessEvent) -> str:
+    return (
+        event.type.value
+        if isinstance(event.type, HarnessEventType)
+        else str(event.type)
+    )
+
+
+def _normalized_tool_label(label: str) -> str:
+    """Normalize an MCP-scoped tool label to its bare name for status."""
+    if label.startswith("mcp__") and "__" in label:
+        return label.rsplit("__", 1)[-1]
+    return label
+
+
+def _emit_status(agent_id: str, event: str, payload: dict[str, Any]) -> None:
+    from ...portal.control.reporter import get_reporter
+
+    asyncio.ensure_future(get_reporter().emit(agent_id, event, payload))
+
+
+class _LegacyStatusProjector:
+    """Turn-scoped pre-2.0 status projection from normalized Driver events.
+
+    Emits only the safe legacy surface: one bounded ``assistant_text`` per
+    completed assistant block unless the accumulated text is silent, and one
+    label-only ``tool_use`` per normalized tool start. It never reads the
+    native diagnostic payload, tool arguments or results, reasoning events, or
+    unknown provider frames; duplicate lifecycle events and post-terminal
+    fragments are ignored, and buffers are discarded at terminal, abandonment,
+    or runtime teardown.
+    """
+
+    def __init__(self, agent_id: str) -> None:
+        self._agent_id = agent_id
+        self._turn: str | None = None
+        self._block_buffers: dict[str, str] = {}
+        self._emitted_blocks: set[str] = set()
+        self._emitted_tools: set[str] = set()
+
+    def project(self, event: HarnessEvent) -> None:
+        kind = _event_kind(event)
+        turn = str(event.turn_ref.value) if event.turn_ref is not None else ""
+        if kind == "turn.started":
+            self._turn = turn
+            self._reset()
+            return
+        if kind in {"turn.completed", "turn.abandoned", "runtime.exited"}:
+            self._turn = None
+            self._reset()
+            return
+        if not turn or self._turn != turn:
+            return
+        data = event.data
+        if kind == "turn.assistant_delta":
+            text = data.get("text")
+            if isinstance(text, str):
+                block_id = str(data.get("block_id") or "")
+                buffer = self._block_buffers.get(block_id, "")
+                room = STATUS_PREVIEW_CHARS - len(buffer)
+                if room > 0:
+                    self._block_buffers[block_id] = buffer + text[:room]
+            return
+        if kind == "turn.assistant_completed":
+            block_id = str(data.get("block_id") or "")
+            if block_id in self._emitted_blocks:
+                return
+            self._emitted_blocks.add(block_id)
+            text = self._block_buffers.pop(block_id, "")
+            if text and not is_silent(text):
+                _emit_status(self._agent_id, "assistant_text", {"text": text})
+            return
+        if kind == "turn.tool_started":
+            ref = str(data.get("tool_call_ref") or "")
+            if ref in self._emitted_tools:
+                return
+            self._emitted_tools.add(ref)
+            label = _normalized_tool_label(str(data.get("label") or ""))
+            if label:
+                _emit_status(self._agent_id, "tool_use", {"tool": label})
+
+    def _reset(self) -> None:
+        self._block_buffers.clear()
+        self._emitted_blocks.clear()
+        self._emitted_tools.clear()
+
+
 def build_local_runtime_adapter(
     prepared: PreparedLocalRuntime,
     *,
@@ -659,6 +757,7 @@ def build_local_runtime_adapter(
         scope=TrustedScope(),
     )
     projecting_sink = RuntimeEventProjectingSink(outbox, projector)
+    legacy_projector = _LegacyStatusProjector(prepared.preparer.agent_id)
     manager: RuntimeManager
     session_fingerprint = [prepared.session_fingerprint]
 
@@ -684,6 +783,7 @@ def build_local_runtime_adapter(
         await outbox.arequire_turn_capacity(estimated_start_bytes=estimated)
 
     async def persist_event(event: HarnessEvent) -> None:
+        legacy_projector.project(event)
         logical_session = str(event.session_ref or manager.session_ref)
         projector.session_ref = logical_session
         await projecting_sink(event)

--- a/src/puffo_agent/agent/harness/local_runtime.py
+++ b/src/puffo_agent/agent/harness/local_runtime.py
@@ -47,7 +47,10 @@ from ...portal.state import (
     sync_host_skills,
     strip_claude_api_key_from_settings,
 )
-from ...portal.workspace_layout import ensure_workspace_shared_link
+from ...portal.workspace_layout import (
+    AVAILABLE_SHARED_WORKSPACE_STATES,
+    ensure_workspace_shared_link,
+)
 from ...portal.runtime_matrix import (
     resolve_effective_harness,
     resolve_effective_provider,
@@ -380,7 +383,17 @@ class LocalRuntimePreparer:
         )
 
     async def refresh_spec(self, system_prompt: str) -> RuntimeSpec:
-        ensure_workspace_shared_link(self.workspace_dir, shared_fs_dir())
+        shared_status = ensure_workspace_shared_link(
+            self.workspace_dir,
+            shared_fs_dir(),
+        )
+        if shared_status not in AVAILABLE_SHARED_WORKSPACE_STATES:
+            logger.error(
+                "agent %s: shared workspace is %s; cross-Agent file handoffs "
+                "are unavailable",
+                self.agent_id,
+                shared_status,
+            )
         self.claude_dir.mkdir(parents=True, exist_ok=True)
         if self.harness_name == "claude-code":
             self._sync_claude_host_state()

--- a/src/puffo_agent/agent/harness/local_runtime.py
+++ b/src/puffo_agent/agent/harness/local_runtime.py
@@ -38,6 +38,7 @@ from ...portal.state import (
     cli_session_json_path,
     read_host_codex_mcp_servers,
     seed_claude_home,
+    shared_fs_dir,
     sync_host_claude_code_auth_view,
     sync_host_codex_auth_view,
     sync_host_enabled_plugins,
@@ -46,6 +47,7 @@ from ...portal.state import (
     sync_host_skills,
     strip_claude_api_key_from_settings,
 )
+from ...portal.workspace_layout import ensure_workspace_shared_link
 from ...portal.runtime_matrix import (
     resolve_effective_harness,
     resolve_effective_provider,
@@ -378,7 +380,7 @@ class LocalRuntimePreparer:
         )
 
     async def refresh_spec(self, system_prompt: str) -> RuntimeSpec:
-        self.workspace_dir.mkdir(parents=True, exist_ok=True)
+        ensure_workspace_shared_link(self.workspace_dir, shared_fs_dir())
         self.claude_dir.mkdir(parents=True, exist_ok=True)
         if self.harness_name == "claude-code":
             self._sync_claude_host_state()
@@ -404,6 +406,7 @@ class LocalRuntimePreparer:
             space_id=pc.space_id,
             keystore_dir=str(agent_dir(self.agent_id) / "keys"),
             workspace=str(self.workspace_dir),
+            shared_workspace=str(shared_fs_dir()),
             agent_id=self.agent_id,
             data_service_url=(
                 f"http://127.0.0.1:{self.daemon_cfg.data_service.port}"

--- a/src/puffo_agent/agent/harness/local_runtime.py
+++ b/src/puffo_agent/agent/harness/local_runtime.py
@@ -13,9 +13,10 @@ import hashlib
 import json
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from ...macos.keychain import is_macos
 from ...mcp.config import (
@@ -58,7 +59,7 @@ from ..runtime_event_outbox import (
 from ..runtime_events import RuntimeEventProjector, TrustedScope
 from ..shared_content import MEMORY_SECTION_HEADER
 from . import UnsupportedDriver, build_driver
-from .driver import HarnessEvent, RuntimeSpec, SessionRef, TurnRef
+from .driver import Driver, HarnessEvent, RuntimeSpec, SessionRef, TurnRef
 from .runtime_manager import RuntimeManager, RuntimeManagerAdapter
 
 logger = logging.getLogger(__name__)
@@ -160,6 +161,82 @@ def _read_json_object(path: Path) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def compute_session_fingerprint(
+    *,
+    agent_cfg: AgentConfig,
+    harness_name: str,
+    provider: str,
+    spec: RuntimeSpec,
+) -> str:
+    """Fingerprint only inputs that make a native session incompatible.
+
+    Shared by the host-local and Docker runtime owners so a persisted
+    logical session stays comparable across restarts of the same runtime.
+    """
+    prompt_core = spec.system_prompt.split(MEMORY_SECTION_HEADER, 1)[0]
+    payload = {
+        "version": 1,
+        "harness": harness_name,
+        "provider": provider,
+        "model": spec.model,
+        "workspace": str(Path(spec.workspace_dir).resolve()),
+        "sandbox": spec.sandbox,
+        "permission_mode": spec.permission_mode,
+        "inference_level": agent_cfg.runtime.inference_level,
+        "llm_base_url": agent_cfg.runtime.llm_base_url.rstrip("/"),
+        "prompt_core_sha256": hashlib.sha256(
+            prompt_core.encode("utf-8")
+        ).hexdigest(),
+    }
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "v1:" + hashlib.sha256(encoded).hexdigest()
+
+
+def build_codex_gateway_provider(
+    *,
+    model: str,
+    llm_base_url: str,
+    api_key: str,
+) -> dict[str, str] | None:
+    """Return the LiteLLM / OpenAI-compatible gateway provider block.
+
+    ``None`` unless both a gateway URL and a virtual key are configured;
+    when present codex talks to ``base_url`` via the Responses API using
+    the bearer key in ``env_key`` instead of native ChatGPT OAuth.
+    """
+    if not (llm_base_url and api_key):
+        return None
+    base = llm_base_url.rstrip("/")
+    if not base.endswith("/v1"):
+        base += "/v1"
+    return {
+        "name": "litellm",
+        "display_name": "LiteLLM gateway",
+        "base_url": base,
+        "env_key": "OPENAI_API_KEY",
+        "model": model or "codex",
+        "wire_api": "responses",
+    }
+
+
+class RuntimePreparer(Protocol):
+    """Minimal contract a runtime owner satisfies to be bound into the
+    durable Runtime Manager by :func:`build_local_runtime_adapter`.
+
+    Both the host-local and the Docker Codex preparers implement it; the
+    Docker owner additionally exposes ``process_factory`` and ``aclose``
+    that the composition boundary wires into the Driver.
+    """
+
+    agent_id: str
+
+    async def refresh_spec(self, system_prompt: str) -> RuntimeSpec: ...
+
+    def session_fingerprint(self, spec: RuntimeSpec) -> str: ...
+
+
 @dataclass(slots=True)
 class PreparedLocalRuntime:
     harness_name: str
@@ -167,7 +244,7 @@ class PreparedLocalRuntime:
     native_session_id: str
     migration_source: str
     legacy_session_path: Path
-    preparer: LocalRuntimePreparer
+    preparer: RuntimePreparer
     session_fingerprint: str
     discarded_persisted_session: bool = False
 
@@ -278,28 +355,15 @@ class LocalRuntimePreparer:
 
     def session_fingerprint(self, spec: RuntimeSpec) -> str:
         """Fingerprint only inputs that make a native session incompatible."""
-        prompt_core = spec.system_prompt.split(MEMORY_SECTION_HEADER, 1)[0]
-        payload = {
-            "version": 1,
-            "harness": self.harness_name,
-            "provider": resolve_effective_provider(
+        return compute_session_fingerprint(
+            agent_cfg=self.agent_cfg,
+            harness_name=self.harness_name,
+            provider=resolve_effective_provider(
                 self.agent_cfg.runtime.kind or "cli-local",
                 self.agent_cfg.runtime.provider,
             ),
-            "model": spec.model,
-            "workspace": str(Path(spec.workspace_dir).resolve()),
-            "sandbox": spec.sandbox,
-            "permission_mode": spec.permission_mode,
-            "inference_level": self.agent_cfg.runtime.inference_level,
-            "llm_base_url": self.agent_cfg.runtime.llm_base_url.rstrip("/"),
-            "prompt_core_sha256": hashlib.sha256(
-                prompt_core.encode("utf-8")
-            ).hexdigest(),
-        }
-        encoded = json.dumps(
-            payload, sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
-        return "v1:" + hashlib.sha256(encoded).hexdigest()
+            spec=spec,
+        )
 
     async def refresh_spec(self, system_prompt: str) -> RuntimeSpec:
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
@@ -557,20 +621,11 @@ class LocalRuntimePreparer:
         )
 
     def _codex_gateway_provider(self) -> dict[str, str] | None:
-        runtime = self.agent_cfg.runtime
-        if not (runtime.llm_base_url and runtime.api_key):
-            return None
-        base = runtime.llm_base_url.rstrip("/")
-        if not base.endswith("/v1"):
-            base += "/v1"
-        return {
-            "name": "litellm",
-            "display_name": "LiteLLM gateway",
-            "base_url": base,
-            "env_key": "OPENAI_API_KEY",
-            "model": self.model or "codex",
-            "wire_api": "responses",
-        }
+        return build_codex_gateway_provider(
+            model=self.model,
+            llm_base_url=self.agent_cfg.runtime.llm_base_url,
+            api_key=self.agent_cfg.runtime.api_key,
+        )
 
     def _ensure_codex_self_invoke(self, executable: str) -> None:
         if not is_macos():
@@ -648,9 +703,18 @@ def build_local_runtime_adapter(
     *,
     outbox: RuntimeEventOutbox,
     logical_session_ref: str,
+    driver: Driver | None = None,
+    cleanup: Callable[[], Awaitable[None]] | None = None,
 ) -> RuntimeManagerAdapter:
-    """Bind a prepared local Driver to the durable Runtime Manager."""
-    driver = build_driver(prepared.harness_name)
+    """Bind a prepared Driver runtime to the durable Runtime Manager.
+
+    ``driver`` defaults to the ratified Driver for ``prepared.harness_name``;
+    the Docker Codex composition injects ``CodexAppServerDriver`` with its
+    exec transport factory and passes ``cleanup`` (bounded container stop)
+    that runs after the manager closes.
+    """
+    if driver is None:
+        driver = build_driver(prepared.harness_name)
     if isinstance(driver, UnsupportedDriver):
         raise RuntimeError(driver.diagnostic)
     projector = RuntimeEventProjector(
@@ -724,14 +788,18 @@ def build_local_runtime_adapter(
     return RuntimeManagerAdapter(
         manager,
         spec_reloader=reload_spec,
+        post_close=cleanup,
     )
 
 
 __all__ = [
     "LocalRuntimePreparer",
     "PreparedLocalRuntime",
+    "RuntimePreparer",
     "SUPPORTED_LOCAL_DRIVERS",
     "VALID_PERMISSION_MODES",
     "VALID_SANDBOX_MODES",
     "build_local_runtime_adapter",
+    "build_codex_gateway_provider",
+    "compute_session_fingerprint",
 ]

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -802,6 +802,7 @@ class RuntimeManagerAdapter(Adapter):
                     if key in {
                         "input_tokens", "output_tokens", "tool_calls",
                         "provider_session_id", "send_message_targets",
+                        "context_tokens",
                     }
                 })
                 return TurnResult(

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -733,10 +733,15 @@ class RuntimeManagerAdapter(Adapter):
         *,
         spec_reloader: Callable[[str], Awaitable[RuntimeSpec]] | None = None,
         compaction_wait_seconds: float = COMPACTION_WAIT_SECONDS,
+        post_close: Callable[[], Awaitable[None]] | None = None,
     ):
         self.manager = manager
         self.spec_reloader = spec_reloader
         self.compaction_wait_seconds = compaction_wait_seconds
+        # Optional bounded lifecycle owner hook awaited after the manager
+        # (and its Driver) close. Used by the Docker Codex runtime to stop
+        # the per-agent container once the exec transport has terminated.
+        self.post_close = post_close
         self.assistant_text_parts: list[str] = []
         self._latest_context_limits: tuple[int | None, int | None] = (
             None,
@@ -924,7 +929,11 @@ class RuntimeManagerAdapter(Adapter):
         )
 
     async def aclose(self) -> None:
-        await self.manager.close()
+        try:
+            await self.manager.close()
+        finally:
+            if self.post_close is not None:
+                await self.post_close()
 
     def get_provider_session_id(self) -> str | None:
         value = (

--- a/src/puffo_agent/agent/ingress_policy.py
+++ b/src/puffo_agent/agent/ingress_policy.py
@@ -63,6 +63,7 @@ class GateVerdict:
     disposition: ReceiptDisposition
     reason: str
     content: str | None = None
+    defer_ack: bool = False
 
 
 def signed_http_available(client: Any) -> bool:

--- a/src/puffo_agent/agent/ingress_policy.py
+++ b/src/puffo_agent/agent/ingress_policy.py
@@ -36,9 +36,9 @@ A keyless agent cannot call subkey-signed routes. Gate *dispositions*
 are enforced locally in every case; gate *side effects* that need
 signed HTTP (allowlist writes, the operator approval prompt, the
 first-DM notice) are skipped with an explicit log line — a documented
-degrade, never a silent one. Where native has no gate either (no
-``operator_slug`` configured means nobody can approve), keyless matches
-native rather than inventing a stricter rule.
+degrade, never a silent one. A keyless foreign DM with no configured
+``operator_slug`` is retained fail-closed; native keeps its existing
+no-operator behavior.
 """
 
 from __future__ import annotations
@@ -186,10 +186,9 @@ async def foreign_dm_gate(
     """Hold a DM from an untrusted stranger until the operator approves.
 
     The server never applies this gate — it is entirely Agent-owned on
-    both transports. Keyless cannot send the approval prompt, so it
-    holds the DM gated instead of delivering it unapproved; the one
-    case where it declines to gate is the case native also declines,
-    namely no ``operator_slug`` to ask.
+    both transports. Keyless holds an untrusted DM gated until its local
+    approval control plane resolves it, including when no operator is
+    configured. The signed/native no-operator behavior remains unchanged.
     """
     if payload.envelope_kind != "dm":
         return None
@@ -220,14 +219,16 @@ async def foreign_dm_gate(
 
     if not signed:
         if not client.operator_slug:
-            # Native declines to gate for exactly this reason too: with
-            # no operator there is no one who could ever approve.
             client._log.warning(
                 "auto_accept_dm=False but no operator_slug configured; "
-                "delivering DM from %s without approval",
+                "holding keyless DM from %s fail-closed",
                 sender,
             )
-            return None
+            return GateVerdict(
+                gate="foreign_dm",
+                disposition=ReceiptDisposition.FOREIGN_DM_GATED,
+                reason="foreign dm gated (keyless: no operator configured)",
+            )
         client._log.info(
             "dm_gate: keyless transport cannot send the operator approval "
             "prompt for %s — holding the DM gated rather than delivering "

--- a/src/puffo_agent/agent/keyless_dm_approval_flow.py
+++ b/src/puffo_agent/agent/keyless_dm_approval_flow.py
@@ -1,0 +1,473 @@
+"""Resumable keyless DM operator-approval component.
+
+One durable :class:`~puffo_agent.agent.dm_approvals.KeylessDmApproval` per
+held foreign-DM envelope, one operator prompt per ``(operator_slug,
+sender_slug)`` group. The three async entry points are scheduled by the
+later integration layer; nothing here is wired into ``bridge_transport`` or
+``dm_gate`` yet.
+
+Grouping: every held envelope from one sender against one operator shares a
+single stable ``prompt_client_ref``, prompt thread, and decision. The local
+application phase is per-envelope and always starts ``pending`` — a later
+envelope that joins a decided group is finalized through its own local
+transition and bridge ACK, never by inheriting an older member's phase.
+
+Replay: the record is persisted before the prompt is sent, and
+``phase=applied`` is persisted before the bridge ACK, so
+``resume_pending_approvals`` can re-send a missing prompt, resume a local
+transition, or complete an ACK after every reconnect. A crash between the
+remote prompt send and the local persistence of the returned ids is
+explicitly at-least-once; no server-side dedupe is assumed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import replace
+from typing import Any
+
+from .dm_approvals import (
+    KEYLESS_APPROVAL_KIND,
+    KeylessDmApproval,
+    parse_keyless_approval,
+    save_pending_dm_approvals,
+)
+from .message_store import ReceiptWriteStatus
+from .permission_prompt import format_permission_prompt
+
+logger = logging.getLogger(__name__)
+
+APPROVED_REASON = "foreign dm approved by operator"
+
+_YES = frozenset({"y", "yes"})
+_NO = frozenset({"n", "no"})
+
+# Approvals only ever ride these two receipt results; anything else is a
+# fail-closed hold that keeps the record resumable without an ACK.
+_APPLIED_STATUSES = frozenset(
+    {ReceiptWriteStatus.COMMITTED, ReceiptWriteStatus.IDEMPOTENT}
+)
+
+
+def _prompt_client_ref() -> str:
+    return f"prompt_{uuid.uuid4().hex[:12]}"
+
+
+def _keyless_records(
+    pending: dict[str, dict[str, Any]],
+) -> list[KeylessDmApproval]:
+    return [
+        parsed
+        for value in pending.values()
+        if value.get("kind") == KEYLESS_APPROVAL_KIND
+        and (parsed := parse_keyless_approval(value)) is not None
+    ]
+
+
+def _persist(client, pending: dict[str, dict[str, Any]]) -> bool:
+    """Save the whole pending dict; legacy native entries pass through
+    unchanged. Returns whether the write landed."""
+    try:
+        save_pending_dm_approvals(client.slug, pending)
+    except OSError as exc:
+        client._log.warning(
+            "keyless_dm_approval: pending state persist failed: %s",
+            exc,
+        )
+        return False
+    return True
+
+
+def _persist_or_restore(
+    client,
+    pending: dict[str, dict[str, Any]],
+    before: dict[str, dict[str, Any]],
+) -> bool:
+    """Keep the in-memory mirror aligned with the durable file on failure."""
+    if _persist(client, pending):
+        return True
+    pending.clear()
+    pending.update(before)
+    return False
+
+
+def _approval_lock(client) -> asyncio.Lock:
+    lock = getattr(client, "_keyless_dm_approval_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        client._keyless_dm_approval_lock = lock
+    return lock
+
+
+def _notify_runtime(client) -> None:
+    runtime = getattr(client, "global_runtime", None)
+    if runtime is not None:
+        runtime.notify()
+
+
+async def record_gated_dm(
+    client,
+    *,
+    envelope_id: str,
+    sender_slug: str,
+    server_seq: int | None,
+) -> None:
+    """Durably record one held foreign-DM envelope for operator approval.
+
+    A new ``(operator_slug, sender_slug)`` group gets one stable
+    ``prompt_client_ref``; the record is persisted before the prompt is
+    sent, and the correlated ACK's returned prompt envelope/thread ids are
+    persisted across every current group member. A later envelope joins the
+    group's prompt and decision with its own ``phase=pending``. A missing
+    operator fails closed: the held record is retained, logged, and nothing
+    is sent.
+    """
+    async with _approval_lock(client):
+        await _record_gated_dm_locked(
+            client,
+            envelope_id=envelope_id,
+            sender_slug=sender_slug,
+            server_seq=server_seq,
+        )
+
+
+async def _record_gated_dm_locked(
+    client,
+    *,
+    envelope_id: str,
+    sender_slug: str,
+    server_seq: int | None,
+) -> None:
+    pending = client._pending_dm_approvals
+    if envelope_id in pending:
+        return
+    operator_slug = getattr(client, "operator_slug", "") or ""
+    record = KeylessDmApproval(
+        envelope_id=envelope_id,
+        sender_slug=sender_slug,
+        operator_slug=operator_slug,
+        server_seq=server_seq,
+        prompt_client_ref=_prompt_client_ref(),
+        prompt_envelope_id=None,
+        prompt_thread_id=None,
+        decision="pending",
+        phase="pending",
+    )
+    if not operator_slug:
+        before = dict(pending)
+        pending[envelope_id] = record.to_dict()
+        if not _persist_or_restore(client, pending, before):
+            return
+        client._log.warning(
+            "keyless_dm_approval: no operator_slug configured; held DM %s "
+            "from %s retained with no prompt",
+            envelope_id,
+            sender_slug,
+        )
+        return
+    group = [
+        member
+        for member in _keyless_records(pending)
+        if member.envelope_id != envelope_id
+        and member.operator_slug == operator_slug
+        and member.sender_slug == sender_slug
+    ]
+    if not group:
+        before = dict(pending)
+        pending[envelope_id] = record.to_dict()
+        if not _persist_or_restore(client, pending, before):
+            return
+        await _send_prompt(client, pending, record, operator_slug)
+        return
+    base = group[0]
+    joined = replace(
+        record,
+        prompt_client_ref=base.prompt_client_ref,
+        prompt_envelope_id=base.prompt_envelope_id,
+        prompt_thread_id=base.prompt_thread_id,
+        decision=base.decision,
+    )
+    before = dict(pending)
+    pending[envelope_id] = joined.to_dict()
+    if not _persist_or_restore(client, pending, before):
+        return
+    if base.decision == "approved":
+        await _finalize_record(client, pending, envelope_id, approved=True)
+    elif base.decision == "denied":
+        await _finalize_record(client, pending, envelope_id, approved=False)
+
+
+async def _send_prompt(
+    client,
+    pending: dict[str, dict[str, Any]],
+    record: KeylessDmApproval,
+    operator_slug: str,
+) -> None:
+    """Send the group's root-level permission prompt to the operator and
+    persist the returned prompt envelope/thread ids across the group.
+
+    The pre-send record is already durable, so any failure keeps the group
+    resumable: ``resume_pending_approvals`` re-sends with the same
+    ``prompt_client_ref``. The ACK envelope id is the prompt's thread root;
+    the operator's reply frame carries it as ``thread_root_id``.
+    """
+    prompt = format_permission_prompt(
+        f"{record.sender_slug} is DM-ing me — allow (allowlist + deliver) or block?"
+    )
+    bridge = client._bridge
+    if bridge is None:
+        client._log.warning(
+            "keyless_dm_approval: no bridge transport; prompt for %s not "
+            "sent (record retained)",
+            record.sender_slug,
+        )
+        return
+    try:
+        ack = await bridge.send_send(
+            plaintext=prompt,
+            recipient_slug=operator_slug,
+            client_ref=record.prompt_client_ref,
+        )
+    except Exception as exc:  # noqa: BLE001 - resumable transport failure
+        client._log.warning(
+            "keyless_dm_approval: prompt send for %s failed (%s); record "
+            "retained for resume",
+            record.sender_slug,
+            exc,
+        )
+        return
+    prompt_envelope = ack.get("envelope_id") or ""
+    if not prompt_envelope:
+        client._log.warning(
+            "keyless_dm_approval: prompt ack for %s carried no envelope_id; "
+            "record retained for resume",
+            record.sender_slug,
+        )
+        return
+    prompt_thread = ack.get("thread_root_id") or prompt_envelope
+    before = dict(pending)
+    changed = False
+    for member in _keyless_records(pending):
+        if (
+            member.operator_slug == operator_slug
+            and member.sender_slug == record.sender_slug
+        ):
+            pending[member.envelope_id] = replace(
+                member,
+                prompt_envelope_id=prompt_envelope,
+                prompt_thread_id=prompt_thread,
+            ).to_dict()
+            changed = True
+    if changed:
+        _persist_or_restore(client, pending, before)
+
+
+async def maybe_handle_operator_reply(
+    client,
+    *,
+    thread_root_id: str,
+    text: str,
+) -> bool:
+    """Consume an exact threaded ``y``/``yes``/``n``/``no`` operator reply.
+
+    Persists the decision across every record in the matched prompt group
+    before any local transition, then finalizes each member. Unknown text or
+    an unknown thread returns ``False`` without any save or mutation.
+    """
+    async with _approval_lock(client):
+        return await _maybe_handle_operator_reply_locked(
+            client,
+            thread_root_id=thread_root_id,
+            text=text,
+        )
+
+
+async def _maybe_handle_operator_reply_locked(
+    client,
+    *,
+    thread_root_id: str,
+    text: str,
+) -> bool:
+    normalized = text.strip().lower()
+    if normalized in _YES:
+        approved = True
+    elif normalized in _NO:
+        approved = False
+    else:
+        return False
+    pending = client._pending_dm_approvals
+    matched = [
+        record
+        for record in _keyless_records(pending)
+        if record.prompt_envelope_id == thread_root_id
+        or record.prompt_thread_id == thread_root_id
+    ]
+    if not matched:
+        return False
+    decision = "approved" if approved else "denied"
+    terminal = {record.decision for record in matched if record.decision != "pending"}
+    if len(terminal) > 1 or (terminal and decision not in terminal):
+        client._log.warning(
+            "keyless_dm_approval: ignored conflicting %s reply for already "
+            "decided prompt %s (%s)",
+            decision,
+            thread_root_id,
+            ", ".join(sorted(terminal)),
+        )
+        return True
+    if any(record.decision == "pending" for record in matched):
+        before = dict(pending)
+        for record in matched:
+            if record.decision == "pending":
+                pending[record.envelope_id] = replace(
+                    record,
+                    decision=decision,
+                ).to_dict()
+        if not _persist_or_restore(client, pending, before):
+            return True
+    resolved_approved = next(iter(terminal), decision) == "approved"
+    for record in matched:
+        await _finalize_record(
+            client,
+            pending,
+            record.envelope_id,
+            approved=resolved_approved,
+        )
+    return True
+
+
+async def resume_pending_approvals(client) -> None:
+    """Deterministic replay of persisted keyless approvals after a reconnect.
+
+    Fail-closed groups (no configured operator) are retained with a log.
+    Pending groups without a known prompt id have their missing prompt
+    re-sent with the persisted ``prompt_client_ref``; pending groups with a
+    known prompt id are left waiting for the operator reply; persisted
+    approved/denied records resume at application or ACK by phase.
+    """
+    async with _approval_lock(client):
+        await _resume_pending_approvals_locked(client)
+
+
+async def _resume_pending_approvals_locked(client) -> None:
+    pending = client._pending_dm_approvals
+    for record in sorted(
+        _keyless_records(pending),
+        key=lambda r: r.envelope_id,
+    ):
+        if record.decision == "approved":
+            await _finalize_record(client, pending, record.envelope_id, approved=True)
+        elif record.decision == "denied":
+            await _finalize_record(client, pending, record.envelope_id, approved=False)
+    operator_slug = getattr(client, "operator_slug", "") or ""
+    groups: dict[tuple[str, str], list[KeylessDmApproval]] = {}
+    for record in _keyless_records(pending):
+        if record.decision != "pending":
+            continue
+        if not operator_slug or record.operator_slug != operator_slug:
+            client._log.warning(
+                "keyless_dm_approval: resume fail-closed — no operator for "
+                "held DM %s from %s; retained",
+                record.envelope_id,
+                record.sender_slug,
+            )
+            continue
+        groups.setdefault((record.operator_slug, record.sender_slug), []).append(record)
+    for (group_operator, _), members in groups.items():
+        if any(member.prompt_envelope_id is not None for member in members):
+            # Prompt known — still waiting for the operator's exact reply.
+            continue
+        await _send_prompt(client, pending, members[0], group_operator)
+
+
+async def _finalize_record(
+    client,
+    pending: dict[str, dict[str, Any]],
+    envelope_id: str,
+    *,
+    approved: bool,
+) -> None:
+    """Advance one decided record through local application and bridge ACK.
+
+    Re-reads the record from ``pending`` so a caller's just-persisted
+    decision is never clobbered. ``phase=applied`` is saved before the ACK;
+    the record is removed only after the ACK succeeds. Any failure retains
+    the record in its current resumable state (pre-apply at ``pending``, or
+    ACK-only retry at ``applied``) and never sends the ACK.
+    """
+    record = parse_keyless_approval(pending.get(envelope_id))
+    if record is None:
+        return
+    if record.phase == "pending":
+        if not await _apply_local_transition(client, record, approved=approved):
+            return
+        before = dict(pending)
+        pending[envelope_id] = replace(record, phase="applied").to_dict()
+        if not _persist_or_restore(client, pending, before):
+            return
+        if approved:
+            _notify_runtime(client)
+    try:
+        await client._bridge.send_ack([envelope_id])
+    except Exception as exc:  # noqa: BLE001 - ack failure retains applied state
+        client._log.warning(
+            "keyless_dm_approval: bridge ack for %s failed (%s); kept at "
+            "phase=applied for ack-only retry",
+            envelope_id,
+            exc,
+        )
+        return
+    before = dict(pending)
+    pending.pop(envelope_id, None)
+    _persist_or_restore(client, pending, before)
+
+
+async def _apply_local_transition(
+    client,
+    record: KeylessDmApproval,
+    *,
+    approved: bool,
+) -> bool:
+    """Apply one decided record's local mutation. Returns whether it is
+    applied (``COMMITTED`` or ``IDEMPOTENT``). ``CONFLICT``, an exception,
+    or any other result retains the record and never ACKs it."""
+    if approved:
+        client._contacts.note_allowed(record.sender_slug)
+        try:
+            result = await client.store.promote_gated_receipt(
+                record.envelope_id,
+                record.server_seq,
+                reason=APPROVED_REASON,
+            )
+        except Exception as exc:  # noqa: BLE001 - resumable store failure
+            client._log.warning(
+                "keyless_dm_approval: promote for %s failed (%s); retained resumable",
+                record.envelope_id,
+                exc,
+            )
+            return False
+    else:
+        client._contacts.note_blocked(record.sender_slug, True)
+        try:
+            result = await client.store.tombstone_gated_dm(
+                record.envelope_id,
+                record.server_seq,
+            )
+        except Exception as exc:  # noqa: BLE001 - resumable store failure
+            client._log.warning(
+                "keyless_dm_approval: tombstone for %s failed (%s); retained resumable",
+                record.envelope_id,
+                exc,
+            )
+            return False
+    if result.status not in _APPLIED_STATUSES:
+        client._log.warning(
+            "keyless_dm_approval: %s for %s returned %s; retained, no ACK",
+            "promotion" if approved else "tombstone",
+            record.envelope_id,
+            result.status,
+        )
+        return False
+    return True

--- a/src/puffo_agent/agent/keyless_dm_approval_flow.py
+++ b/src/puffo_agent/agent/keyless_dm_approval_flow.py
@@ -3,8 +3,9 @@
 One durable :class:`~puffo_agent.agent.dm_approvals.KeylessDmApproval` per
 held foreign-DM envelope, one operator prompt per ``(operator_slug,
 sender_slug)`` group. The three async entry points are scheduled by the
-later integration layer; nothing here is wired into ``bridge_transport`` or
-``dm_gate`` yet.
+bridge ingress integration in ``bridge_transport``: ``record_gated_dm`` on a
+held DM, ``maybe_handle_operator_reply`` as tracked reply work, and
+``resume_pending_approvals`` on each reconnect's ``pending_delivered``.
 
 Grouping: every held envelope from one sender against one operator shares a
 single stable ``prompt_client_ref``, prompt thread, and decision. The local
@@ -316,8 +317,9 @@ async def maybe_handle_operator_reply(
     """Consume an exact threaded ``y``/``yes``/``n``/``no`` operator reply.
 
     Persists the decision across every record in the matched prompt group
-    before any local transition, then finalizes each member. Unknown text or
-    an unknown thread returns ``False`` without any save or mutation.
+    before any local transition, then finalizes each member. ``True`` means
+    the reply is represented by a durable decision and may be acknowledged;
+    unknown replies and failed decision persistence return ``False``.
     """
     async with _approval_lock(client):
         return await _maybe_handle_operator_reply_locked(
@@ -369,7 +371,7 @@ async def _maybe_handle_operator_reply_locked(
                     decision=decision,
                 ).to_dict()
         if not _persist_or_restore(client, pending, before):
-            return True
+            return False
     resolved_approved = next(iter(terminal), decision) == "approved"
     for record in matched:
         await _finalize_record(

--- a/src/puffo_agent/agent/keyless_dm_approval_flow.py
+++ b/src/puffo_agent/agent/keyless_dm_approval_flow.py
@@ -66,6 +66,49 @@ def _keyless_records(
     ]
 
 
+def is_keyless_operator_approval_reply(
+    pending: dict[str, dict[str, Any]],
+    *,
+    thread_root_id: str,
+    text: str,
+) -> bool:
+    """Whether ``text`` is an exact threaded operator decision for a durable
+    keyless approval prompt.
+
+    Pure and synchronous: bridge ingress runs this on the frame-pump stack to
+    recognise the reply before scheduling the response-waiting
+    :func:`maybe_handle_operator_reply` as a tracked task. It mirrors the
+    handler's exact ``y``/``yes``/``n``/``no`` vocabulary and thread match but
+    never mutates or persists anything.
+    """
+    if not thread_root_id:
+        return False
+    if text.strip().lower() not in _YES | _NO:
+        return False
+    return any(
+        record.prompt_envelope_id == thread_root_id
+        or record.prompt_thread_id == thread_root_id
+        for record in _keyless_records(pending)
+    )
+
+
+def is_keyless_prompt_envelope(
+    pending: dict[str, dict[str, Any]],
+    *,
+    envelope_id: str,
+) -> bool:
+    """Whether ``envelope_id`` is a durable keyless approval-prompt envelope.
+
+    The server echoes the agent's own approval prompt back; that self-echo
+    must be stored with ``DM_GATE_PROMPT_PLACEHOLDER`` rather than as the
+    operator-visible prompt text, which quotes the withheld stranger's body.
+    """
+    return any(
+        record.prompt_envelope_id == envelope_id
+        for record in _keyless_records(pending)
+    )
+
+
 def _persist(client, pending: dict[str, dict[str, Any]]) -> bool:
     """Save the whole pending dict; legacy native entries pass through
     unchanged. Returns whether the write landed."""

--- a/src/puffo_agent/agent/keyless_dm_approval_flow.py
+++ b/src/puffo_agent/agent/keyless_dm_approval_flow.py
@@ -434,7 +434,16 @@ async def _apply_local_transition(
     applied (``COMMITTED`` or ``IDEMPOTENT``). ``CONFLICT``, an exception,
     or any other result retains the record and never ACKs it."""
     if approved:
-        client._contacts.note_allowed(record.sender_slug)
+        try:
+            client._contacts.note_allowed(record.sender_slug)
+        except OSError as exc:
+            client._log.warning(
+                "keyless_dm_approval: contact allow persistence for %s "
+                "failed (%s); retained resumable",
+                record.sender_slug,
+                exc,
+            )
+            return False
         try:
             result = await client.store.promote_gated_receipt(
                 record.envelope_id,
@@ -449,7 +458,16 @@ async def _apply_local_transition(
             )
             return False
     else:
-        client._contacts.note_blocked(record.sender_slug, True)
+        try:
+            client._contacts.note_blocked(record.sender_slug, True)
+        except OSError as exc:
+            client._log.warning(
+                "keyless_dm_approval: contact block persistence for %s "
+                "failed (%s); retained resumable",
+                record.sender_slug,
+                exc,
+            )
+            return False
         try:
             result = await client.store.tombstone_gated_dm(
                 record.envelope_id,

--- a/src/puffo_agent/agent/keyless_invitation_flow.py
+++ b/src/puffo_agent/agent/keyless_invitation_flow.py
@@ -3,8 +3,8 @@
 One durable :class:`~puffo_agent.agent.keyless_invitation_state.KeylessInvitation`
 per authoritative ``invitation_event_id``. The three async entry points
 (``reconcile``, ``handle_operator_reply``, ``resume``) are scheduled by the
-later integration layer; nothing here is wired into ``bridge_transport`` or
-the bridge frame pump.
+bridge ingress integration in ``bridge_transport``, which owns the
+connection-scoped invitation poller that feeds this flow.
 
 Reconcile: merge the Server's authoritative pending list by exact event id
 without duplicating a prompt, retire/log active records that vanished from
@@ -103,8 +103,9 @@ class KeylessInvitationFlow:
         self, *, thread_root_id: str, text: str,
     ) -> bool:
         """Consume an exact threaded ``y``/``yes``/``n``/``no`` operator
-        reply for one prompted invite; other text or an unknown thread is
-        returned unconsumed."""
+        reply for one prompted invite. ``True`` means its decision is durable
+        and the reply may be acknowledged; unknown replies and failed decision
+        persistence return ``False``."""
         async with self._lock:
             return await self._handle_reply_locked(thread_root_id, text)
 
@@ -115,6 +116,39 @@ class KeylessInvitationFlow:
         known prompt awaiting its exact reply."""
         async with self._lock:
             await self._resume_locked()
+
+    def is_prompt_envelope(self, envelope_id: str) -> bool:
+        """Whether ``envelope_id`` is a durable invitation-prompt envelope.
+
+        Pure and synchronous: bridge ingress runs this on the frame-pump
+        stack so the echo of the agent's own operator prompt is stored as a
+        short control placeholder rather than delivered to model context.
+        Terminal records still count — a late echo of an already-decided
+        prompt must not resurface as operator-visible prompt text.
+        """
+        if not envelope_id:
+            return False
+        return any(
+            (record := parse_keyless_invitation(value)) is not None
+            and record.prompt_envelope_id == envelope_id
+            for value in self._pending.values()
+        )
+
+    def is_operator_reply(self, *, thread_root_id: str, text: str) -> bool:
+        """Whether ``text`` is an exact threaded operator decision for a
+        durable invitation prompt.
+
+        Pure and synchronous: bridge ingress recognizes the reply on the
+        frame-pump stack before scheduling the response-waiting
+        :meth:`handle_operator_reply` as a tracked task. It mirrors the
+        handler's exact ``y``/``yes``/``n``/``no`` vocabulary and thread
+        match but never mutates or persists anything.
+        """
+        if not thread_root_id:
+            return False
+        if text.strip().lower() not in _YES | _NO:
+            return False
+        return self._matching_record(thread_root_id) is not None
 
     async def _reconcile_locked(self, invites: Any) -> None:
         if isinstance(invites, dict) and isinstance(invites.get("invites"), list):
@@ -182,6 +216,15 @@ class KeylessInvitationFlow:
                     event_id,
                 )
                 continue
+            if scope == "channel":
+                channel_id = invite.get("channel_id")
+                if not isinstance(channel_id, str) or not channel_id:
+                    self._log.warning(
+                        "keyless_invitation: skipping channel invite %s "
+                        "without channel_id",
+                        event_id,
+                    )
+                    continue
             valid.append(invite)
         return valid
 
@@ -300,7 +343,7 @@ class KeylessInvitationFlow:
             phase="decided",
         ).to_dict()
         if not self._persist_or_restore(before):
-            return True
+            return False
         await self._send_decision_locked(record.invitation_event_id)
         return True
 

--- a/src/puffo_agent/agent/keyless_invitation_flow.py
+++ b/src/puffo_agent/agent/keyless_invitation_flow.py
@@ -1,0 +1,435 @@
+"""Resumable keyless invitation operator-decision component.
+
+One durable :class:`~puffo_agent.agent.keyless_invitation_state.KeylessInvitation`
+per authoritative ``invitation_event_id``. The three async entry points
+(``reconcile``, ``handle_operator_reply``, ``resume``) are scheduled by the
+later integration layer; nothing here is wired into ``bridge_transport`` or
+the bridge frame pump.
+
+Reconcile: merge the Server's authoritative pending list by exact event id
+without duplicating a prompt, retire/log active records that vanished from
+the list, preserve the existing space-only auto-accept policy (space-scope
+invites when the flag is set, plus the native path's operator auto-accept),
+and fail closed with a clear warning when ``operator_slug`` is missing.
+
+Progression: a new external invite is prompted once via the configured
+operator; only an exact threaded ``y``/``yes``/``n``/``no`` reply is
+consumed; the decision (and its stable ``decision_client_ref``) is persisted
+before the decision frame is sent; ``applied`` / ``already_applied`` are
+terminal success while ``conflict`` / ``not_found`` resolve terminal and
+logged without a retry loop.
+
+Replay: the record is persisted before the prompt and before the decision
+send, so ``resume`` can re-send a missing prompt with its stable prompt ref
+or retry a decided-but-nonterminal record with its stable decision ref after
+every reconnect, while leaving a known prompt awaiting its exact reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import replace
+from typing import Any, Awaitable, Callable
+
+from .keyless_invitation_state import (
+    INVITATION_OUTCOMES,
+    KeylessInvitation,
+    load_keyless_invitations,
+    parse_keyless_invitation,
+    save_keyless_invitations,
+)
+from .permission_prompt import format_permission_prompt
+
+logger = logging.getLogger(__name__)
+
+_YES = frozenset({"y", "yes"})
+_NO = frozenset({"n", "no"})
+
+# Auto-accept mirrors the native ``process_invite`` path: an invite sent by
+# the configured operator is inherently authorized, and the
+# ``auto_accept_space_invitations`` flag applies to space scope only (no new
+# channel default).
+_SCOPE_LABELS = {"space": "space", "channel": "channel"}
+
+
+def _prompt_client_ref() -> str:
+    return f"invite_prompt_{uuid.uuid4().hex[:12]}"
+
+
+def _decision_client_ref() -> str:
+    return f"invite_dec_{uuid.uuid4().hex[:12]}"
+
+
+class KeylessInvitationFlow:
+    """Schedulable, resumable keyless invitation decision component.
+
+    Owns the in-memory mirror of the durable per-Agent invitation state
+    plus the async lock that serializes reconcile / prompt / reply / resume
+    transitions, so a caller can schedule it outside the bridge frame pump
+    without corrupting state or duplicating a prompt.
+    """
+
+    def __init__(
+        self,
+        *,
+        slug: str,
+        bridge: Any,
+        operator_slug: str,
+        send_dm: Callable[..., Awaitable[dict]],
+        auto_accept_space_invitations: bool = False,
+        log: Any = None,
+        load_state: Callable[[str], dict[str, dict[str, Any]]] = load_keyless_invitations,
+        save_state: Callable[[str, dict[str, dict[str, Any]]], None] = save_keyless_invitations,
+    ) -> None:
+        self._slug = slug
+        self._bridge = bridge
+        self._operator_slug = operator_slug or ""
+        self._send_dm = send_dm
+        self._auto_accept_space = bool(auto_accept_space_invitations)
+        self._log = log or logging.getLogger(__name__)
+        self._load_state = load_state
+        self._save_state = save_state
+        self._pending = load_state(slug)
+        self._lock = asyncio.Lock()
+
+    async def reconcile(self, invites: Any) -> None:
+        """Merge the authoritative pending invite list into durable state."""
+        async with self._lock:
+            await self._reconcile_locked(invites)
+
+    async def handle_operator_reply(
+        self, *, thread_root_id: str, text: str,
+    ) -> bool:
+        """Consume an exact threaded ``y``/``yes``/``n``/``no`` operator
+        reply for one prompted invite; other text or an unknown thread is
+        returned unconsumed."""
+        async with self._lock:
+            return await self._handle_reply_locked(thread_root_id, text)
+
+    async def resume(self) -> None:
+        """Deterministic replay of persisted keyless invitations after a
+        reconnect: re-send an unsent prompt with its stable ref, retry a
+        decided-but-nonterminal decision with its stable ref, and leave a
+        known prompt awaiting its exact reply."""
+        async with self._lock:
+            await self._resume_locked()
+
+    async def _reconcile_locked(self, invites: Any) -> None:
+        if isinstance(invites, dict) and isinstance(invites.get("invites"), list):
+            invites = invites["invites"]
+        if not isinstance(invites, list):
+            self._log.warning(
+                "keyless_invitation: reconcile expected an invites list, "
+                "got %r; ignoring",
+                type(invites).__name__,
+            )
+            return
+        valid = self._valid_invites(invites)
+        seen: set[str] = set()
+        for invite in valid:
+            event_id = invite["invitation_event_id"]
+            seen.add(event_id)
+            existing = parse_keyless_invitation(self._pending.get(event_id))
+            if existing is not None:
+                # Known (active or terminal) — never prompt twice.
+                continue
+            await self._adopt_new_invite(invite)
+        before = dict(self._pending)
+        retired = False
+        for event_id, value in list(self._pending.items()):
+            record = parse_keyless_invitation(value)
+            if record is None or record.phase == "terminal":
+                continue
+            if record.invitation_event_id not in seen:
+                self._log.warning(
+                    "keyless_invitation: retiring active invite %s absent "
+                    "from authoritative list",
+                    event_id,
+                )
+                del self._pending[event_id]
+                retired = True
+        if retired:
+            self._persist_or_restore(before)
+
+    def _valid_invites(self, invites: list[Any]) -> list[dict[str, Any]]:
+        valid: list[dict[str, Any]] = []
+        for invite in invites:
+            if not isinstance(invite, dict):
+                self._log.warning(
+                    "keyless_invitation: skipping malformed invite %r", invite,
+                )
+                continue
+            event_id = invite.get("invitation_event_id")
+            scope = invite.get("scope")
+            space_id = invite.get("space_id")
+            if not isinstance(event_id, str) or not event_id:
+                self._log.warning(
+                    "keyless_invitation: skipping invite without an event id",
+                )
+                continue
+            if scope not in _SCOPE_LABELS:
+                self._log.warning(
+                    "keyless_invitation: skipping invite %s with bad scope %r",
+                    event_id,
+                    scope,
+                )
+                continue
+            if not isinstance(space_id, str) or not space_id:
+                self._log.warning(
+                    "keyless_invitation: skipping invite %s without space_id",
+                    event_id,
+                )
+                continue
+            valid.append(invite)
+        return valid
+
+    async def _adopt_new_invite(self, invite: dict[str, Any]) -> None:
+        event_id = invite["invitation_event_id"]
+        record = KeylessInvitation(
+            invitation_event_id=event_id,
+            invite=invite,
+            prompt_client_ref=_prompt_client_ref(),
+            prompt_envelope_id=None,
+            prompt_thread_id=None,
+            decision="pending",
+            decision_client_ref=None,
+            phase="unsent",
+            outcome=None,
+        )
+        if not self._operator_slug:
+            before = dict(self._pending)
+            self._pending[event_id] = record.to_dict()
+            if not self._persist_or_restore(before):
+                return
+            self._log.warning(
+                "keyless_invitation: no operator_slug configured; invite %s "
+                "retained pending locally and on Server",
+                event_id,
+            )
+            return
+        if self._auto_accept(invite):
+            before = dict(self._pending)
+            self._pending[event_id] = record.to_dict()
+            if not self._persist_or_restore(before):
+                return
+            await self._send_decision_locked(event_id, decision="accept")
+            return
+        before = dict(self._pending)
+        self._pending[event_id] = record.to_dict()
+        if not self._persist_or_restore(before):
+            return
+        await self._send_prompt_locked(event_id)
+
+    def _auto_accept(self, invite: dict[str, Any]) -> bool:
+        if invite.get("inviter_slug") == self._operator_slug:
+            return True
+        return invite.get("scope") == "space" and self._auto_accept_space
+
+    async def _send_prompt_locked(self, event_id: str) -> None:
+        record = parse_keyless_invitation(self._pending.get(event_id))
+        if record is None or record.phase != "unsent":
+            return
+        scope = record.invite.get("scope", "space")
+        intent = (
+            f"{record.invite.get('inviter_slug') or 'someone'} invited me "
+            f"to the {_SCOPE_LABELS.get(scope, 'space')} "
+            f"{record.invite.get('space_id')} — accept or reject?"
+        )
+        prompt = format_permission_prompt(intent)
+        try:
+            ack = await self._send_dm(prompt, client_ref=record.prompt_client_ref)
+        except Exception as exc:  # noqa: BLE001 - resumable transport failure
+            self._log.warning(
+                "keyless_invitation: prompt send for %s failed (%s); record "
+                "retained unsent for resume",
+                event_id,
+                exc,
+            )
+            return
+        envelope = (ack or {}).get("envelope_id") or ""
+        if not envelope:
+            self._log.warning(
+                "keyless_invitation: prompt ack for %s carried no "
+                "envelope_id; record retained unsent for resume",
+                event_id,
+            )
+            return
+        thread = (ack or {}).get("thread_root_id") or envelope
+        before = dict(self._pending)
+        self._pending[event_id] = replace(
+            record,
+            prompt_envelope_id=envelope,
+            prompt_thread_id=thread,
+            phase="awaiting_reply",
+        ).to_dict()
+        self._persist_or_restore(before)
+
+    async def _handle_reply_locked(
+        self, thread_root_id: str, text: str,
+    ) -> bool:
+        normalized = text.strip().lower()
+        if normalized in _YES:
+            decision = "accept"
+        elif normalized in _NO:
+            decision = "reject"
+        else:
+            return False
+        record = self._matching_record(thread_root_id)
+        if record is None:
+            return False
+        if record.phase == "terminal":
+            return True
+        if record.decision != "pending":
+            if record.decision != decision:
+                self._log.warning(
+                    "keyless_invitation: ignored conflicting %s reply for "
+                    "already decided invite %s (%s)",
+                    decision,
+                    record.invitation_event_id,
+                    record.decision,
+                )
+            return True
+        decision_client_ref = record.decision_client_ref or _decision_client_ref()
+        before = dict(self._pending)
+        self._pending[record.invitation_event_id] = replace(
+            record,
+            decision=decision,
+            decision_client_ref=decision_client_ref,
+            phase="decided",
+        ).to_dict()
+        if not self._persist_or_restore(before):
+            return True
+        await self._send_decision_locked(record.invitation_event_id)
+        return True
+
+    def _matching_record(self, thread_root_id: str) -> KeylessInvitation | None:
+        for value in self._pending.values():
+            record = parse_keyless_invitation(value)
+            if record is None:
+                continue
+            if (
+                record.prompt_envelope_id == thread_root_id
+                or record.prompt_thread_id == thread_root_id
+            ):
+                return record
+        return None
+
+    async def _send_decision_locked(
+        self, event_id: str, *, decision: str | None = None,
+    ) -> None:
+        record = parse_keyless_invitation(self._pending.get(event_id))
+        if record is None or record.phase == "terminal":
+            return
+        resolved = decision or record.decision
+        if resolved not in ("accept", "reject"):
+            return
+        decision_client_ref = record.decision_client_ref
+        if decision_client_ref is None:
+            decision_client_ref = _decision_client_ref()
+            before = dict(self._pending)
+            self._pending[event_id] = replace(
+                record,
+                decision=resolved,
+                decision_client_ref=decision_client_ref,
+                phase="decided",
+            ).to_dict()
+            if not self._persist_or_restore(before):
+                return
+            record = parse_keyless_invitation(self._pending.get(event_id))
+        try:
+            result = await self._bridge.send_decide_invitation(
+                invitation_event_id=event_id,
+                decision=resolved,
+                client_ref=decision_client_ref,
+            )
+        except Exception as exc:  # noqa: BLE001 - resumable; no retry loop
+            self._log.warning(
+                "keyless_invitation: decision send for %s failed (%s); "
+                "record retained decided for resume",
+                event_id,
+                exc,
+            )
+            return
+        outcome = (result or {}).get("outcome") or ""
+        if outcome not in INVITATION_OUTCOMES:
+            self._log.warning(
+                "keyless_invitation: unexpected decision outcome %r for %s; "
+                "record retained decided for resume",
+                outcome,
+                event_id,
+            )
+            return
+        before = dict(self._pending)
+        self._pending[event_id] = replace(
+            record,
+            phase="terminal",
+            outcome=outcome,
+        ).to_dict()
+        self._persist_or_restore(before)
+        if outcome in ("conflict", "not_found"):
+            self._log.warning(
+                "keyless_invitation: invite %s resolved terminal %s",
+                event_id,
+                outcome,
+            )
+        else:
+            self._log.info(
+                "keyless_invitation: invite %s decision %s -> %s",
+                event_id,
+                resolved,
+                outcome,
+            )
+
+    async def _resume_locked(self) -> None:
+        decided: list[str] = []
+        for record in self._active_records():
+            if record.phase == "decided":
+                decided.append(record.invitation_event_id)
+            elif record.phase == "unsent":
+                await self._resume_prompt(record)
+            elif record.phase == "awaiting_reply":
+                if record.prompt_envelope_id is None and record.prompt_thread_id is None:
+                    await self._resume_prompt(record)
+                # A known prompt keeps awaiting its exact reply.
+        for event_id in decided:
+            await self._send_decision_locked(event_id)
+
+    async def _resume_prompt(self, record: KeylessInvitation) -> None:
+        if not self._operator_slug:
+            self._log.warning(
+                "keyless_invitation: resume fail-closed — no operator_slug "
+                "for invite %s; retained pending",
+                record.invitation_event_id,
+            )
+            return
+        await self._send_prompt_locked(record.invitation_event_id)
+
+    def _active_records(self) -> list[KeylessInvitation]:
+        records = []
+        for value in self._pending.values():
+            record = parse_keyless_invitation(value)
+            if record is not None and record.phase != "terminal":
+                records.append(record)
+        return records
+
+    def _persist(self) -> bool:
+        try:
+            self._save_state(self._slug, self._pending)
+        except OSError as exc:
+            self._log.warning(
+                "keyless_invitation: state persist failed: %s", exc,
+            )
+            return False
+        return True
+
+    def _persist_or_restore(
+        self, before: dict[str, dict[str, Any]],
+    ) -> bool:
+        """Keep the in-memory mirror aligned with the durable file on failure."""
+        if self._persist():
+            return True
+        self._pending.clear()
+        self._pending.update(before)
+        return False

--- a/src/puffo_agent/agent/keyless_invitation_state.py
+++ b/src/puffo_agent/agent/keyless_invitation_state.py
@@ -1,0 +1,201 @@
+"""Durable per-Agent keyless invitation decision state.
+
+One compact JSON document under ``agent_dir(slug) / ".puffo-agent"`` holds
+one record per authoritative ``invitation_event_id``. The exact event id is
+both the JSON key and a validated field, and each record retains the same
+stable prompt / decision ``client_ref``s across a reload so a reconnect can
+resume an unsent prompt or an undecided/decided record without generating a
+second logical prompt or decision.
+
+Writes are atomic (sibling ``*.tmp`` plus ``os.replace``) and fail closed:
+the caller keeps its prior in-memory mirror when a save raises ``OSError``.
+Malformed or key-mismatched rows are skipped with an observable warning so a
+corrupt or hand-edited file can never resurface as decision state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..portal.state import agent_dir
+
+logger = logging.getLogger(__name__)
+
+# Marker distinguishing a keyless invitation record inside the JSON file.
+KEYLESS_INVITATION_KIND = "keyless_invitation"
+
+# Completion phases: ``unsent`` (prompt not yet sent / send failed),
+# ``awaiting_reply`` (prompt sent, operator reply pending), ``decided``
+# (operator decision durable, decision frame not yet resolved), and
+# ``terminal`` (server decision outcome recorded).
+INVITATION_PHASES = frozenset({"unsent", "awaiting_reply", "decided", "terminal"})
+
+# The exact operator decisions a keyless record may carry. ``pending``
+# means no exact answer has been received yet.
+INVITATION_DECISIONS = frozenset({"pending", "accept", "reject"})
+
+# Terminal decision outcomes from the Server contract. ``applied`` and
+# ``already_applied`` are terminal success; ``conflict`` and ``not_found``
+# resolve without a retry loop.
+INVITATION_OUTCOMES = frozenset(
+    {"applied", "already_applied", "conflict", "not_found"}
+)
+
+# Authoritative invite fields required on every snapshot row.
+_REQUIRED_INVITE_FIELDS = ("invitation_event_id", "scope", "space_id")
+
+
+@dataclass(frozen=True)
+class KeylessInvitation:
+    """Resumable keyless invitation record, keyed by ``invitation_event_id``.
+
+    ``invite`` is the authoritative invite snapshot as delivered by the
+    Server (validated on parse). ``prompt_client_ref`` is stable across
+    reconnects; ``prompt_envelope_id`` / ``prompt_thread_id`` carry the
+    returned prompt identity once the prompt is sent. ``decision`` is the
+    exact operator answer and ``phase`` its completion stage; ``outcome``
+    records the Server's terminal decision result.
+    """
+
+    invitation_event_id: str
+    invite: dict[str, Any]
+    prompt_client_ref: str
+    prompt_envelope_id: str | None
+    prompt_thread_id: str | None
+    decision: str
+    decision_client_ref: str | None
+    phase: str
+    outcome: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": KEYLESS_INVITATION_KIND,
+            "invitation_event_id": self.invitation_event_id,
+            "invite": self.invite,
+            "prompt_client_ref": self.prompt_client_ref,
+            "prompt_envelope_id": self.prompt_envelope_id,
+            "prompt_thread_id": self.prompt_thread_id,
+            "decision": self.decision,
+            "decision_client_ref": self.decision_client_ref,
+            "phase": self.phase,
+            "outcome": self.outcome,
+        }
+
+
+def parse_keyless_invitation(value: Any) -> KeylessInvitation | None:
+    """Validate one keyless record's exact shape; ``None`` when malformed.
+
+    Every field is type-checked, the decision/phase/outcome vocabularies
+    are enforced, the embedded invite snapshot must carry the authoritative
+    fields, and a terminal phase must carry a valid outcome (while a
+    non-terminal phase must not), so a corrupt record can never silently
+    resurface as promptable or decidable state.
+    """
+    if not isinstance(value, dict) or value.get("kind") != KEYLESS_INVITATION_KIND:
+        return None
+    invitation_event_id = value.get("invitation_event_id")
+    if not isinstance(invitation_event_id, str) or not invitation_event_id:
+        return None
+    invite = value.get("invite")
+    if not isinstance(invite, dict):
+        return None
+    for field in _REQUIRED_INVITE_FIELDS:
+        if not isinstance(invite.get(field), str) or not invite.get(field):
+            return None
+    if invite.get("scope") not in ("space", "channel"):
+        return None
+    if invite.get("invitation_event_id") != invitation_event_id:
+        return None
+    prompt_client_ref = value.get("prompt_client_ref")
+    if not isinstance(prompt_client_ref, str) or not prompt_client_ref:
+        return None
+    prompt_envelope_id = value.get("prompt_envelope_id")
+    if prompt_envelope_id is not None and not isinstance(prompt_envelope_id, str):
+        return None
+    prompt_thread_id = value.get("prompt_thread_id")
+    if prompt_thread_id is not None and not isinstance(prompt_thread_id, str):
+        return None
+    decision = value.get("decision")
+    decision_client_ref = value.get("decision_client_ref")
+    if decision not in INVITATION_DECISIONS:
+        return None
+    if decision_client_ref is not None and (
+        not isinstance(decision_client_ref, str) or not decision_client_ref
+    ):
+        return None
+    phase = value.get("phase")
+    outcome = value.get("outcome")
+    if phase not in INVITATION_PHASES:
+        return None
+    if phase == "terminal":
+        if outcome not in INVITATION_OUTCOMES:
+            return None
+    elif outcome is not None:
+        return None
+    return KeylessInvitation(
+        invitation_event_id=invitation_event_id,
+        invite=invite,
+        prompt_client_ref=prompt_client_ref,
+        prompt_envelope_id=prompt_envelope_id,
+        prompt_thread_id=prompt_thread_id,
+        decision=decision,
+        decision_client_ref=decision_client_ref,
+        phase=phase,
+        outcome=outcome,
+    )
+
+
+def keyless_invitations_path(slug: str) -> Path:
+    return agent_dir(slug) / ".puffo-agent" / "keyless_invitations.json"
+
+
+def load_keyless_invitations(slug: str) -> dict[str, dict[str, Any]]:
+    """Load the per-Agent invitation document; malformed or
+    key-mismatched rows are skipped with a warning, never resurfaced.
+    """
+    path = keyless_invitations_path(slug)
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "keyless_invitations: %s unreadable (%s); starting empty",
+            path,
+            exc,
+        )
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    loaded: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        parsed = parse_keyless_invitation(value)
+        if parsed is None or parsed.invitation_event_id != key:
+            logger.warning(
+                "keyless_invitations: skipping malformed record %s", key,
+            )
+            continue
+        loaded[key] = parsed.to_dict()
+    return loaded
+
+
+def save_keyless_invitations(
+    slug: str,
+    pending: dict[str, dict[str, Any]],
+) -> None:
+    """Atomically persist the whole invitation document.
+
+    Writes a sibling ``*.tmp`` file then ``os.replace`` over the target so
+    a crash mid-write never leaves a truncated document; raises ``OSError``
+    on failure so the caller restores its in-memory mirror.
+    """
+    path = keyless_invitations_path(slug)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(pending, indent=2), encoding="utf-8")
+    os.replace(tmp, path)

--- a/src/puffo_agent/agent/keyless_invitation_state.py
+++ b/src/puffo_agent/agent/keyless_invitation_state.py
@@ -190,8 +190,10 @@ def save_keyless_invitations(
 ) -> None:
     """Atomically persist the whole invitation document.
 
-    Writes a sibling ``*.tmp`` file then ``os.replace`` over the target so
-    a crash mid-write never leaves a truncated document; raises ``OSError``
+    Writes a sibling ``*.tmp`` file then atomically replaces the target, so
+    readers do not observe an in-progress write during ordinary process
+    failure. This does not claim power-loss durability because neither the
+    temporary file nor its directory is explicitly fsynced. Raises ``OSError``
     on failure so the caller restores its in-memory mirror.
     """
     path = keyless_invitations_path(slug)

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -1449,6 +1449,102 @@ class MessageStore(ReminderStoreMixin, InboxStoreMixin):
             await db.commit()
             return count
 
+    async def tombstone_gated_dm(
+        self,
+        envelope_id: str,
+        server_seq: int | None = None,
+    ) -> ReceiptResult:
+        """Discard the refused plaintext of exactly one correlated gated DM.
+
+        Envelope-and-optional-sequence sibling of the sender-wide
+        ``tombstone_gated_dms_from``, mirroring ``promote_gated_receipt`` on
+        the denial side: only the matching ``foreign_dm_gated`` receipt is
+        tombstoned with the same terminal placeholder, so envelope accounting
+        and redelivery dedupe keep working while the plaintext the operator
+        refused is gone. First exact transition is ``COMMITTED``; replay of
+        an already-denied receipt is ``IDEMPOTENT``; a missing, sequence-
+        mismatched, or otherwise incompatible receipt is ``CONFLICT``.
+        """
+        async with self._inbox_lock:
+            return await self._tombstone_gated_dm_unlocked(
+                envelope_id, server_seq
+            )
+
+    async def _tombstone_gated_dm_unlocked(
+        self,
+        envelope_id: str,
+        server_seq: int | None,
+    ) -> ReceiptResult:
+        db = await self._ensure_db()
+        await db.execute("BEGIN IMMEDIATE")
+        try:
+            async with db.execute(
+                "SELECT server_seq, receipt_disposition, processing_state, "
+                "content FROM messages WHERE envelope_id = ?",
+                (envelope_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None or (
+                server_seq is not None and row["server_seq"] != server_seq
+            ) or (
+                server_seq is None and row["server_seq"] is not None
+            ):
+                await db.rollback()
+                return ReceiptResult(
+                    ReceiptWriteStatus.CONFLICT,
+                    ReceiptDisposition.FOREIGN_DM_GATED,
+                    "gated receipt association mismatch",
+                    False,
+                )
+            denied = (
+                row["receipt_disposition"] == ReceiptDisposition.TERMINAL.value
+                and row["content"] == _encode_content(DENIED_DM_PLACEHOLDER)
+            )
+            if denied:
+                await db.rollback()
+                return ReceiptResult(
+                    ReceiptWriteStatus.IDEMPOTENT,
+                    ReceiptDisposition.TERMINAL,
+                    "foreign dm denied by operator",
+                    True,
+                )
+            if (
+                row["receipt_disposition"] != ReceiptDisposition.FOREIGN_DM_GATED.value
+                or row["processing_state"] is not None
+            ):
+                await db.rollback()
+                return ReceiptResult(
+                    ReceiptWriteStatus.CONFLICT,
+                    ReceiptDisposition.FOREIGN_DM_GATED,
+                    "receipt is not approval-gated",
+                    False,
+                )
+            await db.execute(
+                """UPDATE messages
+                   SET content = ?, content_type = 'text/plain',
+                       receipt_disposition = ?, receipt_reason = ?
+                   WHERE envelope_id = ? AND receipt_disposition = ?
+                     AND processing_state IS NULL AND server_seq IS ?""",
+                (
+                    _encode_content(DENIED_DM_PLACEHOLDER),
+                    ReceiptDisposition.TERMINAL.value,
+                    "foreign dm denied by operator",
+                    envelope_id,
+                    ReceiptDisposition.FOREIGN_DM_GATED.value,
+                    server_seq,
+                ),
+            )
+            await db.commit()
+            return ReceiptResult(
+                ReceiptWriteStatus.COMMITTED,
+                ReceiptDisposition.TERMINAL,
+                "foreign dm denied by operator",
+                True,
+            )
+        except Exception:
+            await db.rollback()
+            raise
+
     async def cleanup(self, retention_days: int = 90) -> int:
         async with self._inbox_lock:
             db = await self._ensure_db()

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -35,6 +35,7 @@ from .held_context import build_held_context_output
 from .message_projection import CONTEXT_VERSION
 from .send_models import SemanticSendRequest, SendResult
 from .send_response_validation import (
+    BASELINE_PERSISTENCE_WARNING,
     coordinator_config,
     http_error_detail,
     optional_response_int,
@@ -655,8 +656,15 @@ class SendCoordinator:
                 logger.exception(
                     "sent keyless message but could not clear held state"
                 )
-            await persist_baseline(self.baseline_source, space_id, channel_id,
-                                   boundary.baseline, result.context_baseline_seq)
+            baseline_saved = await persist_baseline(
+                self.baseline_source,
+                space_id,
+                channel_id,
+                boundary.baseline,
+                result.context_baseline_seq,
+            )
+            if not baseline_saved:
+                result.note = f"{result.note} {BASELINE_PERSISTENCE_WARNING}"
             acknowledged = max(result.seen_seq or 0, result.context_baseline_seq or 0)
             if (
                 result.latest_seq_before_send == acknowledged
@@ -969,8 +977,15 @@ class SendCoordinator:
             logger.exception("sent message but could not clear held state")
         # A stale send_anyway may cross messages this turn has not seen. The
         # outbound is visible, but the boundary advances only without a gap.
-        await persist_baseline(self.baseline_source, space_id, channel_id,
-                               boundary.baseline, result.context_baseline_seq)
+        baseline_saved = await persist_baseline(
+            self.baseline_source,
+            space_id,
+            channel_id,
+            boundary.baseline,
+            result.context_baseline_seq,
+        )
+        if not baseline_saved:
+            result.note = f"{result.note} {BASELINE_PERSISTENCE_WARNING}"
         acknowledged = max(result.seen_seq or 0, result.context_baseline_seq or 0)
         if result.latest_seq_before_send == acknowledged:
             try:

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -38,6 +38,7 @@ from .send_response_validation import (
     coordinator_config,
     http_error_detail,
     optional_response_int,
+    persist_baseline,
     validate_channel_response,
     validate_keyless_response,
 )
@@ -214,7 +215,7 @@ class _ReconsiderationDecision:
 
 @dataclass(frozen=True)
 class _ChannelSendBoundary:
-    baseline: int
+    baseline: int | None
     seen_seq: int
     held_key: tuple[str, str, str, str]
     attempt_fingerprint: str
@@ -243,6 +244,7 @@ class ContextBaselineSource(Protocol):
     async def get_context_baseline_seq(
         self, space_id: str, channel_id: str
     ) -> Optional[int]: ...
+    async def set_context_baseline_seq(self, space_id, channel_id, context_baseline_seq: int) -> None: ...
 
 
 @runtime_checkable
@@ -774,8 +776,11 @@ class SendCoordinator:
                 logger.exception(
                     "sent keyless message but could not clear held state"
                 )
+            await persist_baseline(self.baseline_source, space_id, channel_id,
+                                   boundary.baseline, result.context_baseline_seq)
+            acknowledged = max(result.seen_seq or 0, result.context_baseline_seq or 0)
             if (
-                result.latest_seq_before_send == boundary.seen_seq
+                result.latest_seq_before_send == acknowledged
                 and result.seq is not None
             ):
                 try:
@@ -867,9 +872,7 @@ class SendCoordinator:
     ) -> _ChannelSendBoundary | dict[str, Any]:
         held_generation = self._held_generation  # read before any await
         baseline = await self._baseline(space_id, channel_id)
-        if baseline is None:
-            baseline = 0
-        baseline_invalid = (
+        baseline_invalid = baseline is not None and (
             isinstance(baseline, bool) or not isinstance(baseline, int) or baseline < 0
         )
         if baseline_invalid and not combined_error:
@@ -911,7 +914,7 @@ class SendCoordinator:
                 result["_reconsideration_audit"] = reconsideration.audit_fields()
                 return result
             active = reconsideration.admitted_seq
-        seen_seq = max(baseline, active if active is not None else baseline)
+        seen_seq = max(baseline or 0, active or 0)
         session_id, turn_id = self._turn_identity()
         return _ChannelSendBoundary(
             baseline=baseline,
@@ -1087,7 +1090,10 @@ class SendCoordinator:
             logger.exception("sent message but could not clear held state")
         # A stale send_anyway may cross messages this turn has not seen. The
         # outbound is visible, but the boundary advances only without a gap.
-        if result.latest_seq_before_send == result.seen_seq:
+        await persist_baseline(self.baseline_source, space_id, channel_id,
+                               boundary.baseline, result.context_baseline_seq)
+        acknowledged = max(result.seen_seq or 0, result.context_baseline_seq or 0)
+        if result.latest_seq_before_send == acknowledged:
             try:
                 await self._advance(
                     space_id,

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -304,6 +304,7 @@ class SendCoordinator:
         http_client: Any,
         data_client: Any,
         workspace: str | None = None,
+        shared_workspace: str | None = None,
         baseline_source: ContextBaselineSource | Any | None = None,
         active_turn_source: ActiveTurnBoundarySource | Any | None = None,
         held_recovery_source: HeldRecoverySource | Any | None = None,
@@ -314,6 +315,7 @@ class SendCoordinator:
         self.http_client = http_client
         self.data_client = data_client
         self.workspace = workspace
+        self.shared_workspace = shared_workspace
         self.baseline_source = baseline_source
         self.active_turn_source = active_turn_source
         self.held_recovery_source = held_recovery_source
@@ -1463,6 +1465,9 @@ class SendCoordinator:
                 "send_message_with_attachments: too many files (> 10 cap)"
             )
         workspace = Path(self.workspace).resolve()
+        shared_workspace = (
+            Path(self.shared_workspace).resolve() if self.shared_workspace else None
+        )
         targets: list[Path] = []
         for raw in request.attachment_paths:
             rel = raw.strip()
@@ -1474,10 +1479,15 @@ class SendCoordinator:
             if rel_path.is_absolute():
                 raise RuntimeError(f"absolute paths not allowed ({rel!r})")
             target = (workspace / rel_path).resolve()
-            try:
-                target.relative_to(workspace)
-            except ValueError as exc:
-                raise RuntimeError(f"{rel!r} escapes the workspace") from exc
+            inside_workspace = target.is_relative_to(workspace)
+            inside_managed_shared = bool(
+                shared_workspace
+                and rel_path.parts
+                and rel_path.parts[0] == "shared"
+                and target.is_relative_to(shared_workspace)
+            )
+            if not (inside_workspace or inside_managed_shared):
+                raise RuntimeError(f"{rel!r} escapes the workspace")
             if not target.is_file():
                 raise RuntimeError(f"{rel!r} is not a file")
             if target.stat().st_size > 8 * 1024 * 1024:

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
 import logging
 import mimetypes
 import urllib.parse
 import uuid
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Optional, Protocol, Sequence, runtime_checkable
 
@@ -34,6 +33,7 @@ from ..crypto.message import (
 from ..crypto.primitives import Ed25519KeyPair
 from .held_context import build_held_context_output
 from .message_projection import CONTEXT_VERSION
+from .send_models import SemanticSendRequest, SendResult
 from .send_response_validation import (
     coordinator_config,
     http_error_detail,
@@ -51,129 +51,6 @@ _KNOWN_ERROR_STATUSES = {400, 401, 403, 404, 405, 409, 413, 429, 500, 503}
 # Held evidence holds decrypted context, so retention is bounded even when a
 # turn is abandoned without any further coordinated send in that channel.
 _MAX_HELD_RECORDS = 8
-
-@dataclass(frozen=True)
-class SemanticSendRequest:
-    """The complete model-facing send contract (and nothing freshness-related)."""
-
-    destination: str
-    text: str = ""
-    attachment_paths: tuple[str, ...] = ()
-    caption: str = ""
-    root_id: str = ""
-    visibility_level: str = "default"
-    send_anyway: bool = False
-
-    @classmethod
-    def from_mapping(cls, value: Mapping[str, Any]) -> SemanticSendRequest:
-        allowed = {
-            "destination",
-            "channel",
-            "text",
-            "attachment_paths",
-            "paths",
-            "caption",
-            "root_id",
-            "visibility_level",
-            "send_anyway",
-        }
-        unknown = set(value) - allowed
-        if unknown:
-            raise ValueError(f"unknown send field(s): {', '.join(sorted(unknown))}")
-        destination = value.get("destination", value.get("channel", ""))
-        paths = value.get("attachment_paths", value.get("paths", ())) or ()
-        if not isinstance(paths, (list, tuple)) or not all(
-            isinstance(item, str) for item in paths
-        ):
-            raise ValueError("attachment paths must be a list of strings")
-        return cls(
-            destination=str(destination or ""),
-            text=str(value.get("text") or ""),
-            attachment_paths=tuple(paths),
-            caption=str(value.get("caption") or ""),
-            root_id=str(value.get("root_id") or ""),
-            visibility_level=str(value.get("visibility_level") or "default"),
-            send_anyway=value.get("send_anyway", False) is True,
-        )
-
-    def to_rpc_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            "channel": self.destination,
-            "root_id": self.root_id,
-            "visibility_level": self.visibility_level,
-            "send_anyway": self.send_anyway,
-        }
-        if self.attachment_paths:
-            body["paths"] = list(self.attachment_paths)
-            body["caption"] = self.caption
-        else:
-            body["text"] = self.text
-        return body
-
-    def attempt_fingerprint(self) -> str:
-        """Identify the logical draft behind one send attempt.
-
-        ``send_anyway`` is excluded so an unchanged draft's reconsideration
-        retry keeps the fingerprint of the attempt that was held, while any
-        revised draft — different text, caption, attachments, thread root, or
-        visibility — gets a different one.
-        """
-        arguments = self.to_tool_arguments()
-        arguments.pop("send_anyway", None)
-        return hashlib.sha256(
-            json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode()
-        ).hexdigest()
-
-    def to_tool_arguments(self) -> dict[str, Any]:
-        """Mirror the public model call without materializing omitted defaults."""
-        arguments: dict[str, Any] = {"channel": self.destination}
-        if self.attachment_paths:
-            arguments.update(
-                {
-                    "caption": self.caption,
-                    "paths": list(self.attachment_paths),
-                }
-            )
-        else:
-            arguments["text"] = self.text
-        if self.root_id:
-            arguments["root_id"] = self.root_id
-        if self.visibility_level != "default":
-            arguments["visibility_level"] = self.visibility_level
-        if self.send_anyway:
-            arguments["send_anyway"] = True
-        return arguments
-
-
-@dataclass
-class SendResult:
-    state: str
-    attempted: bool = True
-    envelope_id: Optional[str] = None
-    seq: Optional[int] = None
-    replay: Optional[bool] = None
-    devices_queued: Optional[int] = None
-    context_baseline_seq: Optional[int] = None
-    seen_seq: Optional[int] = None
-    latest_seq: Optional[int] = None
-    latest_envelope_id: Optional[str] = None
-    blocking_seq: Optional[int] = None
-    blocking_envelope_id: Optional[str] = None
-    blocking_sender_slug: Optional[str] = None
-    latest_seq_before_send: Optional[int] = None
-    mode: Optional[str] = None
-    missing_devices: list[str] = field(default_factory=list)
-    recovered_messages: list[dict[str, Any]] = field(default_factory=list)
-    error: Optional[str] = None
-    error_kind: Optional[str] = None
-    status: Optional[int] = None
-    note: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        return {
-            key: value for key, value in data.items() if value not in (None, [], "")
-        }
 
 
 @dataclass

--- a/src/puffo_agent/agent/send_models.py
+++ b/src/puffo_agent/agent/send_models.py
@@ -1,0 +1,131 @@
+"""Data contracts shared by semantic message send coordination."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class SemanticSendRequest:
+    """The complete model-facing send contract (and nothing freshness-related)."""
+
+    destination: str
+    text: str = ""
+    attachment_paths: tuple[str, ...] = ()
+    caption: str = ""
+    root_id: str = ""
+    visibility_level: str = "default"
+    send_anyway: bool = False
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> SemanticSendRequest:
+        allowed = {
+            "destination",
+            "channel",
+            "text",
+            "attachment_paths",
+            "paths",
+            "caption",
+            "root_id",
+            "visibility_level",
+            "send_anyway",
+        }
+        unknown = set(value) - allowed
+        if unknown:
+            raise ValueError(f"unknown send field(s): {', '.join(sorted(unknown))}")
+        destination = value.get("destination", value.get("channel", ""))
+        paths = value.get("attachment_paths", value.get("paths", ())) or ()
+        if not isinstance(paths, (list, tuple)) or not all(
+            isinstance(item, str) for item in paths
+        ):
+            raise ValueError("attachment paths must be a list of strings")
+        return cls(
+            destination=str(destination or ""),
+            text=str(value.get("text") or ""),
+            attachment_paths=tuple(paths),
+            caption=str(value.get("caption") or ""),
+            root_id=str(value.get("root_id") or ""),
+            visibility_level=str(value.get("visibility_level") or "default"),
+            send_anyway=value.get("send_anyway", False) is True,
+        )
+
+    def to_rpc_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "channel": self.destination,
+            "root_id": self.root_id,
+            "visibility_level": self.visibility_level,
+            "send_anyway": self.send_anyway,
+        }
+        if self.attachment_paths:
+            body["paths"] = list(self.attachment_paths)
+            body["caption"] = self.caption
+        else:
+            body["text"] = self.text
+        return body
+
+    def attempt_fingerprint(self) -> str:
+        """Identify the logical draft behind one send attempt.
+
+        ``send_anyway`` is excluded so an unchanged draft's reconsideration
+        retry keeps the fingerprint of the attempt that was held, while any
+        revised draft gets a different one.
+        """
+        arguments = self.to_tool_arguments()
+        arguments.pop("send_anyway", None)
+        return hashlib.sha256(
+            json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+
+    def to_tool_arguments(self) -> dict[str, Any]:
+        """Mirror the public model call without materializing omitted defaults."""
+        arguments: dict[str, Any] = {"channel": self.destination}
+        if self.attachment_paths:
+            arguments.update(
+                {
+                    "caption": self.caption,
+                    "paths": list(self.attachment_paths),
+                }
+            )
+        else:
+            arguments["text"] = self.text
+        if self.root_id:
+            arguments["root_id"] = self.root_id
+        if self.visibility_level != "default":
+            arguments["visibility_level"] = self.visibility_level
+        if self.send_anyway:
+            arguments["send_anyway"] = True
+        return arguments
+
+
+@dataclass
+class SendResult:
+    state: str
+    attempted: bool = True
+    envelope_id: Optional[str] = None
+    seq: Optional[int] = None
+    replay: Optional[bool] = None
+    devices_queued: Optional[int] = None
+    context_baseline_seq: Optional[int] = None
+    seen_seq: Optional[int] = None
+    latest_seq: Optional[int] = None
+    latest_envelope_id: Optional[str] = None
+    blocking_seq: Optional[int] = None
+    blocking_envelope_id: Optional[str] = None
+    blocking_sender_slug: Optional[str] = None
+    latest_seq_before_send: Optional[int] = None
+    mode: Optional[str] = None
+    missing_devices: list[str] = field(default_factory=list)
+    recovered_messages: list[dict[str, Any]] = field(default_factory=list)
+    error: Optional[str] = None
+    error_kind: Optional[str] = None
+    status: Optional[int] = None
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        return {
+            key: value for key, value in data.items() if value not in (None, [], "")
+        }

--- a/src/puffo_agent/agent/send_response_validation.py
+++ b/src/puffo_agent/agent/send_response_validation.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
     from .send_coordinator import SendResult
+
+
+logger = logging.getLogger(__name__)
 
 
 _LEGACY_HELD_RESPONSE_FIELDS = frozenset(
@@ -61,6 +65,25 @@ def optional_response_int(raw: Any, name: str, prefix: str) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(f"{prefix} has invalid {name}")
     return value
+
+
+async def persist_baseline(
+    source: Any,
+    space_id: str,
+    channel_id: str,
+    request_baseline: int | None,
+    established: int | None,
+) -> None:
+    """Persist a validated Server-established baseline from a null-baseline commit."""
+    if request_baseline is not None or established is None:
+        return
+    try:
+        from .send_coordinator import _call_first
+
+        await _call_first(source, ("set_context_baseline_seq",),
+                          space_id, channel_id, established)
+    except Exception:
+        logger.exception("persist baseline failed for %s/%s", space_id, channel_id)
 
 
 def validate_keyless_response(raw: Any, request_body: Mapping[str, Any]) -> SendResult:
@@ -128,7 +151,7 @@ def _keyless_sent_result(
         replay=replay,
         devices_queued=queued,
         missing_devices=list(missing),
-        context_baseline_seq=freshness["context_baseline_seq"],
+        context_baseline_seq=echoed["context_baseline_seq"],
         seen_seq=freshness["seen_seq"],
         latest_seq_before_send=echoed["latest_seq_before_send"],
         mode=echoed["mode"],
@@ -144,14 +167,33 @@ def _keyless_freshness_is_valid(echoed: Any, freshness: Mapping[str, Any]) -> bo
     }:
         return False
     latest = echoed.get("latest_seq_before_send")
+    echoed_baseline = echoed.get("context_baseline_seq")
+    request_baseline = freshness["context_baseline_seq"]
+    baseline_ok = (
+        not isinstance(echoed_baseline, bool)
+        and isinstance(echoed_baseline, int)
+        and echoed_baseline >= 0
+        and (request_baseline is None or echoed_baseline == request_baseline)
+    )
+    # A null-baseline commit has no local boundary, so the Server establishes
+    # the baseline at the latest committed seq; the echo must agree exactly.
+    established_at_latest = request_baseline is not None or (
+        not isinstance(latest, bool)
+        and isinstance(latest, int)
+        and latest == echoed_baseline
+    )
     return (
         echoed.get("mode") == freshness["mode"]
         and echoed.get("seen_seq") == freshness["seen_seq"]
-        and echoed.get("context_baseline_seq") == freshness["context_baseline_seq"]
+        and baseline_ok
+        and established_at_latest
         and not isinstance(latest, bool)
         and isinstance(latest, int)
         and latest >= freshness["seen_seq"]
-        and (freshness["mode"] != "require_current" or latest == freshness["seen_seq"])
+        and (
+            freshness["mode"] != "require_current"
+            or latest == max(echoed_baseline, freshness["seen_seq"])
+        )
     )
 
 
@@ -164,10 +206,7 @@ def _keyless_held_result(
     has_blocker = any(key in raw for key in _BLOCKING_HELD_RESPONSE_FIELDS)
     valid = (
         raw.get("seen_seq") == freshness["seen_seq"]
-        and (
-            raw.get("context_baseline_seq") is None
-            or raw.get("context_baseline_seq") == freshness["context_baseline_seq"]
-        )
+        and raw.get("context_baseline_seq") == freshness["context_baseline_seq"]
         and not isinstance(latest, bool)
         and isinstance(latest, int)
         and latest > freshness["seen_seq"]
@@ -243,7 +282,7 @@ def _validate_sent_channel_response(
     validated = _validate_sent_freshness(raw, freshness, replay)
     if isinstance(validated, SendResult):
         return validated
-    has_freshness, latest_before = validated
+    has_freshness, latest_before, established_baseline = validated
     if "missing_devices" not in raw:
         return _protocol_error("sent response omitted missing_devices")
     missing = raw["missing_devices"]
@@ -264,7 +303,7 @@ def _validate_sent_channel_response(
         seq=seq,
         replay=replay,
         devices_queued=devices_queued,
-        context_baseline_seq=freshness["context_baseline_seq"],
+        context_baseline_seq=established_baseline,
         seen_seq=freshness["seen_seq"],
         latest_seq_before_send=latest_before if has_freshness else None,
         missing_devices=missing,
@@ -273,7 +312,7 @@ def _validate_sent_channel_response(
 
 def _validate_sent_freshness(
     raw: Mapping[str, Any], freshness: Mapping[str, Any], replay: bool
-) -> tuple[bool, int | None] | SendResult:
+) -> tuple[bool, int | None, int | None] | SendResult:
     has_freshness = "freshness" in raw
     response = raw.get("freshness")
     # Legacy-created replay is identified by replay=true and no stored v2
@@ -281,7 +320,7 @@ def _validate_sent_freshness(
     if not has_freshness and replay is not True:
         return _protocol_error("sent response omitted freshness")
     if not has_freshness:
-        return False, None
+        return False, None, None
     if not isinstance(response, Mapping):
         return _protocol_error("sent response freshness is malformed")
     if set(response) != {
@@ -298,7 +337,7 @@ def _validate_sent_freshness(
         response, freshness, baseline_echo, seen_echo, latest_before
     ):
         return _protocol_error("sent response freshness mismatch")
-    return True, latest_before
+    return True, latest_before, baseline_echo
 
 
 def _sent_freshness_matches(
@@ -308,12 +347,24 @@ def _sent_freshness_matches(
     seen_echo: Any,
     latest_before: Any,
 ) -> bool:
+    request_baseline = freshness["context_baseline_seq"]
+    baseline_ok = (
+        not isinstance(baseline_echo, bool)
+        and isinstance(baseline_echo, int)
+        and baseline_echo >= 0
+        and (request_baseline is None or baseline_echo == request_baseline)
+    )
+    # A null-baseline commit has no local boundary, so the Server establishes
+    # the baseline at the latest committed seq; the echo must agree exactly.
+    established_at_latest = request_baseline is not None or (
+        not isinstance(latest_before, bool)
+        and isinstance(latest_before, int)
+        and latest_before == baseline_echo
+    )
     return not (
         response.get("mode") != freshness["mode"]
-        or isinstance(baseline_echo, bool)
-        or not isinstance(baseline_echo, int)
-        or baseline_echo < 0
-        or baseline_echo != freshness["context_baseline_seq"]
+        or not baseline_ok
+        or not established_at_latest
         or isinstance(seen_echo, bool)
         or not isinstance(seen_echo, int)
         or seen_echo < 0
@@ -322,7 +373,10 @@ def _sent_freshness_matches(
         or not isinstance(latest_before, int)
         or latest_before < 0
         or latest_before < max(baseline_echo, seen_echo)
-        or (freshness["mode"] == "require_current" and latest_before != seen_echo)
+        or (
+            freshness["mode"] == "require_current"
+            and latest_before != max(baseline_echo, seen_echo)
+        )
     )
 
 
@@ -337,8 +391,9 @@ def _validate_held_channel_response(
         _CURRENT_HELD_RESPONSE_FIELDS,
     }:
         return _protocol_error("held response fields mismatch")
+    if raw["context_baseline_seq"] != freshness["context_baseline_seq"]:
+        return _protocol_error("held response watermark mismatch")
     values = {
-        "context_baseline_seq": raw["context_baseline_seq"],
         "seen_seq": raw["seen_seq"],
         "latest_seq": raw["latest_seq"],
     }
@@ -347,11 +402,12 @@ def _validate_held_channel_response(
         for value in values.values()
     ):
         return _protocol_error("held response has incomplete boundary watermarks")
+    boundary = freshness["seen_seq"]
+    if freshness["context_baseline_seq"] is not None:
+        boundary = max(boundary, freshness["context_baseline_seq"])
     if (
-        values["context_baseline_seq"] != freshness["context_baseline_seq"]
-        or values["seen_seq"] != freshness["seen_seq"]
-        or values["latest_seq"]
-        <= max(freshness["context_baseline_seq"], freshness["seen_seq"])
+        values["seen_seq"] != freshness["seen_seq"]
+        or values["latest_seq"] <= boundary
         or not isinstance(raw.get("latest_envelope_id"), str)
         or not raw.get("latest_envelope_id").strip()
     ):

--- a/src/puffo_agent/agent/send_response_validation.py
+++ b/src/puffo_agent/agent/send_response_validation.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+BASELINE_PERSISTENCE_WARNING = (
+    "The message was committed, but the local freshness baseline could not be "
+    "saved; a later channel send may need to resynchronize context."
+)
 
 
 _LEGACY_HELD_RESPONSE_FIELDS = frozenset(
@@ -73,17 +77,32 @@ async def persist_baseline(
     channel_id: str,
     request_baseline: int | None,
     established: int | None,
-) -> None:
+) -> bool:
     """Persist a validated Server-established baseline from a null-baseline commit."""
     if request_baseline is not None or established is None:
-        return
-    try:
-        from .send_coordinator import _call_first
+        return True
+    from .send_coordinator import _call_first
 
-        await _call_first(source, ("set_context_baseline_seq",),
-                          space_id, channel_id, established)
-    except Exception:
-        logger.exception("persist baseline failed for %s/%s", space_id, channel_id)
+    last_error: Exception | None = None
+    for _attempt in range(2):
+        try:
+            await _call_first(
+                source,
+                ("set_context_baseline_seq",),
+                space_id,
+                channel_id,
+                established,
+            )
+            return True
+        except Exception as exc:
+            last_error = exc
+    logger.error(
+        "persist baseline failed after retry for %s/%s: %s",
+        space_id,
+        channel_id,
+        last_error,
+    )
+    return False
 
 
 def validate_keyless_response(raw: Any, request_body: Mapping[str, Any]) -> SendResult:

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -19,6 +19,7 @@ from pathlib import Path
 # the claude-code convention, so the codex variants must strip the
 # prefix or codex rejects with "unsupported call".
 _MCP_PUFFO_PREFIX_RE = re.compile(r"\bmcp__puffo__")
+_WORKSPACE_STATUS_MARKER = "<!-- puffo:workspace-status -->"
 
 
 def _strip_puffo_mcp_prefix_for_codex(text: str) -> str:
@@ -117,8 +118,8 @@ at the point of use. `refresh` rebuilds the prompt and resyncs those skills.
 
 ## Your workspace
 
-Your `cwd` is your persistent private workspace. `shared/` inside it is the
-host-wide collaboration directory for Agents managed by the same Puffo home.
+Your `cwd` is your persistent private workspace.
+<!-- puffo:workspace-status -->
 
 ## Memory
 
@@ -1251,12 +1252,22 @@ def assemble_claude_md(
     shared_primer: str,
     profile: str,
     memory_briefing: str,
+    workspace_shared_status: str = "existing",
 ) -> str:
     """Produce the per-agent CLAUDE.md. Order: primer (platform
     conventions) → memory (the compiled bounded briefing, including profile).
     """
     parts: list[str] = []
     if shared_primer.strip():
+        workspace_context = _workspace_shared_context(workspace_shared_status)
+        if _WORKSPACE_STATUS_MARKER in shared_primer:
+            shared_primer = shared_primer.replace(
+                _WORKSPACE_STATUS_MARKER,
+                workspace_context,
+                1,
+            )
+        else:
+            shared_primer = f"{shared_primer.rstrip()}\n\n{workspace_context}"
         parts.append(shared_primer.strip())
     if memory_briefing.strip():
         # ``briefing/profile.md`` retains its title on disk, but the generated
@@ -1269,6 +1280,24 @@ def assemble_claude_md(
         )
         parts.append(MEMORY_SECTION_HEADER + memory_briefing.strip())
     return "\n\n".join(parts) + "\n"
+
+
+def _workspace_shared_context(status: str) -> str:
+    if status in {"created", "existing", "mounted"}:
+        return (
+            "`shared/` inside it is the host-wide collaboration directory for "
+            "Agents managed by the same Puffo home."
+        )
+    if status == "conflict":
+        return (
+            "`shared/` currently contains private local data and is not connected "
+            "to the host-wide collaboration directory. Do not use it for "
+            "cross-Agent handoffs until the operator resolves the conflict."
+        )
+    return (
+        "The host-wide collaboration directory is unavailable in this runtime. "
+        "Do not rely on `shared/` for cross-Agent handoffs."
+    )
 
 
 def write_claude_md(claude_dir: Path, content: str) -> Path:
@@ -1319,6 +1348,7 @@ def rebuild_agent_codex_md(
     role: str = "",
     role_short: str = "",
     puffo_handle: str = "",
+    workspace_shared_status: str = "existing",
 ) -> str:
     """Assemble + write one codex agent's AGENTS.md.
 
@@ -1339,6 +1369,7 @@ def rebuild_agent_codex_md(
     agents_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
+        workspace_shared_status=workspace_shared_status,
         memory_briefing=compile_agent_memory_briefing(
             memory_dir=memory_dir,
             profile_text=profile_text,
@@ -1366,6 +1397,7 @@ def rebuild_agent_claude_md(
     role: str = "",
     role_short: str = "",
     puffo_handle: str = "",
+    workspace_shared_status: str = "existing",
 ) -> str:
     """Assemble + write one agent's managed CLAUDE.md / GEMINI.md.
 
@@ -1390,6 +1422,7 @@ def rebuild_agent_claude_md(
     claude_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
+        workspace_shared_status=workspace_shared_status,
         memory_briefing=compile_agent_memory_briefing(
             memory_dir=memory_dir,
             profile_text=profile_text,

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -99,10 +99,8 @@ at the point of use. `refresh` rebuilds the prompt and resyncs those skills.
 
 ## Your workspace
 
-Your `cwd` is `/workspace` (cli-docker) or
-`~/.puffo-agent/agents/<your-id>/workspace/` (cli-local). Survives
-daemon and container restarts. Agents on the same host share
-`/workspace/.shared` (cli-docker) or `~/.puffo-agent/shared/` (cli-local).
+Your `cwd` is your persistent private workspace. `shared/` inside it is the
+host-wide collaboration directory for Agents managed by the same Puffo home.
 
 ## Memory
 
@@ -1141,7 +1139,7 @@ _MANAGED_MARKER = ".puffo-managed"
 _MANAGED_MARKER_BODY = (
     "This skill is mirrored from the puffo-agent install on every "
     "worker start. Edits to SKILL.md here are overwritten; edit "
-    "the source under ~/.puffo-agent/shared/skills/<id>/SKILL.md\n"
+    "the source under <puffo-home>/docker/shared/skills/<id>/SKILL.md\n"
 )
 
 

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -41,9 +41,9 @@ Pending messages wake you with metadata, not message bodies:
 </global_inbox_notice>
 ```
 
-Use `mcp__puffo__read_inbox` when you need the pending content. The
-`read-inbox` skill describes paging and prior context. The `decide-response`
-skill owns the response judgment after you have read the relevant context.
+Use `mcp__puffo__read_inbox` to inspect the pending content. A metadata-only
+notice means unread content exists; it is not evidence that there is no work or
+response to handle. The `read-inbox` skill describes paging and prior context.
 
 ## Context contract
 
@@ -67,31 +67,49 @@ as runtime facts or recovery instructions, not as a person speaking. A long
 message placeholder names `mcp__puffo__get_post_segment`; fetch only the
 segments you need.
 
-## Conversation decisions
+## Communication
 
-Use the latest visible context. After reading it, apply `decide-response`
-before each Puffo response decision.
+When you receive a concrete message, process it and respond through
+`mcp__puffo__send_message` as appropriate. If it needs a visible
+acknowledgment, ownership signal, blocker question, or clarification, send that
+before beginning deeper work.
 
-For small, cheap, reversible work, act directly. When several participants
-must choose distinct substantive parts, or before other substantial divisible
-work, claim one uncovered part before doing that work.
-A claim exists only after its message is committed and remains provisional as
-new context arrives. Other claims normally need no acknowledgement; adapt
-silently unless a conflict or useful correction matters.
+For multi-step work, keep people informed with concise, useful updates. When
+finished, report the outcome, including a blocker or negative result. Before
+stopping, make sure any result, handoff, decision, or reply you owe has been
+sent. If material ambiguity prevents useful action, ask one concise
+clarification question. If continuation depends on future state, create a
+suitable reminder and read the latest conversation when it fires.
 
-Choose Send, Clarify, Wait, or Silent according to what best advances the
-user's goal. `[SILENT]` means the context supports no useful response now;
-material ambiguity calls for clarification, not silence. Waiting for future
-context requires a suitable reminder. A reminder is a future request to
-reconsider, not an instruction to execute an old plan. Reconcile related
-claims and reminders when context changes.
+Agent messages may legitimately trigger further Agent work. Continue while an
+exchange adds information, changes shared state, resolves uncertainty, or
+converges on a useful outcome. Stop when it would only repeat or self-propagate
+without progress. Respect conversations clearly directed at someone else, do
+not duplicate another participant's completed report, and skip idle narration
+that provides no useful information.
 
-Choose explicitly: call `mcp__puffo__send_message` for a Puffo message, or
-write `[SILENT]` when you choose not to send. Preserve the Inbox
-route by default: DMs use `@<peer>`; channels use `channel_id`; threads also
-use `thread_root_id` as `root_id`. Starting a new thread is your presentation
-choice. The `send-message` skill describes destinations, visibility, held
-results, and `send_anyway`.
+## Coordination
+
+For small, cheap, reversible work where duplicate effort is negligible, act
+directly. When a request benefits from several Agents or can be divided into
+substantive independent parts, inspect the latest conversation, choose one
+uncovered part that best fits your role, capabilities, and available tools,
+and send a concise claim before beginning that work. A claim becomes visible
+only after it is successfully sent and remains provisional as context changes.
+
+## Threads and delivery
+
+Visible Puffo messages must be sent with `mcp__puffo__send_message`; ordinary
+assistant text is not delivered. Preserve the Inbox route by default: DMs use
+`@<peer>` and channels use `channel_id`.
+
+Threads are focused conversations attached to a specific message. When a
+message comes from an existing thread, reply in that thread by passing its
+`thread_root_id` as `root_id`. For a top-level message, start a thread by using
+its `message_id` as `root_id` when the response opens a focused discussion
+around that message; keep channel-wide coordination, announcements, and broadly
+relevant updates at the channel level. The `send-message` skill describes
+destinations, visibility, held results, and `send_anyway`.
 
 Tool schemas define arguments and results. Detailed procedures are managed
 skills under `.claude/skills/` or `.agents/skills/`; load the relevant skill
@@ -131,131 +149,12 @@ an agent to force).
 # ── Default skill markdowns ───────────────────────────────────────────────────
 
 
-INBOX_RESPONSE_DECISION_CUE = """\
+INBOX_TURN_CUE = """\
 <puffo_runtime_instruction>
-Read the pending content, then apply the `decide-response` skill before
-choosing Send, Wait, Clarify, or Silent.
+Read the relevant pending content. Process concrete messages and respond
+through `send_message` as appropriate. Complete the current work and report
+any result or handoff you owe before stopping.
 </puffo_runtime_instruction>"""
-
-
-DEFAULT_SKILL_DECIDE_RESPONSE = """\
-# Skill: decide-response
-
-Decide what to do after reading the relevant Puffo conversation context. Use
-this method before every choice to Send, Wait, Clarify, or remain Silent. It is
-a context-dependent judgment, not a fixed reply policy.
-
-## Establish the interaction
-
-Privately reconstruct the current interaction from the message that originated
-it through the latest relevant rows. Earlier unrelated activity is context,
-not evidence of assignment, turn position, or participation unless the current
-interaction refers to it.
-
-Before treating participation or completion as established, confirm that the
-originating message and the evidence needed for that judgment are visible. A
-bounded excerpt is not evidence that omitted rows do not exist. Retrieve enough
-target history when the available context does not reach the interaction's
-origin or cannot establish an outstanding obligation.
-
-Identify the facts that determine the next useful action. Separate facts in the
-context from assumptions. If another reasonable interpretation of an
-unsupported assumption would materially change the user-visible result, the
-decision is not grounded yet. Confidence is not evidence.
-
-Infer who is addressed, whether the interaction expects distinct participation
-or one shared result, how many turns each participant is expected to take, and
-what completes it. When an ordered group request gives no indication of
-repetition, one successful visible turn per addressed identity normally
-completes that round. Explicit repetition, multiple rounds, or later work may
-require more.
-
-Use `sender_identity` and `self=true` to track visible participation within the
-current interaction. Another participant's response does not substitute for
-yours in distinct-participation mode. An attempted, held, or failed draft is
-not visible participation. A successful response completes only the
-participation it visibly fulfills. Later peer activity alone does not reopen a
-completed obligation, but an originating request for several contributions or
-rounds leaves the remaining contributions open, and peer progress can make the
-next one due. In shared-result mode, an existing result may already satisfy the
-request.
-
-For ordered interactions, keep participant position separate from the content
-or value produced at that position. A special value at one position does not
-reset later positions unless the request or conversation indicates a reset.
-When the interaction leaves the next contributor open and the originating
-request proves that your own participation obligation remains, lack of a
-preassigned identity is not by itself material uncertainty: you may attempt the
-next useful step against the latest context. This does not create or reopen an
-obligation; establish it from the originating request and your visible
-participation first. An unfinished contribution assigned to another participant
-does not by itself become yours merely because it remains open. Preserve an
-explicit contributor order or assignment when one exists.
-
-Agent messages may legitimately trigger further Agent work. Continue when an
-iteration adds information, changes shared state, resolves uncertainty,
-advances work, or converges on a useful outcome. Stop when it would only
-repeat, oscillate, or self-propagate without progress. Explicitly requested
-repetition follows its intended scope and stopping condition.
-
-## Coordinate the work
-
-For small, cheap, reversible work where duplicate effort is negligible, act
-directly. If several participants must choose distinct substantive
-contributions, inspect the latest context and send a concise claim for one
-uncovered part before doing your contribution, even when your own part seems
-quick. Use the same sequence before other substantial divisible work. The
-claim must be a separate committed message before the work or result; combining
-it with the result does not create a coordination window. A held or failed
-claim establishes nothing: reconsider current claims and pick another useful
-part when needed. Claims are provisional; later messages may confirm,
-override, reassign, or complete the work.
-
-Claims normally need no acknowledgement. Silently update your own plan unless
-a conflict, correction, or material ambiguity needs a response. When cost,
-risk, or irreversibility makes an objection window valuable, you may Wait after
-a committed claim and set a short reminder. Otherwise continue without delay.
-
-## Reconcile reminders
-
-When new context can change a future intention, use
-`mcp__puffo__list_reminders` to inspect scheduled reminders. Keep one whose
-target, purpose, and timing still fit. Cancel one whose intention completed,
-was cancelled, or was reassigned. To change its purpose or timing, cancel it
-and create one replacement. Do not accumulate equivalent active reminders.
-
-Reminder content identifies the interaction, future intention or claim, and
-question to reconsider. A fired reminder is an earlier intention, not a current
-command: read the latest target context and decide again.
-
-## Choose the current outcome
-
-- **Send:** A useful response is grounded in the available context. Use the
-  `send-message` skill. A Send can complete the immediate step while leaving an
-  explicit continuing obligation. If work remains and no reliable later event
-  will wake you to continue it, schedule a reminder before ending the turn.
-- **Wait:** A concrete later event is likely to resolve the next action, or the
-  target is changing too quickly to judge. Before ending the turn, ensure one
-  suitable reminder exists for the same target and purpose: reuse an adequate
-  scheduled reminder or use `mcp__puffo__create_reminder` after cancelling the
-  one it replaces. Its content must identify the interaction and question to
-  reevaluate. Choose a reasonable delay from the conversation pace, active
-  participants, observed response timing, urgency, and recent holds; prefer
-  earlier reevaluation over an unnecessarily long delay. When it fires, read
-  the latest target context and run this skill again. If the expected event did
-  not occur and your grounded obligation remains, do not repeat Wait solely
-  because no next participant was preassigned; reassess Send, Clarify, and
-  Silent. Repeat Wait only while another concrete event remains likely. A
-  reminder schedules reconsideration; it does not authorize a stale draft.
-- **Clarify:** A material uncertainty remains and only human intent or a human
-  repair choice can resolve it. Send one concise question. First check whether
-  an equivalent clarification is already present; if so, choose Wait instead
-  of asking again.
-- **Silent:** The available context positively supports that no useful response
-  is needed now, such as completed participation or an already satisfied shared
-  result. Silence is not the fallback for unresolved work or missing material
-  information.
-"""
 
 
 HELD_SEND_RECONSIDERATION_GUIDANCE = """\
@@ -277,8 +176,9 @@ If the draft was a claim, it did not establish ownership. Inspect newer claims
 and select an uncovered part before investing significant effort.
 
 Read the returned context and any additional target history you need, then
-apply the `decide-response` skill to choose Send, Wait, Clarify, or Silent. A
-Wait outcome follows that skill's reminder reconciliation requirement.
+reconsider what response, clarification, or follow-up still advances the
+conversation. If continuation depends on future state, make it durable with a
+suitable reminder. If no visible response is useful, do not send one.
 
 If you choose Send, judge whether newer context can change the draft's
 correctness, sequence position, target, necessity, interpretation,
@@ -338,9 +238,9 @@ boundary/latest pair, `context_ready`, `visible_draft_basis`,
 `new_channel_context`, and dynamic `guidance`. Follow that returned guidance;
 it is injected only when a draft is actually held.
 
-When `context_ready=false`,
-do not infer unseen messages: read the relevant tools if more context is needed
-or choose silence. A sequence watermark alone is not semantic context.
+When `context_ready=false`, do not infer unseen messages: retrieve enough
+relevant context before acting or concluding that no response is needed. A
+sequence watermark alone is not semantic context.
 
 **Examples:**
 
@@ -543,9 +443,9 @@ message bodies and is not enough context for a reply.
 - A notice is metadata only. It never substitutes for a content-bearing
   Inbox or history read. Use the `send-message` skill for held-send guidance.
 
-After reading enough relevant context, apply the `decide-response` skill. This
-tool owns retrieval and acknowledgement; it does not decide whether to Send,
-Wait, Clarify, remain Silent, or use `send_anyway`.
+After reading enough relevant context, handle it according to the standing
+communication guidance. This tool owns retrieval and acknowledgement; it does
+not decide whether to respond or use `send_anyway`.
 
 **When to use:**
 - When a notice points to pending work relevant to the current decision.
@@ -1095,10 +995,6 @@ DEFAULT_SKILLS: dict[str, tuple[str, str]] = {
     "read-inbox": (
         "Read pending Puffo Inbox work and supplementary route context after a metadata notice.",
         DEFAULT_SKILL_READ_INBOX,
-    ),
-    "decide-response": (
-        "Decide whether to send, wait with a reminder, clarify, or stay silent after reading Puffo context.",
-        DEFAULT_SKILL_DECIDE_RESPONSE,
     ),
     "channel-members": (
         "List a channel's member slugs + roles.",

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -136,9 +136,9 @@ class StatusReporter:
         """Best-effort status refresh used after bridge reconnects."""
         await self._send_heartbeat()
 
-    async def begin_turn(self, message_id: str) -> str:
+    async def begin_turn(self, message_id: str, *, run_id: str | None = None) -> str:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
-        run_id = f"run_{uuid.uuid4().hex}"
+        run_id = run_id or f"run_{uuid.uuid4().hex}"
         if self._keyless:
             # No signed /processing/* call for bridge agents (see __init__);
             # report "busy" over the bridge so the operator's Log gets the
@@ -225,10 +225,13 @@ class StatusReporter:
         if self._keyless:
             # Bridge agents: mirror the batch outcome into local status +
             # report it over the bridge (see __init__).
-            any_failed = any(not r["succeeded"] for r in runs)
-            self._current_status = "error" if any_failed else "idle"
+            failed = next((r for r in runs if not r["succeeded"]), None)
+            self._current_status = "error" if failed is not None else "idle"
             self._current_message_id = None
-            await self._emit_keyless(self._current_status, None, None)
+            error_text = None
+            if failed is not None and failed.get("error_text") is not None:
+                error_text = str(failed["error_text"])[:1024]
+            await self._emit_keyless(self._current_status, None, error_text)
             return
         payload_runs: list[dict[str, Any]] = []
         for r in runs:

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -22,7 +22,11 @@ DEFAULT_HEARTBEAT_INTERVAL_S = 60.0
 
 # Synthetic local envelopes have no server row; /messages/<id>/processing/*
 # would 404, so skip the HTTP round-trip (the worker still tracks the run).
-_LOCAL_ONLY_ENVELOPE_PREFIXES = ("intro-prompt-",)
+_LOCAL_ONLY_ENVELOPE_PREFIXES = (
+    "intro-prompt-",
+    "membership-",
+    "reminder-occurrence:",
+)
 
 
 def _is_local_only_envelope(message_id: str) -> bool:

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -329,6 +329,7 @@ def puffo_core_mcp_env(
     space_id: str = "",
     keystore_dir: str,
     workspace: str,
+    shared_workspace: str = "",
     agent_id: str = "",
     data_service_url: str = "http://127.0.0.1:63386",
     rpc_url: str = "http://127.0.0.1:63385",
@@ -360,6 +361,8 @@ def puffo_core_mcp_env(
         LOCAL_SERVICE_TOKEN_ENV: issue_local_service_token(effective_agent_id),
         **_python_user_base_env(runtime_kind),
     }
+    if shared_workspace:
+        env["PUFFO_SHARED_WORKSPACE"] = shared_workspace
     # The MCP starts with the agent workspace as cwd. A relative PYTHONPATH
     # would therefore resolve against the wrong directory and can silently
     # load a different editable checkout than the daemon.

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -320,6 +320,7 @@ def build_server(
     workspace: str,
     agent_id: str,
     data_service_url: str,
+    shared_workspace: str = "",
     runtime_kind: str = "",
     harness: str = "",
     memory_dir: str = "",
@@ -356,6 +357,7 @@ def build_server(
         data_client=data,
         space_id=space_id,
         workspace=workspace,
+        shared_workspace=shared_workspace or None,
         rpc_client=rpc_client,
     )
 
@@ -406,6 +408,7 @@ def _cfg_from_env() -> dict[str, str]:
         "space_id": os.environ.get("PUFFO_CORE_SPACE_ID", ""),
         "keystore_dir": os.environ.get("PUFFO_CORE_KEYSTORE_DIR", ""),
         "workspace": os.environ.get("PUFFO_WORKSPACE", "/workspace"),
+        "shared_workspace": os.environ.get("PUFFO_SHARED_WORKSPACE", ""),
         "agent_id": agent_id,
         "data_service_url": data_service_url,
         "runtime_kind": os.environ.get("PUFFO_RUNTIME_KIND", ""),

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -290,6 +290,9 @@ class PuffoCoreToolsConfig:
     # safety-resolve LLM-supplied relative paths (no ``..`` escape,
     # no absolutes).
     workspace: Optional[str] = None
+    # Canonical target of the managed ``workspace/shared`` link. This is
+    # intentionally separate so arbitrary symlink escapes remain forbidden.
+    shared_workspace: Optional[str] = None
     # None when PUFFO_RPC_URL isn't set; install/sync tools surface
     # a clear error rather than touching operator files in-process.
     rpc_client: Optional[PuffoRpcClient] = None
@@ -325,6 +328,8 @@ async def _dispatch_semantic_send(
         try:
             if hasattr(coordinator, "workspace"):
                 coordinator.workspace = cfg.workspace
+            if hasattr(coordinator, "shared_workspace"):
+                coordinator.shared_workspace = cfg.shared_workspace
             result = await coordinator.send(request)
         except Exception as exc:
             return failed_result(
@@ -364,6 +369,7 @@ async def _dispatch_semantic_send(
             http_client=cfg.http_client,
             data_client=cfg.data_client,
             workspace=cfg.workspace,
+            shared_workspace=cfg.shared_workspace,
         )
         return await coordinator.send(request)
     return failed_result(

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -54,7 +54,10 @@ from .state import (
     write_refresh_token_request,
     write_stop_request,
 )
-from .workspace_layout import ensure_workspace_shared_link
+from .workspace_layout import (
+    AVAILABLE_SHARED_WORKSPACE_STATES,
+    prepare_workspace_shared_access,
+)
 
 DEFAULT_PROFILE = """# Agent Profile
 
@@ -83,6 +86,21 @@ question that invites a response. Stay silent when the conversation is
 between other people and you have nothing useful to add — output
 exactly `[SILENT]` to stay silent.
 """
+
+
+def _prepare_cli_shared_workspace(cfg: AgentConfig) -> str:
+    status = prepare_workspace_shared_access(
+        cfg.resolve_workspace_dir(),
+        shared_fs_dir(),
+        mounted=(cfg.runtime.kind or "cli-local") == "cli-docker",
+    )
+    if status not in AVAILABLE_SHARED_WORKSPACE_STATES:
+        print(
+            f"warning: shared workspace is {status}; cross-Agent file "
+            "handoffs through workspace/shared are unavailable",
+            file=sys.stderr,
+        )
+    return status
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -535,7 +553,7 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
         created_at=int(time.time()),
     )
     cfg.save()
-    ensure_workspace_shared_link(cfg.resolve_workspace_dir(), shared_fs_dir())
+    _prepare_cli_shared_workspace(cfg)
 
     from ..agent.memory import ensure_memory_tree, sync_profile_briefing
 
@@ -1538,6 +1556,7 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
             rc = 2
             continue
         try:
+            workspace_shared_status = _prepare_cli_shared_workspace(cfg)
             rebuild_agent_claude_md(
                 shared_dir=shared_dir,
                 profile_path=cfg.resolve_profile_path(),
@@ -1550,6 +1569,7 @@ def cmd_agent_reset_primer(args: argparse.Namespace) -> int:
                 role=cfg.role,
                 role_short=cfg.role_short,
                 puffo_handle=cfg.puffo_core.slug,
+                workspace_shared_status=workspace_shared_status,
             )
         except BriefingCompileError as exc:
             print(f"error: agent {agent_id!r}: {exc}", file=sys.stderr)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -50,9 +50,11 @@ from .state import (
     refresh_model_flag_path,
     refresh_runtime_flag_path,
     refresh_session_flag_path,
+    shared_fs_dir,
     write_refresh_token_request,
     write_stop_request,
 )
+from .workspace_layout import ensure_workspace_shared_link
 
 DEFAULT_PROFILE = """# Agent Profile
 
@@ -534,6 +536,7 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
         created_at=int(time.time()),
     )
     cfg.save()
+    ensure_workspace_shared_link(cfg.resolve_workspace_dir(), shared_fs_dir())
 
     from ..agent.memory import ensure_memory_tree, sync_profile_briefing
 

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -487,7 +487,6 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     if not validation.ok:
         print(f"error: {validation.error}", file=sys.stderr)
         return 2
-
     role = (args.role or "").strip()
     role_short_raw = getattr(args, "role_short", None)
     role_short_raw = role_short_raw.strip() if role_short_raw else ""

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -1321,6 +1321,10 @@ async def run_daemon(
     daemon_cfg = DaemonConfig.load()
     pid = os.getpid()
     try:
+        # With no live daemon proven above, a leftover stop sentinel
+        # (old-CLI timestamp-only or stale JSON) must not kill the new
+        # process — clear it before publishing our own pid.
+        clear_stop_request()
         write_daemon_pid(pid)
         daemon = Daemon(daemon_cfg)
         loop = asyncio.get_running_loop()

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -62,11 +62,13 @@ from .state import (
     refresh_session_flag_path,
     refresh_token_request_path,
     restart_flag_path,
+    shared_fs_dir,
     stop_request_path,
     stop_requested_for,
     write_daemon_pid,
     write_daemon_ready,
 )
+from .workspace_layout import ensure_workspace_shared_link
 from .worker import Worker
 
 logger = logging.getLogger(__name__)
@@ -286,6 +288,7 @@ class Daemon:
         if cached is not None and (cached[0], cached[1]) == key:
             return cached[2]
         cfg = AgentConfig.load(agent_id)
+        ensure_workspace_shared_link(cfg.resolve_workspace_dir(), shared_fs_dir())
         self._agent_cfg_cache[agent_id] = (st.st_mtime_ns, st.st_size, cfg)
         return cfg
 

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -36,6 +36,7 @@ from .data_service import (
 )
 from .host_mcp_handler import HostMcpContext
 from .rpc_service import set_rpc_resolver, start_rpc_service, stop_rpc_service
+from .runtime_matrix import RUNTIME_CLI_DOCKER, RUNTIME_CLI_LOCAL
 from .state import (
     AgentConfig,
     DaemonConfig,
@@ -68,7 +69,10 @@ from .state import (
     write_daemon_pid,
     write_daemon_ready,
 )
-from .workspace_layout import ensure_workspace_shared_link
+from .workspace_layout import (
+    AVAILABLE_SHARED_WORKSPACE_STATES,
+    prepare_workspace_shared_access,
+)
 from .worker import Worker
 
 logger = logging.getLogger(__name__)
@@ -288,7 +292,18 @@ class Daemon:
         if cached is not None and (cached[0], cached[1]) == key:
             return cached[2]
         cfg = AgentConfig.load(agent_id)
-        ensure_workspace_shared_link(cfg.resolve_workspace_dir(), shared_fs_dir())
+        shared_status = prepare_workspace_shared_access(
+            cfg.resolve_workspace_dir(),
+            shared_fs_dir(),
+            mounted=(cfg.runtime.kind or RUNTIME_CLI_LOCAL) == RUNTIME_CLI_DOCKER,
+        )
+        if shared_status not in AVAILABLE_SHARED_WORKSPACE_STATES:
+            logger.error(
+                "agent %s: shared workspace is %s; cross-Agent file handoffs "
+                "are unavailable",
+                agent_id,
+                shared_status,
+            )
         self._agent_cfg_cache[agent_id] = (st.st_mtime_ns, st.st_size, cfg)
         return cfg
 

--- a/src/puffo_agent/portal/runtime_matrix.py
+++ b/src/puffo_agent/portal/runtime_matrix.py
@@ -6,13 +6,14 @@ are bound to one provider (``claude-code`` → anthropic, ``gemini-cli``
 → google); ``hermes`` is multi-provider.
 
 Supported today: ``cli-local`` with ``claude-code`` or ``codex``,
-``cli-docker`` with ``claude-code``, and ``ws-local`` (external tool,
-no internal engine). ``hermes`` and ``gemini-cli`` remain design-only —
-no runtime accepts them, because their provider admission happens after
-MCP execution and they cannot correlate a concrete ``read_inbox`` tool
-result, so they cannot complete the metadata-notified Inbox contract.
-They stay enumerated here so a persisted agent.yml carrying one fails
-with that explicit diagnostic instead of a misleading "unknown harness".
+``cli-docker`` with ``claude-code`` or ``codex``, and ``ws-local``
+(external tool, no internal engine). ``hermes`` and ``gemini-cli``
+remain design-only — no runtime accepts them, because their provider
+admission happens after MCP execution and they cannot correlate a
+concrete ``read_inbox`` tool result, so they cannot complete the
+metadata-notified Inbox contract. They stay enumerated here so a
+persisted agent.yml carrying one fails with that explicit diagnostic
+instead of a misleading "unknown harness".
 """
 
 from __future__ import annotations
@@ -69,9 +70,10 @@ VALID_HARNESSES: frozenset[str] = frozenset({
 # ── Constraints ───────────────────────────────────────────────────────────────
 
 # Harness → providers it supports. ``resolve_effective_harness`` selects Codex
-# for OpenAI on ``cli-local``. The design-only Hermes/Gemini entries are kept
-# so provider defaults still resolve to a named harness and ``validate_triple``
-# can reject it with the design-only diagnostic; no runtime admits them.
+# for OpenAI on both harness-bearing CLI runtimes. The design-only
+# Hermes/Gemini entries are kept so provider defaults still resolve to a
+# named harness and ``validate_triple`` can reject it with the design-only
+# diagnostic; no runtime admits them.
 HARNESS_PROVIDERS: dict[str, frozenset[str]] = {
     HARNESS_CLAUDE_CODE: frozenset({PROVIDER_ANTHROPIC}),
     HARNESS_HERMES:      frozenset({PROVIDER_ANTHROPIC, PROVIDER_OPENAI}),
@@ -201,21 +203,19 @@ def validate_triple(
             f"harness {harness!r} is not implemented by the Driver runtime"
         ))
 
-    if runtime == RUNTIME_CLI_DOCKER and harness != HARNESS_CLAUDE_CODE:
-        if harness == HARNESS_CODEX:
-            return ValidationResult(False, (
-                f"runtime {RUNTIME_CLI_DOCKER!r} supports only "
-                f"{HARNESS_CLAUDE_CODE!r}; harness {HARNESS_CODEX!r} "
-                "requires the host-local Driver runtime — set runtime.kind "
-                f"to {RUNTIME_CLI_LOCAL!r}"
-            ))
+    if runtime == RUNTIME_CLI_DOCKER and harness not in {
+        HARNESS_CLAUDE_CODE,
+        HARNESS_CODEX,
+    }:
         return ValidationResult(False, (
             f"runtime {RUNTIME_CLI_DOCKER!r} supports only "
-            f"{HARNESS_CLAUDE_CODE!r}; harness {harness!r} is design-only in "
-            "this release — it cannot complete the metadata-notified Inbox "
-            f"contract. Set runtime.kind {RUNTIME_CLI_LOCAL!r} with harness "
-            f"{HARNESS_CLAUDE_CODE!r} or {HARNESS_CODEX!r}, or keep "
-            f"{RUNTIME_CLI_DOCKER!r} with harness {HARNESS_CLAUDE_CODE!r}"
+            f"{HARNESS_CLAUDE_CODE!r} and {HARNESS_CODEX!r}; "
+            f"harness {harness!r} is design-only in this release — it "
+            "cannot complete the metadata-notified Inbox contract. Keep "
+            f"{RUNTIME_CLI_DOCKER!r} with harness {HARNESS_CLAUDE_CODE!r} "
+            f"or {HARNESS_CODEX!r}, or set runtime.kind "
+            f"{RUNTIME_CLI_LOCAL!r} with harness {HARNESS_CLAUDE_CODE!r} "
+            f"or {HARNESS_CODEX!r}"
         ))
 
     if provider:
@@ -240,15 +240,14 @@ def resolve_effective_harness(runtime: str, provider: str, harness: str) -> str:
     """Return the effective harness for this runtime.
 
     Empty string when the field doesn't apply; otherwise the input if
-    set, or the provider-specific default.
+    set, or the provider-specific default. Both CLI runtimes default
+    OpenAI to Codex and Anthropic to Claude Code.
     """
     if not harness_applies(runtime):
         return ""
     if harness:
         return harness
     provider = resolve_effective_provider(runtime, provider)
-    if runtime == RUNTIME_CLI_LOCAL and provider == PROVIDER_OPENAI:
-        return HARNESS_CODEX
     return DEFAULT_HARNESS_FOR_PROVIDER.get(provider, HARNESS_CLAUDE_CODE)
 
 

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1125,21 +1125,55 @@ def stop_request_path() -> Path:
     return home_dir() / ".stop_requested"
 
 
-def read_stop_request_pid() -> int | None:
+def _classify_stop_request() -> tuple[str, int | None]:
+    """Classify the stop sentinel for the daemon stop boundary.
+
+    Returns ``("none", None)`` when the sentinel is absent,
+    ``("pid", pid)`` for the JSON PID sentinel the current CLI writes,
+    ``("legacy", None)`` for the timestamp-only scalar the pre-2.0 CLI
+    wrote, and ``("malformed", None)`` for content that is neither.
+    ``legacy`` and ``malformed`` are distinguished so the upgrade
+    boundary can clear a stale pre-start legacy file without treating
+    every corrupt file as a stop request.
+    """
     path = stop_request_path()
     if not path.exists():
-        return None
+        return "none", None
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        pid = payload.get("pid") if isinstance(payload, dict) else None
-        return int(pid) if pid is not None else None
-    except (OSError, TypeError, ValueError, json.JSONDecodeError):
-        # Timestamp-only sentinels from older versions are deliberately stale.
-        return None
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return "malformed", None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return "malformed", None
+    if isinstance(payload, dict):
+        pid = payload.get("pid")
+        if pid is None:
+            return "malformed", None
+        try:
+            return "pid", int(pid)
+        except (TypeError, ValueError):
+            return "malformed", None
+    if isinstance(payload, (int, float)) and not isinstance(payload, bool):
+        return "legacy", None
+    return "malformed", None
+
+
+def read_stop_request_pid() -> int | None:
+    """PID targeted by a JSON stop sentinel, or None when absent or the
+    sentinel is not a JSON PID request (e.g. the timestamp-only legacy
+    format)."""
+    kind, pid = _classify_stop_request()
+    return pid if kind == "pid" else None
 
 
 def stop_requested_for(pid: int) -> bool:
-    return read_stop_request_pid() == pid
+    """True when a stop is requested for ``pid``: the JSON sentinel
+    carries exactly ``pid``, or the sentinel is a timestamp-only legacy
+    request, which targets whichever daemon is running."""
+    kind, target_pid = _classify_stop_request()
+    return (kind == "pid" and target_pid == pid) or kind == "legacy"
 
 
 def write_stop_request(pid: int | None = None) -> None:
@@ -1156,9 +1190,7 @@ def write_stop_request(pid: int | None = None) -> None:
     temporary.replace(path)
 
 
-def clear_stop_request(expected_pid: int | None = None) -> bool:
-    if expected_pid is not None and read_stop_request_pid() != expected_pid:
-        return False
+def _unlink_stop_request() -> bool:
     path = stop_request_path()
     try:
         path.unlink()
@@ -1167,6 +1199,26 @@ def clear_stop_request(expected_pid: int | None = None) -> bool:
         return False
     except OSError:
         return False
+
+
+def clear_stop_request(expected_pid: int | None = None) -> bool:
+    """Remove the stop sentinel.
+
+    JSON sentinels clear only when ``expected_pid`` matches their target
+    pid (exact PID matching is preserved); a timestamp-only legacy
+    sentinel targets whichever daemon is running, so it is removed
+    whenever the daemon would have accepted it. With no ``expected_pid``
+    (startup sweep) any stale file is removed so it cannot affect a
+    freshly started daemon.
+    """
+    kind, target_pid = _classify_stop_request()
+    if kind == "none":
+        return False
+    if kind == "malformed":
+        return _unlink_stop_request() if expected_pid is None else False
+    if kind == "pid" and expected_pid is not None and target_pid != expected_pid:
+        return False
+    return _unlink_stop_request()
 
 
 def refresh_token_request_path() -> Path:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -93,9 +93,7 @@ def agent_codex_user_dir(agent_id: str) -> Path:
 
 
 def shared_fs_dir() -> Path:
-    """Shared dir for cross-agent cooperation. Bind-mounted to
-    ``/workspace/.shared`` for cli-docker; referenced by absolute path
-    for cli-local agents."""
+    """Canonical host-wide directory exposed as ``workspace/shared``."""
     return home_dir() / "shared"
 
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -122,8 +122,9 @@ def build_docker_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Ad
     """Construct a non-Driver adapter for ``runtime.kind``.
 
     Host-local Claude and Codex runtimes are built by Worker through the
-    Driver runtime. This factory remains only for the Docker compatibility
-    runtime.
+    Driver runtime; cli-docker + codex routes through
+    :func:`build_docker_codex_runtime`. This factory remains only for the
+    Docker Claude compatibility runtime.
     """
     kind = agent_cfg.runtime.kind or "cli-local"
     if kind == "cli-docker":
@@ -142,6 +143,22 @@ def build_docker_adapter(daemon_cfg: DaemonConfig, agent_cfg: AgentConfig) -> Ad
         f"agent {agent_cfg.id!r}: unknown runtime kind {kind!r} "
         "(valid: cli-local, cli-docker, ws-local)"
     )
+
+
+def build_docker_codex_runtime(
+    daemon_cfg: DaemonConfig, agent_cfg: AgentConfig,
+):
+    """Construct the Docker Codex runtime owner for the Driver path.
+
+    ``cli-docker`` + ``codex`` runs the pinned Codex CLI through
+    ``CodexAppServerDriver`` over a per-agent ``docker exec`` transport;
+    the returned preparer owns the container, the agent-scoped Codex home,
+    and the bounded ``docker stop`` shutdown. The Driver/outbox assembly
+    lives in ``worker_run`` through ``build_local_runtime_adapter``.
+    """
+    from ..agent.harness.docker_runtime import DockerCodexPreparer
+
+    return DockerCodexPreparer(daemon_cfg, agent_cfg)
 
 
 def _resolve_docker_harness(agent_cfg: AgentConfig):

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -234,6 +234,7 @@ def _configure_docker_mcp(
         space_id=core.space_id,
         keystore_dir=str(agent_dir(agent_cfg.id) / "keys"),
         workspace=str(agent_cfg.resolve_workspace_dir()),
+        shared_workspace="/workspace/shared",
         agent_id=agent_cfg.id,
         data_service_url=f"http://host.docker.internal:{daemon_cfg.data_service.port}",
         rpc_url=f"http://host.docker.internal:{daemon_cfg.rpc_service.port}",

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -68,6 +68,7 @@ def _rebuild_managed_system_prompt(
     role: str = "",
     role_short: str = "",
     puffo_handle: str = "",
+    workspace_shared_status: str = "existing",
 ) -> str:
     """Dispatch wrapper: write the right system-prompt file(s) for the
     agent's harness. Codex agents get ``$CODEX_HOME/AGENTS.md``; other
@@ -91,6 +92,7 @@ def _rebuild_managed_system_prompt(
             role=role,
             role_short=role_short,
             puffo_handle=puffo_handle,
+            workspace_shared_status=workspace_shared_status,
         )
     return rebuild_agent_claude_md(
         shared_dir=shared_path,
@@ -104,6 +106,7 @@ def _rebuild_managed_system_prompt(
         role=role,
         role_short=role_short,
         puffo_handle=puffo_handle,
+        workspace_shared_status=workspace_shared_status,
     )
 
 
@@ -1335,6 +1338,7 @@ async def _process_refresh_flags(
     role: str = "",
     role_short: str = "",
     puffo_handle: str = "",
+    workspace_shared_status: str = "existing",
 ) -> None:
     """Consume any worker-scope refresh flags into a single
     ``adapter.reload(prompt, with_session=…)`` call at turn start.
@@ -1369,6 +1373,7 @@ async def _process_refresh_flags(
                 role=role,
                 role_short=role_short,
                 puffo_handle=puffo_handle,
+                workspace_shared_status=workspace_shared_status,
             )
             from ..agent.shared_content import MEMORY_SECTION_HEADER
 

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -87,6 +87,69 @@ class _NoopStatusReporter:
         return None
 
 
+class GlobalInboxStatusLifecycle:
+    """Mirror one durable Global Inbox turn into Server processing rows.
+
+    ``begin_turn`` fires once for the first admitted real message and its run
+    id is retained; later active-union expansions reuse that lifecycle without
+    reopening rows. Terminal cleanup settles the exact active union in one
+    ``end_turn_batch``: the initial run id is reused for the first entry, every
+    additional entry mints a fresh run id, and the same success/error result is
+    applied to all. State always resets so the next turn cannot inherit runs.
+    """
+
+    def __init__(self, reporter) -> None:
+        self._reporter = reporter
+        self._began = False
+        self._begin_run_id: str | None = None
+
+    async def on_turn_active(self, message_ids: tuple[str, ...]) -> None:
+        if not message_ids or self._began:
+            return
+        self._began = True
+        self._begin_run_id = await self._reporter.begin_turn(message_ids[0])
+
+    async def on_turn_terminal(
+        self,
+        *,
+        message_ids: tuple[str, ...],
+        succeeded: bool,
+        error_text: str | None,
+    ) -> None:
+        runs = self._build_runs(message_ids, succeeded, error_text) if self._began else []
+        try:
+            if runs:
+                await self._reporter.end_turn_batch(runs)
+        finally:
+            self.reset()
+
+    def _build_runs(
+        self,
+        message_ids: tuple[str, ...],
+        succeeded: bool,
+        error_text: str | None,
+    ) -> list[dict[str, Any]]:
+        runs: list[dict[str, Any]] = []
+        for index, message_id in enumerate(message_ids):
+            entry: dict[str, Any] = {
+                "run_id": self._begin_run_id if index == 0 else self._mint_run_id(),
+                "message_id": message_id,
+                "succeeded": succeeded,
+            }
+            if error_text is not None:
+                entry["error_text"] = error_text
+            runs.append(entry)
+        return runs
+
+    def reset(self) -> None:
+        self._began = False
+        self._begin_run_id = None
+
+    @staticmethod
+    def _mint_run_id() -> str:
+        return f"run_{uuid.uuid4().hex}"
+
+
 class StandardWorkerRun:
     """Own the non-ws-local phases of one ``Worker._run`` invocation."""
 
@@ -499,7 +562,7 @@ class StandardWorkerRun:
         run_global_turn.handle_global_inbox_retry = retry_global_turn
         return run_global_turn
 
-    def _build_global_runtime(self, context: WorkerRunContext):
+    def _build_global_runtime(self, context: WorkerRunContext, *, status_lifecycle=None):
         from ..agent.global_inbox_runtime import (
             ActiveBoundaryAdapter,
             BaselineAdapter,
@@ -521,6 +584,7 @@ class StandardWorkerRun:
             send_mode_keys=(paths.agent_id, client.slug),
             agent_id=paths.agent_id,
             runtime_event_outbox=context.runtime_event_outbox,
+            status_lifecycle=status_lifecycle,
         )
         coordinator = SendCoordinator(
             slug=client.slug,
@@ -594,7 +658,11 @@ class StandardWorkerRun:
     async def _start_services(self, context: WorkerRunContext) -> WorkerRunServices:
         worker = self.worker
         uploader = self._build_runtime_event_uploader(context)
-        global_runtime = self._build_global_runtime(context)
+        reporter = self._build_reporter(context.client)
+        global_runtime = self._build_global_runtime(
+            context,
+            status_lifecycle=GlobalInboxStatusLifecycle(reporter),
+        )
         reminder_sync = await self._prepare_reminder_sync(context, global_runtime)
         global_task = asyncio.ensure_future(global_runtime.run())
         reminder_task = None
@@ -602,7 +670,6 @@ class StandardWorkerRun:
             reminder_task = asyncio.ensure_future(
                 reminder_sync.run(request_snapshot_on_start=False)
             )
-        reporter = self._build_reporter(context.client)
         heartbeat_task = asyncio.ensure_future(self._heartbeat(context.paths.agent_id))
         status_task = asyncio.ensure_future(reporter.run_heartbeat_loop())
         watch_task = asyncio.ensure_future(

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -18,7 +18,8 @@ from .runtime_matrix import (
     resolve_effective_harness,
     resolve_effective_provider,
 )
-from .state import agent_dir
+from .state import agent_dir, shared_fs_dir
+from .workspace_layout import ensure_workspace_shared_link
 
 if TYPE_CHECKING:
     from .worker import Worker
@@ -183,7 +184,7 @@ class StandardWorkerRun:
         workspace_path = str(agent_cfg.resolve_workspace_dir())
         claude_path = str(agent_cfg.resolve_claude_dir())
         shared_path = worker_module.docker_shared_dir()
-        Path(workspace_path).mkdir(parents=True, exist_ok=True)
+        ensure_workspace_shared_link(Path(workspace_path), shared_fs_dir())
         worker_module._seed_claude_dir(Path(claude_path))
         system_prompt = worker_module._rebuild_managed_system_prompt(
             harness_name=effective_harness,
@@ -682,6 +683,7 @@ class StandardWorkerRun:
             http_client=client.http,
             data_client=InProcessDataClient(client.store, client),
             workspace=paths.workspace_path,
+            shared_workspace=str(shared_fs_dir()),
             baseline_source=BaselineAdapter(client.store),
             active_turn_source=ActiveBoundaryAdapter(
                 client.store, global_runtime.active

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 from . import worker as worker_module
-from .runtime_matrix import RUNTIME_CLI_DOCKER, RUNTIME_CLI_LOCAL
+from .runtime_matrix import (
+    HARNESS_CODEX,
+    RUNTIME_CLI_DOCKER,
+    RUNTIME_CLI_LOCAL,
+    resolve_effective_harness,
+    resolve_effective_provider,
+)
 from .state import agent_dir
 
 if TYPE_CHECKING:
@@ -174,15 +180,44 @@ class StandardWorkerRun:
         self, paths: WorkerRunPaths, outbox_ref: list[Any]
     ) -> tuple[Any, str, Any]:
         worker = self.worker
-        if worker.agent_cfg.runtime.kind != RUNTIME_CLI_LOCAL:
+        kind = worker.agent_cfg.runtime.kind or RUNTIME_CLI_LOCAL
+        provider = resolve_effective_provider(
+            kind, worker.agent_cfg.runtime.provider
+        )
+        harness = resolve_effective_harness(
+            kind, provider, worker.agent_cfg.runtime.harness
+        )
+        if kind == RUNTIME_CLI_DOCKER and harness == HARNESS_CODEX:
+            return await self._prepare_driver_runtime(
+                paths,
+                outbox_ref,
+                worker_module.build_docker_codex_runtime(
+                    worker.daemon_cfg, worker.agent_cfg
+                ),
+            )
+        if kind != RUNTIME_CLI_LOCAL:
             worker._adapter = worker_module.build_docker_adapter(
                 worker.daemon_cfg, worker.agent_cfg
             )
             return None, "", None
-        from ..agent.harness.local_runtime import (
-            LocalRuntimePreparer,
-            build_local_runtime_adapter,
+        from ..agent.harness.local_runtime import LocalRuntimePreparer
+
+        return await self._prepare_driver_runtime(
+            paths,
+            outbox_ref,
+            LocalRuntimePreparer(worker.daemon_cfg, worker.agent_cfg),
         )
+
+    async def _prepare_driver_runtime(
+        self,
+        paths: WorkerRunPaths,
+        outbox_ref: list[Any],
+        preparer: Any,
+    ) -> tuple[Any, str, Any]:
+        """Prepare a Driver-backed runtime and bind it to the durable
+        outbox. Shared by host-local Claude/Codex and Docker Codex; the
+        Docker owner's exec transport and bounded container stop are wired
+        into the Driver here at the composition boundary."""
         from ..agent.runtime_event_outbox import (
             RuntimeEventOutbox,
             runtime_event_outbox_path,
@@ -193,7 +228,6 @@ class StandardWorkerRun:
         )
         outbox_ref[0] = outbox
         persisted = outbox.state()
-        preparer = LocalRuntimePreparer(worker.daemon_cfg, worker.agent_cfg)
         prepared = await preparer.prepare(
             system_prompt=paths.system_prompt,
             persisted_native_session_id=persisted.get("native_session_id", ""),
@@ -201,6 +235,32 @@ class StandardWorkerRun:
                 "session_fingerprint", ""
             ),
         )
+        try:
+            return await self._bind_driver_runtime(
+                outbox, prepared, persisted
+            )
+        except Exception:
+            # The Docker owner starts the per-agent container inside
+            # ``prepare``; if anything between that and adapter
+            # construction fails, the not-yet-wired preparer must stop it
+            # so partial initialization never orphans a running container.
+            await self._abort_docker_preparation(preparer)
+            raise
+
+    async def _bind_driver_runtime(
+        self,
+        outbox: Any,
+        prepared: Any,
+        persisted: dict[str, Any],
+    ) -> tuple[Any, str, Any]:
+        """Bind the prepared runtime to the durable outbox and the Runtime
+        Manager, injecting the Docker Codex Driver transport at the
+        composition boundary."""
+        worker = self.worker
+        from ..agent.harness.codex_driver import CodexAppServerDriver
+        from ..agent.harness.docker_runtime import DockerCodexPreparer
+        from ..agent.harness.local_runtime import build_local_runtime_adapter
+
         if prepared.discarded_persisted_session:
             session_ref = f"session_{uuid.uuid4().hex}"
             active_turn_ref = None
@@ -216,10 +276,40 @@ class StandardWorkerRun:
             native_session_id=prepared.native_session_id,
             session_fingerprint=prepared.session_fingerprint,
         )
+        driver = None
+        cleanup = None
+        if isinstance(preparer := prepared.preparer, DockerCodexPreparer):
+            driver = CodexAppServerDriver(
+                process_factory=preparer.process_factory
+            )
+            cleanup = preparer.aclose
         worker._adapter = build_local_runtime_adapter(
-            prepared, outbox=outbox, logical_session_ref=session_ref
+            prepared,
+            outbox=outbox,
+            logical_session_ref=session_ref,
+            driver=driver,
+            cleanup=cleanup,
         )
         return outbox, session_ref, prepared
+
+    async def _abort_docker_preparation(self, preparer: Any) -> None:
+        """Stop the Docker Codex container after a partial Driver assembly.
+
+        Only the Docker owner starts a container inside ``prepare``; the
+        host-local preparer has nothing to tear down.
+        """
+        from ..agent.harness.docker_runtime import DockerCodexPreparer
+
+        if not isinstance(preparer, DockerCodexPreparer):
+            return
+        try:
+            await preparer.aclose()
+        except Exception:
+            logger.exception(
+                "agent %s: failed to stop Docker Codex container after "
+                "preparation failure",
+                self.worker.agent_cfg.id,
+            )
 
     async def _initialize(self) -> WorkerRunContext | None:
         worker = self.worker

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
 import uuid
@@ -19,7 +20,10 @@ from .runtime_matrix import (
     resolve_effective_provider,
 )
 from .state import agent_dir, shared_fs_dir
-from .workspace_layout import ensure_workspace_shared_link
+from .workspace_layout import (
+    AVAILABLE_SHARED_WORKSPACE_STATES,
+    prepare_workspace_shared_access,
+)
 
 if TYPE_CHECKING:
     from .worker import Worker
@@ -39,6 +43,7 @@ class WorkerRunPaths:
     workspace_path: str
     claude_path: str
     shared_path: Path
+    workspace_shared_status: str
     system_prompt: str
 
     @property
@@ -75,7 +80,7 @@ class WorkerRunServices:
 
 
 class _NoopStatusReporter:
-    async def begin_turn(self, _mid):
+    async def begin_turn(self, _mid, *, run_id=None):
         return None
 
     async def end_turn(self, *_args, **_kwargs):
@@ -97,33 +102,46 @@ class _NoopStatusReporter:
 class GlobalInboxStatusLifecycle:
     """Mirror one durable Global Inbox turn into Server processing rows.
 
-    ``begin_turn`` fires once for the first admitted real message and its run
-    id is retained; later active-union expansions reuse that lifecycle without
-    reopening rows. Terminal cleanup settles the exact active union in one
-    ``end_turn_batch``: the initial run id is reused for the first entry, every
-    additional entry mints a fresh run id, and the same success/error result is
-    applied to all. State always resets so the next turn cannot inherit runs.
+    ``begin_turn`` fires once for the first admitted real message. Run ids are
+    derived from the durable turn and message identities, so crash recovery
+    reopens and settles the same Server row. Later active-union expansions do
+    not reopen rows. Terminal cleanup settles the exact active union in one
+    ``end_turn_batch`` with the same success/error result. State always resets
+    so the next turn cannot inherit runs.
     """
 
     def __init__(self, reporter) -> None:
         self._reporter = reporter
         self._began = False
-        self._begin_run_id: str | None = None
+        self._turn_id: str | None = None
 
-    async def on_turn_active(self, message_ids: tuple[str, ...]) -> None:
-        if not message_ids or self._began:
+    async def on_turn_active(
+        self, *, turn_id: str, message_ids: tuple[str, ...]
+    ) -> None:
+        if not message_ids:
+            return
+        if self._began:
+            if self._turn_id != turn_id:
+                raise RuntimeError("status lifecycle already owns another turn")
             return
         self._began = True
-        self._begin_run_id = await self._reporter.begin_turn(message_ids[0])
+        self._turn_id = turn_id
+        await self._reporter.begin_turn(
+            message_ids[0],
+            run_id=self._run_id(turn_id, message_ids[0]),
+        )
 
     async def on_turn_terminal(
         self,
         *,
+        turn_id: str,
         message_ids: tuple[str, ...],
         succeeded: bool,
         error_text: str | None,
     ) -> None:
-        runs = self._build_runs(message_ids, succeeded, error_text) if self._began else []
+        if self._began and self._turn_id != turn_id:
+            raise RuntimeError("status lifecycle terminal turn does not match")
+        runs = self._build_runs(turn_id, message_ids, succeeded, error_text)
         try:
             if runs:
                 await self._reporter.end_turn_batch(runs)
@@ -132,6 +150,7 @@ class GlobalInboxStatusLifecycle:
 
     def _build_runs(
         self,
+        turn_id: str,
         message_ids: tuple[str, ...],
         succeeded: bool,
         error_text: str | None,
@@ -139,7 +158,7 @@ class GlobalInboxStatusLifecycle:
         runs: list[dict[str, Any]] = []
         for index, message_id in enumerate(message_ids):
             entry: dict[str, Any] = {
-                "run_id": self._begin_run_id if index == 0 else self._mint_run_id(),
+                "run_id": self._run_id(turn_id, message_id),
                 "message_id": message_id,
                 "succeeded": succeeded,
             }
@@ -150,11 +169,12 @@ class GlobalInboxStatusLifecycle:
 
     def reset(self) -> None:
         self._began = False
-        self._begin_run_id = None
+        self._turn_id = None
 
     @staticmethod
-    def _mint_run_id() -> str:
-        return f"run_{uuid.uuid4().hex}"
+    def _run_id(turn_id: str, message_id: str) -> str:
+        identity = f"{turn_id}\0{message_id}".encode("utf-8")
+        return f"run_{hashlib.sha256(identity).hexdigest()[:32]}"
 
 
 class StandardWorkerRun:
@@ -184,7 +204,19 @@ class StandardWorkerRun:
         workspace_path = str(agent_cfg.resolve_workspace_dir())
         claude_path = str(agent_cfg.resolve_claude_dir())
         shared_path = worker_module.docker_shared_dir()
-        ensure_workspace_shared_link(Path(workspace_path), shared_fs_dir())
+        workspace_shared_status = prepare_workspace_shared_access(
+            Path(workspace_path),
+            shared_fs_dir(),
+            mounted=(agent_cfg.runtime.kind or RUNTIME_CLI_LOCAL)
+            == RUNTIME_CLI_DOCKER,
+        )
+        if workspace_shared_status not in AVAILABLE_SHARED_WORKSPACE_STATES:
+            logger.error(
+                "agent %s: shared workspace is %s; cross-Agent file handoffs "
+                "through workspace/shared are unavailable",
+                agent_id,
+                workspace_shared_status,
+            )
         worker_module._seed_claude_dir(Path(claude_path))
         system_prompt = worker_module._rebuild_managed_system_prompt(
             harness_name=effective_harness,
@@ -197,6 +229,7 @@ class StandardWorkerRun:
             role=agent_cfg.role,
             role_short=agent_cfg.role_short,
             puffo_handle=agent_cfg.puffo_core.slug,
+            workspace_shared_status=workspace_shared_status,
         )
         paths = WorkerRunPaths(
             agent_id=agent_id,
@@ -206,6 +239,7 @@ class StandardWorkerRun:
             workspace_path=workspace_path,
             claude_path=claude_path,
             shared_path=shared_path,
+            workspace_shared_status=workspace_shared_status,
             system_prompt=system_prompt,
         )
         self._remove_stale_managed_prompt(paths)
@@ -574,6 +608,7 @@ class StandardWorkerRun:
             role=worker.agent_cfg.role,
             role_short=worker.agent_cfg.role_short,
             puffo_handle=worker.agent_cfg.puffo_core.slug,
+            workspace_shared_status=paths.workspace_shared_status,
             puffo=context.puffo,
             adapter=worker._adapter,
             refresh_agent_flag=refresh_agent,

--- a/src/puffo_agent/portal/workspace_layout.py
+++ b/src/puffo_agent/portal/workspace_layout.py
@@ -1,0 +1,79 @@
+"""Filesystem layout shared by all daemon-owned Agent workspaces."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+SHARED_WORKSPACE_NAME = "shared"
+
+
+def _same_location(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return False
+
+
+def _create_windows_junction(link: Path, target: Path) -> bool:
+    if os.name != "nt":
+        return False
+    try:
+        completed = subprocess.run(
+            ["cmd", "/d", "/c", "mklink", "/J", str(link), str(target)],
+            capture_output=True,
+            text=True,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except OSError:
+        return False
+    return completed.returncode == 0
+
+
+def ensure_workspace_shared_link(workspace: Path, shared_root: Path) -> str:
+    """Expose one Puffo-home shared root as ``<workspace>/shared``.
+
+    Existing real files and directories are never replaced. A stale symlink is
+    safe to replace because the link itself owns no content. Returns one of
+    ``created``, ``existing``, ``conflict``, or ``unavailable``.
+    """
+    workspace = workspace.expanduser()
+    shared_root = shared_root.expanduser()
+    workspace.mkdir(parents=True, exist_ok=True)
+    shared_existed = shared_root.exists()
+    shared_root.mkdir(parents=True, exist_ok=True)
+    if not shared_existed and os.name != "nt":
+        shared_root.chmod(0o700)
+
+    link = workspace / SHARED_WORKSPACE_NAME
+    if link.exists() and _same_location(link, shared_root):
+        return "existing"
+    if link.is_symlink():
+        link.unlink()
+    elif link.exists():
+        logger.warning(
+            "workspace shared path %s already contains local data; preserving it "
+            "instead of replacing it with the Puffo shared workspace",
+            link,
+        )
+        return "conflict"
+
+    relative_target = os.path.relpath(shared_root, start=workspace)
+    try:
+        os.symlink(relative_target, link, target_is_directory=True)
+    except OSError as exc:
+        if _create_windows_junction(link, shared_root):
+            return "created"
+        logger.warning(
+            "could not expose Puffo shared workspace %s at %s: %s",
+            shared_root,
+            link,
+            exc,
+        )
+        return "unavailable"
+    return "created"

--- a/src/puffo_agent/portal/workspace_layout.py
+++ b/src/puffo_agent/portal/workspace_layout.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 SHARED_WORKSPACE_NAME = "shared"
+AVAILABLE_SHARED_WORKSPACE_STATES = frozenset({"created", "existing", "mounted"})
 
 
 def _same_location(left: Path, right: Path) -> bool:
@@ -55,6 +56,20 @@ def ensure_workspace_shared_link(workspace: Path, shared_root: Path) -> str:
         return "existing"
     if link.is_symlink():
         link.unlink()
+    elif link.is_dir():
+        # Docker creates an empty mountpoint when ``shared`` is bind-mounted
+        # below the workspace mount. Replacing that empty directory is safe and
+        # keeps a later Docker -> local runtime switch from becoming a false
+        # migration conflict.
+        try:
+            link.rmdir()
+        except OSError:
+            logger.warning(
+                "workspace shared path %s contains local data; preserving it "
+                "instead of replacing it with the Puffo shared workspace",
+                link,
+            )
+            return "conflict"
     elif link.exists():
         logger.warning(
             "workspace shared path %s already contains local data; preserving it "
@@ -77,3 +92,52 @@ def ensure_workspace_shared_link(workspace: Path, shared_root: Path) -> str:
         )
         return "unavailable"
     return "created"
+
+
+def prepare_workspace_shared_access(
+    workspace: Path,
+    shared_root: Path,
+    *,
+    mounted: bool = False,
+) -> str:
+    """Prepare one runtime's shared path and return its prompt-facing state.
+
+    Docker exposes the shared root with a bind mount, so it removes a prior
+    local-runtime symlink instead of mounting over it. Local runtimes use the
+    symlink. Existing real content is never hidden by either mode.
+    """
+    if not mounted:
+        return ensure_workspace_shared_link(workspace, shared_root)
+    workspace = workspace.expanduser()
+    workspace.mkdir(parents=True, exist_ok=True)
+    shared_root = shared_root.expanduser()
+    shared_existed = shared_root.exists()
+    shared_root.mkdir(parents=True, exist_ok=True)
+    if not shared_existed and os.name != "nt":
+        shared_root.chmod(0o700)
+
+    mountpoint = workspace / SHARED_WORKSPACE_NAME
+    if mountpoint.is_symlink():
+        mountpoint.unlink()
+    elif mountpoint.is_dir():
+        try:
+            next(mountpoint.iterdir())
+        except StopIteration:
+            pass
+        except OSError:
+            return "unavailable"
+        else:
+            logger.warning(
+                "workspace shared path %s contains local data; preserving it "
+                "instead of hiding it with the Puffo shared-workspace mount",
+                mountpoint,
+            )
+            return "conflict"
+    elif mountpoint.exists():
+        logger.warning(
+            "workspace shared path %s contains local data; preserving it "
+            "instead of hiding it with the Puffo shared-workspace mount",
+            mountpoint,
+        )
+        return "conflict"
+    return "mounted"

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -30,6 +30,7 @@ from .in_process_data_client import InProcessDataClient
 from .protocol import Error, encode
 from .session import Transport, WsLocalSession
 from .tool_dispatch import build_dispatch as _build_dispatch
+from ..state import shared_fs_dir
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +194,7 @@ def _build_tool_dispatch(point: AttachPoint, runtime=None):
         data_client=InProcessDataClient(client.store, client),
         space_id=getattr(client, "space_id", None),
         workspace=getattr(client, "workspace", None),
+        shared_workspace=str(shared_fs_dir()),
         message_client=client,
         send_coordinator=send_coordinator,
         inbox_runtime=inbox_runtime,
@@ -331,6 +333,7 @@ def _make_owned_runtime(point: AttachPoint, bridge, holder: dict[str, WsLocalSes
         http_client=client.http,
         data_client=InProcessDataClient(client.store, client),
         workspace=workspace,
+        shared_workspace=str(shared_fs_dir()),
         baseline_source=BaselineAdapter(client.store),
         active_turn_source=ActiveBoundaryAdapter(client.store, runtime.active),
         held_recovery_source=runtime.held_recovery_source,

--- a/tests/test_auto_accept_dm.py
+++ b/tests/test_auto_accept_dm.py
@@ -175,6 +175,95 @@ def test_pending_dm_approvals_non_dict_json_returns_empty(tmp_path):
 
 
 # ─────────────────────────────────────────────────────────────────────
+# Keyless resumable approval record (backward compatible)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "server_seq, prompt_envelope_id, prompt_thread_id",
+    [
+        (None, None, None),
+        (41, "prompt_env_1", "prompt_thread_1"),
+    ],
+)
+def test_keyless_approval_record_round_trip_and_rejects_malformed(
+    tmp_path, server_seq, prompt_envelope_id, prompt_thread_id,
+):
+    """A validated keyless approval record round-trips through the shared
+    pending file, malformed keyless records are rejected, and legacy native
+    records keep loading unchanged.
+
+    The bridge orchestrator later keys a resumable approval by held envelope,
+    so a restart must reproduce every field exactly (including an absent
+    server sequence) or the reply cannot be correlated. The malformed cases
+    guard silent corruption: a hand-edited or half-written keyless record
+    must never resurface as approval state. The legacy row pins that the
+    same file keeps loading native records untouched.
+    """
+    isolated_home()
+    from puffo_agent.portal.state import agent_dir
+    from puffo_agent.agent.dm_approvals import (
+        KEYLESS_APPROVAL_KIND,
+        KeylessDmApproval,
+        load_pending_dm_approvals,
+        parse_keyless_approval,
+        save_pending_dm_approvals,
+    )
+
+    agent_dir("alpha").mkdir(parents=True, exist_ok=True)
+    record = KeylessDmApproval(
+        envelope_id="held_env_1",
+        sender_slug="mallory-9",
+        operator_slug="op-1",
+        server_seq=server_seq,
+        prompt_client_ref="prompt-ref-abc",
+        prompt_envelope_id=prompt_envelope_id,
+        prompt_thread_id=prompt_thread_id,
+        decision="pending",
+        phase="pending",
+    )
+    pending = {
+        record.envelope_id: record.to_dict(),
+        # One legacy native prompt record must keep loading unchanged.
+        "native_prompt_env_1": {
+            "sender_slug": "alice-1234",
+            "sender_display_name": "Alice",
+        },
+        # Malformed keyless records must be rejected, not resurfaced.
+        "bad_env_1": {
+            "kind": KEYLESS_APPROVAL_KIND,
+            "envelope_id": "bad_env_1",
+            "sender_slug": "mallory-9",
+            "operator_slug": "op-1",
+            "server_seq": "not-an-int",
+            "prompt_client_ref": "prompt-ref",
+            "decision": "pending",
+            "phase": "pending",
+        },
+        "bad_env_2": {
+            "kind": KEYLESS_APPROVAL_KIND,
+            "envelope_id": "wrong-key",
+            "sender_slug": "mallory-9",
+            "operator_slug": "op-1",
+            "server_seq": None,
+            "prompt_client_ref": "prompt-ref",
+            "decision": "maybe",  # not in the exact decision vocabulary
+            "phase": "pending",
+        },
+    }
+    save_pending_dm_approvals("alpha", pending)
+    loaded = load_pending_dm_approvals("alpha")
+
+    assert parse_keyless_approval(loaded[record.envelope_id]) == record
+    assert loaded["native_prompt_env_1"] == {
+        "sender_slug": "alice-1234",
+        "sender_display_name": "Alice",
+    }
+    assert "bad_env_1" not in loaded
+    assert "bad_env_2" not in loaded
+
+
+# ─────────────────────────────────────────────────────────────────────
 # Gate logic — manual client surgery, no WS / HTTP
 # ─────────────────────────────────────────────────────────────────────
 

--- a/tests/test_bridge_ingress_policy.py
+++ b/tests/test_bridge_ingress_policy.py
@@ -28,6 +28,13 @@ import asyncio
 
 import pytest
 
+from puffo_agent.agent import bridge_transport as bridge_transport_mod
+from puffo_agent.agent.client_support import DM_GATE_PROMPT_PLACEHOLDER
+from puffo_agent.agent.dm_approvals import (
+    parse_keyless_approval,
+    pending_dm_approvals_path,
+    save_pending_dm_approvals,
+)
 from puffo_agent.agent.message_store import MessageStore
 from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
 from puffo_agent.crypto.http_client import PuffoCoreHttpClient
@@ -38,13 +45,29 @@ OPERATOR = "ops-0001"
 STRANGER = "mallory-0009"
 
 
+@pytest.fixture(autouse=True)
+def _isolated_agent_home(tmp_path, monkeypatch):
+    home = str(tmp_path / "agent-home")
+    monkeypatch.setenv("PUFFO_AGENT_HOME", home)
+    monkeypatch.setenv("PUFFO_HOME", home)
+
+
 class _OfflineBridge:
     """Enough ``CloudBridgeClient`` surface for inbound dispatch."""
 
     def __init__(self) -> None:
         self.acked: list[str] = []
+        self.sent: list[dict] = []
+        self.ack_gate: asyncio.Event | None = None
+
+    async def send_send(self, **kwargs) -> dict:
+        self.sent.append(kwargs)
+        envelope_id = f"prompt_{len(self.sent)}"
+        return {"envelope_id": envelope_id, "thread_root_id": envelope_id}
 
     async def send_ack(self, envelope_ids: list[str]) -> None:
+        if self.ack_gate is not None:
+            await self.ack_gate.wait()
         self.acked.extend(envelope_ids)
 
 
@@ -156,21 +179,140 @@ async def test_operator_control_reply_over_bridge_is_consumed_not_delivered(
 
 
 @pytest.mark.asyncio
-async def test_foreign_dm_over_bridge_is_gated_not_eligible(tmp_path):
+async def test_keyless_gated_dm_lifecycle_is_durable_and_prompt_echo_is_redacted(
+    tmp_path,
+):
     client = _client(tmp_path, operator_slug=OPERATOR)
     await client.store.open()
+    frame = _dm_frame(STRANGER, "let me in", seq=9)
 
-    await client._dispatch_bridge_frame(
-        _dm_frame(STRANGER, "let me in", seq=9)
-    )
+    await client._dispatch_bridge_frame(frame)
+    await asyncio.gather(*tuple(client._ack_tasks))
 
     assert await client.store.get_pending() == ()
     stored = await client.store.get_message_by_envelope("env_9")
     assert stored is not None
     assert stored.receipt_disposition == "foreign_dm_gated"
-    # Never acked — the DM stays queued server-side until the operator
-    # answers, so a lost gate cannot silently drop the message.
+    assert stored.server_seq == 9
+    assert stored.content["text"] == "let me in"
     assert client._bridge.acked == []
+
+    record = parse_keyless_approval(client._pending_dm_approvals["env_9"])
+    assert record is not None
+    assert (record.envelope_id, record.sender_slug, record.server_seq) == (
+        "env_9",
+        STRANGER,
+        9,
+    )
+    assert pending_dm_approvals_path(SELF).is_file()
+
+    # Simulate losing the side record after the receipt commit. An
+    # idempotent Server redelivery reconstructs it and still does not ACK.
+    client._pending_dm_approvals.clear()
+    save_pending_dm_approvals(SELF, client._pending_dm_approvals)
+    await client._dispatch_bridge_frame(frame)
+    await asyncio.gather(*tuple(client._ack_tasks))
+    replayed = parse_keyless_approval(client._pending_dm_approvals["env_9"])
+    assert replayed is not None and replayed.server_seq == 9
+    assert client._bridge.acked == []
+
+    prompt_id = replayed.prompt_envelope_id
+    assert prompt_id
+    await client._dispatch_bridge_frame(
+        _dm_frame(SELF, "quoted secret", seq=10, envelope_id=prompt_id)
+    )
+    await asyncio.gather(*tuple(client._ack_tasks))
+    prompt_echo = await client.store.get_message_by_envelope(prompt_id)
+    assert prompt_echo is not None
+    assert prompt_echo.content == DM_GATE_PROMPT_PLACEHOLDER
+    await client.store.close()
+
+
+@pytest.mark.asyncio
+async def test_keyless_operator_reply_is_consumed_then_promotes_without_blocking(
+    tmp_path,
+):
+    client = _client(tmp_path, operator_slug=OPERATOR)
+    await client.store.open()
+
+    await client._dispatch_bridge_frame(_dm_frame(STRANGER, "hello", seq=20))
+    await asyncio.gather(*tuple(client._ack_tasks))
+    record = parse_keyless_approval(client._pending_dm_approvals["env_20"])
+    assert record is not None and record.prompt_envelope_id
+
+    # The prompt echo is deliberately absent locally. The raw wire thread id
+    # must still identify the exact durable prompt, and dispatch must return
+    # while the response-waiting ACK work remains tracked in the background.
+    client._bridge.ack_gate = asyncio.Event()
+    runtime = type("Runtime", (), {"notifications": 0})()
+    runtime.notify = lambda: setattr(runtime, "notifications", runtime.notifications + 1)
+    client.global_runtime = runtime
+    await client._dispatch_bridge_frame(
+        _dm_frame(
+            OPERATOR,
+            " yes ",
+            seq=21,
+            thread_root_id=record.prompt_envelope_id,
+        )
+    )
+    await asyncio.sleep(0)
+    assert any(not task.done() for task in client._ack_tasks)
+    # Local promotion is durable before the original envelope ACK. This is
+    # precisely the resumable state the blocked bridge call is exposing.
+    assert [message.envelope_id for message in await client.store.get_pending()] == [
+        "env_20"
+    ]
+
+    client._bridge.ack_gate.set()
+    await asyncio.gather(*tuple(client._ack_tasks))
+    pending = await client.store.get_pending()
+    assert [message.envelope_id for message in pending] == ["env_20"]
+    assert client._bridge.acked.count("env_20") == 1
+    assert client._bridge.acked.count("env_21") == 1
+    assert runtime.notifications == 1
+    assert "env_20" not in client._pending_dm_approvals
+    await client.store.close()
+
+
+@pytest.mark.asyncio
+async def test_missing_operator_fails_closed_and_reconnect_replay_is_tracked(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    client = _client(tmp_path)
+    await client.store.open()
+
+    with caplog.at_level("WARNING"):
+        await client._dispatch_bridge_frame(_dm_frame(STRANGER, "private", seq=30))
+        await asyncio.gather(*tuple(client._ack_tasks))
+    stored = await client.store.get_message_by_envelope("env_30")
+    record = parse_keyless_approval(client._pending_dm_approvals["env_30"])
+    assert stored is not None and stored.receipt_disposition == "foreign_dm_gated"
+    assert record is not None and record.operator_slug == ""
+    assert client._bridge.sent == [] and client._bridge.acked == []
+    assert "holding keyless DM" in caplog.text
+
+    started, release = asyncio.Event(), asyncio.Event()
+
+    async def _blocking_replay(_client):
+        started.set()
+        await release.wait()
+
+    async def _no_refresh(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        bridge_transport_mod,
+        "resume_pending_approvals",
+        _blocking_replay,
+    )
+    client._refresh_bridge_spaces = _no_refresh
+    await client._dispatch_bridge_frame({"type": "pending_delivered", "count": 1})
+    await started.wait()
+    assert any(not task.done() for task in client._ack_tasks)
+    release.set()
+    await asyncio.gather(*tuple(client._ack_tasks))
     await client.store.close()
 
 

--- a/tests/test_cli_agent_create.py
+++ b/tests/test_cli_agent_create.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from puffo_agent.portal.cli import main
-from puffo_agent.portal.state import AgentConfig, agent_dir
+from puffo_agent.portal.state import AgentConfig
 
 
-def test_create_cli_docker_openai_is_rejected_before_writing(
-    tmp_path, monkeypatch, capsys,
-):
+def test_create_cli_docker_openai_persists_codex(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
 
     rc = main([
@@ -14,9 +12,10 @@ def test_create_cli_docker_openai_is_rejected_before_writing(
         "--runtime", "cli-docker", "--provider", "openai",
     ])
 
-    assert rc == 2
-    assert "requires the host-local Driver runtime" in capsys.readouterr().err
-    assert not agent_dir("docker-codex").exists()
+    assert rc == 0
+    cfg = AgentConfig.load("docker-codex")
+    assert cfg.runtime.provider == "openai"
+    assert cfg.runtime.harness == "codex"
 
 
 def test_create_cli_docker_anthropic_uses_claude(tmp_path, monkeypatch):

--- a/tests/test_cli_bin.py
+++ b/tests/test_cli_bin.py
@@ -282,6 +282,85 @@ def test_hermes_bundle_paths_per_platform(platform_value, want_substr, monkeypat
     assert want_substr in first
 
 
+def test_windows_claude_bundle_paths_include_npm_global_shims(monkeypatch):
+    """Regression-pin for the A1 gap: the Windows Claude candidates must
+    list the npm-global ``%APPDATA%\\npm`` ``.exe``, ``.cmd``, ``.ps1``
+    shims in that order, or ``resolve_claude_bin`` never finds the shim
+    a fresh shell actually runs."""
+    monkeypatch.setattr(cli_bin.sys, "platform", "win32")
+    paths = [str(path).lower() for path in cli_bin._claude_bundle_paths()]
+    assert r"%appdata%\npm\claude.exe" in paths
+    assert r"%appdata%\npm\claude.cmd" in paths
+    assert r"%appdata%\npm\claude.ps1" in paths
+    assert paths.index(r"%appdata%\npm\claude.exe") < paths.index(
+        r"%appdata%\npm\claude.cmd"
+    ) < paths.index(r"%appdata%\npm\claude.ps1")
+
+
+@pytest.mark.parametrize(
+    ("platform_value", "executable", "siblings", "expected"),
+    [
+        # POSIX: the executable passes through untouched, whatever its shape.
+        ("darwin", "claude", (), ("claude",)),
+        ("linux", "claude", (), ("claude",)),
+        (
+            "linux",
+            r"C:\Program Files\Claude\claude.exe",
+            (),
+            (r"C:\Program Files\Claude\claude.exe",),
+        ),
+        # Windows: .exe sibling wins over every shim.
+        (
+            "win32", "claude",
+            ("claude.exe", "claude.cmd", "claude.bat", "claude.ps1"),
+            ("claude.exe",),
+        ),
+        # Windows: .cmd beats .bat and both run through cmd.exe /c.
+        (
+            "win32", "claude",
+            ("claude.bat", "claude.cmd"),
+            ("cmd.exe", "/c", "claude.cmd"),
+        ),
+        ("win32", "claude", ("claude.cmd",), ("cmd.exe", "/c", "claude.cmd")),
+        ("win32", "claude", ("claude.bat",), ("cmd.exe", "/c", "claude.bat")),
+        # Windows: .ps1 runs through powershell.exe -NoProfile -NonInteractive -File.
+        (
+            "win32", "claude",
+            ("claude.ps1",),
+            ("powershell.exe", "-NoProfile", "-NonInteractive", "-File", "claude.ps1"),
+        ),
+        # Windows: extensionless path with no sibling launches directly.
+        ("win32", "claude", (), ("claude",)),
+        # Windows: an explicit .exe path passes straight through.
+        ("win32", "claude.exe", (), ("claude.exe",)),
+        # Windows: paths with spaces stay single argv elements.
+        (
+            "win32",
+            os.path.join("Program Files", "Claude", "claude"),
+            (os.path.join("Program Files", "Claude", "claude.cmd"),),
+            (
+                "cmd.exe", "/c",
+                os.path.join("Program Files", "Claude", "claude.cmd"),
+            ),
+        ),
+    ],
+)
+def test_normalize_launch_argv(
+    platform_value, executable, siblings, expected, tmp_path, monkeypatch,
+):
+    """Regression-pin for the A1 gap: ``create_subprocess_exec`` cannot run
+    a Windows ``.cmd`` / ``.bat`` / ``.ps1`` shim directly, so the launch
+    argv must wrap it in the right interpreter. Sibling checks resolve
+    against the test cwd, so each case writes the sibling files it names."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli_bin.sys, "platform", platform_value)
+    for name in siblings:
+        path = tmp_path / Path(name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+    assert cli_bin.normalize_launch_argv(executable) == list(expected)
+
+
 # ── credential presence (UI 3-state status) ──────────────────────────
 
 

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -141,7 +141,9 @@ async def test_send_send_correlates_ack_via_client_ref():
         consumer = asyncio.create_task(_drain(c))
         try:
             ack = await c.send_send(
-                plaintext="hi alice", recipient_slug="alice",
+                plaintext="hi alice",
+                recipient_slug="alice",
+                client_ref="stable-ref",
             )
         finally:
             await c.close()
@@ -152,7 +154,7 @@ async def test_send_send_correlates_ack_via_client_ref():
     sent = bridge_app.recv_send[0]
     assert sent["type"] == "send"
     assert sent["plaintext"] == "hi alice"
-    assert sent["client_ref"] == ack["client_ref"]
+    assert sent["client_ref"] == ack["client_ref"] == "stable-ref"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cloud_bridge_client.py
+++ b/tests/test_cloud_bridge_client.py
@@ -532,6 +532,112 @@ async def test_f3_send_list_spaces_timeout_discards_waiter_then_next_resolves():
             pass
 
 
+# --------------------------------------------------------------------------
+# Keyless invitation bridge contract: list_invites FIFO routing, exact-
+# client_ref decide_invitation_result / error routing, timeout removal,
+# and close() waiter cleanup with BridgeClosed.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invites_fifo_decision_correlation_and_close_cleanup():
+    """Guarded regression: invites resolves the FIFO waiter (never a dead
+    timed-out one), decide results/errors route by exact client_ref, and
+    close() fails every remaining waiter with BridgeClosed."""
+    c, ws = await _client_with_scripted_ws()
+    consumer = asyncio.create_task(_drain(c))
+    try:
+        async def _feed_when(ready, frame):
+            while not ready():
+                await asyncio.sleep(0)
+            ws.feed(frame)
+
+        # A timed-out waiter is pulled out of the FIFO so the next invites
+        # frame resolves the next call, not the dead future.
+        with pytest.raises(asyncio.TimeoutError):
+            await c.send_list_invites(timeout=0.05)
+        assert c._invites_waiters.empty()
+        res, _ = await asyncio.gather(
+            c.send_list_invites(timeout=2.0),
+            _feed_when(
+                lambda: not c._invites_waiters.empty(),
+                {"type": "invites", "invites": [{"invitation_event_id": "iv_1"}]},
+            ),
+        )
+        assert res["invites"] == [{"invitation_event_id": "iv_1"}]
+
+        # A decide result routes by exact client_ref.
+        result, _ = await asyncio.gather(
+            c.send_decide_invitation(
+                invitation_event_id="iv_1", decision="accept", client_ref="dec-1",
+            ),
+            _feed_when(
+                lambda: "dec-1" in c._decide_waiters,
+                {"type": "decide_invitation_result", "client_ref": "dec-1",
+                 "invitation_event_id": "iv_1", "decision": "accept",
+                 "outcome": "applied"},
+            ),
+        )
+        assert result["outcome"] == "applied"
+        assert c._decide_waiters == {}
+
+        # A correlated error routes to that waiter as a BridgeError.
+        with pytest.raises(BridgeError) as excinfo:
+            await asyncio.gather(
+                c.send_decide_invitation(
+                    invitation_event_id="iv_2", decision="reject", client_ref="dec-2",
+                ),
+                _feed_when(
+                    lambda: "dec-2" in c._decide_waiters,
+                    {"type": "error", "code": "NOT_FOUND", "message": "gone",
+                     "client_ref": "dec-2"},
+                ),
+            )
+        assert excinfo.value.code == "NOT_FOUND"
+        assert c._decide_waiters == {}
+
+        # Validation rejects a bad decision / blank ref before any frame.
+        for decision, ref in (("maybe", "dec-3"), ("accept", "  ")):
+            with pytest.raises(ValueError):
+                await c.send_decide_invitation(
+                    invitation_event_id="iv_3", decision=decision, client_ref=ref,
+                )
+
+        # close() fails every remaining waiter with a clean BridgeClosed.
+        async def _wait_pending():
+            await c.send_list_invites(timeout=10.0)
+
+        pending_task = asyncio.create_task(_wait_pending())
+        while c._invites_waiters.empty():
+            await asyncio.sleep(0)
+        await c.close()
+        with pytest.raises(BridgeClosed):
+            await pending_task
+        assert c._invites_waiters.empty()
+        assert c._decide_waiters == {}
+
+        # Outbound frames: exactly the four contract keys on decisions and
+        # nothing but type on list_invites.
+        assert [
+            frame for frame in ws.sent if frame.get("type") == "decide_invitation"
+        ] == [
+            {"type": "decide_invitation", "client_ref": "dec-1",
+             "invitation_event_id": "iv_1", "decision": "accept"},
+            {"type": "decide_invitation", "client_ref": "dec-2",
+             "invitation_event_id": "iv_2", "decision": "reject"},
+        ]
+        assert all(
+            set(frame) == {"type"} for frame in ws.sent
+            if frame.get("type") == "list_invites"
+        )
+    finally:
+        consumer.cancel()
+        try:
+            await consumer
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
 def test_fresh_tls_context_is_rebuilt_per_call_not_cached():
     """PUF-192: the helper must return a NEW verifying SSLContext each call,
     never a reused singleton — that's what lets a reconnect pick up E2B's

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -221,6 +221,7 @@ class FakeHttp:
             return self.responses[path]
         if path == "/v2/cloud-agents/agent-runtime/messages:send":
             freshness = body["freshness"]
+            request_baseline = freshness["context_baseline_seq"]
             return {
                 "state": "sent",
                 "envelope_id": "msg_bridgeack",
@@ -230,7 +231,9 @@ class FakeHttp:
                 "freshness": {
                     "mode": freshness["mode"],
                     "context_baseline_seq": (
-                        freshness["context_baseline_seq"]
+                        request_baseline
+                        if request_baseline is not None
+                        else freshness["seen_seq"]
                     ),
                     "seen_seq": freshness["seen_seq"],
                     "latest_seq_before_send": freshness["seen_seq"],

--- a/tests/test_cloud_bridge_msgflow.py
+++ b/tests/test_cloud_bridge_msgflow.py
@@ -584,6 +584,7 @@ async def test_a_inbound_dm_frame_routes_as_dm(tmp_path):
         "plaintext": "ping",
     }])
     client = _bridge_client(tmp_path, bridge, db="dm.db")
+    client.auto_accept_dm = True
     done = asyncio.Event()
 
     await _drive_listen_until(client, done=done)

--- a/tests/test_cmd_stop_specific_pid.py
+++ b/tests/test_cmd_stop_specific_pid.py
@@ -6,9 +6,11 @@ misleading "still running (pid=<old>)".
 from __future__ import annotations
 
 import argparse
+import asyncio
 from unittest.mock import patch
 
 from puffo_agent.portal import cli, state
+from puffo_agent.portal.daemon import run_daemon
 
 
 def _args(timeout: int = 5) -> argparse.Namespace:
@@ -159,9 +161,41 @@ def test_stop_request_is_scoped_to_target_pid(monkeypatch, tmp_path):
     assert state.clear_stop_request(expected_pid=1234) is True
 
 
-def test_legacy_timestamp_stop_request_is_stale(monkeypatch, tmp_path):
+def test_legacy_stop_request_upgrade_lifecycle(monkeypatch, tmp_path):
+    """Old-CLI (timestamp-only) stop sentinel survives the 2.0 upgrade:
+    startup clears a stale pre-start sentinel before the new daemon
+    publishes its pid, a timestamp sentinel written after startup is a
+    valid stop request for the running daemon, and owned cleanup removes
+    the accepted request."""
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
-    state.stop_request_path().write_text("1720000000", encoding="utf-8")
+    legacy = "1720000000"
+    state.stop_request_path().write_text(legacy, encoding="utf-8")
 
-    assert state.read_stop_request_pid() is None
-    assert state.stop_requested_for(1720000000) is False
+    published: dict[str, int] = {}
+
+    def publish_pid(pid):
+        # Pre-start stale sentinel must be gone before PID publication,
+        # so it cannot kill the freshly started daemon.
+        assert not state.stop_request_path().exists()
+        published["pid"] = pid
+
+    async def fake_daemon_run(_self, external_stop_requested=None):
+        state.stop_request_path().write_text(legacy, encoding="utf-8")
+        assert state.stop_requested_for(published["pid"]) is True
+
+    with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=False), \
+         patch(
+             "puffo_agent.portal.daemon.write_daemon_pid",
+             side_effect=publish_pid,
+         ), \
+         patch(
+             "puffo_agent.portal.daemon._install_posix_stop_handlers",
+             return_value=True,
+         ), \
+         patch("puffo_agent.portal.daemon.Daemon.run", fake_daemon_run), \
+         patch("puffo_agent.portal.daemon.os._exit"):
+        asyncio.run(run_daemon())
+
+    assert "pid" in published
+    # Owned shutdown cleanup removed the accepted legacy request.
+    assert not state.stop_request_path().exists()

--- a/tests/test_contact_cache.py
+++ b/tests/test_contact_cache.py
@@ -144,3 +144,60 @@ def test_note_blocked_empty_slug_is_noop():
     c = ContactCache(_FakeHttp(), log)
     c.note_blocked("", True)
     assert c._block == set()
+
+
+class _KeylessHttp:
+    keyless = True
+
+    async def get(self, path):
+        return {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_path", [True, False])
+async def test_keyless_local_allow_block_state(tmp_path, with_path):
+    """Keyless allow/block decisions persist to the per-agent local set and
+    stay mutually exclusive; a cache without a local path writes nothing.
+
+    A keyless transport cannot hydrate from the signed server lists, so its
+    decisions only survive a daemon restart through the local JSON set. The
+    regression this guards: an in-memory-only keyless cache re-admitted a
+    blocked sender after every restart, because ``refresh`` is a no-op for
+    keyless. The no-path arm pins that callers without a local file keep
+    today's in-memory behavior and never create one.
+    """
+    path = tmp_path / "contacts.json"
+    cache = ContactCache(
+        _KeylessHttp(), log, local_state_path=path if with_path else None
+    )
+
+    cache.note_allowed("alice-1")
+    cache.note_blocked("bob-2", True)
+    cache.note_blocked("mallory-9", True)
+    # Sets stay mutually exclusive under keyless: blocking an allowed slug
+    # moves it out of allow, and un-blocking reverses the move.
+    cache.note_blocked("alice-1", True)
+    assert "alice-1" not in cache._allow
+    assert "alice-1" in cache._block
+    cache.note_blocked("mallory-9", False)
+    assert await cache.is_blocked("mallory-9") is False
+
+    if not with_path:
+        assert list(tmp_path.iterdir()) == []
+        return
+
+    assert path.exists()
+    reloaded = ContactCache(_KeylessHttp(), log, local_state_path=path)
+    assert await reloaded.is_allowed("alice-1") is False
+    assert await reloaded.is_blocked("alice-1") is True
+    assert await reloaded.is_blocked("bob-2") is True
+    assert await reloaded.is_allowed("mallory-9") is False
+    assert reloaded._allow & reloaded._block == set()
+
+    # Allowing a blocked slug keeps the sets disjoint and persists too.
+    reloaded.note_allowed("bob-2")
+    assert await reloaded.is_blocked("bob-2") is False
+    again = ContactCache(_KeylessHttp(), log, local_state_path=path)
+    assert await again.is_allowed("bob-2") is True
+    assert await again.is_blocked("bob-2") is False
+    assert again._allow & again._block == set()

--- a/tests/test_contact_cache.py
+++ b/tests/test_contact_cache.py
@@ -201,3 +201,28 @@ async def test_keyless_local_allow_block_state(tmp_path, with_path):
     assert await again.is_allowed("bob-2") is True
     assert await again.is_blocked("bob-2") is False
     assert again._allow & again._block == set()
+
+    # A failed durable write must roll the in-memory sets back, in both the
+    # allow and block directions, so a later note retries the full mutation
+    # and the decision actually lands on disk. Without the rollback the
+    # memory stays ahead of disk and the retry skips persistence entirely.
+    write = again._persist_local_state
+
+    def _disk_full():
+        raise OSError("disk full")
+
+    again._persist_local_state = _disk_full
+    with pytest.raises(OSError):
+        again.note_allowed("dave-4")
+    with pytest.raises(OSError):
+        again.note_blocked("carol-3", True)
+    again._persist_local_state = write
+    assert "dave-4" not in again._allow
+    assert "carol-3" not in again._allow
+    assert "carol-3" not in again._block
+    again.note_blocked("carol-3", True)
+    assert "carol-3" in again._block
+    assert "carol-3" not in again._allow
+    disk = ContactCache(_KeylessHttp(), log, local_state_path=path)
+    assert await disk.is_blocked("carol-3") is True
+    assert disk._allow & disk._block == set()

--- a/tests/test_docker_codex_driver.py
+++ b/tests/test_docker_codex_driver.py
@@ -129,6 +129,7 @@ def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
     config = (preparer.codex_home / "config.toml").read_text(encoding="utf-8")
     assert 'CODEX_HOME = "/home/agent/.codex"' in config
     assert 'PUFFO_WORKSPACE = "/workspace"' in config
+    assert 'PUFFO_SHARED_WORKSPACE = "/workspace/shared"' in config
     assert 'PUFFO_RUNTIME_KIND = "cli-docker"' in config
     assert 'PUFFO_HARNESS = "codex"' in config
     assert "host.docker.internal" in config
@@ -165,6 +166,7 @@ def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
         assert f"{preparer.codex_home}:/home/agent/.codex" in run_cmd
         assert f"{preparer.agent_home}:/home/agent/.puffo-agent-state" in run_cmd
         assert any(":/workspace" in part for part in run_cmd)
+        assert any(":/workspace/shared" in part for part in run_cmd)
         assert any(":/workspace/.shared" in part for part in run_cmd)
         assert any(
             str(part).endswith(":/opt/puffoagent-pkg:ro") for part in run_cmd

--- a/tests/test_docker_codex_driver.py
+++ b/tests/test_docker_codex_driver.py
@@ -1,0 +1,205 @@
+"""Generated Docker Codex runtime boundary.
+
+One compact test pins the Dockerfile's Codex/Claude installs and the
+container argv, mounts, config.toml, exec transport, secret forwarding,
+bounded stop ordering, and the Worker composition wiring that injects
+``CodexAppServerDriver`` + the container stop into the Runtime Manager.
+Mocked at the docker-command boundary — no daemon or credential required.
+
+Regression guard: if the pinned codex install, agent-scoped Codex home
+mount, ``/workspace`` thread cwd, container-local MCP paths, named-only
+bearer forwarding, stop-before-recreate, or the Driver wiring drift, this
+fails before a real container smoke would surface it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from puffo_agent.agent.adapters import docker_cli
+from puffo_agent.agent.harness.codex_driver import CodexAppServerDriver
+from puffo_agent.agent.harness.docker_runtime import DockerCodexPreparer
+from puffo_agent.agent.harness.runtime_manager import RuntimeManagerAdapter
+from puffo_agent.portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    PuffoCoreConfig,
+    RuntimeConfig,
+)
+from puffo_agent.portal.worker_run import StandardWorkerRun, WorkerRunPaths
+
+
+def _preparer(tmp_path, monkeypatch, *, gateway=False) -> DockerCodexPreparer:
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
+    config = AgentConfig(
+        id="docker-codex",
+        runtime=RuntimeConfig(
+            kind="cli-docker",
+            provider="openai",
+            harness="codex",
+            api_key="gateway-key" if gateway else "",
+            llm_base_url="https://gateway.example/v1" if gateway else "",
+        ),
+        puffo_core=PuffoCoreConfig(
+            server_url="http://localhost:3000",
+            slug="bot-0001",
+            device_id="dev_1",
+            space_id="sp_1",
+        ),
+    )
+    return DockerCodexPreparer(DaemonConfig(), config)
+
+
+def _capture_run():
+    captured: list[list[str]] = []
+
+    async def fake_run(cmd, check=True, **_kwargs):
+        captured.append(list(cmd))
+        return 0, b"", b""
+
+    return captured, fake_run
+
+
+def _docker_patches(fake_run):
+    return (
+        patch(
+            "puffo_agent.agent.harness.docker_runtime.resolve_docker_bin",
+            lambda: "/fake/docker",
+        ),
+        patch(
+            "puffo_agent.agent.harness.docker_runtime._run_cmd", new=fake_run
+        ),
+        patch(
+            "puffo_agent.agent.harness.docker_runtime.container_state",
+            new=AsyncMock(return_value="running"),
+        ),
+        patch(
+            "puffo_agent.agent.harness.docker_runtime.ensure_docker_image",
+            new=AsyncMock(),
+        ),
+    )
+
+
+def _wire_driver_runtime(tmp_path, preparer):
+    worker = SimpleNamespace(_adapter=None, agent_cfg=preparer.agent_cfg)
+    run = StandardWorkerRun(worker)  # type: ignore[arg-type]
+    paths = WorkerRunPaths(
+        agent_id=preparer.agent_id,
+        effective_harness="codex",
+        profile_path=str(tmp_path / "profile"),
+        memory_path=str(tmp_path / "memory"),
+        workspace_path=str(preparer.workspace_dir),
+        claude_path=str(preparer.claude_dir),
+        shared_path=tmp_path / "shared",
+        system_prompt="prompt",
+    )
+    outbox_ref: list = [None]
+    outbox, _session_ref, _prepared = asyncio.run(
+        run._prepare_driver_runtime(paths, outbox_ref, preparer)
+    )
+    return outbox, worker._adapter
+
+
+def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
+    preparer = _preparer(tmp_path, monkeypatch, gateway=True)
+    (Path.home() / ".codex").mkdir(parents=True, exist_ok=True)
+    (Path.home() / ".codex" / "config.toml").write_text(
+        "[mcp_servers.host_only]\n"
+        'command = "/Users/operator/bin/server"\n',
+        encoding="utf-8",
+    )
+    (preparer.agent_home).mkdir(parents=True)
+    (preparer.agent_home / ".docker-layout").write_text(
+        docker_cli.CONTAINER_LAYOUT_VERSION + "\n", encoding="utf-8"
+    )
+
+    assert docker_cli.DEFAULT_IMAGE == "puffo/agent-runtime:v19"
+    assert f"@openai/codex@{docker_cli.CODEX_NPM_VERSION}" in docker_cli.DOCKERFILE
+    assert (
+        f"@anthropic-ai/claude-code@{docker_cli.CLAUDE_CODE_NPM_VERSION}"
+        in docker_cli.DOCKERFILE
+    )
+
+    spec = asyncio.run(preparer.refresh_spec("prompt"))
+    config = (preparer.codex_home / "config.toml").read_text(encoding="utf-8")
+    assert 'CODEX_HOME = "/home/agent/.codex"' in config
+    assert 'PUFFO_WORKSPACE = "/workspace"' in config
+    assert 'PUFFO_RUNTIME_KIND = "cli-docker"' in config
+    assert 'PUFFO_HARNESS = "codex"' in config
+    assert "host.docker.internal" in config
+    assert 'command = "python3"' in config
+    assert "host_only" not in config
+    assert "/Users/operator" not in config
+    assert str(preparer.codex_home).replace("\\", "\\\\") not in config
+    assert spec.workspace_dir == "/workspace"
+    assert spec.sandbox == "danger-full-access"
+
+    captured, fake_run = _capture_run()
+    exec_calls: list[dict] = []
+
+    class _FakeProc:
+        returncode = None
+
+    async def fake_create(*args, **kwargs):
+        exec_calls.append({"args": list(args), "kwargs": kwargs})
+        return _FakeProc()
+
+    with ExitStack() as stack:
+        for dependency_patch in _docker_patches(fake_run):
+            stack.enter_context(dependency_patch)
+        # A live prior container on a stale layout must be stopped through
+        # the owned bounded lifecycle before removal — never ``rm -f`` a
+        # running container.
+        asyncio.run(preparer.ensure_container())
+        assert captured[0] == [
+            "/fake/docker", "stop", "-t", "5", "puffo-docker-codex",
+        ]
+        assert captured[1] == ["/fake/docker", "rm", "puffo-docker-codex"]
+        run_cmd = captured[2]
+        assert run_cmd[:2] == ["/fake/docker", "run"]
+        assert f"{preparer.codex_home}:/home/agent/.codex" in run_cmd
+        assert f"{preparer.agent_home}:/home/agent/.puffo-agent-state" in run_cmd
+        assert any(":/workspace" in part for part in run_cmd)
+        assert any(":/workspace/.shared" in part for part in run_cmd)
+        assert any(
+            str(part).endswith(":/opt/puffoagent-pkg:ro") for part in run_cmd
+        )
+        assert not any(
+            str(Path.home() / ".codex") in str(part) for part in run_cmd
+        )
+        assert [
+            part for part in run_cmd if str(part).endswith(":/home/agent/.codex")
+        ] == [f"{preparer.codex_home}:/home/agent/.codex"]
+
+        with patch("asyncio.create_subprocess_exec", new=fake_create):
+            asyncio.run(preparer._exec_process(spec))
+        command = exec_calls[0]["args"]
+        assert command[-3:] == ["puffo-docker-codex", "codex", "app-server"]
+        assert "gateway-key" not in command
+        index = command.index("OPENAI_API_KEY")
+        assert command[index - 1] == "-e"
+        assert command[index + 1] != "gateway-key"
+        assert "CODEX_HOME=/home/agent/.codex" in command
+        assert "ANTHROPIC_API_KEY" not in command
+        assert exec_calls[0]["kwargs"]["env"]["OPENAI_API_KEY"] == "gateway-key"
+
+        outbox, adapter = _wire_driver_runtime(tmp_path, preparer)
+        assert isinstance(adapter, RuntimeManagerAdapter)
+        assert isinstance(adapter.manager.driver, CodexAppServerDriver)
+        assert adapter.manager.driver.process_factory.__self__ is preparer
+        assert adapter.manager.driver.process_factory.__func__ is (
+            DockerCodexPreparer._exec_process
+        )
+        assert adapter.post_close.__self__ is preparer
+
+        captured.clear()
+        asyncio.run(adapter.aclose())
+        assert captured == [
+            ["/fake/docker", "stop", "-t", "5", "puffo-docker-codex"]
+        ]
+    outbox.close()

--- a/tests/test_docker_codex_driver.py
+++ b/tests/test_docker_codex_driver.py
@@ -31,6 +31,7 @@ from puffo_agent.portal.state import (
     RuntimeConfig,
 )
 from puffo_agent.portal.worker_run import StandardWorkerRun, WorkerRunPaths
+from puffo_agent.portal.workspace_layout import ensure_workspace_shared_link
 
 
 def _preparer(tmp_path, monkeypatch, *, gateway=False) -> DockerCodexPreparer:
@@ -96,6 +97,7 @@ def _wire_driver_runtime(tmp_path, preparer):
         workspace_path=str(preparer.workspace_dir),
         claude_path=str(preparer.claude_dir),
         shared_path=tmp_path / "shared",
+        workspace_shared_status="mounted",
         system_prompt="prompt",
     )
     outbox_ref: list = [None]
@@ -103,6 +105,16 @@ def _wire_driver_runtime(tmp_path, preparer):
         run._prepare_driver_runtime(paths, outbox_ref, preparer)
     )
     return outbox, worker._adapter
+
+
+def _seed_local_to_docker_layout(preparer):
+    preparer.agent_home.mkdir(parents=True)
+    (preparer.agent_home / ".docker-layout").write_text(
+        docker_cli.CONTAINER_LAYOUT_VERSION + "\n", encoding="utf-8"
+    )
+    assert ensure_workspace_shared_link(
+        preparer.workspace_dir, preparer.shared_fs_dir
+    ) == "created"
 
 
 def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
@@ -113,10 +125,7 @@ def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
         'command = "/Users/operator/bin/server"\n',
         encoding="utf-8",
     )
-    (preparer.agent_home).mkdir(parents=True)
-    (preparer.agent_home / ".docker-layout").write_text(
-        docker_cli.CONTAINER_LAYOUT_VERSION + "\n", encoding="utf-8"
-    )
+    _seed_local_to_docker_layout(preparer)
 
     assert docker_cli.DEFAULT_IMAGE == "puffo/agent-runtime:v19"
     assert f"@openai/codex@{docker_cli.CODEX_NPM_VERSION}" in docker_cli.DOCKERFILE
@@ -166,7 +175,8 @@ def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
         assert f"{preparer.codex_home}:/home/agent/.codex" in run_cmd
         assert f"{preparer.agent_home}:/home/agent/.puffo-agent-state" in run_cmd
         assert any(":/workspace" in part for part in run_cmd)
-        assert any(":/workspace/shared" in part for part in run_cmd)
+        assert f"{preparer.shared_fs_dir}:/workspace/shared" in run_cmd
+        assert not (preparer.workspace_dir / "shared").is_symlink()
         assert any(":/workspace/.shared" in part for part in run_cmd)
         assert any(
             str(part).endswith(":/opt/puffoagent-pkg:ro") for part in run_cmd

--- a/tests/test_global_inbox_runtime_held_and_reminders.py
+++ b/tests/test_global_inbox_runtime_held_and_reminders.py
@@ -1141,11 +1141,21 @@ async def test_startup_recovers_orphaned_turn_without_crash_join(
             provider_session_id="provider-old",
         )
 
+    status_events = []
+
+    class StatusLifecycle:
+        async def on_turn_active(self, **event):
+            status_events.append(("active", event))
+
+        async def on_turn_terminal(self, **event):
+            status_events.append(("terminal", event))
+
     runtime = GlobalInboxRuntime(
         store=store,
         adapter=Adapter(),
         run_turn=lambda _planned: None,
         workspace=tmp_path,
+        status_lifecycle=StatusLifecycle(),
     )
     assert await runtime.recover_orphaned_turns() == 1
 
@@ -1157,6 +1167,11 @@ async def test_startup_recovers_orphaned_turn_without_crash_join(
     ]
     assert repaired.delivery_pending
     assert await store.get_active_turn_runs() == ()
+    if admitted:
+        assert [kind for kind, _event in status_events] == ["active", "terminal"]
+        assert status_events[-1][1]["succeeded"] is False
+    else:
+        assert status_events == []
     assert await runtime.recover_orphaned_turns() == 0
     await store.close()
 

--- a/tests/test_global_inbox_runtime_held_and_reminders.py
+++ b/tests/test_global_inbox_runtime_held_and_reminders.py
@@ -38,7 +38,7 @@ from puffo_agent.agent.reminder_sync import (
     encrypt_reminder_payload,
 )
 from puffo_agent.agent.runtime_event_outbox import RuntimeEventOutbox
-from puffo_agent.agent.shared_content import INBOX_RESPONSE_DECISION_CUE
+from puffo_agent.agent.shared_content import INBOX_TURN_CUE
 from puffo_agent.crypto.keystore import KeyStore
 
 from _global_inbox_support import _run_prior_context_delivery_case
@@ -538,8 +538,9 @@ async def test_initial_and_busy_notices_are_complete_content_free_inputs(tmp_pat
     assert '"content_included":false' in initial.provider_input
     assert '"read_tool":"read_inbox"' in initial.provider_input
     assert "channel:sp-1:ch-1" in initial.provider_input
-    assert initial.provider_input.endswith(INBOX_RESPONSE_DECISION_CUE)
-    assert "decide-response" in initial.provider_input
+    assert initial.provider_input.endswith(INBOX_TURN_CUE)
+    assert "respond" in initial.provider_input
+    assert "decide-response" not in initial.provider_input
     assert plaintext not in initial_serialized
     assert attachment not in initial_serialized
 

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1749,3 +1749,251 @@ async def test_codex_child_environment_merges_over_process_environment(
     assert captured["env"]["CODEX_HOME"] == "/tmp/codex"
     assert captured["env"]["PUFFO_HARNESS_MARKER"] == "inherited"
     assert captured["env"]["PATH"] == os.environ["PATH"]
+
+
+def _token_telemetry_driver(provider):
+    holder: dict = {}
+
+    def codex_on_frame(frame):
+        proc = holder["proc"]
+        method = frame.get("method")
+        if method == "initialize":
+            proc.feed({"id": frame["id"], "result": {}})
+        elif method == "thread/start":
+            proc.feed({"id": frame["id"], "result": {"thread": {"id": "th_token"}}})
+        elif method == "turn/start":
+            proc.feed({"id": frame["id"], "result": {"turn": {"id": "turn_token"}}})
+
+    if provider in {"codex", "codex-absent"}:
+        proc = _FakeProcess(codex_on_frame)
+        holder["proc"] = proc
+        expected = (140, 100, 110) if provider == "codex" else (140, 100, None)
+        return proc, CodexAppServerDriver(lambda _spec: proc), expected
+
+    def claude_on_frame(frame):
+        if frame.get("type") == "user":
+            holder["proc"].feed({**frame, "isReplay": True})
+
+    proc = _FakeProcess(claude_on_frame)
+    proc.feed({
+        "type": "system", "subtype": "init",
+        "session_id": "claude-1", "slash_commands": [],
+    })
+    holder["proc"] = proc
+    return (
+        proc,
+        ClaudeCodeCliDriver(lambda *_args: proc, replay_timeout=1),
+        (40, 30, 80),
+    )
+
+
+def _feed_token_telemetry(provider, proc):
+    if provider in {"codex", "codex-absent"}:
+        base_last = {"inputTokens": 100, "cachedInputTokens": 60,
+                     "outputTokens": 40}
+        final_last = {"inputTokens": 150, "cachedInputTokens": 100,
+                      "outputTokens": 60}
+        if provider == "codex":
+            base_last = {**base_last, "totalTokens": 80}
+            final_last = {**final_last, "totalTokens": 110}
+        proc.feed({"method": "thread/tokenUsage/updated", "params": {"tokenUsage": {
+            "last": base_last,
+            "total": {"inputTokens": 500, "cachedInputTokens": 300,
+                      "outputTokens": 80},
+        }}})
+        proc.feed({"method": "thread/tokenUsage/updated", "params": {"tokenUsage": {
+            "last": final_last,
+            "total": {"inputTokens": 700, "cachedInputTokens": 400,
+                      "outputTokens": 140},
+        }}})
+        proc.feed({"method": "turn/completed", "params": {"turn": {"status": "completed"}}})
+    else:
+        proc.feed({"type": "result", "subtype": "success", "usage": {
+            "input_tokens": 25,
+            "cache_creation_input_tokens": 15,
+            "cache_read_input_tokens": 40,
+            "output_tokens": 30,
+        }})
+
+
+def _reporter_emits(monkeypatch):
+    emits = []
+
+    async def fake_emit(agent_slug, event, payload):
+        emits.append((event, payload))
+
+    import puffo_agent.portal.control.reporter as reporter_mod
+
+    monkeypatch.setattr(
+        reporter_mod, "get_reporter", lambda: SimpleNamespace(emit=fake_emit)
+    )
+    return emits
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["codex", "codex-absent", "claude-code"])
+async def test_terminal_token_telemetry_reaches_turn_complete_current_context(
+    tmp_path, monkeypatch, provider,
+):
+    """Per-turn tokens must survive the Driver -> RuntimeManagerAdapter -> core
+    handoff and surface as ``turn_complete.current_context``; post-2.0 dropped
+    Codex ``last``/``total`` deltas, Claude cache semantics, and the whitelist.
+    """
+    proc, driver, expected = _token_telemetry_driver(provider)
+    emits = _reporter_emits(monkeypatch)
+    manager = RuntimeManager(
+        driver, RuntimeSpec(str(tmp_path)), session_ref=SessionRef("logical-session")
+    )
+    adapter = RuntimeManagerAdapter(manager)
+    await adapter.warm("system")
+    agent = PuffoAgent(
+        adapter, "system", str(tmp_path / "memory"),
+        workspace_dir=str(tmp_path), agent_id="agent",
+    )
+    agent.log.append({"role": "user", "content": "hello"})
+    task = asyncio.create_task(agent._run_turn_and_route("channel", "alice", None))
+    await _wait_until(lambda: bool(manager._turn_refs))
+    _feed_token_telemetry(provider, proc)
+    await asyncio.wait_for(task, timeout=5)
+    await _wait_until(lambda: len(emits) == 2)
+    turn_complete = {event: payload for event, payload in emits}["turn_complete"]
+    assert turn_complete["tokens"] == {
+        "input": expected[0], "output": expected[1],
+    }
+    if expected[2] is None:
+        assert "current_context" not in turn_complete
+    else:
+        assert turn_complete["current_context"] == expected[2]
+    await adapter.aclose()
+
+
+def _projection_event(type_, data, *, native=None):
+    return HarnessEvent.normalized(
+        type=type_, driver="codex",
+        session_ref=SessionRef("native-session"),
+        turn_ref=TurnRef("driver-turn"),
+        native_session_id="native-session", native_turn_id="native-turn",
+        data=data, native_payload=native,
+    )
+
+
+def _projection_events():
+    return [
+        _projection_event(
+            "turn.started", {},
+            native={"_puffo_internal": "frame", "secret": "NATIVE_FRAME_SECRET"},
+        ),
+        _projection_event("turn.assistant_delta",
+                          {"text": "first half ", "block_id": "block-1"}),
+        _projection_event("turn.assistant_delta",
+                          {"text": "second half", "block_id": "block-1"}),
+        _projection_event("turn.assistant_completed", {"block_id": "block-1"}),
+        _projection_event("turn.assistant_completed", {"block_id": "block-1"}),
+        _projection_event("turn.tool_started",
+                          {"tool_call_ref": "tool-1",
+                           "label": "mcp__puffo__read_inbox"},
+                          native={"_puffo_internal": "tool_result",
+                                  "arguments": {"secret_arg": "TOOL_ARG_SECRET"}}),
+        _projection_event("turn.tool_started",
+                          {"tool_call_ref": "tool-1",
+                           "label": "mcp__puffo__read_inbox"}),
+        _projection_event("turn.tool_completed",
+                          {"tool_call_ref": "tool-1", "label": "read_inbox",
+                           "outcome": "succeeded"},
+                          native={"_puffo_internal": "tool_result",
+                                  "result": "TOOL_RESULT_SECRET"}),
+        _projection_event("turn.reasoning", {"text": "REASONING_SECRET"},
+                          native={"reasoning": "COT_SECRET"}),
+        _projection_event("turn.assistant_delta",
+                          {"text": "[SILENT] do not surface",
+                           "block_id": "block-2"}),
+        _projection_event("turn.assistant_completed", {"block_id": "block-2"}),
+        _projection_event("turn.assistant_delta",
+                          {"text": "X" * 210 + "OVERBOUND_SECRET",
+                           "block_id": "block-3"}),
+        _projection_event("turn.assistant_completed", {"block_id": "block-3"}),
+        _projection_event("turn.completed", {"outcome": "succeeded"}),
+    ]
+
+
+async def _feed_projection_events(driver, events):
+    for event in events:
+        await driver.queue.put(event)
+
+
+def _build_projection_adapter(tmp_path, driver, monkeypatch):
+    import puffo_agent.agent.harness.local_runtime as local_runtime
+    from puffo_agent.agent.harness.local_runtime import (
+        PreparedLocalRuntime,
+        build_local_runtime_adapter,
+    )
+
+    class _StubPreparer:
+        agent_id = "agent"
+
+    prepared = PreparedLocalRuntime(
+        harness_name="codex",
+        spec=RuntimeSpec(str(tmp_path)),
+        native_session_id="",
+        migration_source="fresh",
+        legacy_session_path=tmp_path / "legacy.json",
+        preparer=_StubPreparer(),
+        session_fingerprint="fp",
+    )
+    outbox = RuntimeEventOutbox(tmp_path / "runtime_events.db")
+    monkeypatch.setattr(local_runtime, "build_driver", lambda name: driver)
+    adapter = build_local_runtime_adapter(
+        prepared, outbox=outbox, logical_session_ref="logical-session"
+    )
+    return adapter, outbox
+
+
+@pytest.mark.asyncio
+async def test_local_sink_projects_only_bounded_safe_legacy_status(
+    tmp_path, monkeypatch,
+):
+    """The local runtime sink must emit only bounded ``assistant_text`` (once per
+    completed non-silent block) and label-only ``tool_use`` per normalized start,
+    never duplicates, post-terminal fragments, or native/argument/reasoning
+    material. Post-2.0 the sink emitted nothing; a native replay would leak.
+    """
+    from puffo_agent.agent.adapters.base import TurnContext
+
+    driver = _ToolResultDriver()
+    emits = _reporter_emits(monkeypatch)
+    adapter, outbox = _build_projection_adapter(tmp_path, driver, monkeypatch)
+    manager = adapter.manager
+    ctx = TurnContext(
+        system_prompt="system",
+        messages=[{"role": "user", "content": "hello"}],
+        workspace_dir=str(tmp_path),
+        claude_dir=str(tmp_path),
+        memory_dir=str(tmp_path / "memory"),
+    )
+    task = asyncio.create_task(adapter.run_turn(ctx))
+    await _wait_until(lambda: bool(manager._turn_refs))
+    await _feed_projection_events(driver, _projection_events())
+    await asyncio.wait_for(task, timeout=5)
+    await _feed_projection_events(driver, [
+        _projection_event("turn.assistant_delta",
+                          {"text": "STALE_TEXT", "block_id": "block-stale"}),
+        _projection_event("turn.assistant_completed", {"block_id": "block-stale"}),
+    ])
+    await _wait_until(lambda: driver.queue.empty())
+    await _wait_until(lambda: len(emits) == 3)
+    await asyncio.sleep(0.02)
+
+    assert emits == [
+        ("assistant_text", {"text": "first half second half"}),
+        ("tool_use", {"tool": "read_inbox"}),
+        ("assistant_text", {"text": "X" * 200}),
+    ]
+    serialized = "".join(json.dumps(payload) for _, payload in emits)
+    for sentinel in (
+        "NATIVE_FRAME_SECRET", "TOOL_ARG_SECRET", "TOOL_RESULT_SECRET",
+        "REASONING_SECRET", "COT_SECRET", "OVERBOUND_SECRET", "[SILENT]",
+        "STALE_TEXT",
+    ):
+        assert sentinel not in serialized
+    await adapter.aclose()
+    outbox.close()

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1416,6 +1416,42 @@ async def test_claude_driver_accepts_init_after_first_stream_input():
 
 
 @pytest.mark.asyncio
+async def test_claude_driver_prepends_normalized_launch_argv(monkeypatch):
+    """Regression-pin for the A1 gap: the launch argv must be the
+    normalized executable prefix (the Windows wrapper block) followed by
+    the untouched flags. On this host the real boundary passes the
+    executable through, so the wiring + ordering both stay pinned."""
+    import puffo_agent.agent.harness.claude_code_driver as driver_mod
+
+    def make_factory(captured):
+        def factory(args, _spec):
+            captured.extend(args)
+            proc = _FakeProcess()
+            proc.feed({
+                "type": "system", "subtype": "init",
+                "session_id": f"claude-{len(captured)}", "slash_commands": [],
+            })
+            return proc
+        return factory
+
+    posix = []
+    driver = ClaudeCodeCliDriver(make_factory(posix), replay_timeout=1)
+    await driver.open(RuntimeSpec("/workspace", executable="claude"))
+    await driver.close()
+    assert posix[:2] == ["claude", "-p"]
+
+    monkeypatch.setattr(
+        driver_mod, "normalize_launch_argv",
+        lambda executable: ["cmd.exe", "/c", executable + ".cmd"],
+    )
+    windows = []
+    driver = ClaudeCodeCliDriver(make_factory(windows), replay_timeout=1)
+    await driver.open(RuntimeSpec("/workspace", executable="claude"))
+    await driver.close()
+    assert windows[:4] == ["cmd.exe", "/c", "claude.cmd", "-p"]
+
+
+@pytest.mark.asyncio
 async def test_claude_driver_resume_flag_maps_to_resumed_system_init():
     captured = []
 

--- a/tests/test_inbox_admission_contract.py
+++ b/tests/test_inbox_admission_contract.py
@@ -164,6 +164,7 @@ class HeldTransport:
                 "latest_seq": self.held_seq,
                 "latest_envelope_id": self.held_envelope_id,
             }
+        request_baseline = freshness["context_baseline_seq"]
         return {
             "state": "sent",
             "envelope_id": "send-anyway-result",
@@ -172,7 +173,11 @@ class HeldTransport:
             "missing_devices": [],
             "freshness": {
                 "mode": freshness["mode"],
-                "context_baseline_seq": freshness["context_baseline_seq"],
+                "context_baseline_seq": (
+                    request_baseline
+                    if request_baseline is not None
+                    else freshness["seen_seq"]
+                ),
                 "seen_seq": freshness["seen_seq"],
                 "latest_seq_before_send": freshness["seen_seq"],
             },
@@ -575,7 +580,7 @@ async def test_exact_held_chain_admits_only_at_original_send_result_boundary(
     assert sent["state"] == "sent"
     assert len(h.transport.calls) == 2
     assert h.transport.calls[-1][1]["freshness"] == {
-        "context_baseline_seq": 0,
+        "context_baseline_seq": None,
         "seen_seq": 7,
         "mode": "send_anyway",
     }

--- a/tests/test_keyless_dm_approval_flow.py
+++ b/tests/test_keyless_dm_approval_flow.py
@@ -14,6 +14,7 @@ from puffo_agent.agent.contact_cache import ContactCache
 from puffo_agent.agent.dm_approvals import (
     load_pending_dm_approvals,
     parse_keyless_approval,
+    save_pending_dm_approvals,
 )
 from puffo_agent.agent.keyless_dm_approval_flow import (
     maybe_handle_operator_reply,
@@ -310,6 +311,40 @@ async def test_denial_conflict_missing_operator_and_persist_failure_fail_closed(
     )
     assert "held-p" not in failed._pending_dm_approvals
     assert failed._bridge.send_calls == []
+
+    # A keyless contact write failure fails closed in both directions: the
+    # decided record stays pending, nothing transitions or ACKs, and replay
+    # retries the durable contact mutation before applying and ACKing the
+    # exact held envelope.
+    monkeypatch.setattr(flow, "save_pending_dm_approvals", save_pending_dm_approvals)
+
+    def _disk_full():
+        raise OSError("disk full")
+
+    for approve, word, seq, sender in ((True, "y", 51, "frank-1"), (False, "n", 61, "grace-1")):
+        slug = "approve-fail" if approve else "deny-fail"
+        fail = _client(slug)
+        await record_gated_dm(fail, envelope_id="held-f", sender_slug=sender, server_seq=seq)
+        write = fail._contacts._persist_local_state
+        fail._contacts._persist_local_state = _disk_full
+        assert await maybe_handle_operator_reply(fail, thread_root_id="prompt-1", text=word) is True
+        fail._contacts._persist_local_state = write
+        assert _record(fail, "held-f").phase == "pending"
+        assert _record(fail, "held-f").decision == ("approved" if approve else "denied")
+        assert fail._bridge.ack_calls == []
+        assert fail.store.promote_calls == []
+        assert fail.store.tombstone_calls == []
+        if approve:
+            assert fail.global_runtime.notifications == 0
+        retry = _client(slug)
+        await resume_pending_approvals(retry)
+        if approve:
+            assert retry.store.promote_calls == [("held-f", seq, flow.APPROVED_REASON)]
+        else:
+            assert retry.store.tombstone_calls == [("held-f", seq)]
+        assert retry._bridge.ack_calls == [["held-f"]]
+        assert (await retry._contacts.is_allowed(sender)) == approve
+        assert (await retry._contacts.is_blocked(sender)) == (not approve)
 
 
 def test_contact_construction_seam():

--- a/tests/test_keyless_dm_approval_flow.py
+++ b/tests/test_keyless_dm_approval_flow.py
@@ -1,0 +1,335 @@
+"""Focused contract tests for keyless DM operator approval."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.agent import keyless_dm_approval_flow as flow
+from puffo_agent.agent.client_setup import initial_client_state
+from puffo_agent.agent.contact_cache import ContactCache
+from puffo_agent.agent.dm_approvals import (
+    load_pending_dm_approvals,
+    parse_keyless_approval,
+)
+from puffo_agent.agent.keyless_dm_approval_flow import (
+    maybe_handle_operator_reply,
+    record_gated_dm,
+    resume_pending_approvals,
+)
+from puffo_agent.agent.message_store import ReceiptDisposition, ReceiptWriteStatus
+from puffo_agent.agent.message_store_models import ReceiptResult
+from _portal_support import isolated_home
+
+log = logging.getLogger("keyless-dm-approval-test")
+
+
+class _Bridge:
+    def __init__(self) -> None:
+        self.send_calls: list[dict] = []
+        self.ack_calls: list[list[str]] = []
+        self.send_snapshots: list[dict] = []
+        self.ack_snapshots: list[dict] = []
+        self.ack_error: Exception | None = None
+        self.snapshot = lambda: {}
+
+    async def send_send(self, **kwargs) -> dict:
+        self.send_snapshots.append(dict(self.snapshot()))
+        self.send_calls.append(kwargs)
+        return {
+            "type": "ack",
+            "client_ref": kwargs["client_ref"],
+            "envelope_id": "prompt-1",
+        }
+
+    async def send_ack(self, envelope_ids, *, timeout: float = 30.0) -> dict:
+        self.ack_snapshots.append(dict(self.snapshot()))
+        if self.ack_error is not None:
+            raise self.ack_error
+        ids = list(envelope_ids)
+        self.ack_calls.append(ids)
+        return {"type": "ack_result", "acked": ids}
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.promote_calls: list[tuple] = []
+        self.tombstone_calls: list[tuple] = []
+        self.snapshots: list[dict] = []
+        self.status: dict[str, ReceiptWriteStatus] = {}
+        self.snapshot = lambda: {}
+
+    async def promote_gated_receipt(
+        self,
+        envelope_id,
+        server_seq,
+        *,
+        reason,
+        approved_payload=None,
+    ) -> ReceiptResult:
+        self.promote_calls.append((envelope_id, server_seq, reason))
+        self.snapshots.append(dict(self.snapshot()))
+        status = self.status.get(envelope_id, ReceiptWriteStatus.COMMITTED)
+        return ReceiptResult(
+            status,
+            ReceiptDisposition.ELIGIBLE,
+            reason,
+            status is not ReceiptWriteStatus.CONFLICT,
+        )
+
+    async def tombstone_gated_dm(
+        self,
+        envelope_id,
+        server_seq=None,
+    ) -> ReceiptResult:
+        self.tombstone_calls.append((envelope_id, server_seq))
+        self.snapshots.append(dict(self.snapshot()))
+        status = self.status.get(envelope_id, ReceiptWriteStatus.COMMITTED)
+        return ReceiptResult(
+            status,
+            ReceiptDisposition.TERMINAL,
+            "foreign dm denied by operator",
+            status is not ReceiptWriteStatus.CONFLICT,
+        )
+
+
+class _Runtime:
+    def __init__(self) -> None:
+        self.notifications = 0
+
+    def notify(self) -> None:
+        self.notifications += 1
+
+
+class _KeylessHttp:
+    keyless = True
+
+
+class _SignedHttp:
+    keyless = False
+
+
+def _client(slug: str, operator: str = "operator-1"):
+    from puffo_agent.portal.state import agent_dir
+
+    bridge = _Bridge()
+    store = _Store()
+    pending = load_pending_dm_approvals(slug)
+    client = SimpleNamespace(
+        slug=slug,
+        operator_slug=operator,
+        _bridge=bridge,
+        store=store,
+        global_runtime=_Runtime(),
+        _contacts=ContactCache(
+            _KeylessHttp(),
+            log,
+            local_state_path=(
+                agent_dir(slug) / ".puffo-agent" / "keyless_contacts.json"
+            ),
+        ),
+        _pending_dm_approvals=pending,
+        _keyless_dm_approval_lock=asyncio.Lock(),
+        _log=log,
+    )
+    bridge.snapshot = lambda: client._pending_dm_approvals
+    store.snapshot = lambda: client._pending_dm_approvals
+    return client
+
+
+def _record(client, envelope_id: str):
+    return parse_keyless_approval(client._pending_dm_approvals[envelope_id])
+
+
+@pytest.mark.asyncio
+async def test_grouped_approval_is_durable_serial_and_resumable():
+    isolated_home()
+    client = _client("agent-1")
+    client._pending_dm_approvals["native"] = {"sender_slug": "legacy-1"}
+
+    await asyncio.gather(
+        record_gated_dm(
+            client,
+            envelope_id="held-1",
+            sender_slug="alice-1",
+            server_seq=11,
+        ),
+        record_gated_dm(
+            client,
+            envelope_id="held-2",
+            sender_slug="alice-1",
+            server_seq=12,
+        ),
+    )
+    assert len(client._bridge.send_calls) == 1
+    assert client._bridge.send_snapshots[0]["held-1"]["phase"] == "pending"
+    assert (
+        _record(client, "held-1").prompt_client_ref
+        == _record(
+            client,
+            "held-2",
+        ).prompt_client_ref
+    )
+    assert (
+        await maybe_handle_operator_reply(
+            client,
+            thread_root_id="wrong",
+            text="y",
+        )
+        is False
+    )
+    assert (
+        await maybe_handle_operator_reply(
+            client,
+            thread_root_id="prompt-1",
+            text="later",
+        )
+        is False
+    )
+
+    client.store.status["held-2"] = ReceiptWriteStatus.IDEMPOTENT
+    client._bridge.ack_error = RuntimeError("connection dropped")
+    assert (
+        await maybe_handle_operator_reply(
+            client,
+            thread_root_id="prompt-1",
+            text=" yes ",
+        )
+        is True
+    )
+    assert {call[:2] for call in client.store.promote_calls} == {
+        ("held-1", 11),
+        ("held-2", 12),
+    }
+    assert all(
+        value["decision"] == "approved"
+        for key, value in (client._pending_dm_approvals.items())
+        if key.startswith("held-")
+    )
+    assert all(
+        value["phase"] == "applied"
+        for key, value in (client._pending_dm_approvals.items())
+        if key.startswith("held-")
+    )
+    assert client.store.snapshots[0]["held-1"]["decision"] == "approved"
+    assert client._bridge.ack_snapshots[0]["held-1"]["phase"] == "applied"
+
+    # A contradictory retry cannot reverse a durable decision or its effects.
+    assert (
+        await maybe_handle_operator_reply(
+            client,
+            thread_root_id="prompt-1",
+            text="n",
+        )
+        is True
+    )
+    assert client.store.tombstone_calls == []
+    assert _record(client, "held-1").decision == "approved"
+
+    # A later group member gets its own transition, not an inherited phase.
+    await record_gated_dm(
+        client,
+        envelope_id="held-3",
+        sender_slug="alice-1",
+        server_seq=13,
+    )
+    assert len(client._bridge.send_calls) == 1
+    assert _record(client, "held-3").phase == "applied"
+
+    client._bridge.ack_error = None
+    reboot = _client("agent-1")
+    await resume_pending_approvals(reboot)
+    assert reboot.store.promote_calls == []
+    assert reboot._bridge.ack_calls == [["held-1"], ["held-2"], ["held-3"]]
+    assert reboot._pending_dm_approvals == {"native": {"sender_slug": "legacy-1"}}
+
+
+@pytest.mark.asyncio
+async def test_denial_conflict_missing_operator_and_persist_failure_fail_closed(
+    monkeypatch,
+):
+    isolated_home()
+    denied = _client("denied")
+    await record_gated_dm(
+        denied,
+        envelope_id="held-n",
+        sender_slug="bob-1",
+        server_seq=21,
+    )
+    assert (
+        await maybe_handle_operator_reply(
+            denied,
+            thread_root_id="prompt-1",
+            text="no",
+        )
+        is True
+    )
+    assert denied.store.tombstone_calls == [("held-n", 21)]
+    assert denied._bridge.ack_calls == [["held-n"]]
+
+    conflict = _client("conflict")
+    await record_gated_dm(
+        conflict,
+        envelope_id="held-c",
+        sender_slug="cora-1",
+        server_seq=31,
+    )
+    conflict.store.status["held-c"] = ReceiptWriteStatus.CONFLICT
+    await maybe_handle_operator_reply(
+        conflict,
+        thread_root_id="prompt-1",
+        text="y",
+    )
+    assert _record(conflict, "held-c").phase == "pending"
+    assert conflict._bridge.ack_calls == []
+
+    no_operator = _client("no-operator", operator="")
+    await record_gated_dm(
+        no_operator,
+        envelope_id="held-o",
+        sender_slug="dana-1",
+        server_seq=None,
+    )
+    assert no_operator._bridge.send_calls == []
+    assert _record(no_operator, "held-o").decision == "pending"
+
+    failed = _client("persist-failure")
+
+    def _raise(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(flow, "save_pending_dm_approvals", _raise)
+    await record_gated_dm(
+        failed,
+        envelope_id="held-p",
+        sender_slug="erin-1",
+        server_seq=41,
+    )
+    assert "held-p" not in failed._pending_dm_approvals
+    assert failed._bridge.send_calls == []
+
+
+def test_contact_construction_seam():
+    isolated_home()
+    keyless = initial_client_state(
+        slug="agent-1",
+        device_id="dev-1",
+        space_id="space-1",
+        keystore=None,
+        http_client=_KeylessHttp(),
+        message_store=None,
+    )
+    signed = initial_client_state(
+        slug="agent-2",
+        device_id="dev-2",
+        space_id="space-1",
+        keystore=None,
+        http_client=_SignedHttp(),
+        message_store=None,
+    )
+    assert keyless["_contacts"]._local_state_path.name == "keyless_contacts.json"
+    assert signed["_contacts"]._local_state_path is None
+    assert isinstance(keyless["_keyless_dm_approval_lock"], asyncio.Lock)

--- a/tests/test_keyless_invitation_flow.py
+++ b/tests/test_keyless_invitation_flow.py
@@ -1,0 +1,294 @@
+"""Focused contract tests for the keyless invitation decision flow."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from puffo_agent.agent.keyless_invitation_flow import KeylessInvitationFlow
+from puffo_agent.agent.keyless_invitation_state import (
+    load_keyless_invitations,
+    save_keyless_invitations,
+)
+from _portal_support import isolated_home
+
+log = logging.getLogger("keyless-invitation-test")
+
+
+class _Dms:
+    """Fake keyless DM prompt lane. Snapshots the durable state file at the
+    moment a prompt is about to be sent so ordering is observable."""
+
+    def __init__(self, slug: str) -> None:
+        self.slug = slug
+        self.send_calls: list[dict] = []
+        self.file_at_send: list[dict] = []
+        self.send_error: Exception | None = None
+
+    async def send_dm(self, text: str, *, client_ref: str) -> dict:
+        self.file_at_send.append(dict(load_keyless_invitations(self.slug)))
+        if self.send_error is not None:
+            raise self.send_error
+        self.send_calls.append({"text": text, "client_ref": client_ref})
+        return {
+            "type": "ack",
+            "client_ref": client_ref,
+            "envelope_id": f"env_{client_ref}",
+            "thread_root_id": f"thread_{client_ref}",
+        }
+
+
+class _Bridge:
+    """Fake Server bridge decision lane. Snapshots the durable state file
+    at the moment a decision frame is about to be sent."""
+
+    def __init__(self, slug: str) -> None:
+        self.slug = slug
+        self.decision_calls: list[dict] = []
+        self.file_at_decide: list[dict] = []
+        self.decide_error: Exception | None = None
+        self.decide_outcomes: dict[str, str] = {}
+
+    async def send_decide_invitation(self, **kwargs) -> dict:
+        self.file_at_decide.append(dict(load_keyless_invitations(self.slug)))
+        if self.decide_error is not None:
+            raise self.decide_error
+        self.decision_calls.append(kwargs)
+        event_id = kwargs["invitation_event_id"]
+        outcome = self.decide_outcomes.get(event_id, "applied")
+        return {
+            "type": "decide_invitation_result",
+            "client_ref": kwargs["client_ref"],
+            "invitation_event_id": event_id,
+            "decision": kwargs["decision"],
+            "outcome": outcome,
+        }
+
+
+def _flow(
+    slug: str,
+    *,
+    operator: str = "operator-1",
+    auto_accept: bool = False,
+    bridge: _Bridge | None = None,
+    dms: _Dms | None = None,
+) -> tuple[KeylessInvitationFlow, _Bridge, _Dms]:
+    bridge = bridge or _Bridge(slug)
+    dms = dms or _Dms(slug)
+    flow = KeylessInvitationFlow(
+        slug=slug,
+        bridge=bridge,
+        operator_slug=operator,
+        send_dm=dms.send_dm,
+        auto_accept_space_invitations=auto_accept,
+        log=log,
+    )
+    return flow, bridge, dms
+
+
+def _invite(event_id: str, *, scope: str, space_id: str, inviter: str) -> dict:
+    invite: dict = {
+        "invitation_event_id": event_id,
+        "scope": scope,
+        "space_id": space_id,
+        "inviter_slug": inviter,
+    }
+    if scope == "channel":
+        invite["channel_id"] = f"ch_{event_id}"
+    return invite
+
+
+@pytest.mark.asyncio
+async def test_accept_lifecycle_is_durable_resumable_and_terminal():
+    """Guarded regression: no prompt or Server decision may be sent before
+    its state transition is durable; reconnect/replay reuses the stable
+    prompt and decision client refs instead of a second logical prompt or
+    decision; applied/already_applied leave the record terminal with no
+    further send on another resume; an operator-sent invite auto-accepts
+    without prompting."""
+    isolated_home()
+    slug = "agent-1"
+    flow, bridge, dms = _flow(slug)
+    iv_1 = _invite("iv_1", scope="space", space_id="sp_1", inviter="alice-1")
+    iv_2 = _invite("iv_2", scope="channel", space_id="sp_1", inviter="bob-1")
+    iv_3 = _invite("iv_3", scope="space", space_id="sp_3", inviter="carol-1")
+    full = [iv_1, iv_2, iv_3]
+
+    await flow.reconcile([iv_1, iv_2])
+    assert len(dms.send_calls) == 2
+    # The prompt is sent only after the record was durable (unsent at send).
+    assert dms.file_at_send[0]["iv_1"]["phase"] == "unsent"
+    state = load_keyless_invitations(slug)
+    assert state["iv_1"]["phase"] == "awaiting_reply"
+    ref_1 = state["iv_1"]["prompt_client_ref"]
+    ref_2 = state["iv_2"]["prompt_client_ref"]
+
+    # A prompt that fails leaves the record durable-unsent for resume; a
+    # re-reconcile of the full authoritative set never prompts a known invite.
+    dms.send_error = OSError("network down")
+    await flow.reconcile(full)
+    dms.send_error = None
+    assert load_keyless_invitations(slug)["iv_3"]["phase"] == "unsent"
+    ref_3 = load_keyless_invitations(slug)["iv_3"]["prompt_client_ref"]
+    await flow.reconcile(full)
+    assert len(dms.send_calls) == 2
+
+    # Operator-sent invites auto-accept without prompting the operator.
+    await flow.reconcile([*full, _invite("iv_op", scope="channel", space_id="sp_op", inviter="operator-1")])
+    assert len(dms.send_calls) == 2
+    assert load_keyless_invitations(slug)["iv_op"]["phase"] == "terminal"
+
+    # Reboot + resume: known prompts are left awaiting their exact reply,
+    # and the unsent prompt is re-sent with the SAME stable ref.
+    reboot, bridge_r, dms_r = _flow(slug)
+    await reboot.resume()
+    assert len(dms_r.send_calls) == 1
+    assert dms_r.send_calls[0]["client_ref"] == ref_3
+    assert bridge_r.decision_calls == []
+
+    # Only an exact threaded y/yes/n/no reply is consumed.
+    assert await reboot.handle_operator_reply(thread_root_id=f"thread_{ref_1}", text="maybe") is False
+    assert await reboot.handle_operator_reply(thread_root_id="unknown-thread", text="y") is False
+
+    # Operator accepts iv_1; the decision (and its ref) is durable before
+    # the decision frame; a dropped decision send keeps it decided.
+    bridge_r.decide_error = RuntimeError("connection dropped")
+    assert await reboot.handle_operator_reply(thread_root_id=f"thread_{ref_1}", text="  YES ") is True
+    assert bridge_r.decision_calls == []
+    assert bridge_r.file_at_decide[0]["iv_1"]["phase"] == "decided"
+    decision_ref_1 = load_keyless_invitations(slug)["iv_1"]["decision_client_ref"]
+    assert bridge_r.file_at_decide[0]["iv_1"]["decision_client_ref"] == decision_ref_1
+
+    # Reboot + resume retries the decided record with the SAME decision ref
+    # and reaches terminal applied with no duplicate prompt.
+    replay, bridge_r2, dms_r2 = _flow(slug)
+    await replay.resume()
+    assert len(bridge_r2.decision_calls) == 1
+    assert bridge_r2.decision_calls[0]["client_ref"] == decision_ref_1
+    assert dms_r2.send_calls == []
+    assert load_keyless_invitations(slug)["iv_1"]["phase"] == "terminal"
+
+    # A channel invite accepted to already_applied is terminal too; a
+    # contradictory retry cannot reverse the durable decision.
+    bridge_r2.decide_outcomes["iv_2"] = "already_applied"
+    assert await replay.handle_operator_reply(thread_root_id=f"thread_{ref_2}", text="yes") is True
+    assert await replay.handle_operator_reply(thread_root_id=f"thread_{ref_2}", text="n") is True
+    state = load_keyless_invitations(slug)
+    assert state["iv_2"]["phase"] == "terminal"
+    assert state["iv_2"]["outcome"] == "already_applied"
+    assert state["iv_2"]["decision"] == "accept"
+
+    # Another resume sends nothing: terminal records stay put.
+    again, bridge_r3, dms_r3 = _flow(slug)
+    await again.resume()
+    assert bridge_r3.decision_calls == []
+    assert dms_r3.send_calls == []
+    assert {k: v["phase"] for k, v in load_keyless_invitations(slug).items()} == {
+        "iv_1": "terminal",
+        "iv_2": "terminal",
+        "iv_3": "awaiting_reply",
+        "iv_op": "terminal",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_and_terminal_resolution(caplog):
+    """Guarded regressions: with no operator an invite stays pending with
+    no prompt/decision; a failed persist restores in-memory state and sends
+    nothing; malformed/key-mismatched rows are skipped with a warning;
+    conflict/not_found resolve terminal and are logged without a retry loop;
+    and auto_accept_space_invitations decides only space-scope records."""
+    isolated_home()
+
+    # A) Missing operator -> invite retained pending, nothing is sent.
+    flow_none, bridge_none, dms_none = _flow("agent-none", operator="")
+    await flow_none.reconcile([_invite("iv_miss", scope="space", space_id="sp_m", inviter="alice-1")])
+    assert dms_none.send_calls == []
+    assert bridge_none.decision_calls == []
+    state = load_keyless_invitations("agent-none")
+    assert state["iv_miss"]["decision"] == "pending"
+    assert state["iv_miss"]["phase"] == "unsent"
+    # A later authoritative list keeps it pending (not retired).
+    await flow_none.reconcile([_invite("iv_miss", scope="space", space_id="sp_m", inviter="alice-1")])
+    assert "iv_miss" in load_keyless_invitations("agent-none")
+
+    # B) Write failure -> nothing prompted, in-memory mirror restored.
+    flow_fail, bridge_fail, dms_fail = _flow("agent-fail")
+    flow_fail._save_state = lambda slug, pending: (_ for _ in ()).throw(OSError("disk full"))
+    await flow_fail.reconcile([_invite("iv_fail", scope="channel", space_id="sp_f", inviter="bob-1")])
+    assert dms_fail.send_calls == []
+    assert bridge_fail.decision_calls == []
+    assert "iv_fail" not in flow_fail._pending
+
+    # C) Malformed and key-mismatched rows are skipped with a warning.
+    save_keyless_invitations("agent-mal", {
+        "iv_ok": {
+            "kind": "keyless_invitation",
+            "invitation_event_id": "iv_ok",
+            "invite": {"invitation_event_id": "iv_ok", "scope": "space", "space_id": "sp_o"},
+            "prompt_client_ref": "p_ok",
+            "prompt_envelope_id": None,
+            "prompt_thread_id": None,
+            "decision": "pending",
+            "decision_client_ref": None,
+            "phase": "unsent",
+            "outcome": None,
+        },
+        "iv_bad": {"kind": "keyless_invitation", "invitation_event_id": "iv_bad"},
+        "iv_key": {
+            "kind": "keyless_invitation",
+            "invitation_event_id": "OTHER",
+            "invite": {"invitation_event_id": "OTHER", "scope": "space", "space_id": "sp_x"},
+            "prompt_client_ref": "p_k",
+            "prompt_envelope_id": None,
+            "prompt_thread_id": None,
+            "decision": "pending",
+            "decision_client_ref": None,
+            "phase": "unsent",
+            "outcome": None,
+        },
+    })
+    with caplog.at_level(logging.WARNING, logger="puffo_agent.agent.keyless_invitation_state"):
+        loaded = load_keyless_invitations("agent-mal")
+    assert set(loaded) == {"iv_ok"}
+    assert any("skipping malformed record" in record.message for record in caplog.records)
+
+    # D) conflict/not_found resolve terminal, logged, with no retry loop.
+    flow_c, bridge_c, dms_c = _flow("agent-term")
+    bridge_c.decide_outcomes = {"iv_conf": "conflict", "iv_nf": "not_found"}
+    await flow_c.reconcile([
+        _invite("iv_conf", scope="space", space_id="sp_c", inviter="carol-1"),
+        _invite("iv_nf", scope="channel", space_id="sp_c", inviter="dave-1"),
+    ])
+    refs = load_keyless_invitations("agent-term")
+    assert await flow_c.handle_operator_reply(
+        thread_root_id=f"thread_{refs['iv_conf']['prompt_client_ref']}", text="y",
+    ) is True
+    assert await flow_c.handle_operator_reply(
+        thread_root_id=f"thread_{refs['iv_nf']['prompt_client_ref']}", text="y",
+    ) is True
+    state = load_keyless_invitations("agent-term")
+    assert state["iv_conf"]["phase"] == "terminal"
+    assert state["iv_conf"]["outcome"] == "conflict"
+    assert state["iv_nf"]["phase"] == "terminal"
+    assert state["iv_nf"]["outcome"] == "not_found"
+    replay, bridge_r, dms_r = _flow("agent-term", bridge=_Bridge("agent-term"))
+    await replay.resume()
+    assert bridge_r.decision_calls == []
+    assert dms_r.send_calls == []
+
+    # E) The auto-accept flag decides only space-scope records; a channel
+    # invite gains no new default and is still prompted.
+    flow_aa, bridge_aa, dms_aa = _flow("agent-aa", auto_accept=True)
+    await flow_aa.reconcile([
+        _invite("iv_sp", scope="space", space_id="sp_a", inviter="eve-1"),
+        _invite("iv_ch", scope="channel", space_id="sp_a", inviter="frank-1"),
+    ])
+    state = load_keyless_invitations("agent-aa")
+    assert state["iv_sp"]["phase"] == "terminal"
+    assert state["iv_sp"]["decision"] == "accept"
+    assert state["iv_ch"]["phase"] == "awaiting_reply"
+    assert len(dms_aa.send_calls) == 1
+    assert len(bridge_aa.decision_calls) == 1
+    assert bridge_aa.decision_calls[0]["invitation_event_id"] == "iv_sp"

--- a/tests/test_keyless_invitation_ingress.py
+++ b/tests/test_keyless_invitation_ingress.py
@@ -1,0 +1,463 @@
+"""Keyless invitation bridge ingress integration.
+
+The durable ``KeylessInvitationFlow`` is constructed per real bridge client
+and fed by a connection-owned poller armed on ``pending_delivered``. These
+three tests guard the wiring boundary that the component suites cannot: that
+the flow really reads the authoritative ``send_list_invites`` list through a
+live frame pump, prompts exactly once via ``send_send``, consumes an exact
+threaded operator reply as tracked work without blocking the pump, stores its
+own prompt echo as a control placeholder, and owns exactly one poller per
+connection that is cancelled on reconnect.
+
+Regression each guards:
+
+  1. ``test_invitation_lifecycle_...`` — pagination/repeated polls would
+     prompt twice; malformed channel invites would be adopted; the prompt
+     echo would reach model context; the operator decision would never reach
+     a terminal outcome; native clients would gain a keyless flow.
+  2. ``test_operator_reply_is_tracked_...`` — awaiting ``send_decide_`` on
+     the frame-pump stack would freeze delivery; the decision work would
+     never be resolved by the pump; a nonmatching operator DM would be
+     swallowed.
+  3. ``test_poller_arms_once_per_connection_...`` — a duplicate poller (or a
+     leaked one) would double-prompt; a poll failure would kill delivery; a
+     reconnect would reuse a dead poller slot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from puffo_agent.agent import bridge_transport as bridge_transport_mod
+from puffo_agent.agent.client_support import INVITE_PROMPT_PLACEHOLDER
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+from puffo_agent.crypto.keystore import KeyStore
+
+SELF = "bot-0001"
+OPERATOR = "ops-0001"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_agent_home(tmp_path, monkeypatch):
+    home = str(tmp_path / "agent-home")
+    monkeypatch.setenv("PUFFO_AGENT_HOME", home)
+    monkeypatch.setenv("PUFFO_HOME", home)
+
+
+class _FakeBridge:
+    """Offline ``CloudBridgeClient`` stand-in whose ``frames()`` routes
+    correlated replies exactly like the real client (ack → ``send_send``,
+    invites → ``send_list_invites``, decide_invitation_result →
+    ``send_decide_invitation``, ack_result → ``send_ack``) and yields every
+    other frame for dispatch. A ``None`` queue item ends the stream so the
+    test can drive a reconnect."""
+
+    def __init__(self) -> None:
+        self._out: asyncio.Queue = asyncio.Queue()
+        self._acks: dict[str, asyncio.Future] = {}
+        self._decides: dict[str, asyncio.Future] = {}
+        self._invites_waiters: asyncio.Queue = asyncio.Queue()
+        self._ack_result_waiters: asyncio.Queue = asyncio.Queue()
+        self.sent: list[dict] = []
+        self.decisions: list[dict] = []
+        self.acked: list[list[str]] = []
+        self.list_invites_calls = 0
+        self.invites_payload: list[dict] = []
+        self.connect_count = 0
+        self.fetch_pending_count = 0
+        self.close_count = 0
+        self.decide_gate: asyncio.Event | None = None
+        self.decide_outcomes: dict[str, str] = {}
+        self.list_error: Exception | None = None
+        self.connected: asyncio.Event = asyncio.Event()
+
+    async def connect(self) -> None:
+        self.connect_count += 1
+        self.connected.set()
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+    async def send_fetch_pending(self, *, limit=None) -> None:
+        self.fetch_pending_count += 1
+
+    async def send_send(self, **kwargs) -> dict:
+        client_ref = kwargs.get("client_ref")
+        fut = asyncio.get_running_loop().create_future()
+        self._acks[client_ref] = fut
+        self.sent.append(kwargs)
+        await self._out.put({
+            "type": "ack",
+            "client_ref": client_ref,
+            "envelope_id": f"env_{client_ref}",
+            "thread_root_id": f"thread_{client_ref}",
+        })
+        return await asyncio.wait_for(fut, timeout=5)
+
+    async def send_list_invites(self, *, timeout: float = 30.0) -> dict:
+        self.list_invites_calls += 1
+        if self.list_error is not None:
+            raise self.list_error
+        fut = asyncio.get_running_loop().create_future()
+        await self._invites_waiters.put(fut)
+        await self._out.put({"type": "invites", "invites": list(self.invites_payload)})
+        return await asyncio.wait_for(fut, timeout=5)
+
+    async def send_decide_invitation(self, **kwargs) -> dict:
+        client_ref = kwargs["client_ref"]
+        fut = asyncio.get_running_loop().create_future()
+        self._decides[client_ref] = fut
+        self.decisions.append(kwargs)
+        if self.decide_gate is not None:
+            await self.decide_gate.wait()
+        outcome = self.decide_outcomes.get(kwargs["invitation_event_id"], "applied")
+        await self._out.put({
+            "type": "decide_invitation_result",
+            "client_ref": client_ref,
+            "invitation_event_id": kwargs["invitation_event_id"],
+            "decision": kwargs["decision"],
+            "outcome": outcome,
+        })
+        return await asyncio.wait_for(fut, timeout=5)
+
+    async def send_ack(self, envelope_ids: list[str], *, timeout: float = 30.0) -> dict:
+        fut = asyncio.get_running_loop().create_future()
+        await self._ack_result_waiters.put(fut)
+        self.acked.append(list(envelope_ids))
+        await self._out.put({"type": "ack_result", "acked": list(envelope_ids)})
+        return await asyncio.wait_for(fut, timeout=5)
+
+    async def frames(self):
+        while True:
+            frame = await self._out.get()
+            if frame is None:
+                return
+            kind = frame.get("type")
+            if kind == "ack":
+                ref = frame.get("client_ref")
+                if ref in self._acks:
+                    self._acks.pop(ref).set_result(frame)
+                continue
+            if kind == "invites":
+                if not self._invites_waiters.empty():
+                    self._invites_waiters.get_nowait().set_result(frame)
+                continue
+            if kind == "decide_invitation_result":
+                ref = frame.get("client_ref")
+                if ref in self._decides:
+                    self._decides.pop(ref).set_result(frame)
+                continue
+            if kind == "ack_result":
+                if not self._ack_result_waiters.empty():
+                    self._ack_result_waiters.get_nowait().set_result(frame)
+                continue
+            yield frame
+
+
+def _client(
+    tmp_path,
+    bridge,
+    *,
+    operator_slug: str = OPERATOR,
+    auto_accept_space_invitations: bool = False,
+    keyless: bool = True,
+) -> PuffoCoreMessageClient:
+    ks = KeyStore(str(tmp_path / "keys"))
+    http = PuffoCoreHttpClient("http://127.0.0.1:1", ks, SELF, keyless=keyless)
+    client = PuffoCoreMessageClient(
+        slug=SELF,
+        device_id="dev_test",
+        space_id="sp_home",
+        keystore=ks,
+        http_client=http,
+        message_store=MessageStore(str(tmp_path / "messages.db")),
+        operator_slug=operator_slug,
+        auto_accept_space_invitations=auto_accept_space_invitations,
+        catchup_stale_hours=0,
+        bridge_client=bridge,
+    )
+    return client
+
+
+def _invite(
+    event_id: str,
+    *,
+    scope: str,
+    space_id: str,
+    inviter: str = "alice-1",
+    channel_id: str | None = None,
+) -> dict:
+    invite: dict = {
+        "invitation_event_id": event_id,
+        "scope": scope,
+        "space_id": space_id,
+        "inviter_slug": inviter,
+    }
+    if channel_id is not None:
+        invite["channel_id"] = channel_id
+    return invite
+
+
+def _dm_frame(sender: str, content: str, *, seq: int, **extra) -> dict:
+    frame = {
+        "type": "message",
+        "seq": seq,
+        "envelope_id": f"env_{seq}",
+        "envelope_kind": "dm",
+        "sender_slug": sender,
+        "recipient_slug": SELF,
+        "content": content,
+        "content_type": "text/plain",
+        "sent_at": 1_700_000_000_000,
+    }
+    frame.update(extra)
+    return frame
+
+
+def _chan_frame(sender: str, content: str, *, seq: int) -> dict:
+    return {
+        "type": "message",
+        "seq": seq,
+        "envelope_id": f"env_{seq}",
+        "envelope_kind": "channel",
+        "sender_slug": sender,
+        "space_id": "sp_1",
+        "channel_id": "ch_1",
+        "content": content,
+        "content_type": "text/plain",
+        "sent_at": 1_700_000_000_000,
+    }
+
+
+async def _await_true(predicate, timeout: float = 5.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("condition not reached within timeout")
+        await asyncio.sleep(0.01)
+
+
+async def _await_envelope(client, envelope_id: str, timeout: float = 5.0):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        row = await client.store.get_message_by_envelope(envelope_id)
+        if row is not None:
+            return row
+        if loop.time() > deadline:
+            raise AssertionError(f"envelope {envelope_id} never stored")
+        await asyncio.sleep(0.01)
+
+
+@contextlib.asynccontextmanager
+async def _run_listen(client):
+    task = asyncio.ensure_future(client._listen_bridge())
+    try:
+        yield task
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_invitation_lifecycle_reconciles_dedupes_and_stores_placeholder(
+    tmp_path,
+):
+    """Guarded regression: repeated authoritative polls (pagination) and a
+    correlated prompt/decision through the live pump must not prompt twice,
+    adopt a channel invite without ``channel_id``, leak the prompt echo into
+    model context, call a signed HTTP route, or give a native client a
+    keyless flow."""
+    bridge = _FakeBridge()
+    client = _client(tmp_path, bridge=bridge)
+    assert client._keyless_invitation_flow is not None
+    await client.store.open()
+
+    http_calls: list[str] = []
+
+    async def _spy_get(path, *a, **k):
+        http_calls.append(f"GET {path}")
+        return {}
+
+    async def _spy_post(path, *a, **k):
+        http_calls.append(f"POST {path}")
+        return {}
+
+    client.http.get = _spy_get  # type: ignore[method-assign]
+    client.http.post = _spy_post  # type: ignore[method-assign]
+
+    async with _run_listen(client):
+        await asyncio.wait_for(bridge.connected.wait(), timeout=5)
+        flow = client._keyless_invitation_flow
+
+        # One authoritative round: a valid space invite prompts once; a
+        # channel invite missing channel_id is skipped entirely.
+        bridge.invites_payload = [
+            _invite("iv_1", scope="space", space_id="sp_1"),
+            _invite("iv_bad", scope="channel", space_id="sp_1"),
+        ]
+        await bridge_transport_mod.poll_keyless_invites(client, flow)
+        assert len(bridge.sent) == 1
+        assert bridge.sent[0]["recipient_slug"] == OPERATOR
+        assert "iv_bad" not in flow._pending
+
+        # Pagination: the same authoritative list again must not re-prompt.
+        await bridge_transport_mod.poll_keyless_invites(client, flow)
+        assert len(bridge.sent) == 1
+        assert flow._pending["iv_1"]["phase"] == "awaiting_reply"
+
+        # The agent's own prompt echo is a control placeholder, not context.
+        prompt_env = flow._pending["iv_1"]["prompt_envelope_id"]
+        await bridge._out.put(
+            _dm_frame(SELF, "echo of prompt", seq=1, envelope_id=prompt_env)
+        )
+        echo = await _await_envelope(client, prompt_env)
+        assert echo.content == INVITE_PROMPT_PLACEHOLDER
+
+        # An exact threaded operator reply is consumed to a terminal outcome.
+        await bridge._out.put(
+            _dm_frame(OPERATOR, " y ", seq=2, thread_root_id=prompt_env)
+        )
+        await _await_true(lambda: bool(bridge.decisions))
+        await asyncio.gather(*tuple(client._ack_tasks))
+        assert flow._pending["iv_1"]["phase"] == "terminal"
+        assert bridge.decisions[0]["decision"] == "accept"
+
+        # An operator-sent invite auto-accepts with no second prompt.
+        bridge.invites_payload = [
+            _invite("iv_1", scope="space", space_id="sp_1"),
+            _invite("iv_op", scope="space", space_id="sp_2", inviter=OPERATOR),
+        ]
+        await bridge_transport_mod.poll_keyless_invites(client, flow)
+        await _await_true(
+            lambda: any(d["invitation_event_id"] == "iv_op" for d in bridge.decisions)
+        )
+        assert len(bridge.sent) == 1
+        assert flow._pending["iv_op"]["phase"] == "terminal"
+
+    # No signed HTTP invitation route was ever called.
+    assert not any("spaces/events" in call for call in http_calls)
+    await client.store.close()
+
+    # A native client keeps no keyless flow.
+    native_bridge = None
+    native = _client(tmp_path, native_bridge, keyless=False)
+    assert native._keyless_invitation_flow is None
+    await native.store.close()
+
+
+@pytest.mark.asyncio
+async def test_operator_reply_is_tracked_and_pump_stays_live(tmp_path):
+    """Guarded regression: the frame pump must never await the decision work
+    inline. The reply dispatch returns while ``send_decide_invitation`` is
+    parked, ordinary delivery continues, the pump resolves the decision to
+    terminal, and a nonmatching operator DM keeps ordinary ingress."""
+    bridge = _FakeBridge()
+    client = _client(tmp_path, bridge=bridge)
+    await client.store.open()
+
+    async with _run_listen(client):
+        await asyncio.wait_for(bridge.connected.wait(), timeout=5)
+        flow = client._keyless_invitation_flow
+
+        bridge.invites_payload = [_invite("iv_1", scope="space", space_id="sp_1")]
+        await bridge_transport_mod.poll_keyless_invites(client, flow)
+        prompt_env = flow._pending["iv_1"]["prompt_envelope_id"]
+
+        bridge.decide_gate = asyncio.Event()
+        reply = _dm_frame(OPERATOR, "yes", seq=1, thread_root_id=prompt_env)
+        del reply["seq"]  # exercise the legacy sequence-less redelivery lane
+        await bridge._out.put(reply)
+        await _await_true(lambda: bool(bridge.decisions))
+        assert any(not t.done() for t in tuple(client._ack_tasks))
+        assert ["env_1"] not in bridge.acked
+
+        # A redelivery while the decision is not yet durable must remain
+        # unacked and rejoin the same serialized flow.
+        await bridge._out.put(dict(reply))
+        await asyncio.sleep(0.01)
+        assert ["env_1"] not in bridge.acked
+
+        # The pump still resolves ordinary delivery while the decision work
+        # is parked inside send_decide_invitation.
+        await bridge._out.put(_chan_frame("alice-1", "still alive", seq=2))
+        row = await _await_envelope(client, "env_2")
+        assert row.receipt_disposition == "eligible"
+
+        # Releasing the decision lets the live pump resolve it to terminal.
+        bridge.decide_gate.set()
+        await asyncio.gather(*tuple(client._ack_tasks))
+        assert flow._pending["iv_1"]["phase"] == "terminal"
+        assert bridge.decisions[0]["decision"] == "accept"
+        assert ["env_1"] in bridge.acked
+
+        # A nonmatching operator DM (unknown thread) keeps ordinary ingress:
+        # it is not consumed as a control reply and stays queued for the model.
+        await bridge._out.put(
+            _dm_frame(OPERATOR, "y", seq=3, thread_root_id="unknown_thread")
+        )
+        row3 = await _await_envelope(client, "env_3")
+        assert row3.receipt_disposition == "eligible"
+        pending_ids = [m.envelope_id for m in await client.store.get_pending()]
+        assert "env_3" in pending_ids
+
+    await client.store.close()
+
+
+@pytest.mark.asyncio
+async def test_poller_arms_once_per_connection_and_fails_soft(tmp_path):
+    """Guarded regression: repeated ``pending_delivered`` markers must never
+    spawn a second poller, the connection finally must cancel and await the
+    poller, a reconnect must create exactly one fresh poller, and a failing
+    poll round must be logged and retried without killing delivery."""
+    bridge = _FakeBridge()
+    client = _client(tmp_path, bridge=bridge)
+    await client.store.open()
+
+    async with _run_listen(client):
+        await asyncio.wait_for(bridge.connected.wait(), timeout=5)
+        assert client._keyless_invite_poll_task is None
+
+        await bridge._out.put({"type": "pending_delivered", "count": 1})
+        await _await_true(lambda: client._keyless_invite_poll_task is not None)
+        poller = client._keyless_invite_poll_task
+        assert not poller.done()
+
+        # A repeated marker must not replace the slot with a second poller.
+        await bridge._out.put({"type": "pending_delivered", "count": 2})
+        await asyncio.sleep(0.01)
+        assert client._keyless_invite_poll_task is poller
+
+        # A failing poll round is fail-soft: it returns, the poller keeps
+        # its cadence (still pending), and delivery continues.
+        bridge.list_error = RuntimeError("list invites boom")
+        await bridge_transport_mod.poll_keyless_invites(
+            client, client._keyless_invitation_flow
+        )
+        assert not poller.done()
+        await bridge._out.put(_chan_frame("alice-1", "still alive", seq=1))
+        await _await_envelope(client, "env_1")
+
+        # Ending the connection cancels and awaits the poller, clearing the
+        # ownership slot for the reconnect. The native cadence helper absorbs
+        # the cancellation and returns, so the task is done (never leaked),
+        # not flagged cancelled.
+        await bridge._out.put(None)
+        await _await_true(lambda: client._keyless_invite_poll_task is None)
+        await _await_true(lambda: poller.done())
+        await _await_true(lambda: bridge.close_count == 1)
+        await _await_true(lambda: bridge.connect_count == 2)
+
+        # The fresh connection arms exactly one fresh poller.
+        await bridge._out.put({"type": "pending_delivered", "count": 1})
+        await _await_true(lambda: client._keyless_invite_poll_task is not None)
+        assert client._keyless_invite_poll_task is not poller
+
+    await client.store.close()

--- a/tests/test_message_store.py
+++ b/tests/test_message_store.py
@@ -1689,3 +1689,95 @@ async def test_gated_dm_is_withheld_from_the_model_visible_envelope_read():
     assert released is not None
     assert secret in str(released.content)
     await store.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "row_seq, call_seq",
+    [
+        (None, None),
+        (7, 7),
+        (7, None),
+    ],
+)
+async def test_exact_gated_dm_denial_tombstones_only_the_correlated_receipt(
+    row_seq, call_seq,
+):
+    """The envelope-and-sequence-scoped denial tombstones exactly one gated
+    receipt, is idempotent on replay, and leaves siblings alone.
+
+    The keyless bridge correlates a denial to a single held envelope; the
+    sender-wide ``tombstone_gated_dms_from`` bulk path cannot, because a
+    denied sender may still have approved siblings pending. This guards that
+    the wrong row is never tombstoned, that the refused plaintext is gone,
+    and that an exact replay reports ``IDEMPOTENT`` instead of counting a
+    second tombstone. A sequence-less correlation to a sequenced row must be
+    a ``CONFLICT``: answering ``COMMITTED`` there would let the caller ACK a
+    frame whose refused plaintext was never removed.
+    """
+    store = _temp_store()
+    secret = "refused-plaintext-never-seen-again"
+    sibling = "approved-sibling-stays-readable"
+    if row_seq is None:
+        await store.store_local_receipt(
+            _dm_payload("env_denied", "mallory-9f21", "bot-0001", content=secret),
+            disposition=ReceiptDisposition.FOREIGN_DM_GATED,
+            reason="foreign dm awaiting approval",
+        )
+        await store.store_local_receipt(
+            _dm_payload("env_sibling", "mallory-9f21", "bot-0001", content=sibling),
+            disposition=ReceiptDisposition.FOREIGN_DM_GATED,
+            reason="foreign dm awaiting approval",
+        )
+    else:
+        await store.store_receipt(
+            _dm_payload("env_denied", "mallory-9f21", "bot-0001", content=secret),
+            server_seq=row_seq,
+            disposition=ReceiptDisposition.FOREIGN_DM_GATED,
+            reason="foreign dm awaiting approval",
+        )
+        await store.store_receipt(
+            _dm_payload("env_sibling", "mallory-9f21", "bot-0001", content=sibling),
+            server_seq=row_seq + 100,
+            disposition=ReceiptDisposition.FOREIGN_DM_GATED,
+            reason="foreign dm awaiting approval",
+        )
+
+    if call_seq != row_seq:
+        # A sequence-less correlation to a sequenced row is a mismatch: the
+        # refused plaintext must survive, never be silently tombstoned.
+        mismatch = await store.tombstone_gated_dm("env_denied", call_seq)
+        assert mismatch.status is ReceiptWriteStatus.CONFLICT
+        kept = await store.get_message_by_envelope("env_denied")
+        assert secret in str(kept.content)
+        assert kept.receipt_disposition == ReceiptDisposition.FOREIGN_DM_GATED
+        sibling_row = await store.get_message_by_envelope("env_sibling")
+        assert sibling in str(sibling_row.content)
+        await store.close()
+        return
+
+    if row_seq is not None:
+        wrong = await store.tombstone_gated_dm("env_denied", row_seq + 1)
+        assert wrong.status is ReceiptWriteStatus.CONFLICT
+
+    result = await store.tombstone_gated_dm("env_denied", call_seq)
+    assert result.status is ReceiptWriteStatus.COMMITTED
+    assert result.disposition is ReceiptDisposition.TERMINAL
+
+    row = await store.get_message_by_envelope("env_denied")
+    assert row is not None
+    assert secret not in str(row.content)
+    assert row.receipt_disposition == ReceiptDisposition.TERMINAL
+
+    # Exact replay is idempotent; a missing envelope is a conflict.
+    replay = await store.tombstone_gated_dm("env_denied", call_seq)
+    assert replay.status is ReceiptWriteStatus.IDEMPOTENT
+    missing = await store.tombstone_gated_dm("env_never_seen", call_seq)
+    assert missing.status is ReceiptWriteStatus.CONFLICT
+
+    # The sibling stays gated and its plaintext intact.
+    sibling_row = await store.get_message_by_envelope("env_sibling")
+    assert sibling_row is not None
+    assert sibling in str(sibling_row.content)
+    assert sibling_row.receipt_disposition == ReceiptDisposition.FOREIGN_DM_GATED
+    await store.close()

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -191,6 +191,7 @@ class KeylessFakeHttpClient:
             return self.responses[path]
         if path == "/v2/cloud-agents/agent-runtime/messages:send":
             freshness = body["freshness"]
+            request_baseline = freshness["context_baseline_seq"]
             return {
                 "state": "sent",
                 "envelope_id": "msg_keyless",
@@ -200,7 +201,9 @@ class KeylessFakeHttpClient:
                 "freshness": {
                     "mode": freshness["mode"],
                     "context_baseline_seq": (
-                        freshness["context_baseline_seq"]
+                        request_baseline
+                        if request_baseline is not None
+                        else freshness["seen_seq"]
                     ),
                     "seen_seq": freshness["seen_seq"],
                     "latest_seq_before_send": freshness["seen_seq"],

--- a/tests/test_puffo_core_tools_routes_and_keyless.py
+++ b/tests/test_puffo_core_tools_routes_and_keyless.py
@@ -1304,7 +1304,7 @@ async def test_keyless_send_message_channel_posts_unsigned():
     assert isinstance(body["client_ref"], str) and body["client_ref"]
     assert "client_request_id" not in body
     assert body["freshness"] == {
-        "context_baseline_seq": 0,
+        "context_baseline_seq": None,
         "seen_seq": 0,
         "mode": "require_current",
     }

--- a/tests/test_runtime_matrix.py
+++ b/tests/test_runtime_matrix.py
@@ -72,6 +72,8 @@ def test_supported_runtime_surface_is_explicit():
     (RUNTIME_CLI_LOCAL, PROVIDER_OPENAI, HARNESS_CODEX),
     (RUNTIME_CLI_LOCAL, PROVIDER_OPENAI, ""),
     (RUNTIME_CLI_DOCKER, PROVIDER_ANTHROPIC, HARNESS_CLAUDE_CODE),
+    (RUNTIME_CLI_DOCKER, PROVIDER_OPENAI, HARNESS_CODEX),
+    (RUNTIME_CLI_DOCKER, PROVIDER_OPENAI, ""),
     (RUNTIME_CLI_DOCKER, "", ""),
     (RUNTIME_WS_LOCAL, "", "anything-external"),
 ])
@@ -86,14 +88,12 @@ def test_validate_triple_accepts_supported_combinations(
     (RUNTIME_CLI_LOCAL, "cohere", HARNESS_CLAUDE_CODE, "unknown provider"),
     (RUNTIME_CLI_LOCAL, PROVIDER_GOOGLE, HARNESS_GEMINI_CLI, "Driver runtime"),
     (RUNTIME_CLI_LOCAL, PROVIDER_ANTHROPIC, HARNESS_HERMES, "Driver runtime"),
-    (RUNTIME_CLI_DOCKER, PROVIDER_OPENAI, HARNESS_CODEX, "Driver runtime"),
     (RUNTIME_CLI_DOCKER, PROVIDER_GOOGLE, HARNESS_CLAUDE_CODE, "does not support"),
     # Docker Hermes/Gemini cannot complete the metadata-notified Inbox
     # contract, so the matrix rejects them before any Worker is built —
     # explicitly, and via the provider-resolved default harness.
     (RUNTIME_CLI_DOCKER, PROVIDER_ANTHROPIC, HARNESS_HERMES, "design-only"),
     (RUNTIME_CLI_DOCKER, PROVIDER_GOOGLE, HARNESS_GEMINI_CLI, "design-only"),
-    (RUNTIME_CLI_DOCKER, PROVIDER_OPENAI, "", "Driver runtime"),
     (RUNTIME_CLI_SANDBOX, PROVIDER_ANTHROPIC, HARNESS_CLAUDE_CODE, "reserved"),
 ])
 def test_validate_triple_rejects_unsupported_combinations(
@@ -112,6 +112,13 @@ def test_runtime_defaults_select_the_ratified_local_drivers():
     assert resolve_effective_harness(
         RUNTIME_CLI_LOCAL, PROVIDER_OPENAI, "",
     ) == HARNESS_CODEX
+    # Docker defaults mirror cli-local: openai → codex, anthropic → claude.
+    assert resolve_effective_harness(
+        RUNTIME_CLI_DOCKER, PROVIDER_OPENAI, "",
+    ) == HARNESS_CODEX
+    assert resolve_effective_harness(
+        RUNTIME_CLI_DOCKER, PROVIDER_ANTHROPIC, "",
+    ) == HARNESS_CLAUDE_CODE
     assert harness_applies(RUNTIME_CLI_LOCAL)
     assert harness_applies(RUNTIME_CLI_DOCKER)
     assert not harness_applies(RUNTIME_WS_LOCAL)

--- a/tests/test_send_coordinator.py
+++ b/tests/test_send_coordinator.py
@@ -274,6 +274,58 @@ async def test_null_baseline_lifecycle_preserves_none_and_persists_established(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("lane", ["native", "keyless"])
+async def test_committed_send_reports_baseline_persistence_failure(lane):
+    coordinator, _active, http, store = await _baseline_lifecycle_coordinator(lane)
+
+    class FailingBaseline:
+        def __init__(self):
+            self.calls = 0
+
+        async def get_context_baseline_seq(self, _space_id, _channel_id):
+            return None
+
+        async def set_context_baseline_seq(self, _space_id, _channel_id, _seq):
+            self.calls += 1
+            raise RuntimeError("sqlite unavailable")
+
+    baseline = FailingBaseline()
+    coordinator.baseline_source = baseline
+
+    async def commit(_path, body=None):
+        envelope_id = (
+            body["envelope"]["envelope_id"] if lane == "native" else "msg_keyless"
+        )
+        return {
+            "state": "sent",
+            "envelope_id": envelope_id,
+            "seq": 7,
+            "replay": False,
+            "missing_devices": [],
+            "freshness": {
+                "mode": "require_current",
+                "context_baseline_seq": 5,
+                "seen_seq": 0,
+                "latest_seq_before_send": 5,
+            },
+        }
+
+    if lane == "native":
+        http.post = commit
+    else:
+        http.post_unsigned = commit
+
+    result = await coordinator.send(SemanticSendRequest(
+        destination="ch_a", text="already committed",
+    ))
+
+    assert result["state"] == "sent"
+    assert "local freshness baseline could not be saved" in result["note"]
+    assert baseline.calls == 2
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_committed_send_stays_sent_when_local_boundary_update_fails():
     coordinator, _freshness, http = await coordinator_fixture(
         baseline=5, active=5

--- a/tests/test_send_coordinator.py
+++ b/tests/test_send_coordinator.py
@@ -8,6 +8,7 @@ import pytest
 from aiohttp import web
 
 from puffo_agent.agent import send_coordinator as sc_mod
+from puffo_agent.agent.global_inbox_types import BaselineAdapter
 from puffo_agent.agent.send_coordinator import (
     CHANNEL_SEND_PATH,
     KEYLESS_CHANNEL_SEND_PATH,
@@ -109,22 +110,130 @@ async def test_baseline_invalid_fails_without_send(baseline):
     assert not [call for call in http.calls if call[0].startswith("POST")]
 
 
-@pytest.mark.asyncio
-async def test_missing_baseline_defaults_to_zero_and_active_turn_advances_seen():
-    coordinator, _, http = await coordinator_fixture(baseline=None, active=7)
-    result = await coordinator.send(
-        SemanticSendRequest(destination="ch_a", text="hello"),
-    )
-    assert result["state"] == "sent", result
-    body = [
-        body for method, path, body in http.calls
-        if method == "POST" and path == CHANNEL_SEND_PATH
-    ][-1]
-    assert body["freshness"] == {
-        "context_baseline_seq": 0,
-        "seen_seq": 7,
-        "mode": "require_current",
+async def _baseline_lifecycle_coordinator(lane):
+    if lane == "keyless":
+        cfg, http, store = _setup_keyless()
+    else:
+        cfg, http, store = _setup()
+    await store.mark_channel_space("ch_a", "sp_1")
+    device = KemKeyPair.generate()
+    http.responses["/spaces/sp_1/channels/ch_a/members"] = {
+        "members": [{"slug": "alice-1"}],
     }
+    http.responses["/certs/sync?slugs=alice-1"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "cert": {
+                "device_id": "dev_a",
+                "kem_public_key": base64url_encode(device.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
+    }
+    active = Freshness(active=None)
+    coordinator = SendCoordinator(
+        slug=cfg.slug,
+        keystore=cfg.keystore,
+        http_client=http,
+        data_client=store,
+        baseline_source=BaselineAdapter(store),
+        active_turn_source=active,
+    )
+    return coordinator, active, http, store
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lane", "replay"),
+    [
+        ("native", False),
+        ("native", True),
+        ("keyless", False),
+        ("keyless", True),
+    ],
+    ids=["native-new", "native-replay", "keyless-new", "keyless-replay"],
+)
+async def test_null_baseline_lifecycle_preserves_none_and_persists_established(
+    lane, replay,
+):
+    coordinator, active, http, store = await _baseline_lifecycle_coordinator(lane)
+    bodies = []
+    sent_once = {"done": False}
+    send_path = CHANNEL_SEND_PATH if lane == "native" else KEYLESS_CHANNEL_SEND_PATH
+
+    async def commit(_path, body=None):
+        bodies.append((_path, body))
+        envelope_id = (
+            body["envelope"]["envelope_id"] if lane == "native" else "msg_keyless"
+        )
+        if not sent_once["done"]:
+            sent_once["done"] = True
+            return {
+                "state": "held",
+                "envelope_id": envelope_id,
+                "context_baseline_seq": body["freshness"]["context_baseline_seq"],
+                "seen_seq": body["freshness"]["seen_seq"],
+                "latest_seq": 3,
+                "latest_envelope_id": "msg_latest",
+            }
+        return {
+            "state": "sent",
+            "envelope_id": envelope_id,
+            "seq": 7,
+            "replay": replay,
+            "missing_devices": [],
+            "freshness": {
+                "mode": "require_current",
+                "context_baseline_seq": 5,
+                "seen_seq": 0,
+                "latest_seq_before_send": 5,
+            },
+        }
+
+    if lane == "native":
+        http.post = commit
+    else:
+        http.post_unsigned = commit
+
+    held = await coordinator.send(SemanticSendRequest(
+        destination="ch_a", text="probe",
+    ))
+    assert held["state"] == "held", held
+    null_body = [body for path, body in bodies if path == send_path][0]
+    assert null_body["freshness"]["context_baseline_seq"] is None
+    assert null_body["freshness"]["seen_seq"] == 0
+    assert await store.get_context_baseline("sp_1", "ch_a") is None
+
+    sent = await coordinator.send(SemanticSendRequest(
+        destination="ch_a", text="establish",
+    ))
+    assert sent["state"] == "sent", sent
+    assert sent["context_baseline_seq"] == 5
+    assert sent["seen_seq"] == 0
+    assert active.active == 7
+    established_body = [body for path, body in bodies if path == send_path][-1]
+    assert established_body["freshness"]["context_baseline_seq"] is None
+    assert established_body["freshness"]["seen_seq"] == 0
+    assert await store.get_context_baseline("sp_1", "ch_a") == 5
+
+    rebuilt = SendCoordinator(
+        slug=coordinator.slug,
+        keystore=coordinator.keystore,
+        http_client=http,
+        data_client=store,
+        baseline_source=BaselineAdapter(store),
+        active_turn_source=Freshness(active=5),
+    )
+    boundary = await rebuilt._resolve_send_boundary(
+        SemanticSendRequest(destination="ch_a", text="later"),
+        "sp_1",
+        "ch_a",
+        combined_error=True,
+    )
+    assert boundary.baseline == 5
+    assert boundary.seen_seq == 5
+    await store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_send_coordinator.py
+++ b/tests/test_send_coordinator.py
@@ -20,6 +20,7 @@ from puffo_agent.crypto.http_client import HttpError
 from puffo_agent.crypto.http_client import PuffoCoreHttpClient
 from puffo_agent.crypto.primitives import KemKeyPair
 from puffo_agent.mcp.data_client import DataNotFound
+from puffo_agent.portal.workspace_layout import ensure_workspace_shared_link
 
 from .test_puffo_core_tools import _setup, _setup_keyless
 
@@ -84,6 +85,42 @@ async def coordinator_fixture(*, baseline=0, active=None):
         active_turn_source=freshness,
     )
     return coordinator, freshness, http
+
+
+def test_attachment_validation_allows_only_managed_shared_link(tmp_path):
+    workspace = tmp_path / "agents" / "alice" / "workspace"
+    shared = tmp_path / "shared"
+    ensure_workspace_shared_link(workspace, shared)
+    (shared / "evidence.txt").write_text("shared evidence", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("private", encoding="utf-8")
+    (workspace / "escape").symlink_to(outside, target_is_directory=True)
+
+    coordinator = SendCoordinator(
+        slug="alice",
+        keystore=SimpleNamespace(),
+        http_client=SimpleNamespace(),
+        data_client=SimpleNamespace(),
+        workspace=str(workspace),
+        shared_workspace=str(shared),
+    )
+    request = SemanticSendRequest(
+        destination="ch_test",
+        text="evidence",
+        attachment_paths=("shared/evidence.txt",),
+    )
+    assert coordinator._validate_attachment_targets(request) == [
+        (shared / "evidence.txt").resolve()
+    ]
+
+    escaped = SemanticSendRequest(
+        destination="ch_test",
+        text="secret",
+        attachment_paths=("escape/secret.txt",),
+    )
+    with pytest.raises(RuntimeError, match="escapes the workspace"):
+        coordinator._validate_attachment_targets(escaped)
 
 
 @pytest.mark.asyncio

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -20,7 +20,9 @@ def _tmp() -> Path:
     return Path(tempfile.mkdtemp())
 
 
-def _rebuild(root: Path) -> tuple[str, str]:
+def _rebuild(
+    root: Path, *, workspace_shared_status: str = "existing"
+) -> tuple[str, str]:
     profile = root / "profile.md"
     profile.write_text("# Soul\nSOUL-MARKER-7b", encoding="utf-8")
     memory = root / "memory"
@@ -31,6 +33,7 @@ def _rebuild(root: Path) -> tuple[str, str]:
         workspace_dir=workspace, agent_id="AGENT-ID-MARKER-8c",
         display_name="DISPLAY-NAME-MARKER-9d", role="LONG-ROLE-MARKER-ae",
         role_short="SHORT-ROLE-MARKER-bf",
+        workspace_shared_status=workspace_shared_status,
     )
     claude = rebuild_agent_claude_md(
         **common, claude_user_dir=root / ".claude", gemini_user_dir=root / ".gemini",
@@ -75,7 +78,6 @@ def test_standing_prompt_owns_communication_policy_and_retains_contract():
         "ordinary assistant text is not delivered",
         "message comes from an existing thread",
         "message_id` as `root_id",
-        "`shared/` inside it is the host-wide collaboration directory",
     ):
         assert phrase in primer
     for absent in ("decide-response", "[SILENT]", "Send, Clarify, Wait, or Silent"):
@@ -124,6 +126,17 @@ def test_standing_prompt_owns_communication_policy_and_retains_contract():
         assert phrase.lower() in normalized_send
     assert "common held-send procedure" in DEFAULT_SKILLS["send-message-with-attachments"][1]
     assert "A held draft was attempted but not sent" not in send
+
+    for text in _rebuild(_tmp()):
+        assert "`shared/` inside it is the host-wide collaboration directory" in text
+
+
+def test_standing_prompt_reports_unavailable_shared_workspace_truthfully():
+    conflict, _ = _rebuild(_tmp(), workspace_shared_status="conflict")
+    unavailable, _ = _rebuild(_tmp(), workspace_shared_status="unavailable")
+
+    assert "not connected to the host-wide collaboration directory" in conflict
+    assert "host-wide collaboration directory is unavailable" in unavailable
 
 
 def test_inbox_turn_cue_is_short_and_reinforces_the_standing_default():

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -74,8 +74,11 @@ def test_policy_has_one_detailed_owner_and_primer_retains_contract():
         "claim one uncovered part",
         "only after its message is committed",
         "A reminder is a future request to reconsider",
+        "`shared/` inside it is the host-wide collaboration directory",
     ):
         assert phrase in primer
+    assert "~/.puffo-agent/shared" not in primer
+    assert "/workspace/.shared" not in primer
     for absent in (
         "prior_context", "visible_draft_basis", "new_channel_context",
         "context_ready", "same originating assignment", "send_anyway=True",

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -1,14 +1,11 @@
 import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 
-from puffo_agent.mcp.puffo_core_tools import register_core_tools
 from puffo_agent.agent.shared_content import (
-    DEFAULT_SKILL_DECIDE_RESPONSE,
     DEFAULT_SHARED_CLAUDE_MD,
     DEFAULT_SKILLS,
     HELD_SEND_RECONSIDERATION_GUIDANCE,
-    INBOX_RESPONSE_DECISION_CUE,
+    INBOX_TURN_CUE,
     ensure_shared_primer,
     rebuild_agent_claude_md,
     rebuild_agent_codex_md,
@@ -62,21 +59,27 @@ def test_standing_prompt_is_compact_and_identity_is_compiled_once():
     assert len(codex.encode()) < PARENT_CODEX_BYTES
 
 
-def test_policy_has_one_detailed_owner_and_primer_retains_contract():
+def test_standing_prompt_owns_communication_policy_and_retains_contract():
     primer = " ".join(DEFAULT_SHARED_CLAUDE_MD.split())
     for phrase in (
         "<global_inbox_notice>", '"content_included":false', "read_inbox",
         "context_version=1", "target_ref", "sender_identity", "sender_type",
-        "An `@slug` identity is unique", "send_message", "[SILENT]",
-        "decide-response", "Send, Clarify, Wait, or Silent",
-        "For small, cheap, reversible work",
-        "choose distinct substantive parts",
-        "claim one uncovered part",
-        "only after its message is committed",
-        "A reminder is a future request to reconsider",
+        "An `@slug` identity is unique", "send_message",
+        "A metadata-only notice means unread content exists",
+        "When you receive a concrete message",
+        "visible acknowledgment", "For multi-step work",
+        "report the outcome", "material ambiguity",
+        "Agent messages may legitimately trigger further Agent work",
+        "choose one uncovered part that best fits your role",
+        "A claim becomes visible only after it is successfully sent",
+        "ordinary assistant text is not delivered",
+        "message comes from an existing thread",
+        "message_id` as `root_id",
         "`shared/` inside it is the host-wide collaboration directory",
     ):
         assert phrase in primer
+    for absent in ("decide-response", "[SILENT]", "Send, Clarify, Wait, or Silent"):
+        assert absent not in primer
     assert "~/.puffo-agent/shared" not in primer
     assert "/workspace/.shared" not in primer
     for absent in (
@@ -90,7 +93,6 @@ def test_policy_has_one_detailed_owner_and_primer_retains_contract():
     history = DEFAULT_SKILLS["channel-history"][1]
     post = DEFAULT_SKILLS["get-post"][1]
     send = DEFAULT_SKILLS["send-message"][1]
-    decision = DEFAULT_SKILLS["decide-response"][1]
     for phrase in (
         "context_version", "## context", "target_ref", "seq", "sent_at",
         "message_id", "sender_identity", "sender_type", "self", "encrypted",
@@ -104,18 +106,8 @@ def test_policy_has_one_detailed_owner_and_primer_retains_contract():
     assert "prior_context_has_more" in read
     assert "strictly earlier" in normalized_read
     assert "do not acknowledge pending Inbox rows" in read
-    assert "apply the `decide-response` skill" in normalized_read
-    decision_guidance = " ".join(DEFAULT_SKILL_DECIDE_RESPONSE.split())
-    assert decision == DEFAULT_SKILL_DECIDE_RESPONSE
-    all_prompt_surfaces = " ".join(
-        " ".join(body.split())
-        for body in (DEFAULT_SHARED_CLAUDE_MD, *[body for _, body in DEFAULT_SKILLS.values()])
-    )
-    assert all_prompt_surfaces.count(decision_guidance) == 1
-    assert "Confidence is not evidence" in decision
-    assert "Agent messages may legitimately trigger further Agent work" in decision
-    assert "Silence is not the fallback" in decision
-    assert "Confidence is not evidence" not in read
+    assert "standing communication guidance" in normalized_read
+    assert "decide-response" not in DEFAULT_SKILLS
     assert "originating request and conversation intent" not in DEFAULT_SHARED_CLAUDE_MD
     assert "does not acknowledge pending Inbox work" in " ".join(history.split())
     assert "does not acknowledge pending Inbox work" in " ".join(post.split())
@@ -134,128 +126,14 @@ def test_policy_has_one_detailed_owner_and_primer_retains_contract():
     assert "A held draft was attempted but not sent" not in send
 
 
-def test_conversation_judgment_is_absent_from_mcp_descriptions_and_profiles():
-    decision_guidance = " ".join(DEFAULT_SKILL_DECIDE_RESPONSE.split())
-
-    class CapturingMCP:
-        def __init__(self) -> None:
-            self.tools = []
-
-        def tool(self):
-            def register(function):
-                self.tools.append(function)
-                return function
-            return register
-
-    mcp = CapturingMCP()
-    register_core_tools(mcp, SimpleNamespace(bridge_client=None))
-    mcp_descriptions = " ".join(
-        "\n".join(tool.__doc__ or "" for tool in mcp.tools).split()
-    )
-    assert decision_guidance not in mcp_descriptions
-    assert "Confidence is not evidence" not in mcp_descriptions
-
-    claude, codex = _rebuild(_tmp())
-    for generated_profile_surface in (claude, codex):
-        normalized = " ".join(generated_profile_surface.split())
-        assert decision_guidance not in normalized
-        assert "Confidence is not evidence" not in normalized
-
-
-def test_decide_response_owns_response_judgment():
-    decision_guidance = " ".join(DEFAULT_SKILL_DECIDE_RESPONSE.split())
-    read = " ".join(DEFAULT_SKILLS["read-inbox"][1].split())
-    decision = " ".join(DEFAULT_SKILLS["decide-response"][1].split())
-    assert decision == decision_guidance
-    for phrase in (
-        "A bounded excerpt is not evidence that omitted rows do not exist",
-        "Earlier unrelated activity is context",
-        "Confidence is not evidence",
-        "distinct participation",
-        "one shared result",
-        "how many turns each participant is expected to take",
-        "one successful visible turn per addressed identity",
-        "sender_identity",
-        "self=true",
-        "An attempted, held, or failed draft is not visible participation",
-        "remaining contributions open, and peer progress can make the next one due",
-        "lack of a preassigned identity is not by itself material uncertainty",
-        "does not create or reopen an obligation",
-        "does not by itself become yours merely because it remains open",
-        "keep participant position separate from the content",
-        "Agent messages may legitimately trigger further Agent work",
-        "repeat, oscillate, or self-propagate without progress",
-        "choose distinct substantive contributions",
-        "even when your own part seems quick",
-        "separate committed message before the work or result",
-        "A held or failed claim establishes nothing",
-        "Claims normally need no acknowledgement",
-        "mcp__puffo__list_reminders",
-        "cancel it and create one replacement",
-        "Do not accumulate equivalent active reminders",
-        "A fired reminder is an earlier intention",
-        "mcp__puffo__create_reminder",
-        "explicit continuing obligation",
-        "no reliable later event",
-        "A concrete later event",
-        "do not repeat Wait solely because no next participant was preassigned",
-        "A reminder schedules reconsideration",
-        "equivalent clarification is already present",
-        "Silence is not the fallback",
-    ):
-        assert phrase in decision
-    assert "apply the `decide-response` skill" in read
-    assert "Confidence is not evidence" not in read
-    assert "mcp__puffo__create_reminder" not in read
-
-    root = _tmp()
-    claude, codex = _rebuild(root)
-    claude_skill = (
-        root / "workspace" / ".claude" / "skills" / "decide-response" / "SKILL.md"
-    ).read_text(encoding="utf-8")
-    codex_skill = (
-        root / "workspace" / ".agents" / "skills" / "decide-response" / "SKILL.md"
-    ).read_text(encoding="utf-8")
-    assert decision_guidance in " ".join(claude_skill.split())
-    assert decision_guidance.replace("mcp__puffo__", "") in " ".join(
-        codex_skill.split()
-    )
-    assert codex_skill == claude_skill.replace("mcp__puffo__", "")
-
-    other_prompt_surfaces = [" ".join(surface.split()) for surface in (claude, codex)]
-    other_prompt_surfaces.extend(
-        " ".join(body.split())
-        for skill_id, (_, body) in DEFAULT_SKILLS.items()
-        if skill_id != "decide-response"
-    )
-    assert not any(decision_guidance in surface for surface in other_prompt_surfaces)
-
-    class CapturingMCP:
-        def __init__(self) -> None:
-            self.tools = []
-
-        def tool(self):
-            def register(function):
-                self.tools.append(function)
-                return function
-            return register
-
-    mcp = CapturingMCP()
-    register_core_tools(mcp, SimpleNamespace(bridge_client=None))
-    mcp_descriptions = " ".join(
-        "\n".join(tool.__doc__ or "" for tool in mcp.tools).split()
-    )
-    assert decision_guidance not in mcp_descriptions
-
-
-def test_inbox_decision_cue_is_short_and_points_to_the_skill():
-    cue = " ".join(INBOX_RESPONSE_DECISION_CUE.split())
+def test_inbox_turn_cue_is_short_and_reinforces_the_standing_default():
+    cue = " ".join(INBOX_TURN_CUE.split())
     assert "<puffo_runtime_instruction>" in cue
-    assert "read the pending content" in cue.lower()
-    assert "`decide-response` skill" in cue
-    assert "Send, Wait, Clarify, or Silent" in cue
-    assert "Confidence is not evidence" not in cue
-    assert len(INBOX_RESPONSE_DECISION_CUE.encode()) < 256
+    assert "read the relevant pending content" in cue.lower()
+    assert "respond through `send_message` as appropriate" in cue
+    assert "report any result or handoff you owe" in cue
+    assert "decide-response" not in cue
+    assert len(INBOX_TURN_CUE.encode()) < 320
 
 
 def test_held_send_applies_the_shared_judgment_to_the_attempted_draft():
@@ -269,9 +147,10 @@ def test_held_send_applies_the_shared_judgment_to_the_attempted_draft():
         assert phrase in send
     for phrase in (
         "attempted but not sent", "reconsider the originating interaction",
-        "apply the `decide-response` skill", "send_anyway=true", "is rare",
+        "send_anyway=true", "is rare",
         "if the draft was a claim", "it did not establish ownership",
-        "wait outcome follows that skill's reminder reconciliation requirement",
+        "make it durable with a suitable reminder",
+        "if no visible response is useful, do not send one",
         "it neither creates nor settles a participation obligation",
         "decide those questions independently",
         "rather than treating overlapping peer content as your participation",
@@ -307,7 +186,7 @@ def test_harnesses_discover_managed_skills_with_correct_tool_names():
     assert "mcp__puffo__" not in codex
     assert "send_message" in codex
     ensure_shared_primer(root / "shared")
-    for skill_id in ("read-inbox", "decide-response", "send-message"):
+    for skill_id in ("read-inbox", "send-message"):
         claude_skill = root / "workspace" / ".claude" / "skills" / skill_id / "SKILL.md"
         codex_skill = root / "workspace" / ".agents" / "skills" / skill_id / "SKILL.md"
         for skill in (claude_skill, codex_skill):
@@ -326,3 +205,11 @@ def test_managed_refresh_rewrites_stale_skill():
     actions = dict(ensure_shared_primer(shared))
     assert actions["skills/read-inbox/SKILL.md"] == "updated"
     assert "prior_context" in skill.read_text(encoding="utf-8")
+
+    removed = shared / "skills" / "decide-response"
+    removed.mkdir()
+    (removed / "SKILL.md").write_text("legacy", encoding="utf-8")
+    (removed / ".puffo-managed").write_text("managed", encoding="utf-8")
+    actions = dict(ensure_shared_primer(shared))
+    assert actions["skills/decide-response"] == "pruned"
+    assert not removed.exists()

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -308,16 +308,24 @@ async def test_end_turn_batch_swallows_http_error():
 
 
 @pytest.mark.asyncio
-async def test_begin_turn_skips_http_for_local_only_envelope():
-    """Daemon-minted synthetic envelopes (intro-prompt-...) have no
+@pytest.mark.parametrize(
+    "message_id",
+    [
+        "intro-prompt-ch_xxx-1778641626040",
+        "membership-joined-ch_xxx-agent_xxx-event_xxx",
+        "reminder-occurrence:occurrence_xxx",
+    ],
+)
+async def test_begin_turn_skips_http_for_local_only_envelope(message_id):
+    """Daemon-minted synthetic envelopes have no
     server-side row, so we skip ``/messages/<id>/processing/start``
     (which used to 404 + WARN per nudge) — but push an immediate busy
-    heartbeat so the agent shows in-progress while composing its intro,
+    heartbeat so the agent shows in-progress while composing,
     not idle until the next scheduled beat."""
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=999)
 
-    run_id = await rep.begin_turn("intro-prompt-ch_xxx-1778641626040")
+    run_id = await rep.begin_turn(message_id)
 
     assert run_id.startswith("run_")
     # No per-message processing POST — just a busy heartbeat.
@@ -336,9 +344,11 @@ async def test_end_turn_skips_http_for_local_only_envelope():
     http = FakeHttp()
     rep = StatusReporter(http, heartbeat_interval_s=999)
     rep._current_status = "busy"
-    rep._current_message_id = "intro-prompt-ch_a-1"
+    rep._current_message_id = "membership-joined-ch_a-agent_a-event_a"
 
-    await rep.end_turn("intro-prompt-ch_a-1", "run_x", succeeded=True)
+    await rep.end_turn(
+        "membership-joined-ch_a-agent_a-event_a", "run_x", succeeded=True,
+    )
 
     # No /processing/end POST — just an idle heartbeat.
     assert not any("/processing/" in p for p, _ in http.calls)
@@ -380,7 +390,7 @@ async def test_end_turn_batch_all_local_only_skips_http():
 
     await rep.end_turn_batch([
         {"run_id": "run_a", "message_id": "intro-prompt-ch_a-1", "succeeded": True},
-        {"run_id": "run_b", "message_id": "intro-prompt-ch_b-1", "succeeded": True},
+        {"run_id": "run_b", "message_id": "reminder-occurrence:occ_b", "succeeded": True},
     ])
 
     assert not any("/processing/" in p for p, _ in http.calls)

--- a/tests/test_status_reporter.py
+++ b/tests/test_status_reporter.py
@@ -631,6 +631,16 @@ async def test_keyless_end_turn_batch_emits_over_bridge():
         {"run_id": "run_a", "message_id": "msg_a", "succeeded": True},
     ])
     assert sender.calls[0]["status"] == "idle"
+
+    sender.calls.clear()
+    await rep.end_turn_batch([{
+        "run_id": "run_b",
+        "message_id": "msg_b",
+        "succeeded": False,
+        "error_text": "batch failed",
+    }])
+    assert sender.calls[0]["status"] == "error"
+    assert sender.calls[0]["error_text"] == "batch failed"
     assert http.calls == []
 
 

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -112,6 +112,7 @@ def test_puffo_core_mcp_env():
         space_id="sp_test",
         keystore_dir="/tmp/keys",
         workspace="/workspace",
+        shared_workspace="/workspace/shared",
         agent_id="bot-0001",
         runtime_kind="cli-local",
         harness="claude-code",
@@ -127,6 +128,7 @@ def test_puffo_core_mcp_env():
     assert env["PUFFO_DATA_SERVICE_URL"] == "http://127.0.0.1:63386"
     assert env["PUFFO_AGENT_ID"] == "bot-0001"
     assert env["PUFFO_WORKSPACE"] == "/workspace"
+    assert env["PUFFO_SHARED_WORKSPACE"] == "/workspace/shared"
     assert env["PUFFO_RUNTIME_KIND"] == "cli-local"
     assert env["PUFFO_HARNESS"] == "claude-code"
     assert env[LOCAL_SERVICE_TOKEN_ENV]

--- a/tests/test_worker_status_lifecycle.py
+++ b/tests/test_worker_status_lifecycle.py
@@ -1,0 +1,208 @@
+"""One table-driven regression test for the worker Global Inbox status lifecycle.
+
+The durable Global Inbox turn — not WebSocket receipt — owns
+``StatusReporter.begin_turn`` / ``end_turn_batch``: exactly one begin on the
+first real admitted message, exactly one terminal batch over the exact active
+union, and no Server processing rows for synthetic ``intro-prompt-*``
+envelopes even though busy state is shown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from puffo_agent.agent.context_controller import ProviderAdmissionEvent
+from puffo_agent.agent.core import AgentAPIError
+from puffo_agent.agent.global_inbox_runtime import GlobalInboxRuntime
+from puffo_agent.agent.status_reporter import StatusReporter
+from puffo_agent.portal.worker_run import GlobalInboxStatusLifecycle
+
+from test_global_inbox_runtime import _ContinuationAdapter, make_store, receipt
+from test_status_reporter import FakeHttp
+
+INTRO_ID = "intro-prompt-ch_x-1778641626040"
+
+
+class _PoppingContinuationAdapter(_ContinuationAdapter):
+    """Fires each registered ``read_inbox`` continuation exactly once."""
+
+    async def admit_continuation(self):
+        callback, key, *_ = self.continuations.pop(0)
+        await callback(ProviderAdmissionEvent(
+            planning_cycle_key=key, provider_session_id="provider-1",
+            provider_turn_id="provider-turn", tool_call_id="read",
+            admitted_at=datetime.now(timezone.utc),
+        ))
+
+
+class _LifecycleRunner:
+    """Drive one durable Global Inbox turn through notice + read_inbox."""
+
+    def __init__(self, adapter, *, expand, outcome, error):
+        self.adapter = adapter
+        self.expand = expand
+        self.outcome = outcome
+        self.error = error
+        self.runtime = None
+
+    async def __call__(self, planned):
+        await self.adapter.admit()
+        await self.runtime.read_inbox(limit=1, tool_arguments={"limit": 1})
+        await self.adapter.admit_continuation()
+        if self.expand:
+            await self.runtime.read_inbox(limit=1, tool_arguments={"limit": 1})
+            await self.adapter.admit_continuation()
+        if self.outcome == "failure":
+            raise self.error
+        if self.outcome == "cancelled":
+            raise asyncio.CancelledError()
+        if self.outcome == "retry":
+            raise AgentAPIError("rate limit", is_auth=False)
+        return None
+
+    async def handle_global_inbox_retry(self, _planned):
+        return None
+
+
+_CASES = [
+    {"id": "success_expanded", "outcome": "success", "expand": True},
+    {"id": "success_then_second_turn", "outcome": "success", "expand": False, "second": True},
+    {"id": "provider_failure", "outcome": "failure", "expand": False},
+    {"id": "cancelled", "outcome": "cancelled", "expand": False},
+    {"id": "retry_same_turn", "outcome": "retry", "expand": False},
+    {"id": "synthetic_intro", "outcome": "success", "expand": False, "synthetic": True},
+]
+
+
+def _begin_runs(http) -> dict[str, str]:
+    """Map each admitted message id to the run id its processing/start minted."""
+    return {
+        path.split("/")[2]: body["run_id"]
+        for path, body in http.calls
+        if path.endswith("/processing/start")
+    }
+
+
+def _batch_runs(http) -> list[list[dict]]:
+    return [
+        body["runs"]
+        for path, body in http.calls
+        if path == "/messages/processing/end:batch"
+    ]
+
+
+def _assert_status_wire(case: dict, http, lifecycle) -> None:
+    begin_runs = _begin_runs(http)
+    batch_runs = _batch_runs(http)
+    turns = 2 if case.get("second") else 1
+    # Clean per-turn state: a subsequent case/turn cannot inherit runs.
+    assert lifecycle._began is False
+    if case.get("synthetic"):
+        heartbeats = [
+            body for path, body in http.calls if path == "/agents/me/heartbeat"
+        ]
+        # Busy is shown for the synthetic turn, but no processing row reaches
+        # the wire for the synthetic id.
+        assert [body["status"] for body in heartbeats] == ["busy", "idle"]
+        assert "current_message_id" not in heartbeats[0]
+        assert begin_runs == {}
+        assert batch_runs == []
+        assert not any("/processing/" in path for path, _ in http.calls)
+        return
+    # Exactly one begin per logical turn, and one terminal batch per turn.
+    assert len(begin_runs) == turns
+    assert len(batch_runs) == turns
+    assert len(set(begin_runs.values())) == turns
+    run_ids = list(begin_runs.values())
+    if case.get("second"):
+        assert batch_runs[0] == [
+            {"run_id": run_ids[0], "message_id": "m1", "succeeded": True}
+        ]
+        assert batch_runs[1] == [
+            {"run_id": run_ids[1], "message_id": "m3", "succeeded": True}
+        ]
+        return
+    if case["outcome"] in ("success", "retry"):
+        if case["expand"]:
+            # Mid-turn active-union expansion settles the exact union in one
+            # batch: first entry reuses the begin run id, later entries are new.
+            assert batch_runs[0][0] == {
+                "run_id": run_ids[0], "message_id": "m1", "succeeded": True,
+            }
+            assert batch_runs[0][1]["message_id"] == "m2"
+            assert batch_runs[0][1]["succeeded"] is True
+            assert batch_runs[0][1]["run_id"] != run_ids[0]
+        else:
+            assert batch_runs[0] == [
+                {"run_id": run_ids[0], "message_id": "m1", "succeeded": True}
+            ]
+        return
+    entry = batch_runs[0][0]
+    assert entry["run_id"] == run_ids[0]
+    assert entry["message_id"] == "m1"
+    assert entry["succeeded"] is False
+    assert entry["error_text"] and len(entry["error_text"]) <= 1024
+    if case["outcome"] == "cancelled":
+        assert "cancelled" in entry["error_text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", _CASES, ids=lambda case: case["id"])
+async def test_global_inbox_turn_owns_one_status_lifecycle(tmp_path, monkeypatch, case):
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.store.current_machine_id", lambda: None,
+    )
+    store = await make_store(tmp_path)
+    http = FakeHttp()
+    lifecycle = GlobalInboxStatusLifecycle(
+        StatusReporter(http, heartbeat_interval_s=999)
+    )
+    if case.get("synthetic"):
+        await store.store_local_event(
+            {
+                "envelope_id": INTRO_ID,
+                "envelope_kind": "channel",
+                "sender_slug": "system",
+                "channel_id": "ch-x",
+                "space_id": "sp-x",
+                "content": "introduce yourself",
+                "sent_at": 1,
+            },
+            reason="intro",
+        )
+    else:
+        await receipt(store, "m1", 1)
+        if case["expand"]:
+            await receipt(store, "m2", 2)
+
+    adapter = _PoppingContinuationAdapter()
+    runner = _LifecycleRunner(
+        adapter,
+        expand=case["expand"],
+        outcome=case["outcome"],
+        error=RuntimeError("provider exploded"),
+    )
+    runtime = GlobalInboxRuntime(
+        store=store,
+        adapter=adapter,
+        run_turn=runner,
+        workspace=tmp_path,
+        status_lifecycle=lifecycle,
+        max_api_retries=1,
+        retry_sleep=lambda _delay: asyncio.sleep(0),
+    )
+    runner.runtime = runtime
+
+    if case["outcome"] == "cancelled":
+        with pytest.raises(asyncio.CancelledError):
+            await runtime.process_once()
+    else:
+        assert await runtime.process_once() is True
+    if case.get("second"):
+        await receipt(store, "m3", 3)
+        assert await runtime.process_once() is True
+    _assert_status_wire(case, http, lifecycle)
+    await store.close()

--- a/tests/test_worker_status_lifecycle.py
+++ b/tests/test_worker_status_lifecycle.py
@@ -206,3 +206,59 @@ async def test_global_inbox_turn_owns_one_status_lifecycle(tmp_path, monkeypatch
         assert await runtime.process_once() is True
     _assert_status_wire(case, http, lifecycle)
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_crash_recovery_reuses_and_settles_original_processing_run(tmp_path):
+    store = await make_store(tmp_path)
+    await receipt(store, "m1", 1)
+    http = FakeHttp()
+
+    original_adapter = _ContinuationAdapter()
+    original_lifecycle = GlobalInboxStatusLifecycle(
+        StatusReporter(http, heartbeat_interval_s=999)
+    )
+    original = GlobalInboxRuntime(
+        store=store,
+        adapter=original_adapter,
+        run_turn=lambda _planned: None,
+        workspace=tmp_path,
+        status_lifecycle=original_lifecycle,
+    )
+    planned = await original.plan_pending(items=tuple(await store.get_pending()))
+    assert planned is not None
+    original._write_current_turn(planned)
+    original_adapter.register_admission_callback(
+        lambda event: original._admit(planned, event),
+        planned.planning_cycle_key,
+    )
+    await original_adapter.admit()
+
+    class RecoveredRunner:
+        async def handle_global_inbox_retry(self, _planned):
+            return None
+
+    recovered = GlobalInboxRuntime(
+        store=store,
+        adapter=_ContinuationAdapter(),
+        run_turn=RecoveredRunner(),
+        workspace=tmp_path,
+        status_lifecycle=GlobalInboxStatusLifecycle(
+            StatusReporter(http, heartbeat_interval_s=999)
+        ),
+    )
+
+    assert await recovered.recover_current_turn() is True
+    starts = [
+        body
+        for path, body in http.calls
+        if path.endswith("/processing/start")
+    ]
+    assert len(starts) == 2
+    assert starts[0]["run_id"] == starts[1]["run_id"]
+    assert _batch_runs(http) == [[{
+        "run_id": starts[0]["run_id"],
+        "message_id": "m1",
+        "succeeded": True,
+    }]]
+    await store.close()

--- a/tests/test_workspace_layout.py
+++ b/tests/test_workspace_layout.py
@@ -1,4 +1,7 @@
-from puffo_agent.portal.workspace_layout import ensure_workspace_shared_link
+from puffo_agent.portal.workspace_layout import (
+    ensure_workspace_shared_link,
+    prepare_workspace_shared_access,
+)
 
 
 def test_shared_workspace_link_is_common_and_preserves_conflicts(tmp_path):
@@ -18,3 +21,25 @@ def test_shared_workspace_link_is_common_and_preserves_conflicts(tmp_path):
     (local_shared / "keep.txt").write_text("keep", encoding="utf-8")
     assert ensure_workspace_shared_link(carol, shared) == "conflict"
     assert (local_shared / "keep.txt").read_text(encoding="utf-8") == "keep"
+    assert prepare_workspace_shared_access(
+        carol, shared, mounted=True
+    ) == "conflict"
+
+    dave = tmp_path / "agents" / "dave" / "workspace"
+    (dave / "shared").mkdir(parents=True)
+    assert ensure_workspace_shared_link(dave, shared) == "created"
+    assert (dave / "shared").is_symlink()
+
+
+def test_shared_workspace_repairs_stale_and_dangling_links(tmp_path):
+    shared = tmp_path / "shared"
+    stale_target = tmp_path / "old-shared"
+    stale_target.mkdir()
+
+    for name, target in (("stale", stale_target), ("dangling", tmp_path / "gone")):
+        workspace = tmp_path / "agents" / name / "workspace"
+        workspace.mkdir(parents=True)
+        (workspace / "shared").symlink_to(target, target_is_directory=True)
+
+        assert ensure_workspace_shared_link(workspace, shared) == "created"
+        assert (workspace / "shared").resolve() == shared.resolve()

--- a/tests/test_workspace_layout.py
+++ b/tests/test_workspace_layout.py
@@ -1,0 +1,20 @@
+from puffo_agent.portal.workspace_layout import ensure_workspace_shared_link
+
+
+def test_shared_workspace_link_is_common_and_preserves_conflicts(tmp_path):
+    shared = tmp_path / "shared"
+    alice = tmp_path / "agents" / "alice" / "workspace"
+    bob = tmp_path / "agents" / "bob" / "workspace"
+
+    assert ensure_workspace_shared_link(alice, shared) == "created"
+    assert ensure_workspace_shared_link(bob, shared) == "created"
+    assert ensure_workspace_shared_link(alice, shared) == "existing"
+    (alice / "shared" / "handoff.txt").write_text("ready", encoding="utf-8")
+    assert (bob / "shared" / "handoff.txt").read_text(encoding="utf-8") == "ready"
+
+    carol = tmp_path / "agents" / "carol" / "workspace"
+    local_shared = carol / "shared"
+    local_shared.mkdir(parents=True)
+    (local_shared / "keep.txt").write_text("keep", encoding="utf-8")
+    assert ensure_workspace_shared_link(carol, shared) == "conflict"
+    assert (local_shared / "keep.txt").read_text(encoding="utf-8") == "keep"

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a2"
+version = "2.0.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a1"
+version = "2.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Agent Foundation landed in #225, but the stable-readiness audit found locally actionable compatibility gaps around existing installations, Docker Codex, Windows Claude launch behavior, runtime status/telemetry, keyless operator authorization, and shared workspaces.

This PR closes those code-level gaps in the `puffo-agent==2.0.0a3` candidate before staging validation. It does **not** authorize a stable `2.0.0` release.

## System shape

```mermaid
flowchart LR
    State[Existing Agent state] --> Daemon[Daemon reconciliation]
    Daemon --> Driver[Claude or Codex Driver]
    Driver --> Inbox[Global Inbox]
    Inbox --> Send[Send Coordinator]
    Driver --> Events[Bounded Runtime Events]

    Bridge[Keyless bridge] --> Approval[Operator DM and invitation approval]
    Approval --> Inbox

    Daemon --> Private[Per-Agent private workspace]
    Private --> Shared[shared symlink or Docker mount]
    Shared --> Root[Puffo-home shared directory]
```

## What changed

- Restored runtime compatibility after #225:
  - Docker Codex Driver support and container lifecycle.
  - Windows Claude Code shim launch handling.
  - Legacy daemon stop-request behavior.
  - Global Inbox status lifecycle and local runtime-event status projection.
  - Safe telemetry and optional context-baseline compatibility.
- Added durable, resumable keyless operator authorization:
  - Foreign DM allow/block decisions.
  - Space invitation approve/reject decisions.
  - Restart/replay-safe local persistence and bridge ingress.
- Unified the workspace contract:
  - `<puffo-home>/agents/<agent-id>/workspace` remains private.
  - `workspace/shared` exposes `<puffo-home>/shared` through a local symlink/junction or Docker bind mount.
  - Existing Agents are repaired lazily by daemon reconciliation.
  - Existing real `workspace/shared` content is preserved and surfaced as a conflict rather than overwritten or hidden.
  - Docker keeps `/workspace/.shared` as a compatibility alias.
  - Attachment validation permits only the managed shared root, not arbitrary symlink escapes.
- Addressed review findings around workspace status propagation, Docker mount transitions, crash recovery, keyless error detail, held-baseline compatibility, and baseline-persistence observability.
- Added the source audit, compatibility matrix, and stable-readiness backlog.

## Compatibility and scope

- Existing `agent.yml`, profile, memory, workspace, keys, message history, and supported session references remain in place.
- Channel encryption/plaintext policy remains outside this PR and stays owned by the separate Server/Agent workstream.
- Stable publishing remains blocked on the external Windows, staging bridge, Runtime Event, production inventory, cloud-template, and final candidate evidence documented in [STABLE-2.0-READINESS.md](https://github.com/puffo-ai/puffo-agent/blob/feat/agent-foundation-stable-readiness/roadmap/agent-foundation/STABLE-2.0-READINESS.md).

## Validation

Current head `e4791e6`, package `puffo-agent==2.0.0a3`:

- Full local pytest suite passed with one expected Windows-only skip.
- `pre-commit run --all-files` passed, including Ruff and Python structural limits.
- `git diff --check` passed.
- Wheel and sdist builds passed; artifacts report `2.0.0a3`.
- GitHub CI passed on Python 3.11 and 3.12; CodeQL passed.

Real Windows execution and staging bridge acceptance remain external evidence and are not represented as locally completed tests.

## Review focus

1. Upgrade and existing-install compatibility.
2. Claude/Codex local and Docker runtime boundaries.
3. Keyless DM/invitation authorization lifecycle and replay.
4. Runtime status/telemetry privacy.
5. Managed shared-workspace safety and migration behavior.
6. Alpha-candidate and stable-release gate accuracy.
