### PR TITLE
chore(release): prepare 2.0.0a25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0a25] - 2026-08-23
+
+> Staging candidate hardening Claude turn delivery, runtime recovery, and
+> durable processing acknowledgements across provider and daemon restarts.
+
+### Added
+
+- **Claude lifecycle-gated Inbox delivery.** When the CLI advertises the
+  supported lifecycle capability, steering waits for the native command's
+  queued acknowledgement and fails closed for unknown lifecycle dialects.
+  Ambiguous queue timeouts retire the native session before retry. (#274)
+- **Durable processed-receipt replay.** Failed server acknowledgements are
+  queued locally, retried with bounded backoff, and replayed after restart;
+  acknowledgements conditionally remove only the exact payload sent. (#280)
+- **Autonomous provider-run adoption.** Harness runs started by background
+  tasks are bound to durable daemon turns, including deferred adoption,
+  Inbox reads, freshness-aware sends, and idempotent terminal recovery. (#283)
+
+### Changed
+
+- **Outbound encryption is decided per send.** Turn-scoped send-mode state was
+  removed so one route cannot leak its encryption decision into another. (#281)
+
+### Fixed
+
+- **Provider failures retain their recovery semantics.** Authentication,
+  permission, quota, rate-limit, availability, invalid-resume, and runtime-exit
+  outcomes now use one operator-safe classification path without converting
+  permission errors into sign-in failures or losing retry boundaries. The CLI
+  also exposes detached headless startup for safe upgrade restart flows. (#282)
+
 ## [2.0.0a24] - 2026-08-22
 
 > Staging candidate closing the audited message-reliability gaps: silent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a24"
+version = "2.0.0a25"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a24"
+version = "2.0.0a25"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare the next TestPyPI staging candidate after merging #274, #280, #281, #282, and #283.

- lifecycle-gated Claude Inbox delivery
- durable processed-receipt replay
- per-call encryption decisions
- shared provider failure and retry semantics
- daemon adoption of autonomous harness turns

## Release scope

- bumps `pyproject.toml` and `uv.lock` from `2.0.0a24` to `2.0.0a25`
- adds the `2.0.0a25` changelog entry
- TestPyPI only; no stable PyPI release

## Verification

- all five implementation PRs passed repository CI
- combined implementation passed pre-commit and the full local test suite (one expected Windows-only skip)
- release metadata passed pre-commit and `git diff --check`
