### PR TITLE
fix(runtime): extend the turn timeout on activity instead of a flat cap

### DIFF
--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -47,6 +47,15 @@ logger = logging.getLogger(__name__)
 # the per-request timeout is far too tight to bound its completion.
 COMPACTION_WAIT_SECONDS = 120.0
 
+# Signs of forward progress within a turn -- each one pushes the turn
+# timeout's deadline back out (see RuntimeManagerAdapter._consume_turn_events).
+_TURN_ACTIVITY_EVENTS = frozenset({
+    "turn.assistant_delta",
+    "turn.tool_started",
+    "turn.tool_updated",
+    "turn.tool_completed",
+})
+
 
 class RuntimeStateError(RuntimeError):
     """Internal state-machine contract violation, never retried automatically."""
@@ -923,8 +932,17 @@ class RuntimeManagerAdapter(Adapter):
         stream,
         turn: TurnRef,
         metadata: dict[str, Any],
+        *,
+        timeout: asyncio.Timeout | None = None,
+        idle_timeout_seconds: float | None = None,
     ) -> TurnResult | None:
-        """Drain the turn's events; None means the runtime stream ended."""
+        """Drain the turn's events; None means the runtime stream ended.
+
+        A long task that keeps producing output shouldn't die to the turn
+        timeout just because its total wall-clock crossed the ceiling --
+        only real silence should. Any sign of forward progress pushes the
+        deadline out another idle_timeout_seconds.
+        """
         async for event in stream:
             if event.turn_ref != turn:
                 continue
@@ -932,6 +950,14 @@ class RuntimeManagerAdapter(Adapter):
                 event.type.value
                 if isinstance(event.type, HarnessEventType) else event.type
             )
+            if (
+                timeout is not None
+                and idle_timeout_seconds is not None
+                and event_type in _TURN_ACTIVITY_EVENTS
+            ):
+                timeout.reschedule(
+                    asyncio.get_running_loop().time() + idle_timeout_seconds
+                )
             if event_type == "turn.assistant_delta":
                 text = event.data.get("text")
                 if isinstance(text, str):
@@ -1001,7 +1027,7 @@ class RuntimeManagerAdapter(Adapter):
         metadata: dict[str, Any],
     ) -> TurnResult:
         logger.warning(
-            "provider turn %s exceeded %.3fs timeout",
+            "provider turn %s produced nothing for %.3fs; treating as stuck",
             turn,
             timeout_seconds,
         )
@@ -1015,7 +1041,7 @@ class RuntimeManagerAdapter(Adapter):
             else f"{timeout_seconds:g} second"
         )
         return TurnResult(
-            reply=f"Task exceeded the {label} timeout.",
+            reply=f"Task produced no activity for {label} and was stopped.",
             metadata={
                 **metadata,
                 "runtime_turn_timeout": True,
@@ -1052,7 +1078,8 @@ class RuntimeManagerAdapter(Adapter):
                 metadata["turn_ref"] = str(turn)
                 await self._announce_admission(started)
                 completed = await self._consume_turn_events(
-                    ctx, stream, turn, metadata
+                    ctx, stream, turn, metadata,
+                    timeout=timeout, idle_timeout_seconds=timeout_seconds,
                 )
         except TimeoutError:
             if not timeout.expired():

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -561,7 +561,7 @@ async def test_turn_timeout_interrupts_abandons_and_retires_runtime():
     )
 
     assert result.metadata["runtime_turn_timeout"] is True
-    assert result.reply == "Task exceeded the 0.01 second timeout."
+    assert result.reply == "Task produced no activity for 0.01 second and was stopped."
     assert driver.cancel_calls == 1
     assert driver.close_calls == 1
     assert manager.active_turn_ref is None
@@ -569,6 +569,43 @@ async def test_turn_timeout_interrupts_abandons_and_retires_runtime():
     terminal = persisted[-1]
     assert str(terminal.type).endswith("TURN_ABANDONED")
     assert terminal.data["error_code"] == "turn_timeout"
+
+
+@pytest.mark.asyncio
+async def test_turn_timeout_extends_on_activity_and_never_fires():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(
+        driver,
+        RuntimeSpec("/tmp", task_timeout_seconds=0.05),
+        driver_name="claude-code",
+    )
+    running = asyncio.create_task(
+        RuntimeManagerAdapter(manager).run_turn(_context())
+    )
+    await driver.started.wait()
+
+    # Three gaps, each shorter than the timeout but summing to well over
+    # it -- would time out if activity didn't keep pushing the deadline out.
+    for _ in range(3):
+        await asyncio.sleep(0.03)
+        await driver.queue.put(HarnessEvent(
+            type="turn.tool_started",
+            driver="claude-code",
+            session_ref=SessionRef(manager.native_session_id),
+            turn_ref=driver.turn,
+            data={},
+        ))
+    await driver.queue.put(HarnessEvent(
+        type="turn.completed",
+        driver="claude-code",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        data={"outcome": "succeeded"},
+    ))
+
+    result = await asyncio.wait_for(running, timeout=2)
+    assert "runtime_turn_timeout" not in result.metadata
+    await manager.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`task_timeout_seconds` is enforced as a hard wall-clock cap on the entire turn (`RuntimeManagerAdapter.run_turn()` wraps it in `asyncio.timeout(timeout_seconds)`). Investigated after noticing agents "stop mid-task" — turned out several were being abandoned right at the ceiling while still actively working:

```
calculatio  11 hits (claude-code, stale 600s config)
old-coder    7 hits (claude-code, stale 600s config)
verity       6 hits (codex, default 1800s)
integral     5 hits (codex, default 1800s)
equation     1 hit  (claude-code, stale 600s config)
arbiter      1 hit  (codex, default 1800s)
```

(counted by `turn.processed` events whose `duration_ms` landed within 15s of exactly 600_000 or 1_800_000 — a dead giveaway of truncation, not organic completion)

Two contributing issues, this PR addresses the second:
1. The four `claude-code` agents above carry a `task_timeout_seconds: 600.0` left over from 1.2.0, where `ClaudeSession` never actually read that field — it was inert until the 2.0.0 harness rewrite started enforcing it uniformly. Fixed directly in their `agent.yml` (600 → 1800), not part of this PR.
2. Even at the correct default (1800s / 30 min), a task can legitimately need longer — `verity`/`integral` are proof, hitting the codex default repeatedly while still emitting tool calls. A flat per-turn cap can't distinguish "still working" from "actually stuck."

Turns that hit this look identical to a successful completion in the event log (`outcome: "processed"`) — the reply is just a canned "Task exceeded the timeout" string, so they don't show up in any failure-rate stat. That's the "stops mid-task" symptom: no error, no retry, just silently truncated work.

## Fix

`_consume_turn_events()` now reschedules the `asyncio.timeout()` deadline on every sign of forward progress — `turn.assistant_delta`, `turn.tool_started`, `turn.tool_updated`, `turn.tool_completed` — instead of leaving it fixed at turn start. The timeout now only fires on genuine silence (a runtime that's actually stuck, which is what it originally existed to catch), never on a task that keeps producing output for longer than `task_timeout_seconds` total.

Updated the timeout reply/log wording ("Task produced no activity for X and was stopped") to match the new semantics — it was never really a duration cap, now it accurately isn't one.

## Verification
- Full test suite + ruff: clean
- New test `test_turn_timeout_extends_on_activity_and_never_fires`: three activity gaps, each shorter than the configured timeout but summing to well over it — proves the turn completes instead of timing out
- Existing `test_turn_timeout_interrupts_abandons_and_retires_runtime` (genuine silence, no activity events) still times out and abandons correctly — the safety net is unchanged for a truly stuck runtime