### PR TITLE
fix(runtime): restore late-bound provider compatibility

### DIFF
--- a/src/puffo_agent/agent/event_kinds.py
+++ b/src/puffo_agent/agent/event_kinds.py
@@ -24,3 +24,4 @@ class EventKind(StrEnum):
     REMOVE_FROM_SPACE = "remove_from_space"
     REMOVE_FROM_CHANNEL = "remove_from_channel"
     CREATE_CHANNEL = "create_channel"
+    REDEEM_INVITE_CAPABILITY = "redeem_invite_capability"

--- a/src/puffo_agent/agent/harness/codex_driver.py
+++ b/src/puffo_agent/agent/harness/codex_driver.py
@@ -227,6 +227,9 @@ class CodexAppServerDriver(Driver):
         self._usage_baseline: tuple[int, int] | None = None
         self._usage_latest: dict[str, int] = {}
 
+    def current_capabilities(self) -> DriverCapabilities:
+        return CODEX_CAPABILITIES
+
     async def open(
         self, spec: RuntimeSpec, resume: SessionRef | None = None
     ) -> RuntimeOpened:

--- a/src/puffo_agent/agent/membership_actions.py
+++ b/src/puffo_agent/agent/membership_actions.py
@@ -423,6 +423,8 @@ def _space_membership_actor(
     if kind == EventKind.ACCEPT_SPACE_INVITE:
         inviter = _inviter_slug(payload, inviter_by_event_id)
         return event.get("signer_slug") or "", "joined_space", "", inviter
+    if kind == EventKind.REDEEM_INVITE_CAPABILITY:
+        return payload.get("redeemer_slug") or "", "joined_space", "", ""
     if kind == EventKind.LEAVE_SPACE:
         return event.get("signer_slug") or "", "left_space", "", ""
     if kind == EventKind.REMOVE_FROM_SPACE:

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -296,6 +296,7 @@ class PuffoCoreMessageClient:
         )
         self._ws.on_message = receipt_handler.handle
         self._ws.on_event = self._handle_event
+        self._ws.on_space_membership_changed = self._handle_space_membership_changed
         # Re-warms caches on every (re)connect, first connect included.
         self._ws.on_connect = self._on_ws_connect
         await self.store.open()
@@ -401,6 +402,11 @@ class PuffoCoreMessageClient:
             return
         await self._handle_invite_cancellation_event(kind, payload)
 
+    async def _handle_space_membership_changed(self, space_id: str) -> None:
+        """Invalidate the roster projection without emitting a second event."""
+        if space_id:
+            self._space_members.pop(space_id, None)
+
     async def _prepare_membership_event(
         self,
         kind: str | None,
@@ -413,6 +419,7 @@ class PuffoCoreMessageClient:
             self._log.exception("mark_channel_space from %s failed", kind)
         if kind in (
             EventKind.ACCEPT_SPACE_INVITE,
+            EventKind.REDEEM_INVITE_CAPABILITY,
             EventKind.LEAVE_SPACE,
             EventKind.REMOVE_FROM_SPACE,
         ):
@@ -524,6 +531,7 @@ class PuffoCoreMessageClient:
             EventKind.LEAVE_SPACE,
             EventKind.REMOVE_FROM_SPACE,
             EventKind.ACCEPT_SPACE_INVITE,
+            EventKind.REDEEM_INVITE_CAPABILITY,
         ):
             await self._maybe_announce_space_membership_change(kind, event, payload)
             return True

--- a/src/puffo_agent/crypto/http_session.py
+++ b/src/puffo_agent/crypto/http_session.py
@@ -26,6 +26,13 @@ def _is_socks_proxy(proxy_url: str) -> bool:
     return urlsplit(proxy_url).scheme.lower() in _SOCKS_SCHEMES
 
 
+def create_remote_ssl_context() -> ssl.SSLContext:
+    """Fresh trust store shared by remote HTTP and WebSocket transports."""
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.load_verify_locations(cafile=certifi.where())
+    return ssl_ctx
+
+
 def create_remote_http_session(
     base_url: str,
     *,
@@ -42,8 +49,7 @@ def create_remote_http_session(
     # and every request to the relay fails until the process restarts. Building
     # the context here means a session recreated after a CA change picks the new
     # CA up — the same fix bridge_client applies at the WS.
-    ssl_ctx = ssl.create_default_context()
-    ssl_ctx.load_verify_locations(cafile=certifi.where())
+    ssl_ctx = create_remote_ssl_context()
 
     proxy_url = _env_proxy_for_url(base_url)
     if proxy_url and _is_socks_proxy(proxy_url):

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -14,6 +14,7 @@ import websockets.exceptions  # websockets>=16 lazy-loads submodules; bare `impo
 
 from .encoding import base64url_encode, generate_nonce
 from .http_client import PuffoCoreHttpClient
+from .http_session import create_remote_ssl_context
 from .keystore import KeyStore, decode_secret
 from .primitives import Ed25519KeyPair
 
@@ -58,6 +59,7 @@ class DeliveryResult:
 MessageHandler = Callable[[ServerDelivery], Awaitable[TransportOutcome]]
 EventHandler = Callable[[str, dict], Coroutine[Any, Any, None]]
 CertHandler = Callable[[dict], Coroutine[Any, Any, None]]
+SpaceMembershipHandler = Callable[[str], Coroutine[Any, Any, None]]
 
 
 class PuffoCoreWsClient:
@@ -79,6 +81,7 @@ class PuffoCoreWsClient:
         self.on_message: MessageHandler | None = None
         self.on_event: EventHandler | None = None
         self.on_cert_update: CertHandler | None = None
+        self.on_space_membership_changed: SpaceMembershipHandler | None = None
         # Fires after every (re)connect handshake, before catch-up.
         self.on_connect: Callable[[], Coroutine[Any, Any, None]] | None = None
         self._catchup_lock = asyncio.Lock()
@@ -313,13 +316,24 @@ class PuffoCoreWsClient:
                 except Exception:
                     logger.exception("on_event callback failed")
 
+        elif msg_type == "space_membership_changed":
+            space_id = msg.get("space_id")
+            if self.on_space_membership_changed and isinstance(space_id, str):
+                try:
+                    await self.on_space_membership_changed(space_id)
+                except Exception:
+                    logger.exception("on_space_membership_changed callback failed")
+
     async def _listen_loop(self) -> None:
         async for raw in self._ws:
             await self._handle_frame(raw)
 
     async def connect_once(self) -> None:
         await self.http_client._ensure_subkey()
-        async with websockets.connect(self.ws_url) as ws:
+        ssl_context = (
+            create_remote_ssl_context() if self.ws_url.startswith("wss://") else None
+        )
+        async with websockets.connect(self.ws_url, ssl=ssl_context) as ws:
             self._ws = ws
             self.session_id = await self._handshake(ws)
             logger.info("[%s] WS connected, session=%s", self.slug, self.session_id)

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -493,12 +493,16 @@ def build_capabilities() -> dict:
         "claude-code": cli_tool_status(resolve_claude_bin, claude_has_credentials),
         "codex": cli_tool_status(resolve_codex_bin, codex_has_credentials),
     }
+    claude_ready = cli_tools["claude-code"] == "ready"
     providers = [
         {
             "provider": h,
             "models": [
                 {"id": o.id, "label": o.label, "alias": o.is_alias}
-                for o in provider_models(h, fetch=False)
+                for o in provider_models(
+                    h,
+                    fetch=h == "claude-code" and claude_ready,
+                )
                 if o.id
             ],
         }

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -23,6 +23,26 @@ def test_daemon_run_calls_model_catalog_prefetch_at_startup():
     assert "model_catalog" in source and "prefetch" in source
 
 
+def test_capabilities_fetch_claude_catalog_after_late_login(monkeypatch):
+    from puffo_agent.agent import cli_bin, model_catalog
+    from puffo_agent.portal.control.client import build_capabilities
+
+    calls = []
+    monkeypatch.setattr(cli_bin, "resolve_claude_bin", lambda: "/bin/claude")
+    monkeypatch.setattr(cli_bin, "claude_has_credentials", lambda: True)
+    monkeypatch.setattr(cli_bin, "resolve_codex_bin", lambda: None)
+    monkeypatch.setattr(model_catalog, "KNOWN_HARNESSES", ("claude-code", "codex"))
+    monkeypatch.setattr(
+        model_catalog,
+        "provider_models",
+        lambda harness, *, fetch=False: calls.append((harness, fetch)) or [],
+    )
+
+    build_capabilities()
+
+    assert calls == [("claude-code", True), ("codex", False)]
+
+
 def test_run_daemon_short_circuit_does_not_prefetch(monkeypatch):
     """The already-running short-circuit lives in ``run_daemon``, not
     ``Daemon.run`` — so a second daemon getting refused mustn't fire a

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -213,6 +213,7 @@ def test_typed_refs_are_not_interchangeable():
 
 
 def test_codex_effective_capabilities():
+    assert CodexAppServerDriver().current_capabilities() == CODEX_CAPABILITIES
     assert CODEX_CAPABILITIES.session_resume is True
     assert CODEX_CAPABILITIES.inflight_turn_recovery is False
     assert CODEX_CAPABILITIES.steer == "current_turn"

--- a/tests/test_membership_events.py
+++ b/tests/test_membership_events.py
@@ -12,6 +12,7 @@ and "not for me" no-ops.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 
@@ -104,6 +105,38 @@ def _make_client(
 
     client.http = _StubHttp()
     return client, sent
+
+
+@pytest.mark.asyncio
+async def test_capability_redemption_invalidates_roster_and_announces_join():
+    client, _ = _make_client()
+    client._space_members["sp_1"] = {"alice-0001": "human"}
+    client._channel_space["ch_1"] = "sp_1"
+    client._processed_membership_event_ids = set()
+    client._log = logging.getLogger(__name__)
+    announcements = []
+
+    async def enqueue(**message):
+        announcements.append(message)
+
+    client._enqueue_membership_system_message = enqueue
+    event = {
+        "event_id": "ev_redeem",
+        "kind": "redeem_invite_capability",
+        "signer_slug": "alice-0001",
+        "payload": {"space_id": "sp_1", "redeemer_slug": "alice-0001"},
+    }
+    await client._handle_event(scope="sp_1", event=event)
+
+    assert "sp_1" not in client._space_members
+    assert announcements == [{
+        "channel_id": "ch_1",
+        "actor_slug": "alice-0001",
+        "action": "joined_space",
+        "kicker_slug": "",
+        "inviter_slug": "",
+        "event_id": "ev_redeem",
+    }]
 
 
 # ─── leave_space (synthetic cascade + self-signed) ─────────────────

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -62,6 +62,41 @@ class TestHttpToWs:
         assert _http_to_ws("ws://localhost:3000") == "ws://localhost:3000"
 
 
+@pytest.mark.asyncio
+async def test_wss_connect_uses_remote_tls_context(monkeypatch):
+    ks, _ = _make_keystore()
+    client = PuffoCoreWsClient("https://api.puffo.ai", ks, "alice-0001", FakeHttpClient())
+    tls_context = object()
+    captured = {}
+
+    class Connection:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *_args):
+            return False
+
+    def connect(url, **kwargs):
+        captured.update(url=url, **kwargs)
+        return Connection()
+
+    async def handshake(_ws):
+        return "session"
+
+    async def noop():
+        return None
+
+    monkeypatch.setattr("puffo_agent.crypto.ws_client.create_remote_ssl_context", lambda: tls_context)
+    monkeypatch.setattr("puffo_agent.crypto.ws_client.websockets.connect", connect)
+    client._handshake = handshake
+    client._catchup = noop
+    client._listen_loop = noop
+
+    await client.connect_once()
+
+    assert captured == {"url": "wss://api.puffo.ai/subscribe", "ssl": tls_context}
+
+
 class FakeWsServer:
     """Minimal WS server for testing handshake and message flows."""
 
@@ -453,17 +488,22 @@ async def test_event_and_cert_handlers():
     server._push_after_connect = [
         {"type": "cert_update", "entry": {"seq": 5, "kind": "subkey_cert"}},
         {"type": "event", "scope": "sp_123", "event": {"action": "join"}},
+        {"type": "space_membership_changed", "space_id": "sp_123"},
     ]
     await server.start()
 
     cert_updates = []
     events = []
+    membership_changes = []
 
     async def on_cert(entry):
         cert_updates.append(entry)
 
     async def on_event(scope, event):
         events.append((scope, event))
+
+    async def on_membership_change(space_id):
+        membership_changes.append(space_id)
 
     http = FakeHttpClient()
     client = PuffoCoreWsClient(
@@ -473,6 +513,7 @@ async def test_event_and_cert_handlers():
     client.ws_url = f"ws://127.0.0.1:{server.port}"
     client.on_cert_update = on_cert
     client.on_event = on_event
+    client.on_space_membership_changed = on_membership_change
 
     task = asyncio.create_task(client.connect_once())
     await asyncio.sleep(0.5)
@@ -487,6 +528,7 @@ async def test_event_and_cert_handlers():
     assert len(events) == 1
     assert events[0][0] == "sp_123"
     assert events[0][1]["action"] == "join"
+    assert membership_changes == ["sp_123"]
     await server.stop()
 
 


### PR DESCRIPTION
## Summary

Restore runtime behavior that regressed when Server and provider state changes arrive after daemon startup:

- route the canonical `redeem_invite_capability` event as a Space join and invalidate the roster cache;
- consume `space_membership_changed` as projection invalidation only, without emitting a duplicate system message;
- share the certifi-backed TLS context between signed HTTP and crypto WebSocket connections;
- refresh the Claude model catalog when credentials become ready after daemon startup;
- expose Codex fixed capabilities before app-server `open`, so an idle-exited runtime can be reopened instead of backing off as unsupported.

This is additive and changes no persisted Agent state or migration.

## Verification

- `uv run --extra dev pytest -q tests/test_membership_events.py tests/test_ws_client.py`
- `uv run --extra dev pytest -q tests/test_model_catalog.py tests/test_daemon_catalog_prefetch.py`
- `uv run --extra dev pytest -q tests/test_harness_driver.py -k codex_effective_capabilities`
- `uv run --extra dev pre-commit run --all-files`
