### PR TITLE
chore(release): prepare 2.0.0a21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a21] - 2026-08-19
+
+> Staging candidate preventing Claude Code context observation from corrupting
+> its next process launch and improving local crash diagnostics.
+
+### Fixed
+
+- **Claude Code autocompact remains stable across context observations.** The
+  launch-time token ceiling is authoritative for Claude; a reported live
+  context window no longer reapplies the percentage and progressively shrinks
+  the next `--autocompact` value below the CLI minimum.
+- **Unexpected Claude Code exits include bounded local diagnostics.** The daemon
+  logs only the final 8 KiB of child-process stderr, making pre-init failures
+  diagnosable without unbounded buffering or remote telemetry.
+
 ## [2.0.0a20] - 2026-08-19
 
 > Staging candidate recovering provider runtimes and bounded context without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a20"
+version = "2.0.0a21"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a20"
+version = "2.0.0a21"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release `2.0.0a21` from current `main`.

- keep Claude Code `--autocompact` launch threshold stable across context observations
- capture a bounded local stderr tail when Claude exits unexpectedly
- update package and lockfile versions plus changelog

## Validation

- `uv lock --check`
- `uv run puffo-agent version` -> `2.0.0a21`
- `SKIP=no-commit-to-branch uv run --extra dev pre-commit run --all-files`
- `uv build --out-dir /private/tmp/puffo-agent-a21-dist`
- source PR #265: Python 3.11/3.12, pre-commit, and CodeQL green