### PR TITLE
fix: close acceptance message contract gaps

### DIFF
--- a/src/puffo_agent/agent/bridge_transport.py
+++ b/src/puffo_agent/agent/bridge_transport.py
@@ -76,7 +76,11 @@ from .keyless_dm_approval_flow import (
     resume_pending_approvals,
 )
 from .membership_events import invite_poll_loop
-from .message_context import MENTION_RE, maybe_redact_long_text
+from .message_context import (
+    MENTION_RE,
+    content_with_visibility,
+    maybe_redact_long_text,
+)
 from .message_store import ReceiptDisposition, ReceiptWriteStatus
 
 KEYLESS_DM_REPLY_REASON = "handled keyless dm approval reply"
@@ -888,7 +892,15 @@ async def _commit_bridge_verdict(
     foreign DM must not be, since it stays queued server-side until the
     operator answers.
     """
-    if verdict.content is not None:
+    if verdict.gate == "self_echo":
+        row = dict(row)
+        row["content"] = content_with_visibility(
+            payload.content if verdict.content is None else verdict.content,
+            is_visible_to_human=payload.is_visible_to_human,
+        )
+        if verdict.content is not None:
+            row["content_type"] = "text/plain"
+    elif verdict.content is not None:
         row = dict(row)
         row["content"] = verdict.content
         row["content_type"] = "text/plain"

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -6,6 +6,7 @@ from ._time import ms_to_iso as _ms_to_iso
 from .adapters import Adapter, TurnContext
 from .adapters.base import STATUS_PREVIEW_CHARS, is_silent
 from .errors import AgentAPIError
+from .message_projection import model_attachment_path
 from .memory import MemoryManager
 
 MAX_LOG_ENTRIES = 60
@@ -597,7 +598,8 @@ class PuffoAgent:
                 lines.append(f"  - {m['username']}{suffix}")
         if attachments:
             lines.append("- attachments:")
-            for path in attachments:
+            for raw_path in attachments:
+                path = model_attachment_path(raw_path)
                 lines.append(f"  - {path}")
                 origin = _origin_for_compressed(path)
                 if origin:
@@ -639,7 +641,7 @@ def _user_metadata_lines(
     """Render stable user-message metadata before optional projections."""
     lines: list[str] = []
     if post_id:
-        lines.append(f"- post_id: {post_id}")
+        lines.append(f"- message_id: {post_id}")
     if space_name:
         lines.append("- space: " + space_name)
     if space_id:
@@ -656,15 +658,16 @@ def _user_metadata_lines(
         lines.append(f"- timestamp: {timestamp}")
     lines.append(f"- sender: {sender_display_name or sender}")
     lines.append(f"- sender_slug: {sender}")
-    projected = (
-        sender_type
-        if sender_type in {"human", "agent"}
-        else (
-            "agent"
-            if (sender_is_agent or sender_owner_slug)
-            else ("human" if is_from_operator else "unknown")
-        )
-    )
+    if sender_type in {"human", "agent", "system"}:
+        projected = sender_type
+    elif sender.lstrip("@").lower() == "system":
+        projected = "system"
+    elif sender_is_agent or sender_owner_slug:
+        projected = "agent"
+    elif is_from_operator:
+        projected = "human"
+    else:
+        projected = "unknown"
     lines.append(f"- sender_type: {projected}")
     if sender_owner_slug:
         lines.append(f"- sender_owner_slug: {sender_owner_slug}")

--- a/src/puffo_agent/agent/inbound_receipts.py
+++ b/src/puffo_agent/agent/inbound_receipts.py
@@ -19,7 +19,11 @@ from .ingress_policy import (
     foreign_dm_gate,
     operator_control_gate,
 )
-from .message_context import MENTION_RE, maybe_redact_long_text
+from .message_context import (
+    MENTION_RE,
+    content_with_visibility,
+    maybe_redact_long_text,
+)
 from .message_store import ReceiptDisposition, ReceiptWriteStatus
 
 if TYPE_CHECKING:
@@ -379,10 +383,16 @@ class InboundReceiptHandler:
             return None
         if payload.envelope_kind == "dm":
             await self.client._maybe_allowlist_outbound_dm(payload.recipient_slug)
+        replacement = self._echo_redaction(payload)
+        committer.stored_payload["content"] = content_with_visibility(
+            payload.content if replacement is None else replacement,
+            is_visible_to_human=payload.is_visible_to_human,
+        )
+        if replacement is not None:
+            committer.stored_payload["content_type"] = "text/plain"
         return await committer.commit(
             ReceiptDisposition.TERMINAL,
             "self echo",
-            content=self._echo_redaction(payload),
         )
 
     def _echo_redaction(self, payload: MessagePayload) -> str | None:

--- a/src/puffo_agent/agent/message_context.py
+++ b/src/puffo_agent/agent/message_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any, Mapping
 
 
 logger = logging.getLogger(__name__)
@@ -15,6 +16,20 @@ MENTION_RE = re.compile(
 )
 
 _LONG_MESSAGE_PREVIEW_CHARS = 240
+
+
+def content_with_visibility(
+    content: object,
+    *,
+    is_visible_to_human: bool,
+) -> dict[str, Any]:
+    """Preserve message content while attaching its authenticated visibility."""
+    if isinstance(content, Mapping):
+        projected = dict(content)
+    else:
+        projected = {"text": "" if content is None else str(content)}
+    projected["is_visible_to_human"] = bool(is_visible_to_human)
+    return projected
 
 
 def maybe_redact_long_text(

--- a/src/puffo_agent/agent/message_projection.py
+++ b/src/puffo_agent/agent/message_projection.py
@@ -341,14 +341,14 @@ def _attachment_paths(message: Any) -> list[str]:
     )
     if isinstance(attachments, Sequence) and not isinstance(attachments, (str, bytes)):
         return [
-            _model_attachment_path(path)
+            model_attachment_path(path)
             for path in attachments
             if path not in (None, "")
         ]
     return []
 
 
-def _model_attachment_path(value: Any) -> str:
+def model_attachment_path(value: Any) -> str:
     """Project a materialized Inbox file into the harness workspace."""
     raw = str(value)
     parts = raw.replace("\\", "/").split("/")

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -215,7 +215,7 @@ Post a message to a Puffo.ai channel or DM a user.
   channel. No `#<name>` shortcut; use `list_channels_in_all_spaces`
   to look up an id.
 - `text` (required) — message body. Markdown preserved on the wire.
-- `root_id` (optional) — envelope_id (`msg_<uuid>`) of the post you
+- `root_id` (optional) — `message_id` (`msg_<uuid>`) of the post you
   are replying to; opens a thread. It must be the true thread root,
   not an arbitrary reply id. Preserve the Inbox target by default:
   omit it for `target_type="channel"`, and pass the supplied
@@ -303,7 +303,7 @@ separate messages).
 - `caption`: optional text posted alongside the files. Empty by
   default; recipients see just the attachments.
 - `root_id`: optional — reply with the attachments inside an
-  existing thread. Pass the true thread-root envelope_id; see the
+  existing thread. Pass the true thread-root `message_id`; see the
   `send-message` skill for validation details.
 - `visibility_level`: same semantics as `send_message` — `"human"` /
   `"default"` / `"agent_only"`. Default `"default"`; the @-mention
@@ -324,10 +324,10 @@ DEFAULT_SKILL_ATTACHMENTS = """\
 
 When a user sends you a file, the daemon decrypts it before your
 turn starts and saves it at
-``<workspace>/.puffo/inbox/<envelope_id>/<filename>``. Its
+``<workspace>/.puffo/inbox/<message_id>/<filename>``. Its
 workspace-relative path shows up in the message's
 `attachment_paths=[...]` field, for example
-``.puffo/inbox/<envelope_id>/<filename>``.
+``.puffo/inbox/<message_id>/<filename>``.
 
 **What to do with them:**
 - Read text-shaped files (`.md`, `.txt`, `.json`, source code, …)
@@ -482,14 +482,14 @@ agents. Use `identity`, not display name, as the unique identity.
 DEFAULT_SKILL_GET_POST = """\
 # Skill: get_post
 
-Fetch a single message by its envelope_id from the daemon's local
+Fetch a single message by its `message_id` from the daemon's local
 message store. Its result uses the shared projection described by the
 `read-messages` skill.
 
 **Tool:** `mcp__puffo__get_post`
 
 **Arguments:**
-- `post_ref` (required) — envelope_id (`msg_<uuid>`). Permalinks
+- `post_ref` (required) — `message_id` (`msg_<uuid>`). Permalinks
   aren't a thing on puffo-core; agents address messages by id.
 
 **Important:** this reads from local storage only. The daemon stores

--- a/src/puffo_agent/mcp/core_post_tools.py
+++ b/src/puffo_agent/mcp/core_post_tools.py
@@ -116,7 +116,7 @@ async def _get_post_segment(
 def register_post_tools(mcp: FastMCP, cfg: Any) -> None:
     @mcp.tool()
     async def get_post(post_ref: str) -> str:
-        """Fetch one local message by envelope id.
+        """Fetch one local message by model-facing message id.
 
         Returns the semantic target/row projection. See the managed
         ``read-messages`` skill for supplementary-context guidance.

--- a/src/puffo_agent/mcp/tool_result_projection.py
+++ b/src/puffo_agent/mcp/tool_result_projection.py
@@ -163,16 +163,13 @@ def _send_result_header(
             result,
             (
                 "attempted",
-                "envelope_id",
                 "seq",
                 "replay",
                 "devices_queued",
                 "context_baseline_seq",
                 "seen_seq",
                 "latest_seq",
-                "latest_envelope_id",
                 "blocking_seq",
-                "blocking_envelope_id",
                 "blocking_sender_slug",
                 "latest_seq_before_send",
                 "mode",
@@ -184,6 +181,14 @@ def _send_result_header(
             ),
         )
     )
+    for model_name, transport_name in (
+        ("message_id", "envelope_id"),
+        ("latest_message_id", "latest_envelope_id"),
+        ("blocking_message_id", "blocking_envelope_id"),
+    ):
+        value = result.get(transport_name)
+        if value not in (None, ""):
+            header_fields.append(_field(model_name, value))
     if reconsideration:
         header_fields.extend(
             _fields(

--- a/tests/test_attachment_annotation.py
+++ b/tests/test_attachment_annotation.py
@@ -41,3 +41,12 @@ def test_plain_attachment_has_no_annotation():
     assert "/inbox/env/thumb.png" in block
     assert "origin" not in block
     assert "crop a region" not in block
+
+
+def test_host_inbox_path_is_projected_into_the_workspace():
+    block = _block([
+        "/home/hanchen/.puffo-agent/agents/linus/workspace/"
+        ".puffo/inbox/msg_1/ballerz.jpeg"
+    ])
+    assert "  - .puffo/inbox/msg_1/ballerz.jpeg" in block
+    assert "/home/hanchen" not in block

--- a/tests/test_batch_reaches_adapter.py
+++ b/tests/test_batch_reaches_adapter.py
@@ -77,7 +77,7 @@ def test_every_batch_message_reaches_the_adapter(tmp_path):
     # Per-message metadata is intact for each block.
     assert sent.count("- sender_slug: alice") == 2
     assert sent.count("- sender_slug: bob") == 1
-    assert "- post_id: msg_2" in sent
+    assert "- message_id: msg_2" in sent
 
 
 def test_batch_is_one_log_entry(tmp_path):

--- a/tests/test_bridge_ingress_policy.py
+++ b/tests/test_bridge_ingress_policy.py
@@ -224,7 +224,10 @@ async def test_keyless_gated_dm_lifecycle_is_durable_and_prompt_echo_is_redacted
     await asyncio.gather(*tuple(client._ack_tasks))
     prompt_echo = await client.store.get_message_by_envelope(prompt_id)
     assert prompt_echo is not None
-    assert prompt_echo.content == DM_GATE_PROMPT_PLACEHOLDER
+    assert prompt_echo.content == {
+        "text": DM_GATE_PROMPT_PLACEHOLDER,
+        "is_visible_to_human": True,
+    }
     await client.store.close()
 
 

--- a/tests/test_inbox_admission_contract.py
+++ b/tests/test_inbox_admission_contract.py
@@ -508,7 +508,7 @@ async def test_exact_held_chain_admits_only_at_original_send_result_boundary(
     assert '[send_result context_version=1 state="held"' in held_result
     assert "synchronized=true" in held_result
     assert "latest_seq=7" in held_result
-    assert 'latest_envelope_id="held-peer"' in held_result
+    assert 'latest_message_id="held-peer"' in held_result
     assert '[window context_version=1 kind="held_basis"' in held_result
     assert '[window context_version=1 kind="held_new_context"' in held_result
     assert held_result.count("previous self contribution") == 1

--- a/tests/test_keyless_invitation_ingress.py
+++ b/tests/test_keyless_invitation_ingress.py
@@ -319,7 +319,10 @@ async def test_invitation_lifecycle_reconciles_dedupes_and_stores_placeholder(
             _dm_frame(SELF, "echo of prompt", seq=1, envelope_id=prompt_env)
         )
         echo = await _await_envelope(client, prompt_env)
-        assert echo.content == INVITE_PROMPT_PLACEHOLDER
+        assert echo.content == {
+            "text": INVITE_PROMPT_PLACEHOLDER,
+            "is_visible_to_human": True,
+        }
 
         # An exact threaded operator reply is consumed to a terminal outcome.
         await bridge._out.put(

--- a/tests/test_puffo_core_client_admit_validate.py
+++ b/tests/test_puffo_core_client_admit_validate.py
@@ -25,6 +25,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from puffo_agent.agent.inbound_receipts import InboundReceiptHandler
+from puffo_agent.agent.client_support import DM_GATE_PROMPT_PLACEHOLDER
 from puffo_agent.agent.message_store import MessageStore
 from puffo_agent.agent.puffo_core_client import PuffoCoreMessageClient
 from puffo_agent.crypto.http_client import PuffoCoreHttpClient
@@ -492,8 +493,8 @@ async def test_native_ingress_withholds_uncleared_sender_content(
     await handler.handle(_delivery("env_prompt", SELF_SLUG, 2))
 
     echo = await client.store.get_message_by_envelope("env_prompt")
-    assert echo is not None
-    assert marker not in str(echo.content)
+    assert echo is not None and marker not in str(echo.content)
+    assert echo.content == {"text": DM_GATE_PROMPT_PLACEHOLDER, "is_visible_to_human": True}
 
     operator_anchor = await client.store.store_local_event(
         {

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -645,7 +645,12 @@ async def test_semantic_out_of_process_uses_structured_rpc_client():
     class Rpc:
         async def send_message(self, **body):
             bodies.append(body)
-            return {"state": "sent", "attempted": True, "seq": 3}
+            return {
+                "state": "sent",
+                "attempted": True,
+                "envelope_id": "msg_sent",
+                "seq": 3,
+            }
 
     cfg.send_coordinator = None
     cfg.rpc_client = Rpc()
@@ -654,6 +659,8 @@ async def test_semantic_out_of_process_uses_structured_rpc_client():
         "send_message", {"channel": "ch_a", "text": "x", "send_anyway": True},
     )
     assert 'state="sent"' in result
+    assert 'message_id="msg_sent"' in result
+    assert "envelope_id=" not in result
     assert bodies == [{
         "channel": "ch_a",
         "root_id": "",

--- a/tests/test_sender_identity_metadata.py
+++ b/tests/test_sender_identity_metadata.py
@@ -49,6 +49,10 @@ def test_unclassified_non_operator_stays_unknown():
     assert "- sender_type: unknown" in block
 
 
+def test_system_sender_stays_system():
+    assert "- sender_type: system" in _block(sender="system")
+
+
 def test_agent_owned_by_current_operator_gets_both():
     # An agent whose sender IS also somehow the operator is unusual, but the
     # two annotations are independent — both fire when both conditions hold.
@@ -110,6 +114,6 @@ def test_metadata_block_field_order():
         return next(i for i, ln in enumerate(lines) if ln.startswith(prefix))
 
     assert (
-        idx("- post_id:") < idx("- space_id:") < idx("- channel_id:")
+        idx("- message_id:") < idx("- space_id:") < idx("- channel_id:")
         < idx("- thread_root_id:") < idx("- is_encrypted:") < idx("- sender:")
     )


### PR DESCRIPTION
## Context

Follow-up to Han/Linus's `2026-08-17` Puffo message-platform acceptance report. PR #250 already fixed the blocker by projecting inbound attachment paths as workspace-relative paths that work in both local and Docker harnesses. This PR closes the remaining actionable model-facing contract gaps.

## What changed

- Canonicalize model-facing message identifiers as `message_id` across compatibility prompts and send results.
  - Raw transport/storage fields remain `envelope_id`; no wire or database migration is involved.
  - Held responses expose `latest_message_id` and `blocking_message_id` to the model.
- Preserve authenticated `sender_type="system"` instead of degrading system messages to `unknown` in the compatibility projection.
- Add `human_visible` metadata to self-sent history rows in both native E2EE and keyless bridge ingress.
  - Existing DM/invitation prompt redaction remains intact.
  - Structured attachment content and its original content type remain intact.
- Apply the same workspace-relative attachment projection to the retained compatibility/retry prompt path.
- Align managed skill/tool wording with the model-facing `message_id` vocabulary.

```mermaid
flowchart LR
  A[Native or keyless delivery] --> B{Self echo?}
  B -- no --> C[Normal semantic prompt projection]
  B -- yes --> D[Preserve content + authenticated visibility]
  C --> E[Local message store]
  D --> E
  E --> F[Unified model projection: message_id / sender_type / human_visible]
```

## Acceptance report disposition

| Item | Result |
|---|---|
| #1 Docker attachment path | Fixed by #250; compatibility path covered here too |
| #6 system sender type | Fixed |
| #9 mentions | Already projected structurally when present |
| #19 identifier naming | Model-facing output unified; transport internals unchanged |
| #20 self-message visibility | Fixed in native and keyless lanes |
| #21 local events without server seq | Intentional: local events use local ordering/time because no server message row exists |
| #22 attachment-only empty text | Valid content shape; attachment metadata remains authoritative |
| #3/#4 client failure/retry display | Still require client-side reproduction; not changed speculatively |

## Verification

- Full `pytest -q` suite passed (one expected Windows-only skip).
- `SKIP=no-commit-to-branch pre-commit run --all-files` passed.
- Focused native/keyless ingress, projection, attachment, inbox, and MCP tests passed.
- `git diff --check` passed.
- Docker mount proof for #1: `.puffo/inbox/<message_id>/ballerz.jpeg` was readable from a `/workspace` mount in `alpine:latest`.
