### PR TITLE
Release puffo-agent 2.0.0a17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a17] - 2026-08-18
+
+> Staging candidate restoring Claude Code progress after runtime context-window
+> discovery.
+
+### Fixed
+
+- **Claude Code no longer stalls before a turn when its learned context usage
+  requires compaction.** The runtime now applies the learned native
+  `--autocompact` threshold when it reloads Claude Code and permits `/compact`
+  before the deferred `system/init` frame. Admitted turns resume the existing
+  Profile Log stream of bounded assistant status and tool labels.
+
 ## [2.0.0a16] - 2026-08-17
 
 > Staging candidate closing the message-contract acceptance gaps and restoring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a16"
+version = "2.0.0a17"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a16"
+version = "2.0.0a17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the staging candidate to `2.0.0a17`
- document the Claude Code context-admission deadlock fix from #253
- keep the existing bounded Profile Log projection for Claude and Codex

## Verification

- #253 CI and CodeQL passed on Python 3.11 and 3.12
- repository pre-commit suite passed
- built sdist and wheel locally
- installed the wheel into a clean Python 3.11 environment
- `puffo-agent --help` and `puffo-agent version` passed

## Release

After merge, dispatch `Publish to TestPyPI` from `main` and verify `2.0.0a17` is downloadable.