### PR TITLE
fix(runtime): preserve launch-owned Claude compact threshold

### DIFF
--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -49,10 +49,7 @@ COMPACTION_WAIT_SECONDS = 120.0
 
 
 def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
-    """Same call local_runtime.py makes at launch -- static per-model window,
-    never the driver's live-reported one (see PR #219: once --autocompact is
-    active, Claude echoes that configured ceiling back as its own window).
-    """
+    """Same call local_runtime.py makes at launch -- static per-model window."""
     from ...portal.control.context_telemetry import claude_autocompact_tokens
 
     return claude_autocompact_tokens(model=model, pct=pct)
@@ -894,11 +891,8 @@ class RuntimeManagerAdapter(Adapter):
         if pct is None:
             return configured
         if self.manager.driver_name == "claude-code":
-            # Claude echoes the configured --autocompact ceiling as its live
-            # context window, so window * pct compounds smaller on every
-            # observation (PR #219). Resolve from the static per-model
-            # table instead -- deterministic for a fixed model+pct, same
-            # call local_runtime.py already made at launch.
+            # Claude echoes our configured ceiling as its live window, so
+            # window * pct would compound smaller each time (PR #219).
             return (
                 _resolve_claude_autocompact_tokens(
                     model=self.manager.spec.model, pct=pct
@@ -1193,10 +1187,7 @@ class RuntimeManagerAdapter(Adapter):
         window = status.context_window
         threshold = self._context_threshold(status, window)
         pct = self.manager.spec.auto_compact_threshold_pct
-        # codex's raw window*pct needs a live window to mean anything;
-        # claude-code's static-table resolution doesn't (see
-        # _context_threshold) and reconciles a pct that changed after
-        # launch even while the window is momentarily unavailable.
+        # claude-code's static-table resolution doesn't need a live window.
         needs_window = self.manager.driver_name != "claude-code"
         if pct is not None and (window is not None or not needs_window):
             if (

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import uuid
 import weakref
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any
@@ -48,11 +48,17 @@ logger = logging.getLogger(__name__)
 COMPACTION_WAIT_SECONDS = 120.0
 
 
-def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
-    """Same call local_runtime.py makes at launch -- static per-model window."""
+def _resolve_claude_autocompact_tokens(
+    *, model: str, pct: float, environment: Mapping[str, str]
+) -> int | None:
+    """Resolve a missing threshold from the runtime's launch environment."""
     from ...portal.control.context_telemetry import claude_autocompact_tokens
 
-    return claude_autocompact_tokens(model=model, pct=pct)
+    return claude_autocompact_tokens(
+        model=model,
+        pct=pct,
+        env=dict(environment),
+    )
 
 
 class RuntimeStateError(RuntimeError):
@@ -883,21 +889,26 @@ class RuntimeManagerAdapter(Adapter):
         status: ContextStatus,
         context_window: int | None,
     ) -> int | None:
+        spec_threshold = self.manager.spec.auto_compact_threshold_tokens
         configured = (
-            self.manager.spec.auto_compact_threshold_tokens
-            or status.auto_compact_threshold_tokens
+            spec_threshold
+            if spec_threshold is not None
+            else status.auto_compact_threshold_tokens
         )
         pct = self.manager.spec.auto_compact_threshold_pct
         if pct is None:
             return configured
         if self.manager.driver_name == "claude-code":
             # Claude echoes our configured ceiling as its live window, so
-            # window * pct would compound smaller each time (PR #219).
-            return (
-                _resolve_claude_autocompact_tokens(
-                    model=self.manager.spec.model, pct=pct
-                )
-                or configured
+            # window * pct would compound smaller each time (PR #219). The
+            # launch-owned threshold stays authoritative; only repair a spec
+            # where both launch and provider omitted the token value.
+            if configured is not None:
+                return configured
+            return _resolve_claude_autocompact_tokens(
+                model=self.manager.spec.model,
+                pct=pct,
+                environment=self.manager.spec.environment,
             )
         if context_window is not None and context_window > 0:
             return int(context_window * pct / 100)

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -48,6 +48,16 @@ logger = logging.getLogger(__name__)
 COMPACTION_WAIT_SECONDS = 120.0
 
 
+def _resolve_claude_autocompact_tokens(*, model: str, pct: float) -> int | None:
+    """Same call local_runtime.py makes at launch -- static per-model window,
+    never the driver's live-reported one (see PR #219: once --autocompact is
+    active, Claude echoes that configured ceiling back as its own window).
+    """
+    from ...portal.control.context_telemetry import claude_autocompact_tokens
+
+    return claude_autocompact_tokens(model=model, pct=pct)
+
+
 class RuntimeStateError(RuntimeError):
     """Internal state-machine contract violation, never retried automatically."""
 
@@ -881,11 +891,20 @@ class RuntimeManagerAdapter(Adapter):
             or status.auto_compact_threshold_tokens
         )
         pct = self.manager.spec.auto_compact_threshold_pct
-        # Claude echoes the configured --autocompact ceiling as its live
-        # context window. The launch spec is therefore authoritative; applying
-        # the percentage again compounds the threshold on every observation.
-        if pct is None or self.manager.driver_name == "claude-code":
+        if pct is None:
             return configured
+        if self.manager.driver_name == "claude-code":
+            # Claude echoes the configured --autocompact ceiling as its live
+            # context window, so window * pct compounds smaller on every
+            # observation (PR #219). Resolve from the static per-model
+            # table instead -- deterministic for a fixed model+pct, same
+            # call local_runtime.py already made at launch.
+            return (
+                _resolve_claude_autocompact_tokens(
+                    model=self.manager.spec.model, pct=pct
+                )
+                or configured
+            )
         if context_window is not None and context_window > 0:
             return int(context_window * pct / 100)
         return configured
@@ -1174,11 +1193,12 @@ class RuntimeManagerAdapter(Adapter):
         window = status.context_window
         threshold = self._context_threshold(status, window)
         pct = self.manager.spec.auto_compact_threshold_pct
-        if (
-            self.manager.driver_name != "claude-code"
-            and window is not None
-            and pct is not None
-        ):
+        # codex's raw window*pct needs a live window to mean anything;
+        # claude-code's static-table resolution doesn't (see
+        # _context_threshold) and reconciles a pct that changed after
+        # launch even while the window is momentarily unavailable.
+        needs_window = self.manager.driver_name != "claude-code"
+        if pct is not None and (window is not None or not needs_window):
             if (
                 threshold is not None
                 and self.manager.active_turn_ref is None

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -874,6 +874,29 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
 
 
 @pytest.mark.asyncio
+async def test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once():
+    # pct is configured but the spec's token value predates it (e.g. a
+    # live config change after launch). The static-table resolution must
+    # still land on 300_000 and reload once to apply it; every poll after
+    # that already agrees, so no further reload.
+    driver = _AutocompactEchoDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", model="opus-4-7", auto_compact_threshold_pct=30),
+        driver_name="claude-code",
+    )
+    await manager.open()
+    adapter = RuntimeManagerAdapter(manager, compaction_wait_seconds=10)
+
+    await adapter.get_context_snapshot()
+    assert manager.spec.auto_compact_threshold_tokens == 300_000
+    assert driver.open_calls == 2
+
+    await adapter.get_context_snapshot()
+    assert driver.open_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_context_rollover_preserves_logical_session_and_opens_fresh_native():
     driver = _ControllableDriver()
     manager = RuntimeManager(

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -842,7 +842,7 @@ class _AutocompactEchoDriver(_ControllableDriver):
 
 
 @pytest.mark.asyncio
-async def test_context_snapshot_stays_pinned_once_it_matches_launch():
+async def test_context_snapshot_stays_pinned_once_it_matches_launch(monkeypatch):
     # equation-7256-87f7's real failure: launched with threshold=300_000
     # (opus-4-7's 1_000_000 static window * 30%, per PR #219's
     # claude_autocompact_tokens()). Claude Code then echoes context_window
@@ -850,6 +850,10 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
     # on every poll shrank the threshold each time (300k -> 90k -> ...)
     # until the CLI rejected the value outright. The launch spec must stay
     # authoritative across later observations.
+    # Docker launch intentionally ignores the daemon's host-level window.
+    # A later telemetry poll must not replace that launch-owned decision by
+    # consulting a different environment.
+    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "500000")
     driver = _AutocompactEchoDriver()
     manager = RuntimeManager(
         driver,
@@ -874,9 +878,13 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
 
 
 @pytest.mark.asyncio
-async def test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once():
+async def test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once(
+    monkeypatch,
+):
     # pct is configured but spec has no token value yet -- resolve once,
-    # reload, then agree on every later poll.
+    # from the spec environment rather than the daemon environment, reload,
+    # then agree on every later poll.
+    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "500000")
     driver = _AutocompactEchoDriver()
     manager = RuntimeManager(
         driver,

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -875,10 +875,8 @@ async def test_context_snapshot_stays_pinned_once_it_matches_launch():
 
 @pytest.mark.asyncio
 async def test_context_snapshot_corrects_a_stale_claude_threshold_exactly_once():
-    # pct is configured but the spec's token value predates it (e.g. a
-    # live config change after launch). The static-table resolution must
-    # still land on 300_000 and reload once to apply it; every poll after
-    # that already agrees, so no further reload.
+    # pct is configured but spec has no token value yet -- resolve once,
+    # reload, then agree on every later poll.
     driver = _AutocompactEchoDriver()
     manager = RuntimeManager(
         driver,


### PR DESCRIPTION
## Summary

- retain the Claude auto-compact threshold already resolved by the launch preparer
- repair legacy/incomplete runtime specs only when both launch and provider omit the token threshold
- use the runtime spec environment for that fallback instead of the daemon process environment

This supersedes #268 and preserves its missing-threshold repair without allowing telemetry to overwrite a valid Docker launch decision.

## Why

Docker intentionally resolves Claude auto-compact without inheriting the daemon-level `CLAUDE_CODE_AUTO_COMPACT_WINDOW`. The previous runtime recomputation read that global environment and could change a valid `300000` launch threshold to `150000`, causing an unnecessary provider reload.

## Verification

- regression reproduced before the fix (`300000` changed to `150000`)
- `uv run --extra dev pytest -q tests/test_runtime_manager_failures.py tests/test_context_telemetry_threshold.py`
- `uv run --extra dev pre-commit run --all-files`
- full suite: `3216 passed, 1 skipped`