### PR TITLE
feat(runtime): gate Claude inbox delivery by lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,12 +221,15 @@ failures. Provider-native diagnostics stay opaque and are not serialized.
 are rejected by the current runtime matrix.
 
 Codex accepts active-turn Inbox deltas through native `turn/steer`. Claude Code
-stream-json accepts another user frame, but even one written immediately after
-a tool result is queued as a separate Claude native turn; an arbitrary busy-time
-write can also interrupt the current request. Puffo therefore does not report
-that write as admission into the active logical turn. Its durable delta remains
-pending until the current terminal event, then starts as a separately tracked
-turn.
+exposes gated delivery only after `system/init` advertises the exact
+`msg_lifecycle_v1` protocol. Puffo then writes at most one additional stream-json
+user frame and considers it accepted only after the matching
+`command_lifecycle: queued` record. The active Puffo turn owns both native
+command UUIDs and emits one logical terminal event after every owned command is
+terminal. Without that capability, with an unknown lifecycle dialect, or when
+the queue acknowledgement is absent, the durable Inbox delta remains pending
+and is delivered by the next Puffo turn. Capability is read live because Claude
+does not publish it until the first input has started the native session.
 
 ## 6. Durable State
 

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -219,7 +219,7 @@ class GlobalInboxRuntime(InboxAdmissionMixin):
         self.formatter = self._format_for_provider
         capability = getattr(adapter, "inbox_notice_delivery_capability", None)
         self.notice_delivery = notice_delivery or InboxNoticeDelivery(
-            capability() if callable(capability) else NoticeDeliveryCapability.NEXT_TURN
+            capability if callable(capability) else NoticeDeliveryCapability.NEXT_TURN
         )
         self._busy_notice_task: asyncio.Task[None] | None = None
         self._busy_notice_dirty = False

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -23,6 +23,7 @@ from .driver import (
     Driver,
     HarnessEvent,
     HarnessEventType,
+    InputReceipt,
     PermissionDecision,
     PermissionRef,
     ProtocolDiagnostics,
@@ -46,13 +47,22 @@ class _ContextUsageUnsupported(RuntimeError):
 
 
 _CONTEXT_USAGE_TIMEOUT_SECONDS = 2.0
+_MESSAGE_LIFECYCLE_V1 = "msg_lifecycle_v1"
+_COMMAND_TERMINAL_STATES = frozenset({"completed", "cancelled", "canceled"})
 
 
-def claude_capabilities(compact_advertised: bool = False) -> DriverCapabilities:
+def claude_capabilities(
+    compact_advertised: bool = False,
+    message_lifecycle_v1: bool = False,
+) -> DriverCapabilities:
     return DriverCapabilities(
         session_resume=True,
         inflight_turn_recovery=False,
-        steer=SteerCapability.NONE,
+        steer=(
+            SteerCapability.GATED
+            if message_lifecycle_v1
+            else SteerCapability.NONE
+        ),
         cancel=CancelCapability.NONE,
         context_status=ContextStatusCapability.PULL,
         compact=(
@@ -65,9 +75,9 @@ def claude_capabilities(compact_advertised: bool = False) -> DriverCapabilities:
 
 
 class ClaudeCodeCliDriver(Driver):
-    # A second stream-json user frame is queued as another Claude native Turn.
-    # It is not an admission into the active Puffo Turn, even when written just
-    # after a tool result, so the scheduler must deliver it through next-turn.
+    # Before system/init, no native lifecycle contract has been established.
+    # current_capabilities() upgrades this to GATED only for the known v1
+    # protocol and steer_turn() confirms every write with its queued receipt.
     static_steer_capability = SteerCapability.NONE
 
     def __init__(
@@ -79,7 +89,9 @@ class ClaudeCodeCliDriver(Driver):
     ):
         self.process_factory = process_factory
         self.executable_version = executable_version
-        self.replay_timeout = replay_timeout
+        # Keep the established constructor parameter while using it for the
+        # only bounded input acknowledgement the current protocol requires.
+        self._input_ack_timeout = replay_timeout
         self._proc: Any = None
         self._reader: asyncio.Task | None = None
         self._stderr_reader: asyncio.Task | None = None
@@ -98,6 +110,17 @@ class ClaudeCodeCliDriver(Driver):
         self._active_native_turn_id = ""
         self._closed = False
         self._compact_advertised = False
+        self._message_lifecycle_v1 = False
+        self._owned_commands: set[str] = set()
+        self._terminal_commands: set[str] = set()
+        self._gated_command_id = ""
+        self._gated_ack: asyncio.Future[InputReceipt] | None = None
+        self._result_input_tokens = 0
+        self._result_output_tokens = 0
+        self._result_context_tokens = 0
+        self._result_failed = False
+        self._result_error_code = ""
+        self._last_result_payload: dict[str, Any] | None = None
         self._output_block_counter = 0
         self._tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
         self._context_request_counter = 0
@@ -106,7 +129,10 @@ class ClaudeCodeCliDriver(Driver):
         self._context = ContextStatus(stale=True)
 
     def current_capabilities(self) -> DriverCapabilities:
-        return claude_capabilities(self._compact_advertised)
+        return claude_capabilities(
+            self._compact_advertised,
+            self._message_lifecycle_v1,
+        )
 
     async def open(
         self, spec: RuntimeSpec, resume: SessionRef | None = None
@@ -197,6 +223,7 @@ class ClaudeCodeCliDriver(Driver):
         local = TurnRef(f"turn_{uuid.uuid4().hex}")
         replay_uuid = input.client_correlation_id or str(uuid.uuid4())
         self._active = local
+        self._reset_turn_tracking(replay_uuid)
         self._pending_content = _normalize_content(input.content)
         self._pending_uuid = replay_uuid
         self._active_native_turn_id = replay_uuid
@@ -221,6 +248,7 @@ class ClaudeCodeCliDriver(Driver):
             self._active = TurnRef("")
             self._active_native_turn_id = ""
             self._clear_pending_replay()
+            self._reset_turn_tracking()
             raise
         return TurnStarted(
             local,
@@ -230,7 +258,66 @@ class ClaudeCodeCliDriver(Driver):
         )
 
     async def steer_turn(self, turn: TurnRef, input: TurnInput):
-        return UnsupportedCapability("steer")
+        if self.current_capabilities().steer is not SteerCapability.GATED:
+            return UnsupportedCapability("steer")
+        if not self._active.value or turn != self._active:
+            raise RuntimeError("stale or foreign turn reference")
+        if self._gated_command_id:
+            return InputReceipt(
+                False,
+                turn,
+                input.client_correlation_id,
+                "gated_input_already_owned",
+            )
+
+        command_id = input.client_correlation_id or str(uuid.uuid4())
+        if command_id in self._owned_commands:
+            return InputReceipt(
+                False,
+                turn,
+                input.client_correlation_id,
+                "duplicate_command_id",
+            )
+        ack = asyncio.get_running_loop().create_future()
+        self._gated_command_id = command_id
+        self._gated_ack = ack
+        # Own the command before writing so a concurrent result cannot close
+        # the logical Puffo turn and orphan an accepted native command.
+        self._owned_commands.add(command_id)
+        frame = {
+            "type": "user",
+            "session_id": self._native_session_id,
+            "parent_tool_use_id": None,
+            "uuid": command_id,
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": input.content}],
+            },
+        }
+        try:
+            await self._write(frame)
+            return await asyncio.wait_for(
+                asyncio.shield(ack),
+                timeout=self._input_ack_timeout,
+            )
+        except asyncio.TimeoutError:
+            if self._gated_ack is ack:
+                self._drop_unacknowledged_gated_command(command_id)
+                await self._maybe_complete_lifecycle_turn(frame)
+            return InputReceipt(
+                False,
+                turn,
+                input.client_correlation_id,
+                "queue_ack_timeout",
+            )
+        except BaseException:
+            if self._gated_ack is ack:
+                self._drop_unacknowledged_gated_command(command_id)
+                await self._maybe_complete_lifecycle_turn(frame)
+            raise
+        finally:
+            if self._gated_ack is ack and ack.done():
+                self._gated_ack = None
 
     async def cancel_turn(self, turn: TurnRef):
         return UnsupportedCapability("cancel")
@@ -362,6 +449,7 @@ class ClaudeCodeCliDriver(Driver):
         self._active_native_turn_id = ""
         self._pending_content = ""
         self._pending_uuid = ""
+        self._reset_turn_tracking()
         self._tool_calls.clear()
         await self._events.put(None)
 
@@ -377,6 +465,8 @@ class ClaudeCodeCliDriver(Driver):
         self._active_native_turn_id = ""
         self._tool_calls.clear()
         self._compact_advertised = False
+        self._message_lifecycle_v1 = False
+        self._reset_turn_tracking()
         self._resumed = False
         self._init_commands = ()
         self._context_usage_supported = None
@@ -394,11 +484,13 @@ class ClaudeCodeCliDriver(Driver):
     def _fail_pending_futures(self, message: str) -> None:
         for future in (
             self._init,
+            self._gated_ack,
             *self._context_requests.values(),
         ):
             if future is not None and not future.done():
                 future.set_exception(RuntimeError(message))
         self._init = None
+        self._gated_ack = None
         self._clear_pending_replay()
         self._context_requests.clear()
 
@@ -409,6 +501,30 @@ class ClaudeCodeCliDriver(Driver):
         self._pending_replay = None
         self._pending_content = ""
         self._pending_uuid = ""
+
+    def _reset_turn_tracking(self, primary_command_id: str = "") -> None:
+        pending = self._gated_ack
+        if pending is not None and not pending.done():
+            pending.cancel()
+        self._gated_ack = None
+        self._gated_command_id = ""
+        self._owned_commands = {primary_command_id} if primary_command_id else set()
+        self._terminal_commands.clear()
+        self._result_input_tokens = 0
+        self._result_output_tokens = 0
+        self._result_context_tokens = 0
+        self._result_failed = False
+        self._result_error_code = ""
+        self._last_result_payload = None
+
+    def _drop_unacknowledged_gated_command(self, command_id: str) -> None:
+        pending = self._gated_ack
+        if pending is not None and not pending.done():
+            pending.cancel()
+        self._owned_commands.discard(command_id)
+        self._terminal_commands.discard(command_id)
+        self._gated_command_id = ""
+        self._gated_ack = None
 
     async def _write(self, frame: dict[str, Any]) -> None:
         encoded = (
@@ -436,6 +552,10 @@ class ClaudeCodeCliDriver(Driver):
                 await self._handle(frame)
         finally:
             self._clear_pending_replay()
+            pending = self._gated_ack
+            if pending is not None and not pending.done():
+                pending.set_exception(RuntimeError("Claude exited before input ack"))
+            self._gated_ack = None
             if self._init is not None and not self._init.done():
                 self._init.set_exception(RuntimeError("Claude exited before init"))
             if not self._closed:
@@ -469,6 +589,9 @@ class ClaudeCodeCliDriver(Driver):
         subtype = str(frame.get("subtype") or "")
         if type_ == "control_response":
             self._handle_control_response(frame)
+            return
+        if type_ == "command_lifecycle":
+            await self._handle_command_lifecycle(frame)
             return
         if type_ == "system" and subtype == "init":
             await self._complete_init(frame)
@@ -539,6 +662,18 @@ class ClaudeCodeCliDriver(Driver):
         self._session_ref = SessionRef(native)
         commands = frame.get("slash_commands") or ()
         self._init_commands = tuple(str(value) for value in commands)
+        capabilities = tuple(str(value) for value in frame.get("capabilities") or ())
+        self._message_lifecycle_v1 = _MESSAGE_LIFECYCLE_V1 in capabilities
+        unknown_lifecycle = tuple(
+            value
+            for value in capabilities
+            if value.startswith("msg_lifecycle_") and value != _MESSAGE_LIFECYCLE_V1
+        )
+        if unknown_lifecycle:
+            logger.warning(
+                "Claude advertised unsupported message lifecycle capabilities: %s",
+                ", ".join(unknown_lifecycle),
+            )
         self._compact_advertised = self._compact_advertised or (
             "/compact" in self._init_commands or "compact" in self._init_commands
         )
@@ -549,6 +684,34 @@ class ClaudeCodeCliDriver(Driver):
             else HarnessEventType.SESSION_OPENED,
             native_payload=frame,
         )
+
+    async def _handle_command_lifecycle(self, frame: dict[str, Any]) -> None:
+        command_id = str(frame.get("command_uuid") or "")
+        state = str(frame.get("state") or "")
+        if not command_id or command_id not in self._owned_commands:
+            await self._emit(
+                HarnessEventType.SESSION_UPDATED,
+                data={"record_type": "command_lifecycle"},
+                native_payload=frame,
+            )
+            return
+        if state == "queued" and command_id == self._gated_command_id:
+            pending = self._gated_ack
+            if pending is not None and not pending.done():
+                pending.set_result(
+                    InputReceipt(
+                        True,
+                        self._active,
+                        command_id,
+                        "queued_native_command",
+                    )
+                )
+        if state in _COMMAND_TERMINAL_STATES:
+            self._terminal_commands.add(command_id)
+            if state != "completed":
+                self._result_failed = True
+                self._result_error_code = f"command_{state}"
+            await self._maybe_complete_lifecycle_turn(frame)
 
     async def _complete_replay(self, frame: dict[str, Any]) -> None:
         pending = self._pending_replay
@@ -666,27 +829,54 @@ class ClaudeCodeCliDriver(Driver):
                 native_payload=frame,
             )
             return
+        self._record_result(frame, subtype)
+        if self._message_lifecycle_v1:
+            await self._maybe_complete_lifecycle_turn(frame)
+            return
+        await self._finish_turn(frame)
+
+    def _record_result(self, frame: dict[str, Any], subtype: str) -> None:
         usage = frame.get("usage") or {}
         input_tokens = int(usage.get("input_tokens") or 0) + int(
             usage.get("cache_creation_input_tokens") or 0
         )
-        context_tokens = input_tokens + int(
+        self._result_input_tokens += input_tokens
+        self._result_output_tokens += int(usage.get("output_tokens") or 0)
+        self._result_context_tokens = input_tokens + int(
             usage.get("cache_read_input_tokens") or 0
         )
-        outcome = "failed" if subtype not in {"success", ""} else "succeeded"
+        self._last_result_payload = frame
+        if subtype not in {"success", ""}:
+            self._result_failed = True
+            if not self._result_error_code:
+                self._result_error_code = _result_error_code(frame, subtype)
+
+    async def _maybe_complete_lifecycle_turn(
+        self, native_payload: dict[str, Any]
+    ) -> None:
+        if (
+            not self._active.value
+            or not self._owned_commands
+            or not self._owned_commands.issubset(self._terminal_commands)
+        ):
+            return
+        await self._finish_turn(self._last_result_payload or native_payload)
+
+    async def _finish_turn(self, native_payload: dict[str, Any]) -> None:
+        outcome = "failed" if self._result_failed else "succeeded"
         data: dict[str, Any] = {
             "outcome": outcome,
-            "input_tokens": input_tokens,
-            "output_tokens": int(usage.get("output_tokens") or 0),
-            "context_tokens": context_tokens,
+            "input_tokens": self._result_input_tokens,
+            "output_tokens": self._result_output_tokens,
+            "context_tokens": self._result_context_tokens,
         }
         if outcome == "failed":
-            data["error_code"] = _result_error_code(frame, subtype)
+            data["error_code"] = self._result_error_code or "provider_error"
         await self._emit(
             HarnessEventType.TURN_COMPLETED,
             turn_ref=self._active,
             data=data,
-            native_payload=frame,
+            native_payload=native_payload,
         )
         self._clear_pending_replay()
         self._active, self._active_native_turn_id = TurnRef(""), ""
@@ -694,6 +884,7 @@ class ClaudeCodeCliDriver(Driver):
         # its name and arguments alive until close, so a later turn reusing the
         # id would report the stale call.
         self._tool_calls.clear()
+        self._reset_turn_tracking()
 
     def _is_exact_replay(self, frame: dict[str, Any]) -> bool:
         if self._pending_replay is None or self._pending_replay.done():

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -9,6 +9,7 @@ import os
 import uuid
 from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any
 
 from ..cli_bin import normalize_launch_argv
@@ -44,6 +45,12 @@ logger = logging.getLogger(__name__)
 
 class _ContextUsageUnsupported(RuntimeError):
     pass
+
+
+class _InputAckOutcome(str, Enum):
+    QUEUED = "queued"
+    REJECTED = "rejected"
+    AMBIGUOUS = "ambiguous"
 
 
 _CONTEXT_USAGE_TIMEOUT_SECONDS = 2.0
@@ -114,7 +121,7 @@ class ClaudeCodeCliDriver(Driver):
         self._owned_commands: set[str] = set()
         self._terminal_commands: set[str] = set()
         self._gated_command_id = ""
-        self._gated_ack: asyncio.Future[bool] | None = None
+        self._gated_ack: asyncio.Future[_InputAckOutcome] | None = None
         self._result_input_tokens = 0
         self._result_output_tokens = 0
         self._result_context_tokens = 0
@@ -308,21 +315,27 @@ class ClaudeCodeCliDriver(Driver):
                 session_reusable,
             )
 
+        def receipt_for(outcome: _InputAckOutcome) -> InputReceipt:
+            if outcome is _InputAckOutcome.QUEUED:
+                return receipt(True, "queued_native_command")
+            if outcome is _InputAckOutcome.REJECTED:
+                return receipt(False, "native_command_rejected")
+            return receipt(
+                False,
+                "queue_ack_ambiguous",
+                session_reusable=False,
+            )
+
         try:
             await self._write(frame)
-            accepted = await asyncio.wait_for(
+            outcome = await asyncio.wait_for(
                 asyncio.shield(ack),
                 timeout=self._input_ack_timeout,
             )
-            return receipt(
-                accepted,
-                "queued_native_command"
-                if accepted
-                else "turn_terminal_before_queue_ack",
-            )
+            return receipt_for(outcome)
         except asyncio.TimeoutError:
-            if ack.done() and not ack.cancelled() and ack.result():
-                return receipt(True, "queued_native_command")
+            if ack.done() and not ack.cancelled():
+                return receipt_for(ack.result())
             if self._gated_ack is ack:
                 self._drop_unacknowledged_gated_command(command_id)
                 await self._maybe_complete_lifecycle_turn(frame)
@@ -331,10 +344,6 @@ class ClaudeCodeCliDriver(Driver):
                 "queue_ack_timeout",
                 session_reusable=False,
             )
-        except asyncio.CancelledError:
-            # The write may already have crossed the process boundary. Keep
-            # ownership until lifecycle or process teardown settles it.
-            raise
         except Exception:
             if self._gated_ack is ack:
                 self._drop_unacknowledged_gated_command(command_id)
@@ -509,7 +518,7 @@ class ClaudeCodeCliDriver(Driver):
             if future is not None and not future.done():
                 future.set_exception(RuntimeError(message))
         self._init = None
-        self._settle_gated_ack(False)
+        self._settle_gated_ack(_InputAckOutcome.AMBIGUOUS)
         self._clear_pending_replay()
         self._context_requests.clear()
 
@@ -522,7 +531,7 @@ class ClaudeCodeCliDriver(Driver):
         self._pending_uuid = ""
 
     def _reset_turn_tracking(self, primary_command_id: str = "") -> None:
-        self._settle_gated_ack(False)
+        self._settle_gated_ack(_InputAckOutcome.REJECTED)
         self._gated_command_id = ""
         self._owned_commands = {primary_command_id} if primary_command_id else set()
         self._terminal_commands.clear()
@@ -532,13 +541,13 @@ class ClaudeCodeCliDriver(Driver):
         self._result_error_code = ""
         self._last_result_payload = None
 
-    def _settle_gated_ack(self, accepted: bool) -> None:
+    def _settle_gated_ack(self, outcome: _InputAckOutcome) -> None:
         pending, self._gated_ack = self._gated_ack, None
         if pending is not None and not pending.done():
-            pending.set_result(accepted)
+            pending.set_result(outcome)
 
     def _drop_unacknowledged_gated_command(self, command_id: str) -> None:
-        self._settle_gated_ack(False)
+        self._settle_gated_ack(_InputAckOutcome.REJECTED)
         self._owned_commands.discard(command_id)
         self._terminal_commands.discard(command_id)
         self._gated_command_id = ""
@@ -601,8 +610,10 @@ class ClaudeCodeCliDriver(Driver):
         if type_ == "control_response":
             self._handle_control_response(frame)
             return
-        if type_ == "command_lifecycle" and await self._handle_command_lifecycle(
-            frame
+        if (
+            type_ == "command_lifecycle"
+            and self._message_lifecycle_v1
+            and await self._handle_command_lifecycle(frame)
         ):
             return
         if type_ == "system" and subtype == "init":
@@ -705,6 +716,8 @@ class ClaudeCodeCliDriver(Driver):
         if not command_id or command_id not in self._owned_commands:
             return False
         if state not in _COMMAND_LIFECYCLE_STATES:
+            if command_id == self._gated_command_id and self._gated_ack is not None:
+                self._settle_gated_ack(_InputAckOutcome.AMBIGUOUS)
             self._terminal_commands.add(command_id)
             if not self._result_error_code:
                 self._result_error_code = "command_lifecycle_protocol"
@@ -717,8 +730,12 @@ class ClaudeCodeCliDriver(Driver):
             await self._maybe_complete_lifecycle_turn(frame)
             return True
         if state == "queued" and command_id == self._gated_command_id:
-            self._settle_gated_ack(True)
+            self._settle_gated_ack(_InputAckOutcome.QUEUED)
         if state in _COMMAND_TERMINAL_STATES:
+            if command_id == self._gated_command_id and self._gated_ack is not None:
+                self._drop_unacknowledged_gated_command(command_id)
+                await self._maybe_complete_lifecycle_turn(frame)
+                return True
             self._terminal_commands.add(command_id)
             if state != "completed" and not self._result_error_code:
                 self._result_error_code = f"command_{state}"

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -47,8 +47,10 @@ class _ContextUsageUnsupported(RuntimeError):
 
 
 _CONTEXT_USAGE_TIMEOUT_SECONDS = 2.0
+_INPUT_ACK_TIMEOUT_SECONDS = 2.0
 _MESSAGE_LIFECYCLE_V1 = "msg_lifecycle_v1"
-_COMMAND_TERMINAL_STATES = frozenset({"completed", "cancelled", "canceled"})
+_COMMAND_TERMINAL_STATES = frozenset({"completed", "cancelled", "discarded"})
+_COMMAND_LIFECYCLE_STATES = _COMMAND_TERMINAL_STATES | {"queued", "started"}
 
 
 def claude_capabilities(
@@ -85,13 +87,11 @@ class ClaudeCodeCliDriver(Driver):
         process_factory: Callable[..., Any] | None = None,
         *,
         executable_version: str = "",
-        replay_timeout: float = 30,
+        input_ack_timeout: float = _INPUT_ACK_TIMEOUT_SECONDS,
     ):
         self.process_factory = process_factory
         self.executable_version = executable_version
-        # Keep the established constructor parameter while using it for the
-        # only bounded input acknowledgement the current protocol requires.
-        self._input_ack_timeout = replay_timeout
+        self._input_ack_timeout = input_ack_timeout
         self._proc: Any = None
         self._reader: asyncio.Task | None = None
         self._stderr_reader: asyncio.Task | None = None
@@ -114,11 +114,10 @@ class ClaudeCodeCliDriver(Driver):
         self._owned_commands: set[str] = set()
         self._terminal_commands: set[str] = set()
         self._gated_command_id = ""
-        self._gated_ack: asyncio.Future[InputReceipt] | None = None
+        self._gated_ack: asyncio.Future[bool] | None = None
         self._result_input_tokens = 0
         self._result_output_tokens = 0
         self._result_context_tokens = 0
-        self._result_failed = False
         self._result_error_code = ""
         self._last_result_payload: dict[str, Any] | None = None
         self._output_block_counter = 0
@@ -209,7 +208,7 @@ class ClaudeCodeCliDriver(Driver):
             self._session_ref,
             self._native_session_id,
             self._resumed,
-            claude_capabilities(self._compact_advertised),
+            self.current_capabilities(),
             ProtocolDiagnostics(
                 executable_version=self.executable_version,
                 schema_source="documented",
@@ -294,30 +293,43 @@ class ClaudeCodeCliDriver(Driver):
                 "content": [{"type": "text", "text": input.content}],
             },
         }
+
+        def receipt(accepted: bool, delivery: str) -> InputReceipt:
+            return InputReceipt(
+                accepted,
+                turn,
+                input.client_correlation_id,
+                delivery,
+            )
+
         try:
             await self._write(frame)
-            return await asyncio.wait_for(
+            accepted = await asyncio.wait_for(
                 asyncio.shield(ack),
                 timeout=self._input_ack_timeout,
             )
+            return receipt(
+                accepted,
+                "queued_native_command"
+                if accepted
+                else "turn_terminal_before_queue_ack",
+            )
         except asyncio.TimeoutError:
+            if ack.done() and not ack.cancelled() and ack.result():
+                return receipt(True, "queued_native_command")
             if self._gated_ack is ack:
                 self._drop_unacknowledged_gated_command(command_id)
                 await self._maybe_complete_lifecycle_turn(frame)
-            return InputReceipt(
-                False,
-                turn,
-                input.client_correlation_id,
-                "queue_ack_timeout",
-            )
-        except BaseException:
+            return receipt(False, "queue_ack_timeout")
+        except asyncio.CancelledError:
+            # The write may already have crossed the process boundary. Keep
+            # ownership until lifecycle or process teardown settles it.
+            raise
+        except Exception:
             if self._gated_ack is ack:
                 self._drop_unacknowledged_gated_command(command_id)
                 await self._maybe_complete_lifecycle_turn(frame)
             raise
-        finally:
-            if self._gated_ack is ack and ack.done():
-                self._gated_ack = None
 
     async def cancel_turn(self, turn: TurnRef):
         return UnsupportedCapability("cancel")
@@ -447,8 +459,7 @@ class ClaudeCodeCliDriver(Driver):
         self._fail_pending_futures("Claude Code CLI closed")
         self._active = TurnRef("")
         self._active_native_turn_id = ""
-        self._pending_content = ""
-        self._pending_uuid = ""
+        self._message_lifecycle_v1 = False
         self._reset_turn_tracking()
         self._tool_calls.clear()
         await self._events.put(None)
@@ -466,7 +477,6 @@ class ClaudeCodeCliDriver(Driver):
         self._tool_calls.clear()
         self._compact_advertised = False
         self._message_lifecycle_v1 = False
-        self._reset_turn_tracking()
         self._resumed = False
         self._init_commands = ()
         self._context_usage_supported = None
@@ -484,13 +494,12 @@ class ClaudeCodeCliDriver(Driver):
     def _fail_pending_futures(self, message: str) -> None:
         for future in (
             self._init,
-            self._gated_ack,
             *self._context_requests.values(),
         ):
             if future is not None and not future.done():
                 future.set_exception(RuntimeError(message))
         self._init = None
-        self._gated_ack = None
+        self._settle_gated_ack(False)
         self._clear_pending_replay()
         self._context_requests.clear()
 
@@ -503,28 +512,26 @@ class ClaudeCodeCliDriver(Driver):
         self._pending_uuid = ""
 
     def _reset_turn_tracking(self, primary_command_id: str = "") -> None:
-        pending = self._gated_ack
-        if pending is not None and not pending.done():
-            pending.cancel()
-        self._gated_ack = None
+        self._settle_gated_ack(False)
         self._gated_command_id = ""
         self._owned_commands = {primary_command_id} if primary_command_id else set()
         self._terminal_commands.clear()
         self._result_input_tokens = 0
         self._result_output_tokens = 0
         self._result_context_tokens = 0
-        self._result_failed = False
         self._result_error_code = ""
         self._last_result_payload = None
 
-    def _drop_unacknowledged_gated_command(self, command_id: str) -> None:
-        pending = self._gated_ack
+    def _settle_gated_ack(self, accepted: bool) -> None:
+        pending, self._gated_ack = self._gated_ack, None
         if pending is not None and not pending.done():
-            pending.cancel()
+            pending.set_result(accepted)
+
+    def _drop_unacknowledged_gated_command(self, command_id: str) -> None:
+        self._settle_gated_ack(False)
         self._owned_commands.discard(command_id)
         self._terminal_commands.discard(command_id)
         self._gated_command_id = ""
-        self._gated_ack = None
 
     async def _write(self, frame: dict[str, Any]) -> None:
         encoded = (
@@ -551,13 +558,7 @@ class ClaudeCodeCliDriver(Driver):
                     continue
                 await self._handle(frame)
         finally:
-            self._clear_pending_replay()
-            pending = self._gated_ack
-            if pending is not None and not pending.done():
-                pending.set_exception(RuntimeError("Claude exited before input ack"))
-            self._gated_ack = None
-            if self._init is not None and not self._init.done():
-                self._init.set_exception(RuntimeError("Claude exited before init"))
+            self._fail_pending_futures("Claude Code CLI exited")
             if not self._closed:
                 await self._log_unexpected_exit()
                 await self._emit(
@@ -590,8 +591,9 @@ class ClaudeCodeCliDriver(Driver):
         if type_ == "control_response":
             self._handle_control_response(frame)
             return
-        if type_ == "command_lifecycle":
-            await self._handle_command_lifecycle(frame)
+        if type_ == "command_lifecycle" and await self._handle_command_lifecycle(
+            frame
+        ):
             return
         if type_ == "system" and subtype == "init":
             await self._complete_init(frame)
@@ -685,33 +687,31 @@ class ClaudeCodeCliDriver(Driver):
             native_payload=frame,
         )
 
-    async def _handle_command_lifecycle(self, frame: dict[str, Any]) -> None:
+    async def _handle_command_lifecycle(self, frame: dict[str, Any]) -> bool:
         command_id = str(frame.get("command_uuid") or "")
         state = str(frame.get("state") or "")
         if not command_id or command_id not in self._owned_commands:
+            return False
+        if state not in _COMMAND_LIFECYCLE_STATES:
+            self._terminal_commands.add(command_id)
+            if not self._result_error_code:
+                self._result_error_code = "command_lifecycle_protocol"
             await self._emit(
-                HarnessEventType.SESSION_UPDATED,
-                data={"record_type": "command_lifecycle"},
+                HarnessEventType.RUNTIME_WARNING,
+                turn_ref=self._active,
+                data={"code": "unknown_command_lifecycle_state", "state": state},
                 native_payload=frame,
             )
-            return
+            await self._maybe_complete_lifecycle_turn(frame)
+            return True
         if state == "queued" and command_id == self._gated_command_id:
-            pending = self._gated_ack
-            if pending is not None and not pending.done():
-                pending.set_result(
-                    InputReceipt(
-                        True,
-                        self._active,
-                        command_id,
-                        "queued_native_command",
-                    )
-                )
+            self._settle_gated_ack(True)
         if state in _COMMAND_TERMINAL_STATES:
             self._terminal_commands.add(command_id)
-            if state != "completed":
-                self._result_failed = True
+            if state != "completed" and not self._result_error_code:
                 self._result_error_code = f"command_{state}"
             await self._maybe_complete_lifecycle_turn(frame)
+        return True
 
     async def _complete_replay(self, frame: dict[str, Any]) -> None:
         pending = self._pending_replay
@@ -829,10 +829,20 @@ class ClaudeCodeCliDriver(Driver):
                 native_payload=frame,
             )
             return
-        self._record_result(frame, subtype)
         if self._message_lifecycle_v1:
-            await self._maybe_complete_lifecycle_turn(frame)
+            command_id = str(frame.get("user_message_uuid") or "")
+            if command_id not in self._owned_commands:
+                await self._emit(
+                    HarnessEventType.SESSION_UPDATED,
+                    data={"record_type": "result"},
+                    native_payload=frame,
+                )
+                return
+            # Lifecycle v1 emits each result before its terminal record; the
+            # terminal record remains the sole turn-completion authority.
+            self._record_result(frame, subtype)
             return
+        self._record_result(frame, subtype)
         await self._finish_turn(frame)
 
     def _record_result(self, frame: dict[str, Any], subtype: str) -> None:
@@ -847,7 +857,6 @@ class ClaudeCodeCliDriver(Driver):
         )
         self._last_result_payload = frame
         if subtype not in {"success", ""}:
-            self._result_failed = True
             if not self._result_error_code:
                 self._result_error_code = _result_error_code(frame, subtype)
 
@@ -856,14 +865,13 @@ class ClaudeCodeCliDriver(Driver):
     ) -> None:
         if (
             not self._active.value
-            or not self._owned_commands
             or not self._owned_commands.issubset(self._terminal_commands)
         ):
             return
         await self._finish_turn(self._last_result_payload or native_payload)
 
     async def _finish_turn(self, native_payload: dict[str, Any]) -> None:
-        outcome = "failed" if self._result_failed else "succeeded"
+        outcome = "failed" if self._result_error_code else "succeeded"
         data: dict[str, Any] = {
             "outcome": outcome,
             "input_tokens": self._result_input_tokens,
@@ -871,7 +879,7 @@ class ClaudeCodeCliDriver(Driver):
             "context_tokens": self._result_context_tokens,
         }
         if outcome == "failed":
-            data["error_code"] = self._result_error_code or "provider_error"
+            data["error_code"] = self._result_error_code
         await self._emit(
             HarnessEventType.TURN_COMPLETED,
             turn_ref=self._active,

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -294,12 +294,18 @@ class ClaudeCodeCliDriver(Driver):
             },
         }
 
-        def receipt(accepted: bool, delivery: str) -> InputReceipt:
+        def receipt(
+            accepted: bool,
+            delivery: str,
+            *,
+            session_reusable: bool = True,
+        ) -> InputReceipt:
             return InputReceipt(
                 accepted,
                 turn,
                 input.client_correlation_id,
                 delivery,
+                session_reusable,
             )
 
         try:
@@ -320,7 +326,11 @@ class ClaudeCodeCliDriver(Driver):
             if self._gated_ack is ack:
                 self._drop_unacknowledged_gated_command(command_id)
                 await self._maybe_complete_lifecycle_turn(frame)
-            return receipt(False, "queue_ack_timeout")
+            return receipt(
+                False,
+                "queue_ack_timeout",
+                session_reusable=False,
+            )
         except asyncio.CancelledError:
             # The write may already have crossed the process boundary. Keep
             # ownership until lifecycle or process teardown settles it.
@@ -665,11 +675,13 @@ class ClaudeCodeCliDriver(Driver):
         commands = frame.get("slash_commands") or ()
         self._init_commands = tuple(str(value) for value in commands)
         capabilities = tuple(str(value) for value in frame.get("capabilities") or ())
-        self._message_lifecycle_v1 = _MESSAGE_LIFECYCLE_V1 in capabilities
         unknown_lifecycle = tuple(
             value
             for value in capabilities
             if value.startswith("msg_lifecycle_") and value != _MESSAGE_LIFECYCLE_V1
+        )
+        self._message_lifecycle_v1 = (
+            _MESSAGE_LIFECYCLE_V1 in capabilities and not unknown_lifecycle
         )
         if unknown_lifecycle:
             logger.warning(

--- a/src/puffo_agent/agent/harness/driver.py
+++ b/src/puffo_agent/agent/harness/driver.py
@@ -149,6 +149,7 @@ class InputReceipt:
     turn_ref: TurnRef
     correlation_id: str = ""
     delivery: str = "accepted"
+    session_reusable: bool = True
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -299,6 +299,24 @@ class RuntimeManager:
             )
             if isinstance(receipt, UnsupportedCapability):
                 return receipt
+            if not receipt.accepted and not receipt.session_reusable:
+                event = HarnessEvent(
+                    type=HarnessEventType.TURN_ABANDONED,
+                    driver=self.driver_name,
+                    session_ref=self.session_ref,
+                    turn_ref=turn,
+                    native_session_id=self.native_session_id,
+                    native_turn_id=self.native_turn_id,
+                    data={
+                        "outcome": "abandoned",
+                        "error_code": "input_admission_ambiguous",
+                        "retryable": True,
+                    },
+                )
+                try:
+                    await self._publish_terminal_locked(event, turn)
+                finally:
+                    await self._retire_runtime_locked(preserve_session=False)
             return replace(receipt, turn_ref=turn)
 
     async def cancel_turn(self, turn: TurnRef) -> Any:

--- a/src/puffo_agent/agent/inbox_scheduler.py
+++ b/src/puffo_agent/agent/inbox_scheduler.py
@@ -32,9 +32,18 @@ class InboxNoticeDelivery:
 
     def __init__(
         self,
-        capability: NoticeDeliveryCapability | str = NoticeDeliveryCapability.NEXT_TURN,
+        capability: (
+            NoticeDeliveryCapability
+            | str
+            | Callable[[], NoticeDeliveryCapability | str]
+        ) = NoticeDeliveryCapability.NEXT_TURN,
     ) -> None:
-        self.capability = NoticeDeliveryCapability(capability)
+        self._capability = capability
+
+    @property
+    def capability(self) -> NoticeDeliveryCapability:
+        value = self._capability() if callable(self._capability) else self._capability
+        return NoticeDeliveryCapability(value)
 
     async def offer(
         self,

--- a/tests/test_claude_gated_lifecycle.py
+++ b/tests/test_claude_gated_lifecycle.py
@@ -120,7 +120,7 @@ def test_claude_lifecycle_capability_is_explicit():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "delivery_shape",
-    ["folded", "separate", "cancelled", "discarded", "unknown"],
+    ["folded", "separate", "discarded", "unknown"],
 )
 async def test_gated_commands_share_one_logical_turn(delivery_shape):
     proc, driver, stream, started = await _open_driver()
@@ -143,7 +143,7 @@ async def test_gated_commands_share_one_logical_turn(delivery_shape):
         _lifecycle(proc, "gated", "completed")
         expected = (30, 3, 20)
         expected_error = ""
-    elif delivery_shape in {"cancelled", "discarded"}:
+    elif delivery_shape == "discarded":
         _result(proc, "primary", 10, 1)
         _lifecycle(proc, "primary", "completed")
         _lifecycle(proc, "gated", delivery_shape)
@@ -176,6 +176,44 @@ async def test_gated_command_without_queue_ack_is_not_accepted():
     _lifecycle(proc, "primary", "completed")
     completed = await _next(stream, "turn.completed")
     assert completed.data["input_tokens"] == 0
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_process_exit_makes_pending_input_admission_ambiguous():
+    proc, driver, _stream, started = await _open_driver()
+    pending = asyncio.create_task(driver.steer_turn(
+        started.turn_ref,
+        TurnInput("new inbox", client_correlation_id="gated"),
+    ))
+    while len(proc.stdin.writes) < 2:
+        await asyncio.sleep(0)
+    proc.stdout.feed_eof()
+
+    receipt = await pending
+    assert not receipt.accepted and not receipt.session_reusable
+    assert receipt.delivery == "queue_ack_ambiguous"
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_gated_command_rejected_before_queue_keeps_session_usable():
+    proc, driver, stream, started = await _open_driver()
+    pending = asyncio.create_task(driver.steer_turn(
+        started.turn_ref,
+        TurnInput("new inbox", client_correlation_id="gated"),
+    ))
+    while len(proc.stdin.writes) < 2:
+        await asyncio.sleep(0)
+    _lifecycle(proc, "gated", "discarded")
+
+    receipt = await pending
+    assert not receipt.accepted and receipt.session_reusable
+    assert receipt.delivery == "native_command_rejected"
+    _result(proc, "primary", 10, 1)
+    _lifecycle(proc, "primary", "completed")
+    completed = await _next(stream, "turn.completed")
+    assert completed.data["outcome"] == "succeeded"
     await driver.close()
 
 

--- a/tests/test_claude_gated_lifecycle.py
+++ b/tests/test_claude_gated_lifecycle.py
@@ -10,6 +10,7 @@ from puffo_agent.agent.harness.claude_code_driver import (
     claude_capabilities,
 )
 from puffo_agent.agent.harness.driver import RuntimeSpec, TurnInput
+from puffo_agent.agent.harness.runtime_manager import RuntimeManager
 
 
 class _Stdin:
@@ -169,6 +170,7 @@ async def test_gated_command_without_queue_ack_is_not_accepted():
     proc, driver, stream, started = await _open_driver(ack_timeout=0.01)
     receipt = await driver.steer_turn(started.turn_ref, TurnInput("new inbox"))
     assert not receipt.accepted and receipt.delivery == "queue_ack_timeout"
+    assert not receipt.session_reusable
     _result(proc, "orphaned-gated-command", 99, 99)
     _result(proc, "primary", 0, 0)
     _lifecycle(proc, "primary", "completed")
@@ -178,16 +180,51 @@ async def test_gated_command_without_queue_ack_is_not_accepted():
 
 
 @pytest.mark.asyncio
-async def test_unknown_lifecycle_dialect_does_not_enable_gated_delivery():
+@pytest.mark.parametrize(
+    "capabilities",
+    [["msg_lifecycle_v2"], ["msg_lifecycle_v1", "msg_lifecycle_v2"]],
+)
+async def test_unknown_lifecycle_dialect_does_not_enable_gated_delivery(
+    capabilities,
+):
     proc = _Process()
     proc.feed({
         "type": "system",
         "subtype": "init",
         "session_id": "claude-v2",
-        "capabilities": ["msg_lifecycle_v2"],
+        "capabilities": capabilities,
     })
     driver = ClaudeCodeCliDriver(lambda _args, _spec: proc)
     await driver.open(RuntimeSpec("/workspace"))
     await _next(driver.events(), "session.opened")
     assert driver.current_capabilities().steer == "none"
     await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_gated_receipt_retires_native_session():
+    proc = _Process()
+    proc.feed({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "ambiguous-session",
+        "capabilities": ["msg_lifecycle_v1"],
+    })
+    driver = ClaudeCodeCliDriver(
+        lambda _args, _spec: proc,
+        input_ack_timeout=0.01,
+    )
+    manager = RuntimeManager(driver, RuntimeSpec("/workspace"))
+    await manager.open()
+    started = await manager.start_turn(
+        TurnInput("first", client_correlation_id="primary")
+    )
+
+    receipt = await manager.steer_turn(started.turn_ref, TurnInput("new inbox"))
+
+    assert not receipt.accepted and not receipt.session_reusable
+    assert manager.active_turn_ref is None
+    assert manager.opened is None
+    assert manager.native_session_id == ""
+    assert proc.returncode == 0
+    await manager.close()

--- a/tests/test_claude_gated_lifecycle.py
+++ b/tests/test_claude_gated_lifecycle.py
@@ -78,7 +78,7 @@ async def _open_driver(*, ack_timeout: float = 0.2):
     })
     driver = ClaudeCodeCliDriver(
         lambda _args, _spec: proc,
-        replay_timeout=ack_timeout,
+        input_ack_timeout=ack_timeout,
     )
     await driver.open(RuntimeSpec("/workspace"))
     stream = driver.events()
@@ -117,7 +117,10 @@ def test_claude_lifecycle_capability_is_explicit():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("delivery_shape", ["folded", "separate"])
+@pytest.mark.parametrize(
+    "delivery_shape",
+    ["folded", "separate", "cancelled", "discarded", "unknown"],
+)
 async def test_gated_commands_share_one_logical_turn(delivery_shape):
     proc, driver, stream, started = await _open_driver()
     receipt = await _offer_gated(proc, driver, started)
@@ -130,19 +133,34 @@ async def test_gated_commands_share_one_logical_turn(delivery_shape):
         _result(proc, "primary", 10, 1)
         _lifecycle(proc, "primary", "completed")
         expected = (10, 1, 10)
-    else:
+        expected_error = ""
+    elif delivery_shape == "separate":
         _result(proc, "primary", 10, 1)
         _lifecycle(proc, "primary", "completed")
         _lifecycle(proc, "gated", "started")
         _result(proc, "gated", 20, 2)
         _lifecycle(proc, "gated", "completed")
         expected = (30, 3, 20)
+        expected_error = ""
+    elif delivery_shape in {"cancelled", "discarded"}:
+        _result(proc, "primary", 10, 1)
+        _lifecycle(proc, "primary", "completed")
+        _lifecycle(proc, "gated", delivery_shape)
+        expected = (10, 1, 10)
+        expected_error = f"command_{delivery_shape}"
+    else:
+        _result(proc, "primary", 10, 1)
+        _lifecycle(proc, "primary", "completed")
+        _lifecycle(proc, "gated", "future_state")
+        expected = (10, 1, 10)
+        expected_error = "command_lifecycle_protocol"
 
     completed = await _next(stream, "turn.completed")
     assert completed.native_turn_id == "primary"
     assert tuple(completed.data[key] for key in (
         "input_tokens", "output_tokens", "context_tokens"
     )) == expected
+    assert completed.data.get("error_code", "") == expected_error
     await driver.close()
 
 
@@ -151,7 +169,25 @@ async def test_gated_command_without_queue_ack_is_not_accepted():
     proc, driver, stream, started = await _open_driver(ack_timeout=0.01)
     receipt = await driver.steer_turn(started.turn_ref, TurnInput("new inbox"))
     assert not receipt.accepted and receipt.delivery == "queue_ack_timeout"
+    _result(proc, "orphaned-gated-command", 99, 99)
     _result(proc, "primary", 0, 0)
     _lifecycle(proc, "primary", "completed")
-    await _next(stream, "turn.completed")
+    completed = await _next(stream, "turn.completed")
+    assert completed.data["input_tokens"] == 0
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_lifecycle_dialect_does_not_enable_gated_delivery():
+    proc = _Process()
+    proc.feed({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "claude-v2",
+        "capabilities": ["msg_lifecycle_v2"],
+    })
+    driver = ClaudeCodeCliDriver(lambda _args, _spec: proc)
+    await driver.open(RuntimeSpec("/workspace"))
+    await _next(driver.events(), "session.opened")
+    assert driver.current_capabilities().steer == "none"
     await driver.close()

--- a/tests/test_claude_gated_lifecycle.py
+++ b/tests/test_claude_gated_lifecycle.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from puffo_agent.agent.harness.claude_code_driver import (
+    ClaudeCodeCliDriver,
+    claude_capabilities,
+)
+from puffo_agent.agent.harness.driver import RuntimeSpec, TurnInput
+
+
+class _Stdin:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+
+    def write(self, value: bytes) -> None:
+        json.loads(value)
+        self.writes.append(value)
+
+    async def drain(self) -> None:
+        await asyncio.sleep(0)
+
+
+class _Process:
+    def __init__(self) -> None:
+        self.stdin = _Stdin()
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.returncode = None
+
+    def feed(self, frame: dict) -> None:
+        self.stdout.feed_data(json.dumps(frame).encode() + b"\n")
+
+    def terminate(self) -> None:
+        self.returncode = 0
+        self.stdout.feed_eof()
+
+    kill = terminate
+
+    async def wait(self) -> int:
+        return int(self.returncode or 0)
+
+
+def _lifecycle(proc: _Process, command_id: str, state: str) -> None:
+    proc.feed({
+        "type": "command_lifecycle",
+        "command_uuid": command_id,
+        "state": state,
+    })
+
+
+def _result(proc: _Process, command_id: str, input_: int, output: int) -> None:
+    proc.feed({
+        "type": "result",
+        "subtype": "success",
+        "user_message_uuid": command_id,
+        "usage": {"input_tokens": input_, "output_tokens": output},
+    })
+
+
+async def _next(stream, event_type: str):
+    async for event in stream:
+        if getattr(event.type, "value", event.type) == event_type:
+            return event
+    raise AssertionError(f"event stream ended before {event_type}")
+
+
+async def _open_driver(*, ack_timeout: float = 0.2):
+    proc = _Process()
+    proc.feed({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "claude-lifecycle",
+        "capabilities": ["msg_lifecycle_v1"],
+    })
+    driver = ClaudeCodeCliDriver(
+        lambda _args, _spec: proc,
+        replay_timeout=ack_timeout,
+    )
+    await driver.open(RuntimeSpec("/workspace"))
+    stream = driver.events()
+    await _next(stream, "session.opened")
+    started = await driver.start_turn(
+        TurnInput("first", client_correlation_id="primary")
+    )
+    _lifecycle(proc, "primary", "queued")
+    _lifecycle(proc, "primary", "started")
+    proc.feed({
+        "type": "user",
+        "session_id": "claude-lifecycle",
+        "parent_tool_use_id": None,
+        "uuid": "primary",
+        "isReplay": True,
+        "message": {"role": "user", "content": "first"},
+    })
+    assert (await _next(stream, "turn.started")).native_turn_id == "primary"
+    return proc, driver, stream, started
+
+
+async def _offer_gated(proc, driver, started):
+    pending = asyncio.create_task(driver.steer_turn(
+        started.turn_ref,
+        TurnInput("new inbox", client_correlation_id="gated"),
+    ))
+    while len(proc.stdin.writes) < 2:
+        await asyncio.sleep(0)
+    _lifecycle(proc, "gated", "queued")
+    return await pending
+
+
+def test_claude_lifecycle_capability_is_explicit():
+    assert claude_capabilities().steer == "none"
+    assert claude_capabilities(message_lifecycle_v1=True).steer == "gated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delivery_shape", ["folded", "separate"])
+async def test_gated_commands_share_one_logical_turn(delivery_shape):
+    proc, driver, stream, started = await _open_driver()
+    receipt = await _offer_gated(proc, driver, started)
+    assert receipt.accepted and receipt.delivery == "queued_native_command"
+    assert not (await driver.steer_turn(started.turn_ref, TurnInput("third"))).accepted
+
+    if delivery_shape == "folded":
+        _lifecycle(proc, "gated", "started")
+        _lifecycle(proc, "gated", "completed")
+        _result(proc, "primary", 10, 1)
+        _lifecycle(proc, "primary", "completed")
+        expected = (10, 1, 10)
+    else:
+        _result(proc, "primary", 10, 1)
+        _lifecycle(proc, "primary", "completed")
+        _lifecycle(proc, "gated", "started")
+        _result(proc, "gated", 20, 2)
+        _lifecycle(proc, "gated", "completed")
+        expected = (30, 3, 20)
+
+    completed = await _next(stream, "turn.completed")
+    assert completed.native_turn_id == "primary"
+    assert tuple(completed.data[key] for key in (
+        "input_tokens", "output_tokens", "context_tokens"
+    )) == expected
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_gated_command_without_queue_ack_is_not_accepted():
+    proc, driver, stream, started = await _open_driver(ack_timeout=0.01)
+    receipt = await driver.steer_turn(started.turn_ref, TurnInput("new inbox"))
+    assert not receipt.accepted and receipt.delivery == "queue_ack_timeout"
+    _result(proc, "primary", 0, 0)
+    _lifecycle(proc, "primary", "completed")
+    await _next(stream, "turn.completed")
+    await driver.close()

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -671,7 +671,7 @@ def _metadata_driver(provider, provider_inputs):
         "type": "system", "subtype": "init",
         "session_id": "native-session", "slash_commands": [],
     })
-    return proc, ClaudeCodeCliDriver(lambda *_args: proc, replay_timeout=0.5)
+    return proc, ClaudeCodeCliDriver(lambda *_args: proc, input_ack_timeout=0.5)
 
 
 async def _metadata_store(tmp_path):
@@ -1072,7 +1072,7 @@ async def test_claude_driver_emits_compaction_boundary_and_clears_tool_calls():
         "type": "system", "subtype": "init",
         "session_id": "claude-1", "slash_commands": [],
     })
-    driver = ClaudeCodeCliDriver(lambda _args, _spec: proc, replay_timeout=1)
+    driver = ClaudeCodeCliDriver(lambda _args, _spec: proc, input_ack_timeout=1)
     await driver.open(RuntimeSpec("/workspace"))
     stream = driver.events()
     await driver.start_turn(TurnInput("hello"))
@@ -1249,7 +1249,7 @@ async def test_claude_driver_reopens_cleanly_after_closing_an_active_turn():
         })
         return proc
 
-    driver = ClaudeCodeCliDriver(factory, replay_timeout=1)
+    driver = ClaudeCodeCliDriver(factory, input_ack_timeout=1)
     await driver.open(RuntimeSpec("/workspace"))
     first = await driver.start_turn(TurnInput("first"))
     assert first.accepted
@@ -1321,7 +1321,7 @@ async def test_claude_driver_exact_replay_trailing_records_and_unsupported_zero_
         })
         return proc
 
-    driver = ClaudeCodeCliDriver(factory, replay_timeout=1)
+    driver = ClaudeCodeCliDriver(factory, input_ack_timeout=1)
     opened = await driver.open(RuntimeSpec("/workspace"))
     assert "--replay-user-messages" in captured_args
     assert opened.capabilities.compact == "session_command"
@@ -1395,7 +1395,7 @@ async def test_claude_driver_accepts_init_after_first_stream_input():
         holder["proc"] = proc
         return proc
 
-    driver = ClaudeCodeCliDriver(factory, replay_timeout=1)
+    driver = ClaudeCodeCliDriver(factory, input_ack_timeout=1)
     opened = await driver.open(RuntimeSpec("/workspace"))
     session_id_index = captured.index("--session-id")
     assert captured[session_id_index + 1] == opened.native_session_id
@@ -1430,7 +1430,7 @@ async def test_claude_driver_prepends_normalized_launch_argv(monkeypatch):
         return factory
 
     posix = []
-    driver = ClaudeCodeCliDriver(make_factory(posix), replay_timeout=1)
+    driver = ClaudeCodeCliDriver(make_factory(posix), input_ack_timeout=1)
     opened = await driver.open(RuntimeSpec("/workspace", executable="claude", launch_args=("--autocompact", "100000"), auto_compact_threshold_tokens=500000))
     await driver.close()
     assert posix[:4] == ["claude", "--autocompact", "500000", "-p"] and opened.capabilities.compact == "session_command"
@@ -1440,7 +1440,7 @@ async def test_claude_driver_prepends_normalized_launch_argv(monkeypatch):
         lambda executable: ["cmd.exe", "/c", executable + ".cmd"],
     )
     windows = []
-    driver = ClaudeCodeCliDriver(make_factory(windows), replay_timeout=1)
+    driver = ClaudeCodeCliDriver(make_factory(windows), input_ack_timeout=1)
     await driver.open(RuntimeSpec("/workspace", executable="claude", auto_compact_threshold_tokens=500000))
     await driver.close()
     assert windows[:6] == ["cmd.exe", "/c", "claude.cmd", "--autocompact", "500000", "-p"]
@@ -1459,7 +1459,7 @@ async def test_claude_driver_resume_flag_maps_to_resumed_system_init():
         })
         return proc
 
-    driver = ClaudeCodeCliDriver(factory, replay_timeout=1)
+    driver = ClaudeCodeCliDriver(factory, input_ack_timeout=1)
     opened = await driver.open(
         RuntimeSpec("/workspace"), SessionRef("native-claude-session")
     )
@@ -1484,7 +1484,7 @@ async def test_claude_driver_stdin_delivery_does_not_wait_for_replay():
         })
         return proc
 
-    driver = ClaudeCodeCliDriver(factory, replay_timeout=1)
+    driver = ClaudeCodeCliDriver(factory, input_ack_timeout=1)
     await driver.open(RuntimeSpec("/workspace"))
     receipt = await driver.start_turn(TurnInput("accepted maybe"))
     assert receipt.accepted
@@ -1559,7 +1559,7 @@ def _two_block_claude_driver():
         "type": "system", "subtype": "init",
         "session_id": "claude-1", "slash_commands": [],
     })
-    return proc, ClaudeCodeCliDriver(lambda _args, _spec: proc, replay_timeout=1)
+    return proc, ClaudeCodeCliDriver(lambda _args, _spec: proc, input_ack_timeout=1)
 
 
 def _two_message_codex_driver():
@@ -1782,7 +1782,7 @@ def _token_telemetry_driver(provider):
     holder["proc"] = proc
     return (
         proc,
-        ClaudeCodeCliDriver(lambda *_args: proc, replay_timeout=1),
+        ClaudeCodeCliDriver(lambda *_args: proc, input_ack_timeout=1),
         (40, 30, 84),
     )
 

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -226,14 +226,12 @@ def test_codex_effective_capabilities():
 def test_claude_effective_capabilities():
     baseline = claude_capabilities()
     compact = claude_capabilities(True)
-    lifecycle = claude_capabilities(message_lifecycle_v1=True)
     assert baseline.session_resume is True
     assert baseline.inflight_turn_recovery is False
     assert (baseline.steer, baseline.cancel) == ("none", "none")
     assert baseline.context_status == "pull"
     assert baseline.compact == "none"
     assert compact.compact == "session_command"
-    assert lifecycle.steer == "gated"
     assert baseline.permission_bridge is False
 
 
@@ -1371,174 +1369,6 @@ async def test_claude_driver_exact_replay_trailing_records_and_unsupported_zero_
         driver, started, holder["proc"]
     )
     assert (await driver.compact(CompactRequest("now"))).accepted
-    await driver.close()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("delivery_shape", ["folded", "separate"])
-async def test_claude_gated_input_stays_in_one_logical_turn(delivery_shape):
-    proc = _FakeProcess()
-    proc.feed({
-        "type": "system",
-        "subtype": "init",
-        "session_id": "claude-lifecycle",
-        "capabilities": ["msg_lifecycle_v1"],
-    })
-    driver = ClaudeCodeCliDriver(
-        lambda _args, _spec: proc,
-        replay_timeout=0.2,
-    )
-    await driver.open(RuntimeSpec("/workspace"))
-    stream = driver.events()
-    await _next_matching(stream, "session.opened")
-    started = await driver.start_turn(
-        TurnInput("first", client_correlation_id="primary-command")
-    )
-    proc.feed({
-        "type": "command_lifecycle",
-        "command_uuid": "primary-command",
-        "state": "queued",
-    })
-    proc.feed({
-        "type": "command_lifecycle",
-        "command_uuid": "primary-command",
-        "state": "started",
-    })
-    proc.feed({
-        "type": "user",
-        "session_id": "claude-lifecycle",
-        "parent_tool_use_id": None,
-        "uuid": "primary-command",
-        "isReplay": True,
-        "message": {"role": "user", "content": "first"},
-    })
-    turn_started = await _next_matching(stream, "turn.started")
-    assert turn_started.native_turn_id == "primary-command"
-    assert driver.current_capabilities().steer == "gated"
-
-    gated = asyncio.create_task(driver.steer_turn(
-        started.turn_ref,
-        TurnInput("new inbox", client_correlation_id="gated-command"),
-    ))
-    await _wait_until(lambda: len(proc.stdin.writes) == 2)
-    proc.feed({
-        "type": "command_lifecycle",
-        "command_uuid": "gated-command",
-        "state": "queued",
-    })
-    receipt = await gated
-    assert receipt.accepted and receipt.delivery == "queued_native_command"
-    duplicate = await driver.steer_turn(started.turn_ref, TurnInput("third"))
-    assert not duplicate.accepted
-
-    if delivery_shape == "folded":
-        proc.feed({
-            "type": "command_lifecycle",
-            "command_uuid": "gated-command",
-            "state": "started",
-        })
-        proc.feed({
-            "type": "command_lifecycle",
-            "command_uuid": "gated-command",
-            "state": "completed",
-        })
-        proc.feed({
-            "type": "result",
-            "subtype": "success",
-            "user_message_uuid": "primary-command",
-            "usage": {"input_tokens": 10, "output_tokens": 1},
-        })
-        proc.feed({
-            "type": "command_lifecycle",
-            "command_uuid": "primary-command",
-            "state": "completed",
-        })
-        expected_usage = (10, 1, 10)
-    else:
-        proc.feed({
-            "type": "result",
-            "subtype": "success",
-            "user_message_uuid": "primary-command",
-            "usage": {"input_tokens": 10, "output_tokens": 1},
-        })
-        proc.feed({
-            "type": "command_lifecycle",
-            "command_uuid": "primary-command",
-            "state": "completed",
-        })
-        proc.feed({
-            "type": "command_lifecycle",
-            "command_uuid": "gated-command",
-            "state": "started",
-        })
-        proc.feed({
-            "type": "result",
-            "subtype": "success",
-            "user_message_uuid": "gated-command",
-            "usage": {"input_tokens": 20, "output_tokens": 2},
-        })
-        proc.feed({
-            "type": "command_lifecycle",
-            "command_uuid": "gated-command",
-            "state": "completed",
-        })
-        expected_usage = (30, 3, 20)
-
-    completed = await _next_matching(stream, "turn.completed")
-    assert completed.native_turn_id == "primary-command"
-    assert (
-        completed.data["input_tokens"],
-        completed.data["output_tokens"],
-        completed.data["context_tokens"],
-    ) == expected_usage
-    assert not driver._active.value
-    await driver.close()
-
-
-@pytest.mark.asyncio
-async def test_claude_gated_input_requires_matching_queue_ack():
-    proc = _FakeProcess()
-    proc.feed({
-        "type": "system",
-        "subtype": "init",
-        "session_id": "claude-no-ack",
-        "capabilities": ["msg_lifecycle_v1"],
-    })
-    driver = ClaudeCodeCliDriver(
-        lambda _args, _spec: proc,
-        replay_timeout=0.01,
-    )
-    await driver.open(RuntimeSpec("/workspace"))
-    stream = driver.events()
-    await _next_matching(stream, "session.opened")
-    started = await driver.start_turn(
-        TurnInput("first", client_correlation_id="primary-command")
-    )
-    proc.feed({
-        "type": "user",
-        "session_id": "claude-no-ack",
-        "parent_tool_use_id": None,
-        "uuid": "primary-command",
-        "isReplay": True,
-        "message": {"role": "user", "content": "first"},
-    })
-    await _next_matching(stream, "turn.started")
-
-    receipt = await driver.steer_turn(started.turn_ref, TurnInput("new inbox"))
-    assert not receipt.accepted
-    assert receipt.delivery == "queue_ack_timeout"
-    proc.feed({
-        "type": "result",
-        "subtype": "success",
-        "user_message_uuid": "primary-command",
-        "usage": {},
-    })
-    proc.feed({
-        "type": "command_lifecycle",
-        "command_uuid": "primary-command",
-        "state": "completed",
-    })
-    await _next_matching(stream, "turn.completed")
     await driver.close()
 
 

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -226,12 +226,14 @@ def test_codex_effective_capabilities():
 def test_claude_effective_capabilities():
     baseline = claude_capabilities()
     compact = claude_capabilities(True)
+    lifecycle = claude_capabilities(message_lifecycle_v1=True)
     assert baseline.session_resume is True
     assert baseline.inflight_turn_recovery is False
     assert (baseline.steer, baseline.cancel) == ("none", "none")
     assert baseline.context_status == "pull"
     assert baseline.compact == "none"
     assert compact.compact == "session_command"
+    assert lifecycle.steer == "gated"
     assert baseline.permission_bridge is False
 
 
@@ -1369,6 +1371,174 @@ async def test_claude_driver_exact_replay_trailing_records_and_unsupported_zero_
         driver, started, holder["proc"]
     )
     assert (await driver.compact(CompactRequest("now"))).accepted
+    await driver.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delivery_shape", ["folded", "separate"])
+async def test_claude_gated_input_stays_in_one_logical_turn(delivery_shape):
+    proc = _FakeProcess()
+    proc.feed({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "claude-lifecycle",
+        "capabilities": ["msg_lifecycle_v1"],
+    })
+    driver = ClaudeCodeCliDriver(
+        lambda _args, _spec: proc,
+        replay_timeout=0.2,
+    )
+    await driver.open(RuntimeSpec("/workspace"))
+    stream = driver.events()
+    await _next_matching(stream, "session.opened")
+    started = await driver.start_turn(
+        TurnInput("first", client_correlation_id="primary-command")
+    )
+    proc.feed({
+        "type": "command_lifecycle",
+        "command_uuid": "primary-command",
+        "state": "queued",
+    })
+    proc.feed({
+        "type": "command_lifecycle",
+        "command_uuid": "primary-command",
+        "state": "started",
+    })
+    proc.feed({
+        "type": "user",
+        "session_id": "claude-lifecycle",
+        "parent_tool_use_id": None,
+        "uuid": "primary-command",
+        "isReplay": True,
+        "message": {"role": "user", "content": "first"},
+    })
+    turn_started = await _next_matching(stream, "turn.started")
+    assert turn_started.native_turn_id == "primary-command"
+    assert driver.current_capabilities().steer == "gated"
+
+    gated = asyncio.create_task(driver.steer_turn(
+        started.turn_ref,
+        TurnInput("new inbox", client_correlation_id="gated-command"),
+    ))
+    await _wait_until(lambda: len(proc.stdin.writes) == 2)
+    proc.feed({
+        "type": "command_lifecycle",
+        "command_uuid": "gated-command",
+        "state": "queued",
+    })
+    receipt = await gated
+    assert receipt.accepted and receipt.delivery == "queued_native_command"
+    duplicate = await driver.steer_turn(started.turn_ref, TurnInput("third"))
+    assert not duplicate.accepted
+
+    if delivery_shape == "folded":
+        proc.feed({
+            "type": "command_lifecycle",
+            "command_uuid": "gated-command",
+            "state": "started",
+        })
+        proc.feed({
+            "type": "command_lifecycle",
+            "command_uuid": "gated-command",
+            "state": "completed",
+        })
+        proc.feed({
+            "type": "result",
+            "subtype": "success",
+            "user_message_uuid": "primary-command",
+            "usage": {"input_tokens": 10, "output_tokens": 1},
+        })
+        proc.feed({
+            "type": "command_lifecycle",
+            "command_uuid": "primary-command",
+            "state": "completed",
+        })
+        expected_usage = (10, 1, 10)
+    else:
+        proc.feed({
+            "type": "result",
+            "subtype": "success",
+            "user_message_uuid": "primary-command",
+            "usage": {"input_tokens": 10, "output_tokens": 1},
+        })
+        proc.feed({
+            "type": "command_lifecycle",
+            "command_uuid": "primary-command",
+            "state": "completed",
+        })
+        proc.feed({
+            "type": "command_lifecycle",
+            "command_uuid": "gated-command",
+            "state": "started",
+        })
+        proc.feed({
+            "type": "result",
+            "subtype": "success",
+            "user_message_uuid": "gated-command",
+            "usage": {"input_tokens": 20, "output_tokens": 2},
+        })
+        proc.feed({
+            "type": "command_lifecycle",
+            "command_uuid": "gated-command",
+            "state": "completed",
+        })
+        expected_usage = (30, 3, 20)
+
+    completed = await _next_matching(stream, "turn.completed")
+    assert completed.native_turn_id == "primary-command"
+    assert (
+        completed.data["input_tokens"],
+        completed.data["output_tokens"],
+        completed.data["context_tokens"],
+    ) == expected_usage
+    assert not driver._active.value
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_claude_gated_input_requires_matching_queue_ack():
+    proc = _FakeProcess()
+    proc.feed({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "claude-no-ack",
+        "capabilities": ["msg_lifecycle_v1"],
+    })
+    driver = ClaudeCodeCliDriver(
+        lambda _args, _spec: proc,
+        replay_timeout=0.01,
+    )
+    await driver.open(RuntimeSpec("/workspace"))
+    stream = driver.events()
+    await _next_matching(stream, "session.opened")
+    started = await driver.start_turn(
+        TurnInput("first", client_correlation_id="primary-command")
+    )
+    proc.feed({
+        "type": "user",
+        "session_id": "claude-no-ack",
+        "parent_tool_use_id": None,
+        "uuid": "primary-command",
+        "isReplay": True,
+        "message": {"role": "user", "content": "first"},
+    })
+    await _next_matching(stream, "turn.started")
+
+    receipt = await driver.steer_turn(started.turn_ref, TurnInput("new inbox"))
+    assert not receipt.accepted
+    assert receipt.delivery == "queue_ack_timeout"
+    proc.feed({
+        "type": "result",
+        "subtype": "success",
+        "user_message_uuid": "primary-command",
+        "usage": {},
+    })
+    proc.feed({
+        "type": "command_lifecycle",
+        "command_uuid": "primary-command",
+        "state": "completed",
+    })
+    await _next_matching(stream, "turn.completed")
     await driver.close()
 
 

--- a/tests/test_inbox_scheduler.py
+++ b/tests/test_inbox_scheduler.py
@@ -324,7 +324,17 @@ async def test_notice_delivery_capability_matrix_is_turn_guarded():
     assert not await next_turn.offer(
         named_turn_id="active", active_turn_id="active", deliver=deliver
     )
-    assert delivered == ["delivered", "delivered"]
+
+    live_capability = NoticeDeliveryCapability.NEXT_TURN
+    dynamic = InboxNoticeDelivery(lambda: live_capability)
+    assert not await dynamic.offer(
+        named_turn_id="active", active_turn_id="active", deliver=deliver
+    )
+    live_capability = NoticeDeliveryCapability.GATED
+    assert await dynamic.offer(
+        named_turn_id="active", active_turn_id="active", deliver=deliver
+    )
+    assert delivered == ["delivered", "delivered", "delivered"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Claude Code stream-json may either fold a second user frame into the active provider request or queue it as a separate native command. Treating either timing shape as a new Puffo turn loses mid-turn Inbox updates; treating every stdin write as accepted can orphan work.

## Design

```text
system/init
  |-- exact msg_lifecycle_v1 only? -- no --> NEXT_TURN
  |
  yes
  v
GATED offer -> write one user frame -> lifecycle outcome
                                      |-- rejected --> keep session; Inbox stays pending
                                      |-- ambiguous/timeout --> abandon + retire native session
                                      `-- queued --> active Puffo turn owns both command UUIDs
                                                     |
                                                     `-> one logical terminal after both finish
```

- Detects the provider protocol capability, not the Claude executable version.
- Requires a matching per-command queue acknowledgement before durable notice delivery is recorded.
- Keeps one stable Puffo turn and primary `native_turn_id` across folded and separately queued native commands.
- Aggregates usage only from results owned by the active logical turn.
- Allows at most one gated Inbox injection per logical turn.
- Reads Driver capability live because Claude publishes it only after first-input initialization.
- Unknown or mixed lifecycle dialects fail closed to durable next-turn delivery.
- Explicit pre-queue rejection preserves the healthy active turn; ambiguous admission abandons the turn and retires the native session before retry.

No server, database, prompt, or provider-version contract changes.

## Review

Fable 5 High performed two read-only reviews with an explicit redundancy pass. The follow-ups remove duplicate result state and acknowledgement cleanup, isolate late foreign results, distinguish queued/rejected/ambiguous admission, handle process-exit and timeout races, and remove duplicate lifecycle test coverage. Its final verdict was that the design is sound with no blocking defects; the only remaining consolidation suggestion is a separate RuntimeManager event-construction cleanup outside this PR.

## Validation

- `uv run pre-commit run --all-files`
- Focused Driver, RuntimeManager, and Inbox scheduler tests
- `uv run pytest -q --disable-warnings` (3228 passed, 1 skipped)
