### PR TITLE
chore(release): prepare 2.0.0a18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a18] - 2026-08-19
+
+> Staging candidate making Claude Code and Codex account changes safe for
+> already-running Agent runtimes.
+
+### Fixed
+
+- **Provider account changes now take effect without restarting the Agent.**
+  Canonical credentials are copied into each Agent view before its provider
+  runtime reloads at an idle turn boundary; the Puffo logical session remains
+  continuous and the native session is resumed when still available.
+- **Credential refresh is serialized across local Puffo daemons.** Production
+  and staging processes sharing one host login use a provider-level OS lock,
+  preventing rotating refresh credentials from racing each other.
+- **Transient provider failures no longer discard resumable sessions.** A new
+  native session is created only when the provider explicitly reports that the
+  saved session or transcript is missing or incompatible.
+
 ## [2.0.0a17] - 2026-08-18
 
 > Staging candidate restoring Claude Code progress after runtime context-window

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a17"
+version = "2.0.0a18"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a17"
+version = "2.0.0a18"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare the `2.0.0a18` TestPyPI staging release after merging provider account cutover support.

## Included behavior

- reload running Claude Code and Codex providers after host account changes
- preserve Puffo logical sessions and resume provider-native sessions when available
- serialize rotating credential refresh across sibling local daemons
- retain native session IDs across transient auth, network, rate-limit, and process failures

## Release verification

- `uv lock --check`
- `uv run --extra dev pre-commit run --all-files`
- `uv build`
- clean-venv wheel install
- `puffo-agent version` reports `2.0.0a18`
- `puffo-agent --help` smoke passed
