### PR TITLE
Release 2.0.0a16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a16] - 2026-08-17
+
+> Staging candidate closing the message-contract acceptance gaps and restoring
+> legacy token-usage audit metadata.
+
+### Fixed
+
+- **Inbound attachment paths now work in local and Docker harnesses.** Model
+  context consistently receives workspace-relative paths instead of host-only
+  absolute paths, including the retained compatibility/retry projection.
+- **Message metadata uses one model-facing vocabulary.** Compatibility prompts
+  and send results expose `message_id`, authenticated system messages retain
+  `sender_type="system"`, and native plus keyless self-sent history preserves
+  `human_visible` without weakening approval-prompt redaction.
+- **Completed turns again report the 1.2 token-usage shape.** Runtime history
+  records input/output token counts and an optional current-context value for
+  successful turns, including events recovered from the durable outbox;
+  failed, cancelled, and abandoned turns remain usage-free.
+
 ## [2.0.0a15] - 2026-08-17
 
 > Staging candidate removing the fixed Inbox delay for idle Agents.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a15"
+version = "2.0.0a16"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a15"
+version = "2.0.0a16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release scope

`2.0.0a16` is the next staging candidate after `2.0.0a15`. It packages the already-merged changes from:

- #250 — container-readable, workspace-relative inbound attachment paths
- #249 — 1.2-compatible successful-turn token usage in Runtime Event history
- #251 — canonical model-facing message metadata and self-message visibility

The corresponding Server schema extension was merged first in `puffo-server` #303 and is deploying to staging before TestPyPI publication.

## Release files

- `pyproject.toml`: `2.0.0a15` → `2.0.0a16`
- `uv.lock`: synchronized package version
- `CHANGELOG.md`: a16 acceptance and audit fixes

## Verification

- Full `uv run --extra dev pytest -q` suite passed (one expected Windows-only skip).
- `SKIP=no-commit-to-branch uv run --extra dev pre-commit run --all-files` passed.
- Built both `puffo_agent-2.0.0a16.tar.gz` and `puffo_agent-2.0.0a16-py3-none-any.whl`.
- Installed the wheel into a clean Python 3.12 environment.
- `puffo-agent version` reports `2.0.0a16`; `puffo-agent --help` loads successfully.
