### PR TITLE
chore(release): prepare 2.0.0a15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a15] - 2026-08-17
+
+> Staging candidate removing the fixed Inbox delay for idle Agents.
+
+### Fixed
+
+- **Idle Agents now begin Inbox processing immediately.** The three-second,
+  non-resetting aggregation window applies only while a durable turn is active;
+  startup recovery with pending work also wakes immediately.
+- **Bursts of immediate notifications no longer enqueue redundant planning
+  cycles.** Multiple committed receipts share one unconsumed wake while the
+  next plan reads the complete durable pending set.
+
 ## [2.0.0a14] - 2026-08-17
 
 > Staging candidate unifying Docker execution with the shared Driver and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a14"
+version = "2.0.0a15"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a14"
+version = "2.0.0a15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- publish the merged idle Inbox wake-up fix as `2.0.0a15`
- document immediate idle/startup wake behavior and active-turn aggregation
- document coalescing of repeated immediate notifications

## Verification

- full test suite passed on the implementation PR (#247)
- pre-commit and Ruff checks passed
- `uv lock --check`
- built wheel and sdist locally
- isolated Python 3.11 wheel install
- `puffo-agent version` reports `2.0.0a15`
- `puffo-agent --help` starts successfully

This is a TestPyPI staging candidate; it does not create a production PyPI release.