### PR TITLE
Fix cli-docker inbound attachment paths

### DIFF
--- a/src/puffo_agent/agent/inbound_attachments.py
+++ b/src/puffo_agent/agent/inbound_attachments.py
@@ -214,7 +214,11 @@ async def save_inbound_attachments(
     strip_wrapper: Callable[[bytes], bytes] = strip_multipart_wrapper,
     scale_image: ImageScaler = downscale_oversized_image,
 ) -> list[str]:
-    """Save decrypted attachments and return model-readable absolute paths."""
+    """Save decrypted attachments and return host paths for durable storage.
+
+    The conversation projection converts these to workspace-relative paths
+    before exposing them to a local or containerized harness.
+    """
     if not workspace or not metas_raw:
         return []
     if not is_safe_path_component(envelope_id):

--- a/src/puffo_agent/agent/message_projection.py
+++ b/src/puffo_agent/agent/message_projection.py
@@ -292,6 +292,8 @@ def sender_type(message: Any, *, current_agent_aliases: Sequence[str] = ()) -> s
     explicit = content.get("sender_type") or _value(message, "sender_type", "")
     if explicit in {"human", "agent", "system"}:
         return str(explicit)
+    if _normalized_slug(_value(message, "sender_slug")) == "system":
+        return "system"
     if (
         content.get("sender_is_agent")
         or content.get("sender_is_bot")
@@ -338,8 +340,25 @@ def _attachment_paths(message: Any) -> list[str]:
         "attachment_paths", _content(message).get("attachments"),
     )
     if isinstance(attachments, Sequence) and not isinstance(attachments, (str, bytes)):
-        return [str(path) for path in attachments if path not in (None, "")]
+        return [
+            _model_attachment_path(path)
+            for path in attachments
+            if path not in (None, "")
+        ]
     return []
+
+
+def _model_attachment_path(value: Any) -> str:
+    """Project a materialized Inbox file into the harness workspace."""
+    raw = str(value)
+    parts = raw.replace("\\", "/").split("/")
+    for index in range(len(parts) - 1):
+        if parts[index:index + 2] != [".puffo", "inbox"]:
+            continue
+        relative = parts[index:]
+        if ".." not in relative:
+            return "/".join(relative)
+    return raw
 
 
 def _mentions(message: Any) -> list[dict[str, Any]]:

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -324,9 +324,10 @@ DEFAULT_SKILL_ATTACHMENTS = """\
 
 When a user sends you a file, the daemon decrypts it before your
 turn starts and saves it at
-``<workspace>/.puffo/inbox/<envelope_id>/<filename>``. The absolute
-path shows up in the `attachments:` block of the message metadata —
-one line per file.
+``<workspace>/.puffo/inbox/<envelope_id>/<filename>``. Its
+workspace-relative path shows up in the message's
+`attachment_paths=[...]` field, for example
+``.puffo/inbox/<envelope_id>/<filename>``.
 
 **What to do with them:**
 - Read text-shaped files (`.md`, `.txt`, `.json`, source code, …)

--- a/tests/test_message_projection.py
+++ b/tests/test_message_projection.py
@@ -116,6 +116,22 @@ def test_dm_projection_preserves_paths_mentions_visibility_and_reply_count():
         assert field in output
 
 
+def test_attachment_paths_are_projected_relative_to_the_harness_workspace():
+    host_path = (
+        "/home/hanchen/.puffo-agent/agents/linus/workspace/"
+        ".puffo/inbox/msg_attachment/ballerz.jpeg"
+    )
+    output = format_message_group([
+        message(content={"text": "image", "attachment_paths": [host_path]})
+    ])
+
+    assert (
+        'attachment_paths=[".puffo/inbox/msg_attachment/ballerz.jpeg"]'
+        in output
+    )
+    assert "/home/hanchen" not in output
+
+
 def test_sender_type_normalizes_legacy_bot_fields_but_explicit_type_wins():
     rows = [
         message(
@@ -126,6 +142,10 @@ def test_sender_type_normalizes_legacy_bot_fields_but_explicit_type_wins():
             envelope_id="explicit", thread_root_id=None,
             content={"text": "explicit", "sender_type": "human", "sender_is_bot": True},
         ),
+        message(
+            envelope_id="system", thread_root_id=None, sender_slug="system",
+            content={"text": "system"},
+        ),
     ]
     output = format_message_group(rows)
     legacy = output[
@@ -134,8 +154,12 @@ def test_sender_type_normalizes_legacy_bot_fields_but_explicit_type_wins():
     explicit = output[
         output.index('message_id="explicit"'):output.index('\ncontent="explicit"')
     ]
+    system = output[
+        output.index('message_id="system"'):output.index('\ncontent="system"')
+    ]
     assert 'sender_type="agent"' in legacy
     assert 'sender_type="human"' in explicit
+    assert 'sender_type="system"' in system
 
 
 def test_optional_chronological_projection_orders_held_context_by_sequence():


### PR DESCRIPTION
## Problem

Inbound attachments are materialized in each Agent workspace on the host. `cli-docker` bind-mounts that workspace at `/workspace`, but the model context currently exposes the host absolute path, which does not exist inside the container. This reproduces acceptance report item #1. System-authored rows can also be projected as `sender_type="unknown"` despite an authenticated `@system` sender.

## Fix

- keep host absolute paths in local storage for durable file ownership
- at the shared model-context projection boundary, expose `.puffo/inbox/<message>/<file>` for every generated Inbox attachment path
- apply the same projection to initial Inbox reads, history reads, held context, and `get_post` because all use `format_message_group`
- transparently normalize already-stored absolute paths, so no database migration is needed
- document the workspace-relative `attachment_paths=[...]` contract
- classify authenticated `@system` rows as `sender_type="system"`

## Compatibility

Local and Docker harnesses both run with the Agent workspace as their cwd, and `send_message_with_attachments` already accepts workspace-relative paths. Unknown external paths remain unchanged.

## Verification

- projection/primer/membership tests: 19 passed
- attachment ingress tests: 7 passed
- Inbox/history/get-post tests: 10 passed
- held/reminder runtime tests: 49 passed
- focused `ruff check`
- `git diff --check`