### PR TITLE
chore(release): prepare 2.0.0a20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a20] - 2026-08-19
+
+> Staging candidate recovering provider runtimes and bounded context without
+> breaking the Puffo logical conversation.
+
+### Fixed
+
+- **Crashed or abandoned provider turns now enter bounded recovery.** Retryable
+  runtime exits reach the existing session-transfer path instead of being
+  requeued forever against the same broken runtime state.
+- **Invalid Claude Code resume targets recover automatically.** Puffo retires a
+  native session when Claude explicitly reports that it no longer exists, while
+  preserving valid sessions across ordinary failures and resource reloads.
+- **Context admission can recover after compaction is unavailable.** Puffo tries
+  native compaction, shrinks the pending Inbox batch, and finally rolls over the
+  provider-native session while preserving Puffo session history, memory, and
+  workspace state.
+- **DM thread replies expose their root message ID.** Agents can now route a
+  reply back into the originating DM thread without changing DM target identity.
+- **Provider account changes are acknowledged only after delivery.** External
+  Claude Code and Codex credential revisions remain retryable until Agent views
+  are current and each daemon has requested provider reload, including login
+  changes that race a failed or unchanged refresh.
+- **Long-message segment reads use the durable source body.** Bounded Inbox
+  projections no longer truncate later segment reads, while unchanged
+  structured messages avoid storing a duplicate body.
+- **Link-based space joins refresh Agent membership context.** The Agent now
+  consumes the signed join event and invalidates its cached roster when the
+  Server announces a membership projection change.
+- **Late provider login self-recovers.** A daemon started before Claude Code
+  login refreshes the account model catalog on a later capability heartbeat,
+  and Codex advertises its fixed capabilities before opening a runtime.
+- **Signed WebSocket and HTTP transports share one trust policy.** Both now use
+  the certifi-backed remote TLS context, avoiding macOS/Homebrew CA divergence.
+
 ## [2.0.0a19] - 2026-08-19
 
 > Staging candidate preserving provider conversations while Agent resources and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a19"
+version = "2.0.0a20"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a19"
+version = "2.0.0a20"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release

Prepare the `2.0.0a20` TestPyPI staging candidate after #255, #262, #263, and #266.

## Included

- Recover retryable provider-runtime exits through bounded session transfer.
- Replace invalid Claude Code resume targets without discarding valid sessions on ordinary failures.
- Apply compact -> Inbox shrink -> provider-native rollover while preserving the Puffo logical session, memory, and workspace.
- Expose DM `thread_root_id` for correctly routed DM thread replies.
- Reconcile externally replaced Claude Code and Codex credentials before acknowledging provider reload.
- Preserve the durable source for long-message segment reads without duplicating unchanged structured bodies.
- Consume link-based space membership events and invalidate stale Agent roster caches.
- Refresh Claude model discovery after late login and expose Codex capabilities before runtime open.
- Use the same certifi-backed trust policy for signed HTTP and WebSocket transports.

## Validation

- Combined #262/#263/#266 integration tree: full Python 3.12 pytest suite passed with one expected Windows-only skip.
- `uv lock --check`
- `puffo-agent version` reports `2.0.0a20`
- `SKIP=no-commit-to-branch uv run --extra dev pre-commit run --all-files`
- `uv build`
- GitHub Python 3.11/3.12, pre-commit, and CodeQL are the final publish gate.
