### PR TITLE
feat(reminders): complete one-shot lifecycle and replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a4] — 2026-08-12
+
+> Staging candidate for the complete one-shot Reminder lifecycle.
+
+### Added
+
+- **Scheduled reminders can be replaced atomically.** The new semantic
+  `replace_reminder` tool preserves omitted fields, fences live delivery, and
+  converges after an uncertain network result without creating duplicate work.
+
+### Changed
+
+- **Cancellation now coordinates with remote custody.** Prepared reminders can
+  be cancelled until delivery starts, and retained terminal snapshots rebuild
+  matching local cancelled or fired state after restart.
+- **Delivery claims stay internal.** Reminder tools continue to show claimed
+  work as `scheduled`; the transient SQLite custody state is not part of the
+  public lifecycle.
+
 ## [2.0.0a3] — 2026-08-12
 
 > Staging-only prompt candidate for manual conversation validation.

--- a/docs/reminder-one-shot-contract.md
+++ b/docs/reminder-one-shot-contract.md
@@ -10,17 +10,22 @@ content, cancellation, delivery, and local scheduling in its per-Agent
   content, a canonical target (`dm:<peer>`, `channel:<space>:<channel>`, or a
   channel thread target), and an RFC3339 timestamp with an explicit offset.
 - `list_reminders(state="", limit=50)` returns reminders ordered by intended
-  time and occurrence identity.
-- `cancel_reminder(reminder_id)` is idempotent after a local cancellation. It
-  succeeds only for scheduled, untouched local-only work. Once the occurrence
-  is claimed, or once an envelope, Server acknowledgement, snapshot conflict,
-  or delivery claim is durable,
-  cancellation fails closed because this client cannot revoke possible remote
-  custody. It never removes a delivered local Inbox event.
+  time and occurrence identity. Public states are `scheduled`, `cancelled`,
+  and `delivered`; the internal `claimed` coordination state is projected as
+  `scheduled`.
+- `cancel_reminder(reminder_id)` idempotently cancels scheduled work. Local-only
+  work commits in SQLite; remotely prepared work is fenced against a live
+  delivery claim by the Server. A transient local `claimed` state is resolved
+  against that lease; work already delivered locally is too late to cancel.
+- `replace_reminder(reminder_id, content="", target="", intended_at="")`
+  atomically cancels one scheduled occurrence and creates its replacement.
+  At least one non-empty field is required; omitted fields inherit their old
+  values. A live delivery claim makes the replacement too late.
 
 Each create/cancel result is the same structured object containing immutable
 `reminder_id`, `occurrence_id`, target, exact content, intended UTC time, and
 the actual-fire, creation, cancellation, and delivery facts when present.
+Replace returns the cancelled object and the replacement object together.
 
 ## Durable delivery
 
@@ -29,8 +34,13 @@ The state transition is:
 
 ```text
 scheduled -> claimed -> delivered
-scheduled -> cancelled (only before claim or remote preparation)
+scheduled -> cancelled
+scheduled -> cancelled + replacement scheduled (one atomic replace)
 ```
+
+`claimed` is transient local delivery coordination, not a separate
+user-visible reminder phase. Product surfaces may label terminal `delivered`
+as `fired`; the v1 wire and SQLite compatibility name remains `delivered`.
 
 Claiming records the actual fire time once. Delivery creates
 `reminder-occurrence:<occurrence_id>` as a `local_runtime` pending Inbox row
@@ -88,11 +98,15 @@ body contains only:
 The ciphertext encrypts exactly canonical `{"content":...,"target":...}`
 JSON using a fresh 12-byte nonce. Canonical AAD binds `owner_slug`,
 `reminder_id`, `occurrence_id`, canonical UTC `intended_at`, and envelope
-version. Every retry reuses the same stored envelope bytes; it never
-re-encrypts an occurrence. The Server receives only base64url of that envelope
-plus occurrence metadata, never target, content, a DEK, provider/model data,
-or a payload-derived wake reason. The complete encoded envelope is limited to
-32,768 bytes; create rejects content that cannot fit that bound.
+version. Once an occurrence is materialized locally, every retry reuses its
+stored envelope bytes. An atomic replacement whose first response is lost may
+reconstruct a fresh envelope under the same deterministic replacement identity;
+the Server returns the first committed canonical envelope, which the Agent
+decrypts and validates before local materialization. The Server receives only
+base64url envelope bytes plus occurrence metadata, never target, content, a
+DEK, provider/model data, or a payload-derived wake reason. The complete
+encoded envelope is limited to 32,768 bytes; create rejects content that cannot
+fit that bound.
 
 `reminder_occurrences` remains both the local source of truth and its embedded
 outbox. A create is local revision 1. `claimed` is local crash recovery only
@@ -108,16 +122,19 @@ Native Agents use signed:
 - `PUT /v2/agent-runtime/reminder-occurrences/{occurrence_id}`
 - `GET /v2/agent-runtime/reminder-occurrences?after=<opaque_cursor>&limit=<n>`
 - `POST /v2/agent-runtime/reminder-occurrences/{occurrence_id}/delivery-claim`
+- `POST /v2/agent-runtime/reminder-occurrences/{occurrence_id}/replace`
 
 Bridge Agents use the same DTO through the existing keyless boundary:
 
 - `PUT /v2/cloud-agents/agent-runtime/reminder-occurrences/{occurrence_id}`
 - `GET /v2/cloud-agents/agent-runtime/reminder-occurrences?after=<opaque_cursor>&limit=<n>`
 - `POST /v2/cloud-agents/agent-runtime/reminder-occurrences/{occurrence_id}/delivery-claim`
+- `POST /v2/cloud-agents/agent-runtime/reminder-occurrences/{occurrence_id}/replace`
 
 PUT sends `revision`, `reminder_id`, RFC3339 `due_at`, `lifecycle`,
 `lifecycle_at`, `payload_format`, and base64url `opaque_payload`. The Server
-current-state snapshot returns scheduled rows as `{occurrences,next_after}`.
+current-state snapshot returns retained scheduled and terminal rows as
+`{occurrences,next_after}`. Terminal rows omit `opaque_payload`.
 `next_after` is an opaque, snapshot-bound cursor; the Agent passes it back
 verbatim and restarts the snapshot if the Server reports that the cursor's
 snapshot revision changed. On startup and reconnect, the Agent consumes every
@@ -148,9 +165,14 @@ ID and `lease_expires_at`; an acquired bit without an expiry is not custody.
 Only `acquired` may enter the existing atomic local Inbox-event and
 delivered-state transaction. `terminal` reconciles local state without creating
 an Inbox row or Agent turn. Claim IDs are coordination metadata only: snapshots
-never expose them and the Server never sees reminder plaintext. Once work is
-claimed or any remote-custody evidence is durable, local cancellation fails
-closed; cancellation cannot erase work in flight or a possible Server copy.
+never expose them and the Server never sees reminder plaintext. Cancellation
+and replacement lock the old Server row and reject a live delivery claim. An
+expired claim does not permanently strand scheduled work. The replacement
+endpoint inserts the new row and cancels the old row in one PostgreSQL
+transaction. Its replacement occurrence identity is also the retry identity:
+after a response is lost, the Server returns the first committed canonical
+row, and the Agent decrypts and validates it before committing the paired
+result to SQLite.
 
 Successful local delivery immediately wakes the outbox so revision 2 reaches
 the Server without waiting for the idle sync cadence. A held runtime retries
@@ -178,30 +200,19 @@ SQLite transaction prevents duplicate Inbox events within one local database,
 but the transferable lease does not provide cross-runtime exactly-once delivery
 after a crashed or partitioned holder loses its lease.
 
-## Current Server limits
+## Current limits
 
-The deployed Server contract is narrower than the eventual protocol:
-
-- snapshots currently return only `scheduled` rows; terminal rows are retained
-  for 30 days but are not snapshot tombstones, so a fresh runtime cannot fully
-  reconstruct prior cancellation or delivery from the snapshot alone;
-- the Agent emits revision 1 for scheduled and revision 2 for terminal state,
-  while the Server currently validates only that a revision is positive;
-- a terminal cancellation can clear a live delivery claim, so the Agent must
-  fail closed once an occurrence has entered remote custody rather than promise
-  race-free remote cancellation; and
-- a lease prevents concurrent live holders, not duplicate delivery after lease
-  transfer.
-
-Terminal snapshot rows and strict revision transitions must land in the Server
-before the client may advertise cross-runtime terminal reconstruction.
-Cancellation fencing would be required before supporting remote cancellation.
-None of these prerequisites upgrades a transferable lease to cross-runtime
+Terminal rows are retained by the Server for 30 days. They reconcile matching
+local occurrences after restart but omit plaintext and cannot recreate missing
+terminal history in a fresh local database. The Server enforces revision 1 for
+scheduled and revision 2 for terminal rows. A lease prevents concurrent live
+holders, not duplicate delivery after lease transfer; none of the cancellation
+or replacement guarantees upgrades that transferable lease to cross-runtime
 exactly-once delivery.
 
 ## Non-goals
 
-This slice has no editing, rescheduling, recurrence, snooze, browser surface,
-cloud sandbox lifecycle scheduling, race-free remote cancellation, or
-provider-specific scheduler behavior. Server-side decryption, recovery-key
-upload, and cross-runtime exactly-once delivery are not part of this contract.
+This slice has no recurrence, snooze, browser surface, cloud sandbox lifecycle
+scheduling, or provider-specific scheduler behavior. Server-side decryption,
+recovery-key upload, and cross-runtime exactly-once delivery are not part of
+this contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a3"
+version = "2.0.0a4"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -268,6 +268,21 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             reminder_id=reminder_id,
         )
 
+    async def replace_reminder(
+        self,
+        *,
+        reminder_id: str,
+        content: str = "",
+        target: str = "",
+        intended_at: str = "",
+    ) -> dict[str, object]:
+        return await self.reminder_scheduler.replace_reminder(
+            reminder_id=reminder_id,
+            content=content,
+            target=target,
+            intended_at=intended_at,
+        )
+
     def notify_delivery(self) -> None:
         self.held_recovery_source.notify_delivery()
 

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -33,6 +33,7 @@ ReminderOccurrence = _models.ReminderOccurrence
 ReminderSyncRecord = _models.ReminderSyncRecord
 ReminderMaterializationResult = _models.ReminderMaterializationResult
 REMINDER_STATES = _models.REMINDER_STATES
+PUBLIC_REMINDER_STATES = _models.PUBLIC_REMINDER_STATES
 MAX_REMINDER_LIST_LIMIT = _models.MAX_REMINDER_LIST_LIMIT
 MAX_REMINDER_ENVELOPE_BYTES = _models.MAX_REMINDER_ENVELOPE_BYTES
 reminder_plaintext_envelope_size = _models.reminder_plaintext_envelope_size

--- a/src/puffo_agent/agent/message_store_models.py
+++ b/src/puffo_agent/agent/message_store_models.py
@@ -182,16 +182,17 @@ class ReminderOccurrence:
 
     def as_dict(self) -> dict[str, Any]:
         """The stable, provider-neutral reminder tool result."""
+        is_internal_claim = self.state == "claimed"
         return {
             "reminder_id": self.reminder_id,
             "occurrence_id": self.occurrence_id,
-            "state": self.state,
+            "state": "scheduled" if is_internal_claim else self.state,
             "target": self.target,
             "content": self.content,
             "intended_at": reminder_time_to_rfc3339(self.intended_at_ms),
             "actual_fire_at": (
                 reminder_time_to_rfc3339(self.actual_fire_at_ms)
-                if self.actual_fire_at_ms is not None
+                if self.actual_fire_at_ms is not None and not is_internal_claim
                 else None
             ),
             "created_at": reminder_time_to_rfc3339(self.created_at_ms),
@@ -280,6 +281,7 @@ class ReminderMaterializationResult:
 
 
 REMINDER_STATES = frozenset({"scheduled", "claimed", "cancelled", "delivered"})
+PUBLIC_REMINDER_STATES = frozenset({"scheduled", "cancelled", "delivered"})
 MAX_REMINDER_LIST_LIMIT = 100
 
 

--- a/src/puffo_agent/agent/reminder_scheduler.py
+++ b/src/puffo_agent/agent/reminder_scheduler.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+import uuid
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from typing import Awaitable, Callable
 
 from .message_store import (
     MAX_REMINDER_LIST_LIMIT,
-    REMINDER_STATES,
+    PUBLIC_REMINDER_STATES,
     MessageStore,
     ReminderOccurrence,
     ReminderSyncRecord,
@@ -37,6 +38,11 @@ class ReminderDeliveryAuthorization:
 
 ReminderDeliveryAuthorizer = Callable[
     [tuple[ReminderSyncRecord, ...]], Awaitable[ReminderDeliveryAuthorization]
+]
+ReminderCancellationHandler = Callable[[str], Awaitable[ReminderOccurrence]]
+ReminderReplacementHandler = Callable[
+    [str, str | None, str | None, int | None],
+    Awaitable[tuple[ReminderOccurrence, ReminderOccurrence]],
 ]
 
 
@@ -73,6 +79,8 @@ class ReminderScheduler:
         wait_for_change: Callable[[asyncio.Event, float | None], Awaitable[None]] | None = None,
         delivery_authorizer: ReminderDeliveryAuthorizer | None = None,
         on_lifecycle_committed: Callable[[], None] | None = None,
+        cancellation_handler: ReminderCancellationHandler | None = None,
+        replacement_handler: ReminderReplacementHandler | None = None,
     ) -> None:
         self.store = store
         self._notify = notify
@@ -80,6 +88,8 @@ class ReminderScheduler:
         self._wait_for_change = wait_for_change
         self._delivery_authorizer = delivery_authorizer
         self._on_lifecycle_committed = on_lifecycle_committed
+        self._cancellation_handler = cancellation_handler
+        self._replacement_handler = replacement_handler
         self._authorization_retry_after_ms: int | None = None
         self._wakeup = asyncio.Event()
         self._stopping = False
@@ -107,6 +117,16 @@ class ReminderScheduler:
         """Wake a provider-neutral outbox after any local lifecycle commit."""
         self._on_lifecycle_committed = callback
 
+    def set_mutation_handlers(
+        self,
+        *,
+        cancel: ReminderCancellationHandler | None,
+        replace: ReminderReplacementHandler | None,
+    ) -> None:
+        """Install the one coordinator that owns remote lifecycle mutations."""
+        self._cancellation_handler = cancel
+        self._replacement_handler = replace
+
     async def create_reminder(
         self, *, content: str, target: str, intended_at: str,
     ) -> dict[str, object]:
@@ -124,8 +144,12 @@ class ReminderScheduler:
     async def list_reminders(
         self, *, state: str = "", limit: int = 50,
     ) -> dict[str, object]:
-        if not isinstance(state, str) or (state and state not in REMINDER_STATES):
-            raise ValueError("state must be empty or one of scheduled, claimed, cancelled, delivered")
+        if not isinstance(state, str) or (
+            state and state not in PUBLIC_REMINDER_STATES
+        ):
+            raise ValueError(
+                "state must be empty or one of scheduled, cancelled, delivered"
+            )
         if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_REMINDER_LIST_LIMIT:
             raise ValueError(
                 f"limit must be between 1 and {MAX_REMINDER_LIST_LIMIT}"
@@ -134,11 +158,60 @@ class ReminderScheduler:
         return {"reminders": [item.as_dict() for item in reminders]}
 
     async def cancel_reminder(self, *, reminder_id: str) -> dict[str, object]:
-        reminder = await self.store.cancel_reminder(reminder_id)
+        if self._cancellation_handler is None:
+            reminder = await self.store.cancel_reminder(reminder_id)
+        else:
+            reminder = await self._cancellation_handler(reminder_id)
         self.signal()
         if self._on_lifecycle_committed is not None:
             self._on_lifecycle_committed()
         return reminder.as_dict()
+
+    async def replace_reminder(
+        self,
+        *,
+        reminder_id: str,
+        content: str = "",
+        target: str = "",
+        intended_at: str = "",
+    ) -> dict[str, object]:
+        """Atomically supersede one scheduled reminder with changed intent."""
+        intended_at_ms = (
+            normalize_reminder_timestamp(intended_at)[0] if intended_at else None
+        )
+        if not any((content, target, intended_at)):
+            raise ValueError("replace_reminder requires at least one changed field")
+        if self._replacement_handler is not None:
+            cancelled, replacement = await self._replacement_handler(
+                reminder_id,
+                content or None,
+                target or None,
+                intended_at_ms,
+            )
+        else:
+            old = await self.store.get_reminder(reminder_id)
+            if old is None:
+                raise ValueError("unknown reminder_id")
+            cancelled, replacement = await self.store.replace_local_reminder(
+                reminder_id=reminder_id,
+                replacement_reminder_id=f"reminder-{uuid.uuid4()}",
+                replacement_occurrence_id=f"occurrence-{uuid.uuid4()}",
+                content=content or old.content,
+                target=target or old.target,
+                intended_at_ms=(
+                    intended_at_ms
+                    if intended_at_ms is not None
+                    else old.intended_at_ms
+                ),
+                replaced_at_ms=int(self._now_ms()),
+            )
+        self.signal()
+        if self._on_lifecycle_committed is not None:
+            self._on_lifecycle_committed()
+        return {
+            "cancelled": cancelled.as_dict(),
+            "replacement": replacement.as_dict(),
+        }
 
     async def process_due_once(self) -> tuple[ReminderOccurrence, ...]:
         """Deliver due or restart-recovered claims and wake after each commit set."""

--- a/src/puffo_agent/agent/reminder_store.py
+++ b/src/puffo_agent/agent/reminder_store.py
@@ -1629,7 +1629,7 @@ class ReminderStoreMixin:
             opaque_payload=opaque_payload,
         ):
             raise LifecycleConflict("replacement identity changed")
-        if replacement.state == "scheduled" and lifecycle != "scheduled":
+        if replacement.state in {"scheduled", "claimed"} and lifecycle != "scheduled":
             await db.execute(
                 """UPDATE reminder_occurrences
                    SET state = ?, actual_fire_at_ms = ?, cancelled_at_ms = ?,
@@ -1640,7 +1640,7 @@ class ReminderStoreMixin:
                        sync_retry_after_ms = NULL, sync_retry_count = 0,
                        sync_permanent_revision = NULL,
                        sync_permanent_code = NULL, snapshot_conflict = 0
-                   WHERE occurrence_id = ? AND state = 'scheduled'""",
+                   WHERE occurrence_id = ? AND state IN ('scheduled', 'claimed')""",
                 (
                     lifecycle,
                     actual_fire_at_ms,

--- a/src/puffo_agent/agent/reminder_store.py
+++ b/src/puffo_agent/agent/reminder_store.py
@@ -321,10 +321,9 @@ class ReminderStoreMixin:
         values = cls._terminal_values(record, lifecycle, lifecycle_at_ms)
         next_state = values[0]
         next_revision = max(record.revision, revision)
-        # A snapshot only acknowledges the lifecycle it actually returned.
-        next_ack_revision = record.server_ack_revision
-        if next_state == lifecycle:
-            next_ack_revision = max(next_ack_revision, revision)
+        # The remote terminal revision is authoritative for future sync even
+        # when a locally committed delivery fact must remain visible.
+        next_ack_revision = max(record.server_ack_revision, revision)
         return (*values, next_revision, next_ack_revision)
 
     async def create_reminder(
@@ -432,6 +431,26 @@ class ReminderStoreMixin:
             return await self._get_reminder_sync_by_occurrence_unlocked(
                 await self._ensure_db(),
                 occurrence_id,
+            )
+
+    async def get_reminder_sync_record_by_reminder_id(
+        self,
+        reminder_id: str,
+    ) -> ReminderSyncRecord | None:
+        """Return the worker-only sync view addressed by the MCP identity."""
+        if not isinstance(reminder_id, str) or not reminder_id:
+            raise ValueError("reminder_id must be a non-empty string")
+        async with self._inbox_lock:
+            db = await self._ensure_db()
+            async with db.execute(
+                "SELECT * FROM reminder_occurrences WHERE reminder_id = ?",
+                (reminder_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            return (
+                self._reminder_sync_record_from_row(row)
+                if row is not None
+                else None
             )
 
     async def persist_reminder_envelope(
@@ -688,6 +707,9 @@ class ReminderStoreMixin:
             or record.sync_retry_count != 0
             or record.sync_permanent_revision is not None
             or record.sync_permanent_code is not None
+            or record.delivery_claim_id is not None
+            or record.delivery_claim_acquired
+            or record.delivery_claim_expires_at_ms is not None
             or record.snapshot_conflict
         )
 
@@ -902,7 +924,8 @@ class ReminderStoreMixin:
                            sync_retry_after_ms = NULL, sync_retry_count = 0,
                            sync_permanent_revision = NULL,
                            sync_permanent_code = NULL,
-                           snapshot_conflict = 0
+                           delivery_claim_id = NULL, delivery_claim_acquired = 0,
+                           delivery_claim_expires_at_ms = NULL, snapshot_conflict = 0
                        WHERE occurrence_id = ?""",
                     (
                         next_state,
@@ -938,12 +961,19 @@ class ReminderStoreMixin:
             raise ValueError(f"limit must be between 1 and {MAX_REMINDER_LIST_LIMIT}")
         async with self._inbox_lock:
             db = await self._ensure_db()
-            if state:
+            if state == "scheduled":
+                query = (
+                    "SELECT * FROM reminder_occurrences "
+                    "WHERE state IN ('scheduled', 'claimed') "
+                    "ORDER BY intended_at_ms, occurrence_id LIMIT ?"
+                )
+                params: tuple[Any, ...] = (limit,)
+            elif state:
                 query = (
                     "SELECT * FROM reminder_occurrences WHERE state = ? "
                     "ORDER BY intended_at_ms, occurrence_id LIMIT ?"
                 )
-                params: tuple[Any, ...] = (state, limit)
+                params = (state, limit)
             else:
                 query = (
                     "SELECT * FROM reminder_occurrences "
@@ -1373,6 +1403,363 @@ class ReminderStoreMixin:
                     delivered.append(occurrence)
             return tuple(delivered)
 
+    @staticmethod
+    def _replacement_terminal_fields(
+        lifecycle: str,
+        lifecycle_at_ms: int,
+    ) -> tuple[int | None, int | None, int | None]:
+        if lifecycle == "scheduled":
+            return None, None, None
+        if lifecycle == "cancelled":
+            return None, lifecycle_at_ms, None
+        if lifecycle == "delivered":
+            return lifecycle_at_ms, None, lifecycle_at_ms
+        raise ValueError("invalid replacement lifecycle")
+
+    @staticmethod
+    def _replacement_matches(
+        record: ReminderSyncRecord,
+        *,
+        reminder_id: str,
+        target: str,
+        content: str,
+        intended_at_ms: int,
+        payload_format: str | None,
+        opaque_payload: bytes | None,
+    ) -> bool:
+        return (
+            record.reminder_id == reminder_id
+            and record.target == target
+            and record.content == content
+            and record.intended_at_ms == intended_at_ms
+            and record.payload_format == payload_format
+            and record.opaque_payload == opaque_payload
+        )
+
+    async def replace_local_reminder(
+        self,
+        *,
+        reminder_id: str,
+        replacement_reminder_id: str,
+        replacement_occurrence_id: str,
+        content: str,
+        target: str,
+        intended_at_ms: int,
+        replaced_at_ms: int,
+    ) -> tuple[ReminderOccurrence, ReminderOccurrence]:
+        """Atomically replace work that has never crossed the remote boundary."""
+        parse_reminder_target(target)
+        if (
+            not content
+            or reminder_plaintext_envelope_size(target, content)
+            > MAX_REMINDER_ENVELOPE_BYTES
+            or not self._valid_reminder_time(intended_at_ms)
+            or not self._valid_reminder_time(replaced_at_ms)
+        ):
+            raise ValueError("invalid reminder replacement")
+        async with self._inbox_lock:
+            db = await self._ensure_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                old = await self._get_reminder_unlocked(db, reminder_id)
+                if old is None:
+                    raise ValueError("unknown reminder_id")
+                record = await self._get_reminder_sync_by_occurrence_unlocked(
+                    db, old.occurrence_id
+                )
+                assert record is not None
+                existing = await self._get_reminder_sync_by_occurrence_unlocked(
+                    db, replacement_occurrence_id
+                )
+                if old.state == "cancelled" and existing is not None:
+                    if not self._replacement_matches(
+                        existing,
+                        reminder_id=replacement_reminder_id,
+                        target=target,
+                        content=content,
+                        intended_at_ms=intended_at_ms,
+                        payload_format=None,
+                        opaque_payload=None,
+                    ):
+                        raise LifecycleConflict("replacement identity changed")
+                    await db.rollback()
+                    return old, self._reminder_from_sync_record(existing)
+                if existing is not None:
+                    raise LifecycleConflict("replacement identity already exists")
+                if old.state != "scheduled" or not record.is_unprepared_local_only:
+                    raise LifecycleConflict(
+                        "reminder replacement conflicts with claimed or remote work"
+                    )
+                await db.execute(
+                    """INSERT INTO reminder_occurrences
+                       (reminder_id, occurrence_id, target, content, intended_at_ms,
+                        state, created_at_ms, revision, server_ack_revision)
+                       VALUES (?, ?, ?, ?, ?, 'scheduled', ?, 1, 0)""",
+                    (
+                        replacement_reminder_id,
+                        replacement_occurrence_id,
+                        target,
+                        content,
+                        intended_at_ms,
+                        replaced_at_ms,
+                    ),
+                )
+                await db.execute(
+                    """UPDATE reminder_occurrences
+                       SET state = 'cancelled', cancelled_at_ms = ?, revision = 2,
+                           sync_retry_after_ms = NULL, sync_retry_count = 0
+                       WHERE reminder_id = ? AND state = 'scheduled'""",
+                    (replaced_at_ms, reminder_id),
+                )
+                await db.commit()
+            except BaseException:
+                await db.rollback()
+                raise
+            cancelled = await self._get_reminder_unlocked(db, reminder_id)
+            replacement = await self._get_reminder_unlocked(
+                db, replacement_reminder_id
+            )
+            assert cancelled is not None and replacement is not None
+            return cancelled, replacement
+
+    @staticmethod
+    def _reminder_from_sync_record(record: ReminderSyncRecord) -> ReminderOccurrence:
+        return ReminderOccurrence(
+            reminder_id=record.reminder_id,
+            occurrence_id=record.occurrence_id,
+            target=record.target,
+            content=record.content,
+            intended_at_ms=record.intended_at_ms,
+            state=record.state,
+            created_at_ms=record.created_at_ms,
+            claimed_at_ms=record.claimed_at_ms,
+            actual_fire_at_ms=record.actual_fire_at_ms,
+            cancelled_at_ms=record.cancelled_at_ms,
+            delivered_at_ms=record.delivered_at_ms,
+            delivered_event_id=record.delivered_event_id,
+        )
+
+    def _validate_remote_replacement_fields(
+        self,
+        *,
+        reminder_id: str,
+        occurrence_id: str,
+        target: str,
+        content: str,
+        intended_at_ms: int,
+        lifecycle: str,
+        lifecycle_at_ms: int,
+        revision: int,
+        payload_format: str,
+        opaque_payload: bytes,
+    ) -> tuple[int | None, int | None, int | None]:
+        self._validate_remote_scheduled_reminder(
+            reminder_id=reminder_id,
+            occurrence_id=occurrence_id,
+            target=target,
+            content=content,
+            intended_at_ms=intended_at_ms,
+            lifecycle_at_ms=lifecycle_at_ms,
+            revision=revision,
+            payload_format=payload_format,
+            opaque_payload=opaque_payload,
+        )
+        if revision != (1 if lifecycle == "scheduled" else 2):
+            raise ValueError("invalid replacement lifecycle revision")
+        return self._replacement_terminal_fields(lifecycle, lifecycle_at_ms)
+
+    async def _upsert_remote_replacement_unlocked(
+        self,
+        db: aiosqlite.Connection,
+        *,
+        reminder_id: str,
+        occurrence_id: str,
+        target: str,
+        content: str,
+        intended_at_ms: int,
+        lifecycle: str,
+        lifecycle_at_ms: int,
+        revision: int,
+        payload_format: str,
+        opaque_payload: bytes,
+        actual_fire_at_ms: int | None,
+        cancelled_at_ms: int | None,
+        delivered_at_ms: int | None,
+    ) -> None:
+        replacement = await self._get_reminder_sync_by_occurrence_unlocked(
+            db, occurrence_id
+        )
+        if replacement is None:
+            await db.execute(
+                """INSERT INTO reminder_occurrences
+                   (reminder_id, occurrence_id, target, content, intended_at_ms,
+                    state, created_at_ms, actual_fire_at_ms, cancelled_at_ms,
+                    delivered_at_ms, revision, server_ack_revision,
+                    payload_format, opaque_payload)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    reminder_id,
+                    occurrence_id,
+                    target,
+                    content,
+                    intended_at_ms,
+                    lifecycle,
+                    lifecycle_at_ms,
+                    actual_fire_at_ms,
+                    cancelled_at_ms,
+                    delivered_at_ms,
+                    revision,
+                    revision,
+                    payload_format,
+                    opaque_payload,
+                ),
+            )
+            return
+        if not self._replacement_matches(
+            replacement,
+            reminder_id=reminder_id,
+            target=target,
+            content=content,
+            intended_at_ms=intended_at_ms,
+            payload_format=payload_format,
+            opaque_payload=opaque_payload,
+        ):
+            raise LifecycleConflict("replacement identity changed")
+        if replacement.state == "scheduled" and lifecycle != "scheduled":
+            await db.execute(
+                """UPDATE reminder_occurrences
+                   SET state = ?, actual_fire_at_ms = ?, cancelled_at_ms = ?,
+                       delivered_at_ms = ?, revision = ?, server_ack_revision = ?,
+                       claimed_at_ms = NULL, delivery_claim_id = NULL,
+                       delivery_claim_acquired = 0,
+                       delivery_claim_expires_at_ms = NULL,
+                       sync_retry_after_ms = NULL, sync_retry_count = 0,
+                       sync_permanent_revision = NULL,
+                       sync_permanent_code = NULL, snapshot_conflict = 0
+                   WHERE occurrence_id = ? AND state = 'scheduled'""",
+                (
+                    lifecycle,
+                    actual_fire_at_ms,
+                    cancelled_at_ms,
+                    delivered_at_ms,
+                    revision,
+                    revision,
+                    occurrence_id,
+                ),
+            )
+
+    @staticmethod
+    async def _cancel_replaced_occurrence_unlocked(
+        db: aiosqlite.Connection,
+        occurrence_id: str,
+        cancelled_at_ms: int,
+    ) -> None:
+        await db.execute(
+            """UPDATE reminder_occurrences
+               SET state = CASE
+                       WHEN state = 'delivered' THEN state
+                       ELSE 'cancelled'
+                   END,
+                   claimed_at_ms = NULL,
+                   actual_fire_at_ms = CASE
+                       WHEN state = 'delivered' THEN actual_fire_at_ms
+                       ELSE NULL
+                   END,
+                   cancelled_at_ms = CASE
+                       WHEN state = 'delivered' THEN cancelled_at_ms
+                       ELSE ?
+                   END,
+                   delivered_at_ms = CASE
+                       WHEN state = 'delivered' THEN delivered_at_ms
+                       ELSE NULL
+                   END,
+                   delivered_event_id = CASE
+                       WHEN state = 'delivered' THEN delivered_event_id
+                       ELSE NULL
+                   END,
+                   revision = MAX(revision, 2),
+                   server_ack_revision = MAX(server_ack_revision, 2),
+                   delivery_claim_id = NULL, delivery_claim_acquired = 0,
+                   delivery_claim_expires_at_ms = NULL,
+                   sync_retry_after_ms = NULL, sync_retry_count = 0,
+                   sync_permanent_revision = NULL,
+                   sync_permanent_code = NULL, snapshot_conflict = 0
+               WHERE occurrence_id = ?""",
+            (cancelled_at_ms, occurrence_id),
+        )
+
+    async def materialize_remote_replacement(
+        self,
+        *,
+        reminder_id: str,
+        occurrence_id: str,
+        cancelled_at_ms: int,
+        replacement_reminder_id: str,
+        replacement_occurrence_id: str,
+        target: str,
+        content: str,
+        intended_at_ms: int,
+        lifecycle: str,
+        lifecycle_at_ms: int,
+        revision: int,
+        payload_format: str,
+        opaque_payload: bytes,
+    ) -> tuple[ReminderOccurrence, ReminderOccurrence]:
+        """Commit one authenticated Server replacement to SQLite atomically."""
+        fields = self._validate_remote_replacement_fields(
+            reminder_id=replacement_reminder_id,
+            occurrence_id=replacement_occurrence_id,
+            target=target,
+            content=content,
+            intended_at_ms=intended_at_ms,
+            lifecycle=lifecycle,
+            lifecycle_at_ms=lifecycle_at_ms,
+            revision=revision,
+            payload_format=payload_format,
+            opaque_payload=opaque_payload,
+        )
+        actual_fire_at_ms, replacement_cancelled_at_ms, delivered_at_ms = fields
+        async with self._inbox_lock:
+            db = await self._ensure_db()
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                old = await self._get_reminder_sync_by_occurrence_unlocked(
+                    db, occurrence_id
+                )
+                if old is None or old.reminder_id != reminder_id:
+                    raise LifecycleConflict("reminder replacement identity changed")
+                if old.state not in {
+                    "scheduled", "claimed", "cancelled", "delivered",
+                }:
+                    raise LifecycleConflict("invalid reminder lifecycle")
+                await self._upsert_remote_replacement_unlocked(
+                    db,
+                    reminder_id=replacement_reminder_id,
+                    occurrence_id=replacement_occurrence_id,
+                    target=target,
+                    content=content,
+                    intended_at_ms=intended_at_ms,
+                    lifecycle=lifecycle,
+                    lifecycle_at_ms=lifecycle_at_ms,
+                    revision=revision,
+                    payload_format=payload_format,
+                    opaque_payload=opaque_payload,
+                    actual_fire_at_ms=actual_fire_at_ms,
+                    cancelled_at_ms=replacement_cancelled_at_ms,
+                    delivered_at_ms=delivered_at_ms,
+                )
+                await self._cancel_replaced_occurrence_unlocked(
+                    db, occurrence_id, cancelled_at_ms
+                )
+                await db.commit()
+            except BaseException:
+                await db.rollback()
+                raise
+            cancelled = await self._get_reminder_unlocked(db, reminder_id)
+            created = await self._get_reminder_unlocked(db, replacement_reminder_id)
+            assert cancelled is not None and created is not None
+            return cancelled, created
+
     async def cancel_reminder(
         self,
         reminder_id: str,
@@ -1399,8 +1786,8 @@ class ReminderStoreMixin:
                     reminder.occurrence_id,
                 )
                 assert record is not None
-                if reminder.state == "claimed" or (
-                    reminder.state == "scheduled"
+                if (
+                    reminder.state in {"scheduled", "claimed"}
                     and not record.is_unprepared_local_only
                 ):
                     raise LifecycleConflict(
@@ -1410,6 +1797,7 @@ class ReminderStoreMixin:
                     cursor = await db.execute(
                         """UPDATE reminder_occurrences
                            SET state = 'cancelled', cancelled_at_ms = ?,
+                               claimed_at_ms = NULL, actual_fire_at_ms = NULL,
                                revision = revision + 1,
                                delivery_claim_id = NULL,
                                delivery_claim_acquired = 0,

--- a/src/puffo_agent/agent/reminder_store.py
+++ b/src/puffo_agent/agent/reminder_store.py
@@ -1547,6 +1547,7 @@ class ReminderStoreMixin:
         target: str,
         content: str,
         intended_at_ms: int,
+        created_at_ms: int,
         lifecycle: str,
         lifecycle_at_ms: int,
         revision: int,
@@ -1564,6 +1565,8 @@ class ReminderStoreMixin:
             payload_format=payload_format,
             opaque_payload=opaque_payload,
         )
+        if not self._valid_reminder_time(created_at_ms):
+            raise ValueError("invalid replacement creation time")
         if revision != (1 if lifecycle == "scheduled" else 2):
             raise ValueError("invalid replacement lifecycle revision")
         return self._replacement_terminal_fields(lifecycle, lifecycle_at_ms)
@@ -1577,6 +1580,7 @@ class ReminderStoreMixin:
         target: str,
         content: str,
         intended_at_ms: int,
+        created_at_ms: int,
         lifecycle: str,
         lifecycle_at_ms: int,
         revision: int,
@@ -1604,7 +1608,7 @@ class ReminderStoreMixin:
                     content,
                     intended_at_ms,
                     lifecycle,
-                    lifecycle_at_ms,
+                    created_at_ms,
                     actual_fire_at_ms,
                     cancelled_at_ms,
                     delivered_at_ms,
@@ -1699,6 +1703,7 @@ class ReminderStoreMixin:
         target: str,
         content: str,
         intended_at_ms: int,
+        replacement_created_at_ms: int,
         lifecycle: str,
         lifecycle_at_ms: int,
         revision: int,
@@ -1712,6 +1717,7 @@ class ReminderStoreMixin:
             target=target,
             content=content,
             intended_at_ms=intended_at_ms,
+            created_at_ms=replacement_created_at_ms,
             lifecycle=lifecycle,
             lifecycle_at_ms=lifecycle_at_ms,
             revision=revision,
@@ -1739,6 +1745,7 @@ class ReminderStoreMixin:
                     target=target,
                     content=content,
                     intended_at_ms=intended_at_ms,
+                    created_at_ms=replacement_created_at_ms,
                     lifecycle=lifecycle,
                     lifecycle_at_ms=lifecycle_at_ms,
                     revision=revision,

--- a/src/puffo_agent/agent/reminder_sync.py
+++ b/src/puffo_agent/agent/reminder_sync.py
@@ -786,7 +786,9 @@ class ReminderSync:
         existing_result = await self._existing_replacement_result(record, intent)
         if existing_result is not None:
             return existing_result
-        if record.state in {"cancelled", "delivered"}:
+        if record.state == "delivered" or (
+            record.state == "cancelled" and record.server_ack_revision < 1
+        ):
             raise LifecycleConflict("reminder delivery already started or was replaced")
         replaced_at_ms = int(self._now_ms())
         if record.is_unprepared_local_only:
@@ -807,7 +809,9 @@ class ReminderSync:
                 )
                 if existing_result is not None:
                     return existing_result
-                if record.state in {"cancelled", "delivered"}:
+                if record.state == "delivered" or (
+                    record.state == "cancelled" and record.server_ack_revision < 1
+                ):
                     raise LifecycleConflict(
                         "reminder delivery already started or was replaced"
                     ) from local_conflict

--- a/src/puffo_agent/agent/reminder_sync.py
+++ b/src/puffo_agent/agent/reminder_sync.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -25,6 +27,7 @@ from .message_store import (
     LifecycleConflict,
     MAX_REMINDER_ENVELOPE_BYTES,
     MessageStore,
+    ReminderOccurrence,
     ReminderSyncRecord,
     parse_reminder_target,
     reminder_time_to_rfc3339,
@@ -50,6 +53,7 @@ DELIVERY_CLAIM_RETRY_MS = 5_000
 MIN_DELIVERY_LEASE_REMAINING_MS = 5_000
 SNAPSHOT_REQUEST_TIMEOUT_SECONDS = 10.0
 CLAIM_REQUEST_TIMEOUT_SECONDS = 10.0
+MUTATION_REQUEST_TIMEOUT_SECONDS = 10.0
 SYNC_IDLE_SECONDS = 30.0
 
 _ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
@@ -291,6 +295,15 @@ class _RemoteOccurrence:
     content: str | None
 
 
+@dataclass(frozen=True)
+class _ReplacementIntent:
+    reminder_id: str
+    occurrence_id: str
+    target: str
+    content: str
+    intended_at_ms: int
+
+
 class ReminderSync:
     """Small provider-neutral outbox + snapshot state machine."""
 
@@ -306,6 +319,7 @@ class ReminderSync:
         idle_seconds: float = SYNC_IDLE_SECONDS,
         snapshot_request_timeout_seconds: float = SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
         claim_request_timeout_seconds: float = CLAIM_REQUEST_TIMEOUT_SECONDS,
+        mutation_request_timeout_seconds: float = MUTATION_REQUEST_TIMEOUT_SECONDS,
     ) -> None:
         self.store = store
         self.owner_slug = _validate_owner(owner_slug)
@@ -318,6 +332,9 @@ class ReminderSync:
         )
         self._claim_request_timeout_seconds = max(
             0.01, float(claim_request_timeout_seconds)
+        )
+        self._mutation_request_timeout_seconds = max(
+            0.01, float(mutation_request_timeout_seconds)
         )
         # This is the sole custody call.  Nothing in this object logs or
         # returns these bytes; only the AEAD helpers receive them.
@@ -441,6 +458,386 @@ class ReminderSync:
                 raise ReminderContractError("missing keyless reminder transport")
             return await method(path, body)
         return await self.http_client.post(path, body)
+
+    @staticmethod
+    def _http_error_code(exc: HttpError) -> str:
+        try:
+            body = json.loads(exc.body)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return ""
+        code = body.get("error") if isinstance(body, Mapping) else None
+        return code if isinstance(code, str) else ""
+
+    def _replacement_ids(
+        self,
+        *,
+        occurrence_id: str,
+        target: str,
+        content: str,
+        intended_at_ms: int,
+    ) -> tuple[str, str]:
+        intent = _canonical_json({
+            "content": content,
+            "intended_at": _canonical_utc(intended_at_ms),
+            "occurrence_id": occurrence_id,
+            "target": target,
+        })
+
+        def identifier(kind: bytes) -> str:
+            digest = hmac.new(self._dek, kind + b"\0" + intent, hashlib.sha256).digest()
+            return str(uuid.UUID(bytes=digest[:16], version=4))
+
+        return (
+            f"reminder-{identifier(b'reminder')}",
+            f"occurrence-{identifier(b'occurrence')}",
+        )
+
+    async def _record_by_reminder_id(self, reminder_id: str) -> ReminderSyncRecord:
+        record = await self.store.get_reminder_sync_record_by_reminder_id(reminder_id)
+        if record is None:
+            raise ValueError("unknown reminder_id")
+        return record
+
+    async def _ensure_remote_scheduled(
+        self,
+        record: ReminderSyncRecord,
+    ) -> ReminderSyncRecord:
+        prepared = await self._ensure_envelope(record)
+        if prepared.server_ack_revision >= 1:
+            return prepared
+        body = self._put_body(prepared)
+        response = await asyncio.wait_for(
+            self._put(f"{self.route_prefix}/{prepared.occurrence_id}", body),
+            timeout=self._mutation_request_timeout_seconds,
+        )
+        self._validate_put_response(response, prepared, body)
+        await self.store.acknowledge_reminder_sync_revision(
+            occurrence_id=prepared.occurrence_id,
+            revision=1,
+        )
+        refreshed = await self.store.get_reminder_sync_record(
+            prepared.occurrence_id
+        )
+        if refreshed is None:
+            raise LifecycleConflict("reminder identity changed")
+        return refreshed
+
+    def _validate_cancel_response(
+        self,
+        response: Any,
+        record: ReminderSyncRecord,
+    ) -> _RemoteOccurrence:
+        remote = self._validate_snapshot_row(response)
+        if (
+            remote.occurrence_id != record.occurrence_id
+            or remote.reminder_id != record.reminder_id
+            or remote.intended_at_ms != record.intended_at_ms
+            or remote.lifecycle != "cancelled"
+            or remote.revision != 2
+        ):
+            raise ReminderContractError("invalid reminder cancellation response")
+        return remote
+
+    async def cancel_reminder(self, reminder_id: str) -> ReminderOccurrence:
+        """Cancel locally untouched work or coordinate a remote terminal write."""
+        record = await self._record_by_reminder_id(reminder_id)
+        if record.state == "cancelled":
+            reminder = await self.store.get_reminder(reminder_id)
+            assert reminder is not None
+            return reminder
+        if record.state == "delivered":
+            raise LifecycleConflict("reminder delivery already started")
+        if record.is_unprepared_local_only:
+            try:
+                return await self.store.cancel_reminder(reminder_id)
+            except LifecycleConflict:
+                record = await self._record_by_reminder_id(reminder_id)
+                if record.state == "cancelled":
+                    reminder = await self.store.get_reminder(reminder_id)
+                    assert reminder is not None
+                    return reminder
+                if record.state == "delivered":
+                    raise LifecycleConflict("reminder delivery already started")
+
+        prepared = await self._ensure_envelope(record)
+        if prepared.opaque_payload is None:
+            raise ReminderEnvelopeError("invalid opaque envelope")
+        cancelled_at_ms = int(self._now_ms())
+        body = {
+            "revision": 2,
+            "delivery_claim_id": None,
+            "reminder_id": prepared.reminder_id,
+            "due_at": _canonical_utc(prepared.intended_at_ms),
+            "lifecycle": "cancelled",
+            "lifecycle_at": _canonical_utc(cancelled_at_ms),
+            "payload_format": prepared.payload_format,
+            "opaque_payload": _base64url_encode(prepared.opaque_payload),
+        }
+        try:
+            response = await asyncio.wait_for(
+                self._put(f"{self.route_prefix}/{prepared.occurrence_id}", body),
+                timeout=self._mutation_request_timeout_seconds,
+            )
+            remote = self._validate_cancel_response(response, prepared)
+        except asyncio.CancelledError:
+            raise
+        except HttpError as exc:
+            self.signal_snapshot()
+            if exc.status == 409 and self._http_error_code(exc) == "too_late":
+                raise LifecycleConflict("reminder delivery already started") from exc
+            raise RuntimeError("reminder cancellation could not be confirmed") from exc
+        except (asyncio.TimeoutError, TimeoutError, OSError) as exc:
+            self.signal_snapshot()
+            raise RuntimeError("reminder cancellation could not be confirmed") from exc
+        except ReminderContractError:
+            self.signal_snapshot()
+            raise
+        except Exception as exc:
+            self.signal_snapshot()
+            raise RuntimeError("reminder cancellation could not be confirmed") from exc
+        result = await self.store.materialize_remote_terminal_reminder(
+            reminder_id=remote.reminder_id,
+            occurrence_id=remote.occurrence_id,
+            intended_at_ms=remote.intended_at_ms,
+            lifecycle=remote.lifecycle,
+            lifecycle_at_ms=remote.lifecycle_at_ms,
+            revision=remote.revision,
+            payload_format=remote.payload_format,
+        )
+        if result.conflict:
+            raise LifecycleConflict("reminder cancellation conflicted locally")
+        reminder = await self.store.get_reminder(reminder_id)
+        assert reminder is not None
+        if reminder.state != "cancelled":
+            raise LifecycleConflict("reminder delivery already started")
+        return reminder
+
+    def _validate_replacement_response(
+        self,
+        response: Any,
+        *,
+        old: ReminderSyncRecord,
+        replacement_reminder_id: str,
+        replacement_occurrence_id: str,
+        target: str,
+        content: str,
+        intended_at_ms: int,
+    ) -> tuple[_RemoteOccurrence, _RemoteOccurrence]:
+        if not isinstance(response, Mapping) or set(response) != {
+            "cancelled", "replacement",
+        }:
+            raise ReminderContractError("invalid reminder replacement response")
+        cancelled = self._validate_snapshot_row(response["cancelled"])
+        replacement = self._validate_snapshot_row(response["replacement"])
+        if (
+            cancelled.occurrence_id != old.occurrence_id
+            or cancelled.reminder_id != old.reminder_id
+            or cancelled.intended_at_ms != old.intended_at_ms
+            or cancelled.lifecycle != "cancelled"
+            or replacement.occurrence_id != replacement_occurrence_id
+            or replacement.reminder_id != replacement_reminder_id
+            or replacement.intended_at_ms != intended_at_ms
+        ):
+            raise ReminderContractError("invalid reminder replacement response")
+        if replacement.lifecycle == "scheduled":
+            if replacement.target != target or replacement.content != content:
+                raise ReminderContractError("invalid reminder replacement response")
+        elif replacement.lifecycle not in {"cancelled", "delivered"}:
+            raise ReminderContractError("invalid reminder replacement response")
+        return cancelled, replacement
+
+    def _replacement_intent(
+        self,
+        record: ReminderSyncRecord,
+        *,
+        content: str | None,
+        target: str | None,
+        intended_at_ms: int | None,
+    ) -> _ReplacementIntent:
+        replacement_content = content if content is not None else record.content
+        replacement_target = target if target is not None else record.target
+        replacement_time = (
+            intended_at_ms if intended_at_ms is not None else record.intended_at_ms
+        )
+        if (
+            replacement_content == record.content
+            and replacement_target == record.target
+            and replacement_time == record.intended_at_ms
+        ):
+            raise ValueError("replacement must change content, target, or intended_at")
+        parse_reminder_target(replacement_target)
+        reminder_id, occurrence_id = self._replacement_ids(
+            occurrence_id=record.occurrence_id,
+            target=replacement_target,
+            content=replacement_content,
+            intended_at_ms=replacement_time,
+        )
+        return _ReplacementIntent(
+            reminder_id=reminder_id,
+            occurrence_id=occurrence_id,
+            target=replacement_target,
+            content=replacement_content,
+            intended_at_ms=replacement_time,
+        )
+
+    async def _existing_replacement_result(
+        self,
+        record: ReminderSyncRecord,
+        intent: _ReplacementIntent,
+    ) -> tuple[ReminderOccurrence, ReminderOccurrence] | None:
+        if record.state != "cancelled":
+            return None
+        existing = await self.store.get_reminder_sync_record(intent.occurrence_id)
+        if existing is None:
+            return None
+        if (
+            existing.reminder_id != intent.reminder_id
+            or existing.target != intent.target
+            or existing.content != intent.content
+            or existing.intended_at_ms != intent.intended_at_ms
+        ):
+            raise LifecycleConflict("replacement identity changed")
+        cancelled = await self.store.get_reminder(record.reminder_id)
+        replacement = await self.store.get_reminder(intent.reminder_id)
+        if cancelled is None or replacement is None:
+            raise LifecycleConflict("replacement identity changed")
+        return cancelled, replacement
+
+    async def _perform_remote_replacement(
+        self,
+        record: ReminderSyncRecord,
+        intent: _ReplacementIntent,
+        replaced_at_ms: int,
+    ) -> tuple[ReminderOccurrence, ReminderOccurrence]:
+        prepared = await self._ensure_remote_scheduled(record)
+        envelope = encrypt_reminder_payload(
+            dek=self._dek,
+            owner_slug=self.owner_slug,
+            reminder_id=intent.reminder_id,
+            occurrence_id=intent.occurrence_id,
+            intended_at_ms=intent.intended_at_ms,
+            target=intent.target,
+            content=intent.content,
+        )
+        replacement_body: dict[str, object] = {
+            "revision": 1,
+            "delivery_claim_id": None,
+            "reminder_id": intent.reminder_id,
+            "due_at": _canonical_utc(intent.intended_at_ms),
+            "lifecycle": "scheduled",
+            "lifecycle_at": _canonical_utc(replaced_at_ms),
+            "payload_format": REMINDER_PAYLOAD_FORMAT,
+            "opaque_payload": _base64url_encode(envelope),
+        }
+        response = await asyncio.wait_for(
+            self._post(
+                f"{self.route_prefix}/{prepared.occurrence_id}/replace",
+                {
+                    "expected_revision": 1,
+                    "cancelled_at": _canonical_utc(replaced_at_ms),
+                    "replacement_occurrence_id": intent.occurrence_id,
+                    "replacement": replacement_body,
+                },
+            ),
+            timeout=self._mutation_request_timeout_seconds,
+        )
+        cancelled, replacement = self._validate_replacement_response(
+            response,
+            old=prepared,
+            replacement_reminder_id=intent.reminder_id,
+            replacement_occurrence_id=intent.occurrence_id,
+            target=intent.target,
+            content=intent.content,
+            intended_at_ms=intent.intended_at_ms,
+        )
+        materialized_envelope = replacement.opaque_payload or envelope
+        return await self.store.materialize_remote_replacement(
+            reminder_id=prepared.reminder_id,
+            occurrence_id=prepared.occurrence_id,
+            cancelled_at_ms=cancelled.lifecycle_at_ms,
+            replacement_reminder_id=intent.reminder_id,
+            replacement_occurrence_id=intent.occurrence_id,
+            target=intent.target,
+            content=intent.content,
+            intended_at_ms=intent.intended_at_ms,
+            lifecycle=replacement.lifecycle,
+            lifecycle_at_ms=replacement.lifecycle_at_ms,
+            revision=replacement.revision,
+            payload_format=REMINDER_PAYLOAD_FORMAT,
+            opaque_payload=materialized_envelope,
+        )
+
+    async def replace_reminder(
+        self,
+        reminder_id: str,
+        content: str | None,
+        target: str | None,
+        intended_at_ms: int | None,
+    ) -> tuple[ReminderOccurrence, ReminderOccurrence]:
+        """Replace one reminder while preserving Server and SQLite atomicity."""
+        record = await self._record_by_reminder_id(reminder_id)
+        intent = self._replacement_intent(
+            record,
+            content=content,
+            target=target,
+            intended_at_ms=intended_at_ms,
+        )
+        existing_result = await self._existing_replacement_result(record, intent)
+        if existing_result is not None:
+            return existing_result
+        if record.state in {"cancelled", "delivered"}:
+            raise LifecycleConflict("reminder delivery already started or was replaced")
+        replaced_at_ms = int(self._now_ms())
+        if record.is_unprepared_local_only:
+            try:
+                return await self.store.replace_local_reminder(
+                    reminder_id=reminder_id,
+                    replacement_reminder_id=intent.reminder_id,
+                    replacement_occurrence_id=intent.occurrence_id,
+                    content=intent.content,
+                    target=intent.target,
+                    intended_at_ms=intent.intended_at_ms,
+                    replaced_at_ms=replaced_at_ms,
+                )
+            except LifecycleConflict as local_conflict:
+                record = await self._record_by_reminder_id(reminder_id)
+                existing_result = await self._existing_replacement_result(
+                    record, intent
+                )
+                if existing_result is not None:
+                    return existing_result
+                if record.state in {"cancelled", "delivered"}:
+                    raise LifecycleConflict(
+                        "reminder delivery already started or was replaced"
+                    ) from local_conflict
+                if record.is_unprepared_local_only:
+                    raise
+
+        try:
+            return await self._perform_remote_replacement(
+                record, intent, replaced_at_ms
+            )
+        except asyncio.CancelledError:
+            raise
+        except HttpError as exc:
+            self.signal_snapshot()
+            code = self._http_error_code(exc)
+            if exc.status == 409 and code == "too_late":
+                raise LifecycleConflict("reminder delivery already started") from exc
+            if exc.status == 409:
+                raise LifecycleConflict("reminder replacement conflicts with current state") from exc
+            raise RuntimeError("reminder replacement could not be confirmed") from exc
+        except (asyncio.TimeoutError, TimeoutError, OSError) as exc:
+            self.signal_snapshot()
+            raise RuntimeError("reminder replacement could not be confirmed") from exc
+        except ReminderContractError:
+            self.signal_snapshot()
+            raise
+        except (LifecycleConflict, ReminderEnvelopeError, ValueError):
+            raise
+        except Exception as exc:
+            self.signal_snapshot()
+            raise RuntimeError("reminder replacement could not be confirmed") from exc
 
     def _validate_delivery_claim_response(
         self, response: Any, record: ReminderSyncRecord,
@@ -936,6 +1333,10 @@ async def prepare_reminder_sync(
     )
     runtime.reminder_scheduler.set_lifecycle_committed_callback(
         reminder_sync.signal_lifecycle_committed
+    )
+    runtime.reminder_scheduler.set_mutation_handlers(
+        cancel=reminder_sync.cancel_reminder,
+        replace=reminder_sync.replace_reminder,
     )
     register = register_connected or client.add_connected_callback
     register(reminder_sync.on_transport_connected)

--- a/src/puffo_agent/agent/reminder_sync.py
+++ b/src/puffo_agent/agent/reminder_sync.py
@@ -595,20 +595,31 @@ class ReminderSync:
         except Exception as exc:
             self.signal_snapshot()
             raise RuntimeError("reminder cancellation could not be confirmed") from exc
-        result = await self.store.materialize_remote_terminal_reminder(
-            reminder_id=remote.reminder_id,
-            occurrence_id=remote.occurrence_id,
-            intended_at_ms=remote.intended_at_ms,
-            lifecycle=remote.lifecycle,
-            lifecycle_at_ms=remote.lifecycle_at_ms,
-            revision=remote.revision,
-            payload_format=remote.payload_format,
-        )
+        try:
+            result = await self.store.materialize_remote_terminal_reminder(
+                reminder_id=remote.reminder_id,
+                occurrence_id=remote.occurrence_id,
+                intended_at_ms=remote.intended_at_ms,
+                lifecycle=remote.lifecycle,
+                lifecycle_at_ms=remote.lifecycle_at_ms,
+                revision=remote.revision,
+                payload_format=remote.payload_format,
+            )
+        except asyncio.CancelledError:
+            raise
+        except (LifecycleConflict, ValueError):
+            self.signal_snapshot()
+            raise
+        except Exception as exc:
+            self.signal_snapshot()
+            raise RuntimeError("reminder cancellation could not be confirmed") from exc
         if result.conflict:
+            self.signal_snapshot()
             raise LifecycleConflict("reminder cancellation conflicted locally")
         reminder = await self.store.get_reminder(reminder_id)
         assert reminder is not None
         if reminder.state != "cancelled":
+            self.signal_snapshot()
             raise LifecycleConflict("reminder delivery already started")
         return reminder
 

--- a/src/puffo_agent/agent/reminder_sync.py
+++ b/src/puffo_agent/agent/reminder_sync.py
@@ -760,6 +760,7 @@ class ReminderSync:
             target=intent.target,
             content=intent.content,
             intended_at_ms=intent.intended_at_ms,
+            replacement_created_at_ms=cancelled.lifecycle_at_ms,
             lifecycle=replacement.lifecycle,
             lifecycle_at_ms=replacement.lifecycle_at_ms,
             revision=replacement.revision,

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -261,13 +261,17 @@ class PuffoRpcClient:
 
     @staticmethod
     def _validate_reminder_object(data: dict[str, Any]) -> dict[str, Any]:
+        # During a rolling local upgrade, a new MCP subprocess can briefly
+        # talk to an older daemon that still exposed this internal state.
+        if data.get("state") == "claimed":
+            data = {**data, "state": "scheduled"}
         required = {
             "reminder_id", "occurrence_id", "state", "target", "content",
             "intended_at", "actual_fire_at", "created_at", "cancelled_at",
             "delivered_at",
         }
         if set(data) != required or data.get("state") not in {
-            "scheduled", "claimed", "cancelled", "delivered",
+            "scheduled", "cancelled", "delivered",
         } or not all(
             isinstance(data.get(key), str)
             for key in (
@@ -308,6 +312,34 @@ class PuffoRpcClient:
         return self._validate_reminder_object(await self._post_object(
             "cancel-reminder", {"reminder_id": reminder_id},
         ))
+
+    async def replace_reminder(
+        self,
+        *,
+        reminder_id: str,
+        content: str = "",
+        target: str = "",
+        intended_at: str = "",
+    ) -> dict[str, Any]:
+        data = await self._post_object(
+            "replace-reminder",
+            {
+                "reminder_id": reminder_id,
+                "content": content,
+                "target": target,
+                "intended_at": intended_at,
+            },
+        )
+        if set(data) != {"cancelled", "replacement"}:
+            raise RuntimeError("rpc replace reminder returned an invalid result")
+        cancelled = data["cancelled"]
+        replacement = data["replacement"]
+        if not isinstance(cancelled, dict) or not isinstance(replacement, dict):
+            raise RuntimeError("rpc replace reminder returned an invalid result")
+        return {
+            "cancelled": self._validate_reminder_object(cancelled),
+            "replacement": self._validate_reminder_object(replacement),
+        }
 
     async def install_mcp(
         self,

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -264,7 +264,7 @@ class PuffoRpcClient:
         # During a rolling local upgrade, a new MCP subprocess can briefly
         # talk to an older daemon that still exposed this internal state.
         if data.get("state") == "claimed":
-            data = {**data, "state": "scheduled"}
+            data = {**data, "state": "scheduled", "actual_fire_at": None}
         required = {
             "reminder_id", "occurrence_id", "state", "target", "content",
             "intended_at", "actual_fire_at", "created_at", "cancelled_at",

--- a/src/puffo_agent/mcp/core_inbox_tools.py
+++ b/src/puffo_agent/mcp/core_inbox_tools.py
@@ -67,10 +67,8 @@ def register_reminder_tools(mcp: FastMCP, cfg: Any) -> None:
         """Create one durable local reminder for a canonical Inbox target.
 
         ``intended_at`` is an explicit-offset RFC3339 timestamp. The result
-        is a provider-neutral reminder object. Reminders are immutable and
-        single-fire; replace a pending reminder by cancelling it and creating
-        another. A due occurrence enters the ordinary durable Inbox and leaves
-        any action decision to the model.
+        is a provider-neutral reminder object. A due occurrence enters the
+        ordinary durable Inbox and leaves any action decision to the model.
         """
         runtime = getattr(cfg, "inbox_runtime", None)
         if runtime is None:
@@ -114,7 +112,7 @@ def register_reminder_tools(mcp: FastMCP, cfg: Any) -> None:
 
     @mcp.tool()
     async def cancel_reminder(reminder_id: str) -> dict[str, Any]:
-        """Idempotently cancel a local reminder that has not delivered."""
+        """Idempotently cancel a reminder whose delivery has not started."""
         runtime = getattr(cfg, "inbox_runtime", None)
         if runtime is None:
             runtime = getattr(
@@ -129,7 +127,47 @@ def register_reminder_tools(mcp: FastMCP, cfg: Any) -> None:
         raise RuntimeError("global Inbox runtime is unavailable")
 
 
+def register_reminder_replace_tool(mcp: FastMCP, cfg: Any) -> None:
+    @mcp.tool()
+    async def replace_reminder(
+        reminder_id: str,
+        content: str = "",
+        target: str = "",
+        intended_at: str = "",
+    ) -> dict[str, Any]:
+        """Atomically replace one scheduled reminder.
+
+        Supply one or more changed fields; empty fields inherit the existing
+        value. ``intended_at`` uses explicit-offset RFC3339. The result contains
+        the cancelled reminder and its scheduled replacement. Delivery that
+        already started is never revoked.
+        """
+        runtime = getattr(cfg, "inbox_runtime", None)
+        if runtime is None:
+            runtime = getattr(
+                getattr(cfg, "message_client", None),
+                "global_runtime",
+                None,
+            )
+        if runtime is not None:
+            return await runtime.replace_reminder(
+                reminder_id=reminder_id,
+                content=content,
+                target=target,
+                intended_at=intended_at,
+            )
+        if cfg.rpc_client is not None:
+            return await cfg.rpc_client.replace_reminder(
+                reminder_id=reminder_id,
+                content=content,
+                target=target,
+                intended_at=intended_at,
+            )
+        raise RuntimeError("global Inbox runtime is unavailable")
+
+
 def register_inbox_tools(mcp: FastMCP, cfg: Any) -> None:
     """Register Inbox and reminder tools in their established order."""
     register_inbox_read_tool(mcp, cfg)
     register_reminder_tools(mcp, cfg)
+    register_reminder_replace_tool(mcp, cfg)

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -754,6 +754,25 @@ async def cancel_reminder(
     return await runtime.cancel_reminder(reminder_id=reminder_id)
 
 
+async def replace_reminder(
+    ctx: HostMcpContext,
+    *,
+    reminder_id: str,
+    content: str = "",
+    target: str = "",
+    intended_at: str = "",
+) -> dict[str, object]:
+    runtime = getattr(ctx.message_client, "global_runtime", None)
+    if runtime is None:
+        raise RuntimeError("global Inbox runtime is unavailable")
+    return await runtime.replace_reminder(
+        reminder_id=reminder_id,
+        content=content,
+        target=target,
+        intended_at=intended_at,
+    )
+
+
 async def request_command_permission(
     ctx: HostMcpContext,
     *,

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -12,7 +12,11 @@ from typing import Awaitable, Callable, Optional
 
 from aiohttp import web
 
-from ..agent.message_store import MAX_REMINDER_LIST_LIMIT, REMINDER_STATES, parse_reminder_target
+from ..agent.message_store import (
+    MAX_REMINDER_LIST_LIMIT,
+    PUBLIC_REMINDER_STATES,
+    parse_reminder_target,
+)
 from ..agent.message_store_models import LifecycleConflict
 from ..agent.reminder_scheduler import normalize_reminder_timestamp
 from . import host_mcp_handler
@@ -412,7 +416,9 @@ async def list_reminders_route(request: web.Request) -> web.Response:
         )
     state = body.get("state", "")
     limit = body.get("limit", 50)
-    if not isinstance(state, str) or (state and state not in REMINDER_STATES):
+    if not isinstance(state, str) or (
+        state and state not in PUBLIC_REMINDER_STATES
+    ):
         return web.json_response(
             {"error": "state must be empty or a reminder state"}, status=400,
         )
@@ -465,6 +471,52 @@ async def cancel_reminder_route(request: web.Request) -> web.Response:
         return web.json_response({"error": f"handler raised: {exc}"}, status=500)
 
 
+async def replace_reminder_route(request: web.Request) -> web.Response:
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "body must be JSON"}, status=400)
+    expected = {"reminder_id", "content", "target", "intended_at"}
+    if not isinstance(body, dict) or set(body) != expected:
+        return web.json_response(
+            {"error": "replace_reminder accepts reminder_id and replacement fields"},
+            status=400,
+        )
+    if not all(isinstance(body[field], str) for field in expected):
+        return web.json_response(
+            {"error": "replacement fields must be strings"}, status=400
+        )
+    if not body["reminder_id"] or not any(
+        body[field] for field in ("content", "target", "intended_at")
+    ):
+        return web.json_response(
+            {"error": "replace_reminder requires an id and one changed field"},
+            status=400,
+        )
+    try:
+        if body["target"]:
+            parse_reminder_target(body["target"])
+        if body["intended_at"]:
+            _ms, body["intended_at"] = normalize_reminder_timestamp(
+                body["intended_at"]
+            )
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    ctx = _warm_context(request.match_info["agent_id"])
+    if ctx is None:
+        return web.json_response({"error": "no warm worker"}, status=503)
+    try:
+        result = await host_mcp_handler.replace_reminder(ctx, **body)
+    except LifecycleConflict as exc:
+        return web.json_response({"error": str(exc)}, status=409)
+    except (RuntimeError, ValueError) as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    except Exception as exc:
+        logger.exception("rpc-service: replace reminder failed")
+        return web.json_response({"error": f"handler raised: {exc}"}, status=500)
+    return web.json_response(result)
+
+
 def build_app(cfg: RpcServiceConfig) -> web.Application:
     app = web.Application(middlewares=[require_local_service_auth])
     app.router.add_post(
@@ -506,6 +558,10 @@ def build_app(cfg: RpcServiceConfig) -> web.Application:
     app.router.add_post(
         "/v1/rpc/{agent_id}/cancel-reminder",
         cancel_reminder_route,
+    )
+    app.router.add_post(
+        "/v1/rpc/{agent_id}/replace-reminder",
+        replace_reminder_route,
     )
     return app
 

--- a/src/puffo_agent/portal/ws_local/tool_dispatch.py
+++ b/src/puffo_agent/portal/ws_local/tool_dispatch.py
@@ -28,6 +28,7 @@ WS_LOCAL_ALLOWED_TOOLS: frozenset[str] = frozenset({
     "create_reminder",
     "list_reminders",
     "cancel_reminder",
+    "replace_reminder",
     "get_user_info",
     "whoami",
     "get_post",

--- a/tests/test_message_store_context_and_reminders.py
+++ b/tests/test_message_store_context_and_reminders.py
@@ -568,15 +568,13 @@ async def test_reminder_restart_boundaries_and_cancellation_are_atomic(tmp_path,
         content="claimed cancel", target="channel:sp:ch", intended_at_ms=1,
     )
     await reopened.claim_due_reminders(now_ms=3_500)
-    with pytest.raises(LifecycleConflict):
-        await reopened.cancel_reminder(claimed_cancel.reminder_id)
-    assert [
-        item.reminder_id
-        for item in await reopened.deliver_due_reminders(now_ms=5_000)
-    ] == [claimed_cancel.reminder_id]
+    cancelled_claim = await reopened.cancel_reminder(claimed_cancel.reminder_id)
+    assert cancelled_claim.state == "cancelled"
+    assert cancelled_claim.actual_fire_at_ms is None
+    assert not await reopened.deliver_due_reminders(now_ms=5_000)
     assert await reopened.get_message_by_envelope(
         f"reminder-occurrence:{claimed_cancel.occurrence_id}"
-    ) is not None
+    ) is None
 
     delivered = await reopened.create_reminder(
         content="history stays", target="channel:sp:ch", intended_at_ms=1,
@@ -607,9 +605,15 @@ async def test_claimed_cancel_delivery_race_serializes_to_one_valid_terminal_sta
     event = await store.get_message_by_envelope(
         f"reminder-occurrence:{reminder.occurrence_id}"
     )
-    assert terminal.state == "delivered" and event is not None
-    assert len(delivered) == 1
-    assert isinstance(cancel, LifecycleConflict) or cancel.state == "delivered"
+    assert terminal.state in {"cancelled", "delivered"}
+    if terminal.state == "cancelled":
+        assert event is None
+        assert not delivered
+        assert cancel.state == "cancelled"
+    else:
+        assert event is not None
+        assert len(delivered) == 1
+        assert isinstance(cancel, LifecycleConflict) or cancel.state == "delivered"
     await store.close()
 
 

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -468,11 +468,15 @@ async def test_reminder_tools_have_exact_semantic_schemas_and_live_dispatch():
             calls.append(("cancel", kwargs))
             return {**reminder, "state": "cancelled", "cancelled_at": "2026-08-02T11:01:00.000Z"}
 
+        async def replace_reminder(self, **kwargs):
+            calls.append(("replace", kwargs))
+            return {"cancelled": reminder, "replacement": {**reminder, "content": "new"}}
+
     cfg.inbox_runtime = Runtime()
     mcp = _build_tools(cfg)
     tools = {tool.name: tool for tool in await mcp.list_tools()}
     assert set(tools).issuperset({
-        "create_reminder", "list_reminders", "cancel_reminder",
+        "create_reminder", "list_reminders", "cancel_reminder", "replace_reminder",
     })
     assert set(tools["create_reminder"].inputSchema["properties"]) == {
         "content", "target", "intended_at",
@@ -483,12 +487,15 @@ async def test_reminder_tools_have_exact_semantic_schemas_and_live_dispatch():
     assert set(tools["cancel_reminder"].inputSchema["properties"]) == {
         "reminder_id",
     }
+    assert set(tools["replace_reminder"].inputSchema["properties"]) == {
+        "reminder_id", "content", "target", "intended_at",
+    }
     forbidden = {
         "recurrence", "provider", "server", "schedule_wake", "pause",
         "resume", "execute", "skip", "apologize", "reply", "silence",
         "state_machine", "actual_fire_at", "occurrence_id",
     }
-    for name in ("create_reminder", "list_reminders", "cancel_reminder"):
+    for name in ("create_reminder", "list_reminders", "cancel_reminder", "replace_reminder"):
         assert set(tools[name].inputSchema["properties"]).isdisjoint(forbidden)
 
     assert (await mcp.call_tool("create_reminder", {
@@ -502,6 +509,10 @@ async def test_reminder_tools_have_exact_semantic_schemas_and_live_dispatch():
         "reminder_id": "reminder-1",
     }))[1]
     assert cancelled["state"] == "cancelled"
+    replaced = (await mcp.call_tool("replace_reminder", {
+        "reminder_id": "reminder-1", "content": "new",
+    }))[1]
+    assert replaced["replacement"]["content"] == "new"
     assert calls == [
         ("create", {
             "content": "exact content", "target": "channel:sp:ch",
@@ -509,6 +520,10 @@ async def test_reminder_tools_have_exact_semantic_schemas_and_live_dispatch():
         }),
         ("list", {"state": "scheduled", "limit": 3}),
         ("cancel", {"reminder_id": "reminder-1"}),
+        ("replace", {
+            "reminder_id": "reminder-1", "content": "new",
+            "target": "", "intended_at": "",
+        }),
     ]
 
 
@@ -548,6 +563,10 @@ async def test_reminder_tools_fall_back_to_configured_loopback_rpc_client():
             calls.append(("cancel", kwargs))
             return cancelled
 
+        async def replace_reminder(self, **kwargs):
+            calls.append(("replace", kwargs))
+            return {"cancelled": cancelled, "replacement": scheduled}
+
     # No warm in-process runtime is available on the subprocess MCP path.
     cfg.inbox_runtime = None
     cfg.message_client = None
@@ -564,6 +583,9 @@ async def test_reminder_tools_fall_back_to_configured_loopback_rpc_client():
     assert (await mcp.call_tool("cancel_reminder", {
         "reminder_id": "reminder-1",
     }))[1] == cancelled
+    assert (await mcp.call_tool("replace_reminder", {
+        "reminder_id": "reminder-1", "intended_at": "2026-08-03T12:00:00Z",
+    }))[1] == {"cancelled": cancelled, "replacement": scheduled}
     assert calls == [
         ("create", {
             "content": "exact content", "target": "channel:sp:ch",
@@ -571,6 +593,10 @@ async def test_reminder_tools_fall_back_to_configured_loopback_rpc_client():
         }),
         ("list", {"state": "scheduled", "limit": 3}),
         ("cancel", {"reminder_id": "reminder-1"}),
+        ("replace", {
+            "reminder_id": "reminder-1", "content": "", "target": "",
+            "intended_at": "2026-08-03T12:00:00Z",
+        }),
     ]
 
 

--- a/tests/test_reminder_recovery.py
+++ b/tests/test_reminder_recovery.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.reminder_scheduler import ReminderScheduler
+from puffo_agent.agent.reminder_sync import REMINDER_PAYLOAD_FORMAT, ReminderSync
+from puffo_agent.crypto.keystore import KeyStore
+
+
+class _CancelTransport:
+    async def put(self, path: str, body: dict[str, object]) -> dict[str, object]:
+        response = {"occurrence_id": path.rsplit("/", 1)[-1], **body}
+        response.pop("opaque_payload")
+        response.pop("delivery_claim_id", None)
+        return response
+
+
+@pytest.mark.asyncio
+async def test_cancel_requests_snapshot_when_local_materialization_fails(
+    tmp_path, monkeypatch,
+):
+    store = MessageStore(tmp_path / "messages.db", now_ms=lambda: 2_000)
+    sync = ReminderSync(
+        store=store,
+        keystore=KeyStore(tmp_path / "keys"),
+        owner_slug="agent-a",
+        http_client=_CancelTransport(),
+        scheduler=ReminderScheduler(store=store, notify=lambda: None),
+        now_ms=lambda: 2_000,
+    )
+    reminder = await store.create_reminder(
+        content="cancel remotely", target="dm:peer", intended_at_ms=5_000,
+    )
+    record = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert record is not None
+    await sync._ensure_envelope(record)
+
+    async def fail_materialization(**_kwargs):
+        raise OSError("sqlite unavailable")
+
+    monkeypatch.setattr(
+        store, "materialize_remote_terminal_reminder", fail_materialization
+    )
+    with pytest.raises(RuntimeError, match="could not be confirmed"):
+        await sync.cancel_reminder(reminder.reminder_id)
+    assert sync._snapshot_requested
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_replacement_response_converges_a_claimed_row(tmp_path):
+    store = MessageStore(tmp_path / "messages.db", now_ms=lambda: 2_000)
+    old = await store.create_reminder(
+        reminder_id="reminder-old",
+        occurrence_id="occurrence-old",
+        content="old",
+        target="dm:peer",
+        intended_at_ms=1_000,
+    )
+    opaque_payload = b"replacement-envelope"
+    await store.materialize_remote_scheduled_reminder(
+        reminder_id="reminder-new",
+        occurrence_id="occurrence-new",
+        target="dm:peer",
+        content="new",
+        intended_at_ms=1_000,
+        lifecycle_at_ms=2_000,
+        revision=1,
+        payload_format=REMINDER_PAYLOAD_FORMAT,
+        opaque_payload=opaque_payload,
+    )
+    claim_id = "50c0a35a-7f24-4a9d-879a-f87ec418b790"
+    await store.persist_reminder_delivery_claim_id(
+        occurrence_id="occurrence-new", revision=1, claim_id=claim_id,
+    )
+    assert await store.acquire_reminder_delivery_claim(
+        occurrence_id="occurrence-new",
+        revision=1,
+        claim_id=claim_id,
+        lease_expires_at_ms=10_000,
+    )
+    claimed = await store.claim_authorized_reminders(
+        ("occurrence-new",), now_ms=2_000,
+    )
+    assert claimed[0].state == "claimed"
+
+    _cancelled, replacement = await store.materialize_remote_replacement(
+        reminder_id=old.reminder_id,
+        occurrence_id=old.occurrence_id,
+        cancelled_at_ms=2_000,
+        replacement_reminder_id="reminder-new",
+        replacement_occurrence_id="occurrence-new",
+        target="dm:peer",
+        content="new",
+        intended_at_ms=1_000,
+        replacement_created_at_ms=2_000,
+        lifecycle="cancelled",
+        lifecycle_at_ms=2_500,
+        revision=2,
+        payload_format=REMINDER_PAYLOAD_FORMAT,
+        opaque_payload=opaque_payload,
+    )
+    assert (replacement.state, replacement.cancelled_at_ms) == ("cancelled", 2_500)
+    record = await store.get_reminder_sync_record("occurrence-new")
+    assert record is not None
+    assert record.delivery_claim_id is None
+    assert not record.delivery_claim_acquired
+    await store.close()

--- a/tests/test_reminder_scheduler.py
+++ b/tests/test_reminder_scheduler.py
@@ -61,6 +61,11 @@ async def test_scheduler_recovers_claimed_work_after_reopen(tmp_path):
     scheduler = ReminderScheduler(
         store=reopened, notify=lambda: wakes.append("wake"), now_ms=lambda: now[0],
     )
+    listed = await scheduler.list_reminders(state="scheduled")
+    assert listed["reminders"][0]["state"] == "scheduled"
+    assert listed["reminders"][0]["actual_fire_at"] is None
+    with pytest.raises(ValueError, match="scheduled, cancelled, delivered"):
+        await scheduler.list_reminders(state="claimed")
     delivered = await scheduler.process_due_once()
     assert [item.reminder_id for item in delivered] == [reminder.reminder_id]
     assert (await reopened.get_reminder(reminder.reminder_id)).state == "delivered"

--- a/tests/test_reminder_sync.py
+++ b/tests/test_reminder_sync.py
@@ -448,6 +448,12 @@ async def test_remote_replace_retry_preserves_terminal_replacement_creation_time
         "lifecycle_at": reminder_time_to_rfc3339(2_500),
     })
     remote.pop("opaque_payload")
+    transport.rows = list(transport.committed_replace_response.values())
+    assert await sync.reconcile_snapshot() == 1
+    reconciled = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert reconciled is not None
+    assert (reconciled.state, reconciled.server_ack_revision) == ("cancelled", 2)
+    assert await store.get_reminder(str(remote["reminder_id"])) is None
     _cancelled, replacement = await sync.replace_reminder(
         reminder.reminder_id, "new", None, None,
     )

--- a/tests/test_reminder_sync.py
+++ b/tests/test_reminder_sync.py
@@ -71,6 +71,8 @@ class _RecordingTransport:
         self.claim_status = "acquired"
         self.lease_expires_at = "2030-01-01T00:00:00.123456Z"
         self.claims: list[tuple[str, dict[str, object]]] = []
+        self.drop_replace_response_once = False
+        self.committed_replace_response: dict[str, object] | None = None
 
     @staticmethod
     def _response(path: str, body: dict[str, object]) -> dict[str, object]:
@@ -95,6 +97,38 @@ class _RecordingTransport:
         return self._response(path, body)
 
     async def post(self, path: str, body: dict[str, object]) -> dict[str, object]:
+        if path.endswith("/replace"):
+            self.calls.append(("post", path, copy.deepcopy(body)))
+            if self.failure is not None:
+                raise self.failure
+            if self.committed_replace_response is not None:
+                return copy.deepcopy(self.committed_replace_response)
+            old_path = path.removesuffix("/replace")
+            old_body = next(
+                call_body
+                for method, call_path, call_body in reversed(self.calls)
+                if method in {"put", "put_unsigned"}
+                and call_path == old_path
+                and call_body is not None
+            )
+            cancelled = {
+                "occurrence_id": old_path.rsplit("/", 1)[-1],
+                **old_body,
+                "revision": 2,
+                "lifecycle": "cancelled",
+                "lifecycle_at": body["cancelled_at"],
+            }
+            cancelled.pop("opaque_payload")
+            cancelled.pop("delivery_claim_id", None)
+            replacement = copy.deepcopy(body["replacement"])
+            replacement["occurrence_id"] = body["replacement_occurrence_id"]
+            replacement.pop("delivery_claim_id", None)
+            response = {"cancelled": cancelled, "replacement": replacement}
+            self.committed_replace_response = copy.deepcopy(response)
+            if self.drop_replace_response_once:
+                self.drop_replace_response_once = False
+                raise OSError("response lost after commit")
+            return response
         self.claims.append((path, copy.deepcopy(body)))
         if self.failure is not None:
             raise self.failure
@@ -278,6 +312,163 @@ async def test_lifecycle_commits_wake_a_sleeping_sync_outbox(tmp_path):
 
     sync.stop()
     await task
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_cancel_converges_and_rejects_live_delivery(
+    tmp_path, monkeypatch,
+):
+    """A prepared reminder must not fork locally when Server says too_late."""
+    transport = _RecordingTransport()
+    sync, store, _scheduler, _keys = _sync(tmp_path, transport)
+    reminder = await store.create_reminder(
+        content="cancel remotely", target="dm:peer", intended_at_ms=5_000,
+    )
+    record = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert record is not None
+    local_cancel = store.cancel_reminder
+    raced = False
+
+    async def cancel_after_outbox_prepares(reminder_id):
+        nonlocal raced
+        if not raced:
+            raced = True
+            current = await store.get_reminder_sync_record(reminder.occurrence_id)
+            assert current is not None
+            await sync._ensure_envelope(current)
+        return await local_cancel(reminder_id)
+
+    monkeypatch.setattr(store, "cancel_reminder", cancel_after_outbox_prepares)
+
+    cancelled = await sync.cancel_reminder(reminder.reminder_id)
+    synced = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert cancelled.state == "cancelled"
+    assert synced is not None and synced.server_ack_revision == 2
+
+    claimed = await store.create_reminder(
+        content="claimed but not delivered", target="dm:peer", intended_at_ms=1_000,
+    )
+    await store.claim_due_reminders(now_ms=2_000)
+    assert (await store.get_reminder(claimed.reminder_id)).state == "claimed"
+    calls_before_local_cancel = len(transport.calls)
+    cancelled_claim = await sync.cancel_reminder(claimed.reminder_id)
+    assert cancelled_claim.state == "cancelled"
+    assert cancelled_claim.actual_fire_at_ms is None
+    assert len(transport.calls) == calls_before_local_cancel
+
+    blocked = await store.create_reminder(
+        content="already firing", target="dm:peer", intended_at_ms=6_000,
+    )
+    blocked_record = await store.get_reminder_sync_record(blocked.occurrence_id)
+    assert blocked_record is not None
+    await sync._ensure_envelope(blocked_record)
+    transport.failure = HttpError(
+        409, '{"error":"too_late","message":"delivery started"}'
+    )
+    with pytest.raises(LifecycleConflict, match="delivery already started"):
+        await sync.cancel_reminder(blocked.reminder_id)
+    assert (await store.get_reminder(blocked.reminder_id)).state == "scheduled"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_replace_is_atomic_locally_and_idempotent(tmp_path):
+    """A lost retry cannot create a second replacement identity."""
+    transport = _RecordingTransport()
+    sync, store, _scheduler, _keys = _sync(tmp_path, transport)
+    reminder = await store.create_reminder(
+        content="old", target="dm:peer", intended_at_ms=5_000,
+    )
+    record = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert record is not None
+    await sync._ensure_envelope(record)
+
+    transport.drop_replace_response_once = True
+    with pytest.raises(RuntimeError, match="could not be confirmed"):
+        await sync.replace_reminder(reminder.reminder_id, "new", None, None)
+    assert (await store.get_reminder(reminder.reminder_id)).state == "scheduled"
+
+    cancelled, replacement = await sync.replace_reminder(
+        reminder.reminder_id, "new", None, None,
+    )
+    assert (cancelled.state, replacement.state, replacement.content) == (
+        "cancelled", "scheduled", "new",
+    )
+    assert [call[0] for call in transport.calls] == ["put", "post", "post"]
+    replacement_posts = [call[2] for call in transport.calls if call[0] == "post"]
+    assert replacement_posts[0]["replacement"]["opaque_payload"] != (
+        replacement_posts[1]["replacement"]["opaque_payload"]
+    )
+    replacement_record = await store.get_reminder_sync_record(
+        replacement.occurrence_id
+    )
+    assert replacement_record is not None
+    assert replacement_record.opaque_payload is not None
+    assert transport.committed_replace_response is not None
+    canonical_payload = transport.committed_replace_response["replacement"][
+        "opaque_payload"
+    ]
+    assert _base64url_encode(replacement_record.opaque_payload) == canonical_payload
+    transport.rows = list(transport.committed_replace_response.values())
+    assert await sync.reconcile_snapshot() == 0
+    before_retry = len(transport.calls)
+    retried = await sync.replace_reminder(reminder.reminder_id, "new", None, None)
+    assert retried[1].reminder_id == replacement.reminder_id
+    assert len(transport.calls) == before_retry
+    rows = await store.list_reminders()
+    assert {
+        row.reminder_id: (row.state, row.content)
+        for row in rows
+    } == {
+        reminder.reminder_id: ("cancelled", "old"),
+        replacement.reminder_id: ("scheduled", "new"),
+    }
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_replace_preserves_a_racing_local_delivery(
+    tmp_path, monkeypatch,
+):
+    """A committed remote replacement converges without erasing a local fire."""
+    transport = _RecordingTransport()
+    sync, store, _scheduler, _keys = _sync(tmp_path, transport, now=[2_000])
+    reminder = await store.create_reminder(
+        content="old", target="dm:peer", intended_at_ms=1_000,
+    )
+    assert await sync.upload_pending_once() == 1
+    original_post = transport.post
+
+    async def post_then_deliver(path, body):
+        response = await original_post(path, body)
+        claim_id = "50c0a35a-7f24-4a9d-879a-f87ec418b790"
+        await store.persist_reminder_delivery_claim_id(
+            occurrence_id=reminder.occurrence_id, revision=1, claim_id=claim_id,
+        )
+        assert await store.acquire_reminder_delivery_claim(
+            occurrence_id=reminder.occurrence_id,
+            revision=1,
+            claim_id=claim_id,
+            lease_expires_at_ms=10_000,
+        )
+        await store.claim_authorized_reminders(
+            (reminder.occurrence_id,), now_ms=2_000,
+        )
+        delivered = await store.deliver_authorized_reminders(
+            (reminder.occurrence_id,), now_ms=2_000,
+        )
+        assert [item.occurrence_id for item in delivered] == [reminder.occurrence_id]
+        return response
+
+    monkeypatch.setattr(transport, "post", post_then_deliver)
+    old, replacement = await sync.replace_reminder(
+        reminder.reminder_id, "new", None, None,
+    )
+    assert old.state == "delivered"
+    assert replacement.state == "scheduled"
+    old_record = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert old_record is not None and old_record.server_ack_revision == 2
     await store.close()
 
 
@@ -603,8 +794,8 @@ async def test_acknowledged_persisted_delivery_claim_rejects_cancellation(tmp_pa
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("custody", ["prepared", "acknowledged", "claimed"])
-async def test_prepared_acknowledged_or_claimed_work_rejects_cancellation(
+@pytest.mark.parametrize("custody", ["prepared", "acknowledged"])
+async def test_prepared_or_acknowledged_work_rejects_cancellation(
     tmp_path, custody,
 ):
     transport = _RecordingTransport()
@@ -612,9 +803,7 @@ async def test_prepared_acknowledged_or_claimed_work_rejects_cancellation(
     reminder = await store.create_reminder(
         content="due", target="dm:peer", intended_at_ms=1_000,
     )
-    if custody == "claimed":
-        await store.claim_due_reminders(now_ms=2_000)
-    elif custody == "prepared":
+    if custody == "prepared":
         record = await store.get_reminder_sync_record(reminder.occurrence_id)
         assert record is not None
         await sync._ensure_envelope(record)
@@ -626,7 +815,7 @@ async def test_prepared_acknowledged_or_claimed_work_rejects_cancellation(
 
     retained = await store.get_reminder_sync_record(reminder.occurrence_id)
     assert retained is not None
-    assert retained.state == ("claimed" if custody == "claimed" else "scheduled")
+    assert retained.state == "scheduled"
     await store.close()
 
 
@@ -1555,6 +1744,18 @@ async def test_terminal_snapshot_suppresses_stale_local_schedule_without_event(t
         created_at_ms=500,
     )
     assert await sync.upload_pending_once() == 1
+    claim_id = "50c0a35a-7f24-4a9d-879a-f87ec418b790"
+    await store.persist_reminder_delivery_claim_id(
+        occurrence_id=reminder.occurrence_id,
+        revision=1,
+        claim_id=claim_id,
+    )
+    assert await store.acquire_reminder_delivery_claim(
+        occurrence_id=reminder.occurrence_id,
+        revision=1,
+        claim_id=claim_id,
+        lease_expires_at_ms=10_000,
+    )
     transport.rows = [_terminal_row(
         reminder_id=reminder.reminder_id,
         occurrence_id=reminder.occurrence_id,
@@ -1566,6 +1767,9 @@ async def test_terminal_snapshot_suppresses_stale_local_schedule_without_event(t
     assert (record.state, record.revision, record.server_ack_revision) == (
         "delivered", 2, 2,
     )
+    assert record.delivery_claim_id is None
+    assert not record.delivery_claim_acquired
+    assert record.delivery_claim_expires_at_ms is None
     assert await scheduler.process_due_once() == ()
     assert await store.get_message_by_envelope(
         f"reminder-occurrence:{reminder.occurrence_id}"
@@ -1575,7 +1779,7 @@ async def test_terminal_snapshot_suppresses_stale_local_schedule_without_event(t
 
 
 @pytest.mark.asyncio
-async def test_remote_cancellation_does_not_ack_local_delivery(tmp_path):
+async def test_remote_cancellation_acknowledges_but_preserves_local_delivery(tmp_path):
     _syncer, store, _scheduler, _keys = _sync(
         tmp_path,
         _RecordingTransport(),
@@ -1608,10 +1812,10 @@ async def test_remote_cancellation_does_not_ack_local_delivery(tmp_path):
     assert (record.state, record.revision, record.server_ack_revision) == (
         "delivered",
         2,
-        0,
+        2,
     )
     pending = await store.pending_reminder_sync_records(force=True)
-    assert [item.occurrence_id for item in pending] == [reminder.occurrence_id]
+    assert pending == ()
     await store.close()
 
 

--- a/tests/test_reminder_sync.py
+++ b/tests/test_reminder_sync.py
@@ -428,6 +428,36 @@ async def test_remote_replace_is_atomic_locally_and_idempotent(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_remote_replace_retry_preserves_terminal_replacement_creation_time(tmp_path):
+    transport = _RecordingTransport()
+    sync, store, _scheduler, _keys = _sync(tmp_path, transport, now=[2_000])
+    reminder = await store.create_reminder(
+        content="old", target="dm:peer", intended_at_ms=5_000,
+    )
+    record = await store.get_reminder_sync_record(reminder.occurrence_id)
+    assert record is not None
+    await sync._ensure_envelope(record)
+    transport.drop_replace_response_once = True
+    with pytest.raises(RuntimeError, match="could not be confirmed"):
+        await sync.replace_reminder(reminder.reminder_id, "new", None, None)
+    assert transport.committed_replace_response is not None
+    remote = transport.committed_replace_response["replacement"]
+    remote.update({
+        "revision": 2,
+        "lifecycle": "cancelled",
+        "lifecycle_at": reminder_time_to_rfc3339(2_500),
+    })
+    remote.pop("opaque_payload")
+    _cancelled, replacement = await sync.replace_reminder(
+        reminder.reminder_id, "new", None, None,
+    )
+    assert (replacement.state, replacement.created_at_ms, replacement.cancelled_at_ms) == (
+        "cancelled", 2_000, 2_500,
+    )
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_remote_replace_preserves_a_racing_local_delivery(
     tmp_path, monkeypatch,
 ):

--- a/tests/test_rpc_service.py
+++ b/tests/test_rpc_service.py
@@ -434,6 +434,7 @@ async def test_puffo_rpc_client_round_trips_all_reminder_objects(
         "state": "cancelled",
         "cancelled_at": "2026-08-02T11:01:00.000Z",
     }
+    legacy_claimed = {**scheduled, "state": "claimed"}
 
     async def create(_ctx, **kwargs):
         captured.append(("create", kwargs))
@@ -441,15 +442,20 @@ async def test_puffo_rpc_client_round_trips_all_reminder_objects(
 
     async def list_(_ctx, **kwargs):
         captured.append(("list", kwargs))
-        return {"reminders": [scheduled]}
+        return {"reminders": [legacy_claimed]}
 
     async def cancel(_ctx, **kwargs):
         captured.append(("cancel", kwargs))
         return cancelled
 
+    async def replace(_ctx, **kwargs):
+        captured.append(("replace", kwargs))
+        return {"cancelled": cancelled, "replacement": scheduled}
+
     monkeypatch.setattr(rpc_service.host_mcp_handler, "create_reminder", create)
     monkeypatch.setattr(rpc_service.host_mcp_handler, "list_reminders", list_)
     monkeypatch.setattr(rpc_service.host_mcp_handler, "cancel_reminder", cancel)
+    monkeypatch.setattr(rpc_service.host_mcp_handler, "replace_reminder", replace)
     rpc_service.set_rpc_resolver(lambda aid: _stub_ctx(aid))
     app_client = await app_client_factory()
     client = PuffoRpcClient(
@@ -467,6 +473,10 @@ async def test_puffo_rpc_client_round_trips_all_reminder_objects(
             "reminders": [scheduled],
         }
         assert await client.cancel_reminder(reminder_id="reminder-1") == cancelled
+        assert await client.replace_reminder(
+            reminder_id="reminder-1",
+            intended_at="2026-08-03T12:00:00Z",
+        ) == {"cancelled": cancelled, "replacement": scheduled}
     finally:
         await client.close()
     assert captured == [
@@ -476,6 +486,10 @@ async def test_puffo_rpc_client_round_trips_all_reminder_objects(
         }),
         ("list", {"state": "scheduled", "limit": 3}),
         ("cancel", {"reminder_id": "reminder-1"}),
+        ("replace", {
+            "reminder_id": "reminder-1", "content": "", "target": "",
+            "intended_at": "2026-08-03T12:00:00.000Z",
+        }),
     ]
 
 

--- a/tests/test_rpc_service.py
+++ b/tests/test_rpc_service.py
@@ -434,7 +434,11 @@ async def test_puffo_rpc_client_round_trips_all_reminder_objects(
         "state": "cancelled",
         "cancelled_at": "2026-08-02T11:01:00.000Z",
     }
-    legacy_claimed = {**scheduled, "state": "claimed"}
+    legacy_claimed = {
+        **scheduled,
+        "state": "claimed",
+        "actual_fire_at": "2026-08-02T12:00:01.000Z",
+    }
 
     async def create(_ctx, **kwargs):
         captured.append(("create", kwargs))

--- a/tests/test_ws_local_tool_dispatch.py
+++ b/tests/test_ws_local_tool_dispatch.py
@@ -31,6 +31,7 @@ def test_allowed_tools_are_the_send_read_and_membership_tools():
         "create_reminder",
         "list_reminders",
         "cancel_reminder",
+        "replace_reminder",
         "get_user_info",
         "whoami",
         "get_post",
@@ -108,6 +109,7 @@ def test_ws_local_semantic_tool_signatures_expose_no_internal_controls():
         "create_reminder": {"content", "target", "intended_at"},
         "list_reminders": {"state", "limit"},
         "cancel_reminder": {"reminder_id"},
+        "replace_reminder": {"reminder_id", "content", "target", "intended_at"},
         "send_message": {
             "channel", "text", "root_id", "visibility_level", "send_anyway",
         },
@@ -195,6 +197,10 @@ async def test_ws_local_reminder_tools_use_the_live_runtime():
             calls.append(("cancel", kwargs))
             return {"reminder_id": "r", "occurrence_id": "o", "state": "cancelled"}
 
+        async def replace_reminder(self, **kwargs):
+            calls.append(("replace", kwargs))
+            return {"cancelled": {"reminder_id": "r"}, "replacement": {"reminder_id": "r2"}}
+
     cfg = PuffoCoreToolsConfig(
         slug="agent-1", device_id="dev-1", keystore=MagicMock(),
         http_client=MagicMock(), data_client=MagicMock(), inbox_runtime=Runtime(),
@@ -207,6 +213,9 @@ async def test_ws_local_reminder_tools_use_the_live_runtime():
     assert await dispatch["cancel_reminder"](reminder_id="r") == {
         "reminder_id": "r", "occurrence_id": "o", "state": "cancelled",
     }
+    assert await dispatch["replace_reminder"](
+        reminder_id="r", content="new",
+    ) == {"cancelled": {"reminder_id": "r"}, "replacement": {"reminder_id": "r2"}}
     assert calls == [
         ("create", {
             "content": "x", "target": "channel:sp:ch",
@@ -214,6 +223,9 @@ async def test_ws_local_reminder_tools_use_the_live_runtime():
         }),
         ("list", {"state": "scheduled", "limit": 7}),
         ("cancel", {"reminder_id": "r"}),
+        ("replace", {
+            "reminder_id": "r", "content": "new", "target": "", "intended_at": "",
+        }),
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a3"
+version = "2.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- complete durable one-shot reminder recovery and Server reconciliation
- expose semantic `create_reminder`, `list_reminders`, `cancel_reminder`, and atomic `replace_reminder` across MCP, host RPC, and ws-local
- keep internal `claimed` private; callers see only `scheduled`, `cancelled`, or `delivered`
- reconcile retries, lost responses, terminal races, snapshot pagination, and expired delivery claims without duplicating intent
- preserve Agent-owned plaintext and encrypt every remote reminder payload with the existing MessageBackupDEK
- bump the candidate package to `2.0.0a4` and document the one-shot contract

## Lifecycle

`scheduled -> cancelled | delivered`

`claimed` is a local crash-recovery state only. Local-only claimed work may still be cancelled under the SQLite transaction lock; once Server custody exists, cancellation and replacement are fenced by the Server lifecycle contract.

## Dependencies and integration

- Agent Foundation #233 is merged into `main` at `c8d0730` and is included in this branch.
- puffo-server #288 is merged at `978a6e0`; its staging deployment is the release gate for remote replacement calls.
- this PR now targets `main`; the integrated Agent head is `7fb6b28`.

## Validation

- full Agent pytest suite passed on the integrated tree; one expected Windows-only skip
- all pre-commit hooks passed, including Ruff and Python structural limits
- `git diff --check` and `python3 tools/check_python_structure.py` passed
- wheel and sdist build passed; wheel metadata reports `puffo-agent 2.0.0a4`
- fresh wheel install and direct lifecycle smoke passed on the reminder branch
- real Codex MCP smoke passed: create -> list -> cancel -> list
- real Claude MCP smoke confirmed create/list/cancel and atomic rollback behavior against the pre-#288 staging deployment
- two independent adversarial reviews completed; all actionable findings fixed and all review threads resolved

## Rollout

Wait for puffo-server #288 staging deployment and this PR's post-retarget CI to pass. Then merge this PR and publish `2.0.0a4` to TestPyPI for team testing; do not create a production GitHub release for this alpha.
