### PR TITLE
fix(runtime): preserve native sessions across resource reloads

### DIFF
--- a/docs/puffo-agent-architecture.md
+++ b/docs/puffo-agent-architecture.md
@@ -98,7 +98,7 @@ Current concrete engines:
 - `portal/ws_local/`: externally attached runtime.
 
 `agent/harness/local_runtime.py` resolves host binaries, isolated homes,
-session fingerprints, managed config, and common Driver binding. Docker reuses
+durable native-session resume, managed config, and common Driver binding. Docker reuses
 the same Driver and Runtime Manager contracts through a `docker exec -i`
 process factory. `portal/runtime_matrix.py` is the source of truth for supported
 runtime/provider/harness combinations.

--- a/src/puffo_agent/agent/harness/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/docker_runtime.py
@@ -65,7 +65,6 @@ from .local_runtime import (
     PreparedLocalRuntime,
     _read_json_object,
     build_codex_gateway_provider,
-    compute_session_fingerprint,
     remove_legacy_permission_hook,
 )
 
@@ -137,17 +136,11 @@ class DockerRuntimePreparer:
         *,
         system_prompt: str,
         persisted_native_session_id: str = "",
-        persisted_session_fingerprint: str = "",
     ) -> PreparedLocalRuntime:
         spec = await self.refresh_spec(system_prompt)
-        session_fingerprint = self.session_fingerprint(spec)
         legacy_path = self._legacy_session_path()
         legacy_id = self._load_legacy_session_id(legacy_path)
-        discarded_persisted_session = bool(
-            persisted_native_session_id
-            and persisted_session_fingerprint != session_fingerprint
-        )
-        if persisted_native_session_id and not discarded_persisted_session:
+        if persisted_native_session_id:
             native_session_id = persisted_native_session_id
             source = "runtime_event_outbox"
         elif legacy_id:
@@ -155,18 +148,7 @@ class DockerRuntimePreparer:
             source = "legacy_session_file"
         else:
             native_session_id = ""
-            source = (
-                "fresh_incompatible_persisted_session"
-                if discarded_persisted_session
-                else "fresh"
-            )
-        if discarded_persisted_session:
-            logger.info(
-                "agent %s: starting a fresh %s session because the durable "
-                "session fingerprint is missing or incompatible",
-                self.agent_id,
-                self.harness_name,
-            )
+            source = "fresh"
         await self.ensure_container()
         return PreparedLocalRuntime(
             harness_name=self.harness_name,
@@ -175,19 +157,6 @@ class DockerRuntimePreparer:
             migration_source=source,
             legacy_session_path=legacy_path,
             preparer=self,
-            session_fingerprint=session_fingerprint,
-            discarded_persisted_session=discarded_persisted_session,
-        )
-
-    def session_fingerprint(self, spec: RuntimeSpec) -> str:
-        """Fingerprint only inputs that make a native session incompatible."""
-        return compute_session_fingerprint(
-            agent_cfg=self.agent_cfg,
-            harness_name=self.harness_name,
-            provider=resolve_effective_provider(
-                "cli-docker", self.agent_cfg.runtime.provider
-            ),
-            spec=spec,
         )
 
     async def refresh_spec(self, system_prompt: str) -> RuntimeSpec:

--- a/src/puffo_agent/agent/harness/local_runtime.py
+++ b/src/puffo_agent/agent/harness/local_runtime.py
@@ -10,7 +10,6 @@ those responsibilities belong to :mod:`codex_driver`,
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
 import os
@@ -67,7 +66,6 @@ from ..runtime_event_outbox import (
     RuntimeEventProjectingSink,
 )
 from ..runtime_events import RuntimeEventProjector, TrustedScope
-from ..shared_content import MEMORY_SECTION_HEADER
 from . import UnsupportedDriver, build_driver
 from .driver import (
     Driver,
@@ -177,39 +175,6 @@ def _read_json_object(path: Path) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def compute_session_fingerprint(
-    *,
-    agent_cfg: AgentConfig,
-    harness_name: str,
-    provider: str,
-    spec: RuntimeSpec,
-) -> str:
-    """Fingerprint only inputs that make a native session incompatible.
-
-    Shared by the host-local and Docker runtime owners so a persisted
-    logical session stays comparable across restarts of the same runtime.
-    """
-    prompt_core = spec.system_prompt.split(MEMORY_SECTION_HEADER, 1)[0]
-    payload = {
-        "version": 1,
-        "harness": harness_name,
-        "provider": provider,
-        "model": spec.model,
-        "workspace": str(Path(spec.workspace_dir).resolve()),
-        "sandbox": spec.sandbox,
-        "permission_mode": spec.permission_mode,
-        "inference_level": agent_cfg.runtime.inference_level,
-        "llm_base_url": agent_cfg.runtime.llm_base_url.rstrip("/"),
-        "prompt_core_sha256": hashlib.sha256(
-            prompt_core.encode("utf-8")
-        ).hexdigest(),
-    }
-    encoded = json.dumps(
-        payload, sort_keys=True, separators=(",", ":")
-    ).encode("utf-8")
-    return "v1:" + hashlib.sha256(encoded).hexdigest()
-
-
 def build_codex_gateway_provider(
     *,
     model: str,
@@ -250,8 +215,6 @@ class RuntimePreparer(Protocol):
 
     async def refresh_spec(self, system_prompt: str) -> RuntimeSpec: ...
 
-    def session_fingerprint(self, spec: RuntimeSpec) -> str: ...
-
 
 @dataclass(slots=True)
 class PreparedLocalRuntime:
@@ -261,8 +224,6 @@ class PreparedLocalRuntime:
     migration_source: str
     legacy_session_path: Path
     preparer: RuntimePreparer
-    session_fingerprint: str
-    discarded_persisted_session: bool = False
 
     def finalize_legacy_session_migration(self) -> None:
         """Retire the pre-Driver session sentinel after durable adoption."""
@@ -328,17 +289,11 @@ class LocalRuntimePreparer:
         *,
         system_prompt: str,
         persisted_native_session_id: str = "",
-        persisted_session_fingerprint: str = "",
     ) -> PreparedLocalRuntime:
         spec = await self.refresh_spec(system_prompt)
-        session_fingerprint = self.session_fingerprint(spec)
         legacy_path = self._legacy_session_path()
         legacy_id = self._load_legacy_session_id(legacy_path)
-        discarded_persisted_session = bool(
-            persisted_native_session_id
-            and persisted_session_fingerprint != session_fingerprint
-        )
-        if persisted_native_session_id and not discarded_persisted_session:
+        if persisted_native_session_id:
             native_session_id = persisted_native_session_id
             source = "runtime_event_outbox"
         elif legacy_id:
@@ -346,18 +301,7 @@ class LocalRuntimePreparer:
             source = "legacy_session_file"
         else:
             native_session_id = ""
-            source = (
-                "fresh_incompatible_persisted_session"
-                if discarded_persisted_session
-                else "fresh"
-            )
-        if discarded_persisted_session:
-            logger.info(
-                "agent %s: starting a fresh %s session because the durable "
-                "session fingerprint is missing or incompatible",
-                self.agent_id,
-                self.harness_name,
-            )
+            source = "fresh"
         return PreparedLocalRuntime(
             harness_name=self.harness_name,
             spec=spec,
@@ -365,20 +309,6 @@ class LocalRuntimePreparer:
             migration_source=source,
             legacy_session_path=legacy_path,
             preparer=self,
-            session_fingerprint=session_fingerprint,
-            discarded_persisted_session=discarded_persisted_session,
-        )
-
-    def session_fingerprint(self, spec: RuntimeSpec) -> str:
-        """Fingerprint only inputs that make a native session incompatible."""
-        return compute_session_fingerprint(
-            agent_cfg=self.agent_cfg,
-            harness_name=self.harness_name,
-            provider=resolve_effective_provider(
-                self.agent_cfg.runtime.kind or "cli-local",
-                self.agent_cfg.runtime.provider,
-            ),
-            spec=spec,
         )
 
     async def refresh_spec(self, system_prompt: str) -> RuntimeSpec:
@@ -839,7 +769,6 @@ def build_local_runtime_adapter(
     projecting_sink = RuntimeEventProjectingSink(outbox, projector)
     legacy_projector = _LegacyStatusProjector(prepared.preparer.agent_id)
     manager: RuntimeManager
-    session_fingerprint = [prepared.session_fingerprint]
 
     async def persist_event(event: HarnessEvent) -> None:
         try:
@@ -877,7 +806,6 @@ def build_local_runtime_adapter(
                 active_turn,
                 session_ref=logical_session,
                 native_session_id=manager.native_session_id,
-                session_fingerprint=session_fingerprint[0],
             )
         except Exception as exc:
             logger.warning(
@@ -888,9 +816,7 @@ def build_local_runtime_adapter(
             )
 
     async def reload_spec(system_prompt: str) -> RuntimeSpec:
-        spec = await prepared.preparer.refresh_spec(system_prompt)
-        session_fingerprint[0] = prepared.preparer.session_fingerprint(spec)
-        return spec
+        return await prepared.preparer.refresh_spec(system_prompt)
 
     manager = RuntimeManager(
         driver,
@@ -917,6 +843,5 @@ __all__ = [
     "VALID_SANDBOX_MODES",
     "build_local_runtime_adapter",
     "build_codex_gateway_provider",
-    "compute_session_fingerprint",
     "remove_legacy_permission_hook",
 ]

--- a/src/puffo_agent/agent/runtime_event_outbox.py
+++ b/src/puffo_agent/agent/runtime_event_outbox.py
@@ -217,6 +217,9 @@ class RuntimeEventOutbox:
             """
         )
         self._migrate_metadata_only_rows(db)
+        # Session compatibility is decided by the provider's native resume
+        # contract. Remove the retired configuration-derived state key.
+        db.execute("DELETE FROM state WHERE key = 'session_fingerprint'")
         db.commit()
         return db
 
@@ -450,25 +453,21 @@ class RuntimeEventOutbox:
     def set_active_turn(
         self, turn_ref: str | None, *, session_ref: str = "",
         native_session_id: str = "",
-        session_fingerprint: str | None = None,
     ) -> None:
         self._call(
             lambda: self._set_active_turn(
                 turn_ref, session_ref, native_session_id,
-                session_fingerprint,
             )
         )
 
     async def aset_active_turn(
         self, turn_ref: str | None, *, session_ref: str = "",
         native_session_id: str = "",
-        session_fingerprint: str | None = None,
     ) -> None:
         """Commit the active turn without blocking the caller's event loop."""
         await self._acall(
             lambda: self._set_active_turn(
                 turn_ref, session_ref, native_session_id,
-                session_fingerprint,
             )
         )
 
@@ -477,15 +476,12 @@ class RuntimeEventOutbox:
         turn_ref: str | None,
         session_ref: str,
         native_session_id: str,
-        session_fingerprint: str | None,
     ) -> None:
         values = {
             "active_turn_ref": turn_ref or "",
             "session_ref": session_ref,
             "native_session_id": native_session_id,
         }
-        if session_fingerprint is not None:
-            values["session_fingerprint"] = session_fingerprint
         with self._db:
             for key, value in values.items():
                 self._db.execute(

--- a/src/puffo_agent/agent/shared_content.py
+++ b/src/puffo_agent/agent/shared_content.py
@@ -572,7 +572,7 @@ orthogonal axes; combine them freely.
 | `refresh()` | Rebuild `CLAUDE.md` + re-sync puffo default skills. Subprocess respawns on next turn, session preserved. |
 | `refresh(host_sync=True)` | Also re-sync host skills + host MCP. cli-local: hot; cli-docker: requires `session=True` too. |
 | `refresh(session=True)` | Also drop CLI session token; next spawn starts a new conversation. |
-| `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, full worker respawn. Implicit fresh session. |
+| `refresh(harness="codex", model="gpt-5")` | Swap (harness, model), persist to `agent.yml`, and respawn the worker. The same harness resumes its session; a different harness falls back to a new native session. |
 | `refresh(inference_level="medium")` | Set reasoning effort, persist to `agent.yml`, respawn. Standalone or alongside a harness+model swap. |
 
 **When to use:**

--- a/src/puffo_agent/mcp/core_host_mcp_tools.py
+++ b/src/puffo_agent/mcp/core_host_mcp_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -67,8 +68,8 @@ def register_host_mcp_tools(mcp: FastMCP, cfg: Any) -> None:
         """Copy the operator's ``~/.claude.json#mcpServers[<id>]``
         entry into your own ``<agent>/.claude.json``. Pair with
         ``install_host_mcp`` once the operator finishes OAuth on host,
-        then call ``refresh()`` so claude respawns and picks up the
-        new MCP.
+        then the runtime automatically reloads the provider at the next
+        idle boundary so it picks up the new MCP.
 
         If the host config doesn't have the entry yet, returns an
         error asking you to call ``install_host_mcp`` first (and
@@ -80,4 +81,12 @@ def register_host_mcp_tools(mcp: FastMCP, cfg: Any) -> None:
                 "on this MCP runtime, so the puffo-agent daemon's "
                 "rpc_service isn't reachable."
             )
-        return await cfg.rpc_client.sync_mcp(template_id=template_id)
+        result = await cfg.rpc_client.sync_mcp(template_id=template_id)
+        workspace = getattr(cfg, "workspace", None)
+        synced = result.startswith(("Verified host's ", "Synced host's "))
+        if workspace and synced:
+            from .host_tools import _touch_refresh_flag
+
+            _touch_refresh_flag(Path(workspace), "refresh_agent")
+            result += " Runtime refresh requested."
+        return result

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -205,18 +205,20 @@ def _register_skill_tools(mcp: FastMCP, workspace: str, harness: str) -> None:
         """Install a new skill at project scope."""
         _require_claude_code(harness, "install_skill")
         dst = _install_skill(Path(workspace), name, content)
+        _touch_refresh_flag(Path(workspace), "refresh_agent")
         return (
             f"installed skill {name!r} at project scope ({dst}). "
-            "Call refresh() so your next turn picks it up."
+            "Runtime refresh requested; your next turn will pick it up."
         )
     @mcp.tool()
     async def uninstall_skill(name: str) -> str:
         """Remove a skill you previously installed."""
         _require_claude_code(harness, "uninstall_skill")
         _uninstall_skill(Path(workspace), name)
+        _touch_refresh_flag(Path(workspace), "refresh_agent")
         return (
-            f"uninstalled skill {name!r}. Call refresh() so your next "
-            "turn stops seeing it."
+            f"uninstalled skill {name!r}. Runtime refresh requested; your "
+            "next turn will stop seeing it."
         )
     @mcp.tool()
     async def list_skills() -> str:
@@ -244,18 +246,20 @@ def _register_mcp_tools(mcp: FastMCP, workspace: str, runtime_kind: str, harness
             Path(workspace), name, command, args, env,
             check_host_local=check_host_local,
         )
+        _touch_refresh_flag(Path(workspace), "refresh_agent")
         return (
             f"registered MCP server {name!r} at project scope ({path}). "
-            "Call refresh() so the claude subprocess respawns."
+            "Runtime refresh requested so the provider reloads it."
         )
     @mcp.tool()
     async def uninstall_mcp_server(name: str) -> str:
         """Remove an MCP server you previously registered."""
         _require_claude_code(harness, "uninstall_mcp_server")
         _uninstall_mcp_server(Path(workspace), name)
+        _touch_refresh_flag(Path(workspace), "refresh_agent")
         return (
-            f"removed MCP server {name!r}. Call refresh() so the claude "
-            "subprocess respawns without it."
+            f"removed MCP server {name!r}. Runtime refresh requested so the "
+            "provider reloads without it."
         )
     @mcp.tool()
     async def list_mcp_servers() -> str:

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -854,7 +854,7 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
     values. With flags ⇒ update agent.yml, then sync to server."""
     import asyncio
 
-    from .profile_sync import sync_agent_profile
+    from .profile_sync import sync_agent_profile, write_refresh_agent_flag
 
     agent_id = args.id
     if not agent_yml_path(agent_id).exists():
@@ -918,6 +918,7 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
         patch["role_short"] = derived
 
     cfg.save()
+    write_refresh_agent_flag(cfg, reason="cli agent profile")
 
     try:
         asyncio.run(sync_agent_profile(cfg, patch))
@@ -1191,6 +1192,9 @@ def cmd_agent_edit(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    from .profile_sync import write_refresh_agent_flag
+
+    write_refresh_agent_flag(cfg, reason="cli profile editor")
     return 0
 
 

--- a/src/puffo_agent/portal/host_mcp_handler.py
+++ b/src/puffo_agent/portal/host_mcp_handler.py
@@ -554,9 +554,8 @@ async def sync(ctx: HostMcpContext, *, template_id: str) -> str:
         )
         return (
             f"Verified host's ~/.codex/config.toml has {template_id!r}."
-            f"{oauth_note} Call refresh() - your codex worker re-merges the "
-            "host's mcp_servers into your own config on every restart, so "
-            "the new entry will be live immediately."
+            f"{oauth_note} Your codex worker re-merges the host's "
+            "mcp_servers into its own config on provider reload."
         )
 
     host_claude_json = ctx.host_home / ".claude.json"
@@ -580,8 +579,7 @@ async def sync(ctx: HostMcpContext, *, template_id: str) -> str:
     _atomic_write_claude_json(agent_claude_json, agent_data)
     return (
         f"Synced host's {template_id!r} entry into your "
-        f"~/.claude.json. Call refresh() so claude respawns and "
-        f"loads it."
+        f"~/.claude.json. It is ready for the next provider reload."
     )
 
 

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -201,8 +201,7 @@ async def sync_agent_profile(cfg: AgentConfig, patch: dict[str, Any]) -> None:
 
 
 def write_refresh_agent_flag(cfg: AgentConfig, *, reason: str) -> None:
-    """Drop ``refresh_agent.flag`` so the worker rebuilds its system
-    prompt on the next batch. Best-effort."""
+    """Request an idle-boundary system-prompt and provider refresh."""
     from .state import refresh_agent_flag_path
     flag_path = refresh_agent_flag_path(cfg.resolve_workspace_dir())
     try:

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -42,6 +42,7 @@ from ...profile_sync import (
     profile_summary,
     update_profile_summary,
     upload_avatar,
+    write_refresh_agent_flag,
 )
 from ...runtime_matrix import (
     HARNESS_PROVIDERS,
@@ -932,6 +933,7 @@ class AgentDetail(QWidget):
         try:
             cfg.save()
             update_profile_summary(cfg, soul)
+            write_refresh_agent_flag(cfg, reason="desktop agent profile")
         except Exception as exc:
             QMessageBox.warning(self, "Save", f"failed to persist: {exc}")
             return

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1226,8 +1226,8 @@ async def _process_refresh_flags(
 ) -> None:
     """Consume worker refresh flags in one idle-boundary adapter reload.
 
-    Credential replacement preserves session identity. Explicit refresh or
-    changed primer/profile text drops it; identity fields are retained.
+    Resource and credential changes preserve session identity. Only an explicit
+    session refresh starts a new logical and native provider conversation.
     """
     host_sync_seen = refresh_host_sync_flag.exists()
     agent_seen = refresh_agent_flag.exists()
@@ -1240,7 +1240,6 @@ async def _process_refresh_flags(
         _sync_refresh_host_assets(agent_id)
 
     new_prompt: str | None = None
-    prompt_changed = False
     if agent_seen:
         try:
             new_prompt = _rebuild_managed_system_prompt(
@@ -1256,14 +1255,7 @@ async def _process_refresh_flags(
                 puffo_handle=puffo_handle,
                 workspace_shared_status=workspace_shared_status,
             )
-            from ..agent.shared_content import MEMORY_SECTION_HEADER
-
-            def _session_core(prompt: str) -> str:
-                return prompt.split(MEMORY_SECTION_HEADER, 1)[0]
-
-            prompt_changed = _session_core(new_prompt) != _session_core(
-                puffo.system_prompt
-            )
+            prompt_changed = new_prompt != puffo.system_prompt
             puffo.system_prompt = new_prompt
             logger.info(
                 "agent %s: system prompt rebuilt from disk (changed=%s)",
@@ -1280,7 +1272,7 @@ async def _process_refresh_flags(
     try:
         await adapter.reload(
             new_prompt if new_prompt is not None else puffo.system_prompt,
-            with_session=session_seen or prompt_changed,
+            with_session=session_seen,
         )
         if provider_auth_seen:
             logger.info(

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -346,9 +346,6 @@ class StandardWorkerRun:
         prepared = await preparer.prepare(
             system_prompt=paths.system_prompt,
             persisted_native_session_id=persisted.get("native_session_id", ""),
-            persisted_session_fingerprint=persisted.get(
-                "session_fingerprint", ""
-            ),
         )
         try:
             return await self._bind_driver_runtime(
@@ -374,20 +371,15 @@ class StandardWorkerRun:
         from ..agent.harness.docker_runtime import DockerRuntimePreparer
         from ..agent.harness.local_runtime import build_local_runtime_adapter
 
-        if prepared.discarded_persisted_session:
-            session_ref = f"session_{uuid.uuid4().hex}"
-            active_turn_ref = None
-        else:
-            session_ref = (
-                persisted.get("session_ref", "")
-                or f"session_{uuid.uuid4().hex}"
-            )
-            active_turn_ref = persisted.get("active_turn_ref") or None
+        session_ref = (
+            persisted.get("session_ref", "")
+            or f"session_{uuid.uuid4().hex}"
+        )
+        active_turn_ref = persisted.get("active_turn_ref") or None
         outbox.set_active_turn(
             active_turn_ref,
             session_ref=session_ref,
             native_session_id=prepared.native_session_id,
-            session_fingerprint=prepared.session_fingerprint,
         )
         driver = None
         cleanup = None
@@ -503,9 +495,6 @@ class StandardWorkerRun:
                 persisted.get("active_turn_ref") or None,
                 session_ref=context.runtime_session_ref,
                 native_session_id=worker._adapter.get_provider_session_id() or "",
-                session_fingerprint=(
-                    context.prepared_local_runtime.session_fingerprint
-                ),
             )
             context.prepared_local_runtime.finalize_legacy_session_migration()
         if warm_ok:

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -692,7 +692,7 @@ def test_process_refresh_flags_deletes_flags_after_processing(tmp_path, monkeypa
         refresh_provider_auth_flag=tmp_path / "refresh_provider_auth.flag",
     ))
     assert puffo.system_prompt == "new prompt"
-    assert adapter.reload_calls == [("new prompt", True)]
+    assert adapter.reload_calls == [("new prompt", False)]
     assert not agent_flag.exists()
 
 

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1939,7 +1939,6 @@ def _build_projection_adapter(tmp_path, driver, monkeypatch):
         migration_source="fresh",
         legacy_session_path=tmp_path / "legacy.json",
         preparer=_StubPreparer(),
-        session_fingerprint="fp",
     )
     outbox = RuntimeEventOutbox(tmp_path / "runtime_events.db", max_rows=1)
     monkeypatch.setattr(local_runtime, "build_driver", lambda name: driver)

--- a/tests/test_host_mcp_handler.py
+++ b/tests/test_host_mcp_handler.py
@@ -275,7 +275,7 @@ async def test_sync_copies_host_entry_to_agent(tmp_path):
         (ctx.agent_home / ".claude.json").read_text(encoding="utf-8"),
     )
     assert agent_data["mcpServers"]["gmail-read"] == entry
-    assert "refresh()" in msg
+    assert "provider reload" in msg
 
 
 # ── codex harness path ─────────────────────────────────────────────
@@ -394,8 +394,8 @@ async def test_sync_codex_validates_host_entry_present(tmp_path):
 
 @pytest.mark.asyncio
 async def test_sync_codex_does_not_write_agent_file(tmp_path):
-    """Codex sync verifies host has the entry and points the agent
-    at refresh() — the worker's restart code does the re-merge.
+    """Codex sync verifies the host entry and leaves re-merging to the
+    provider reload requested by the MCP tool wrapper.
     Agent-side write would just get overwritten with the same
     content on the next restart, so we skip it."""
     ctx = _ctx(tmp_path, harness="codex")
@@ -408,7 +408,7 @@ async def test_sync_codex_does_not_write_agent_file(tmp_path):
 
     msg = await host_mcp_handler.sync(ctx, template_id="gmail-read")
 
-    assert "refresh()" in msg
+    assert "provider reload" in msg
     assert "re-merges" in msg
     # No file under agent_home/.codex was touched.
     assert not (ctx.agent_home / ".codex").exists()

--- a/tests/test_local_runtime_migration.py
+++ b/tests/test_local_runtime_migration.py
@@ -142,7 +142,7 @@ async def test_old_codex_agent_imports_session_with_matching_sandbox(
 
 
 @pytest.mark.asyncio
-async def test_durable_session_resumes_only_with_matching_fingerprint(
+async def test_durable_session_resumes_across_prompt_refresh(
     puffo_home, monkeypatch,
 ):
     import puffo_agent.agent.harness.local_runtime as local_runtime
@@ -156,7 +156,7 @@ async def test_durable_session_resumes_only_with_matching_fingerprint(
         lambda *_args: "view",
     )
     config = AgentConfig(
-        id="fingerprinted-claude",
+        id="durable-claude",
         runtime=RuntimeConfig(
             kind="cli-local",
             provider="anthropic",
@@ -164,22 +164,17 @@ async def test_durable_session_resumes_only_with_matching_fingerprint(
         ),
     )
     preparer = LocalRuntimePreparer(DaemonConfig(), config)
-    baseline = await preparer.prepare(system_prompt="stable prompt")
     resumed = await preparer.prepare(
         system_prompt="stable prompt",
         persisted_native_session_id="native-old",
-        persisted_session_fingerprint=baseline.session_fingerprint,
     )
-    rotated = await preparer.prepare(
+    refreshed = await preparer.prepare(
         system_prompt="changed identity prompt",
         persisted_native_session_id="native-old",
-        persisted_session_fingerprint=baseline.session_fingerprint,
     )
 
     assert resumed.native_session_id == "native-old"
-    assert not resumed.discarded_persisted_session
-    assert rotated.native_session_id == ""
-    assert rotated.discarded_persisted_session
+    assert refreshed.native_session_id == "native-old"
 
 
 class _ResumeFallbackDriver(Driver):

--- a/tests/test_worker_health_probe_gate.py
+++ b/tests/test_worker_health_probe_gate.py
@@ -291,7 +291,6 @@ def test_prepared_runtime_retries_transient_warm_before_releasing_gate():
         None,
         session_ref="logical-session",
         native_session_id="native-session",
-        session_fingerprint=prepared.session_fingerprint,
     )
     prepared.finalize_legacy_session_migration.assert_called_once_with()
     worker._run_post_warm_gate.assert_awaited_once_with("agent-a")


### PR DESCRIPTION
## Problem

Puffo persisted a configuration-derived `session_fingerprint` beside each provider session. Profile, prompt, model, workspace, or account-adjacent changes could make that hash differ on restart, causing the worker to discard a valid Claude/Codex native session before asking the provider whether it was resumable. Five local production agents lost their original native session this way after profile edits.

## Existing contract retained

- Credential replacement already requests an idle-boundary provider reload with `preserve_session=True`.
- `RuntimeManager` already resumes the saved native session and only falls back to a fresh provider session when the provider explicitly reports it unavailable or incompatible.
- `refresh(session=True)` remains the explicit way to request a new logical/native conversation.
- The separate startup MCP tool-schema fingerprint remains unchanged.

## Changes

- Remove the configuration/session fingerprint from local and Docker runtime preparation and durable outbox state.
- Preserve the Puffo logical session and provider native session through profile, prompt, model, credential, and managed-resource reloads.
- Delete stale `session_fingerprint` state during the existing SQLite open/migration path.
- Route managed profile, skill, project MCP, and host MCP changes through the existing `refresh_agent.flag` idle watcher.
- Replace obsolete tool copy that asked agents to call `refresh()` manually.

No new session store, state machine, watcher, or replacement fingerprint is introduced.

## Validation

- `SKIP=no-commit-to-branch uv run --extra dev pre-commit run --all-files`
- `uv run --extra dev pytest -q`
- `uv build`
- Focused session/account/resource-refresh suite: 195 tests passed
