### PR TITLE
fix(startup): do not kill slow background daemons

### DIFF
--- a/src/puffo_agent/portal/background.py
+++ b/src/puffo_agent/portal/background.py
@@ -16,6 +16,8 @@ import time
 from importlib.util import find_spec
 
 from .state import (
+    DAEMON_STARTUP_OBSERVATION_SECONDS,
+    DaemonStartupState,
     background_log_path,
     is_daemon_alive,
     is_daemon_ready,
@@ -27,7 +29,6 @@ from .state import (
 # POSIX, where ``subprocess`` doesn't define them).
 _DETACHED_PROCESS = 0x00000008
 _CREATE_NEW_PROCESS_GROUP = 0x00000200
-_STARTUP_TIMEOUT_SECONDS = 10.0
 _GUI_EXTRA_HINT = (
     "puffo-agent start --background requires the desktop [gui] extra "
     "(PySide6). install it with: pip install 'puffo-agent[gui]' or "
@@ -61,50 +62,51 @@ def detach_kwargs(log_handle) -> dict:
     return kwargs
 
 
-def _wait_for_pid_ready(
+def _observe_pid_startup(
     pid: int,
     *,
-    timeout: float = _STARTUP_TIMEOUT_SECONDS,
+    timeout: float = DAEMON_STARTUP_OBSERVATION_SECONDS,
     proc=None,
-) -> bool:
+) -> DaemonStartupState:
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    while True:
         if is_daemon_ready(pid):
-            return True
-        if proc is not None and proc.poll() is not None:
-            return False
-        if not is_pid_alive(pid):
-            return False
-        time.sleep(0.1)
-    return is_daemon_ready(pid)
+            return DaemonStartupState.READY
+        if proc is not None:
+            if proc.poll() is not None:
+                return DaemonStartupState.EXITED
+        elif not is_pid_alive(pid):
+            return DaemonStartupState.EXITED
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return DaemonStartupState.STARTING
+        time.sleep(min(0.1, remaining))
 
 
-def _wait_for_background_ready(proc, timeout: float = _STARTUP_TIMEOUT_SECONDS) -> bool:
-    return _wait_for_pid_ready(proc.pid, timeout=timeout, proc=proc)
-
-
-def _stop_failed_background(proc) -> None:
-    if proc.poll() is not None:
-        return
-    try:
-        proc.terminate()
-        proc.wait(timeout=2.0)
-    except (OSError, subprocess.TimeoutExpired):
-        try:
-            proc.kill()
-        except OSError:
-            pass
+def _observe_background_startup(
+    proc,
+    timeout: float = DAEMON_STARTUP_OBSERVATION_SECONDS,
+) -> DaemonStartupState:
+    return _observe_pid_startup(proc.pid, timeout=timeout, proc=proc)
 
 
 def _existing_daemon_result() -> int | None:
     if not is_daemon_alive():
         return None
     pid = read_daemon_pid()
-    if pid is not None and _wait_for_pid_ready(pid):
+    if pid is None:
+        print("puffo-agent daemon has no readable pid.", file=sys.stderr)
+        return 1
+    startup = _observe_pid_startup(pid)
+    if startup is DaemonStartupState.READY:
         print(f"puffo-agent daemon already running (pid={pid}).")
         return 0
+    if startup is DaemonStartupState.STARTING:
+        print(f"puffo-agent daemon already starting (pid={pid}).")
+        print(f"  logs: {background_log_path()}")
+        return 0
     print(
-        f"puffo-agent daemon startup failed to become ready (pid={pid}).",
+        f"puffo-agent daemon exited before becoming ready (pid={pid}).",
         file=sys.stderr,
     )
     return 1
@@ -120,16 +122,24 @@ def _spawn_detached(command: list[str], *, tray: bool) -> int:
         # The child inherited its own copy of the fd; drop ours.
         log_handle.close()
 
-    if not _wait_for_background_ready(proc):
-        _stop_failed_background(proc)
+    startup = _observe_background_startup(proc)
+    if startup is DaemonStartupState.EXITED:
         print(
-            "puffo-agent background startup failed; inspect the log for details.",
+            "puffo-agent background process exited before becoming ready; "
+            "inspect the log for details.",
             file=sys.stderr,
         )
         print(f"  logs: {log_path}", file=sys.stderr)
         return 1
 
-    print(f"puffo-agent running in the background (pid={proc.pid}).")
+    if startup is DaemonStartupState.READY:
+        print(f"puffo-agent running in the background (pid={proc.pid}).")
+    else:
+        print(
+            "puffo-agent started in the background and is still initializing "
+            f"(pid={proc.pid})."
+        )
+        print("  check readiness with `puffo-agent status`.")
     if tray:
         print(
             "  status-bar icon → Open UI (beta) or Quit "

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -432,8 +432,11 @@ def cmd_check_update(args: argparse.Namespace) -> int:
 def cmd_status(args: argparse.Namespace) -> int:
     pid = read_daemon_pid()
     alive = is_daemon_alive()
-    if alive and pid is not None:
+    ready = alive and pid is not None and is_daemon_ready(pid)
+    if ready:
         print(f"daemon: running (pid={pid})")
+    elif alive and pid is not None:
+        print(f"daemon: starting (pid={pid})")
     elif pid is not None:
         print(f"daemon: not running (stale pid file at {daemon_pid_path()}; pid={pid})")
     else:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -38,6 +38,8 @@ from .host_mcp_handler import HostMcpContext
 from .rpc_service import set_rpc_resolver, start_rpc_service, stop_rpc_service
 from .runtime_matrix import RUNTIME_CLI_DOCKER, RUNTIME_CLI_LOCAL
 from .state import (
+    DAEMON_STARTUP_OBSERVATION_SECONDS,
+    DaemonStartupState,
     AgentConfig,
     DaemonConfig,
     agent_dir,
@@ -1301,16 +1303,46 @@ def _install_posix_stop_handlers(loop, handle_signal) -> bool:
     return installed
 
 
-async def _wait_for_existing_daemon_ready(pid: int, timeout: float = 10.0) -> bool:
+async def _observe_existing_daemon_startup(
+    pid: int,
+    timeout: float = DAEMON_STARTUP_OBSERVATION_SECONDS,
+) -> DaemonStartupState:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
-    while loop.time() < deadline:
+    while True:
         if is_daemon_ready(pid):
-            return True
+            return DaemonStartupState.READY
         if not is_pid_alive(pid):
-            return False
-        await asyncio.sleep(0.1)
-    return is_daemon_ready(pid)
+            return DaemonStartupState.EXITED
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return DaemonStartupState.STARTING
+        await asyncio.sleep(min(0.1, remaining))
+
+
+async def _existing_daemon_start_result() -> int | None:
+    if not is_daemon_alive():
+        return None
+    pid = read_daemon_pid()
+    startup = (
+        await _observe_existing_daemon_startup(pid)
+        if pid is not None
+        else DaemonStartupState.EXITED
+    )
+    if startup is DaemonStartupState.READY:
+        msg = f"puffo-agent daemon already running (pid={pid})"
+        logger.info(msg)
+        print(msg)
+        return 0
+    if startup is DaemonStartupState.STARTING:
+        msg = f"puffo-agent daemon already starting (pid={pid})"
+        logger.info(msg)
+        print(msg)
+        return 0
+    msg = f"puffo-agent daemon exited before becoming ready (pid={pid})"
+    logger.error(msg)
+    print(msg)
+    return 1
 
 
 async def run_daemon(
@@ -1321,18 +1353,8 @@ async def run_daemon(
     # exit 1 read as an error in upgrade flows. Enforcement is unchanged:
     # we never spawn a second daemon. A different running version isn't
     # discriminated here; ``stop && start`` is the version-swap path.
-    if is_daemon_alive():
-        pid = read_daemon_pid()
-        if pid is not None and await _wait_for_existing_daemon_ready(pid):
-            # print + log: background / tray runners may not surface INFO.
-            msg = f"puffo-agent daemon already running (pid={pid})"
-            logger.info(msg)
-            print(msg)
-            return 0
-        msg = f"puffo-agent daemon failed to become ready (pid={pid})"
-        logger.error(msg)
-        print(msg)
-        return 1
+    if (existing := await _existing_daemon_start_result()) is not None:
+        return existing
 
     home_dir().mkdir(parents=True, exist_ok=True)
     agents_dir().mkdir(parents=True, exist_ok=True)

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -27,6 +27,7 @@ import os
 import re
 import time
 from dataclasses import asdict, dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,17 @@ from ..limits import DEFAULT_CATCHUP_STALE_HOURS
 
 
 logger = logging.getLogger(__name__)
+
+
+DAEMON_STARTUP_OBSERVATION_SECONDS = 10.0
+
+
+class DaemonStartupState(Enum):
+    """What a bounded startup observation can prove about a daemon."""
+
+    READY = "ready"
+    STARTING = "starting"
+    EXITED = "exited"
 
 
 # Where daemon.yml, agents/, etc. live.

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -14,6 +14,7 @@ import sys
 
 
 from puffo_agent.portal import background as bg
+from puffo_agent.portal.state import DaemonStartupState
 
 
 def test_detached_runner_commands_use_dash_m():
@@ -49,8 +50,8 @@ def test_spawn_background_short_circuits_when_already_running(monkeypatch, capsy
     waited = []
     monkeypatch.setattr(
         bg,
-        "_wait_for_pid_ready",
-        lambda pid: waited.append(pid) or True,
+        "_observe_pid_startup",
+        lambda pid: waited.append(pid) or DaemonStartupState.READY,
     )
 
     def _no_spawn(*a, **k):
@@ -62,17 +63,21 @@ def test_spawn_background_short_circuits_when_already_running(monkeypatch, capsy
     assert "already running (pid=4321)" in capsys.readouterr().out
 
 
-def test_spawn_background_existing_daemon_must_be_ready(monkeypatch, capsys):
+def test_spawn_background_accepts_existing_daemon_still_starting(monkeypatch, capsys):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: True)
     monkeypatch.setattr(bg, "read_daemon_pid", lambda: 4321)
-    monkeypatch.setattr(bg, "_wait_for_pid_ready", lambda _pid: False)
+    monkeypatch.setattr(
+        bg,
+        "_observe_pid_startup",
+        lambda _pid: DaemonStartupState.STARTING,
+    )
 
     def _no_spawn(*_args, **_kwargs):
         raise AssertionError("must not spawn over an existing daemon process")
 
     monkeypatch.setattr(bg.subprocess, "Popen", _no_spawn)
-    assert bg.spawn_background() == 1
-    assert "failed to become ready" in capsys.readouterr().err
+    assert bg.spawn_background() == 0
+    assert "already starting (pid=4321)" in capsys.readouterr().out
 
 
 def test_spawn_background_preflights_gui_before_detach(monkeypatch, capsys):
@@ -91,7 +96,11 @@ def test_spawn_background_detaches_child(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
     monkeypatch.setattr(bg, "find_spec", lambda _name: object())
     monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
-    monkeypatch.setattr(bg, "_wait_for_background_ready", lambda _proc: True)
+    monkeypatch.setattr(
+        bg,
+        "_observe_background_startup",
+        lambda _proc: DaemonStartupState.READY,
+    )
 
     captured = {}
 
@@ -117,13 +126,19 @@ def test_spawn_background_detaches_child(monkeypatch, tmp_path, capsys):
     assert captured["cmd"] == bg.headless_runner_command()
 
 
-def test_spawn_background_reports_readiness_failure(monkeypatch, tmp_path, capsys):
+def test_spawn_background_keeps_a_live_child_after_observation_timeout(
+    monkeypatch, tmp_path, capsys
+):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
     monkeypatch.setattr(bg, "find_spec", lambda _name: object())
     monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
-    monkeypatch.setattr(bg, "_wait_for_background_ready", lambda _proc: False)
+    monkeypatch.setattr(
+        bg,
+        "_observe_background_startup",
+        lambda _proc: DaemonStartupState.STARTING,
+    )
 
-    class _FailedProc:
+    class _SlowProc:
         pid = 9999
         terminated = False
 
@@ -136,12 +151,60 @@ def test_spawn_background_reports_readiness_failure(monkeypatch, tmp_path, capsy
         def wait(self, timeout):
             return 1
 
-    proc = _FailedProc()
+    proc = _SlowProc()
     monkeypatch.setattr(bg.subprocess, "Popen", lambda *_a, **_kw: proc)
 
+    assert bg.spawn_background() == 0
+    assert proc.terminated is False
+    assert "still initializing" in capsys.readouterr().out
+
+
+def test_observation_timeout_classifies_live_child_as_starting(monkeypatch):
+    monkeypatch.setattr(bg, "is_daemon_ready", lambda _pid: False)
+
+    class _LiveProc:
+        pid = 9999
+
+        def poll(self):
+            return None
+
+    assert (
+        bg._observe_background_startup(_LiveProc(), timeout=0)
+        is DaemonStartupState.STARTING
+    )
+
+
+def test_spawn_background_reports_child_exit_before_ready(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
+    monkeypatch.setattr(bg, "find_spec", lambda _name: object())
+    monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
+    monkeypatch.setattr(
+        bg,
+        "_observe_background_startup",
+        lambda _proc: DaemonStartupState.EXITED,
+    )
+
+    class _ExitedProc:
+        pid = 9999
+
+    monkeypatch.setattr(bg.subprocess, "Popen", lambda *_a, **_kw: _ExitedProc())
+
     assert bg.spawn_background() == 1
-    assert proc.terminated is True
-    assert "startup failed" in capsys.readouterr().err
+    assert "exited before becoming ready" in capsys.readouterr().err
+
+
+def test_cmd_status_reports_live_unready_daemon_as_starting(monkeypatch, capsys):
+    from puffo_agent.portal import cli
+
+    monkeypatch.setattr(cli, "read_daemon_pid", lambda: 4321)
+    monkeypatch.setattr(cli, "is_daemon_alive", lambda: True)
+    monkeypatch.setattr(cli, "is_daemon_ready", lambda _pid: False)
+    monkeypatch.setattr(cli, "discover_agents", lambda: [])
+
+    assert cli.cmd_status(argparse.Namespace()) == 0
+    assert "daemon: starting (pid=4321)" in capsys.readouterr().out
 
 
 # ── cmd_start routing ─────────────────────────────────────────────────────────

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -57,8 +57,8 @@ def test_run_daemon_short_circuit_does_not_prefetch(monkeypatch):
     ), patch(
         "puffo_agent.portal.daemon.read_daemon_pid", return_value=4242,
     ), patch(
-        "puffo_agent.portal.daemon._wait_for_existing_daemon_ready",
-        return_value=True,
+        "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+        return_value=state_mod.DaemonStartupState.READY,
     ):
         rc = asyncio.run(daemon_mod.run_daemon())
     assert rc == 0

--- a/tests/test_run_daemon_already_running.py
+++ b/tests/test_run_daemon_already_running.py
@@ -9,15 +9,16 @@ import logging
 from unittest.mock import patch
 
 from puffo_agent.portal.daemon import run_daemon
+from puffo_agent.portal.state import DaemonStartupState
 
 
 class TestRunDaemonAlreadyRunning:
-    def test_returns_0_when_daemon_already_alive(self, caplog):
+    def test_returns_0_when_daemon_already_starting(self, caplog):
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
              patch(
-                 "puffo_agent.portal.daemon._wait_for_existing_daemon_ready",
-                 return_value=True,
+                 "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+                 return_value=DaemonStartupState.STARTING,
              ), \
              caplog.at_level(logging.INFO):
             rc = asyncio.run(run_daemon())
@@ -29,8 +30,8 @@ class TestRunDaemonAlreadyRunning:
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
              patch(
-                 "puffo_agent.portal.daemon._wait_for_existing_daemon_ready",
-                 return_value=True,
+                 "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+                 return_value=DaemonStartupState.READY,
              ), \
              caplog.at_level(logging.INFO):
             asyncio.run(run_daemon())
@@ -44,8 +45,8 @@ class TestRunDaemonAlreadyRunning:
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
              patch(
-                 "puffo_agent.portal.daemon._wait_for_existing_daemon_ready",
-                 return_value=True,
+                 "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+                 return_value=DaemonStartupState.READY,
              ), \
              caplog.at_level(logging.INFO):
             asyncio.run(run_daemon())
@@ -57,22 +58,22 @@ class TestRunDaemonAlreadyRunning:
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
              patch(
-                 "puffo_agent.portal.daemon._wait_for_existing_daemon_ready",
-                 return_value=True,
+                 "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+                 return_value=DaemonStartupState.READY,
              ):
             asyncio.run(run_daemon())
         out = capsys.readouterr().out
         assert "already running" in out
         assert "4242" in out
 
-    def test_returns_1_when_existing_daemon_never_becomes_ready(self, caplog):
+    def test_returns_1_when_existing_daemon_exits_before_ready(self, caplog):
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
              patch(
-                 "puffo_agent.portal.daemon._wait_for_existing_daemon_ready",
-                 return_value=False,
+                 "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+                 return_value=DaemonStartupState.EXITED,
              ), \
              caplog.at_level(logging.ERROR):
             rc = asyncio.run(run_daemon())
         assert rc == 1
-        assert any("failed to become ready" in r.message for r in caplog.records)
+        assert any("exited before becoming ready" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

Background startup treated a fixed 10-second readiness observation as a hard failure deadline. A healthy child that was still initializing was terminated, which reproducibly breaks cold startup on slower Windows machines.

## Change

- model bounded startup observation as `READY`, `STARTING`, or `EXITED`
- keep a live `STARTING` child instead of terminating it
- fail only when the child actually exits before readiness
- treat an existing starting daemon as satisfying the single-daemon guard
- show `daemon: starting` in `puffo-agent status`
- preserve the existing `daemon.ready` boundary and startup ordering

This intentionally does not move MCP fingerprinting, local-service startup, or worker reconciliation. Cold-start performance remains a separate follow-up.

## Verification

- focused startup/onboarding/catalog tests: 42 passed
- full pytest suite: passed (1 existing Windows-only skip)
- `pre-commit run --all-files`: passed
- Python structural limits: passed