### PR TITLE
fix(runtime): reload providers after account changes

### DIFF
--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -48,6 +48,37 @@ class RuntimeStateError(RuntimeError):
     pass
 
 
+def _native_resume_is_unavailable(exc: Exception) -> bool:
+    """Whether the provider explicitly rejected the saved native session."""
+    text = str(exc).lower()
+    identifies_session = any(
+        marker in text
+        for marker in (
+            "session",
+            "thread",
+            "conversation",
+            "rollout",
+            "transcript",
+        )
+    )
+    unavailable = any(
+        marker in text
+        for marker in (
+            "not found",
+            "does not exist",
+            "failed to find",
+            "is gone",
+            "no rollout",
+            "cannot resume",
+            "unable to resume",
+            "incompatible",
+            "invalid session",
+            "invalid thread",
+        )
+    )
+    return identifies_session and unavailable
+
+
 class _EventStream(AsyncIterator[HarnessEvent]):
     """Subscriber handle that releases its queue whether or not it is iterated.
 
@@ -131,19 +162,21 @@ class RuntimeManager:
         )
         try:
             opened = await self.driver.open(self.spec, native_resume)
-        except Exception:
-            if native_resume is None:
-                try:
-                    await self.driver.close()
-                except Exception:
-                    logger.exception("failed to close runtime after open failure")
+        except Exception as exc:
+            try:
+                await self.driver.close()
+            except Exception:
+                logger.exception("failed to close runtime after open failure")
+            # Network, auth, rate-limit, and process failures retry the same
+            # native session. Only explicit absence/incompatibility permits a
+            # transparent fresh native session.
+            if native_resume is None or not _native_resume_is_unavailable(exc):
                 raise
             logger.warning(
                 "%s could not resume native session; starting a fresh session",
                 self.driver_name,
                 exc_info=True,
             )
-            await self.driver.close()
             self.native_session_id = ""
             try:
                 opened = await self.driver.open(self.spec, None)

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1,8 +1,9 @@
 """Daemon-owned Claude / Codex OAuth credential refresh.
 
-All refresh writes go through ONE process (the daemon), so
-Anthropic + OpenAI's single-use rotating refresh tokens can't be
-raced by N agent workers burning each other's in-memory copies.
+All refresh writes go through a daemon-owned coordinator. An OS-backed
+host lock also serializes separate Puffo daemons (for example production
+and staging), so Anthropic + OpenAI's rotating refresh tokens can't be
+raced by workers or sibling daemon processes.
 
 ``CredentialRefresher`` owns an ``asyncio.Lock`` (single-writer),
 the agent-home registry, the ``notify_refresh_needed`` wake event,
@@ -29,9 +30,10 @@ import os
 import random
 import re
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional, Protocol
+from typing import AsyncIterator, Callable, Optional, Protocol
 
 from .._proc import no_window_kwargs
 from ..agent._auth_markers import looks_like_auth_error
@@ -54,6 +56,8 @@ logger = logging.getLogger(__name__)
 REFRESH_POLL_SECONDS = 120
 REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
+REFRESH_LOCK_TIMEOUT_SECONDS = REFRESH_ONESHOT_TIMEOUT_SECONDS + 15
+REFRESH_LOCK_POLL_SECONDS = 0.1
 
 # 2 ticks ≈ 4 min @ 120s poll: surfaces fast, doesn't false-positive on
 # a single transient subprocess hiccup.
@@ -69,6 +73,58 @@ REFRESH_PROBE_MODEL = os.environ.get(
 # then probes drop ``--model`` and use claude's default. Daemon restart
 # resets — fine, the worst case is one extra failed tick before re-latching.
 _probe_model_disabled = False
+
+
+def _try_lock_file(fd: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        if os.fstat(fd).st_size == 0:
+            os.write(fd, b"0")
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_file(fd: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+@asynccontextmanager
+async def _host_refresh_lock(path: Path) -> AsyncIterator[None]:
+    """Serialize provider refreshes across every Puffo daemon on this host."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    acquired = False
+    deadline = time.monotonic() + REFRESH_LOCK_TIMEOUT_SECONDS
+    try:
+        while True:
+            try:
+                _try_lock_file(fd)
+                acquired = True
+                break
+            except (BlockingIOError, PermissionError):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"credential refresh lock timed out: {path}"
+                    )
+                await asyncio.sleep(REFRESH_LOCK_POLL_SECONDS)
+        yield
+    finally:
+        if acquired:
+            _unlock_file(fd)
+        os.close(fd)
 
 # 5-15s randomised so fleet retries don't synchronise post rate-limit.
 RATE_LIMIT_FAST_RETRY_MIN_SECONDS = 5.0
@@ -253,6 +309,11 @@ class CredentialBackend(Protocol):
         every invocation."""
         ...
 
+    @property
+    def refresh_lock_path(self) -> Path:
+        """Host-global lock file for this provider's canonical login."""
+        ...
+
     def sync_to_agent(self, agent_home: Path) -> None:
         """Mirror the canonical credentials to one agent's per-agent
         ``.credentials.json``. Called by the refresher's fan-out after
@@ -282,6 +343,10 @@ class FileBackend:
     @property
     def host_credentials(self) -> Path:
         return self.host_home / ".claude" / ".credentials.json"
+
+    @property
+    def refresh_lock_path(self) -> Path:
+        return self.host_home / ".claude" / ".puffo-refresh.lock"
 
     def expires_in_seconds(self) -> int | None:
         try:
@@ -395,6 +460,10 @@ class CodexFileBackend:
     @property
     def host_auth(self) -> Path:
         return self.host_home / ".codex" / "auth.json"
+
+    @property
+    def refresh_lock_path(self) -> Path:
+        return self.host_home / ".codex" / ".puffo-refresh.lock"
 
     def expires_in_seconds(self) -> int | None:
         try:
@@ -550,6 +619,12 @@ class KeychainBackend:
         # Last blob propagated to agents — cheap byte-equality key so
         # the poll loop only fans out on real changes.
         self._last_propagated_blob: Optional[str] = None
+
+    @property
+    def refresh_lock_path(self) -> Path:
+        # Anchor outside PUFFO_AGENT_HOME so production and staging daemons
+        # coordinate access to the same login Keychain credential.
+        return Path.home() / ".claude" / ".puffo-refresh.lock"
 
     def expires_in_seconds(self) -> int | None:
         """Cache → Keychain → disk file. The disk fallthrough handles
@@ -1069,34 +1144,48 @@ class CredentialRefresher:
     async def _refresh_now(
         self, *, expires_in: int | None, by_agent: bool,
     ) -> None:
-        """Single-writer refresh through the backend; the lock makes
-        the rotating-RT race unwinnable."""
+        """Serialize refreshes within this daemon and across sibling daemons."""
         # Fire only on REFRESHED: UNCHANGED / FAILED leave the on-disk
         # token unchanged, so clearing auth_failed would oscillate.
         outcome: RefreshOutcome | None = None
         async with self._lock:
-            before = self.expires_in_seconds()
-            if (
-                not by_agent
-                and before is not None
-                and before > REFRESH_SAFETY_MARGIN_SECONDS
-            ):
-                logger.debug(
-                    "another caller already refreshed (now expires in %ds)",
-                    before,
+            lock_path = self.backend.refresh_lock_path
+            try:
+                async with _host_refresh_lock(lock_path):
+                    before = self.expires_in_seconds()
+                    if (
+                        not by_agent
+                        and before is not None
+                        and before > REFRESH_SAFETY_MARGIN_SECONDS
+                    ):
+                        logger.debug(
+                            "another daemon already refreshed "
+                            "(now expires in %ds)", before,
+                        )
+                        return
+                    logger.info(
+                        "refreshing credentials (expires_in=%s, by_agent=%s)",
+                        expires_in, by_agent,
+                    )
+                    try:
+                        outcome = await self.backend.refresh()
+                    except Exception as exc:
+                        logger.warning("backend refresh errored: %s", exc)
+                        outcome = RefreshOutcome.FAILED
+            except TimeoutError:
+                logger.warning(
+                    "credential refresh deferred: another daemon held the "
+                    "provider lock for more than %ds",
+                    REFRESH_LOCK_TIMEOUT_SECONDS,
                 )
                 return
-            logger.info(
-                "refreshing credentials (expires_in=%s, by_agent=%s)",
-                expires_in, by_agent,
-            )
-            try:
-                outcome = await self.backend.refresh()
-            except Exception as exc:
-                logger.warning("backend refresh errored: %s", exc)
-                outcome = RefreshOutcome.FAILED
+            assert outcome is not None
             self._propagate_outcome(outcome)
         if outcome is RefreshOutcome.REFRESHED:
+            # Never reopen a provider runtime before its sanitized view holds
+            # the replacement credential.
+            self._sync_views()
+            self._record_cred_fingerprint()
             self._fire_refresh_success()
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -59,6 +59,7 @@ from .state import (
     is_pid_alive,
     read_daemon_pid,
     refresh_model_flag_path,
+    refresh_provider_auth_flag_path,
     refresh_runtime_flag_path,
     refresh_session_flag_path,
     refresh_token_request_path,
@@ -455,7 +456,6 @@ class Daemon:
         agent_id = agent_cfg.id
 
         def on_refresh_success() -> None:
-            was_auth_failed = worker.runtime.health == "auth_failed"
             Worker._clear_auth_failed_if_recoverable(
                 worker.runtime,
                 agent_id,
@@ -464,25 +464,29 @@ class Daemon:
             # Re-arm the auth_failed DM dedup so a re-expiry this
             # session re-notifies the operator.
             worker._auth_failed_notification_sent = False
-            if was_auth_failed:
-                # The running adapter session still holds the stale
-                # credential; a restart re-links the fresh cred and
-                # redelivers the stalled batch (cursor wasn't advanced).
-                try:
-                    flag = restart_flag_path(agent_id)
-                    flag.parent.mkdir(parents=True, exist_ok=True)
-                    flag.write_text("")
-                    logger.info(
-                        "agent %s: credential recovered — requesting restart "
-                        "to pick up the new credential",
-                        agent_id,
-                    )
-                except OSError as exc:
-                    logger.warning(
-                        "agent %s: could not write restart flag: %s",
-                        agent_id,
-                        exc,
-                    )
+            # Long-lived Claude/Codex subprocesses may retain the credential
+            # they opened with. Reload only the provider runtime at the
+            # worker's next idle boundary; keep the bridge connection and
+            # Puffo logical session intact.
+            try:
+                flag = refresh_provider_auth_flag_path(
+                    agent_cfg.resolve_workspace_dir()
+                )
+                flag.parent.mkdir(parents=True, exist_ok=True)
+                flag.write_text(
+                    '{"source":"credential_replaced"}', encoding="utf-8"
+                )
+                worker.notify_refresh()
+                logger.info(
+                    "agent %s: credential replaced — provider reload requested",
+                    agent_id,
+                )
+            except OSError as exc:
+                logger.warning(
+                    "agent %s: could not request provider credential reload: %s",
+                    agent_id,
+                    exc,
+                )
 
         refresher.register_on_refresh_success(on_refresh_success)
         # Stash callback identity for _stop_worker's unregister.

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -214,7 +214,8 @@ def delete_flag_path(agent_id: str) -> Path:
     return agent_dir(agent_id) / ".puffo-agent" / "delete.flag"
 
 
-# Refresh flags — 5 axes touched by MCP refresh() / CLI / control-ws.
+# Refresh flags — user-facing refresh axes plus the daemon-owned provider-auth
+# reload signal.
 # All under ``<workspace>/.puffo-agent/`` so the location is reachable
 # from both the worker and the MCP subprocess in cli-docker.
 
@@ -229,6 +230,17 @@ def refresh_host_sync_flag_path(workspace: Path) -> Path:
 
 def refresh_session_flag_path(workspace: Path) -> Path:
     return workspace / ".puffo-agent" / "refresh_session.flag"
+
+
+def refresh_provider_auth_flag_path(workspace: Path) -> Path:
+    """Request an idle-boundary provider runtime reload after OAuth changes.
+
+    Unlike ``refresh_session.flag``, this preserves the Puffo logical session
+    and asks the harness to resume its native session with the replacement
+    credential. The runtime manager falls back to a fresh native session only
+    when that saved session is explicitly unavailable.
+    """
+    return workspace / ".puffo-agent" / "refresh_provider_auth.flag"
 
 
 def refresh_model_flag_path(workspace: Path) -> Path:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1217,25 +1217,23 @@ async def _process_refresh_flags(
     refresh_agent_flag: Path,
     refresh_host_sync_flag: Path,
     refresh_session_flag: Path,
+    refresh_provider_auth_flag: Path,
     display_name: str = "",
     role: str = "",
     role_short: str = "",
     puffo_handle: str = "",
     workspace_shared_status: str = "existing",
 ) -> None:
-    """Consume any worker-scope refresh flags into a single
-    ``adapter.reload(prompt, with_session=…)`` call at turn start.
-    Order: host sync → CLAUDE.md rebuild → session drop. A changed
-    primer/profile slice drops the session too (``--resume`` would replay
-    the stale baked prompt); memory-only or no-op rebuilds keep it.
-    ``puffo_handle`` rides along with the other identity fields: this
-    rebuild regenerates the managed profile block, so omitting it would
-    revert an imported agent's model-facing handle to ``agent_id`` on the
-    first refresh flag."""
+    """Consume worker refresh flags in one idle-boundary adapter reload.
+
+    Credential replacement preserves session identity. Explicit refresh or
+    changed primer/profile text drops it; identity fields are retained.
+    """
     host_sync_seen = refresh_host_sync_flag.exists()
     agent_seen = refresh_agent_flag.exists()
     session_seen = refresh_session_flag.exists()
-    if not (host_sync_seen or agent_seen or session_seen):
+    provider_auth_seen = refresh_provider_auth_flag.exists()
+    if not (host_sync_seen or agent_seen or session_seen or provider_auth_seen):
         return
 
     if host_sync_seen:
@@ -1284,6 +1282,11 @@ async def _process_refresh_flags(
             new_prompt if new_prompt is not None else puffo.system_prompt,
             with_session=session_seen or prompt_changed,
         )
+        if provider_auth_seen:
+            logger.info(
+                "agent %s: provider runtime reloaded after credential replacement",
+                agent_id,
+            )
     except Exception as exc:
         logger.warning(
             "agent %s: adapter.reload after refresh failed: %s",
@@ -1291,7 +1294,12 @@ async def _process_refresh_flags(
             exc,
         )
 
-    for flag in (refresh_host_sync_flag, refresh_agent_flag, refresh_session_flag):
+    for flag in (
+        refresh_host_sync_flag,
+        refresh_agent_flag,
+        refresh_session_flag,
+        refresh_provider_auth_flag,
+    ):
         try:
             flag.unlink()
         except OSError:

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -44,12 +44,13 @@ class WorkerRunPaths:
     system_prompt: str
 
     @property
-    def refresh_flags(self) -> tuple[Path, Path, Path]:
+    def refresh_flags(self) -> tuple[Path, Path, Path, Path]:
         root = Path(self.workspace_path) / ".puffo-agent"
         return (
             root / "refresh_agent.flag",
             root / "refresh_host_sync.flag",
             root / "refresh_session.flag",
+            root / "refresh_provider_auth.flag",
         )
 
 
@@ -609,7 +610,12 @@ class StandardWorkerRun:
         return RuntimeEventUploader(context.runtime_event_outbox, append_transport)
 
     async def _apply_refresh(self, context: WorkerRunContext) -> None:
-        refresh_agent, refresh_host, refresh_session = context.paths.refresh_flags
+        (
+            refresh_agent,
+            refresh_host,
+            refresh_session,
+            refresh_provider_auth,
+        ) = context.paths.refresh_flags
         paths = context.paths
         worker = self.worker
         await worker_module._process_refresh_flags(
@@ -629,6 +635,7 @@ class StandardWorkerRun:
             refresh_agent_flag=refresh_agent,
             refresh_host_sync_flag=refresh_host,
             refresh_session_flag=refresh_session,
+            refresh_provider_auth_flag=refresh_provider_auth,
         )
 
     async def _execute_global_turn(self, context: WorkerRunContext, planned):

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -606,6 +606,7 @@ def test_process_refresh_flags_noop_when_no_flags(tmp_path):
         refresh_agent_flag=tmp_path / "refresh_agent.flag",
         refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
         refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=tmp_path / "refresh_provider_auth.flag",
     ))
     assert adapter.reload_calls == []
 
@@ -630,12 +631,39 @@ def test_process_refresh_flags_session_only(tmp_path, monkeypatch):
         refresh_agent_flag=tmp_path / "refresh_agent.flag",
         refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
         refresh_session_flag=session_flag,
+        refresh_provider_auth_flag=tmp_path / "refresh_provider_auth.flag",
     ))
     assert len(adapter.reload_calls) == 1
     prompt, with_session = adapter.reload_calls[0]
     assert prompt == "preserved"
     assert with_session is True
     assert not session_flag.exists()
+
+
+def test_process_refresh_flags_provider_auth_preserves_session(tmp_path):
+    """Credential replacement reopens the provider but keeps session identity."""
+    from puffo_agent.portal.worker import _process_refresh_flags
+    adapter = _FakeAdapter()
+    puffo = _FakePuffo(prompt="preserved")
+    provider_flag = tmp_path / "refresh_provider_auth.flag"
+    provider_flag.write_text("{}", encoding="utf-8")
+
+    _run(_process_refresh_flags(
+        agent_id="t",
+        harness_name="codex",
+        shared_path=tmp_path / "shared",
+        profile_path=str(tmp_path / "profile.md"),
+        memory_path=str(tmp_path / "memory"),
+        workspace_path=str(tmp_path),
+        puffo=puffo,
+        adapter=adapter,
+        refresh_agent_flag=tmp_path / "refresh_agent.flag",
+        refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
+        refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=provider_flag,
+    ))
+    assert adapter.reload_calls == [("preserved", False)]
+    assert not provider_flag.exists()
 
 
 def test_process_refresh_flags_deletes_flags_after_processing(tmp_path, monkeypatch):
@@ -661,6 +689,7 @@ def test_process_refresh_flags_deletes_flags_after_processing(tmp_path, monkeypa
         refresh_agent_flag=agent_flag,
         refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
         refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=tmp_path / "refresh_provider_auth.flag",
     ))
     assert puffo.system_prompt == "new prompt"
     assert adapter.reload_calls == [("new prompt", True)]
@@ -695,6 +724,7 @@ def test_process_refresh_flags_keeps_authenticated_puffo_handle(
         refresh_agent_flag=agent_flag,
         refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
         refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=tmp_path / "refresh_provider_auth.flag",
         puffo_handle="bot-42-x9f2",
     ))
 

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -419,7 +419,7 @@ def test_oauth_copy_quotes_agent_id_for_markdown_safety():
     assert "`a-b-c`" in text
 
 
-def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
+def test_daemon_on_refresh_success_resets_dedup(monkeypatch, tmp_path):
     """PR #70 nit #1: the daemon's refresh-success closure resets
     ``worker._auth_failed_notification_sent``. The pieces are
     unit-tested individually; this pins the wiring between
@@ -448,11 +448,19 @@ def test_daemon_on_refresh_success_resets_dedup(monkeypatch):
         class puffo_core:
             slug = "alice-0001"
 
+        @staticmethod
+        def resolve_workspace_dir():
+            return tmp_path / "workspace"
+
     class _StubWorker:
         agent_cfg = _StubAgentCfg()
         runtime = RuntimeState(status="running", started_at=0, msg_count=0)
         _auth_failed_notification_sent = True
         _refresh_success_callback = None
+
+        @staticmethod
+        def notify_refresh():
+            pass
 
     class _StubDaemon:
         refresher = _StubRefresher()

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -5,8 +5,8 @@ FileBackend's symlink-propagation assumption doesn't hold.
 - backends expose a ``fingerprint`` so the refresher can spot the change
 - the refresher fires refresh-success on a detected change (not on the
   first/baseline tick)
-- the daemon's on_refresh_success restarts agents that were auth_failed
-  so their claude session respawns with the fresh credential
+- the daemon's on_refresh_success reloads healthy and auth-failed provider
+  runtimes at an idle boundary without restarting the whole agent
 """
 
 from __future__ import annotations
@@ -108,8 +108,10 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
     from puffo_agent.portal import daemon as daemon_module
     from puffo_agent.portal.state import RuntimeState
 
-    flag = tmp_path / "restart.flag"
-    monkeypatch.setattr(daemon_module, "restart_flag_path", lambda aid: flag)
+    flag = tmp_path / "refresh_provider_auth.flag"
+    monkeypatch.setattr(
+        daemon_module, "refresh_provider_auth_flag_path", lambda workspace: flag,
+    )
 
     class _StubRefresher:
         def __init__(self):
@@ -124,6 +126,10 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
     class _StubAgentCfg:
         id = "t-agent"
 
+        @staticmethod
+        def resolve_workspace_dir():
+            return tmp_path / "workspace"
+
         class runtime:
             harness = "claude-code"
 
@@ -135,6 +141,11 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
         runtime = RuntimeState(status="running", started_at=0, msg_count=0)
         _auth_failed_notification_sent = True
         _refresh_success_callback = None
+        refresh_notifications = 0
+
+        @classmethod
+        def notify_refresh(cls):
+            cls.refresh_notifications += 1
 
     class _StubDaemon:
         refresher = _StubRefresher()
@@ -152,17 +163,19 @@ def _daemon_harness(monkeypatch, tmp_path, health: str):
     return d, w, flag
 
 
-def test_on_refresh_success_restarts_auth_failed_agent(tmp_path, monkeypatch):
+def test_on_refresh_success_reloads_auth_failed_agent(tmp_path, monkeypatch):
     d, w, flag = _daemon_harness(monkeypatch, tmp_path, "auth_failed")
     d.refresher.callback()
     assert w.runtime.health == "ok"
-    assert flag.exists()        # restart requested to pick up new cred
+    assert flag.exists()
+    assert w.refresh_notifications == 1
 
 
-def test_on_refresh_success_no_restart_when_healthy(tmp_path, monkeypatch):
+def test_on_refresh_success_reloads_healthy_agent(tmp_path, monkeypatch):
     d, w, flag = _daemon_harness(monkeypatch, tmp_path, "ok")
     d.refresher.callback()
-    assert not flag.exists()    # nothing to recover → no restart
+    assert flag.exists()
+    assert w.refresh_notifications == 1
 
 
 # ── new message while auth_failed wakes the refresher ──────────────

--- a/tests/test_credential_refresh_clears_auth_failed.py
+++ b/tests/test_credential_refresh_clears_auth_failed.py
@@ -203,12 +203,13 @@ async def test_refresh_now_fires_on_success(tmp_path, monkeypatch):
 
     monkeypatch.setattr(r.backend, "refresh", fake_refresh)
 
-    fired: list[str] = []
-    r.register_on_refresh_success(lambda: fired.append("ok"))
+    events: list[str] = []
+    monkeypatch.setattr(r, "_sync_views", lambda: events.append("views_synced"))
+    r.register_on_refresh_success(lambda: events.append("callback"))
 
     await r._refresh_now(expires_in=10, by_agent=True)
     assert refresh_called["n"] == 1
-    assert fired == ["ok"]
+    assert events == ["views_synced", "callback"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -428,6 +428,8 @@ def test_refresh_now_captures_outcome_instead_of_dropping(tmp_path, monkeypatch)
     captured: list[RefreshOutcome] = []
 
     class _FakeBackend:
+        refresh_lock_path = tmp_path / "fake-refresh.lock"
+
         def expires_in_seconds(self):
             return 60
         async def refresh(self):
@@ -453,6 +455,8 @@ def test_refresh_now_treats_backend_exception_as_failed(tmp_path, monkeypatch):
     captured: list[RefreshOutcome] = []
 
     class _ExplodingBackend:
+        refresh_lock_path = tmp_path / "exploding-refresh.lock"
+
         def expires_in_seconds(self):
             return 60
         async def refresh(self):

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from puffo_agent.agent.errors import AgentAPIError
 from puffo_agent.agent.harness.codex_driver import CODEX_CAPABILITIES
 from puffo_agent.agent.harness.driver import (
     CancelReceipt,
@@ -174,6 +175,56 @@ class _AmbiguousStartDriver(_ControllableDriver):
             accepted=False,
             delivery="ambiguous_at_least_once",
         )
+
+
+class _ResumeBoundaryDriver(_ControllableDriver):
+    def __init__(self, resume_error: Exception) -> None:
+        super().__init__()
+        self.resume_error = resume_error
+        self.resume_values: list[SessionRef | None] = []
+
+    async def open(self, spec, resume=None):
+        self.resume_values.append(resume)
+        if resume is not None:
+            raise self.resume_error
+        return await super().open(spec, resume)
+
+
+@pytest.mark.asyncio
+async def test_native_resume_falls_back_only_when_session_is_missing():
+    driver = _ResumeBoundaryDriver(RuntimeError("Codex thread not found"))
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp"),
+        session_ref=SessionRef("logical-session"),
+        native_session_id="native-old",
+    )
+
+    opened = await manager.open()
+
+    assert driver.resume_values == [SessionRef("native-old"), None]
+    assert opened.session_ref == SessionRef("logical-session")
+    assert manager.native_session_id == "native-session-1"
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_native_resume_keeps_session_on_transient_error():
+    driver = _ResumeBoundaryDriver(
+        AgentAPIError("provider temporarily unavailable", is_auth=False)
+    )
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp"),
+        session_ref=SessionRef("logical-session"),
+        native_session_id="native-old",
+    )
+
+    with pytest.raises(AgentAPIError, match="temporarily unavailable"):
+        await manager.open()
+    assert driver.resume_values == [SessionRef("native-old")]
+    assert manager.session_ref == SessionRef("logical-session")
+    assert manager.native_session_id == "native-old"
 
 
 def _context():


### PR DESCRIPTION
## Summary

Make Claude Code and Codex account changes take effect in running Puffo Agents without restarting the daemon or breaking the Puffo logical session.

## Runtime flow

```text
host credential replaced
  -> CredentialRefresher detects/refreshes canonical credential
  -> sync sanitized per-Agent credential views
  -> write refresh_provider_auth.flag + wake worker
  -> worker waits for an idle turn boundary
  -> reload provider runtime and try native-session resume
  -> create a fresh native session only when the provider explicitly says the saved session is unavailable
```

- Healthy and `auth_failed` workers both reload after credential replacement.
- Network, auth, rate-limit, and process errors retain the native session ID for retry.
- A provider-level OS file lock serializes refreshes across production/staging daemon processes sharing the same host login.
- Puffo bridge connection and logical session remain continuous.
- No server or Web changes are required.

## Verification

- `uv run --extra dev pytest`: 3192 passed, 1 skipped
- focused account-cutover/session tests: 7 passed
- `uv run --extra dev pre-commit run --files ...`: all hooks passed
- real two-process lock check: refresh critical sections serialized without overlap
- `git diff --check`: passed
