### PR TITLE
fix(status): report busy when inbox turn starts

### DIFF
--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -122,9 +122,14 @@ class TurnStatusLifecycle(Protocol):
     """Optional worker-owned mirror of the active Global Inbox turn.
 
     The runtime owns only the durable turn lifecycle; it notifies this
-    callback with immutable active-union snapshots so the worker can drive
-    Server processing-row status without moving status policy in here.
+    callback with immutable notice and active-union snapshots so the worker
+    can drive Server status without moving status policy in here.
     """
+
+    async def on_notice_admitted(
+        self, *, turn_id: str, message_ids: tuple[str, ...]
+    ) -> None:
+        """Report that a provider accepted an Inbox notice for this turn."""
 
     async def on_turn_active(
         self, *, turn_id: str, message_ids: tuple[str, ...]
@@ -837,6 +842,9 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             if self.coordinator is not None:
                 self.coordinator.provider_session_id = provider_session_id
             self._write_current_turn(planned)
+        await self._notify_status_notice_admitted(
+            tuple(planned.notice_message_ids)
+        )
         log_runtime_event(
             logger,
             "turn.admitted",
@@ -856,6 +864,28 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
             message_count=len(self.active.message_ids),
             outcome="bound",
         )
+
+    async def _notify_status_notice_admitted(
+        self, message_ids: tuple[str, ...]
+    ) -> None:
+        """Expose provider admission without claiming Inbox rows were read."""
+        if (
+            self.status_lifecycle is None
+            or not self.active.turn_id
+            or not message_ids
+        ):
+            return
+        try:
+            await self.status_lifecycle.on_notice_admitted(
+                turn_id=self.active.turn_id,
+                message_ids=message_ids,
+            )
+        except Exception:
+            logger.warning(
+                "agent %s: status lifecycle notice notify failed",
+                self.agent_id,
+                exc_info=True,
+            )
 
     async def _notify_status_active(self) -> None:
         """Expose the exact active union to the worker's status lifecycle.

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -36,8 +36,9 @@ def _is_local_only_envelope(message_id: str) -> bool:
 class StatusReporter:
     """Owns the heartbeat loop and turn lifecycle hooks.
 
-    Spawn ``run_heartbeat_loop`` once on startup, then call
-    ``begin_turn`` / ``end_turn`` from the message handler.
+    Spawn ``run_heartbeat_loop`` once on startup. A provider admission calls
+    ``begin_notice_turn``; concrete Inbox admission then calls ``begin_turn``
+    and the matching terminal method.
     """
 
     def __init__(
@@ -143,6 +144,33 @@ class StatusReporter:
         """Best-effort status refresh used after bridge reconnects."""
         await self._send_heartbeat()
 
+    async def begin_notice_turn(self, message_id: str) -> None:
+        """Report a provider turn before the model reads its Inbox.
+
+        ``message_id`` is only a UI routing anchor. This method deliberately
+        does not create a processing run: the message remains pending until
+        ``read_inbox`` exposes it to the model and ``begin_turn`` is called.
+        """
+        self._current_status = "busy"
+        self._current_message_id = (
+            None if _is_local_only_envelope(message_id) else message_id
+        )
+        await self._send_heartbeat()
+
+    async def end_notice_turn(
+        self,
+        *,
+        succeeded: bool,
+        error_text: str | None = None,
+    ) -> None:
+        """Settle a notice turn that never created a processing run."""
+        if not succeeded:
+            await self.report_error(error_text or "agent turn failed")
+            return
+        self._current_status = "idle"
+        self._current_message_id = None
+        await self._send_heartbeat()
+
     async def begin_turn(self, message_id: str, *, run_id: str | None = None) -> str:
         """Returns a ``run_id`` to pass back to ``end_turn``."""
         run_id = run_id or f"run_{uuid.uuid4().hex}"
@@ -160,9 +188,14 @@ class StatusReporter:
             # immediate busy heartbeat so the agent shows in-progress
             # while it composes (e.g. its intro). No current_message_id:
             # the message doesn't exist server-side.
+            should_emit = (
+                self._current_status != "busy"
+                or self._current_message_id is not None
+            )
             self._current_status = "busy"
             self._current_message_id = None
-            await self._send_heartbeat()
+            if should_emit:
+                await self._send_heartbeat()
             return run_id
         try:
             await self._http.post(

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -77,6 +77,12 @@ class WorkerRunServices:
 
 
 class _NoopStatusReporter:
+    async def begin_notice_turn(self, _mid):
+        return None
+
+    async def end_notice_turn(self, **_kwargs):
+        return None
+
     async def begin_turn(self, _mid, *, run_id=None):
         return None
 
@@ -99,30 +105,41 @@ class _NoopStatusReporter:
 class GlobalInboxStatusLifecycle:
     """Mirror one durable Global Inbox turn into Server processing rows.
 
-    ``begin_turn`` fires once for the first admitted real message. Run ids are
+    Provider admission first emits a provisional busy status anchored to the
+    notice's first message without creating a processing row. ``begin_turn``
+    fires only when ``read_inbox`` admits the first real message. Run ids are
     derived from the durable turn and message identities, so crash recovery
-    reopens and settles the same Server row. Later active-union expansions do
-    not reopen rows. Terminal cleanup settles the exact active union in one
-    ``end_turn_batch`` with the same success/error result. State always resets
-    so the next turn cannot inherit runs.
+    reopens and settles the same Server row. Terminal cleanup settles either
+    the exact active union or the provisional status. State always resets so
+    the next turn cannot inherit runs.
     """
 
     def __init__(self, reporter) -> None:
         self._reporter = reporter
+        self._notice_began = False
         self._began = False
         self._turn_id: str | None = None
+
+    async def on_notice_admitted(
+        self, *, turn_id: str, message_ids: tuple[str, ...]
+    ) -> None:
+        if not message_ids:
+            return
+        self._claim_turn(turn_id)
+        if self._notice_began or self._began:
+            return
+        self._notice_began = True
+        await self._reporter.begin_notice_turn(message_ids[0])
 
     async def on_turn_active(
         self, *, turn_id: str, message_ids: tuple[str, ...]
     ) -> None:
         if not message_ids:
             return
+        self._claim_turn(turn_id)
         if self._began:
-            if self._turn_id != turn_id:
-                raise RuntimeError("status lifecycle already owns another turn")
             return
         self._began = True
-        self._turn_id = turn_id
         await self._reporter.begin_turn(
             message_ids[0],
             run_id=self._run_id(turn_id, message_ids[0]),
@@ -136,14 +153,24 @@ class GlobalInboxStatusLifecycle:
         succeeded: bool,
         error_text: str | None,
     ) -> None:
-        if self._began and self._turn_id != turn_id:
+        if (self._notice_began or self._began) and self._turn_id != turn_id:
             raise RuntimeError("status lifecycle terminal turn does not match")
         runs = self._build_runs(turn_id, message_ids, succeeded, error_text)
         try:
             if runs:
                 await self._reporter.end_turn_batch(runs)
+            elif self._notice_began:
+                await self._reporter.end_notice_turn(
+                    succeeded=succeeded,
+                    error_text=error_text,
+                )
         finally:
             self.reset()
+
+    def _claim_turn(self, turn_id: str) -> None:
+        if self._turn_id is not None and self._turn_id != turn_id:
+            raise RuntimeError("status lifecycle already owns another turn")
+        self._turn_id = turn_id
 
     def _build_runs(
         self,
@@ -165,6 +192,7 @@ class GlobalInboxStatusLifecycle:
         return runs
 
     def reset(self) -> None:
+        self._notice_began = False
         self._began = False
         self._turn_id = None
 

--- a/tests/test_worker_status_lifecycle.py
+++ b/tests/test_worker_status_lifecycle.py
@@ -1,10 +1,10 @@
 """One table-driven regression test for the worker Global Inbox status lifecycle.
 
-The durable Global Inbox turn — not WebSocket receipt — owns
-``StatusReporter.begin_turn`` / ``end_turn_batch``: exactly one begin on the
-first real admitted message, exactly one terminal batch over the exact active
-union, and no Server processing rows for synthetic ``intro-prompt-*``
-envelopes even though busy state is shown.
+The durable Global Inbox turn — not WebSocket receipt — owns status reporting:
+provider admission emits one provisional busy heartbeat, while ``read_inbox``
+owns ``StatusReporter.begin_turn`` and the first real processing row. Terminal
+cleanup settles the exact active union, and synthetic ``intro-prompt-*``
+envelopes show busy state without creating Server processing rows.
 """
 
 from __future__ import annotations
@@ -36,6 +36,8 @@ class _LifecycleRunner:
 
     async def __call__(self, planned):
         await self.adapter.admit()
+        if self.outcome == "no_read":
+            return None
         await self.runtime.read_inbox(limit=1, tool_arguments={"limit": 1})
         if self.expand:
             await self.runtime.read_inbox(limit=1, tool_arguments={"limit": 1})
@@ -57,6 +59,7 @@ _CASES = [
     {"id": "provider_failure", "outcome": "failure", "expand": False},
     {"id": "cancelled", "outcome": "cancelled", "expand": False},
     {"id": "retry_same_turn", "outcome": "retry", "expand": False},
+    {"id": "success_without_read", "outcome": "no_read", "expand": False},
     {"id": "synthetic_intro", "outcome": "success", "expand": False, "synthetic": True},
 ]
 
@@ -83,11 +86,12 @@ def _assert_status_wire(case: dict, http, lifecycle) -> None:
     batch_runs = _batch_runs(http)
     turns = 2 if case.get("second") else 1
     # Clean per-turn state: a subsequent case/turn cannot inherit runs.
+    assert lifecycle._notice_began is False
     assert lifecycle._began is False
+    heartbeats = [
+        body for path, body in http.calls if path == "/agents/me/heartbeat"
+    ]
     if case.get("synthetic"):
-        heartbeats = [
-            body for path, body in http.calls if path == "/agents/me/heartbeat"
-        ]
         # Busy is shown for the synthetic turn, but no processing row reaches
         # the wire for the synthetic id.
         assert [body["status"] for body in heartbeats] == ["busy", "idle"]
@@ -96,6 +100,17 @@ def _assert_status_wire(case: dict, http, lifecycle) -> None:
         assert batch_runs == []
         assert not any("/processing/" in path for path, _ in http.calls)
         return
+    if case["outcome"] == "no_read":
+        assert [body["status"] for body in heartbeats] == ["busy", "idle"]
+        assert heartbeats[0]["current_message_id"] == "m1"
+        assert begin_runs == {}
+        assert batch_runs == []
+        return
+    assert len(heartbeats) == turns
+    assert [body["status"] for body in heartbeats] == ["busy"] * turns
+    assert heartbeats[0]["current_message_id"] == "m1"
+    if case.get("second"):
+        assert heartbeats[1]["current_message_id"] == "m3"
     # Exactly one begin per logical turn, and one terminal batch per turn.
     assert len(begin_runs) == turns
     assert len(batch_runs) == turns


### PR DESCRIPTION
## Summary

The daemon previously reported message activity only after the model called `read_inbox`. In measured production turns, provider admission happened in about 1-2 seconds while `read_inbox` could happen 6-14 seconds later, so the UI appeared idle even though the harness was already working.

This change adds a two-phase status lifecycle:

```text
provider admits Inbox notice
  -> provisional busy heartbeat (message ID is UI anchor only)
model calls read_inbox
  -> existing processing/start row
turn ends
  -> existing processing/end batch, or idle/error heartbeat if no message was read
```

The provisional phase does **not** create a processing run and does **not** mark a message read. Synthetic local envelopes keep their existing no-server-row behavior.

## Dependency

- Server transition-rate-limit change: https://github.com/puffo-ai/puffo-server/pull/304

## Verification

- `uv run --extra dev pytest -q`
- `uv run ruff check src/puffo_agent/agent/global_inbox_runtime.py src/puffo_agent/agent/status_reporter.py src/puffo_agent/portal/worker_run.py tests/test_worker_status_lifecycle.py`
- `uv run python tools/check_python_structure.py`