### PR TITLE
fix(data-client): read failures raise DataUnavailable instead of rendering empty

### DIFF
--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -20,6 +20,7 @@ from .reminder_store import ReminderStoreMixin
 PRIOR_CONTEXT_MAX_ITEMS = _models.PRIOR_CONTEXT_MAX_ITEMS
 PRIOR_CONTEXT_MAX_BYTES = _models.PRIOR_CONTEXT_MAX_BYTES
 DataNotFound = _models.DataNotFound
+DataUnavailable = _models.DataUnavailable
 ReceiptDisposition = _models.ReceiptDisposition
 ProcessingState = _models.ProcessingState
 ReceiptWriteStatus = _models.ReceiptWriteStatus

--- a/src/puffo_agent/agent/message_store_models.py
+++ b/src/puffo_agent/agent/message_store_models.py
@@ -61,6 +61,14 @@ class DataNotFound(Exception):
     """
 
 
+class DataUnavailable(RuntimeError):
+    """Raised when a read could not be answered at all — the data
+    service errored or was unreachable. Distinct from an empty
+    result: rendering a failure as "no messages" would hand the
+    model a confidently wrong fact with no error trace.
+    """
+
+
 class ReceiptDisposition(str, Enum):
     ELIGIBLE = "eligible"
     TERMINAL = "terminal"

--- a/src/puffo_agent/mcp/data_client.py
+++ b/src/puffo_agent/mcp/data_client.py
@@ -40,7 +40,10 @@ class StoredMessageDict:
 # DataClient and the in-process MessageStore (used as a duck-type
 # drop-in in tests) raise the same type — the MCP tool layer can
 # ``except DataNotFound`` regardless of which one it has.
-from ..agent.message_store import DataNotFound  # noqa: E402  (intentional placement)
+from ..agent.message_store import (  # noqa: E402  (intentional placement)
+    DataNotFound,
+    DataUnavailable,
+)
 from ..portal.local_service_auth import local_service_headers
 
 
@@ -157,13 +160,18 @@ class DataClient:
                         "data-service: get_channel_history %s -> %d %s",
                         path, resp.status, body,
                     )
-                    return []
+                    raise DataUnavailable(
+                        f"data service failed answering get_channel_history "
+                        f"(status {resp.status})"
+                    )
                 data = await resp.json()
                 msgs = data.get("messages") or []
                 return [_msg_from_dict(m) for m in msgs]
         except aiohttp.ClientError as exc:
             logger.warning("data-service: get_channel_history transport: %s", exc)
-            return []
+            raise DataUnavailable(
+                f"data service unreachable answering get_channel_history: {exc}"
+            ) from exc
 
     async def get_dm_history(
         self,
@@ -200,13 +208,18 @@ class DataClient:
                         "data-service: get_dm_history %s -> %d %s",
                         path, resp.status, body,
                     )
-                    return []
+                    raise DataUnavailable(
+                        f"data service failed answering get_dm_history "
+                        f"(status {resp.status})"
+                    )
                 data = await resp.json()
                 msgs = data.get("messages") or []
                 return [_msg_from_dict(m) for m in msgs]
         except aiohttp.ClientError as exc:
             logger.warning("data-service: get_dm_history transport: %s", exc)
-            return []
+            raise DataUnavailable(
+                f"data service unreachable answering get_dm_history: {exc}"
+            ) from exc
 
     async def get_channel_roots(
         self,
@@ -257,7 +270,10 @@ class DataClient:
                         "data-service: get_channel_roots %s -> %d %s",
                         path, resp.status, body,
                     )
-                    return []
+                    raise DataUnavailable(
+                        f"data service failed answering get_channel_roots "
+                        f"(status {resp.status})"
+                    )
                 data = await resp.json()
                 roots = data.get("roots") or []
                 return [
@@ -269,7 +285,9 @@ class DataClient:
                 ]
         except aiohttp.ClientError as exc:
             logger.warning("data-service: get_channel_roots transport: %s", exc)
-            return []
+            raise DataUnavailable(
+                f"data service unreachable answering get_channel_roots: {exc}"
+            ) from exc
 
     async def get_thread_messages(
         self,
@@ -314,13 +332,18 @@ class DataClient:
                         "data-service: get_thread_messages %s -> %d %s",
                         path, resp.status, body,
                     )
-                    return []
+                    raise DataUnavailable(
+                        f"data service failed answering get_thread_messages "
+                        f"(status {resp.status})"
+                    )
                 data = await resp.json()
                 msgs = data.get("messages") or []
                 return [_msg_from_dict(m) for m in msgs]
         except aiohttp.ClientError as exc:
             logger.warning("data-service: get_thread_messages transport: %s", exc)
-            return []
+            raise DataUnavailable(
+                f"data service unreachable answering get_thread_messages: {exc}"
+            ) from exc
 
     async def get_message_by_envelope(
         self, envelope_id: str,
@@ -343,7 +366,10 @@ class DataClient:
                         "data-service: get_message_by_envelope %s -> %d %s",
                         path, resp.status, body,
                     )
-                    return None
+                    raise DataUnavailable(
+                        f"data service failed answering get_message_by_envelope "
+                        f"(status {resp.status})"
+                    )
                 data = await resp.json()
                 m = data.get("message")
                 if not isinstance(m, dict):
@@ -353,7 +379,9 @@ class DataClient:
             logger.warning(
                 "data-service: get_message_by_envelope transport: %s", exc,
             )
-            return None
+            raise DataUnavailable(
+                f"data service unreachable answering get_message_by_envelope: {exc}"
+            ) from exc
 
     async def get_send_encryption(
         self, slug: str, thread_root_id: str | None,

--- a/tests/test_data_client_honest_errors.py
+++ b/tests/test_data_client_honest_errors.py
@@ -1,0 +1,77 @@
+"""DataClient must not render a failure as a confidently empty result."""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from puffo_agent.mcp.data_client import DataClient, DataNotFound, DataUnavailable
+
+
+def _failing_app(status: int) -> web.Application:
+    async def handler(_request):
+        return web.json_response({"error": "boom"}, status=status)
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", handler)
+    return app
+
+
+async def _client_for(app_or_none) -> tuple[DataClient, TestServer | None]:
+    if app_or_none is None:
+        # A port with nothing listening: transport-level failure.
+        return DataClient(base_url="http://127.0.0.1:9", agent_id="agent_a"), None
+    server = TestServer(app_or_none)
+    await server.start_server()
+    client = DataClient(
+        base_url=str(server.make_url("")).rstrip("/"), agent_id="agent_a",
+    )
+    return client, server
+
+
+READS = (
+    lambda c: c.get_channel_history("ch-1"),
+    lambda c: c.get_dm_history("peer"),
+    lambda c: c.get_channel_roots("ch-1"),
+    lambda c: c.get_thread_messages("root-1"),
+    lambda c: c.get_message_by_envelope("m-1"),
+)
+
+
+@pytest.mark.asyncio
+async def test_server_errors_raise_data_unavailable():
+    client, server = await _client_for(_failing_app(500))
+    try:
+        for read in READS:
+            with pytest.raises(DataUnavailable):
+                await read(client)
+    finally:
+        await client.close()
+        await server.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_errors_raise_data_unavailable():
+    client, _ = await _client_for(None)
+    try:
+        for read in READS:
+            with pytest.raises(DataUnavailable):
+                await read(client)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_404_semantics_are_preserved():
+    """Absence stays absence: no DataUnavailable on 404."""
+    client, server = await _client_for(_failing_app(404))
+    try:
+        assert await client.get_channel_history("ch-1") == []
+        assert await client.get_dm_history("peer") == []
+        assert await client.get_message_by_envelope("m-1") is None
+        with pytest.raises(DataNotFound):
+            await client.get_channel_roots("ch-1")
+        with pytest.raises(DataNotFound):
+            await client.get_thread_messages("root-1")
+    finally:
+        await client.close()
+        await server.close()


### PR DESCRIPTION

## What

Audited P1: `DataClient` swallowed data-service 5xx responses and transport errors into `return []` / `return None` on five read paths (channel history, DM history, channel roots, thread messages, single message). `read_history` then rendered the failure as a definite "no messages" window — the model draws a confidently wrong conclusion (e.g. "this thread has no replies") from a transient outage, with no error trace.

## Fix

- New `DataUnavailable(RuntimeError)` (in `message_store_models`, re-exported beside `DataNotFound`); the five read paths raise it on ≥400 (except 404) and on transport errors.
- The MCP tool layer surfaces it as an explicit tool error the model can retry. Consumers that already degrade gracefully keep doing so — `resolve_outgoing_root` catches broadly and sends top-level with an honest note.
- 404 absence semantics unchanged (`[]` / `None` / `DataNotFound` as before).
- `lookup_channel_space` deliberately stays lenient (auxiliary lookup; `None` is treated as unknown, not as fact) — noted for a follow-up if it ever matters.

## Testing

New `tests/test_data_client_honest_errors.py` (real aiohttp server: 500s, connection-refused transport errors, and 404-preservation). Full suite green, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
