### PR TITLE
Restore 1.2 token usage audit metadata

### DIFF
--- a/src/puffo_agent/agent/runtime_event_outbox.py
+++ b/src/puffo_agent/agent/runtime_event_outbox.py
@@ -71,7 +71,24 @@ def _metadata_only_event(value: Any) -> RuntimeEvent | None:
         if not isinstance(outcome, str) or outcome not in TURN_OUTCOMES:
             return None
         legacy_error = payload.get("error")
+        legacy_tokens = payload.get("tokens")
+        legacy_context = payload.get("current_context")
         payload = {"outcome": outcome}
+        if outcome == "succeeded" and (
+            isinstance(legacy_tokens, dict)
+            and set(legacy_tokens) == {"input", "output"}
+            and all(
+                type(value) is int and value >= 0
+                for value in legacy_tokens.values()
+            )
+        ):
+            payload["tokens"] = legacy_tokens
+        if (
+            outcome == "succeeded"
+            and type(legacy_context) is int
+            and legacy_context > 0
+        ):
+            payload["current_context"] = legacy_context
         if outcome == "failed" and isinstance(legacy_error, dict):
             payload["error"] = safe_error(
                 str(legacy_error.get("code") or "unknown"),

--- a/src/puffo_agent/agent/runtime_events.py
+++ b/src/puffo_agent/agent/runtime_events.py
@@ -127,10 +127,28 @@ def validate_runtime_event(event: RuntimeEvent) -> None:
         if payload["state"] not in PERMISSION_STATES:
             raise ValueError("invalid permission state")
     if event.type == "turn.finished":
-        if not set(payload) <= {"outcome", "error"}:
+        if not set(payload) <= {
+            "outcome", "error", "tokens", "current_context",
+        }:
             raise ValueError("turn.finished has unsupported fields")
         if payload.get("outcome") not in TURN_OUTCOMES:
             raise ValueError("invalid turn outcome")
+        tokens = payload.get("tokens")
+        if tokens is not None and (
+            not isinstance(tokens, Mapping)
+            or set(tokens) != {"input", "output"}
+            or any(type(value) is not int or value < 0 for value in tokens.values())
+        ):
+            raise ValueError("turn.finished tokens are invalid")
+        current_context = payload.get("current_context")
+        if current_context is not None and (
+            type(current_context) is not int or current_context <= 0
+        ):
+            raise ValueError("turn.finished current_context is invalid")
+        if payload.get("outcome") != "succeeded" and (
+            tokens is not None or current_context is not None
+        ):
+            raise ValueError("turn.finished usage requires succeeded outcome")
         if payload.get("outcome") != "failed" and "error" in payload:
             raise ValueError("turn.finished error requires failed outcome")
         if payload.get("outcome") == "failed" and "error" in payload:
@@ -217,6 +235,10 @@ def safe_error(
     }
 
 
+def _token_count(value: Any) -> int:
+    return value if type(value) is int and value >= 0 else 0
+
+
 class RuntimeEventProjector:
     """Allowlist-only projection from normalized Driver events."""
 
@@ -282,14 +304,22 @@ class RuntimeEventProjector:
             if outcome not in TURN_OUTCOMES:
                 outcome = "failed"
             payload: dict[str, Any] = {"outcome": outcome}
+            if kind == "turn.completed" and outcome == "succeeded":
+                payload["tokens"] = {
+                    "input": _token_count(data.get("input_tokens")),
+                    "output": _token_count(data.get("output_tokens")),
+                }
+                context_tokens = data.get("context_tokens")
+                if type(context_tokens) is int and context_tokens > 0:
+                    payload["current_context"] = context_tokens
             if outcome == "failed":
                 payload["error"] = safe_error(
                     str(data.get("error_code") or "unknown"),
                     retryable=bool(data.get("retryable")),
                 )
             return self._make(event, "turn.finished", payload)
-        # Deliberate suppression: native frames, reasoning, context/token
-        # diagnostics, tool payloads, credentials, and unrelated messages.
+        # Deliberate suppression: native frames, reasoning, provider diagnostics,
+        # tool payloads, credentials, and unrelated messages.
         return None
 
     def _tool(self, event: HarnessEvent, state: str) -> RuntimeEvent | None:

--- a/tests/test_runtime_event_outbox.py
+++ b/tests/test_runtime_event_outbox.py
@@ -205,7 +205,10 @@ async def test_assistant_output_is_not_persisted_but_terminal_is_kept(
     assert [value["type"] for value in values] == [
         "turn.started", "activity.updated", "turn.finished"
     ]
-    assert values[-1]["payload"] == {"outcome": "succeeded"}
+    assert values[-1]["payload"] == {
+        "outcome": "succeeded",
+        "tokens": {"input": 0, "output": 0},
+    }
     outbox.close()
 
 
@@ -338,7 +341,8 @@ async def test_byte_bound_and_terminal_capacity_reservation(tmp_path):
 
 @pytest.mark.asyncio
 async def test_sink_projects_metadata_lifecycle_without_assistant_output(tmp_path):
-    outbox = RuntimeEventOutbox(tmp_path / "runtime_events.db")
+    path = tmp_path / "runtime_events.db"
+    outbox = RuntimeEventOutbox(path)
     sink = RuntimeEventProjectingSink(
         outbox,
         RuntimeEventProjector(agent_id="agent", session_ref="session"),
@@ -358,12 +362,23 @@ async def test_sink_projects_metadata_lifecycle_without_assistant_output(tmp_pat
     await sink(native(
         "turn.assistant_completed", {"block_id": "result"}
     ))
-    await sink(native("turn.completed", {"outcome": "succeeded"}))
+    await sink(native("turn.completed", {
+        "outcome": "succeeded",
+        "input_tokens": 12,
+        "output_tokens": 3,
+        "context_tokens": 142_000,
+    }))
+    outbox.close()
+    outbox = RuntimeEventOutbox(path)
     values = [row.event for row in outbox.prefix()]
     assert [value["type"] for value in values] == [
         "turn.started", "activity.updated", "turn.finished",
     ]
-    assert values[-1]["payload"] == {"outcome": "succeeded"}
+    assert values[-1]["payload"] == {
+        "outcome": "succeeded",
+        "tokens": {"input": 12, "output": 3},
+        "current_context": 142_000,
+    }
     assert "abcdefghij" not in json.dumps(values)
     outbox.close()
 

--- a/tests/test_runtime_events.py
+++ b/tests/test_runtime_events.py
@@ -91,6 +91,15 @@ def test_schema_rejects_open_enum_values_and_extra_payload_fields():
             "permission_ref": "perm", "title": "Permission", "state": "maybe",
         }),
         ("turn.finished", {"outcome": "timed_out"}),
+        ("turn.finished", {
+            "outcome": "succeeded", "tokens": {"input": True, "output": 1},
+        }),
+        ("turn.finished", {
+            "outcome": "succeeded", "current_context": 0,
+        }),
+        ("turn.finished", {
+            "outcome": "failed", "tokens": {"input": 1, "output": 0},
+        }),
         ("output.updated", {
             "block_id": "out", "kind": "reasoning", "phase": "start",
         }),


### PR DESCRIPTION
## Summary

- project the existing driver token counts into `turn.finished` using the 1.2.0 shape: `tokens.input`, `tokens.output`, and optional `current_context`
- preserve only that safe usage metadata when the durable runtime-event outbox is reopened after a daemon restart
- keep failed, cancelled, and abandoned turns usage-free, matching the legacy behavior
- add no provider/model/cache/thinking/cost fields and no new event type

## Rollout dependency

Deploy puffo-server PR https://github.com/puffo-ai/puffo-server/pull/303 first. The old Server uses a closed payload schema and rejects these new optional fields.

## Verification

- `uv run --extra dev pytest tests/test_runtime_events.py tests/test_runtime_event_outbox.py` (101 passed)
- `uv run --extra dev pytest tests/test_inbox_observability.py tests/test_runtime_manager_failures.py` (21 passed)
- `uv run --extra dev pytest tests/test_harness_driver.py` (45 passed)
- focused `ruff check`
- `git diff --check`