### PR TITLE
fix(runtime): resolve Claude's autocompact threshold from the static table

### DIFF
--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -49,10 +49,7 @@ COMPACTION_WAIT_SECONDS = 120.0
 
 
 def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
-    """Same call local_runtime.py makes at launch -- static per-model window,
-    never the driver's live-reported one (see PR #219: once --autocompact is
-    active, Claude echoes that configured ceiling back as its own window).
-    """
+    """Same call local_runtime.py makes at launch -- static per-model window."""
     from ...portal.control.context_telemetry import claude_autocompact_tokens
 
     return claude_autocompact_tokens(model=model, pct=pct)
@@ -894,11 +891,8 @@ class RuntimeManagerAdapter(Adapter):
         if pct is None:
             return configured
         if self.manager.driver_name == "claude-code":
-            # Claude echoes the configured --autocompact ceiling as its live
-            # context window, so window * pct compounds smaller on every
-            # observation (PR #219). Resolve from the static per-model
-            # table instead -- deterministic for a fixed model+pct, same
-            # call local_runtime.py already made at launch.
+            # Claude echoes our configured ceiling as its live window, so
+            # window * pct would compound smaller each time (PR #219).
             return (
                 _resolve_claude_autocompact_tokens(
                     model=self.manager.spec.model, pct=pct
@@ -1193,10 +1187,7 @@ class RuntimeManagerAdapter(Adapter):
         window = status.context_window
         threshold = self._context_threshold(status, window)
         pct = self.manager.spec.auto_compact_threshold_pct
-        # codex's raw window*pct needs a live window to mean anything;
-        # claude-code's static-table resolution doesn't (see
-        # _context_threshold) and reconciles a pct that changed after
-        # launch even while the window is momentarily unavailable.
+        # claude-code's static-table resolution doesn't need a live window.
         needs_window = self.manager.driver_name != "claude-code"
         if pct is not None and (window is not None or not needs_window):
             if (

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -48,6 +48,16 @@ logger = logging.getLogger(__name__)
 COMPACTION_WAIT_SECONDS = 120.0
 
 
+def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
+    """Same call local_runtime.py makes at launch -- static per-model window,
+    never the driver's live-reported one (see PR #219: once --autocompact is
+    active, Claude echoes that configured ceiling back as its own window).
+    """
+    from ...portal.control.context_telemetry import claude_autocompact_tokens
+
+    return claude_autocompact_tokens(model=model, pct=pct)
+
+
 class RuntimeStateError(RuntimeError):
     """Internal state-machine contract violation, never retried automatically."""
 
@@ -881,11 +891,20 @@ class RuntimeManagerAdapter(Adapter):
             or status.auto_compact_threshold_tokens
         )
         pct = self.manager.spec.auto_compact_threshold_pct
-        # Claude echoes the configured --autocompact ceiling as its live
-        # context window. The launch spec is therefore authoritative; applying
-        # the percentage again compounds the threshold on every observation.
-        if pct is None or self.manager.driver_name == "claude-code":
+        if pct is None:
             return configured
+        if self.manager.driver_name == "claude-code":
+            # Claude echoes the configured --autocompact ceiling as its live
+            # context window, so window * pct compounds smaller on every
+            # observation (PR #219). Resolve from the static per-model
+            # table instead -- deterministic for a fixed model+pct, same
+            # call local_runtime.py already made at launch.
+            return (
+                _resolve_claude_autocompact_tokens(
+                    model=self.manager.spec.model, pct=pct
+                )
+                or configured
+            )
         if context_window is not None and context_window > 0:
             return int(context_window * pct / 100)
         return configured
@@ -1174,11 +1193,12 @@ class RuntimeManagerAdapter(Adapter):
         window = status.context_window
         threshold = self._context_threshold(status, window)
         pct = self.manager.spec.auto_compact_threshold_pct
-        if (
-            self.manager.driver_name != "claude-code"
-            and window is not None
-            and pct is not None
-        ):
+        # codex's raw window*pct needs a live window to mean anything;
+        # claude-code's static-table resolution doesn't (see
+        # _context_threshold) and reconciles a pct that changed after
+        # launch even while the window is momentarily unavailable.
+        needs_window = self.manager.driver_name != "claude-code"
+        if pct is not None and (window is not None or not needs_window):
             if (
                 threshold is not None
                 and self.manager.active_turn_ref is None

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -874,6 +874,29 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
 
 
 @pytest.mark.asyncio
+async def test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once():
+    # pct is configured but the spec's token value predates it (e.g. a
+    # live config change after launch). The static-table resolution must
+    # still land on 300_000 and reload once to apply it; every poll after
+    # that already agrees, so no further reload.
+    driver = _AutocompactEchoDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", model="opus-4-7", auto_compact_threshold_pct=30),
+        driver_name="claude-code",
+    )
+    await manager.open()
+    adapter = RuntimeManagerAdapter(manager, compaction_wait_seconds=10)
+
+    await adapter.get_context_snapshot()
+    assert manager.spec.auto_compact_threshold_tokens == 300_000
+    assert driver.open_calls == 2
+
+    await adapter.get_context_snapshot()
+    assert driver.open_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_context_rollover_preserves_logical_session_and_opens_fresh_native():
     driver = _ControllableDriver()
     manager = RuntimeManager(

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -875,10 +875,8 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
 
 @pytest.mark.asyncio
 async def test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once():
-    # pct is configured but the spec's token value predates it (e.g. a
-    # live config change after launch). The static-table resolution must
-    # still land on 300_000 and reload once to apply it; every poll after
-    # that already agrees, so no further reload.
+    # pct is configured but spec has no token value yet -- resolve once,
+    # reload, then agree on every later poll.
     driver = _AutocompactEchoDriver()
     manager = RuntimeManager(
         driver,


### PR DESCRIPTION
## Follow-up to #265

#265 fixed the compounding-threshold crash loop (`equation-7256-87f7`, `old-coder-7968-8e7b0303` stuck permanently on `--autocompact` argument `'90000' is invalid`) by pinning the threshold to whatever was already on `spec`/`status` and never recomputing it. That's safe, but doesn't match how this problem was actually solved before, in **#219**.

## What #219 already established

When Claude Code stopped honoring the legacy `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var and we switched to computing `--autocompact <tokens>` ourselves, #219 explicitly called out that Claude echoes the *configured* ceiling back as its own `rawMaxTokens` once `--autocompact` is active — not the model's real capacity. Verified again empirically here: launching with `--autocompact 300000` makes the CLI report `rawMaxTokens: 300000` right back (opus-4-7's real window is 1,000,000). `build_context_runtime()` (still used by `worker.py`/`agent_detail.py` for status/UI) handles this by always resolving from the static per-model table whenever a pct override is configured — never trusting the live-reported window.

`runtime_manager.py`'s `_context_threshold()` (added in #265) doesn't do that yet — it just freezes on `configured` for Claude, meaning the threshold is only ever as correct as whatever happened to be set at launch, and any later pct config change has no path to apply.

## This PR

- `_context_threshold()`: for `driver_name == "claude-code"` with a pct configured, resolve via `claude_autocompact_tokens(model, pct)` against the static table — the identical call `local_runtime.py` makes at launch. Deterministic for a fixed model+pct, so it can never disagree with what's already running from a normal launch.
- `get_context_snapshot()`: the reload-on-mismatch branch was gated `driver_name != "claude-code"` (codex only). Extended to cover claude-code too, now that the resolution is stable — it only fires once, to apply a pct that changed after launch, not on every poll.
- Restored the "corrects a stale threshold exactly once" regression test that didn't survive #265's squash-merge.

## Verification
- Full test suite + ruff: clean
- `test_context_snapshot_stays_pinned_once_it_matches_launch` (already existed): unaffected — resolving from the static table lands on the same 300_000 the launch spec already has, so no reload
- `test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once` (new): spec starts with pct configured but no token value yet; first poll resolves 300_000 and reloads once; second poll doesn't reload again

Not deployed yet — production is currently running #265's version (pinned, no static-table resolution or drift-correction), which is safe and already fixes the crash loop. This is a refinement, not a hotfix.