### PR TITLE
Fix Claude context admission deadlock after runtime window discovery

### DIFF
--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -109,9 +109,20 @@ class ClaudeCodeCliDriver(Driver):
             raise RuntimeError("driver is already open")
         if self._closed:
             self._prepare_reopen()
+        launch_args = list(spec.launch_args)
+        if spec.auto_compact_threshold_tokens is not None:
+            launch_args = _replace_option_value(
+                launch_args,
+                "--autocompact",
+                str(spec.auto_compact_threshold_tokens),
+            )
+            # The CLI can receive /compact as its first stream-json user
+            # frame. Treat the configured native threshold as the startup
+            # capability so context admission can compact before system/init.
+            self._compact_advertised = True
         args = [
             *normalize_launch_argv(spec.executable or "claude"),
-            *spec.launch_args,
+            *launch_args,
             "-p",
             "--input-format",
             "stream-json",
@@ -675,6 +686,26 @@ def _normalize_content(value: Any) -> str:
             if isinstance(item, dict) and item.get("type") == "text"
         ).replace("\r\n", "\n")
     return ""
+
+
+def _replace_option_value(args: list[str], option: str, value: str) -> list[str]:
+    """Return argv with exactly one current value for ``option``."""
+    normalized: list[str] = []
+    index = 0
+    while index < len(args):
+        argument = args[index]
+        if argument == option:
+            index += 1
+            if index < len(args) and not args[index].startswith("-"):
+                index += 1
+            continue
+        if argument.startswith(f"{option}="):
+            index += 1
+            continue
+        normalized.append(argument)
+        index += 1
+    normalized.extend((option, value))
+    return normalized
 
 
 def _positive_int(value: Any) -> int | None:

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1423,16 +1423,16 @@ async def test_claude_driver_prepends_normalized_launch_argv(monkeypatch):
             proc = _FakeProcess()
             proc.feed({
                 "type": "system", "subtype": "init",
-                "session_id": f"claude-{len(captured)}", "slash_commands": [],
+                "session_id": f"claude-{len(captured)}", "slash_commands": ["/compact"],
             })
             return proc
         return factory
 
     posix = []
     driver = ClaudeCodeCliDriver(make_factory(posix), replay_timeout=1)
-    await driver.open(RuntimeSpec("/workspace", executable="claude"))
+    opened = await driver.open(RuntimeSpec("/workspace", executable="claude", launch_args=("--autocompact", "100000"), auto_compact_threshold_tokens=500000))
     await driver.close()
-    assert posix[:2] == ["claude", "-p"]
+    assert posix[:4] == ["claude", "--autocompact", "500000", "-p"] and opened.capabilities.compact == "session_command"
 
     monkeypatch.setattr(
         driver_mod, "normalize_launch_argv",
@@ -1440,9 +1440,9 @@ async def test_claude_driver_prepends_normalized_launch_argv(monkeypatch):
     )
     windows = []
     driver = ClaudeCodeCliDriver(make_factory(windows), replay_timeout=1)
-    await driver.open(RuntimeSpec("/workspace", executable="claude"))
+    await driver.open(RuntimeSpec("/workspace", executable="claude", auto_compact_threshold_tokens=500000))
     await driver.close()
-    assert windows[:4] == ["cmd.exe", "/c", "claude.cmd", "-p"]
+    assert windows[:6] == ["cmd.exe", "/c", "claude.cmd", "--autocompact", "500000", "-p"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Claude models whose context window is learned at runtime can stall permanently at Puffo's 50% context admission boundary. `RuntimeManagerAdapter` updates `auto_compact_threshold_tokens` and reloads the session, but the Claude process was relaunched without the matching `--autocompact` argument. The restarted stream-json process also does not emit `system/init` until its first user frame, so `/compact` was temporarily considered unsupported while admission refused to send that first frame.

The Global Inbox then remained `degraded`, retried every five minutes, and never opened a processing run. Users consequently saw delayed or missing working status even though the normal heartbeat remained alive.

## Change

- Translate the effective runtime threshold into `--autocompact <tokens>` at Claude process launch.
- Replace a stale precomputed flag rather than adding duplicate options.
- Treat that configured native threshold as startup evidence for session-command compaction, allowing `/compact` before `system/init`. A later init frame still refreshes the advertised capability from Claude itself.
- Keep heartbeat, 48-hour catch-up, and runtime-event privacy semantics unchanged.

## Verification

- `uv run --extra dev pytest -q tests/test_harness_driver.py tests/test_runtime_manager_failures.py tests/test_context_telemetry_threshold.py`
- `uv run --extra dev ruff check src/puffo_agent/agent/harness/claude_code_driver.py tests/test_harness_driver.py`
- Local Claude 2.1.233 advertises `--autocompact <auto|tokens>`.