### PR TITLE
chore(release): prepare 2.0.0a19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a19] - 2026-08-19
+
+> Staging candidate preserving provider conversations while Agent resources and
+> credentials change.
+
+### Fixed
+
+- **Profile and runtime configuration changes no longer discard valid native
+  sessions.** Claude Code and Codex now receive the persisted session ID and
+  decide whether it can be resumed; Puffo falls back to a fresh provider
+  session only when the provider explicitly rejects the saved one.
+- **Puffo logical sessions remain continuous across provider reloads.** The
+  retired configuration-derived session fingerprint is removed from durable
+  runtime state during the existing SQLite migration path.
+- **Managed profile, skill, and MCP changes reload automatically.** Existing
+  mutation paths request the current idle-boundary resource refresh instead of
+  asking the Agent to call `refresh()` manually. Explicit
+  `refresh(session=True)` still starts a new conversation.
+
 ## [2.0.0a18] - 2026-08-19
 
 > Staging candidate making Claude Code and Codex account changes safe for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a18"
+version = "2.0.0a19"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a18"
+version = "2.0.0a19"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release

Prepare the `2.0.0a19` TestPyPI staging candidate after #260.

## Included

- Preserve Claude Code and Codex native sessions through profile, prompt, model, credential, and managed-resource reloads.
- Keep the Puffo logical session continuous.
- Remove the retired configuration-derived session fingerprint during SQLite open/migration.
- Auto-request the existing idle-boundary refresh after managed profile, skill, and MCP changes.

## Validation

- Feature PR #260: all Python 3.11/3.12, pre-commit, and CodeQL checks passed.
- `uv lock --check`
- `puffo-agent version` reports `2.0.0a19`
- `SKIP=no-commit-to-branch uv run --extra dev pre-commit run --all-files`
- `uv build`
