### PR TITLE
fix(send): turn-unbound sends never downgrade to plaintext; honest unbound errors

### DIFF
--- a/src/puffo_agent/agent/global_inbox_admission.py
+++ b/src/puffo_agent/agent/global_inbox_admission.py
@@ -632,7 +632,11 @@ class InboxAdmissionMixin:
                 latest_seq=through_seq,
                 state="no_active_turn",
             )
-            raise RuntimeError("no active provider turn for model-visible read")
+            raise RuntimeError(
+                "no active provider turn for model-visible read; reads "
+                "outside an admitted turn (e.g. a background-task wakeup) "
+                "become available on the next admitted turn"
+            )
         await self._add_visible_message_ids(
             visible_ids,
             space_id=space_id if has_boundary else None,
@@ -1026,7 +1030,11 @@ class InboxAdmissionMixin:
         requesting_provider_session_id = self.active.provider_session_id
         requesting_provider_turn_id = self.active.provider_turn_id
         if not requesting_turn_id:
-            raise RuntimeError("no active daemon turn for Inbox read")
+            raise RuntimeError(
+                "no active daemon turn for Inbox read; pending messages "
+                "are delivered on the next admitted turn (reads are not "
+                "available from a background-task wakeup)"
+            )
         page = await self.store.read_inbox_page(
             target=target, cursor=cursor, limit=limit
         )

--- a/src/puffo_agent/agent/global_inbox_admission.py
+++ b/src/puffo_agent/agent/global_inbox_admission.py
@@ -633,9 +633,9 @@ class InboxAdmissionMixin:
                 state="no_active_turn",
             )
             raise RuntimeError(
-                "no active provider turn for model-visible read; reads "
-                "outside an admitted turn (e.g. a background-task wakeup) "
-                "become available on the next admitted turn"
+                "model-visible read is not bound to an admitted provider "
+                "turn (e.g. a background-task wakeup); reads become "
+                "available when a turn is next admitted"
             )
         await self._add_visible_message_ids(
             visible_ids,
@@ -1031,9 +1031,9 @@ class InboxAdmissionMixin:
         requesting_provider_turn_id = self.active.provider_turn_id
         if not requesting_turn_id:
             raise RuntimeError(
-                "no active daemon turn for Inbox read; pending messages "
-                "are delivered on the next admitted turn (reads are not "
-                "available from a background-task wakeup)"
+                "Inbox read is not bound to an admitted daemon turn (e.g. "
+                "a background-task wakeup); pending messages are delivered "
+                "when a turn is next admitted"
             )
         page = await self.store.read_inbox_page(
             target=target, cursor=cursor, limit=limit

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -793,9 +793,22 @@ class SendCoordinator:
                 space_id, channel_id, fingerprint, content_digest
             )
             if not reconsideration.eligible:
+                if reconsideration.reason == "missing_active_identity":
+                    # Outside an admitted daemon turn (e.g. a background-task
+                    # wakeup) there is no identity to validate catch-up
+                    # against; pointing at the normal held procedure would
+                    # send the model in circles.
+                    message = (
+                        "no active daemon turn; send_anyway is unavailable "
+                        "until the next admitted turn delivers fresh context"
+                    )
+                else:
+                    message = (
+                        "send_anyway requires exact held catch-up and an "
+                        "admitted same-Turn read through that boundary"
+                    )
                 result = failed_result(
-                    "send_anyway requires exact held catch-up and an admitted "
-                    "same-Turn read through that boundary",
+                    message,
                     kind="reconsideration_ineligible",
                 )
                 result["_reconsideration_audit"] = reconsideration.audit_fields()
@@ -867,11 +880,6 @@ class SendCoordinator:
             )
         except Exception as exc:
             return failed_result(str(exc), kind="validation")
-        if not resolved["encrypt"]:
-            return failed_result(
-                "plaintext channel sends are not supported",
-                kind="encryption_required",
-            )
 
         envelope, content_key = encrypt_message_with_content_key(
             resolved["input"],
@@ -1236,15 +1244,15 @@ class SendCoordinator:
             space_id=space_id,
             dm_peer=dm_peer,
         )
-        encrypt = bool(request.attachment_paths) or await _send_encryption_required(
-            coordinator_config(self), root
+        # Channel routes are always E2EE. The daemon-level send-mode decision
+        # only exists to allow the plaintext DM downgrade; consulting it for
+        # channels made turn-unbound sends (background wakeups, where the
+        # turn-scoped bundle flag is already cleared) fail as "plaintext".
+        encrypt = (
+            require_encryption
+            or bool(request.attachment_paths)
+            or await _send_encryption_required(coordinator_config(self), root)
         )
-        if require_encryption and not encrypt:
-            return {
-                "encrypt": False,
-                "note": root_note,
-                "recipient_slugs": recipient_slugs,
-            }
 
         attachments, attachment_note = await self._prepare_attachments(
             request, materialized

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -794,13 +794,16 @@ class SendCoordinator:
             )
             if not reconsideration.eligible:
                 if reconsideration.reason == "missing_active_identity":
-                    # Outside an admitted daemon turn (e.g. a background-task
-                    # wakeup) there is no identity to validate catch-up
-                    # against; pointing at the normal held procedure would
-                    # send the model in circles.
+                    # No admitted daemon turn is bound (background-task
+                    # wakeup) or the provider session changed under the
+                    # coordinator; either way there is no identity to
+                    # validate catch-up against, and pointing at the normal
+                    # held procedure would send the model in circles.
                     message = (
-                        "no active daemon turn; send_anyway is unavailable "
-                        "until the next admitted turn delivers fresh context"
+                        "this send is not bound to an admitted daemon turn "
+                        "(background-task wakeup, or the provider session "
+                        "changed); send_anyway is unavailable here — the "
+                        "draft can be resent from a newly admitted turn"
                     )
                 else:
                     message = (
@@ -875,7 +878,6 @@ class SendCoordinator:
                 space_id=space_id,
                 channel_id=channel_id,
                 dm_peer=None,
-                require_encryption=True,
                 materialized=boundary.materialized,
             )
         except Exception as exc:
@@ -1110,7 +1112,6 @@ class SendCoordinator:
                 space_id=None,
                 channel_id=None,
                 dm_peer=recipient_slug,
-                require_encryption=False,
             )
             inp = resolved["input"]
             if resolved["encrypt"]:
@@ -1218,7 +1219,6 @@ class SendCoordinator:
         space_id: str | None,
         channel_id: str | None,
         dm_peer: str | None,
-        require_encryption: bool,
         materialized: Sequence[tuple[str, bytes]] | None = None,
     ) -> dict[str, Any]:
         from ..mcp.puffo_core_tools import (
@@ -1249,7 +1249,7 @@ class SendCoordinator:
         # channels made turn-unbound sends (background wakeups, where the
         # turn-scoped bundle flag is already cleared) fail as "plaintext".
         encrypt = (
-            require_encryption
+            kind == "channel"
             or bool(request.attachment_paths)
             or await _send_encryption_required(coordinator_config(self), root)
         )

--- a/src/puffo_agent/agent/send_mode.py
+++ b/src/puffo_agent/agent/send_mode.py
@@ -2,7 +2,10 @@
 
 Encrypt when the turn's triggering bundle contained an encrypted
 message, or when the send targets a thread whose root is encrypted.
-Everything else goes out as a plaintext envelope.
+Only a turn whose bundle was explicitly plaintext (and no encrypted
+thread root) may downgrade; with no bound turn at all — e.g. a
+background-task wakeup after the daemon turn finalized — the trigger's
+confidentiality is unknown and the decision fails safe to E2EE.
 """
 
 from __future__ import annotations
@@ -48,10 +51,14 @@ async def encryption_required(
     thread_root_id: str | None,
 ) -> bool:
     """Return whether the active turn or target thread requires E2EE."""
-    if turn_bundle_encrypted(key):
+    bundle = _turn_bundle_encrypted.get(key)
+    if bundle:
         return True
     if not thread_root_id:
-        return False
+        # ``bundle is None`` means no turn is bound (the flag is cleared at
+        # turn end): fail safe to E2EE rather than silently downgrading a
+        # turn-unbound send to plaintext.
+        return bundle is None
     try:
         row = await store.get_message_by_envelope(thread_root_id)
     except Exception:

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -354,7 +354,9 @@ async def test_send_encryption_decision_matrix_over_http() -> None:
                 assert resp.status == 200
                 return (await resp.json())["encrypt"]
 
-            assert await ask(base) is False  # default plaintext
+            assert await ask(base) is True  # no bound turn: fail-safe
+            send_mode.note_turn_bundle(["bot-1"], False)
+            assert await ask(base) is False  # explicit plaintext bundle
             assert await ask(base + "&thread_root_id=msg_pt") is False
             assert await ask(base + "&thread_root_id=msg_enc") is True  # legacy row
             assert await ask(base + "&thread_root_id=msg_gone") is True  # fail-safe

--- a/tests/test_global_inbox_runtime.py
+++ b/tests/test_global_inbox_runtime.py
@@ -837,9 +837,8 @@ async def test_turn_send_mode_tracks_encrypted_bundle_and_clears(tmp_path):
         send_mode_keys=("agent-send-mode",),
     )
     assert await runtime.process_once()
-    assert not await send_mode.encryption_required(
-        "agent-send-mode", store, None
-    )
+    # Finalize clears the bundle; no bound turn fails safe to encrypted.
+    assert await send_mode.encryption_required("agent-send-mode", store, None)
     await store.close()
 
 

--- a/tests/test_plaintext_send.py
+++ b/tests/test_plaintext_send.py
@@ -92,7 +92,15 @@ class _Store:
 
 
 @pytest.mark.asyncio
-async def test_default_is_plaintext():
+async def test_no_bound_turn_fails_safe_to_encrypted():
+    # With no turn bundle noted at all (e.g. a turn-unbound background
+    # wakeup) the trigger's confidentiality is unknown: encrypt.
+    assert await send_mode.encryption_required("a-1", _Store(), None) is True
+
+
+@pytest.mark.asyncio
+async def test_plaintext_bundle_allows_downgrade():
+    send_mode.note_turn_bundle(["a-1"], False)
     assert await send_mode.encryption_required("a-1", _Store(), None) is False
 
 
@@ -204,10 +212,12 @@ async def test_in_process_data_client_delegates_to_send_mode():
 
 
 @pytest.mark.asyncio
-async def test_clear_turn_bundle_restores_the_plaintext_default():
+async def test_clear_turn_bundle_restores_the_fail_safe_default():
     send_mode.note_turn_bundle(["a-1"], True)
     assert await send_mode.encryption_required("a-1", _Store(), None) is True
     send_mode.clear_turn_bundle(["a-1"])
-    assert await send_mode.encryption_required("a-1", _Store(), None) is False
+    # Cleared == no bound turn: back to the encrypted fail-safe, not to
+    # the plaintext downgrade.
+    assert await send_mode.encryption_required("a-1", _Store(), None) is True
     # Clearing an unset key is a no-op.
     send_mode.clear_turn_bundle(["never-set"])

--- a/tests/test_puffo_core_tools.py
+++ b/tests/test_puffo_core_tools.py
@@ -719,11 +719,27 @@ async def test_keyless_configured_rpc_failure_does_not_fall_back_to_http():
 
 
 @pytest.mark.asyncio
-async def test_send_message_plaintext_when_daemon_says_unencrypted():
+async def test_send_message_encrypts_when_daemon_says_unencrypted():
+    """Channel sends never downgrade to plaintext: even when the daemon-level
+    send-mode decision reports unencrypted (turn bundle cleared, e.g. a
+    turn-unbound background wakeup), the envelope still goes out E2EE."""
     cfg, http, ms = _setup()
+    recipient_kem = KemKeyPair.generate()
     await ms.mark_channel_space("ch_abc", "sp_test")
     http.responses["/spaces/sp_test/channels/ch_abc/members"] = {
         "members": [{"slug": "alice-0001", "role": "owner"}],
+    }
+    http.responses["/certs/sync?slugs=alice-0001"] = {
+        "entries": [{
+            "seq": 1,
+            "kind": "device_cert",
+            "slug": "alice-0001",
+            "cert": {
+                "device_id": "dev_recipient_1",
+                "kem_public_key": base64url_encode(recipient_kem.public_key_bytes()),
+            },
+        }],
+        "has_more": False,
     }
 
     async def _no_encrypt(slug, root):
@@ -731,13 +747,17 @@ async def test_send_message_plaintext_when_daemon_says_unencrypted():
 
     ms.get_send_encryption = _no_encrypt
     mcp = _build_tools(cfg)
-    with pytest.raises(RuntimeError, match="plaintext channel"):
-        await _call(
-            mcp,
-            "send_message",
-            {"channel": "ch_abc", "text": "hello world", "visibility_level": "human"},
-        )
-    assert not any(m.startswith("POST") for m, _, _ in http.calls)
+    result = await _call(
+        mcp,
+        "send_message",
+        {"channel": "ch_abc", "text": "hello world", "visibility_level": "human"},
+    )
+    assert "posted" in result
+    post_calls = [(p, b) for m, p, b in http.calls if m == "POST"]
+    assert len(post_calls) == 1
+    envelope = post_calls[0][1]["envelope"]
+    assert envelope["type"] == "message_envelope"
+    assert "content_ciphertext" in envelope
 
 
 @pytest.mark.asyncio

--- a/tests/test_send_coordinator.py
+++ b/tests/test_send_coordinator.py
@@ -973,6 +973,9 @@ async def test_legacy_dm_transports_preserve_optional_metadata(
 
 @pytest.mark.asyncio
 async def test_plaintext_channel_no_downgrade():
+    """A channel send never downgrades: even when the daemon-level send-mode
+    decision says plaintext (turn bundle cleared, e.g. a turn-unbound
+    background wakeup), the channel envelope still goes out encrypted."""
     coordinator, _, http = await coordinator_fixture()
 
     async def plaintext(_slug, _root):
@@ -982,9 +985,14 @@ async def test_plaintext_channel_no_downgrade():
     result = await coordinator.send(SemanticSendRequest(
         destination="ch_a", text="must not downgrade",
     ))
-    assert result["state"] == "failed"
-    assert result["error_kind"] == "encryption_required"
-    assert not [call for call in http.calls if call[0].startswith("POST")]
+    assert result["state"] == "sent", result
+    posts = [
+        call for call in http.calls
+        if call[0] == "POST" and call[1] == CHANNEL_SEND_PATH
+    ]
+    assert posts
+    envelope = posts[-1][2]["envelope"]
+    assert envelope["type"] != "plaintext_message_envelope"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_local_in_process_data_client.py
+++ b/tests/test_ws_local_in_process_data_client.py
@@ -212,25 +212,31 @@ async def test_one_send_encryption_policy_across_both_authoring_lanes(
     client = InProcessDataClient(store, MagicMock())
     send_mode.clear_turn_bundle(["agent-0001"])
     try:
-        # (a) The shim returns the send_mode decision, not a constant.
+        # (a) The shim returns the send_mode decision, not a constant:
+        # an explicitly plaintext bundle downgrades, an encrypted one
+        # (or no bound turn at all — the fail-safe) encrypts.
+        send_mode.note_turn_bundle(["agent-0001"], False)
         assert await client.get_send_encryption("agent-0001", None) is False
         send_mode.note_turn_bundle(["agent-0001"], True)
         assert await client.get_send_encryption("agent-0001", None) is True
         assert await send_mode.encryption_required("agent-0001", store, None) is True
+        send_mode.clear_turn_bundle(["agent-0001"])
+        assert await client.get_send_encryption("agent-0001", None) is True
 
         # (b) An encrypted trigger keeps a rootless daemon-authored DM E2EE —
         # that is the envelope dm_gate's operator prompt is built from.
-        send_mode.clear_turn_bundle(["agent-0001"])
         built: dict = {}
         _stub_dm_crypto(monkeypatch, built)
         assert await _daemon_dm_path(store, require_encryption=True) == "/messages"
         assert "plaintext" not in built
 
-        # The untriggered default is unchanged: still policy-driven.
+        # An explicitly plaintext turn is still policy-driven.
+        send_mode.note_turn_bundle(["agent-0001"], False)
         built.clear()
         assert await _daemon_dm_path(store, require_encryption=False) == (
             "/v2/messages/plaintext"
         )
+        send_mode.clear_turn_bundle(["agent-0001"])
 
         # (c) dm_gate supplies that trigger fact, so a prompt quoting a
         # decrypted stranger DM never reaches the plaintext endpoint.


### PR DESCRIPTION
## Summary

Fixes the turn-unbound send/read failures observed 2026-08-21 (agents linus-torv, boris-cher): background-task wakeups run model turns after the daemon turn has been finalized, and in that state sends and reads failed in misleading ways — including one silent plaintext downgrade.

### Changes

1. **Channel sends never consult the turn-scoped send-mode flag** (`send_coordinator._resolve_route_and_content`). Channels are always E2EE; the flag only exists to allow the plaintext DM downgrade. Previously a turn-unbound text send read the cleared flag as "plaintext", and the channel path refused it (`error_kind=encryption_required`) while the attachment path (which forces encryption) went through. The channel-is-always-E2EE invariant now lives in the resolver (`kind == "channel"`); the `require_encryption` parameter it aliased is removed.

2. **`send_mode.encryption_required` fails safe to E2EE when no turn is bound.** The flag registry is cleared at turn finalize, so "no bound turn" was indistinguishable from "explicitly plaintext bundle" — and every DM consumer (coordinator DM path, daemon-authored DMs, operator prompts from the host-MCP handler) silently sent a **plaintext envelope** for turn-unbound rootless DMs. Now only an explicitly plaintext turn bundle (or a plaintext thread root) may downgrade; an absent flag encrypts. Behavior note: an operator with no E2EE devices would previously get a plaintext DM from a turn-unbound send and will now get a loud "no recipient devices found" failure — failing closed is intentional.

3. **Turn-unbound errors tell the truth.** `send_anyway` ineligibility from `missing_active_identity`, and both Inbox/model-visible read gates, now say the operation is not bound to an admitted turn and that recovery comes with the next admitted turn, instead of pointing the model at a held-catch-up/read procedure that is itself rejected in this state.

### Not in this PR

The structural fix — making the daemon admit a turn for harness-initiated background wakeups (the adapter only reads provider stdout inside daemon-driven turns; background turn output is drained as stale) — is a design change to the turn lifecycle and adapter read model, tracked separately.

### Testing

- Full suite: 3217 passed, 1 skipped (Windows-only). `tools/check_python_structure.py` passes.
- Updated contract tests: channel no-downgrade now asserts the send goes out encrypted (both coordinator and MCP layers); send-mode decision matrix covers absent-flag fail-safe vs explicit plaintext bundle across both authoring lanes (HTTP data service + in-process shim).

Incident reference: daemon log 2026-08-20 21:57–22:16 PT — `send.failed error_category=encryption_required` (unbound:3), `held.synchronized outcome=unavailable` (unbound:4/6), `reconsideration.blocked decision_reason=missing_active_identity` (unbound:5), `read-inbox`/`model-visible-read` HTTP 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
