### PR TITLE
fix(inbox): preserve unverifiable thread roots instead of erasing them

### DIFF
--- a/src/puffo_agent/agent/bridge_transport.py
+++ b/src/puffo_agent/agent/bridge_transport.py
@@ -658,6 +658,15 @@ async def _bridge_storage_row(client, payload: MessagePayload) -> dict[str, Any]
         if payload.sender_slug == client.slug
         else payload.sender_slug
     ) if payload.envelope_kind == "dm" else ""
+    thread_root_id, thread_root_unverified = (
+        await client._resolve_incoming_thread_root(
+            payload.thread_root_id,
+            payload.channel_id,
+            payload.space_id,
+            expected_envelope_kind=payload.envelope_kind,
+            expected_dm_peer=dm_peer,
+        )
+    )
     return {
         "envelope_id": payload.envelope_id,
         "envelope_kind": payload.envelope_kind,
@@ -668,13 +677,8 @@ async def _bridge_storage_row(client, payload: MessagePayload) -> dict[str, Any]
         "content_type": payload.content_type,
         "content": payload.content,
         "sent_at": payload.sent_at,
-        "thread_root_id": await client._resolve_incoming_thread_root(
-            payload.thread_root_id,
-            payload.channel_id,
-            payload.space_id,
-            expected_envelope_kind=payload.envelope_kind,
-            expected_dm_peer=dm_peer,
-        ),
+        "thread_root_id": thread_root_id,
+        "thread_root_unverified": thread_root_unverified,
         "reply_to_id": await client._validate_incoming_parent_id(
             payload.reply_to_id,
             payload.channel_id,

--- a/src/puffo_agent/agent/inbound_receipts.py
+++ b/src/puffo_agent/agent/inbound_receipts.py
@@ -305,12 +305,14 @@ class InboundReceiptHandler:
             if payload.sender_slug == self.client.slug
             else payload.sender_slug
         ) if payload.envelope_kind == "dm" else ""
-        thread_root_id = await self.client._resolve_incoming_thread_root(
-            payload.thread_root_id,
-            payload.channel_id,
-            payload.space_id,
-            expected_envelope_kind=payload.envelope_kind,
-            expected_dm_peer=dm_peer,
+        thread_root_id, thread_root_unverified = (
+            await self.client._resolve_incoming_thread_root(
+                payload.thread_root_id,
+                payload.channel_id,
+                payload.space_id,
+                expected_envelope_kind=payload.envelope_kind,
+                expected_dm_peer=dm_peer,
+            )
         )
         reply_to_id = await self.client._validate_incoming_parent_id(
             payload.reply_to_id,
@@ -331,6 +333,7 @@ class InboundReceiptHandler:
             "sent_at": payload.sent_at,
             "thread_root_id": thread_root_id,
             "reply_to_id": reply_to_id,
+            "thread_root_unverified": thread_root_unverified,
             "is_encrypted": not is_plaintext,
         }
         return _ReceiptCommitter(

--- a/src/puffo_agent/agent/message_projection.py
+++ b/src/puffo_agent/agent/message_projection.py
@@ -507,6 +507,8 @@ def format_message_row(
         fields.append(f"mentions={_json(mentions)}")
     if reply_count is not None:
         fields.append(f"reply_count={reply_count}")
+    if bool(_value(message, "thread_root_unverified", False)):
+        fields.append("thread_root_unverified=true")
     return f"[message {' '.join(fields)}]\n{_content_field(message_text(message))}"
 
 

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -1376,9 +1376,16 @@ class MessageStore(ReminderStoreMixin, InboxStoreMixin):
         """
         if not root_id:
             raise DataNotFound("thread root not found: (empty)")
-        if not await self.has_message(root_id):
-            raise DataNotFound(f"thread root not found: {root_id}")
         db = await self._ensure_db()
+        if not await self.has_message(root_id):
+            # The root itself may not be locally readable (kept unverified
+            # on receipt); local replies claiming it still form a thread.
+            async with db.execute(
+                "SELECT 1 FROM messages WHERE thread_root_id = ? LIMIT 1",
+                (root_id,),
+            ) as cursor:
+                if await cursor.fetchone() is None:
+                    raise DataNotFound(f"thread root not found: {root_id}")
         since_resolved = await self._resolve_since_sent_at(since_envelope_id)
         before_resolved = await self._resolve_since_sent_at(before_envelope_id)
 

--- a/src/puffo_agent/agent/message_store.py
+++ b/src/puffo_agent/agent/message_store.py
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS messages (
     received_at INTEGER NOT NULL,
     thread_root_id TEXT,
     reply_to_id TEXT,
+    thread_root_unverified INTEGER NOT NULL DEFAULT 0,
     is_encrypted INTEGER NOT NULL DEFAULT 1
 );
 
@@ -351,6 +352,9 @@ class MessageStore(ReminderStoreMixin, InboxStoreMixin):
                             "model_visible_at": "model_visible_at INTEGER",
                             "processed_at": "processed_at INTEGER",
                             "local_ordinal": "local_ordinal INTEGER",
+                            "thread_root_unverified": (
+                                "thread_root_unverified INTEGER NOT NULL DEFAULT 0"
+                            ),
                             "after_server_seq": "after_server_seq INTEGER",
                         }
                         for name, declaration in additions.items():
@@ -508,6 +512,7 @@ class MessageStore(ReminderStoreMixin, InboxStoreMixin):
             received_at if received_at is not None else _now_ms(),
             value("thread_root_id"),
             value("reply_to_id"),
+            1 if value("thread_root_unverified", False) else 0,
             1 if value("is_encrypted", True) else 0,
         )
 
@@ -876,9 +881,10 @@ class MessageStore(ReminderStoreMixin, InboxStoreMixin):
             """INSERT INTO messages
                (envelope_id, envelope_kind, sender_slug, channel_id, space_id,
                 recipient_slug, content_type, content, sent_at, received_at,
-                thread_root_id, reply_to_id, is_encrypted, receipt_disposition,
+                thread_root_id, reply_to_id, thread_root_unverified,
+                is_encrypted, receipt_disposition,
                 receipt_reason, processing_state, local_ordinal, after_server_seq)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             values
             + (
                 ReceiptDisposition.LOCAL_RUNTIME.value,
@@ -1647,6 +1653,11 @@ class MessageStore(ReminderStoreMixin, InboxStoreMixin):
             received_at=row["received_at"],
             thread_root_id=row["thread_root_id"],
             reply_to_id=row["reply_to_id"],
+            thread_root_unverified=bool(
+                row["thread_root_unverified"]
+                if "thread_root_unverified" in row.keys()
+                else 0
+            ),
             is_encrypted=bool(row["is_encrypted"]),
             server_seq=row["server_seq"],
             receipt_disposition=(

--- a/src/puffo_agent/agent/message_store_models.py
+++ b/src/puffo_agent/agent/message_store_models.py
@@ -364,6 +364,10 @@ class StoredMessage:
     received_at: int
     thread_root_id: Optional[str] = None
     reply_to_id: Optional[str] = None
+    # True when the claimed thread root was not locally verifiable at
+    # receipt time (root not in the local store); grouping still uses the
+    # claimed id, and arrival of the root later settles the flag.
+    thread_root_unverified: bool = False
     # False only for a plaintext (non-E2EE) message; absent/legacy rows are True.
     is_encrypted: bool = True
     server_seq: int | None = None

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -856,7 +856,7 @@ class PuffoCoreMessageClient:
         *,
         expected_envelope_kind: str = "",
         expected_dm_peer: str = "",
-    ) -> Optional[str]:
+    ) -> tuple[Optional[str], bool]:
         """Resolve an inbound reply reference to its canonical thread root."""
         return await resolve_incoming_thread_root(
             store=self.store,

--- a/src/puffo_agent/agent/receipt_persistence.py
+++ b/src/puffo_agent/agent/receipt_persistence.py
@@ -193,11 +193,13 @@ async def _insert_new_receipt(
         """INSERT INTO messages
            (envelope_id, envelope_kind, sender_slug, channel_id, space_id,
             recipient_slug, content_type, content, sent_at, received_at,
-            thread_root_id, reply_to_id, is_encrypted, server_seq,
+            thread_root_id, reply_to_id, thread_root_unverified,
+            is_encrypted, server_seq,
             receipt_disposition, receipt_reason, processing_state)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         values + (server_seq, disposition.value, reason, processing),
     )
+    await _settle_unverified_thread_claims(db, values)
     await store._advance_server_sequence_high_water(db, server_seq)
     if processing == ProcessingState.PENDING.value:
         await store._refresh_notice_state(db, activated_at=int(values[9]))
@@ -207,6 +209,74 @@ async def _insert_new_receipt(
         disposition,
         reason,
         store._receipt_ack(disposition),
+    )
+
+
+async def _settle_unverified_thread_claims(
+    db: aiosqlite.Connection,
+    values: tuple[Any, ...],
+) -> None:
+    """Run the deferred root check for replies that claimed this message.
+
+    A reply whose claimed thread root was not locally verifiable at receipt
+    time kept the claim with ``thread_root_unverified=1``. When the claimed
+    message finally arrives, apply the same ownership rules the live path
+    uses: a matching channel/space (or DM conversation) verifies the claim;
+    a mismatch (or the "root" being no root at all) wipes it.
+    """
+    envelope_id = values[0]
+    envelope_kind, channel_id, space_id = values[1], values[3], values[4]
+    sender_slug, recipient_slug = values[2], values[5]
+    own_root, own_root_unverified = values[10], values[12]
+    if envelope_kind == "channel" and not own_root:
+        await db.execute(
+            """UPDATE messages SET thread_root_unverified = 0
+               WHERE thread_root_unverified = 1 AND thread_root_id = ?
+                 AND channel_id = ?
+                 AND (space_id IS NULL OR ? IS NULL OR space_id = ?)""",
+            (envelope_id, channel_id, space_id, space_id),
+        )
+    elif envelope_kind == "channel" and own_root:
+        # The claimed "root" is itself a reply: re-root claimants to its
+        # own (already validated) root, inheriting its verification state.
+        await db.execute(
+            """UPDATE messages SET thread_root_id = ?, thread_root_unverified = ?
+               WHERE thread_root_unverified = 1 AND thread_root_id = ?
+                 AND channel_id = ?""",
+            (own_root, 1 if own_root_unverified else 0, envelope_id, channel_id),
+        )
+    elif envelope_kind == "dm" and not own_root:
+        # Same-conversation check mirrors validated_parent: both of the
+        # claimant's participants must appear among the root's participants.
+        await db.execute(
+            """UPDATE messages SET thread_root_unverified = 0
+               WHERE thread_root_unverified = 1 AND thread_root_id = ?
+                 AND envelope_kind = 'dm'
+                 AND sender_slug IN (?, ?) AND recipient_slug IN (?, ?)""",
+            (
+                envelope_id,
+                sender_slug, recipient_slug,
+                sender_slug, recipient_slug,
+            ),
+        )
+    elif envelope_kind == "dm" and own_root:
+        await db.execute(
+            """UPDATE messages SET thread_root_id = ?, thread_root_unverified = ?
+               WHERE thread_root_unverified = 1 AND thread_root_id = ?
+                 AND envelope_kind = 'dm'
+                 AND sender_slug IN (?, ?) AND recipient_slug IN (?, ?)""",
+            (
+                own_root, 1 if own_root_unverified else 0, envelope_id,
+                sender_slug, recipient_slug,
+                sender_slug, recipient_slug,
+            ),
+        )
+    # Any remaining claimants live in a different channel/space/DM or
+    # claimed a message of another kind: the deferred check failed, wipe.
+    await db.execute(
+        """UPDATE messages SET thread_root_id = NULL, thread_root_unverified = 0
+           WHERE thread_root_unverified = 1 AND thread_root_id = ?""",
+        (envelope_id,),
     )
 
 
@@ -265,9 +335,10 @@ async def store_local_receipt_unlocked(
             """INSERT INTO messages
                (envelope_id, envelope_kind, sender_slug, channel_id, space_id,
                 recipient_slug, content_type, content, sent_at, received_at,
-                thread_root_id, reply_to_id, is_encrypted, receipt_disposition,
+                thread_root_id, reply_to_id, thread_root_unverified,
+                is_encrypted, receipt_disposition,
                 receipt_reason, local_ordinal, after_server_seq)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             values + (normalized.value, reason, ordinal, frontier),
         )
         await db.commit()

--- a/src/puffo_agent/agent/thread_context.py
+++ b/src/puffo_agent/agent/thread_context.py
@@ -35,7 +35,17 @@ async def validate_incoming_parent_id(
         expected_self_slug=expected_self_slug,
         log_label="_validate_incoming_parent_id",
     )
-    return parent_id if parent is not None else None
+    if parent is PARENT_MISSING or parent is None:
+        return None
+    return parent_id
+
+
+class _ParentMissing:
+    """Sentinel: the parent is not locally verifiable (absent or lookup
+    failed) — distinct from an affirmative ownership mismatch."""
+
+
+PARENT_MISSING = _ParentMissing()
 
 
 async def validated_parent(
@@ -50,15 +60,19 @@ async def validated_parent(
     expected_dm_peer: str = "",
     expected_self_slug: str = "",
 ) -> Any:
-    """Load a parent that belongs to the expected channel and space."""
+    """Load a parent that belongs to the expected channel and space.
+
+    Returns the parent row, ``None`` on an affirmative mismatch, or
+    ``PARENT_MISSING`` when the parent simply is not in the local store.
+    """
     try:
         parent = await store.get_message_by_envelope(parent_id)
     except Exception as exc:
         log.warning("%s: lookup failed for %s: %s", log_label, parent_id, exc)
-        return None
+        return PARENT_MISSING
     if parent is None:
-        log.info("%s: wiped %s — parent not in local cache", log_label, parent_id)
-        return None
+        log.info("%s: parent %s not in local cache", log_label, parent_id)
+        return PARENT_MISSING
     if expected_envelope_kind and parent.envelope_kind != expected_envelope_kind:
         log.info(
             "%s: wiped %s — parent kind %r != incoming kind %r",
@@ -112,10 +126,19 @@ async def resolve_incoming_thread_root(
     expected_envelope_kind: str = "",
     expected_dm_peer: str = "",
     expected_self_slug: str = "",
-) -> str | None:
-    """Resolve a reply reference to its trusted canonical thread root."""
+) -> tuple[str | None, bool]:
+    """Resolve a reply reference to its trusted canonical thread root.
+
+    Returns ``(root_id, unverified)``. An affirmative ownership mismatch,
+    a cycle, or an over-deep chain still wipes the reference (``(None,
+    False)``): those are evidence the claim is wrong. A parent that simply
+    is not in the local store — root predates this agent joining, root was
+    aged out, root failed to decrypt — keeps the claimed id with
+    ``unverified=True`` instead of demoting the reply to the channel
+    level; the arrival of the root later settles the flag.
+    """
     if not parent_id:
-        return parent_id
+        return parent_id, False
     current = parent_id
     seen: set[str] = set()
     for _ in range(_INCOMING_ROOT_MAX_DEPTH):
@@ -124,7 +147,7 @@ async def resolve_incoming_thread_root(
                 "_resolve_incoming_thread_root: wiped %s — cycle in thread chain",
                 parent_id,
             )
-            return None
+            return None, False
         seen.add(current)
         parent = await validated_parent(
             store=store,
@@ -137,8 +160,16 @@ async def resolve_incoming_thread_root(
             expected_self_slug=expected_self_slug,
             log_label="_resolve_incoming_thread_root",
         )
+        if parent is PARENT_MISSING:
+            log.info(
+                "_resolve_incoming_thread_root: kept %s unverified — "
+                "root %s not locally verifiable",
+                parent_id,
+                current,
+            )
+            return current, True
         if parent is None:
-            return None
+            return None, False
         if not parent.thread_root_id or parent.thread_root_id == current:
             if current != parent_id:
                 log.info(
@@ -147,11 +178,11 @@ async def resolve_incoming_thread_root(
                     parent_id,
                     current,
                 )
-            return current
+            return current, False
         current = parent.thread_root_id
     log.info(
         "_resolve_incoming_thread_root: wiped %s — chain deeper than %d",
         parent_id,
         _INCOMING_ROOT_MAX_DEPTH,
     )
-    return None
+    return None, False

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -489,6 +489,43 @@ async def _outgoing_root_claimant(data_client: Any, root_id: str) -> Any:
     return None
 
 
+async def _resolve_missing_outgoing_root(
+    data_client: Any,
+    current: str,
+    root_id: str,
+    missing_note: str,
+    *,
+    self_slug: str,
+    channel_id: Optional[str],
+    space_id: Optional[str],
+    dm_peer: Optional[str],
+) -> tuple[Optional[str], str]:
+    """Resolve a root whose own row is not locally readable.
+
+    Local replies claiming it (kept unverified on receipt) prove the
+    thread is real in this conversation, so after the claimant passes the
+    same scope validation, keep threading under the claimed id. Without a
+    claimant, degrade to a top-level send with the original note.
+    """
+    claimant = await _outgoing_root_claimant(data_client, current)
+    if claimant is None:
+        return None, missing_note
+    _validate_outgoing_root_scope(
+        claimant,
+        root_id,
+        self_slug=self_slug,
+        channel_id=channel_id,
+        space_id=space_id,
+        dm_peer=dm_peer,
+    )
+    logger.info(
+        "resolve_outgoing_root: kept %s — root not locally "
+        "readable but claimed by local thread replies",
+        current,
+    )
+    return current, ""
+
+
 async def _read_outgoing_root_message(
     data_client: Any,
     root_id: str,
@@ -612,26 +649,16 @@ async def _resolve_outgoing_root(
             current,
         )
         if msg is None:
-            claimant = await _outgoing_root_claimant(data_client, current)
-            if claimant is None:
-                return None, missing_note
-            # The root itself is not locally readable, but local replies
-            # claim it (kept unverified on receipt): the thread is real in
-            # this conversation, so keep threading under the claimed id.
-            _validate_outgoing_root_scope(
-                claimant,
+            return await _resolve_missing_outgoing_root(
+                data_client,
+                current,
                 root_id,
+                missing_note,
                 self_slug=self_slug,
                 channel_id=channel_id,
                 space_id=space_id,
                 dm_peer=dm_peer,
             )
-            logger.info(
-                "resolve_outgoing_root: kept %s — root not locally "
-                "readable but claimed by local thread replies",
-                current,
-            )
-            return current, ""
         # Cross-scope first: rejecting before the system/self-ref wipe
         # keeps misdirected content out of the wrong conversation.
         _validate_outgoing_root_scope(

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -473,6 +473,22 @@ async def _supplement_missing_devices(
 _RESOLVE_ROOT_MAX_DEPTH = 8
 
 
+async def _outgoing_root_claimant(data_client: Any, root_id: str) -> Any:
+    """A local reply claiming ``root_id`` as its thread root, or ``None``.
+
+    Proof the thread exists in this conversation even though the root
+    itself is not locally readable (it was kept unverified on receipt).
+    """
+    try:
+        rows = await data_client.get_thread_messages(root_id, limit=1)
+    except Exception:
+        return None
+    for row in rows:
+        if getattr(row, "envelope_id", None) != root_id:
+            return row
+    return None
+
+
 async def _read_outgoing_root_message(
     data_client: Any,
     root_id: str,
@@ -596,7 +612,26 @@ async def _resolve_outgoing_root(
             current,
         )
         if msg is None:
-            return None, missing_note
+            claimant = await _outgoing_root_claimant(data_client, current)
+            if claimant is None:
+                return None, missing_note
+            # The root itself is not locally readable, but local replies
+            # claim it (kept unverified on receipt): the thread is real in
+            # this conversation, so keep threading under the claimed id.
+            _validate_outgoing_root_scope(
+                claimant,
+                root_id,
+                self_slug=self_slug,
+                channel_id=channel_id,
+                space_id=space_id,
+                dm_peer=dm_peer,
+            )
+            logger.info(
+                "resolve_outgoing_root: kept %s — root not locally "
+                "readable but claimed by local thread replies",
+                current,
+            )
+            return current, ""
         # Cross-scope first: rejecting before the system/self-ref wipe
         # keeps misdirected content out of the wrong conversation.
         _validate_outgoing_root_scope(

--- a/tests/test_global_inbox_runtime.py
+++ b/tests/test_global_inbox_runtime.py
@@ -329,16 +329,14 @@ def _configure_listen_client(client, store, tmp_path, events, blocked):
 
 
 def _install_listen_stubs(client, gate_foreign_dm):
-    async def none(*_args, **_kwargs):
-        return None
+    def returns(value):
+        async def stub(*_args, **_kwargs):
+            return value
+        return stub
 
-    async def false(*_args, **_kwargs):
-        return False
+    none, false, empty = returns(None), returns(False), returns({})
 
-    async def empty(*_args, **_kwargs):
-        return {}
-
-    client._resolve_incoming_thread_root = none
+    client._resolve_incoming_thread_root = returns((None, False))
     client._validate_incoming_parent_id = none
     client._maybe_allowlist_outbound_dm = none
     client._apply_invite_replies = empty

--- a/tests/test_message_store.py
+++ b/tests/test_message_store.py
@@ -1123,9 +1123,10 @@ async def test_sequence_less_server_receipt_is_never_pending_work():
         """INSERT INTO messages
            (envelope_id, envelope_kind, sender_slug, channel_id, space_id,
             recipient_slug, content_type, content, sent_at, received_at,
-            thread_root_id, reply_to_id, is_encrypted, receipt_disposition,
+            thread_root_id, reply_to_id, thread_root_unverified,
+            is_encrypted, receipt_disposition,
             receipt_reason, processing_state)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         values + (
             ReceiptDisposition.ELIGIBLE.value,
             "malformed legacy data",

--- a/tests/test_puffo_core_tools_routes_and_keyless.py
+++ b/tests/test_puffo_core_tools_routes_and_keyless.py
@@ -85,6 +85,14 @@ class _FakeDataClient:
             raise self.exc
         return self.messages.get(envelope_id)
 
+    async def get_thread_messages(self, root_id: str, limit: int = 50):
+        if self.exc is not None:
+            raise self.exc
+        return [
+            m for m in self.messages.values()
+            if m.envelope_id == root_id or m.thread_root_id == root_id
+        ][:limit]
+
 
 async def _resolve(dc, root_id, **kw):
     defaults = dict(self_slug="agent-0001", channel_id=None, space_id=None, dm_peer=None)
@@ -136,6 +144,34 @@ async def test_outgoing_root_lookup_miss_wipes_to_none():
     resolved, note = await _resolve(dc, "msg_unknown")
     assert resolved is None
     assert "not in local cache" in note
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_missing_but_claimed_is_kept():
+    dc = _FakeDataClient()
+    dc.add("msg_reply", thread_root_id="ghost-root", channel_id="ch_1")
+    resolved, note = await _resolve(dc, "ghost-root", channel_id="ch_1")
+    assert resolved == "ghost-root" and note == ""
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_missing_claimant_wrong_channel_rejects():
+    dc = _FakeDataClient()
+    dc.add("msg_reply", thread_root_id="ghost-root", channel_id="ch_OTHER")
+    with pytest.raises(RuntimeError):
+        await _resolve(dc, "ghost-root", channel_id="ch_1")
+
+
+@pytest.mark.asyncio
+async def test_outgoing_root_missing_but_claimed_dm_is_kept():
+    dc = _FakeDataClient()
+    dc.add(
+        "msg_reply", thread_root_id="ghost-root",
+        envelope_kind="dm", sender_slug="peer-0001",
+        recipient_slug="agent-0001",
+    )
+    resolved, note = await _resolve(dc, "ghost-root", dm_peer="peer-0001")
+    assert resolved == "ghost-root" and note == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_root_preservation.py
+++ b/tests/test_thread_root_preservation.py
@@ -1,0 +1,162 @@
+"""A locally unverifiable thread root is preserved, not erased.
+
+The live inbound path used to wipe a reply's thread_root_id whenever the
+claimed root was not in the local store (root predates the agent joining,
+aged out, failed to decrypt) — permanently demoting the reply to a
+channel-level message. The claim is now kept with an ``unverified`` mark,
+affirmative ownership mismatches still wipe, and the root's later arrival
+runs the deferred check.
+"""
+
+import logging
+import os
+import tempfile
+
+import pytest
+
+from puffo_agent.agent.message_store import MessageStore
+from puffo_agent.agent.message_store_models import ReceiptDisposition
+from puffo_agent.agent.message_projection import format_message_group
+from puffo_agent.agent.thread_context import resolve_incoming_thread_root
+
+log = logging.getLogger("test")
+
+
+def _temp_store() -> MessageStore:
+    d = tempfile.mkdtemp()
+    return MessageStore(os.path.join(d, "messages.db"))
+
+
+def _payload(envelope_id, *, channel_id="ch_1", space_id="sp_1", root=None,
+             root_unverified=False, kind="channel", sender="alice-0001",
+             recipient=""):
+    return {
+        "envelope_id": envelope_id,
+        "envelope_kind": kind,
+        "sender_slug": sender,
+        "channel_id": channel_id if kind == "channel" else "",
+        "space_id": space_id if kind == "channel" else "",
+        "recipient_slug": recipient,
+        "content_type": "text/plain",
+        "content": f"Message {envelope_id}",
+        "sent_at": 1000,
+        "thread_root_id": root,
+        "thread_root_unverified": root_unverified,
+    }
+
+
+async def _receive(store, envelope_id, seq, **kwargs):
+    await store.store_receipt(
+        _payload(envelope_id, **kwargs),
+        server_seq=seq,
+        disposition=ReceiptDisposition.ELIGIBLE,
+        reason="ok",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_root_is_kept_unverified():
+    store = _temp_store()
+    root, unverified = await resolve_incoming_thread_root(
+        store=store, log=log, parent_id="ghost-root",
+        expected_channel_id="ch_1", expected_space_id="sp_1",
+        expected_envelope_kind="channel",
+    )
+    assert (root, unverified) == ("ghost-root", True)
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_ownership_mismatch_still_wipes():
+    store = _temp_store()
+    await _receive(store, "other-root", 1, channel_id="ch_OTHER")
+    root, unverified = await resolve_incoming_thread_root(
+        store=store, log=log, parent_id="other-root",
+        expected_channel_id="ch_1", expected_space_id="sp_1",
+        expected_envelope_kind="channel",
+    )
+    assert (root, unverified) == (None, False)
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_unverified_claim_round_trips_and_projects():
+    store = _temp_store()
+    await _receive(store, "reply-1", 1, root="ghost-root", root_unverified=True)
+    row = await store.get_message_by_envelope("reply-1")
+    assert row.thread_root_id == "ghost-root"
+    assert row.thread_root_unverified
+    assert "thread_root_unverified=true" in format_message_group([row])
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_root_arrival_settles_matching_claims():
+    store = _temp_store()
+    await _receive(store, "reply-1", 1, root="late-root", root_unverified=True)
+    await _receive(store, "late-root", 2)
+    row = await store.get_message_by_envelope("reply-1")
+    assert row.thread_root_id == "late-root"
+    assert not row.thread_root_unverified
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_root_arrival_in_other_channel_wipes_claim():
+    store = _temp_store()
+    await _receive(store, "reply-1", 1, root="foreign-root", root_unverified=True)
+    await _receive(store, "foreign-root", 2, channel_id="ch_OTHER")
+    row = await store.get_message_by_envelope("reply-1")
+    assert row.thread_root_id is None
+    assert not row.thread_root_unverified
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_claimed_root_that_is_a_reply_reroots_claimants():
+    store = _temp_store()
+    await _receive(store, "true-root", 1)
+    await _receive(store, "reply-1", 2, root="mid-reply", root_unverified=True)
+    await _receive(store, "mid-reply", 3, root="true-root")
+    row = await store.get_message_by_envelope("reply-1")
+    assert row.thread_root_id == "true-root"
+    assert not row.thread_root_unverified
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_dm_root_arrival_settles_same_conversation_claim():
+    store = _temp_store()
+    await _receive(store, "dm-reply", 1, kind="dm", sender="alice-0001",
+                   recipient="self-0001", root="dm-root", root_unverified=True)
+    await _receive(store, "dm-root", 2, kind="dm", sender="self-0001",
+                   recipient="alice-0001")
+    row = await store.get_message_by_envelope("dm-reply")
+    assert row.thread_root_id == "dm-root"
+    assert not row.thread_root_unverified
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_dm_root_arrival_from_other_conversation_wipes_claim():
+    store = _temp_store()
+    await _receive(store, "dm-reply", 1, kind="dm", sender="alice-0001",
+                   recipient="self-0001", root="dm-root", root_unverified=True)
+    await _receive(store, "dm-root", 2, kind="dm", sender="mallory-0002",
+                   recipient="self-0001")
+    row = await store.get_message_by_envelope("dm-reply")
+    assert row.thread_root_id is None
+    assert not row.thread_root_unverified
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_verified_rows_are_untouched_by_arrivals():
+    store = _temp_store()
+    await _receive(store, "root-a", 1)
+    await _receive(store, "reply-a", 2, root="root-a")
+    await _receive(store, "root-a-dup", 3)
+    row = await store.get_message_by_envelope("reply-a")
+    assert row.thread_root_id == "root-a"
+    assert not row.thread_root_unverified
+    await store.close()

--- a/tests/test_thread_root_preservation.py
+++ b/tests/test_thread_root_preservation.py
@@ -160,6 +160,25 @@ async def test_thread_read_works_without_the_root_row():
 
 
 @pytest.mark.asyncio
+async def test_inbound_preserved_root_is_replyable_outbound():
+    """End-to-end flow closure: receive a reply whose root is locally
+    unknown (kept unverified), then resolve an outbound reply into the
+    same thread — it must keep the claimed root, not degrade to a
+    channel-level send."""
+    from puffo_agent.mcp.puffo_core_tools import _resolve_outgoing_root
+
+    store = _temp_store()
+    await _receive(store, "reply-1", 1, root="missing-root",
+                   root_unverified=True)
+    resolved, note = await _resolve_outgoing_root(
+        "missing-root", store, self_slug="agent-0001",
+        channel_id="ch_1", space_id="sp_1", dm_peer=None,
+    )
+    assert (resolved, note) == ("missing-root", "")
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_verified_rows_are_untouched_by_arrivals():
     store = _temp_store()
     await _receive(store, "root-a", 1)

--- a/tests/test_thread_root_preservation.py
+++ b/tests/test_thread_root_preservation.py
@@ -151,6 +151,15 @@ async def test_dm_root_arrival_from_other_conversation_wipes_claim():
 
 
 @pytest.mark.asyncio
+async def test_thread_read_works_without_the_root_row():
+    store = _temp_store()
+    await _receive(store, "reply-1", 1, root="ghost-root", root_unverified=True)
+    rows = await store.get_thread_messages("ghost-root")
+    assert [r.envelope_id for r in rows] == ["reply-1"]
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_verified_rows_are_untouched_by_arrivals():
     store = _temp_store()
     await _receive(store, "root-a", 1)


### PR DESCRIPTION
## What

Audited P2 from the message-reliability investigation: when a reply referenced a thread root that was not in the local store (root predates the agent joining the channel, aged out, or failed to decrypt), the inbound path **wiped** `thread_root_id` and permanently demoted the reply to a channel-level message. Cross-store evidence showed real thread replies rendered as top-level posts, and the idempotent redelivery path never backfilled the lost reference.

## Fix

- `resolve_incoming_thread_root` now distinguishes an **affirmative mismatch** (wrong channel/space/DM, cycle, over-deep chain — still wiped: those prove the claim wrong) from a **locally unverifiable** root, which keeps the claimed id with a new `thread_root_unverified` flag instead of erasing it. Grouping and thread replies keep working off the claimed id.
- New `PARENT_MISSING` sentinel in `validated_parent` carries the distinction; `validate_incoming_parent_id` behavior is unchanged.
- **Deferred verification on root arrival**: when the claimed message later arrives, `_settle_unverified_thread_claims` applies the same ownership rules the live path uses — matching channel/space (or DM conversation participants) settles the flag; a claimed "root" that is itself a reply re-roots claimants to its own root; anything else wipes the claim.
- The flag is persisted (schema migration with default 0), round-trips through `StoredMessage`, and renders as `thread_root_unverified=true` in message projections so the model knows the thread context may be incomplete.

## Testing

New `tests/test_thread_root_preservation.py` (9 cases): missing-root preservation, mismatch still wipes, persistence + projection round-trip, settle-on-arrival (channel and same-conversation DM), wipe-on-arrival for foreign channel and foreign DM conversation, re-rooting through a late reply, and verified rows untouched. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
