### PR TITLE
chore(release): prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-23
+
+> Stable Agent Foundation 2.0 release, promoted from `2.0.0a25` without
+> additional runtime changes after the staged alpha hardening cycle.
+
+### Added
+
+- **Durable multi-target Inbox and turn coordination.** Agents batch pending
+  work across channels, threads, DMs, spaces, and reminders while preserving
+  routing, freshness, processing disposition, and restart recovery.
+- **Driver-based Claude Code and Codex runtimes.** Provider sessions expose a
+  normalized lifecycle, streaming activity, context telemetry, compaction,
+  steering where supported, and explicit provider failure semantics.
+
+### Changed
+
+- **Existing Agent state upgrades in place.** Supported 1.2 installations keep
+  their identity, keys, profile, memory, workspace, message history, and Puffo
+  logical session while the 2.0 runtime adopts the new storage and Driver
+  contracts.
+- **Agent collaboration is model-directed.** Structured Inbox context,
+  reminders, held-draft reconsideration, and semantic messaging tools provide
+  evidence without reducing reply, wait, clarification, or silence decisions
+  to hard-coded social rules.
+
+### Fixed
+
+- **Staged reliability hardening through `2.0.0a25`.** The stable build includes
+  the alpha-cycle fixes for long-message reads, account cutover, degraded
+  provider sessions, autocompaction, background sends, active long turns,
+  message disposition, thread preservation, lifecycle-gated delivery, durable
+  processed receipts, autonomous provider runs, encryption isolation, and
+  provider retry classification.
+
 ## [2.0.0a25] - 2026-08-23
 
 > Staging candidate hardening Claude turn delivery, runtime recovery, and
@@ -4867,7 +4901,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.0a2...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0
 [2.0.0a2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a2
 [2.0.0a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a1
 [1.2.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v1.2.0

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python:
 ```bash
 uv tool install puffo-agent
 # pin to a specific version:
-uv tool install puffo-agent==1.2.0
+uv tool install puffo-agent==2.0.0
 ```
 
 Otherwise use pip:
@@ -70,13 +70,12 @@ Otherwise use pip:
 ```bash
 pip install puffo-agent
 # pin to a specific version:
-pip install puffo-agent==1.2.0
+pip install puffo-agent==2.0.0
 ```
 
-The Agent Foundation `2.0.0a2` candidate is for staging validation and is
-published to TestPyPI only. See
-[`docs/RELEASE-CANDIDATE-2.0.0a2.md`](docs/RELEASE-CANDIDATE-2.0.0a2.md) for
-the install command, test scope, and stable-release TODOs.
+Agent Foundation `2.0.0` is the current stable release. It upgrades supported
+1.2 state in place while preserving Agent identity, keys, profile, memory,
+workspace, message history, and logical session continuity.
 
 Both paths install the `puffo-agent` console script. The CLI's
 `check-update` command detects which way you installed and prints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0a25"
+version = "2.0.0"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/roadmap/agent-foundation/STABLE-2.0-READINESS.md
+++ b/roadmap/agent-foundation/STABLE-2.0-READINESS.md
@@ -1,5 +1,13 @@
 # Agent Foundation 2.0 Stable Readiness
 
+## Stable Release Decision
+
+On 2026-08-23, the product owner explicitly authorized publication of
+`puffo-agent==2.0.0` from the hardened `2.0.0a25` source. The external evidence
+gaps retained below were accepted as post-release follow-up risks; they were not
+retroactively marked complete. This document remains the historical readiness
+backlog and evidence inventory rather than the current package status.
+
 This is the execution backlog for moving `puffo-agent==2.0.0a2` toward a
 stable `2.0.0` release. The release contract and acceptance cases remain in
 [`docs/RELEASE-CANDIDATE-2.0.0a2.md`](../../docs/RELEASE-CANDIDATE-2.0.0a2.md).

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0a25"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- promote the hardened `2.0.0a25` source to stable `2.0.0`
- update package metadata, lockfile, README, and changelog
- record the explicit release decision while retaining external readiness gaps as post-release follow-up risks
- make no runtime code changes after the staged alpha hardening cycle

## Validation

- `uv lock --check`
- fresh Python 3.11 wheel install with production dependencies
- wheel/sdist metadata and CLI smoke checks
- `SKIP=no-commit-to-branch uv run pre-commit run --all-files`
- `QT_QPA_PLATFORM=offscreen uv run pytest -q -p no:warnings` (pass; one Windows-only skip)
- `git diff --check`

## Publish

After merge, publish GitHub release `v2.0.0`. The release workflow validates the stable version/tag pair, rebuilds and smoke-installs the artifacts, then waits for approval on the `pypi` environment before Trusted Publishing.