### PR TITLE
fix(inbox): preserve long-message segment source

### DIFF
--- a/src/puffo_agent/agent/inbound_receipts.py
+++ b/src/puffo_agent/agent/inbound_receipts.py
@@ -521,6 +521,10 @@ class InboundReceiptHandler:
         )
         content: dict[str, Any] = {
             "text": llm_text,
+            # Keep the durable source separate from its bounded prompt view.
+            # get_post_segment pages this value while ordinary Inbox/history
+            # projections continue to read ``text``.
+            "original_content": payload.content,
             "attachment_paths": attachment_paths,
             "mentions": mentions,
             "sender_display_name": names["sender_display_name"],

--- a/src/puffo_agent/agent/inbound_receipts.py
+++ b/src/puffo_agent/agent/inbound_receipts.py
@@ -521,10 +521,6 @@ class InboundReceiptHandler:
         )
         content: dict[str, Any] = {
             "text": llm_text,
-            # Keep the durable source separate from its bounded prompt view.
-            # get_post_segment pages this value while ordinary Inbox/history
-            # projections continue to read ``text``.
-            "original_content": payload.content,
             "attachment_paths": attachment_paths,
             "mentions": mentions,
             "sender_display_name": names["sender_display_name"],
@@ -535,6 +531,10 @@ class InboundReceiptHandler:
             "channel_name": names["channel_name"],
             "space_name": names["space_name"],
         }
+        if payload.content != llm_text:
+            # Keep a durable source when the prompt view was bounded or
+            # normalized. Unchanged short strings need no duplicate copy.
+            content["original_content"] = payload.content
         # Only carried when authenticated facts actually classified the
         # sender; absent means projection falls back to ``unknown``.
         if names.get("sender_type"):

--- a/src/puffo_agent/agent/inbound_receipts.py
+++ b/src/puffo_agent/agent/inbound_receipts.py
@@ -531,7 +531,7 @@ class InboundReceiptHandler:
             "channel_name": names["channel_name"],
             "space_name": names["space_name"],
         }
-        if payload.content != llm_text:
+        if raw_text != llm_text:
             # Keep a durable source when the prompt view was bounded or
             # normalized. Unchanged short strings need no duplicate copy.
             content["original_content"] = payload.content

--- a/src/puffo_agent/mcp/core_post_tools.py
+++ b/src/puffo_agent/mcp/core_post_tools.py
@@ -20,6 +20,13 @@ from .puffo_core_tools import (
 )
 
 
+def _segment_source_text(content: Any) -> str:
+    """Return the durable body rather than its bounded prompt projection."""
+    if isinstance(content, dict) and "original_content" in content:
+        return _history_text(content["original_content"])
+    return _history_text(content)
+
+
 async def _get_post_segment(
     cfg: Any,
     envelope_id: str,
@@ -42,12 +49,10 @@ async def _get_post_segment(
             "message_id": envelope_id,
         }
 
-    # ``content`` carries either a bare string (plain message)
-    # or the ``puffo/message+attachments/v1`` dict shape; pull
-    # the text out of the latter so segmenting works on the
-    # human-readable portion in both cases.
-    content = msg.content
-    text = _history_text(content)
+    # Eligible inbound rows carry a bounded ``text`` projection plus the
+    # durable source. Legacy/outbound rows may still be a bare string or a
+    # structured message without ``original_content``.
+    text = _segment_source_text(msg.content)
 
     if not text:
         return {

--- a/tests/test_long_message_redaction.py
+++ b/tests/test_long_message_redaction.py
@@ -346,7 +346,8 @@ async def test_segment_attachments_content_dict_segments_text():
     payload = "z" * 3000
     tool = _collect_tool("get_post_segment", _StubDataClient(
         _StubMessage(envelope_id="env_attach", content={
-            "text": payload,
+            "text": "[bounded prompt projection]",
+            "original_content": {"text": payload},
             "attachments": [{"name": "screenshot.png"}],
         }),
     ))

--- a/tests/test_puffo_core_client_admit_validate.py
+++ b/tests/test_puffo_core_client_admit_validate.py
@@ -19,6 +19,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -32,6 +33,7 @@ from puffo_agent.crypto.http_client import PuffoCoreHttpClient
 from puffo_agent.crypto.keystore import KeyStore
 from puffo_agent.crypto.message import MessagePayload
 from puffo_agent.crypto.ws_client import TransportOutcome
+from puffo_agent.mcp.core_post_tools import _get_post_segment
 
 
 def _now_ms() -> int:
@@ -522,6 +524,55 @@ async def test_native_ingress_withholds_uncleared_sender_content(
     assert outcome is TransportOutcome.ACK
     assert saved == ["env_friend"]
     assert (inbox_root / "env_friend").exists()
+    await client.store.close()
+
+
+@pytest.mark.asyncio
+async def test_native_long_message_keeps_segment_source_after_prompt_redaction(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "home"))
+    client = _native_client(tmp_path)
+    client._max_inline_chars = 100
+    client._segment_chars = 80
+    await client.store.open()
+    client.http.blocklist_reachable = True
+    client._contacts.note_allowed(FRIEND_SLUG)
+
+    original = "0123456789" * 25
+    payloads = {
+        "env_long": _dm_payload(
+            FRIEND_SLUG,
+            original,
+            envelope_id="env_long",
+        ),
+    }
+    outcome = await _handler(client, payloads).handle(
+        _delivery("env_long", FRIEND_SLUG, 1)
+    )
+    assert outcome is TransportOutcome.ACK
+
+    stored = await client.store.get_visible_message_by_envelope("env_long")
+    assert stored is not None
+    assert "inbound message was too long" in stored.content["text"]
+    assert stored.content["original_content"] == original
+
+    class _StoreDataClient:
+        async def get_message_by_envelope(self, envelope_id):
+            return await client.store.get_visible_message_by_envelope(envelope_id)
+
+    segment = await _get_post_segment(
+        SimpleNamespace(
+            slug=SELF_SLUG,
+            agent_id=SELF_SLUG,
+            data_client=_StoreDataClient(),
+        ),
+        "env_long",
+        1,
+        80,
+    )
+    assert segment["segment"]["count"] == 4
+    assert segment["segment"]["text"] == original[80:160]
     await client.store.close()
 
 

--- a/tests/test_puffo_core_client_admit_validate.py
+++ b/tests/test_puffo_core_client_admit_validate.py
@@ -425,9 +425,7 @@ def _attachment_content(text: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_native_ingress_withholds_uncleared_sender_content(
-    tmp_path, monkeypatch
-):
+async def test_native_ingress_withholds_uncleared_sender_content(tmp_path, monkeypatch):
     """The native gate decides before, and reveals nothing after.
 
     Four production failures, one boundary:
@@ -464,7 +462,6 @@ async def test_native_ingress_withholds_uncleared_sender_content(
         ),
     }
     handler = _handler(client, payloads)
-
     # ── cold-start blocklist: unreadable ⇒ hold, not admit ────────────
     outcome = await handler.handle(_delivery("env_stranger", STRANGER_SLUG, 1))
     assert outcome is TransportOutcome.HOLD
@@ -524,6 +521,9 @@ async def test_native_ingress_withholds_uncleared_sender_content(
     assert outcome is TransportOutcome.ACK
     assert saved == ["env_friend"]
     assert (inbox_root / "env_friend").exists()
+    stored = await client.store.get_visible_message_by_envelope("env_friend")
+    assert stored is not None
+    assert "original_content" not in stored.content
     await client.store.close()
 
 


### PR DESCRIPTION
## Problem

A long inbound message is intentionally replaced with a bounded placeholder in the model-facing Inbox/history view. The placeholder tells the Agent to page the original body with `get_post_segment`, but Agent Foundation 2.0 persisted that placeholder as the message body. The paging tool then segmented the placeholder itself.

This is a regression from 1.2: the old pipeline persisted `payload.content` first and built a separate prompt-only projection afterward. The Global Inbox refactor unified those objects but did not preserve the raw body on the native ingress path. The bridge path already retained `original_content`, but `get_post_segment` ignored it.

## Change

- Keep the bounded/redacted value in `text`, so `read_inbox`, `get_post`, and history reads do not re-inject a large body.
- Preserve `payload.content` as `original_content` whenever the prompt representation changed (redaction, mention normalization, whitespace normalization, or structured content). Unchanged short strings retain one stored copy.
- Make only `get_post_segment` select `original_content`, with the legacy bare-string/structured-text fallback for unchanged, old, and outbound rows.
- Reuse the existing bridge content shape; no SQLite schema migration is required.
- Keep the model-visible foreign-DM gate unchanged: the tool still reads through `get_visible_message_by_envelope`.

```text
inbound envelope
  ├─ durable source: content.original_content (when projection changed)
  └─ bounded model view: content.text
                              │
read_inbox / history ─────────┘
get_post_segment ───── durable source, one requested slice
```

Existing native rows that already contain only a placeholder cannot be reconstructed locally. The fix applies to newly received native messages; existing bridge rows with `original_content` become pageable after upgrade.

## Verification

- Added one end-to-end regression across native receipt → SQLite → `get_post_segment`.
- Updated the structured-content paging case to prove the bounded projection is not used as the segment source.
- `uv run --extra dev pytest -q tests/test_long_message_redaction.py tests/test_puffo_core_client_admit_validate.py tests/test_cloud_bridge_msgflow.py`
- `uv run --extra dev pytest -q` (pass; one existing Windows-only skip)
- `uv run pre-commit run --all-files`
