### PR TITLE
fix(runtime): reconcile account changes after refresh races

### DIFF
--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -931,11 +931,12 @@ class CredentialRefresher:
         self._lock = asyncio.Lock()
         self._consecutive_non_success = 0
         self._rate_limit_retry_task: asyncio.Task | None = None
-        # Last host-credential fingerprint, for spotting an external
-        # rotation (operator re-login) on copy-mode hosts with no symlink
-        # to carry it. ``None`` until the first tick sets a baseline (so
-        # we don't false-fire on start).
-        self._last_cred_fingerprint: tuple[int, int] | None = None
+        # Last host-credential revision handled by this daemon. A revision is
+        # handled only after this daemon has requested provider reloads for its
+        # own workers. Each daemon keeps this independently; the host refresh
+        # lock serializes credential writes but does not broadcast reloads.
+        # ``None`` until the first tick establishes the startup baseline.
+        self._last_handled_credential_revision: tuple[int, int] | None = None
 
     def register_agent(self, agent_home: Path) -> None:
         self._agent_homes.add(Path(agent_home))
@@ -952,15 +953,18 @@ class CredentialRefresher:
         except ValueError:
             pass
 
-    def _fire_refresh_success(self) -> None:
+    def _fire_refresh_success(self) -> bool:
         # list(...) defensive copy: callback may (un)register during dispatch.
+        dispatched = True
         for cb in list(self._on_refresh_success):
             try:
                 cb()
             except Exception as exc:
+                dispatched = False
                 logger.warning(
                     "credential refresh-success callback raised: %s", exc,
                 )
+        return dispatched
 
     def notify_refresh_needed(self) -> None:
         """In-process trigger from an agent that just saw a 401."""
@@ -1091,44 +1095,62 @@ class CredentialRefresher:
             stop_task.cancel()
             refresh_task.cancel()
 
-    def _detect_external_rotation(self) -> None:
+    def _detect_external_rotation(self) -> bool:
         """Spot an external host-credential change (operator re-login)
-        against the last fingerprint and, if changed, sync to agents +
-        fire refresh-success — the copy-mode (Windows) counterpart to the
-        macOS Keychain rotation poll. No-op for backends without
-        ``fingerprint`` (e.g. Keychain, which has its own poll)."""
+        against the last revision handled by this daemon.
+
+        Return whether a changed revision was synced and dispatched. The first
+        observation establishes the startup baseline because provider runtimes
+        open from that same credential. Backends without ``fingerprint`` (for
+        example Keychain) use their own external-rotation poll.
+        """
         fingerprint = getattr(self.backend, "fingerprint", None)
         if fingerprint is None:
-            return
+            return False
         current = fingerprint()
-        if current is None or self._last_cred_fingerprint is None:
-            return
-        if current != self._last_cred_fingerprint:
-            logger.info(
-                "external credential rotation detected (host file changed) "
-                "— syncing agents + firing refresh-success",
-            )
-            self._sync_views()
-            self._fire_refresh_success()
+        if current is None:
+            return False
+        if self._last_handled_credential_revision is None:
+            self._last_handled_credential_revision = current
+            return False
+        if current == self._last_handled_credential_revision:
+            return False
+        logger.info(
+            "external credential rotation detected (host file changed) "
+            "— syncing agents + firing refresh-success",
+        )
+        self._sync_views()
+        if self._fire_refresh_success():
+            # An operator-supplied replacement is a successful recovery just
+            # like a backend REFRESHED outcome. Drop any failure streak so an
+            # old refresh_broken state cannot re-wedge the reloaded providers.
+            self._propagate_outcome(RefreshOutcome.REFRESHED)
+            self._last_handled_credential_revision = current
+            return True
+        return False
 
-    def _record_cred_fingerprint(self) -> None:
+    def _record_handled_credential_revision(self) -> None:
         fingerprint = getattr(self.backend, "fingerprint", None)
         if fingerprint is None:
             return
         current = fingerprint()
         if current is not None:
-            self._last_cred_fingerprint = current
+            self._last_handled_credential_revision = current
 
     async def _tick(self, *, triggered_by_agent: bool = False) -> None:
-        """One refresh cycle: detect external rotation, check expiry,
-        refresh if needed, sync views regardless so rotation propagates.
-        The trailing fingerprint record absorbs our own refresh so it
-        isn't re-seen as 'external' next tick."""
-        self._detect_external_rotation()
+        """One refresh cycle with before/after credential reconciliation.
+
+        The second rotation check is required because an operator can replace
+        the host credential while a provider refresh subprocess is running.
+        A failed or unchanged refresh must not acknowledge that replacement
+        without requesting provider reloads in this daemon.
+        """
+        rotation_handled = self._detect_external_rotation()
         expires_in = self.expires_in_seconds()
         if expires_in is None and not triggered_by_agent:
-            self._sync_views()
-            self._record_cred_fingerprint()
+            if not rotation_handled:
+                self._sync_views()
+            self._detect_external_rotation()
             return
         should_refresh = triggered_by_agent or (
             expires_in is not None
@@ -1138,8 +1160,10 @@ class CredentialRefresher:
             await self._refresh_now(
                 expires_in=expires_in, by_agent=triggered_by_agent,
             )
-        self._sync_views()
-        self._record_cred_fingerprint()
+        # Re-read after refresh: the canonical credential may have changed
+        # concurrently even when backend.refresh() returned FAILED/UNCHANGED.
+        if not self._detect_external_rotation() and not rotation_handled:
+            self._sync_views()
 
     async def _refresh_now(
         self, *, expires_in: int | None, by_agent: bool,
@@ -1185,8 +1209,8 @@ class CredentialRefresher:
             # Never reopen a provider runtime before its sanitized view holds
             # the replacement credential.
             self._sync_views()
-            self._record_cred_fingerprint()
-            self._fire_refresh_success()
+            if self._fire_refresh_success():
+                self._record_handled_credential_revision()
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
         if outcome is RefreshOutcome.REFRESHED:

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import hashlib
 import json
 import logging
 import os
@@ -62,6 +63,8 @@ REFRESH_LOCK_POLL_SECONDS = 0.1
 # 2 ticks ≈ 4 min @ 120s poll: surfaces fast, doesn't false-positive on
 # a single transient subprocess hiccup.
 REFRESH_BROKEN_THRESHOLD = 2
+
+CredentialRevision = tuple[int, int] | str
 
 # Haiku to dodge per-model rate-limit windows on operator's Opus/Sonnet.
 # Override via env or auto-disable on model_not_found (see _probe_model_disabled).
@@ -314,10 +317,15 @@ class CredentialBackend(Protocol):
         """Host-global lock file for this provider's canonical login."""
         ...
 
-    def sync_to_agent(self, agent_home: Path) -> None:
+    def sync_to_agent(self, agent_home: Path) -> bool | None:
         """Mirror the canonical credentials to one agent's per-agent
         ``.credentials.json``. Called by the refresher's fan-out after
-        every tick (refresh or not) so external rotation propagates."""
+        every tick (refresh or not) so external rotation propagates.
+
+        Return ``False`` when the view could not be made current. ``None``
+        remains accepted for compatibility with older backends and test
+        doubles, and is treated as success by the coordinator.
+        """
         ...
 
     async def bootstrap(self) -> tuple[bool, Optional[str]]:
@@ -414,8 +422,13 @@ class FileBackend:
         )
         return RefreshOutcome.REFRESHED
 
-    def sync_to_agent(self, agent_home: Path) -> None:
-        sync_host_claude_code_auth_view(self.host_home, agent_home)
+    def sync_to_agent(self, agent_home: Path) -> bool:
+        result = sync_host_claude_code_auth_view(self.host_home, agent_home)
+        return result not in {
+            "no-host-file",
+            "unparseable-host-file",
+            "write-failed",
+        }
 
     def fingerprint(self) -> tuple[int, int] | None:
         """(mtime_ns, size) of the host credential. Lets the refresher
@@ -547,14 +560,19 @@ class CodexFileBackend:
         )
         return RefreshOutcome.REFRESHED
 
-    def sync_to_agent(self, agent_home: Path) -> None:
+    def sync_to_agent(self, agent_home: Path) -> bool:
         agent_codex_home = agent_home / ".codex"
         # Only codex agents have a ``.codex`` subdir (created lazily by
         # ``LocalRuntimePreparer._prepare_codex_spec``). Skip claude-only
         # agents to avoid cluttering them with a stray auth.json.
         if not agent_codex_home.exists():
-            return
-        sync_host_codex_auth_view(self.host_home, agent_codex_home)
+            return True
+        result = sync_host_codex_auth_view(self.host_home, agent_codex_home)
+        return result not in {
+            "no-host-file",
+            "unparseable-host-file",
+            "write-failed",
+        }
 
     def fingerprint(self) -> tuple[int, int] | None:
         """(mtime_ns, size) of the host codex auth — external-rotation
@@ -616,8 +634,9 @@ class KeychainBackend:
     ):
         self.home = home
         self.cache = cache
-        # Last blob propagated to agents — cheap byte-equality key so
-        # the poll loop only fans out on real changes.
+        # Last blob materialized in the daemon cache. Delivery acknowledgement
+        # is tracked separately by ``CredentialRefresher`` so a failed agent
+        # view write or reload request remains retryable.
         self._last_propagated_blob: Optional[str] = None
 
     @property
@@ -685,7 +704,6 @@ class KeychainBackend:
 
     async def refresh(self) -> RefreshOutcome:
         from ..macos.keychain import read_keychain_blob
-
         host_home = Path.home()
         kr_before = read_keychain_blob()
         before_blob = kr_before.blob if kr_before.ok else None
@@ -736,6 +754,8 @@ class KeychainBackend:
                 logger.warning(
                     "claude credential refresh: cache write failed: %s", exc,
                 )
+                return RefreshOutcome.FAILED
+            self._last_propagated_blob = kr_after.blob
             if before_blob is not None and before_blob == kr_after.blob:
                 logger.info(
                     "claude credential refresh ok in %.1fs but Keychain "
@@ -744,7 +764,6 @@ class KeychainBackend:
                     elapsed,
                 )
                 return RefreshOutcome.UNCHANGED
-            self._last_propagated_blob = kr_after.blob
             logger.info(
                 "claude credential refresh ok in %.1fs (Keychain rotated)",
                 elapsed,
@@ -768,6 +787,8 @@ class KeychainBackend:
             logger.warning(
                 "claude credential refresh: cache write failed: %s", exc,
             )
+            return RefreshOutcome.FAILED
+        self._last_propagated_blob = disk_after
         if disk_before is not None and disk_before == disk_after:
             logger.info(
                 "claude credential refresh ok in %.1fs (Keychain dead; "
@@ -775,7 +796,6 @@ class KeychainBackend:
                 elapsed,
             )
             return RefreshOutcome.UNCHANGED
-        self._last_propagated_blob = disk_after
         logger.info(
             "claude credential refresh ok in %.1fs (Keychain dead; "
             "disk file rotated)",
@@ -783,7 +803,7 @@ class KeychainBackend:
         )
         return RefreshOutcome.REFRESHED
 
-    def sync_to_agent(self, agent_home: Path) -> None:
+    def sync_to_agent(self, agent_home: Path) -> bool:
         """Atomic-write the sanitized (refresh-token-free) view of the
         canonical blob to the agent's per-agent ``.credentials.json``.
         Cache → disk file fallthrough so this works even when the
@@ -793,7 +813,7 @@ class KeychainBackend:
         cache_blob = self.cache.read()
         blob = cache_blob or _read_disk_credentials_blob(Path.home())
         if not blob:
-            return
+            return False
         if cache_blob is None:
             logger.debug(
                 "keychain-backend sync_to_agent: source=disk (cache empty) "
@@ -807,7 +827,7 @@ class KeychainBackend:
                 "syncing to %s",
                 agent_home,
             )
-            return
+            return False
         agent_claude = agent_home / ".claude"
         target = agent_claude / ".credentials.json"
         try:
@@ -817,7 +837,7 @@ class KeychainBackend:
                 _ensure_private_directory(agent_home)
                 _ensure_private_directory(agent_claude)
                 _set_private_file_mode(target)
-                return
+                return True
         except OSError:
             pass
         try:
@@ -829,6 +849,22 @@ class KeychainBackend:
                 "keychain backend: sync to %s failed: %s",
                 agent_home, exc,
             )
+            return False
+        return True
+
+    def fingerprint(self) -> CredentialRevision | None:
+        """Content revision of the daemon cache used for agent views.
+
+        Content hashing avoids treating an idempotent cache rewrite as a new
+        login while keeping credential material out of logs and state.
+        """
+        try:
+            blob = self.cache.read()
+        except OSError:
+            return None
+        if blob is None:
+            return None
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
     async def bootstrap(self) -> tuple[bool, Optional[str]]:
         from ..macos.keychain import bootstrap_from_keychain
@@ -879,14 +915,18 @@ class KeychainBackend:
                 kr.error,
             )
             return False
-        if blob == self._last_propagated_blob:
+        try:
+            cached_blob = self.cache.read()
+        except OSError:
+            cached_blob = None
+        if blob == cached_blob:
             return False
-        self._last_propagated_blob = blob
         try:
             self.cache.write(blob)
         except OSError as exc:
             logger.warning("keychain poll: cache write failed: %s", exc)
             return False
+        self._last_propagated_blob = blob
         logger.info("keychain poll: token rotation detected; fanning out")
         return True
 
@@ -935,8 +975,10 @@ class CredentialRefresher:
         # handled only after this daemon has requested provider reloads for its
         # own workers. Each daemon keeps this independently; the host refresh
         # lock serializes credential writes but does not broadcast reloads.
-        # ``None`` until the first tick establishes the startup baseline.
-        self._last_handled_credential_revision: tuple[int, int] | None = None
+        # Absence is itself a valid startup baseline. Keep a separate bit so a
+        # credential first created after daemon startup is treated as a change.
+        self._credential_revision_initialized = False
+        self._last_handled_credential_revision: CredentialRevision | None = None
 
     def register_agent(self, agent_home: Path) -> None:
         self._agent_homes.add(Path(agent_home))
@@ -1017,7 +1059,10 @@ class CredentialRefresher:
         try:
             ok, reason = await self.backend.bootstrap()
             if not ok:
-                logger.warning(
+                log_bootstrap = (
+                    logger.info if reason == "no-host-codex-auth" else logger.warning
+                )
+                log_bootstrap(
                     "credential backend bootstrap reported not-ok: %s", reason,
                 )
         except Exception as exc:
@@ -1078,9 +1123,13 @@ class CredentialRefresher:
             except Exception as exc:
                 logger.warning("external-rotation poll errored: %s", exc)
                 continue
+            # The backend poll only refreshes the daemon cache. Reconciliation
+            # owns view sync + runtime reload acknowledgement and retries a
+            # previously unhandled cache revision even when this poll found no
+            # newer Keychain value.
             if rotated:
-                self._sync_views()
-                self._fire_refresh_success()
+                logger.debug("external credential cache revision updated")
+            self._detect_external_rotation()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
         stop_task = asyncio.create_task(stop_event.wait())
@@ -1095,23 +1144,27 @@ class CredentialRefresher:
             stop_task.cancel()
             refresh_task.cancel()
 
+    def _current_credential_revision(self) -> CredentialRevision | None:
+        fingerprint = getattr(self.backend, "fingerprint", None)
+        if fingerprint is None:
+            return None
+        return fingerprint()
+
     def _detect_external_rotation(self) -> bool:
         """Spot an external host-credential change (operator re-login)
         against the last revision handled by this daemon.
 
         Return whether a changed revision was synced and dispatched. The first
         observation establishes the startup baseline because provider runtimes
-        open from that same credential. Backends without ``fingerprint`` (for
-        example Keychain) use their own external-rotation poll.
+        open from that same credential. Keychain polling first updates its
+        daemon cache, whose content revision then follows this same path.
         """
-        fingerprint = getattr(self.backend, "fingerprint", None)
-        if fingerprint is None:
-            return False
-        current = fingerprint()
-        if current is None:
-            return False
-        if self._last_handled_credential_revision is None:
+        current = self._current_credential_revision()
+        if not self._credential_revision_initialized:
+            self._credential_revision_initialized = True
             self._last_handled_credential_revision = current
+            return False
+        if current is None:
             return False
         if current == self._last_handled_credential_revision:
             return False
@@ -1119,8 +1172,7 @@ class CredentialRefresher:
             "external credential rotation detected (host file changed) "
             "— syncing agents + firing refresh-success",
         )
-        self._sync_views()
-        if self._fire_refresh_success():
+        if self._sync_views() is not False and self._fire_refresh_success():
             # An operator-supplied replacement is a successful recovery just
             # like a backend REFRESHED outcome. Drop any failure streak so an
             # old refresh_broken state cannot re-wedge the reloaded providers.
@@ -1129,13 +1181,13 @@ class CredentialRefresher:
             return True
         return False
 
-    def _record_handled_credential_revision(self) -> None:
-        fingerprint = getattr(self.backend, "fingerprint", None)
-        if fingerprint is None:
-            return
-        current = fingerprint()
-        if current is not None:
-            self._last_handled_credential_revision = current
+    def _record_handled_credential_revision(
+        self,
+        revision: CredentialRevision | None,
+    ) -> None:
+        self._credential_revision_initialized = True
+        if revision is not None:
+            self._last_handled_credential_revision = revision
 
     async def _tick(self, *, triggered_by_agent: bool = False) -> None:
         """One refresh cycle with before/after credential reconciliation.
@@ -1204,13 +1256,15 @@ class CredentialRefresher:
                 )
                 return
             assert outcome is not None
-            self._propagate_outcome(outcome)
         if outcome is RefreshOutcome.REFRESHED:
             # Never reopen a provider runtime before its sanitized view holds
             # the replacement credential.
-            self._sync_views()
-            if self._fire_refresh_success():
-                self._record_handled_credential_revision()
+            revision = self._current_credential_revision()
+            if self._sync_views() is not False and self._fire_refresh_success():
+                self._record_handled_credential_revision(revision)
+                self._propagate_outcome(outcome)
+            return
+        self._propagate_outcome(outcome)
 
     def _propagate_outcome(self, outcome: RefreshOutcome) -> None:
         if outcome is RefreshOutcome.REFRESHED:
@@ -1369,13 +1423,22 @@ class CredentialRefresher:
                     agent_id, exc,
                 )
 
-    def _sync_views(self) -> None:
+    def _sync_views(self) -> bool:
         """Mirror canonical credentials to every registered agent."""
+        synced = True
         for agent_home in self._agent_homes:
             try:
-                self.backend.sync_to_agent(agent_home)
+                result = self.backend.sync_to_agent(agent_home)
+                if result is False:
+                    synced = False
+                    logger.warning(
+                        "credential view-sync incomplete for %s",
+                        agent_home,
+                    )
             except Exception as exc:
+                synced = False
                 logger.warning(
                     "credential view-sync failed for %s: %s",
                     agent_home, exc,
                 )
+        return synced

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -487,6 +487,7 @@ class Daemon:
                     agent_id,
                     exc,
                 )
+                raise
 
         refresher.register_on_refresh_success(on_refresh_success)
         # Stash callback identity for _stop_worker's unregister.

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -90,6 +90,71 @@ def test_detect_fires_on_fingerprint_change(tmp_path, monkeypatch):
     assert fired == [1]
 
 
+def test_first_credential_after_missing_startup_baseline_fires(
+    tmp_path, monkeypatch,
+):
+    r = CredentialRefresher(host_home=tmp_path)
+    fired: list[int] = []
+    r.register_on_refresh_success(lambda: fired.append(1))
+
+    revision = {"current": None}
+    monkeypatch.setattr(
+        r.backend, "fingerprint", lambda: revision["current"],
+    )
+
+    assert r._detect_external_rotation() is False
+    assert r._credential_revision_initialized is True
+    assert r._last_handled_credential_revision is None
+
+    revision["current"] = (1, 10)
+    assert r._detect_external_rotation() is True
+    assert fired == [1]
+    assert r._last_handled_credential_revision == (1, 10)
+
+
+def test_rotation_is_retried_until_views_and_reload_dispatch_succeed(
+    tmp_path, monkeypatch,
+):
+    r = CredentialRefresher(host_home=tmp_path)
+    agent_home = tmp_path / "agent"
+    r.register_agent(agent_home)
+
+    revision = {"current": (1, 10)}
+    monkeypatch.setattr(
+        r.backend, "fingerprint", lambda: revision["current"],
+    )
+    assert r._detect_external_rotation() is False
+
+    sync_ok = {"value": False}
+    monkeypatch.setattr(
+        r.backend, "sync_to_agent", lambda _home: sync_ok["value"],
+    )
+    callback_ok = {"value": False}
+    fired: list[int] = []
+
+    def reload_provider():
+        fired.append(1)
+        if not callback_ok["value"]:
+            raise OSError("reload flag unavailable")
+
+    r.register_on_refresh_success(reload_provider)
+    revision["current"] = (2, 11)
+
+    assert r._detect_external_rotation() is False
+    assert fired == []
+    assert r._last_handled_credential_revision == (1, 10)
+
+    sync_ok["value"] = True
+    assert r._detect_external_rotation() is False
+    assert fired == [1]
+    assert r._last_handled_credential_revision == (1, 10)
+
+    callback_ok["value"] = True
+    assert r._detect_external_rotation() is True
+    assert fired == [1, 1]
+    assert r._last_handled_credential_revision == (2, 11)
+
+
 @pytest.mark.asyncio
 async def test_first_tick_establishes_baseline_without_firing(tmp_path):
     """A fresh daemon start must NOT fire refresh-success (which would

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -21,6 +21,7 @@ from puffo_agent.portal.credential_refresh import (
     CodexFileBackend,
     CredentialRefresher,
     FileBackend,
+    RefreshOutcome,
 )
 
 
@@ -68,21 +69,23 @@ def test_detect_fires_on_fingerprint_change(tmp_path, monkeypatch):
     r = CredentialRefresher(host_home=tmp_path)
     fired: list[int] = []
     r.register_on_refresh_success(lambda: fired.append(1))
+    r._consecutive_non_success = 3
 
     seq = {"fp": (1, 10)}
     monkeypatch.setattr(r.backend, "fingerprint", lambda: seq["fp"])
 
-    # No baseline yet → no fire.
+    # No baseline yet → establish it without firing.
     r._detect_external_rotation()
     assert fired == []
+    assert r._last_handled_credential_revision == (1, 10)
 
-    r._record_cred_fingerprint()        # baseline = (1, 10)
     seq["fp"] = (2, 11)                  # operator re-login
     r._detect_external_rotation()
     assert fired == [1]
+    assert r._last_handled_credential_revision == (2, 11)
+    assert r._consecutive_non_success == 0
 
     # Unchanged on the next tick → no re-fire.
-    r._record_cred_fingerprint()        # baseline = (2, 11)
     r._detect_external_rotation()
     assert fired == [1]
 
@@ -98,7 +101,38 @@ async def test_first_tick_establishes_baseline_without_firing(tmp_path):
 
     await r._tick()
     assert fired == []
-    assert r._last_cred_fingerprint is not None
+    assert r._last_handled_credential_revision is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "outcome", [RefreshOutcome.FAILED, RefreshOutcome.UNCHANGED],
+)
+async def test_rotation_during_non_success_refresh_is_not_lost(
+    tmp_path, monkeypatch, outcome,
+):
+    """An operator login racing a failed refresh must still reload providers."""
+    _write_creds(tmp_path, expires_in_seconds=3600)
+    r = CredentialRefresher(host_home=tmp_path)
+    fired: list[int] = []
+    r.register_on_refresh_success(lambda: fired.append(1))
+
+    revision = {"current": (1, 10)}
+    monkeypatch.setattr(
+        r.backend, "fingerprint", lambda: revision["current"],
+    )
+    r._detect_external_rotation()  # startup baseline
+
+    async def refresh_while_operator_logs_in():
+        revision["current"] = (2, 11)
+        return outcome
+
+    monkeypatch.setattr(r.backend, "refresh", refresh_while_operator_logs_in)
+
+    await r._tick(triggered_by_agent=True)
+
+    assert fired == [1]
+    assert r._last_handled_credential_revision == (2, 11)
 
 
 # ── daemon: restart auth_failed agents on recovery ─────────────────

--- a/tests/test_credential_refresh_clears_auth_failed.py
+++ b/tests/test_credential_refresh_clears_auth_failed.py
@@ -300,17 +300,29 @@ async def test_external_rotation_loop_fires_on_detected_rotation(
     monkeypatch.setattr(_kc, "KEYCHAIN_POLL_INTERVAL_SECONDS", 0.01)
 
     poll_calls = {"n": 0}
+    revision = {"current": (1, 10)}
+    monkeypatch.setattr(
+        r.backend, "fingerprint", lambda: revision["current"],
+    )
+    r._detect_external_rotation()
 
     async def fake_poll() -> bool:
         poll_calls["n"] += 1
-        return poll_calls["n"] == 1
+        if poll_calls["n"] == 1:
+            revision["current"] = (2, 11)
+            return True
+        return False
 
     monkeypatch.setattr(
         r.backend, "poll_external_rotation", fake_poll, raising=False,
     )
     sync_calls = {"n": 0}
     monkeypatch.setattr(
-        r, "_sync_views", lambda: sync_calls.__setitem__("n", sync_calls["n"] + 1),
+        r,
+        "_sync_views",
+        lambda: (
+            sync_calls.__setitem__("n", sync_calls["n"] + 1) or True
+        ),
     )
 
     fired: list[str] = []

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -592,6 +592,34 @@ def test_keychain_backend_poll_external_rotation_detects_change(
     assert backend._last_propagated_blob == _REFRESHED_BLOB
 
 
+def test_keychain_rotation_stays_retryable_when_cache_write_fails(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(cm, "is_macos", lambda: True)
+    backend = _make_keychain_backend(tmp_path)
+    backend._last_propagated_blob = _BLOB
+    backend.cache.write(_BLOB)
+    monkeypatch.setattr(
+        cm, "read_keychain_blob",
+        lambda timeout=cm.SECURITY_TIMEOUT_SECONDS: cm.KeychainReadResult(
+            True, _REFRESHED_BLOB, None, None,
+        ),
+    )
+
+    real_write = backend.cache.write
+    monkeypatch.setattr(
+        backend.cache,
+        "write",
+        lambda _blob: (_ for _ in ()).throw(OSError("disk unavailable")),
+    )
+    assert asyncio.run(backend.poll_external_rotation()) is False
+    assert backend._last_propagated_blob == _BLOB
+
+    monkeypatch.setattr(backend.cache, "write", real_write)
+    assert asyncio.run(backend.poll_external_rotation()) is True
+    assert backend._last_propagated_blob == _REFRESHED_BLOB
+
+
 def test_keychain_backend_poll_external_rotation_no_change_returns_false(
     monkeypatch, tmp_path,
 ):


### PR DESCRIPTION
## Problem

When an operator switched Codex accounts while a daemon credential refresh subprocess was already running, the canonical auth file could change during a `FAILED` or `UNCHANGED` refresh. The daemon copied the replacement credential and recorded its fingerprint without requesting provider reloads, leaving long-lived Codex app-server processes on the revoked in-memory token. A sibling daemon could recover correctly while this daemon remained wedged.

## Fix

- Track the last credential revision handled by each daemon, rather than treating any observed fingerprint as applied.
- Reconcile the canonical revision both before and after a refresh attempt.
- Dispatch provider reload callbacks even when the overlapping refresh returns `FAILED` or `UNCHANGED`.
- Advance the handled revision only after callbacks dispatch successfully.
- Treat an operator-provided replacement as recovery and clear the stale refresh failure streak.
- Preserve Puffo logical and provider-native sessions through the existing idle-boundary reload path.

## Verification

- Added one parameterized regression covering account rotation during `FAILED` and `UNCHANGED` refresh outcomes.
- 79 focused credential refresher tests passed.
- 128 Codex, Keychain, daemon callback, and runtime/session tests passed.
- 207 relevant tests pass when run in isolated groups; the combined invocation exposes an existing module-reload Enum identity leak in the macOS test suite, unrelated to this diff.
- `ruff check` and `git diff --check` pass.