### PR TITLE
fix(runtime): recover stuck turns after a runtime crash or an unresumable session

### DIFF
--- a/docs/claude-runtime-recovery-investigation-2026-08-18.md
+++ b/docs/claude-runtime-recovery-investigation-2026-08-18.md
@@ -1,0 +1,172 @@
+# Claude Runtime Recovery Investigation
+
+Date: 2026-08-18
+
+## Question
+
+Does `puffo-agent` recover reliably when a Claude Code Agent cannot continue
+its persisted provider session, and do PRs #253 and #255 cover every observed
+way that the Agent can become permanently stuck?
+
+## Observed Failure Families
+
+### 1. Context admission blocks before a provider turn starts
+
+One production Claude Agent has 79 durable pending messages. Its last
+successful turn ended on 2026-08-17. Since then the daemon has repeatedly
+planned work but has never started another provider turn.
+
+Representative admission evidence:
+
+```text
+used_tokens=495678
+projected_tokens=503475
+context_window=1000000
+outcome=degraded
+```
+
+The context controller's soft target is 50% of the provider window. Once the
+projected turn crosses that target, admission requires native compaction or a
+rollover. Claude reports neither capability at process open when
+`auto_compact_threshold_pct` is unset. The Claude stream-json process only
+advertises `/compact` in `system/init`, and current Claude Code does not emit
+that frame until it receives its first user frame. Admission therefore blocks
+the frame that would disclose the capability needed to unblock admission.
+
+PR #253 makes a configured `auto_compact_threshold_tokens` available at open
+time and injects the matching `--autocompact` argument. It does not help
+existing/default Agent configurations where both compact threshold fields are
+unset. The affected production Agent is still in that default state after the
+2.0.0a17 restart.
+
+Two other Claude Agents remained in the same degraded state for roughly 20
+hours before a process restart happened to reopen them with lower reported
+context use. No native compaction event was recorded, so that recovery is not
+a deterministic fix.
+
+### 2. A started provider turn fails on a crashed or invalid resumed session
+
+PR #255 addresses a later failure boundary. A provider turn has already been
+started, but the runtime either exits or reports a failed first turn because
+the persisted `--resume` target is no longer usable.
+
+Two defects are plausible and independently useful to fix:
+
+1. `TURN_ABANDONED(retryable=True)` was converted into a non-retryable
+   `RuntimeStateError`, bypassing Global Inbox's session-transfer retry path.
+2. Claude can accept process startup for an invalid resume ID and report the
+   failure only after the first user frame, so synchronous open fallback is
+   insufficient.
+
+PR #255 propagates retryable terminal events as `AgentAPIError` and tracks an
+unconfirmed resumed runtime until one provider turn succeeds. It clears the
+native session ID and retries from a fresh session when that first resumed
+turn fails or the runtime exits.
+
+## Review Concerns In PR #255
+
+The retryable terminal propagation follows the existing Global Inbox recovery
+contract and appears directionally correct.
+
+The unconfirmed-resume classification is currently broader than its evidence:
+every non-successful first turn on a resumed session is treated as proof that
+the resume ID is invalid. A valid resumed session can have a first turn fail
+for unrelated reasons such as rate limiting, authentication, policy rejection,
+provider execution failure, cancellation, or malformed input. Resetting that
+session loses provider-native history and replays only Puffo's reconstructed
+current turn. Invalid-resume recovery should use a normalized provider reason
+or a deliberately documented fail-open tradeoff, not `outcome != succeeded`
+alone.
+
+PR #255 also does not execute when context admission returns `degraded`,
+because no provider turn or terminal runtime event exists at that point.
+
+## Required Invariants
+
+1. Durable pending messages are never marked processed until a correlated
+   provider turn succeeds.
+2. A runtime crash cannot leave a durable active turn permanently owned by a
+   dead provider session.
+3. A provably invalid resume target is retired, and the exact admitted message
+   union is transferred once to a fresh session.
+4. A transient first-turn failure must not silently discard a valid provider
+   session and its history.
+5. Context admission must always have a bounded forward path: compact, roll
+   over, or explicitly retire to a fresh session. It cannot repeatedly return
+   `degraded` without changing the state that caused degradation.
+6. Repeated admission degradation must be observable as unhealthy/stuck, not
+   merely as an online process with `health=unknown`.
+7. Recovery remains bounded by the existing retry budget and cannot create a
+   hot restart loop.
+
+## Independent Review Questions
+
+1. What is the narrowest reliable signal that a Claude `--resume` target is
+   invalid after process startup?
+2. If Claude's stream-json result does not currently expose that signal, where
+   should raw provider output be normalized into a stable error code?
+3. What startup capability contract avoids the pre-init compaction deadlock
+   without assuming unsupported behavior from older Claude Code releases?
+4. Should the default Claude runtime pass `--autocompact auto`, derive a token
+   threshold from Puffo's context policy, or use a separate bootstrap path?
+5. Which minimal tests distinguish invalid resume, transient first-turn
+   failure, runtime exit, and pre-turn context admission deadlock?
+
+## Evidence From Claude Code
+
+The current CLI answers `get_context_usage` before its first user frame and
+returns the provider's actual context controls:
+
+```text
+totalTokens
+rawMaxTokens
+autocompactSource=auto
+autoCompactThreshold
+isAutoCompactEnabled=true
+```
+
+This removes the bootstrap cycle without inventing a Puffo default: context
+admission can query usage, learn that native compaction is available, and send
+`/compact` before admitting the pending message batch.
+
+An invalid resumed conversation also has a precise provider signal. Claude's
+failed result contains `No conversation found with session ID: ...`; the
+Driver can normalize that private text to `error_code=invalid_resume` without
+exposing the raw diagnostic to the public event stream.
+
+## Independent Fable Review
+
+Claude Fable 5 reviewed the same source independently. It agreed that
+retryable terminal propagation is necessary and identified four additional
+state-machine gaps:
+
+1. capabilities learned after `open` were hidden behind the immutable
+   `RuntimeOpened` snapshot;
+2. every first resumed failure was being classified as an invalid resume;
+3. the stale native session ID was cleared after terminal persistence;
+4. retry delivery inherited the generic full-payload behavior even when the
+   original provider session survived.
+
+It also noted that a resource-only reload could mark an already-confirmed
+session unconfirmed again. Its suggestion to force a new default percentage
+was not adopted because the provider already reports its real threshold and
+the user-led 50% soft-target policy remains authoritative.
+
+## Chosen Resolution
+
+1. Extend provider context status with optional native autocompact metadata.
+2. Let Drivers expose capabilities learned after startup; use those dynamic
+   capabilities for admission and Inbox delivery decisions.
+3. Preserve the existing 50% soft target. Do not add a guessed Claude CLI
+   threshold.
+4. Normalize only Claude's explicit missing-conversation result to
+   `invalid_resume`; unrelated first-turn failures preserve the session.
+5. Clear a proven-invalid session before persisting its terminal event, while
+   retaining the old ID on the diagnostic event itself.
+6. Remember which native session has already completed a successful turn so a
+   resource reload cannot re-arm invalid-resume detection for that session.
+7. Retry with a short continuation only when the native session survives;
+   otherwise send the exact durable fallback to the fresh session.
+
+The resulting recovery paths stay bounded by the existing Global Inbox retry
+budget. No new retry loop or provider-specific policy threshold is introduced.

--- a/docs/claude-runtime-recovery-investigation-2026-08-18.md
+++ b/docs/claude-runtime-recovery-investigation-2026-08-18.md
@@ -167,6 +167,9 @@ the user-led 50% soft-target policy remains authoritative.
    resource reload cannot re-arm invalid-resume detection for that session.
 7. Retry with a short continuation only when the native session survives;
    otherwise send the exact durable fallback to the fresh session.
+8. If native compaction is unavailable or exhausts its bounded attempts and
+   even the smallest batch cannot fit, open a fresh native provider session
+   while preserving the Puffo logical session.
 
 The resulting recovery paths stay bounded by the existing Global Inbox retry
 budget. No new retry loop or provider-specific policy threshold is introduced.

--- a/src/puffo_agent/agent/errors.py
+++ b/src/puffo_agent/agent/errors.py
@@ -8,8 +8,13 @@ class AgentAPIError(Exception):
 
     ``is_auth`` distinguishes credentials requiring operator action from
     retryable provider failures, which are re-enqueued with backoff.
+    ``error_code`` is an optional short tag for allowlisted logging.
     """
 
-    def __init__(self, message: str, *, is_auth: bool = False) -> None:
+    def __init__(
+        self, message: str, *, is_auth: bool = False,
+        error_code: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.is_auth = is_auth
+        self.error_code = error_code

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -1410,6 +1410,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
                     target_count=len(planned.targets),
                     error_category="provider_error",
                     error_type=type(exc).__name__,
+                    error_code=getattr(exc, "error_code", None),
                     outcome="requeued" if terminal else "degraded",
                 )
             finally:

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -102,6 +102,9 @@ class ClaudeCodeCliDriver(Driver):
         self._context_usage_supported: bool | None = None
         self._context = ContextStatus(stale=True)
 
+    def current_capabilities(self) -> DriverCapabilities:
+        return claude_capabilities(self._compact_advertised)
+
     async def open(
         self, spec: RuntimeSpec, resume: SessionRef | None = None
     ) -> RuntimeOpened:
@@ -238,6 +241,10 @@ class ClaudeCodeCliDriver(Driver):
                 context_window=self._context.context_window,
                 stale=True,
                 measured_at=self._context.measured_at,
+                auto_compact_threshold_tokens=(
+                    self._context.auto_compact_threshold_tokens
+                ),
+                auto_compact_enabled=self._context.auto_compact_enabled,
             )
         self._context_request_counter += 1
         request_id = f"ctx_{self._context_request_counter}"
@@ -262,17 +269,36 @@ class ClaudeCodeCliDriver(Driver):
                 context_window=self._context.context_window,
                 stale=True,
                 measured_at=self._context.measured_at,
+                auto_compact_threshold_tokens=(
+                    self._context.auto_compact_threshold_tokens
+                ),
+                auto_compact_enabled=self._context.auto_compact_enabled,
             )
         finally:
             pending = self._context_requests.pop(request_id, None)
             if pending is not None and not pending.done():
                 pending.cancel()
         self._context_usage_supported = True
+        auto_compact_threshold = _positive_int(
+            usage.get("autoCompactThreshold")
+        )
+        raw_auto_compact_enabled = usage.get("isAutoCompactEnabled")
+        auto_compact_enabled = (
+            raw_auto_compact_enabled
+            if isinstance(raw_auto_compact_enabled, bool)
+            else None
+        )
+        if auto_compact_enabled is True and auto_compact_threshold is not None:
+            # Claude exposes this control response before system/init, which
+            # lets context admission discover /compact for the first turn.
+            self._compact_advertised = True
         self._context = ContextStatus(
             used_tokens=_positive_int(usage.get("totalTokens")),
             context_window=_positive_int(usage.get("rawMaxTokens")),
             stale=False,
             measured_at=datetime.now(timezone.utc).isoformat(),
+            auto_compact_threshold_tokens=auto_compact_threshold,
+            auto_compact_enabled=auto_compact_enabled,
         )
         return self._context
 
@@ -356,6 +382,10 @@ class ClaudeCodeCliDriver(Driver):
             context_window=self._context.context_window,
             stale=True,
             measured_at=self._context.measured_at,
+            auto_compact_threshold_tokens=(
+                self._context.auto_compact_threshold_tokens
+            ),
+            auto_compact_enabled=self._context.auto_compact_enabled,
         )
 
     def _fail_pending_futures(self, message: str) -> None:
@@ -486,7 +516,7 @@ class ClaudeCodeCliDriver(Driver):
         self._session_ref = SessionRef(native)
         commands = frame.get("slash_commands") or ()
         self._init_commands = tuple(str(value) for value in commands)
-        self._compact_advertised = (
+        self._compact_advertised = self._compact_advertised or (
             "/compact" in self._init_commands or "compact" in self._init_commands
         )
         self._init.set_result(frame)
@@ -620,15 +650,19 @@ class ClaudeCodeCliDriver(Driver):
         context_tokens = input_tokens + int(
             usage.get("cache_read_input_tokens") or 0
         )
+        outcome = "failed" if subtype not in {"success", ""} else "succeeded"
+        data: dict[str, Any] = {
+            "outcome": outcome,
+            "input_tokens": input_tokens,
+            "output_tokens": int(usage.get("output_tokens") or 0),
+            "context_tokens": context_tokens,
+        }
+        if outcome == "failed":
+            data["error_code"] = _result_error_code(frame, subtype)
         await self._emit(
             HarnessEventType.TURN_COMPLETED,
             turn_ref=self._active,
-            data={
-                "outcome": "failed" if subtype not in {"success", ""} else "succeeded",
-                "input_tokens": input_tokens,
-                "output_tokens": int(usage.get("output_tokens") or 0),
-                "context_tokens": context_tokens,
-            },
+            data=data,
             native_payload=frame,
         )
         self._clear_pending_replay()
@@ -712,6 +746,18 @@ def _positive_int(value: Any) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         return None
     return value
+
+
+def _result_error_code(frame: dict[str, Any], subtype: str) -> str:
+    errors = frame.get("errors")
+    if isinstance(errors, list) and any(
+        "No conversation found with session ID:" in value
+        for value in errors
+        if isinstance(value, str)
+    ):
+        return "invalid_resume"
+    normalized = subtype.strip().lower()
+    return normalized or "execution_error"
 
 
 ClaudeDriver = ClaudeCodeCliDriver

--- a/src/puffo_agent/agent/harness/driver.py
+++ b/src/puffo_agent/agent/harness/driver.py
@@ -163,6 +163,8 @@ class ContextStatus:
     context_window: int | None = None
     stale: bool = False
     measured_at: str = ""
+    auto_compact_threshold_tokens: int | None = None
+    auto_compact_enabled: bool | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -256,6 +258,10 @@ class HarnessEvent:
 
 class Driver(ABC):
     """The exact common command/event surface implemented by Drivers."""
+
+    def current_capabilities(self) -> DriverCapabilities | None:
+        """Return capabilities learned after ``open``, when available."""
+        return None
 
     @abstractmethod
     async def open(

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -21,6 +21,7 @@ from ..context_controller import (
     ToolResultAdmission,
     normalize_context_snapshot,
 )
+from ..errors import AgentAPIError
 from .driver import (
     CompactRequest,
     Driver,
@@ -45,7 +46,11 @@ COMPACTION_WAIT_SECONDS = 120.0
 
 
 class RuntimeStateError(RuntimeError):
-    pass
+    """Internal state-machine contract violation, never retried automatically."""
+
+    def __init__(self, message: str, *, error_code: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
 
 
 class _EventStream(AsyncIterator[HarnessEvent]):
@@ -114,6 +119,10 @@ class RuntimeManager:
         self._permission_refs: set[PermissionRef] = set()
         self._continuation_admissions: list[ToolResultAdmission] = []
         self._compaction: asyncio.Future[None] | None = None
+        # True from a resumed open until its first turn succeeds; an
+        # invalid --resume target isn't always a synchronous open failure.
+        # See _consume_event_locked.
+        self._resume_unconfirmed = False
 
     async def open(self, *, resume: bool = True) -> RuntimeOpened:
         async with self._command_lock:
@@ -159,6 +168,7 @@ class RuntimeManager:
         # Preserve the durable Puffo logical reference independently of the
         # native provider session ID.
         self.opened = replace(opened, session_ref=self.session_ref)
+        self._resume_unconfirmed = opened.resumed
         self._reader = asyncio.create_task(self._consume_events())
         if self.agent_id:
             register_runtime_manager(self.agent_id, self)
@@ -517,6 +527,11 @@ class RuntimeManager:
             self._fail_compaction_locked("runtime exited")
             await self._publish_event(event)
             active = self.active_turn_ref
+            # A crash before this resumed session's first success is
+            # treated the same as the turn.completed case below: discard
+            # the session id so the retry gets a fresh session.
+            unconfirmed = self._resume_unconfirmed
+            self._resume_unconfirmed = False
             try:
                 if active is not None:
                     abandoned = HarnessEvent(
@@ -529,7 +544,10 @@ class RuntimeManager:
                         occurred_at=event.occurred_at,
                         data={
                             "outcome": "abandoned",
-                            "error_code": "runtime_exited",
+                            "error_code": (
+                                "resume_unconfirmed" if unconfirmed
+                                else "runtime_exited"
+                            ),
                             "retryable": True,
                         },
                     )
@@ -537,7 +555,36 @@ class RuntimeManager:
             finally:
                 await self.driver.close()
                 self.opened = None
+                if unconfirmed:
+                    self.native_session_id = ""
             return True
+        if event.type in {
+            HarnessEventType.TURN_COMPLETED, "turn.completed",
+        } and logical_turn is not None:
+            outcome = str(event.data.get("outcome") or "succeeded")
+            if outcome == "succeeded":
+                self._resume_unconfirmed = False
+            elif self._resume_unconfirmed:
+                # First turn on a resumed session failed before any turn
+                # ever succeeded (e.g. claude-code's "No conversation
+                # found" on an invalid --resume target, reported as an
+                # ordinary failed turn.completed rather than a driver
+                # exception). Discard the session id and force retryable
+                # so the retry opens a fresh session instead of resuming
+                # the same unusable one forever.
+                self._resume_unconfirmed = False
+                self._fail_compaction_locked("resume unconfirmed")
+                unconfirmed = replace(event, data={
+                    **event.data,
+                    "error_code": event.data.get("error_code")
+                    or "resume_unconfirmed",
+                    "retryable": True,
+                })
+                await self._publish_terminal_locked(unconfirmed, logical_turn)
+                await self.driver.close()
+                self.opened = None
+                self.native_session_id = ""
+                return True
         if event.type in {
             HarnessEventType.TURN_COMPLETED,
             HarnessEventType.TURN_ABANDONED,
@@ -799,9 +846,14 @@ class RuntimeManagerAdapter(Adapter):
             if event_type in {"turn.completed", "turn.abandoned"}:
                 outcome = str(event.data.get("outcome") or "succeeded")
                 if event_type == "turn.abandoned" or outcome != "succeeded":
-                    raise RuntimeStateError(
-                        f"provider turn ended with outcome {outcome}"
+                    error_code = str(event.data.get("error_code") or outcome)
+                    message = (
+                        f"provider turn ended with outcome {outcome} "
+                        f"(error_code={error_code})"
                     )
+                    if event.data.get("retryable"):
+                        raise AgentAPIError(message, error_code=error_code)
+                    raise RuntimeStateError(message, error_code=error_code)
                 metadata.update({
                     key: value for key, value in event.data.items()
                     if key in {

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -18,6 +18,7 @@ from ..context_controller import (
     ContextCapabilities,
     ContextSnapshot,
     ProviderAdmissionEvent,
+    RolloverResult,
     ToolResultAdmission,
     normalize_context_snapshot,
 )
@@ -315,6 +316,24 @@ class RuntimeManager:
             if self._closed:
                 raise RuntimeStateError("runtime is closed")
             return await self.driver.context_status()
+
+    async def rollover_native_session(self) -> tuple[str, str]:
+        """Open a fresh provider session while preserving Puffo's session."""
+        async with self._command_lock:
+            if self._closed:
+                raise RuntimeStateError("runtime is closed")
+            if self.active_turn_ref is not None:
+                raise RuntimeStateError(
+                    "cannot roll over while a turn is active"
+                )
+            previous = self.native_session_id
+            self._fail_compaction_locked("native session rollover")
+            await self._stop_reader()
+            await self.driver.close()
+            self.opened = None
+            self._clear_native_session()
+            opened = await self._open_locked(resume=False)
+            return previous, opened.native_session_id
 
     async def begin_compaction(
         self, request: CompactRequest | None = None
@@ -1181,7 +1200,7 @@ class RuntimeManagerAdapter(Adapter):
             native_compaction=(
                 compact != "none" and self.manager.active_turn_ref is None
             ),
-            rollover=False,
+            rollover=self.manager.active_turn_ref is None,
             native_measurement=context_status != "none",
             diagnostic="Driver capabilities",
         )
@@ -1216,6 +1235,18 @@ class RuntimeManagerAdapter(Adapter):
             completed=True,
             provider_session_id=self.get_provider_session_id(),
             diagnostic="compaction completed",
+        )
+
+    async def rollover_context(self) -> RolloverResult:
+        previous, current = await self.manager.rollover_native_session()
+        return RolloverResult(
+            completed=True,
+            previous_provider_session_id=previous or None,
+            provider_session_id=current or None,
+            diagnostic=(
+                "fresh native session opened after bounded context controls "
+                "were exhausted"
+            ),
         )
 
 

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -25,6 +25,7 @@ from ..errors import AgentAPIError
 from .driver import (
     CompactRequest,
     Driver,
+    DriverCapabilities,
     HarnessEvent,
     HarnessEventType,
     PermissionDecision,
@@ -123,6 +124,7 @@ class RuntimeManager:
         # invalid --resume target isn't always a synchronous open failure.
         # See _consume_event_locked.
         self._resume_unconfirmed = False
+        self._confirmed_native_session_id = ""
 
     async def open(self, *, resume: bool = True) -> RuntimeOpened:
         async with self._command_lock:
@@ -153,7 +155,7 @@ class RuntimeManager:
                 exc_info=True,
             )
             await self.driver.close()
-            self.native_session_id = ""
+            self._clear_native_session()
             try:
                 opened = await self.driver.open(self.spec, None)
             except Exception:
@@ -168,7 +170,10 @@ class RuntimeManager:
         # Preserve the durable Puffo logical reference independently of the
         # native provider session ID.
         self.opened = replace(opened, session_ref=self.session_ref)
-        self._resume_unconfirmed = opened.resumed
+        self._resume_unconfirmed = (
+            opened.resumed
+            and opened.native_session_id != self._confirmed_native_session_id
+        )
         self._reader = asyncio.create_task(self._consume_events())
         if self.agent_id:
             register_runtime_manager(self.agent_id, self)
@@ -234,7 +239,7 @@ class RuntimeManager:
             # still making the next command open a fresh native session.
             logger.exception("failed to retire runtime after turn start failure")
             self.opened = None
-            self.native_session_id = ""
+            self._clear_native_session()
             self.session_ref = SessionRef(f"session_{uuid.uuid4().hex}")
 
     async def steer_turn(self, turn: TurnRef, input: TurnInput) -> Any:
@@ -422,7 +427,7 @@ class RuntimeManager:
         self.opened = None
         if not preserve_session:
             self.session_ref = SessionRef(f"session_{uuid.uuid4().hex}")
-            self.native_session_id = ""
+            self._clear_native_session()
 
     def events(self) -> AsyncIterator[HarnessEvent]:
         queue: asyncio.Queue[HarnessEvent | None] = asyncio.Queue()
@@ -532,6 +537,11 @@ class RuntimeManager:
             # the session id so the retry gets a fresh session.
             unconfirmed = self._resume_unconfirmed
             self._resume_unconfirmed = False
+            failed_native_session_id = self.native_session_id
+            if unconfirmed:
+                # The event retains the failed native id for diagnostics, but
+                # durable manager state must already point at a fresh session.
+                self._clear_native_session()
             try:
                 if active is not None:
                     abandoned = HarnessEvent(
@@ -539,7 +549,7 @@ class RuntimeManager:
                         driver=self.driver_name,
                         session_ref=self.session_ref,
                         turn_ref=active,
-                        native_session_id=self.native_session_id,
+                        native_session_id=failed_native_session_id,
                         native_turn_id=self.native_turn_id,
                         occurred_at=event.occurred_at,
                         data={
@@ -553,10 +563,10 @@ class RuntimeManager:
                     )
                     await self._publish_terminal_locked(abandoned, active)
             finally:
-                await self.driver.close()
-                self.opened = None
-                if unconfirmed:
-                    self.native_session_id = ""
+                try:
+                    await self.driver.close()
+                finally:
+                    self.opened = None
             return True
         if event.type in {
             HarnessEventType.TURN_COMPLETED, "turn.completed",
@@ -564,26 +574,9 @@ class RuntimeManager:
             outcome = str(event.data.get("outcome") or "succeeded")
             if outcome == "succeeded":
                 self._resume_unconfirmed = False
-            elif self._resume_unconfirmed:
-                # First turn on a resumed session failed before any turn
-                # ever succeeded (e.g. claude-code's "No conversation
-                # found" on an invalid --resume target, reported as an
-                # ordinary failed turn.completed rather than a driver
-                # exception). Discard the session id and force retryable
-                # so the retry opens a fresh session instead of resuming
-                # the same unusable one forever.
-                self._resume_unconfirmed = False
-                self._fail_compaction_locked("resume unconfirmed")
-                unconfirmed = replace(event, data={
-                    **event.data,
-                    "error_code": event.data.get("error_code")
-                    or "resume_unconfirmed",
-                    "retryable": True,
-                })
-                await self._publish_terminal_locked(unconfirmed, logical_turn)
-                await self.driver.close()
-                self.opened = None
-                self.native_session_id = ""
+                self._confirmed_native_session_id = self.native_session_id
+            elif event.data.get("error_code") == "invalid_resume":
+                await self._retire_invalid_resume_locked(event, logical_turn)
                 return True
         if event.type in {
             HarnessEventType.TURN_COMPLETED,
@@ -595,6 +588,24 @@ class RuntimeManager:
         else:
             await self._publish_event(event)
         return False
+
+    async def _retire_invalid_resume_locked(
+        self, event: HarnessEvent, logical_turn: TurnRef
+    ) -> None:
+        # Claude can report an unusable --resume target only after a user
+        # frame. The explicit error remains authoritative even when this
+        # session succeeded before a process restart.
+        self._resume_unconfirmed = False
+        self._fail_compaction_locked("resume unconfirmed")
+        terminal = replace(event, data={**event.data, "retryable": True})
+        self._clear_native_session()
+        try:
+            await self._publish_terminal_locked(terminal, logical_turn)
+        finally:
+            try:
+                await self.driver.close()
+            finally:
+                self.opened = None
 
     async def _publish_event(self, event: HarnessEvent) -> None:
         if self.event_sink is not None:
@@ -770,6 +781,18 @@ class RuntimeManager:
         if not isinstance(turn, TurnRef) or self.active_turn_ref != turn:
             raise RuntimeStateError("stale or foreign turn reference")
 
+    def _clear_native_session(self) -> None:
+        cleared = self.native_session_id
+        self.native_session_id = ""
+        if self._confirmed_native_session_id == cleared:
+            self._confirmed_native_session_id = ""
+
+    def current_capabilities(self) -> DriverCapabilities | None:
+        dynamic = self.driver.current_capabilities()
+        if dynamic is not None:
+            return dynamic
+        return self.opened.capabilities if self.opened is not None else None
+
 
 class RuntimeManagerAdapter(Adapter):
     """Blocking compatibility facade over the event-driven Runtime Manager."""
@@ -896,7 +919,12 @@ class RuntimeManagerAdapter(Adapter):
             metadata["context_window"] = context_window
             pct = self.manager.spec.auto_compact_threshold_pct
             threshold = (
-                int(context_window * pct / 100) if pct is not None else None
+                int(context_window * pct / 100)
+                if pct is not None
+                else (
+                    self.manager.spec.auto_compact_threshold_tokens
+                    or status.auto_compact_threshold_tokens
+                )
             )
             self._latest_context_limits = (context_window, threshold)
         if status.measured_at:
@@ -979,6 +1007,25 @@ class RuntimeManagerAdapter(Adapter):
             return completed
         return TurnResult(reply="", metadata={"stream_error": "runtime_exited"})
 
+    async def run_retry_turn(
+        self,
+        kick_text: str,
+        fallback_user_message: str,
+        ctx: TurnContext,
+    ) -> TurnResult:
+        # A preserved native session already contains the original input and
+        # only needs a cheap continuation. A retired session needs the exact
+        # durable fallback because its replacement has no prior transcript.
+        content = (
+            kick_text
+            if self.manager.native_session_id
+            else fallback_user_message
+        )
+        return await self.run_turn(replace(
+            ctx,
+            messages=[{"role": "user", "content": content}],
+        ))
+
     def register_continuation_callback(
         self,
         callback,
@@ -1032,11 +1079,7 @@ class RuntimeManagerAdapter(Adapter):
         return value or None
 
     def inbox_notice_delivery_capability(self) -> str:
-        capabilities = (
-            self.manager.opened.capabilities
-            if self.manager.opened is not None
-            else None
-        )
+        capabilities = self.manager.current_capabilities()
         steer = (
             capabilities.steer
             if capabilities is not None
@@ -1065,7 +1108,10 @@ class RuntimeManagerAdapter(Adapter):
         if isinstance(status, UnsupportedCapability):
             return await super().get_context_snapshot()
         window = status.context_window
-        threshold: int | None = None
+        threshold = (
+            self.manager.spec.auto_compact_threshold_tokens
+            or status.auto_compact_threshold_tokens
+        )
         pct = self.manager.spec.auto_compact_threshold_pct
         if window and pct is not None:
             threshold = int(window * pct / 100)
@@ -1091,10 +1137,7 @@ class RuntimeManagerAdapter(Adapter):
         return self._latest_context_limits
 
     def get_context_capabilities(self) -> ContextCapabilities:
-        capabilities = (
-            self.manager.opened.capabilities
-            if self.manager.opened is not None else None
-        )
+        capabilities = self.manager.current_capabilities()
         if capabilities is None:
             return super().get_context_capabilities()
         compact = getattr(capabilities.compact, "value", capabilities.compact)

--- a/src/puffo_agent/agent/message_projection.py
+++ b/src/puffo_agent/agent/message_projection.py
@@ -107,11 +107,20 @@ def target_label(
     channel_id = str(_value(message, "channel_id") or "")
     if not channel_id or str(_value(message, "envelope_kind", "")) == "dm":
         peer = _dm_peer(message, current_agent_aliases)
-        return (
+        header = (
             f"context context_version={CONTEXT_VERSION} "
             f"target_type=\"dm\" target_ref={_quoted(f'dm:{peer}')} "
             f"peer_identity={_quoted('@' + peer)}"
         )
+        # DM replies can already carry a thread_root_id (send_message's
+        # root_id validates against the DM's own history), but target_ref
+        # stays dm:<peer> -- DMs aren't independently routable per thread.
+        root_id = _effective_thread_root(
+            message, explicit_thread_root_id=thread_root_id,
+        )
+        if root_id:
+            header += f" thread_root_id={_quoted(root_id)}"
+        return header
     space_id = str(_value(message, "space_id") or "")
     effective_thread_root_id = _effective_thread_root(
         message, explicit_thread_root_id=thread_root_id,

--- a/tests/test_claude_runtime_recovery.py
+++ b/tests/test_claude_runtime_recovery.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.agent.harness.claude_code_driver import ClaudeCodeCliDriver
+from puffo_agent.agent.harness.driver import RuntimeSpec, SessionRef, TurnRef
+from puffo_agent.agent.harness.runtime_manager import (
+    RuntimeManager,
+    RuntimeManagerAdapter,
+)
+
+
+class _ContextStdin:
+    def __init__(self, driver: ClaudeCodeCliDriver) -> None:
+        self.driver = driver
+
+    def write(self, value: bytes) -> None:
+        frame = json.loads(value)
+        request_id = frame["request_id"]
+        self.driver._context_requests[request_id].set_result({
+            "totalTokens": 495_678,
+            "rawMaxTokens": 1_000_000,
+            "autoCompactThreshold": 967_000,
+            "isAutoCompactEnabled": True,
+        })
+
+    async def drain(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_context_query_discovers_pre_turn_compaction_capability():
+    driver = ClaudeCodeCliDriver()
+    driver._proc = SimpleNamespace(stdin=_ContextStdin(driver))
+    manager = RuntimeManager(driver, RuntimeSpec("/workspace"))
+    adapter = RuntimeManagerAdapter(manager)
+
+    assert adapter.get_context_capabilities().native_compaction is False
+    status = await manager.context_status()
+
+    assert status.auto_compact_threshold_tokens == 967_000
+    assert status.auto_compact_enabled is True
+    assert adapter.get_context_capabilities().native_compaction is True
+    assert (await adapter.get_context_snapshot()).used_tokens == 495_678
+    assert adapter.context_limits() == (1_000_000, 967_000)
+
+
+@pytest.mark.asyncio
+async def test_invalid_resume_result_has_stable_error_code():
+    driver = ClaudeCodeCliDriver()
+    driver._session_ref = SessionRef("native")
+    driver._native_session_id = "missing-session"
+    driver._active = TurnRef("turn")
+
+    await driver._handle_result({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "errors": [
+            "No conversation found with session ID: missing-session"
+        ],
+    }, "error_during_execution")
+
+    completed = await driver._events.get()
+    assert completed.data["error_code"] == "invalid_resume"

--- a/tests/test_message_projection.py
+++ b/tests/test_message_projection.py
@@ -114,6 +114,23 @@ def test_dm_projection_preserves_paths_mentions_visibility_and_reply_count():
         "reply_count=2",
     ):
         assert field in output
+    assert "thread_root_id" not in output
+
+
+def test_dm_projection_exposes_thread_root_id_but_keeps_dm_routing():
+    # send_message already validates root_id against the DM's own history
+    # (see _validate_outgoing_root_scope's dm_peer branch); the agent just
+    # needs to see the root here to pass it back. Routing stays dm:<peer> --
+    # DMs aren't independently routable per thread like channels are.
+    row = message(
+        envelope_id="dm_reply", envelope_kind="dm", channel_id="", space_id="",
+        thread_root_id="dm_root", sender_slug="bob-9",
+        content={"text": "replying in-thread"},
+    )
+    output = format_message_group([row])
+    assert 'target_type="dm"' in output
+    assert 'target_ref="dm:bob-9"' in output
+    assert 'thread_root_id="dm_root"' in output
 
 
 def test_attachment_paths_are_projected_relative_to_the_harness_workspace():

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from puffo_agent.agent.errors import AgentAPIError
+from puffo_agent.agent.adapters.base import TurnContext, TurnResult
 from puffo_agent.agent.harness.codex_driver import CODEX_CAPABILITIES
 from puffo_agent.agent.harness.driver import (
     CancelReceipt,
@@ -47,7 +48,9 @@ class _ControllableDriver(Driver):
     async def open(self, spec, resume=None):
         self.open_calls += 1
         self.queue = asyncio.Queue()
-        native_session = f"native-session-{self.open_calls}"
+        native_session = (
+            str(resume) if resume else f"native-session-{self.open_calls}"
+        )
         return RuntimeOpened(
             RuntimeRef(f"runtime-{self.open_calls}"),
             SessionRef(native_session),
@@ -252,11 +255,18 @@ async def test_runtime_exit_abandons_active_turn_and_allows_next_turn():
 @pytest.mark.asyncio
 async def test_first_turn_failure_after_resume_forces_a_fresh_session():
     driver = _ControllableDriver()
+    durable_session_ids: list[str] = []
+
+    async def persist_terminal(event):
+        if getattr(event.type, "value", event.type) == "turn.completed":
+            durable_session_ids.append(manager.native_session_id)
+
     manager = RuntimeManager(
         driver,
         RuntimeSpec("/tmp", task_timeout_seconds=1),
-        driver_name="codex",
+        driver_name="claude-code",
         native_session_id="stale-session-id",
+        event_sink=persist_terminal,
     )
     adapter = RuntimeManagerAdapter(manager)
 
@@ -271,13 +281,14 @@ async def test_first_turn_failure_after_resume_forces_a_fresh_session():
         driver="codex",
         session_ref=SessionRef(manager.native_session_id),
         turn_ref=driver.turn,
-        data={"outcome": "failed"},
+        data={"outcome": "failed", "error_code": "invalid_resume"},
     ))
 
-    with pytest.raises(AgentAPIError, match="resume_unconfirmed") as excinfo:
+    with pytest.raises(AgentAPIError, match="invalid_resume") as excinfo:
         await asyncio.wait_for(running, timeout=1)
     assert excinfo.value.is_auth is False
-    assert excinfo.value.error_code == "resume_unconfirmed"
+    assert excinfo.value.error_code == "invalid_resume"
+    assert durable_session_ids == [""]
     assert manager.native_session_id == ""
     assert manager.opened is None
     assert manager._resume_unconfirmed is False
@@ -367,6 +378,11 @@ async def test_confirmed_resumed_session_keeps_later_failures_non_retryable():
     assert (await asyncio.wait_for(running, timeout=1)).reply == ""
     assert manager._resume_unconfirmed is False
 
+    # A resource-only reload resumes the same already-confirmed session and
+    # must not make its next ordinary provider failure look like a bad resume.
+    await manager.reload_resources(preserve_session=True)
+    assert manager._resume_unconfirmed is False
+
     # A confirmed session's later failure must not trigger a fresh-session
     # reset -- it's a genuine rejection, not proof the resume was bad.
     driver.started = asyncio.Event()
@@ -381,17 +397,35 @@ async def test_confirmed_resumed_session_keeps_later_failures_non_retryable():
     ))
     with pytest.raises(RuntimeStateError, match="outcome failed"):
         await asyncio.wait_for(second, timeout=1)
-    # No retire/reopen: unlike the same failure on turn one, this stays put.
-    assert driver.open_calls == 1
+    # No additional retire/reopen: unlike an invalid resume, this stays put.
+    assert driver.open_calls == 2
     assert manager.opened is not None
     assert manager.native_session_id != ""
+
+    driver.started = asyncio.Event()
+    third = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="claude-code",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "failed", "error_code": "invalid_resume"},
+    ))
+    with pytest.raises(AgentAPIError, match="invalid_resume"):
+        await asyncio.wait_for(third, timeout=1)
+    assert manager.native_session_id == ""
+    await manager.close()
 
 
 @pytest.mark.asyncio
 async def test_provider_reported_failure_without_retryable_flag_stays_terminal():
     driver = _ControllableDriver()
     manager = RuntimeManager(
-        driver, RuntimeSpec("/tmp", task_timeout_seconds=1), driver_name="codex"
+        driver,
+        RuntimeSpec("/tmp", task_timeout_seconds=1),
+        driver_name="claude-code",
+        native_session_id="valid-but-unconfirmed-session",
     )
     adapter = RuntimeManagerAdapter(manager)
 
@@ -410,7 +444,29 @@ async def test_provider_reported_failure_without_retryable_flag_stays_terminal()
         await asyncio.wait_for(running, timeout=1)
     assert excinfo.value.error_code == "failed"
     assert manager.active_turn_ref is None
+    assert manager.native_session_id == "valid-but-unconfirmed-session"
+    assert manager.opened is not None
     await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_retry_payload_depends_on_whether_native_session_survived():
+    manager = SimpleNamespace(native_session_id="preserved-session")
+    adapter = RuntimeManagerAdapter(manager)
+    received: list[str] = []
+
+    async def capture(ctx):
+        received.append(ctx.messages[-1]["content"])
+        return TurnResult(reply="")
+
+    adapter.run_turn = capture
+    context = TurnContext(system_prompt="system", messages=[])
+
+    await adapter.run_retry_turn("continue", "full durable input", context)
+    manager.native_session_id = ""
+    await adapter.run_retry_turn("continue", "full durable input", context)
+
+    assert received == ["continue", "full durable input"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -830,6 +830,29 @@ async def test_context_commands_are_locked_and_fail_closed_after_close():
 
 
 @pytest.mark.asyncio
+async def test_context_rollover_preserves_logical_session_and_opens_fresh_native():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp"),
+        session_ref=SessionRef("logical-session"),
+        native_session_id="native-old",
+    )
+    adapter = RuntimeManagerAdapter(manager)
+    await manager.open()
+
+    result = await adapter.rollover_context()
+
+    assert result.completed is True
+    assert result.previous_provider_session_id == "native-old"
+    assert result.provider_session_id == "native-session-2"
+    assert manager.session_ref == SessionRef("logical-session")
+    assert manager.opened is not None and manager.opened.resumed is False
+    assert adapter.get_context_capabilities().rollover is True
+    await manager.close()
+
+
+@pytest.mark.asyncio
 async def test_continuation_failure_persists_terminal_before_next_turn(tmp_path):
     driver = _ControllableDriver()
     outbox = RuntimeEventOutbox(tmp_path / "runtime_events.db")

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from puffo_agent.agent.errors import AgentAPIError
 from puffo_agent.agent.harness.codex_driver import CODEX_CAPABILITIES
 from puffo_agent.agent.harness.driver import (
     CancelReceipt,
@@ -222,8 +223,11 @@ async def test_runtime_exit_abandons_active_turn_and_allows_next_turn():
         session_ref=SessionRef("native-session-1"),
     ))
 
-    with pytest.raises(RuntimeStateError, match="outcome abandoned"):
+    with pytest.raises(AgentAPIError, match="outcome abandoned") as excinfo:
         await asyncio.wait_for(first, timeout=1)
+    # The Global Inbox retry path only fires for is_auth=False AgentAPIError.
+    assert excinfo.value.is_auth is False
+    assert excinfo.value.error_code == "runtime_exited"
     assert manager.active_turn_ref is None
     assert manager.opened is None
     assert [str(event.type) for event in persisted][-1].endswith(
@@ -243,6 +247,193 @@ async def test_runtime_exit_abandons_active_turn_and_allows_next_turn():
     assert (await asyncio.wait_for(second, timeout=1)).reply == ""
     assert driver.start_calls == 2
     await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_first_turn_failure_after_resume_forces_a_fresh_session():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", task_timeout_seconds=1),
+        driver_name="codex",
+        native_session_id="stale-session-id",
+    )
+    adapter = RuntimeManagerAdapter(manager)
+
+    running = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    assert driver.open_calls == 1
+
+    # claude-code doesn't fail driver.open() on an invalid --resume target --
+    # it reports "No conversation found" as an ordinary failed turn.completed.
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "failed"},
+    ))
+
+    with pytest.raises(AgentAPIError, match="resume_unconfirmed") as excinfo:
+        await asyncio.wait_for(running, timeout=1)
+    assert excinfo.value.is_auth is False
+    assert excinfo.value.error_code == "resume_unconfirmed"
+    assert manager.native_session_id == ""
+    assert manager.opened is None
+    assert manager._resume_unconfirmed is False
+
+    # The next open is a fresh one: no resume target survives the failure.
+    driver.started = asyncio.Event()
+    second = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    assert driver.open_calls == 2
+    assert manager.opened.resumed is False
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "succeeded"},
+    ))
+    assert (await asyncio.wait_for(second, timeout=1)).reply == ""
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runtime_crash_on_unconfirmed_resume_also_forces_a_fresh_session():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", task_timeout_seconds=1),
+        driver_name="codex",
+        native_session_id="stale-session-id",
+    )
+    adapter = RuntimeManagerAdapter(manager)
+
+    # Some broken resume targets crash the whole process (RUNTIME_EXITED)
+    # instead of returning a clean failed turn.completed like the test above.
+    running = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    await driver.queue.put(HarnessEvent(
+        type="runtime.exited",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+    ))
+
+    with pytest.raises(AgentAPIError, match="resume_unconfirmed") as excinfo:
+        await asyncio.wait_for(running, timeout=1)
+    assert excinfo.value.is_auth is False
+    assert excinfo.value.error_code == "resume_unconfirmed"
+    assert manager.native_session_id == ""
+    assert manager.opened is None
+    assert manager._resume_unconfirmed is False
+
+    driver.started = asyncio.Event()
+    second = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    assert driver.open_calls == 2
+    assert manager.opened.resumed is False
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "succeeded"},
+    ))
+    assert (await asyncio.wait_for(second, timeout=1)).reply == ""
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_confirmed_resumed_session_keeps_later_failures_non_retryable():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", task_timeout_seconds=1),
+        driver_name="codex",
+        native_session_id="good-session-id",
+    )
+    adapter = RuntimeManagerAdapter(manager)
+
+    running = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "succeeded"},
+    ))
+    assert (await asyncio.wait_for(running, timeout=1)).reply == ""
+    assert manager._resume_unconfirmed is False
+
+    # A confirmed session's later failure must not trigger a fresh-session
+    # reset -- it's a genuine rejection, not proof the resume was bad.
+    driver.started = asyncio.Event()
+    second = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "failed"},
+    ))
+    with pytest.raises(RuntimeStateError, match="outcome failed"):
+        await asyncio.wait_for(second, timeout=1)
+    # No retire/reopen: unlike the same failure on turn one, this stays put.
+    assert driver.open_calls == 1
+    assert manager.opened is not None
+    assert manager.native_session_id != ""
+
+
+@pytest.mark.asyncio
+async def test_provider_reported_failure_without_retryable_flag_stays_terminal():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver, RuntimeSpec("/tmp", task_timeout_seconds=1), driver_name="codex"
+    )
+    adapter = RuntimeManagerAdapter(manager)
+
+    running = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="codex",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "failed"},
+    ))
+
+    # No "retryable" hint: stays a non-retryable RuntimeStateError.
+    with pytest.raises(RuntimeStateError, match="outcome failed") as excinfo:
+        await asyncio.wait_for(running, timeout=1)
+    assert excinfo.value.error_code == "failed"
+    assert manager.active_turn_ref is None
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_abandon_turn_marked_non_retryable_stays_a_runtime_state_error():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver, RuntimeSpec("/tmp", task_timeout_seconds=1), driver_name="codex"
+    )
+    adapter = RuntimeManagerAdapter(manager)
+
+    running = asyncio.create_task(adapter.run_turn(_context()))
+    await asyncio.wait_for(driver.started.wait(), timeout=1)
+    while manager.active_turn_ref is None:
+        await asyncio.sleep(0)
+
+    await manager.abandon_turn(
+        manager.active_turn_ref, reason="policy_rejected", retryable=False
+    )
+
+    with pytest.raises(RuntimeStateError, match="outcome abandoned") as excinfo:
+        await asyncio.wait_for(running, timeout=1)
+    assert excinfo.value.error_code == "policy_rejected"
+    await manager.close()
 
 
 @pytest.mark.asyncio
@@ -295,7 +486,7 @@ async def test_runtime_exit_waits_for_start_registration_before_abandoning():
     await asyncio.sleep(0)
     driver.release_start.set()
 
-    with pytest.raises(RuntimeStateError, match="outcome abandoned"):
+    with pytest.raises(AgentAPIError, match="outcome abandoned"):
         await asyncio.wait_for(running, timeout=1)
     assert manager.active_turn_ref is None
     assert manager.opened is None
@@ -355,7 +546,7 @@ async def test_terminal_persistence_failure_unblocks_turn_and_retires_runtime():
         data={"outcome": "succeeded"},
     ))
 
-    with pytest.raises(RuntimeStateError, match="outcome abandoned"):
+    with pytest.raises(AgentAPIError, match="outcome abandoned"):
         await asyncio.wait_for(running, timeout=1)
     assert manager.active_turn_ref is None
     assert manager.opened is None
@@ -593,7 +784,7 @@ async def test_continuation_failure_persists_terminal_before_next_turn(tmp_path)
         },
     ))
 
-    with pytest.raises(RuntimeStateError, match="outcome abandoned"):
+    with pytest.raises(AgentAPIError, match="outcome abandoned"):
         await asyncio.wait_for(first, timeout=1)
     assert manager.active_turn_ref is None
 


### PR DESCRIPTION
## Root cause: two distinct bugs in the same failure family

Fixes the 2.0.0a15–a17 regression that got fleet agents stuck permanently in a `RuntimeStateError` → `turn.failed` → requeue loop, unable to recover on their own.

### Bug 1: crashed-runtime abandons never retried

`RuntimeManager._consume_events()` already tags `TURN_ABANDONED` events caused by a crashed provider runtime (`RUNTIME_EXITED`, event-persistence failure, timeout cleanup) with `data["retryable"] = True`. But `RuntimeManagerAdapter._consume_turn_events()` discarded that flag and always raised a bare `RuntimeStateError` — not an `AgentAPIError`, so `global_inbox_runtime._invoke_turn_with_retries()` never entered its session-transfer retry path (`handle_global_inbox_retry` / `transfer_turn_session`, added in `b0c13b5`) and fell through to a dumb requeue that never repairs the persisted session pointer.

**Fix**: `_consume_turn_events()` now raises `AgentAPIError` when the terminal event says `retryable=True`. Genuine provider-reported failures (`turn.completed` with outcome `"failed"`/`"cancelled"` and no `retryable` flag) keep raising `RuntimeStateError` exactly as before.

### Bug 2: an invalid `--resume` target isn't always a synchronous open failure

claude-code CLI doesn't always fail `driver.open()` when `--resume` targets a session id that no longer exists. Sometimes the process spawns and initializes fine, and the invalid resume only surfaces later as an ordinary `turn.completed` with `outcome="failed"` (stderr `"No conversation found with session ID: ..."`); other times it crashes the whole process (`RUNTIME_EXITED`) instead. Neither carries a `retryable` flag on its own, so under Bug 1's fix both stayed non-retryable too — but nothing ever detected that the *persisted* `native_session_id` itself was permanently dead and replaced it, so the agent retried the identical broken id forever.

**Fix**: `RuntimeManager` now tracks `_resume_unconfirmed` (true from a resumed open until its first turn succeeds). A first-turn failure on an unconfirmed resume discards the session id and forces the terminal event retryable so it flows through the same `AgentAPIError` / session-transfer retry path as Bug 1, landing on a genuinely fresh session. Once a turn succeeds, the session is confirmed good and later failures go back to plain `RuntimeStateError`.

**Refined in #256** (merged into this branch as a stacked follow-up, see that PR for its own write-up): rather than gating the reset purely on "is this the first turn after resume", the driver now parses the claude-code `result` frame's structured `errors` field for the exact `"No conversation found with session ID:"` diagnostic and tags it `error_code="invalid_resume"`; `RuntimeManager` resets specifically on that precise signal (not on any first-turn failure), which avoids misfiring on an unrelated provider error that happens to land on turn one. The `RUNTIME_EXITED`-crash variant (no structured signal available) still uses the `_resume_unconfirmed` heuristic. #256 also fixes a related issue where context admission could degrade before the first turn because claude-code's native autocompact capability/threshold wasn't learned until `system/init`, and adds a short retry "kick" when a native session survives across a retry.

Both exception types carry an optional `error_code` (mirroring the terminal event's own `error_code`/`outcome`) through the existing allowlisted `error_code` observability field, so failure sites can be told apart in production logs without ever exposing raw exception text.

`AgentAPIError` lives in `agent/errors.py` with no adapter/harness imports, so this adds no circular dependency.

### DM messages never surfaced their thread_root_id

Separately reported live: an agent replying inside a DM thread could see the DM target (`target_type="dm" target_ref="dm:<peer>"`) but never the `thread_root_id`, even though the row always carries one and `send_message`'s `root_id` parameter already fully supports DM replies (`_validate_outgoing_root_scope` has a dedicated `dm_peer` branch). The read side just never told the agent what `root_id` to pass back.

**Fix**: `target_label()`'s DM branch now also resolves `_effective_thread_root()` and appends `thread_root_id` to the header when present, exactly like the channel branch already does. `target_type` stays `"dm"` and `target_ref` stays `dm:<peer>` — DMs aren't independently routable per thread the way channel threads are, so this is presentation-only, with zero change to routing, coalescing, or `canonical_target_parts()`.

## Tests

- Updated the existing `test_runtime_manager_failures.py` assertions that exercised retryable abandons to expect `AgentAPIError`, with `is_auth`/`error_code` coverage, plus new tests for both Bug 2 failure shapes and the confirmed-session/non-retryable paths that must stay unaffected.
- `test_claude_runtime_recovery.py` (added in #256) covers the `invalid_resume` precision detection and autocompact capability learning.
- `test_dm_projection_exposes_thread_root_id_but_keeps_dm_routing` covers the DM projection fix.

Full suite runs clean (`pytest`, excluding two GUI test files that can't collect without the optional `PySide6` extra — pre-existing, unrelated to this change).

## Live verification against the fleet

Installed this branch into the production pipx daemon (`pipx install git+...`) and restarted, iterating as each newly-discovered failure shape came up. All four previously-stuck agents recovered and completed real turns: `equation-7256-87f7`, `old-coder-7968-8e7b0303`, `solution-5805-d1be`, and `calculatio-4282-36fa`. No regressions observed across the 24-agent fleet. Production is currently running this branch's code.