### PR TITLE
chore(release): prepare 2.0.0a13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a13] - 2026-08-16
+
+> Integrated staging candidate built from the merged Agent Foundation,
+> flat-memory compatibility, and current control-plane fixes.
+
+### Fixed
+
+- **Web Refresh now performs a complete refresh by default.** A parameterless
+  control command reloads the session and host-managed skills/MCP state as well
+  as the Agent prompt; callers can still request a narrower refresh explicitly.
+- **Credential recovery no longer re-flags healthy Agents as broken.** External
+  Claude credential rotation and successful refreshes clear the shared failure
+  state, while a benign unchanged fresh credential is not counted as failure.
+- **Archived and deleted Agents leave their spaces before device revocation.**
+  The daemon and CLI use the same ordered flow, preserve retryable failures for
+  a later sweep, and avoid leaving ordinary channel-roster memberships behind.
+
 ## [2.0.0a12] — 2026-08-16
 
 > Staging candidate restoring Puffo Agent 1.2 memory compatibility while

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a12"
+version = "2.0.0a13"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a12"
+version = "2.0.0a13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare the integrated `2.0.0a13` staging candidate from the current merged `main`.

This candidate includes:
- Agent Foundation inbox/harness telemetry and flat-memory compatibility (#237, #238)
- parameterless Web Refresh full-refresh behavior (#231)
- credential refresh recovery-state correction (#226)
- archive/delete space-leave ordering (#230)

## Consistency contract

The currently installed isolated test package is `2.0.0a12`, built from `2021d7340e6bc5e7793b4575ee12a01f7177cc6f`. It includes #237/#238 but predates #231/#226/#230 on `main`.

This release advances to `2.0.0a13` because published Python versions are immutable. After merge and TestPyPI publication, the isolated local test daemon will be upgraded to this exact package so the tested package and final merged source are aligned.

## Verification

- `git diff --check`
- `uv lock --check`
- `uv build`
- wheel metadata asserted as `Version: 2.0.0a13`
