### PR TITLE
Wake idle agents immediately for Inbox work

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ sequenceDiagram
     DB-->>T: durable receipt decision
     T-->>S: delivery ACK when the decision permits it
     DB->>I: notify pending work
-    I->>I: coalesce and group by space + channel/thread/DM target
+    I->>I: wake idle Agent now; coalesce active-turn deltas
     I->>DB: create daemon-owned active turn
     I->>L: metadata-only Inbox notice
     L->>M: read_inbox and optional read_history calls
@@ -146,9 +146,11 @@ Important boundaries:
 - One `GlobalInboxRuntime` owns one serial provider boundary per Agent. New
   arrivals can be steered only when the active Driver exposes a safe steering
   capability; otherwise they remain durable for the next turn.
-- The three-second window coalesces newly changed pending IDs. It is not a retry
-  interval for an unchanged unread set. A successful notice turn that performs
-  no Inbox read is a normal provider defer and does not immediately run again.
+- An idle Agent is notified immediately. During an active turn, a non-resetting
+  three-second window coalesces newly changed pending IDs before safe steering
+  or the next turn. It is not a retry interval for an unchanged unread set. A
+  successful notice turn that performs no Inbox read is a normal provider defer
+  and does not immediately run again.
 - Notice delivery records the exact pending IDs contributed to the current
   native provider session. Later arrivals produce a delta notice; a replacement
   session rediscovers the remaining pending set once. Provider failure or crash

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -259,7 +259,8 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         self._degraded = False
         self._degraded_until = None
         self._degraded_attempts = 0
-        self.coalescer.notify()
+        delay = self._busy_notice_delay_seconds if self.active.turn_id else 0.0
+        self.coalescer.notify(delay_seconds=delay)
         self._schedule_busy_notice()
 
     async def create_reminder(
@@ -352,20 +353,10 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                 # failed durable union through the initial-turn path.
                 await self.coalescer.wait_for_burst()
             elif await self.store.get_pending(limit=1):
-                notice = await self.store.get_notice_state()
                 if await self.store.get_notice_candidates(
                     self.adapter.get_provider_session_id()
                 ):
-                    remaining = (
-                        max(
-                            0.0,
-                            (notice.first_pending_deadline_ms - int(time.time() * 1000))
-                            / 1000,
-                        )
-                        if notice.first_pending_deadline_ms is not None
-                        else 0.0
-                    )
-                    self.coalescer.notify(delay_seconds=remaining)
+                    self.notify()
             while not self._stopping:
                 burst_task = asyncio.create_task(self.coalescer.wait_for_burst())
                 done, _pending = await asyncio.wait(

--- a/src/puffo_agent/agent/inbox_scheduler.py
+++ b/src/puffo_agent/agent/inbox_scheduler.py
@@ -191,7 +191,7 @@ class InboxPlanner:
 
 
 class InboxCoalescer:
-    """Metadata-free, non-resetting fixed-window wake coalescer."""
+    """Metadata-free, non-resetting deadline wake coalescer."""
 
     def __init__(
         self,
@@ -214,7 +214,17 @@ class InboxCoalescer:
             0.0, delay_seconds
         )
         candidate = now + delay
-        if not self._deadlines or now >= self._deadlines[-1]:
+        if not self._deadlines:
+            self._deadlines.append(candidate)
+        elif delay == 0.0:
+            # One unconsumed immediate wake is enough: the next plan reads the
+            # durable pending set, including every receipt committed before it
+            # starts. A second zero-delay deadline would only create an empty
+            # follow-up planning cycle.
+            if candidate < self._deadlines[0]:
+                self._deadlines[0] = candidate
+                self._pulled.set()
+        elif now >= self._deadlines[-1]:
             self._deadlines.append(candidate)
         elif candidate < self._deadlines[0]:
             # A pending deadline may only move earlier, never later, so the

--- a/tests/test_global_inbox_runtime_held_and_reminders.py
+++ b/tests/test_global_inbox_runtime_held_and_reminders.py
@@ -23,6 +23,7 @@ from puffo_agent.agent.global_inbox_runtime import (
     route_for,
 )
 from puffo_agent.agent.inbox_scheduler import (
+    COALESCE_SECONDS,
     InboxNoticeDelivery,
     NoticeDeliveryCapability,
 )
@@ -419,6 +420,30 @@ async def test_only_intro_system_anchor_authorizes_top_level_channel_send(tmp_pa
     assert route.kind == "thread"
     assert route.thread_root_id == row.envelope_id
     await store.close()
+
+
+def test_notify_wakes_idle_runtime_immediately_and_coalesces_active_turn(tmp_path):
+    class RecordingCoalescer:
+        def __init__(self):
+            self.delays = []
+
+        def notify(self, *, delay_seconds=None):
+            self.delays.append(delay_seconds)
+
+    coalescer = RecordingCoalescer()
+    runtime = GlobalInboxRuntime(
+        store=object(),
+        adapter=Adapter(),
+        run_turn=lambda _planned: None,
+        workspace=tmp_path,
+        coalescer=coalescer,
+    )
+
+    runtime.notify()
+    runtime.active.turn_id = "active-turn"
+    runtime.notify()
+
+    assert coalescer.delays == [0.0, COALESCE_SECONDS]
 
 
 @pytest.mark.asyncio

--- a/tests/test_inbox_scheduler.py
+++ b/tests/test_inbox_scheduler.py
@@ -218,6 +218,23 @@ async def test_coalescer_deadline_starts_at_notify_before_delayed_waiter():
 
 
 @pytest.mark.asyncio
+async def test_immediate_notifications_share_one_unconsumed_wake():
+    sleeps = []
+
+    async def sleep(delay):
+        sleeps.append(delay)
+
+    coalescer = InboxCoalescer(sleep=sleep, monotonic=lambda: 20.0)
+    coalescer.notify(delay_seconds=0)
+    coalescer.notify(delay_seconds=0)
+
+    await coalescer.wait_for_burst()
+
+    assert sleeps == [pytest.approx(0.0)]
+    assert not coalescer._deadlines
+
+
+@pytest.mark.asyncio
 async def test_coalescer_preserves_notification_for_next_expired_window():
     now = 30.0
     sleeps = []


### PR DESCRIPTION
## Summary
- wake an idle Agent immediately when durable Inbox work arrives
- retain the non-resetting 3-second aggregation window only while a turn is active
- coalesce repeated zero-delay notifications into one unconsumed wake
- align startup recovery and architecture docs with the same state-based policy

## State flow

```text
new pending message
  |-- no active turn  -> wake now -> plan Inbox turn
  `-- active turn     -> aggregate for 3s -> steer safely or run next turn
```

## Why

The previous scheduler applied the 3-second window to every notification, including an idle Agent. That introduced an artificial minimum latency before the provider saw the Inbox notice.

## Verification
- full pytest suite passed (one existing Windows-only skip)
- pre-commit passed
- Ruff passed
- Python structural check passed
- regression tests fail on the old implementation and pass on this branch