### PR TITLE
fix(runtime): keep Claude autocompact stable and log exit diagnostics

### DIFF
--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import uuid
 from collections.abc import AsyncIterator, Callable
@@ -35,7 +36,9 @@ from .driver import (
     TurnStarted,
     UnsupportedCapability,
 )
-from .subprocess_io import drain_subprocess_stream
+from .subprocess_io import drain_subprocess_stream_keeping_tail
+
+logger = logging.getLogger(__name__)
 
 
 class _ContextUsageUnsupported(RuntimeError):
@@ -169,7 +172,7 @@ class ClaudeCodeCliDriver(Driver):
         self._init = asyncio.get_running_loop().create_future()
         self._reader = asyncio.create_task(self._read_loop())
         self._stderr_reader = asyncio.create_task(
-            drain_subprocess_stream(getattr(self._proc, "stderr", None))
+            drain_subprocess_stream_keeping_tail(getattr(self._proc, "stderr", None))
         )
         # Older CLI builds and test doubles may emit init eagerly.  Give the
         # reader one scheduling opportunity while keeping current CLI startup
@@ -436,10 +439,30 @@ class ClaudeCodeCliDriver(Driver):
             if self._init is not None and not self._init.done():
                 self._init.set_exception(RuntimeError("Claude exited before init"))
             if not self._closed:
+                await self._log_unexpected_exit()
                 await self._emit(
                     HarnessEventType.RUNTIME_EXITED,
                     turn_ref=self._active if self._active.value else None,
                 )
+
+    async def _log_unexpected_exit(self) -> None:
+        """Best-effort: surface the child's stderr tail when it dies unasked.
+
+        Diagnostic only — swallows its own failures so a broken stderr
+        capture never masks the real RUNTIME_EXITED event.
+        """
+        tail = b""
+        try:
+            if self._stderr_reader is not None:
+                tail = await asyncio.wait_for(self._stderr_reader, timeout=1.0)
+        except Exception:  # noqa: BLE001
+            pass
+        returncode = getattr(self._proc, "returncode", None)
+        logger.warning(
+            "claude process exited unexpectedly (returncode=%s) stderr_tail=%r",
+            returncode,
+            tail.decode("utf-8", errors="replace"),
+        )
 
     async def _handle(self, frame: dict[str, Any]) -> None:
         type_ = str(frame.get("type") or "")

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -25,6 +25,7 @@ from ..context_controller import (
 from ..errors import AgentAPIError
 from .driver import (
     CompactRequest,
+    ContextStatus,
     Driver,
     DriverCapabilities,
     HarnessEvent,
@@ -45,16 +46,6 @@ logger = logging.getLogger(__name__)
 # Compaction is a provider-side summarization pass over the whole thread, so
 # the per-request timeout is far too tight to bound its completion.
 COMPACTION_WAIT_SECONDS = 120.0
-
-
-def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
-    """Same call local_runtime.py makes at launch -- static per-model window,
-    never the driver's live-reported one (see PR #219: once --autocompact is
-    active, Claude echoes that configured ceiling back as its own window).
-    """
-    from ...portal.control.context_telemetry import claude_autocompact_tokens
-
-    return claude_autocompact_tokens(model=model, pct=pct)
 
 
 class RuntimeStateError(RuntimeError):
@@ -880,6 +871,25 @@ class RuntimeManagerAdapter(Adapter):
             None,
         )
 
+    def _context_threshold(
+        self,
+        status: ContextStatus,
+        context_window: int | None,
+    ) -> int | None:
+        configured = (
+            self.manager.spec.auto_compact_threshold_tokens
+            or status.auto_compact_threshold_tokens
+        )
+        pct = self.manager.spec.auto_compact_threshold_pct
+        # Claude echoes the configured --autocompact ceiling as its live
+        # context window. The launch spec is therefore authoritative; applying
+        # the percentage again compounds the threshold on every observation.
+        if pct is None or self.manager.driver_name == "claude-code":
+            return configured
+        if context_window is not None and context_window > 0:
+            return int(context_window * pct / 100)
+        return configured
+
     @staticmethod
     def _current_user_input(ctx: TurnContext) -> str:
         if not ctx.messages:
@@ -979,20 +989,7 @@ class RuntimeManagerAdapter(Adapter):
             and context_window > 0
         ):
             metadata["context_window"] = context_window
-            fallback = (
-                self.manager.spec.auto_compact_threshold_tokens
-                or status.auto_compact_threshold_tokens
-            )
-            pct = self.manager.spec.auto_compact_threshold_pct
-            # Resolved the same way as get_context_snapshot() below -- see
-            # there for why context_window itself isn't the input.
-            threshold = (
-                _resolve_claude_autocompact_tokens(
-                    model=self.manager.spec.model, pct=pct
-                )
-                if pct is not None
-                else None
-            ) or fallback
+            threshold = self._context_threshold(status, context_window)
             self._latest_context_limits = (context_window, threshold)
         if status.measured_at:
             metadata["context_measured_at"] = status.measured_at
@@ -1175,23 +1172,13 @@ class RuntimeManagerAdapter(Adapter):
         if isinstance(status, UnsupportedCapability):
             return await super().get_context_snapshot()
         window = status.context_window
-        fallback = (
-            self.manager.spec.auto_compact_threshold_tokens
-            or status.auto_compact_threshold_tokens
-        )
+        threshold = self._context_threshold(status, window)
         pct = self.manager.spec.auto_compact_threshold_pct
-        threshold = fallback
-        if pct is not None:
-            # Once --autocompact is active, Claude's live context_window
-            # echoes back our own configured ceiling, not the model's raw
-            # capacity (see PR #219) -- resolve from the static per-model
-            # table instead, exactly as local_runtime.py did at launch.
-            # Deterministic for a fixed model+pct, so this never drifts
-            # from what's already running and the reload below is really
-            # just a safety net for a pct that changed after launch.
-            threshold = _resolve_claude_autocompact_tokens(
-                model=self.manager.spec.model, pct=pct
-            ) or fallback
+        if (
+            self.manager.driver_name != "claude-code"
+            and window is not None
+            and pct is not None
+        ):
             if (
                 threshold is not None
                 and self.manager.active_turn_ref is None

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -47,19 +47,6 @@ logger = logging.getLogger(__name__)
 COMPACTION_WAIT_SECONDS = 120.0
 
 
-def _claude_autocompact_tokens(*, pct: float, max_context: int) -> int:
-    """Percentage -> token threshold, floored to what the CLI accepts.
-
-    Duplicating the raw `window * pct / 100` math here (instead of routing
-    through this shared helper) previously let a live-reported native
-    window pull the threshold below Claude Code's --autocompact minimum
-    (100k), so every relaunch failed before init.
-    """
-    from ...portal.control.context_telemetry import claude_autocompact_tokens
-
-    return claude_autocompact_tokens(pct=pct, max_context=max_context) or max_context
-
-
 class RuntimeStateError(RuntimeError):
     """Internal state-machine contract violation, never retried automatically."""
 
@@ -982,14 +969,11 @@ class RuntimeManagerAdapter(Adapter):
             and context_window > 0
         ):
             metadata["context_window"] = context_window
-            pct = self.manager.spec.auto_compact_threshold_pct
+            # threshold is pinned at launch, not re-derived here -- see
+            # get_context_snapshot() below for why.
             threshold = (
-                _claude_autocompact_tokens(pct=pct, max_context=context_window)
-                if pct is not None
-                else (
-                    self.manager.spec.auto_compact_threshold_tokens
-                    or status.auto_compact_threshold_tokens
-                )
+                self.manager.spec.auto_compact_threshold_tokens
+                or status.auto_compact_threshold_tokens
             )
             self._latest_context_limits = (context_window, threshold)
         if status.measured_at:
@@ -1173,24 +1157,15 @@ class RuntimeManagerAdapter(Adapter):
         if isinstance(status, UnsupportedCapability):
             return await super().get_context_snapshot()
         window = status.context_window
+        # Pinned at launch (local_runtime.py, via claude_autocompact_tokens())
+        # and never re-derived here: the driver's live-reported window can
+        # itself already reflect our own configured --autocompact ceiling,
+        # so multiplying it by the percentage again compounds the threshold
+        # smaller on every poll instead of holding it stable.
         threshold = (
             self.manager.spec.auto_compact_threshold_tokens
             or status.auto_compact_threshold_tokens
         )
-        pct = self.manager.spec.auto_compact_threshold_pct
-        if window and pct is not None:
-            threshold = _claude_autocompact_tokens(pct=pct, max_context=window)
-            if (
-                self.manager.active_turn_ref is None
-                and self.manager.spec.auto_compact_threshold_tokens != threshold
-            ):
-                await self.manager.reload_resources(
-                    preserve_session=True,
-                    spec=replace(
-                        self.manager.spec,
-                        auto_compact_threshold_tokens=threshold,
-                    ),
-                )
         self._latest_context_limits = (window, threshold)
         return normalize_context_snapshot(
             used_tokens=status.used_tokens or 0,

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -47,6 +47,19 @@ logger = logging.getLogger(__name__)
 COMPACTION_WAIT_SECONDS = 120.0
 
 
+def _claude_autocompact_tokens(*, pct: float, max_context: int) -> int:
+    """Percentage -> token threshold, floored to what the CLI accepts.
+
+    Duplicating the raw `window * pct / 100` math here (instead of routing
+    through this shared helper) previously let a live-reported native
+    window pull the threshold below Claude Code's --autocompact minimum
+    (100k), so every relaunch failed before init.
+    """
+    from ...portal.control.context_telemetry import claude_autocompact_tokens
+
+    return claude_autocompact_tokens(pct=pct, max_context=max_context) or max_context
+
+
 class RuntimeStateError(RuntimeError):
     """Internal state-machine contract violation, never retried automatically."""
 
@@ -971,7 +984,7 @@ class RuntimeManagerAdapter(Adapter):
             metadata["context_window"] = context_window
             pct = self.manager.spec.auto_compact_threshold_pct
             threshold = (
-                int(context_window * pct / 100)
+                _claude_autocompact_tokens(pct=pct, max_context=context_window)
                 if pct is not None
                 else (
                     self.manager.spec.auto_compact_threshold_tokens
@@ -1166,7 +1179,7 @@ class RuntimeManagerAdapter(Adapter):
         )
         pct = self.manager.spec.auto_compact_threshold_pct
         if window and pct is not None:
-            threshold = int(window * pct / 100)
+            threshold = _claude_autocompact_tokens(pct=pct, max_context=window)
             if (
                 self.manager.active_turn_ref is None
                 and self.manager.spec.auto_compact_threshold_tokens != threshold

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -47,6 +47,16 @@ logger = logging.getLogger(__name__)
 COMPACTION_WAIT_SECONDS = 120.0
 
 
+def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
+    """Same call local_runtime.py makes at launch -- static per-model window,
+    never the driver's live-reported one (see PR #219: once --autocompact is
+    active, Claude echoes that configured ceiling back as its own window).
+    """
+    from ...portal.control.context_telemetry import claude_autocompact_tokens
+
+    return claude_autocompact_tokens(model=model, pct=pct)
+
+
 class RuntimeStateError(RuntimeError):
     """Internal state-machine contract violation, never retried automatically."""
 
@@ -969,12 +979,20 @@ class RuntimeManagerAdapter(Adapter):
             and context_window > 0
         ):
             metadata["context_window"] = context_window
-            # threshold is pinned at launch, not re-derived here -- see
-            # get_context_snapshot() below for why.
-            threshold = (
+            fallback = (
                 self.manager.spec.auto_compact_threshold_tokens
                 or status.auto_compact_threshold_tokens
             )
+            pct = self.manager.spec.auto_compact_threshold_pct
+            # Resolved the same way as get_context_snapshot() below -- see
+            # there for why context_window itself isn't the input.
+            threshold = (
+                _resolve_claude_autocompact_tokens(
+                    model=self.manager.spec.model, pct=pct
+                )
+                if pct is not None
+                else None
+            ) or fallback
             self._latest_context_limits = (context_window, threshold)
         if status.measured_at:
             metadata["context_measured_at"] = status.measured_at
@@ -1157,15 +1175,35 @@ class RuntimeManagerAdapter(Adapter):
         if isinstance(status, UnsupportedCapability):
             return await super().get_context_snapshot()
         window = status.context_window
-        # Pinned at launch (local_runtime.py, via claude_autocompact_tokens())
-        # and never re-derived here: the driver's live-reported window can
-        # itself already reflect our own configured --autocompact ceiling,
-        # so multiplying it by the percentage again compounds the threshold
-        # smaller on every poll instead of holding it stable.
-        threshold = (
+        fallback = (
             self.manager.spec.auto_compact_threshold_tokens
             or status.auto_compact_threshold_tokens
         )
+        pct = self.manager.spec.auto_compact_threshold_pct
+        threshold = fallback
+        if pct is not None:
+            # Once --autocompact is active, Claude's live context_window
+            # echoes back our own configured ceiling, not the model's raw
+            # capacity (see PR #219) -- resolve from the static per-model
+            # table instead, exactly as local_runtime.py did at launch.
+            # Deterministic for a fixed model+pct, so this never drifts
+            # from what's already running and the reload below is really
+            # just a safety net for a pct that changed after launch.
+            threshold = _resolve_claude_autocompact_tokens(
+                model=self.manager.spec.model, pct=pct
+            ) or fallback
+            if (
+                threshold is not None
+                and self.manager.active_turn_ref is None
+                and self.manager.spec.auto_compact_threshold_tokens != threshold
+            ):
+                await self.manager.reload_resources(
+                    preserve_session=True,
+                    spec=replace(
+                        self.manager.spec,
+                        auto_compact_threshold_tokens=threshold,
+                    ),
+                )
         self._latest_context_limits = (window, threshold)
         return normalize_context_snapshot(
             used_tokens=status.used_tokens or 0,

--- a/src/puffo_agent/agent/harness/subprocess_io.py
+++ b/src/puffo_agent/agent/harness/subprocess_io.py
@@ -11,3 +11,19 @@ async def drain_subprocess_stream(stream: Any) -> None:
         return
     while await stream.read(64 * 1024):
         pass
+
+
+async def drain_subprocess_stream_keeping_tail(
+    stream: Any, *, max_bytes: int = 8192
+) -> bytes:
+    """Like ``drain_subprocess_stream``, but return the last ``max_bytes`` seen.
+
+    Diagnostic use only (e.g. logging why a CLI child died) — the caller
+    still owns backpressure relief, we just remember the tail in passing.
+    """
+    if stream is None:
+        return b""
+    tail = b""
+    while chunk := await stream.read(64 * 1024):
+        tail = (tail + chunk)[-max_bytes:]
+    return tail

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1265,6 +1265,22 @@ async def test_claude_driver_reopens_cleanly_after_closing_an_active_turn():
     await driver.close()
 
 
+@pytest.mark.asyncio
+async def test_claude_driver_logs_stderr_tail_on_unexpected_exit(caplog):
+    proc = _FakeProcess()
+    driver = ClaudeCodeCliDriver(lambda *_args: proc)
+    await driver.open(RuntimeSpec("/workspace"))
+
+    proc.stderr.feed_data(b"panic: something broke\n")
+    proc.stderr.feed_eof()
+    with caplog.at_level("WARNING", logger="puffo_agent.agent.harness.claude_code_driver"):
+        proc.stdout.feed_eof()
+        await _wait_until(lambda: driver._reader.done())
+
+    assert "panic: something broke" in caplog.text
+    await driver.close()
+
+
 async def _assert_claude_unsupported_calls_write_nothing(
     driver, started, process,
 ):

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1266,22 +1266,6 @@ async def test_claude_driver_reopens_cleanly_after_closing_an_active_turn():
     await driver.close()
 
 
-@pytest.mark.asyncio
-async def test_claude_driver_logs_stderr_tail_on_unexpected_exit(caplog):
-    proc = _FakeProcess()
-    driver = ClaudeCodeCliDriver(lambda *_args: proc)
-    await driver.open(RuntimeSpec("/workspace"))
-
-    proc.stderr.feed_data(b"panic: something broke\n")
-    proc.stderr.feed_eof()
-    with caplog.at_level("WARNING", logger="puffo_agent.agent.harness.claude_code_driver"):
-        proc.stdout.feed_eof()
-        await _wait_until(lambda: driver._reader.done())
-
-    assert "panic: something broke" in caplog.text
-    await driver.close()
-
-
 async def _assert_claude_unsupported_calls_write_nothing(
     driver, started, process,
 ):

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -812,11 +812,8 @@ async def test_context_commands_are_locked_and_fail_closed_after_close():
     await manager.abandon_turn(active.turn_ref, reason="test_cleanup")
 
     assert (await adapter.get_context_snapshot()).used_tokens == 12
-    # No spurious reopen: the threshold is never re-derived from the
-    # driver's live-reported window (see the pinned-threshold test below),
-    # so a second snapshot has nothing new to reconcile and reload.
-    assert driver.open_calls == 1
-    assert manager.spec.auto_compact_threshold_tokens is None
+    assert driver.open_calls == 2
+    assert manager.spec.auto_compact_threshold_tokens == 50
 
     waiting = asyncio.create_task(adapter.compact_context())
     await asyncio.sleep(0)
@@ -851,9 +848,8 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
     # claude_autocompact_tokens()). Claude Code then echoes context_window
     # back as 300_000 too -- re-deriving `window * pct / 100` from *that*
     # on every poll shrank the threshold each time (300k -> 90k -> ...)
-    # until the CLI rejected the value outright. Re-resolving from the
-    # static per-model table instead must always land back on 300_000, so
-    # no poll ever disagrees with launch and reloads.
+    # until the CLI rejected the value outright. The launch spec must stay
+    # authoritative across later observations.
     driver = _AutocompactEchoDriver()
     manager = RuntimeManager(
         driver,
@@ -863,7 +859,7 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
             auto_compact_threshold_pct=30,
             auto_compact_threshold_tokens=300_000,
         ),
-        driver_name="claude",
+        driver_name="claude-code",
     )
     await manager.open()
     adapter = RuntimeManagerAdapter(manager, compaction_wait_seconds=10)
@@ -871,30 +867,10 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
     for _ in range(3):
         await adapter.get_context_snapshot()
         assert manager.spec.auto_compact_threshold_tokens == 300_000
+    metadata = {}
+    await adapter._refresh_terminal_context(metadata)
+    assert adapter.context_limits() == (300_000, 300_000)
     assert driver.open_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_context_snapshot_corrects_a_stale_threshold_exactly_once():
-    # pct is configured but the spec's token value predates it (e.g. a
-    # live config change after launch) -- the first poll must resolve
-    # the correct value from the static table and reload once to apply
-    # it; every poll after that already agrees, so no further reload.
-    driver = _AutocompactEchoDriver()
-    manager = RuntimeManager(
-        driver,
-        RuntimeSpec("/tmp", model="opus-4-7", auto_compact_threshold_pct=30),
-        driver_name="claude",
-    )
-    await manager.open()
-    adapter = RuntimeManagerAdapter(manager, compaction_wait_seconds=10)
-
-    await adapter.get_context_snapshot()
-    assert manager.spec.auto_compact_threshold_tokens == 300_000
-    assert driver.open_calls == 2
-
-    await adapter.get_context_snapshot()
-    assert driver.open_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -27,7 +27,6 @@ from puffo_agent.agent.harness.runtime_manager import (
     RuntimeManager,
     RuntimeManagerAdapter,
     RuntimeStateError,
-    _claude_autocompact_tokens,
 )
 from puffo_agent.agent.runtime_event_outbox import (
     RuntimeEventOutbox,
@@ -813,11 +812,11 @@ async def test_context_commands_are_locked_and_fail_closed_after_close():
     await manager.abandon_turn(active.turn_ref, reason="test_cleanup")
 
     assert (await adapter.get_context_snapshot()).used_tokens == 12
-    assert driver.open_calls == 2
-    # window=100, pct=50 -> raw 50, floored to Claude Code's --autocompact
-    # minimum (100k) so a small/stale reported window can't relaunch with
-    # an argument the CLI rejects outright.
-    assert manager.spec.auto_compact_threshold_tokens == 100_000
+    # No spurious reopen: the threshold is never re-derived from the
+    # driver's live-reported window (see the pinned-threshold test below),
+    # so a second snapshot has nothing new to reconcile and reload.
+    assert driver.open_calls == 1
+    assert manager.spec.auto_compact_threshold_tokens is None
 
     waiting = asyncio.create_task(adapter.compact_context())
     await asyncio.sleep(0)
@@ -833,13 +832,42 @@ async def test_context_commands_are_locked_and_fail_closed_after_close():
             await command()
 
 
-def test_claude_autocompact_tokens_floors_a_live_reported_window():
-    # equation-7256-87f7's real failure: native window=300000, pct=30 ->
-    # raw 90000, which Claude Code's --autocompact rejects (min 100k) and
-    # crashes the CLI before init on every single relaunch.
-    assert _claude_autocompact_tokens(pct=30, max_context=300_000) == 100_000
-    # Above the floor, the percentage still applies normally.
-    assert _claude_autocompact_tokens(pct=30, max_context=500_000) == 150_000
+class _AutocompactEchoDriver(_ControllableDriver):
+    """Reports back exactly the ceiling it was launched with.
+
+    Models Claude Code's real behavior once --autocompact is active: its
+    live context_window echoes the configured ceiling rather than the
+    model's raw capacity.
+    """
+
+    async def context_status(self):
+        return ContextStatus(used_tokens=1, context_window=300_000)
+
+
+@pytest.mark.asyncio
+async def test_context_snapshot_never_recomputes_a_pinned_threshold():
+    # equation-7256-87f7's real failure: launched with threshold=300_000
+    # (1_000_000 window * 30%). Claude Code then echoes context_window
+    # back as 300_000 too. Re-deriving `window * pct / 100` from that on
+    # every poll shrank the threshold each time (300k -> 90k -> ...)
+    # until the CLI rejected the value outright. It must stay pinned.
+    driver = _AutocompactEchoDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec(
+            "/tmp",
+            auto_compact_threshold_pct=30,
+            auto_compact_threshold_tokens=300_000,
+        ),
+        driver_name="claude",
+    )
+    await manager.open()
+    adapter = RuntimeManagerAdapter(manager, compaction_wait_seconds=10)
+
+    for _ in range(3):
+        await adapter.get_context_snapshot()
+        assert manager.spec.auto_compact_threshold_tokens == 300_000
+    assert driver.open_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -845,17 +845,21 @@ class _AutocompactEchoDriver(_ControllableDriver):
 
 
 @pytest.mark.asyncio
-async def test_context_snapshot_never_recomputes_a_pinned_threshold():
+async def test_context_snapshot_stays_pinned_once_it_matches_launch():
     # equation-7256-87f7's real failure: launched with threshold=300_000
-    # (1_000_000 window * 30%). Claude Code then echoes context_window
-    # back as 300_000 too. Re-deriving `window * pct / 100` from that on
-    # every poll shrank the threshold each time (300k -> 90k -> ...)
-    # until the CLI rejected the value outright. It must stay pinned.
+    # (opus-4-7's 1_000_000 static window * 30%, per PR #219's
+    # claude_autocompact_tokens()). Claude Code then echoes context_window
+    # back as 300_000 too -- re-deriving `window * pct / 100` from *that*
+    # on every poll shrank the threshold each time (300k -> 90k -> ...)
+    # until the CLI rejected the value outright. Re-resolving from the
+    # static per-model table instead must always land back on 300_000, so
+    # no poll ever disagrees with launch and reloads.
     driver = _AutocompactEchoDriver()
     manager = RuntimeManager(
         driver,
         RuntimeSpec(
             "/tmp",
+            model="opus-4-7",
             auto_compact_threshold_pct=30,
             auto_compact_threshold_tokens=300_000,
         ),
@@ -868,6 +872,29 @@ async def test_context_snapshot_never_recomputes_a_pinned_threshold():
         await adapter.get_context_snapshot()
         assert manager.spec.auto_compact_threshold_tokens == 300_000
     assert driver.open_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_context_snapshot_corrects_a_stale_threshold_exactly_once():
+    # pct is configured but the spec's token value predates it (e.g. a
+    # live config change after launch) -- the first poll must resolve
+    # the correct value from the static table and reload once to apply
+    # it; every poll after that already agrees, so no further reload.
+    driver = _AutocompactEchoDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", model="opus-4-7", auto_compact_threshold_pct=30),
+        driver_name="claude",
+    )
+    await manager.open()
+    adapter = RuntimeManagerAdapter(manager, compaction_wait_seconds=10)
+
+    await adapter.get_context_snapshot()
+    assert manager.spec.auto_compact_threshold_tokens == 300_000
+    assert driver.open_calls == 2
+
+    await adapter.get_context_snapshot()
+    assert driver.open_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -27,6 +27,7 @@ from puffo_agent.agent.harness.runtime_manager import (
     RuntimeManager,
     RuntimeManagerAdapter,
     RuntimeStateError,
+    _claude_autocompact_tokens,
 )
 from puffo_agent.agent.runtime_event_outbox import (
     RuntimeEventOutbox,
@@ -813,7 +814,10 @@ async def test_context_commands_are_locked_and_fail_closed_after_close():
 
     assert (await adapter.get_context_snapshot()).used_tokens == 12
     assert driver.open_calls == 2
-    assert manager.spec.auto_compact_threshold_tokens == 50
+    # window=100, pct=50 -> raw 50, floored to Claude Code's --autocompact
+    # minimum (100k) so a small/stale reported window can't relaunch with
+    # an argument the CLI rejects outright.
+    assert manager.spec.auto_compact_threshold_tokens == 100_000
 
     waiting = asyncio.create_task(adapter.compact_context())
     await asyncio.sleep(0)
@@ -827,6 +831,15 @@ async def test_context_commands_are_locked_and_fail_closed_after_close():
     for command in (adapter.compact_context, adapter.get_context_snapshot):
         with pytest.raises(RuntimeStateError, match="runtime is closed"):
             await command()
+
+
+def test_claude_autocompact_tokens_floors_a_live_reported_window():
+    # equation-7256-87f7's real failure: native window=300000, pct=30 ->
+    # raw 90000, which Claude Code's --autocompact rejects (min 100k) and
+    # crashes the CLI before init on every single relaunch.
+    assert _claude_autocompact_tokens(pct=30, max_context=300_000) == 100_000
+    # Above the floor, the percentage still applies normally.
+    assert _claude_autocompact_tokens(pct=30, max_context=500_000) == 150_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_subprocess_io.py
+++ b/tests/test_subprocess_io.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from puffo_agent.agent.harness.subprocess_io import (
-    drain_subprocess_stream,
-    drain_subprocess_stream_keeping_tail,
-)
+from puffo_agent.agent.harness.subprocess_io import drain_subprocess_stream_keeping_tail
 
 
 class _FakeStream:
@@ -35,10 +32,3 @@ async def test_keeping_tail_bounds_to_max_bytes():
     tail = await drain_subprocess_stream_keeping_tail(stream, max_bytes=100)
     assert len(tail) == 100
     assert tail == b"b" * 100
-
-
-@pytest.mark.asyncio
-async def test_drain_without_tail_still_discards_everything():
-    stream = _FakeStream([b"x" * 1000, b""])
-    await drain_subprocess_stream(stream)
-    assert stream._chunks == []

--- a/tests/test_subprocess_io.py
+++ b/tests/test_subprocess_io.py
@@ -1,0 +1,44 @@
+"""Bounded stderr-tail capture used to diagnose an unexpected CLI exit."""
+from __future__ import annotations
+
+import pytest
+
+from puffo_agent.agent.harness.subprocess_io import (
+    drain_subprocess_stream,
+    drain_subprocess_stream_keeping_tail,
+)
+
+
+class _FakeStream:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def read(self, _n: int) -> bytes:
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+@pytest.mark.asyncio
+async def test_keeping_tail_returns_empty_for_none_stream():
+    assert await drain_subprocess_stream_keeping_tail(None) == b""
+
+
+@pytest.mark.asyncio
+async def test_keeping_tail_concatenates_short_output():
+    stream = _FakeStream([b"panic: ", b"boom\n"])
+    tail = await drain_subprocess_stream_keeping_tail(stream)
+    assert tail == b"panic: boom\n"
+
+
+@pytest.mark.asyncio
+async def test_keeping_tail_bounds_to_max_bytes():
+    stream = _FakeStream([b"a" * 5000, b"b" * 5000])
+    tail = await drain_subprocess_stream_keeping_tail(stream, max_bytes=100)
+    assert len(tail) == 100
+    assert tail == b"b" * 100
+
+
+@pytest.mark.asyncio
+async def test_drain_without_tail_still_discards_everything():
+    stream = _FakeStream([b"x" * 1000, b""])
+    await drain_subprocess_stream(stream)
+    assert stream._chunks == []


### PR DESCRIPTION
## Follow-up to #255

Live verification found two independent gaps after a host restart.

### Stable Claude autocompact configuration

Claude Code echoes the configured `--autocompact` ceiling as its live
`context_window`. The Runtime Manager was applying the configured percentage
to that echoed value on every context poll, so a valid `300000` launch value
became `90000`; the next process start then failed before init because Claude
requires at least `100k`.

The launch spec is now authoritative for Claude autocompact tokens. Context
telemetry can report the observed window, but it cannot rewrite Claude's
launch configuration. The existing non-Claude behavior remains unchanged.

### Unexpected-exit diagnostics

Claude stderr is still drained for backpressure, while retaining only the
last 8 KiB locally. An unexpected child exit logs that bounded tail so a
pre-init CLI validation failure is diagnosable from the daemon log.

## Validation

- Focused Runtime Manager, Claude driver, and subprocess suites: 70 passed.
- Repository pre-commit checks passed, including the 2,000-line structural limit.
- The regression test polls an echoed `300000` window repeatedly and verifies
  that the launch threshold stays `300000` without reopening the runtime.
- Python 3.11/3.12 and CodeQL remain the merge gate.
