### PR TITLE
fix(windows): keep background Agent subprocesses windowless

### DIFF
--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
+from ..._proc import no_window_kwargs
 from ..cli_bin import normalize_launch_argv
 from ..provider_failures import classify_provider_failure
 from .driver import (
@@ -198,6 +199,7 @@ class ClaudeCodeCliDriver(Driver):
                 cwd=spec.workspace_dir or None,
                 env=env,
                 limit=16 * 1024 * 1024,
+                **no_window_kwargs(),
             )
         else:
             try:

--- a/src/puffo_agent/agent/harness/codex_driver.py
+++ b/src/puffo_agent/agent/harness/codex_driver.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timezone
 from typing import Any
 
+from ..._proc import no_window_kwargs
 from ..errors import AgentAPIError, ProviderFailureError
 from ..provider_failures import (
     classify_provider_failure,
@@ -315,6 +316,7 @@ class CodexAppServerDriver(Driver):
                 # One provider frame can carry a large tool result; the default
                 # 64 KiB stream limit would terminate the reader mid-session.
                 limit=16 * 1024 * 1024,
+                **no_window_kwargs(),
             )
         else:
             self._proc = self.process_factory(spec)

--- a/src/puffo_agent/agent/memory_git.py
+++ b/src/puffo_agent/agent/memory_git.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .._proc import no_window_kwargs
 from .memory import (
     BRIEFING_DIR,
     IMPORTS_DIR,
@@ -115,6 +116,7 @@ def _run_git(
             text=True,
             timeout=_GIT_TIMEOUT,
             env=_scrubbed_env(),
+            **no_window_kwargs(),
         )
     except (OSError, subprocess.TimeoutExpired, ValueError) as exc:
         logger.warning("memory git %s failed to run: %s", args[:1], exc)

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -3,11 +3,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
 from puffo_agent import _proc
+from puffo_agent.agent import memory_git
+from puffo_agent.agent.harness import claude_code_driver, codex_driver
+from puffo_agent.agent.harness.claude_code_driver import ClaudeCodeCliDriver
+from puffo_agent.agent.harness.codex_driver import CodexAppServerDriver
+from puffo_agent.agent.harness.driver import RuntimeSpec
+
+
+_CREATE_NO_WINDOW = 0x08000000
+
+
+def _finished_process():
+    stdout = asyncio.StreamReader()
+    stderr = asyncio.StreamReader()
+    stdout.feed_eof()
+    stderr.feed_eof()
+    return SimpleNamespace(
+        stdin=object(), stdout=stdout, stderr=stderr, returncode=0
+    )
 
 
 @pytest.mark.skipif(
@@ -24,3 +44,53 @@ def test_no_window_kwargs_on_windows(monkeypatch):
 def test_no_window_kwargs_off_windows(monkeypatch):
     monkeypatch.setattr(_proc.os, "name", "posix")
     assert _proc.no_window_kwargs() == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["claude", "codex"])
+async def test_cli_drivers_request_windowless_child_processes(monkeypatch, provider):
+    """A detached Windows daemon must not create one console per Driver."""
+    captured = {}
+
+    async def fake_exec(*_args, **kwargs):
+        captured.update(kwargs)
+        return _finished_process()
+
+    module = claude_code_driver if provider == "claude" else codex_driver
+    monkeypatch.setattr(
+        module,
+        "no_window_kwargs",
+        lambda: {"creationflags": _CREATE_NO_WINDOW},
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    if provider == "claude":
+        driver = ClaudeCodeCliDriver()
+        await driver.open(RuntimeSpec("/workspace"))
+    else:
+        driver = CodexAppServerDriver()
+        await driver._start_process(RuntimeSpec("/workspace"))
+
+    assert captured["creationflags"] == _CREATE_NO_WINDOW
+    await driver.close()
+
+
+def test_memory_git_requests_a_windowless_child_process(monkeypatch, tmp_path):
+    """Memory maintenance in a detached daemon must not flash a git console."""
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        memory_git,
+        "no_window_kwargs",
+        lambda: {"creationflags": _CREATE_NO_WINDOW},
+    )
+    monkeypatch.setattr(memory_git.subprocess, "run", fake_run)
+
+    result = memory_git._run_git(tmp_path, ["init"], pin_repo=False)
+
+    assert result is not None
+    assert captured["creationflags"] == _CREATE_NO_WINDOW


### PR DESCRIPTION
## Problem

On Windows, `puffo-agent start --background` deliberately detaches the daemon from its console. The current Claude Code and Codex Driver spawn points did not pass the repository's existing `CREATE_NO_WINDOW` policy, so Windows allocated a visible console for every CLI child. Closing a window terminated that child and the reconcile loop correctly restarted it, making the window appear impossible to close. Memory git maintenance had the same lower-frequency console-flash gap.

## Fix

- apply the existing `no_window_kwargs()` helper to the active Claude Code Driver
- apply it to the active Codex app-server Driver
- apply it to daemon-owned memory git subprocesses
- add two focused regression tests covering the two Driver entry points and memory git

No Driver lifecycle, argv, messaging, retry, or reconcile behavior changes. POSIX behavior is unchanged because the helper returns an empty mapping there.

## Validation

- regression test observed red before the fix: both Drivers and memory git lacked the policy
- `uv run pytest tests/test_proc.py -q -p no:warnings`
- `uv run pytest tests/test_proc.py tests/test_harness_driver.py tests/test_memory_m3.py tests/test_memory_m4.py -q -p no:warnings`
- `QT_QPA_PLATFORM=offscreen uv run pytest -q -p no:warnings`
- `SKIP=no-commit-to-branch uv run pre-commit run --all-files`
- `git diff --check`

The reporter also manually validated the Driver-side flag on Windows: all 18 daemon-owned Claude workers reported `MainWindowHandle == 0`. This repository still lacks real Windows CI, so automated coverage verifies the process-creation contract rather than observing an OS window.

## Separate follow-up

The report also identifies the fixed 10-second background readiness timeout on a slow cold start. That is a distinct startup-policy problem and is intentionally not mixed into this console-window patch.