### PR TITLE
Restore Puffo Agent 1.2 flat-memory compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a12] — 2026-08-16
+
+> Staging candidate restoring Puffo Agent 1.2 memory compatibility while
+> retaining the structured-memory alpha data and tools.
+
 ### Fixed
 
 - **Existing Agent memory again follows the 1.2 runtime contract.** The full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Existing Agent memory again follows the 1.2 runtime contract.** The full
+  root `profile.md` and flat `memory/*.md` files are loaded into Codex and
+  Claude Code prompts without destructive startup migration or alpha briefing
+  limits. Existing structured briefing data remains visible through a
+  read-only compatibility view, including notes moved by earlier alpha builds.
+- **Custom memory directories work in Docker runtimes.** Claude Code and Codex
+  containers now mount the resolved Agent memory directory at the canonical
+  MCP path instead of silently reading the default Agent-home directory.
 - **Runtime observability can no longer block Agent execution.** Profile Logs,
   Runtime Events upload, and the local runtime-state snapshot are treated as
   best-effort observations after a provider event occurs. A full or unhealthy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,12 +243,11 @@ Default state is rooted at `~/.puffo-agent/` (overridable with
     runtime_events.db        # bounded local Runtime event outbox
     runtime.json             # daemon health/status projection
     memory/
-      briefing/
-        profile.md
-        <topic>.md
-      notes/
-      recollection/
-      imports/
+      <topic>.md              # standing memory, loaded into every prompt
+      briefing/               # retained 2.0-alpha compatibility topics
+      notes/                  # searchable detail, loaded on demand
+      recollection/           # maintenance-owned chronology
+      imports/                # importer-owned source material
         index.md
     workspace/
       shared -> ../../../shared/ # same host-wide directory for every Agent
@@ -262,17 +261,27 @@ state; native wire encryption does not make the already-decrypted local store
 ciphertext-only.
 
 Existing Agent configuration is normalized at explicit compatibility
-boundaries. Legacy direct-provider runtime names migrate to `cli-local`; old
-flat `memory/*.md` files migrate into the memory tree; existing identity,
-workspace, message, and session state is retained.
+boundaries. Legacy direct-provider runtime names migrate to `cli-local`;
+existing identity, workspace, flat memory, structured alpha memory, message,
+and session state is retained.
 
 ## 7. Memory
 
-The memory tree is implemented end to end:
+The active prompt path preserves the Puffo Agent 1.2 memory contract:
 
-- `briefing/` is deterministic, bounded, and compiled into managed provider
-  prompt artifacts. `briefing/profile.md` receives the managed identity block;
-  additional topics are Agent-owned.
+- The editable root `profile.md` is loaded verbatim under `# Your role`.
+- Flat `memory/*.md` files are standing memory and are loaded without the
+  structured briefing size budget.
+- Prompt assembly is read-only: startup does not move, delete, or rewrite
+  memory files.
+
+The 2.0-alpha structured implementation remains as a compatibility layer:
+
+- `briefing/` topics are included in the same standing-memory view when no
+  same-named flat topic exists. User text outside the old managed
+  `briefing/profile.md` block is retained as profile notes.
+- Notes named by `briefing/migrated-notes.md` are included so an earlier alpha
+  migration cannot make former flat memory disappear.
 - `notes/` holds searchable detail and is not injected by default.
 - `recollection/` is maintenance-owned chronological memory.
 - `imports/` is importer-owned and read-only to ordinary Agent turns;
@@ -282,10 +291,10 @@ The memory tree is implemented end to end:
 - Semantic MCP tools expose notes, briefing topics, recall, imports, and status.
 - `memory_git.py` records write history for audit and rollback.
 
-Briefing files are limited to 16 KiB each and the compiled briefing to 64 KiB.
-Notes and recollection have separate larger per-file limits. A briefing change
-sets a refresh flag; the worker rebuilds managed prompt artifacts and reloads
-the provider at a safe lifecycle boundary.
+Structured briefing writes remain limited to 16 KiB each and 64 KiB total;
+legacy flat files retain their 1.2 unbounded behavior. Writes made through
+Puffo's memory surfaces request a provider prompt refresh at a safe lifecycle
+boundary.
 
 ## 8. Runtime Events And Reminders
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a11"
+version = "2.0.0a12"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/adapters/docker_cli.py
+++ b/src/puffo_agent/agent/adapters/docker_cli.py
@@ -72,7 +72,7 @@ def _puffo_agent_pkg_dir() -> Path:
 # image-tag pruning. ``_ensure_image`` only builds when the tag is
 # missing locally.
 DEFAULT_IMAGE = "puffo/agent-runtime:v19"
-CONTAINER_LAYOUT_VERSION = "21"
+CONTAINER_LAYOUT_VERSION = "22"
 
 # Pinned Claude Code CLI version baked into the image. Floating would
 # let an upstream release shift the stream-json protocol or
@@ -162,6 +162,7 @@ class DockerCLIAdapter(Adapter):
         puffo_core_slug: str = "",
         puffo_core_keys_dir: str = "",
         claude_api_key: str = "",
+        memory_dir: str = "",
     ):
         self.agent_id = agent_id
         self.model = model
@@ -174,6 +175,9 @@ class DockerCLIAdapter(Adapter):
         # are bind-mounted in, not the whole home, so the container's
         # default home skeleton stays intact.
         self.agent_home_dir = Path(agent_home_dir)
+        self.memory_dir = (
+            Path(memory_dir) if memory_dir else self.agent_home_dir / "memory"
+        )
         self.claude_home_src = self.agent_home_dir / ".claude"
         # Cross-agent cooperation dir; same mount in every container
         # on this host — intentional escape hatch from per-agent
@@ -761,6 +765,7 @@ class DockerCLIAdapter(Adapter):
             mounted=True,
         )
         self.agent_home_dir.mkdir(parents=True, exist_ok=True)
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
         (self.agent_home_dir / ".claude").mkdir(parents=True, exist_ok=True)
         agent_claude_json = self.agent_home_dir / ".claude.json"
         agent_claude_json.touch(exist_ok=True)
@@ -771,7 +776,7 @@ class DockerCLIAdapter(Adapter):
         agent_claude_json: Path,
         shared_status: str,
     ) -> list[str]:
-        return [
+        command = [
             self._docker_bin,
             "run",
             "-d",
@@ -804,8 +809,17 @@ class DockerCLIAdapter(Adapter):
             # (-wal, -shm) sit alongside the .db.
             "-v",
             f"{self.agent_home_dir}:/home/agent/.puffo-agent-state",
-            "--init",
         ]
+        default_memory = self.agent_home_dir / "memory"
+        if self.memory_dir.resolve() != default_memory.resolve():
+            command.extend(
+                [
+                    "-v",
+                    f"{self.memory_dir}:/home/agent/.puffo-agent-state/memory",
+                ]
+            )
+        command.append("--init")
+        return command
 
     def _add_optional_container_args(self, command: list[str]) -> None:
         host_plugins = Path.home() / ".claude" / "plugins"

--- a/src/puffo_agent/agent/harness/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/docker_runtime.py
@@ -111,6 +111,7 @@ class DockerCodexPreparer:
         self.workspace_dir = agent_cfg.resolve_workspace_dir()
         self.claude_dir = agent_cfg.resolve_claude_dir()
         self.agent_home = agent_home_dir(self.agent_id)
+        self.memory_dir = agent_cfg.resolve_memory_dir()
         self.codex_home = agent_codex_user_dir(self.agent_id)
         self.shared_fs_dir = shared_fs_dir()
         self.image = agent_cfg.runtime.docker_image or DEFAULT_IMAGE
@@ -453,6 +454,7 @@ class DockerCodexPreparer:
         )
         self.codex_home.mkdir(parents=True, exist_ok=True)
         self.agent_home.mkdir(parents=True, exist_ok=True)
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
         command = [
             self._docker_bin,
             "run",
@@ -479,8 +481,16 @@ class DockerCodexPreparer:
             f"{self.shared_fs_dir}:/workspace/.shared",
             "-v",
             f"{_puffo_agent_pkg_dir()}:/opt/puffoagent-pkg:ro",
-            "--init",
         ]
+        default_memory = self.agent_home / "memory"
+        if self.memory_dir.resolve() != default_memory.resolve():
+            command.extend(
+                [
+                    "-v",
+                    f"{self.memory_dir}:{CODEX_CONTAINER_STATE_DIR}/memory",
+                ]
+            )
+        command.append("--init")
         if self.memory_limit:
             command.extend(["--memory", self.memory_limit])
         if self.memory_reservation:

--- a/src/puffo_agent/agent/memory.py
+++ b/src/puffo_agent/agent/memory.py
@@ -1,18 +1,24 @@
-"""Agent memory tree (M1): bounded briefing compile + notes.
+"""Agent memory persistence and structured-memory compatibility.
+
+The active runtime contract matches Puffo Agent 1.2: ``memory/*.md`` is
+standing memory and is loaded into every provider prompt.  The structured
+memory tree remains available to existing alpha installs and MCP tools, but
+startup never migrates flat files into it or rewrites user content.
 
 Layout under an agent's memory root::
 
     memory/
-      briefing/           # always-loaded; compiled (bounded) into the
-        profile.md        #   provider prompt artifacts. profile.md is
-        <topic>.md        #   identity framing, synced from agent.yml.
+      <topic>.md          # active 1.2 standing memory
+      briefing/           # retained alpha compatibility topics
+        profile.md        # old managed profile; only user addenda survive
+        <topic>.md        # included when no flat topic has the same name
       notes/              # durable detail; searchable, never injected
       recollection/       # reserved (M4)
       imports/index.md    # reserved; provenance of imported content
 
-The compile is deterministic (profile first, then sorted filenames)
-and fails closed: an over-limit briefing raises
-``BriefingCompileError`` rather than truncating.
+The standalone structured compile remains deterministic and bounded for MCP
+compatibility. The active standing-memory view is deterministic but does not
+apply those alpha limits to flat files.
 """
 
 from __future__ import annotations
@@ -60,6 +66,10 @@ PROFILE_MANAGED_END = "<!-- /puffo:managed-profile -->"
 _MANAGED_BLOCK_RE = re.compile(
     re.escape(PROFILE_MANAGED_BEGIN) + r".*?" + re.escape(PROFILE_MANAGED_END),
     re.DOTALL,
+)
+
+_MIGRATED_NOTE_POINTER_RE = re.compile(
+    rf"^- ({re.escape(NOTES_DIR)}/.+\.md) — migrated from flat memory$"
 )
 
 
@@ -290,12 +300,108 @@ def _flat_memory_files(memory_root: Path) -> list[Path]:
             continue
         if path.is_symlink() or not _resolves_within_root(path, memory_root):
             logger.warning(
-                "memory migrate: skipping %s — symlink or resolves outside the memory root",
+                "memory: skipping %s — symlink or resolves outside the memory root",
                 path,
             )
             continue
         files.append(path)
     return files
+
+
+def read_standing_memory_entries(memory_root: Path) -> list[tuple[str, str]]:
+    """Return the prompt-visible standing-memory view.
+
+    Flat ``memory/*.md`` files are authoritative and retain the 1.2 runtime
+    behavior.  Structured briefing topics and notes referenced by the alpha
+    migration pointer are compatibility fallbacks, so an upgrade cannot make
+    previously migrated memory disappear.  Files are never moved or rewritten;
+    a flat topic wins when both layouts contain the same stem.
+    """
+    root = Path(memory_root)
+    if not root.is_dir():
+        return []
+
+    entries: dict[str, str] = {}
+    for path in _flat_memory_files(root):
+        _add_standing_memory_entry(entries, path)
+
+    briefing = safe_memory_scope(root, BRIEFING_DIR)
+    if briefing is not None:
+        for path in sorted(briefing.glob("*.md")):
+            if not _is_briefing_topic(path):
+                continue
+            if not _resolves_within_root(path, root):
+                continue
+            if path.name == PROFILE_BRIEFING_NAME:
+                _add_profile_addendum(entries, path)
+                continue
+            if path.stem == MIGRATED_NOTES_TOPIC:
+                continue
+            _add_standing_memory_entry(entries, path)
+
+    for path in _migrated_note_targets(root):
+        _add_standing_memory_entry(entries, path)
+
+    return sorted(entries.items())
+
+
+def _add_standing_memory_entry(
+    entries: dict[str, str],
+    path: Path,
+    *,
+    topic: str = "",
+) -> None:
+    stem = topic or path.stem
+    if stem in entries:
+        return
+    try:
+        body = path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError):
+        return
+    if body:
+        entries[stem] = body
+
+
+def _add_profile_addendum(entries: dict[str, str], path: Path) -> None:
+    """Keep user text outside the alpha managed-profile block."""
+    try:
+        body = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return
+    addendum = _MANAGED_BLOCK_RE.sub("", body).strip()
+    if addendum:
+        entries.setdefault("profile-notes", addendum)
+
+
+def _migrated_note_targets(memory_root: Path) -> list[Path]:
+    pointer = memory_root / BRIEFING_DIR / f"{MIGRATED_NOTES_TOPIC}.md"
+    if (
+        not pointer.is_file()
+        or pointer.is_symlink()
+        or not _resolves_within_root(pointer, memory_root)
+    ):
+        return []
+    try:
+        lines = pointer.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return []
+
+    targets: list[Path] = []
+    for line in lines:
+        match = _MIGRATED_NOTE_POINTER_RE.fullmatch(line.strip())
+        if match is None:
+            continue
+        logical = Path(match.group(1))
+        if len(logical.parts) != 2 or logical.parts[0] != NOTES_DIR:
+            continue
+        path = memory_root / logical
+        if (
+            path.is_file()
+            and not path.is_symlink()
+            and _resolves_within_root(path, memory_root)
+        ):
+            targets.append(path)
+    return sorted(set(targets))
 
 
 def _migrate_flat_files(memory_root: Path, flat: list[Path]) -> list[str]:
@@ -464,22 +570,23 @@ def sync_profile_briefing(
 
 
 class MemoryManager:
-    """Compat shim over the memory tree. ``save()`` keeps its historic
-    name/signature but writes a briefing topic (bounded, fail closed)
-    and marks the prompt artifacts for rebuild; ``get_context()``
-    returns the compiled briefing instead of a full join."""
+    """The Puffo Agent 1.2 flat-memory compatibility surface."""
 
     def __init__(self, memory_dir: str, workspace_dir: str = ""):
         self.memory_dir = memory_dir
         self.workspace_dir = workspace_dir
-        ensure_memory_tree(Path(memory_dir))
+        Path(memory_dir).mkdir(parents=True, exist_ok=True)
+        self.memories = dict(read_standing_memory_entries(Path(memory_dir)))
 
     def get_context(self) -> str:
-        return compile_briefing(Path(self.memory_dir))
+        if not self.memories:
+            return ""
+        parts = ["## Memory\n"]
+        for topic, content in self.memories.items():
+            parts.append(f"### {topic}\n{content}\n")
+        return "\n".join(parts)
 
     def save(self, topic: str, content: str):
-        from .memory_store import MemoryStore
-
         safe_topic = topic.replace(" ", "_").replace("/", "-")
         # Aware-UTC with ``Z`` suffix (``datetime.utcnow`` is
         # deprecated in 3.12+).
@@ -490,15 +597,10 @@ class MemoryManager:
             .replace("+00:00", "Z")
         )
         body = f"---\ntopic: {topic}\nupdated: {updated}\n---\n\n{content}\n"
-        # The store validates sizes (per-file + would-be compiled
-        # total, raising BriefingCompileError) before any write, so an
-        # oversized save never leaves partial state behind. The
-        # refresh flag stays owned by save() — the store gets no
-        # workspace_dir — so its reason keeps the M1 shape.
-        MemoryStore(self.memory_dir).put_memory_file(
-            f"{BRIEFING_DIR}/{safe_topic}.md",
-            body,
-        )
+        root = Path(self.memory_dir)
+        root.mkdir(parents=True, exist_ok=True)
+        (root / f"{safe_topic}.md").write_text(body, encoding="utf-8")
+        self.memories[topic] = content
         self._request_refresh(topic)
 
     def _request_refresh(self, topic: str) -> None:

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -3,8 +3,8 @@
 The shared platform primer (``~/.puffo-agent/docker/shared/CLAUDE.md``)
 is folded into each agent's generated CLAUDE.md at worker startup.
 ``ensure_shared_primer`` syncs the baked-in primer to disk on every worker
-startup; ``assemble_claude_md`` combines primer + profile + the compiled
-memory briefing (bounded; see ``agent.memory``) into the per-agent prompt.
+startup; ``assemble_claude_md`` combines primer + profile + the standing
+memory view into the per-agent prompt.
 """
 
 from __future__ import annotations
@@ -30,7 +30,8 @@ DEFAULT_SHARED_CLAUDE_MD = """\
 # Puffo.ai platform primer
 
 You are an AI agent on Puffo.ai. The runtime handles transport and
-end-to-end encryption. Your identity and compiled briefing appear below.
+end-to-end encryption. Your identity, role profile, and standing memory
+appear below.
 
 ## Inbox
 
@@ -134,10 +135,10 @@ Your `cwd` is your persistent private workspace.
 
 ## Memory
 
-Memory is a durable, tool-managed tree. Briefing topics are compiled into the
-prompt; notes are recalled on demand. `memory/briefing/profile.md` is managed
-from your Puffo profile. Use the memory tools rather than hand-editing the
-managed tree; their schemas and errors define size limits and update behavior.
+Standing memory is loaded from the Agent's flat `memory/*.md` files. Existing
+tool-managed briefing topics are included through a compatibility view; notes,
+recollections, and imports are recalled on demand. Use the memory tools for
+structured updates and recall; their schemas define limits and update behavior.
 """
 
 
@@ -1190,38 +1191,48 @@ def compile_agent_memory_briefing(
     role_short: str = "",
     puffo_handle: str = "",
 ) -> str:
-    """Bring the memory tree up to date and return the compiled
-    bounded briefing: ensure the tree, migrate legacy flat
-    ``memory/*.md``, re-sync ``briefing/profile.md`` from the native
-    profile surfaces (agent.yml identity fields + the ``# Soul`` body
-    of agent-root profile.md), then compile ``briefing/``.
+    """Compatibility alias for the non-mutating standing-memory view.
 
-    Raises ``memory.BriefingCompileError`` (fail closed — no
-    truncation) when the briefing violates its budget.
+    The historical identity arguments remain accepted so older callers do not
+    break, but identity now comes from the root profile plus runtime metadata;
+    this function never migrates or rewrites memory.
     """
-    from ..portal.profile_sync import extract_soul_body
-    from .memory import (
-        compile_briefing,
-        ensure_memory_tree,
-        migrate_flat_memory,
-        sync_profile_briefing,
+    return read_memory_snapshot(memory_dir)
+
+
+def read_memory_snapshot(memory_dir: Path) -> str:
+    """Compile the 1.2 flat-memory view plus structured compatibility data."""
+    from .memory import read_standing_memory_entries
+
+    return "\n\n".join(
+        f"### {topic}\n\n{body}"
+        for topic, body in read_standing_memory_entries(memory_dir)
     )
 
-    ensure_memory_tree(memory_dir)
-    migrate_flat_memory(memory_dir)
-    sync_profile_briefing(
-        memory_dir,
-        agent_id=agent_id,
-        display_name=display_name,
-        role=role,
-        role_short=role_short,
-        soul=extract_soul_body(profile_text),
-        puffo_handle=puffo_handle,
-    )
-    return compile_briefing(memory_dir)
+
+def _runtime_identity_context(
+    *,
+    agent_id: str = "",
+    display_name: str = "",
+    role: str = "",
+    role_short: str = "",
+    puffo_handle: str = "",
+) -> str:
+    """Render immutable addressing metadata separately from editable profile."""
+    handle = puffo_handle or agent_id
+    lines: list[str] = []
+    if handle:
+        lines.append(f"Puffo handle: `@{handle}` (your unique network identity).")
+    if display_name:
+        lines.append(f"Display name: {display_name}.")
+    if role:
+        lines.append(f"Role: {role}")
+    if role_short:
+        lines.append(f"Role (short): {role_short}")
+    return "\n".join(lines)
 
 
-# Splits the session-relevant slice (primer) from the memory
+# Splits the session-relevant slice (primer + profile) from the memory
 # snapshot for the worker's fresh-session check.
 MEMORY_SECTION_HEADER = "---\n\n# Your memory\n\n"
 
@@ -1230,11 +1241,12 @@ def assemble_claude_md(
     *,
     shared_primer: str,
     profile: str,
-    memory_briefing: str,
+    memory_snapshot: str,
+    runtime_identity: str = "",
     workspace_shared_status: str = "existing",
 ) -> str:
     """Produce the per-agent CLAUDE.md. Order: primer (platform
-    conventions) → memory (the compiled bounded briefing, including profile).
+    conventions) → runtime identity + editable profile → standing memory.
     """
     parts: list[str] = []
     if shared_primer.strip():
@@ -1248,16 +1260,11 @@ def assemble_claude_md(
         else:
             shared_primer = f"{shared_primer.rstrip()}\n\n{workspace_context}"
         parts.append(shared_primer.strip())
-    if memory_briefing.strip():
-        # ``briefing/profile.md`` retains its title on disk, but the generated
-        # prompt uses its identity sentence as the single identity occurrence.
-        memory_briefing = re.sub(
-            r"(<!-- puffo:managed-profile -->)\n# [^\n]+\n\n",
-            r"\1\n",
-            memory_briefing,
-            count=1,
-        )
-        parts.append(MEMORY_SECTION_HEADER + memory_briefing.strip())
+    role_parts = [part.strip() for part in (runtime_identity, profile) if part.strip()]
+    if role_parts:
+        parts.append("---\n\n# Your role\n\n" + "\n\n".join(role_parts))
+    if memory_snapshot.strip():
+        parts.append(MEMORY_SECTION_HEADER + memory_snapshot.strip())
     return "\n\n".join(parts) + "\n"
 
 
@@ -1332,7 +1339,7 @@ def rebuild_agent_codex_md(
     """Assemble + write one codex agent's AGENTS.md.
 
     Same content shape as ``rebuild_agent_claude_md`` (shared primer +
-    agent profile + compiled memory briefing), targeting codex's
+    agent profile + standing memory), targeting codex's
     instruction-file path. Skill bodies mirror into
     ``workspace/.agents/skills/`` where codex's project-scope discovery
     walks; the SKILL.md + frontmatter shape is identical to Claude
@@ -1348,16 +1355,15 @@ def rebuild_agent_codex_md(
     agents_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
-        workspace_shared_status=workspace_shared_status,
-        memory_briefing=compile_agent_memory_briefing(
-            memory_dir=memory_dir,
-            profile_text=profile_text,
+        runtime_identity=_runtime_identity_context(
             agent_id=agent_id,
             display_name=display_name,
             role=role,
             role_short=role_short,
             puffo_handle=puffo_handle,
         ),
+        workspace_shared_status=workspace_shared_status,
+        memory_snapshot=read_memory_snapshot(memory_dir),
     )
     write_agents_md(codex_user_dir, agents_md)
     return agents_md
@@ -1381,12 +1387,10 @@ def rebuild_agent_claude_md(
     """Assemble + write one agent's managed CLAUDE.md / GEMINI.md.
 
     Seeds the shared primer if missing, mirrors shared skills into the
-    workspace, reads the agent's ``profile.md``, brings the memory tree
-    up to date (ensure/migrate/profile-sync) and compiles the bounded
-    briefing, then writes the combined prompt to the agent's USER-level
-    ``.claude/`` / ``.gemini/`` dirs. Returns the assembled CLAUDE.md
-    string. Raises ``memory.BriefingCompileError`` when the briefing
-    is over budget (fail closed — the previous artifact is kept).
+    workspace, reads the agent's ``profile.md`` and standing-memory view,
+    then writes the combined prompt to the agent's USER-level ``.claude/`` /
+    ``.gemini/`` dirs. The read is non-mutating and does not enforce the alpha
+    briefing budget on legacy flat files.
 
     Shared by the worker's startup path and the ``agent reset-primer``
     CLI command so the assembly sequence lives in exactly one place.
@@ -1401,16 +1405,15 @@ def rebuild_agent_claude_md(
     claude_md = assemble_claude_md(
         shared_primer=primer,
         profile=profile_text,
-        workspace_shared_status=workspace_shared_status,
-        memory_briefing=compile_agent_memory_briefing(
-            memory_dir=memory_dir,
-            profile_text=profile_text,
+        runtime_identity=_runtime_identity_context(
             agent_id=agent_id,
             display_name=display_name,
             role=role,
             role_short=role_short,
             puffo_handle=puffo_handle,
         ),
+        workspace_shared_status=workspace_shared_status,
+        memory_snapshot=read_memory_snapshot(memory_dir),
     )
     write_claude_md(claude_user_dir, claude_md)
     write_gemini_md(gemini_user_dir, claude_md)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -61,30 +61,11 @@ from .workspace_layout import (
 
 DEFAULT_PROFILE = """# Agent Profile
 
-## Conversation Format
-Every incoming user message is wrapped in a structured markdown block:
-
-    - channel: <channel name>
-    - sender: <username> (<email>)
-    - message: <actual message text>
-
-The first two fields are context metadata — use them to understand where
-the message was posted and who sent it. Only the `message:` field
-contains the actual text you are replying to.
-
-IMPORTANT: Your reply must contain ONLY your response text. Do NOT
-include the markdown block, field labels like `message:`, bracketed
-prefixes like `[#channel]`, or self-identifiers. If you need to address
-the sender, use `@username` inline.
-
 ## Identity
 You are a helpful assistant.
 
-## When to Reply
-Use your judgement. Reply when someone directly addresses you or asks a
-question that invites a response. Stay silent when the conversation is
-between other people and you have nothing useful to add — output
-exactly `[SILENT]` to stay silent.
+## Soul
+Be thoughtful, capable, and clear.
 """
 
 
@@ -555,31 +536,13 @@ def cmd_agent_create(args: argparse.Namespace) -> int:
     cfg.save()
     _prepare_cli_shared_workspace(cfg)
 
-    from ..agent.memory import ensure_memory_tree, sync_profile_briefing
-
-    ensure_memory_tree(target / "memory")
+    (target / "memory").mkdir()
 
     profile_path = target / "profile.md"
     if args.profile and Path(args.profile).exists():
         shutil.copy2(args.profile, profile_path)
     else:
         profile_path.write_text(DEFAULT_PROFILE, encoding="utf-8")
-
-    # Seed briefing/profile.md now so the agent's very first prompt
-    # rebuild has managed identity framing (the worker's memory sync
-    # re-syncs it, but a freshly created agent shouldn't ship without
-    # it). Mirrors shared_content.rebuild_agent_claude_md's profile sync.
-    from .profile_sync import extract_soul_body
-
-    sync_profile_briefing(
-        target / "memory",
-        agent_id=agent_id,
-        display_name=cfg.display_name,
-        role=role,
-        role_short=role_short,
-        soul=extract_soul_body(profile_path.read_text(encoding="utf-8")),
-        puffo_handle=cfg.puffo_core.slug,
-    )
 
     _print_agent_create_result(agent_id, target)
     return 0

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -73,12 +73,11 @@ def _rebuild_managed_system_prompt(
     """Dispatch wrapper: write the right system-prompt file(s) for the
     agent's harness. Codex agents get ``$CODEX_HOME/AGENTS.md``; other
     harnesses use the shared Claude/Gemini prompt-file builder.
-    Returns the assembled prompt body either way. The identity fields
-    feed the managed ``memory/briefing/profile.md`` re-sync inside the
-    rebuild. ``puffo_handle`` is the authenticated ``puffo_core.slug``
-    the model should call itself on the network; ``agent_id`` continues
-    to name every local path (keystore, agent dir, RPC namespace) and so
-    stays separate.
+    Returns the assembled prompt body either way. The identity fields form
+    immutable addressing context next to the editable root ``profile.md``;
+    prompt rebuilds never rewrite memory. ``puffo_handle`` is the authenticated
+    ``puffo_core.slug`` the model should call itself on the network;
+    ``agent_id`` continues to name local storage and RPC namespaces.
     """
     if harness_name == "codex":
         return rebuild_agent_codex_md(
@@ -216,6 +215,7 @@ def _new_docker_adapter(
         puffo_core_slug=agent_cfg.puffo_core.slug,
         puffo_core_keys_dir=str(agent_dir(agent_cfg.id) / "keys"),
         claude_api_key=_claude_cli_api_key(daemon_cfg, harness.name()),
+        memory_dir=str(agent_cfg.resolve_memory_dir()),
     )
 
 

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -670,12 +670,8 @@ def test_process_refresh_flags_deletes_flags_after_processing(tmp_path, monkeypa
 def test_process_refresh_flags_keeps_authenticated_puffo_handle(
     tmp_path, monkeypatch,
 ):
-    """A refresh flag regenerates the managed profile block, so the
-    identity line is rewritten from whatever the refresh path forwards.
-    An imported agent pairs under a ``puffo_core.slug`` that differs from
-    its local ``agent_id``; if the handle is dropped here, the first
-    memory write (which drops ``refresh_agent.flag``) silently reverts the
-    model's self-identity to the unaddressable local id."""
+    """A prompt refresh keeps the authenticated network handle while leaving
+    memory untouched, even when it differs from the local agent id."""
     from puffo_agent.portal import worker as worker_mod
 
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "home"))
@@ -702,8 +698,8 @@ def test_process_refresh_flags_keeps_authenticated_puffo_handle(
         puffo_handle="bot-42-x9f2",
     ))
 
-    briefing = (memory_dir / "briefing" / "profile.md").read_text(
-        encoding="utf-8",
-    )
-    assert "You are bot-42-x9f2 (agent `bot-42-x9f2`)." in briefing
-    assert "bot-42 (agent" not in briefing
+    prompt = (tmp_path / "home" / "agents" / "bot-42" / ".claude" / "CLAUDE.md")
+    text = prompt.read_text(encoding="utf-8")
+    assert "Puffo handle: `@bot-42-x9f2`" in text
+    assert "Puffo handle: `@bot-42`" not in text
+    assert not (memory_dir / "briefing" / "profile.md").exists()

--- a/tests/test_desired_install_gc_and_harness_gates.py
+++ b/tests/test_desired_install_gc_and_harness_gates.py
@@ -291,6 +291,7 @@ def _make_agent_cfg(
         puffo_core=puffo_core,
         resolve_workspace_dir=lambda: Path("/tmp/ws"),
         resolve_claude_dir=lambda: Path("/tmp/ws/.claude"),
+        resolve_memory_dir=lambda: Path("/tmp/memory"),
     )
 
 

--- a/tests/test_docker_codex_driver.py
+++ b/tests/test_docker_codex_driver.py
@@ -34,11 +34,14 @@ from puffo_agent.portal.worker_run import StandardWorkerRun, WorkerRunPaths
 from puffo_agent.portal.workspace_layout import ensure_workspace_shared_link
 
 
-def _preparer(tmp_path, monkeypatch, *, gateway=False) -> DockerCodexPreparer:
+def _preparer(
+    tmp_path, monkeypatch, *, gateway=False, custom_memory=False,
+) -> DockerCodexPreparer:
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
     config = AgentConfig(
         id="docker-codex",
+        memory_dir=(str(tmp_path / "external-memory") if custom_memory else "memory"),
         runtime=RuntimeConfig(
             kind="cli-docker",
             provider="openai",
@@ -118,7 +121,7 @@ def _seed_local_to_docker_layout(preparer):
 
 
 def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
-    preparer = _preparer(tmp_path, monkeypatch, gateway=True)
+    preparer = _preparer(tmp_path, monkeypatch, gateway=True, custom_memory=True)
     (Path.home() / ".codex").mkdir(parents=True, exist_ok=True)
     (Path.home() / ".codex" / "config.toml").write_text(
         "[mcp_servers.host_only]\n"
@@ -174,6 +177,8 @@ def test_docker_codex_runtime_boundary(tmp_path, monkeypatch):
         assert run_cmd[:2] == ["/fake/docker", "run"]
         assert f"{preparer.codex_home}:/home/agent/.codex" in run_cmd
         assert f"{preparer.agent_home}:/home/agent/.puffo-agent-state" in run_cmd
+        memory_mount = f"{preparer.memory_dir}:/home/agent/.puffo-agent-state/memory"
+        assert memory_mount in run_cmd
         assert any(":/workspace" in part for part in run_cmd)
         assert f"{preparer.shared_fs_dir}:/workspace/shared" in run_cmd
         assert not (preparer.workspace_dir / "shared").is_symlink()

--- a/tests/test_docker_memory_limits.py
+++ b/tests/test_docker_memory_limits.py
@@ -16,7 +16,9 @@ from puffo_agent.agent.adapters import docker_cli
 from puffo_agent.agent.adapters.docker_cli import DockerCLIAdapter
 
 
-def _make_adapter(tmp_path, memory_limit="", memory_reservation=""):
+def _make_adapter(
+    tmp_path, memory_limit="", memory_reservation="", memory_dir="",
+):
     return DockerCLIAdapter(
         agent_id="t",
         model="",
@@ -28,6 +30,7 @@ def _make_adapter(tmp_path, memory_limit="", memory_reservation=""):
         shared_fs_dir=str(tmp_path / "shared"),
         memory_limit=memory_limit,
         memory_reservation=memory_reservation,
+        memory_dir=str(memory_dir) if memory_dir else "",
     )
 
 
@@ -98,6 +101,13 @@ def test_flags_appear_before_image_token(tmp_path):
     image_idx = argv.index("puffo/agent-runtime:test")
     assert argv.index("--memory") < image_idx
     assert argv.index("--memory-reservation") < image_idx
+
+
+def test_custom_memory_dir_is_mounted_at_the_canonical_container_path(tmp_path):
+    custom = tmp_path / "external-memory"
+    adapter = _make_adapter(tmp_path, memory_dir=custom)
+    argv = _capture_docker_run_argv(adapter, tmp_path)
+    assert f"{custom}:/home/agent/.puffo-agent-state/memory" in argv
 
 
 def test_daemon_defaults_apply_when_yaml_omits_fields(tmp_path):

--- a/tests/test_memory_m1.py
+++ b/tests/test_memory_m1.py
@@ -1,7 +1,5 @@
-"""M1 memory acceptance tests: memory tree, bounded briefing compile
-(fail closed), managed profile briefing, flat-memory migration, and
-the MemoryManager compat surface (save → briefing topic + refresh
-flag)."""
+"""Memory compatibility tests: the retained structured implementation plus
+the active Puffo Agent 1.2 flat-memory surface."""
 
 import json
 import re
@@ -17,6 +15,7 @@ from puffo_agent.agent.memory import (
     compile_briefing,
     ensure_memory_tree,
     migrate_flat_memory,
+    read_standing_memory_entries,
     render_profile_briefing,
     sync_profile_briefing,
 )
@@ -47,13 +46,11 @@ def test_ensure_memory_tree_creates_layout(tmp_path):
     }
 
 
-def test_memory_manager_init_seeds_tree(tmp_path):
+def test_memory_manager_init_uses_flat_layout_without_seeding_tree(tmp_path):
     root = tmp_path / "memory"
     MemoryManager(str(root))
-    assert (root / "briefing").is_dir()
-    assert (root / "notes").is_dir()
-    assert (root / "recollection").is_dir()
-    assert (root / "imports" / "index.md").is_file()
+    assert root.is_dir()
+    assert list(root.iterdir()) == []
 
 
 def test_ensure_memory_tree_is_idempotent_and_preserves_content(tmp_path):
@@ -186,6 +183,9 @@ def test_profile_briefing_resync_preserves_user_text_outside_markers(tmp_path):
     assert "New role" in text
     assert "Old role" not in text
     assert "User-authored addendum." in text
+    standing = dict(read_standing_memory_entries(root))
+    assert standing["profile-notes"] == "User-authored addendum."
+    assert "New role" not in standing["profile-notes"]
 
 
 # ── legacy flat-memory migration ─────────────────────────────────────
@@ -218,6 +218,9 @@ def test_migrate_flat_memory_small_to_briefing_big_to_notes(tmp_path):
     assert set(moved) == {"briefing/small.md", "notes/big.md"}
     # The migrated tree still compiles within budget.
     assert "a small fact" in compile_briefing(root)
+    standing = dict(read_standing_memory_entries(root))
+    assert standing["small"] == "a small fact"
+    assert standing["big"] == "x" * (PER_FILE_LIMIT + 1)
 
     # Idempotent: a second pass is a no-op.
     before = _tree_snapshot(root)
@@ -390,25 +393,37 @@ def _rebuild(root: Path) -> str:
     )
 
 
-def test_rebuild_picks_up_new_briefing_topic_and_ignores_notes(tmp_path):
+def test_rebuild_combines_flat_memory_with_structured_compatibility(tmp_path):
     (tmp_path / "profile.md").write_text(
         "# Soul\nI verify briefings.", encoding="utf-8",
     )
     (tmp_path / "workspace").mkdir()
     memory = tmp_path / "memory"
+    memory.mkdir()
 
     first = _rebuild(tmp_path)
     assert "I verify briefings." in first
 
+    (memory / "standing.md").write_text(
+        "Legacy standing fact A12.", encoding="utf-8",
+    )
+    ensure_memory_tree(memory)
     (memory / "briefing" / "deploys.md").write_text(
         "Deploy fact ZQX-77.", encoding="utf-8",
+    )
+    (memory / "briefing" / "standing.md").write_text(
+        "STALE-COMPAT-COPY", encoding="utf-8",
     )
     (memory / "notes" / "scratch.md").write_text(
         "NOTE-ONLY-DETAIL-42", encoding="utf-8",
     )
+    before = _tree_snapshot(memory)
     second = _rebuild(tmp_path)
+    assert "Legacy standing fact A12." in second
+    assert "STALE-COMPAT-COPY" not in second
     assert "Deploy fact ZQX-77." in second
     assert "NOTE-ONLY-DETAIL-42" not in second
+    assert _tree_snapshot(memory) == before
     assert (tmp_path / ".claude" / "CLAUDE.md").read_text(encoding="utf-8") == second
     assert (tmp_path / ".gemini" / "GEMINI.md").read_text(encoding="utf-8") == second
 
@@ -428,37 +443,23 @@ def test_rebuild_flag_dropped_by_memory_manager_save(tmp_path):
 # ── MemoryManager.save() compat ──────────────────────────────────────
 
 
-def test_save_writes_briefing_topic_with_frontmatter(tmp_path):
+def test_save_writes_flat_topic_with_frontmatter(tmp_path):
     root = tmp_path / "memory"
     mm = MemoryManager(str(root))
     mm.save("deploy notes/prod", "The fact.")
-    path = root / "briefing" / "deploy_notes-prod.md"
+    path = root / "deploy_notes-prod.md"
     text = path.read_text(encoding="utf-8")
     assert text.startswith("---\ntopic: deploy notes/prod\nupdated: ")
     assert text.endswith("The fact.\n")
     assert "The fact." in mm.get_context()
 
 
-def test_save_oversized_file_fails_closed_without_partial_state(tmp_path):
+def test_save_retains_legacy_unbounded_flat_behavior(tmp_path):
     root = tmp_path / "memory"
     mm = MemoryManager(str(root))
-    with pytest.raises(BriefingCompileError) as ei:
-        mm.save("big", "x" * (PER_FILE_LIMIT + 1))
-    assert ei.value.code == "memory_file_too_large"
-    assert not (root / "briefing" / "big.md").exists()
-
-
-def test_save_over_total_budget_fails_closed_without_partial_state(tmp_path):
-    root = tmp_path / "memory"
-    mm = MemoryManager(str(root))
-    for i in range(4):
-        (root / "briefing" / f"seed-{i}.md").write_text(
-            "s" * (15 * 1024), encoding="utf-8",
-        )
-    with pytest.raises(BriefingCompileError) as ei:
-        mm.save("overflow", "o" * (8 * 1024))
-    assert ei.value.code == "memory_briefing_too_large"
-    assert not (root / "briefing" / "overflow.md").exists()
+    body = "x" * (TOTAL_LIMIT + 1)
+    mm.save("large", body)
+    assert body in (root / "large.md").read_text(encoding="utf-8")
 
 
 def test_save_without_workspace_dir_drops_no_flag(tmp_path):

--- a/tests/test_shared_primer.py
+++ b/tests/test_shared_primer.py
@@ -12,10 +12,6 @@ from puffo_agent.agent.shared_content import (
 )
 
 
-PARENT_CLAUDE_BYTES = 16109
-PARENT_CODEX_BYTES = 15989
-
-
 def _tmp() -> Path:
     return Path(tempfile.mkdtemp())
 
@@ -26,6 +22,7 @@ def _rebuild(
     profile = root / "profile.md"
     profile.write_text("# Soul\nSOUL-MARKER-7b", encoding="utf-8")
     memory = root / "memory"
+    memory.mkdir()
     workspace = root / "workspace"
     workspace.mkdir()
     common = dict(
@@ -38,8 +35,8 @@ def _rebuild(
     claude = rebuild_agent_claude_md(
         **common, claude_user_dir=root / ".claude", gemini_user_dir=root / ".gemini",
     )
-    (memory / "briefing" / "topic.md").write_text(
-        "NON-PROFILE-TOPIC-MARKER-c0", encoding="utf-8",
+    (memory / "topic.md").write_text(
+        "FLAT-TOPIC-MARKER-c0", encoding="utf-8",
     )
     claude = rebuild_agent_claude_md(
         **common, claude_user_dir=root / ".claude", gemini_user_dir=root / ".gemini",
@@ -48,18 +45,16 @@ def _rebuild(
     return claude, codex
 
 
-def test_standing_prompt_is_compact_and_identity_is_compiled_once():
+def test_standing_prompt_contains_runtime_identity_profile_and_flat_memory():
     claude, codex = _rebuild(_tmp())
     for text in (claude, codex):
         for marker in (
             "DISPLAY-NAME-MARKER-9d", "AGENT-ID-MARKER-8c", "LONG-ROLE-MARKER-ae",
-            "SHORT-ROLE-MARKER-bf", "SOUL-MARKER-7b", "NON-PROFILE-TOPIC-MARKER-c0",
+            "SHORT-ROLE-MARKER-bf", "SOUL-MARKER-7b", "FLAT-TOPIC-MARKER-c0",
         ):
             assert text.count(marker) == 1
-        assert "# Your role" not in text
+        assert "# Your role" in text
         assert "# Your memory" in text
-    assert len(claude.encode()) < PARENT_CLAUDE_BYTES
-    assert len(codex.encode()) < PARENT_CODEX_BYTES
 
 
 def test_standing_prompt_owns_communication_policy_and_retains_contract():

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a11"
+version = "2.0.0a12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Goal

Restore the Puffo Agent 1.2 memory behavior as the active default without deleting or rewriting the structured 2.0-alpha memory data and tools.

This is intentionally stacked on #237 so it can be reviewed independently from the Inbox and Harness telemetry work.

## Runtime architecture

```text
root profile.md ---------------------> # Your role
runtime identity (@handle, role) ----/

memory/*.md -------------------------\
memory/briefing/*.md (fallback) ------> # Your memory -> AGENTS.md / CLAUDE.md / GEMINI.md
migrated notes named by pointer ------/
```

- Flat `memory/*.md` is again the authoritative standing-memory surface.
- A same-named flat topic wins over a structured briefing topic.
- Prompt assembly is read-only: it performs no startup migration, deletion, or profile rewrite.
- Existing structured MCP tools and data remain available. Briefing topics and notes moved by an earlier alpha migration remain prompt-visible through a compatibility view.
- `MemoryManager.save()` again writes flat files and is not subject to the alpha 16 KiB / 64 KiB briefing limits.
- Custom memory roots are mounted at the canonical Puffo state path in Docker Claude Code and Codex runtimes.

## Compatibility

- Existing 1.2 flat memory continues to load and update.
- Existing 2.0-alpha structured memory remains readable and writable through its MCP surfaces.
- Existing authenticated Puffo handles remain explicit in generated provider prompts.
- New Agent creation no longer seeds or mutates the structured tree.

## Validation

- Full pytest suite: passed, with one expected Windows-only skip.
- `pre-commit run --all-files`: passed.
- Ruff lint: passed.
- Python structural limits: passed.
- `git diff --check`: passed.