### PR TITLE
perf(startup): expose daemon readiness before worker prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Background startup now distinguishes slow, stalled, stopped, and exited
+  daemons without terminating a live process after a fixed observation window.
+- Detached startup reports success when a concurrently launched child exits
+  because another daemon won startup, and avoids redundant daemon imports in
+  the parent CLI process.
+
 ## [2.0.0] - 2026-08-23
 
 > Stable Agent Foundation 2.0 release, promoted from `2.0.0a25` without

--- a/src/puffo_agent/portal/background.py
+++ b/src/puffo_agent/portal/background.py
@@ -98,18 +98,18 @@ def _existing_daemon_result() -> int | None:
     if pid is None:
         print("puffo-agent daemon has no readable pid.", file=sys.stderr)
         return 1
+    if is_daemon_startup_stalled(pid):
+        print(
+            f"puffo-agent daemon is alive but stalled during startup (pid={pid}).",
+            file=sys.stderr,
+        )
+        print(f"  logs: {background_log_path()}", file=sys.stderr)
+        return 1
     startup = _observe_pid_startup(pid)
     if startup is DaemonStartupState.READY:
         print(f"puffo-agent daemon already running (pid={pid}).")
         return 0
     if startup is DaemonStartupState.STARTING:
-        if is_daemon_startup_stalled(pid):
-            print(
-                f"puffo-agent daemon is alive but stalled during startup (pid={pid}).",
-                file=sys.stderr,
-            )
-            print(f"  logs: {background_log_path()}", file=sys.stderr)
-            return 1
         print(f"puffo-agent daemon already starting (pid={pid}).")
         print(f"  logs: {background_log_path()}")
         return 0
@@ -132,9 +132,16 @@ def _spawn_detached(command: list[str], *, tray: bool) -> int:
 
     startup = _observe_background_startup(proc)
     if startup is DaemonStartupState.EXITED:
-        if proc.poll() == 0 and is_daemon_alive():
-            pid = read_daemon_pid()
-            print(f"puffo-agent daemon already running or starting (pid={pid}).")
+        winner_pid = read_daemon_pid()
+        if (
+            proc.poll() == 0
+            and winner_pid is not None
+            and is_pid_alive(winner_pid)
+        ):
+            print(
+                "puffo-agent daemon already running or starting "
+                f"(pid={winner_pid})."
+            )
             print(f"  logs: {log_path}")
             return 0
         print(

--- a/src/puffo_agent/portal/background.py
+++ b/src/puffo_agent/portal/background.py
@@ -21,6 +21,7 @@ from .state import (
     background_log_path,
     is_daemon_alive,
     is_daemon_ready,
+    is_daemon_startup_stalled,
     is_pid_alive,
     read_daemon_pid,
 )
@@ -102,6 +103,13 @@ def _existing_daemon_result() -> int | None:
         print(f"puffo-agent daemon already running (pid={pid}).")
         return 0
     if startup is DaemonStartupState.STARTING:
+        if is_daemon_startup_stalled(pid):
+            print(
+                f"puffo-agent daemon is alive but stalled during startup (pid={pid}).",
+                file=sys.stderr,
+            )
+            print(f"  logs: {background_log_path()}", file=sys.stderr)
+            return 1
         print(f"puffo-agent daemon already starting (pid={pid}).")
         print(f"  logs: {background_log_path()}")
         return 0
@@ -124,6 +132,11 @@ def _spawn_detached(command: list[str], *, tray: bool) -> int:
 
     startup = _observe_background_startup(proc)
     if startup is DaemonStartupState.EXITED:
+        if proc.poll() == 0 and is_daemon_alive():
+            pid = read_daemon_pid()
+            print(f"puffo-agent daemon already running or starting (pid={pid}).")
+            print(f"  logs: {log_path}")
+            return 0
         print(
             "puffo-agent background process exited before becoming ready; "
             "inspect the log for details.",

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -41,6 +41,7 @@ from .state import (
     home_dir,
     is_daemon_alive,
     is_daemon_ready,
+    is_daemon_startup_stalled,
     is_pid_alive,
     is_valid_agent_id,
     read_daemon_pid,
@@ -50,6 +51,7 @@ from .state import (
     refresh_runtime_flag_path,
     refresh_session_flag_path,
     shared_fs_dir,
+    stop_requested_for,
     write_refresh_token_request,
     write_stop_request,
 )
@@ -57,13 +59,6 @@ from .workspace_layout import (
     AVAILABLE_SHARED_WORKSPACE_STATES,
     prepare_workspace_shared_access,
 )
-
-
-async def run_daemon() -> int:
-    """Load the daemon only in the process that runs it."""
-    from .daemon import run_daemon as _run_daemon
-
-    return await _run_daemon()
 
 
 DEFAULT_PROFILE = """# Agent Profile
@@ -329,6 +324,8 @@ def cmd_start(args: argparse.Namespace) -> int:
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+    from .daemon import run_daemon
+
     return asyncio.run(run_daemon())
 
 
@@ -440,10 +437,17 @@ def cmd_status(args: argparse.Namespace) -> int:
     pid = read_daemon_pid()
     alive = is_daemon_alive()
     ready = alive and pid is not None and is_daemon_ready(pid)
-    if ready:
+    if alive and pid is not None and stop_requested_for(pid):
+        print(f"daemon: stopping (pid={pid})")
+    elif ready:
         print(f"daemon: running (pid={pid})")
     elif alive and pid is not None:
-        print(f"daemon: starting (pid={pid})")
+        state = (
+            "stalled during startup"
+            if is_daemon_startup_stalled(pid)
+            else "starting"
+        )
+        print(f"daemon: {state} (pid={pid})")
     elif pid is not None:
         print(f"daemon: not running (stale pid file at {daemon_pid_path()}; pid={pid})")
     else:

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -42,6 +42,7 @@ from .state import (
     is_daemon_alive,
     is_daemon_ready,
     is_daemon_startup_stalled,
+    is_daemon_stop_stalled,
     is_pid_alive,
     is_valid_agent_id,
     read_daemon_pid,
@@ -438,7 +439,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     alive = is_daemon_alive()
     ready = alive and pid is not None and is_daemon_ready(pid)
     if alive and pid is not None and stop_requested_for(pid):
-        print(f"daemon: stopping (pid={pid})")
+        state = "stop stalled" if is_daemon_stop_stalled(pid) else "stopping"
+        print(f"daemon: {state} (pid={pid})")
     elif ready:
         print(f"daemon: running (pid={pid})")
     elif alive and pid is not None:

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 from .cli_parser import build_parser as build_cli_parser
-from .daemon import run_daemon
 from .state import (
     AgentConfig,
     DaemonConfig,
@@ -58,6 +57,14 @@ from .workspace_layout import (
     AVAILABLE_SHARED_WORKSPACE_STATES,
     prepare_workspace_shared_access,
 )
+
+
+async def run_daemon() -> int:
+    """Load the daemon only in the process that runs it."""
+    from .daemon import run_daemon as _run_daemon
+
+    return await _run_daemon()
+
 
 DEFAULT_PROFILE = """# Agent Profile
 

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -70,6 +70,7 @@ from .state import (
     shared_fs_dir,
     stop_request_path,
     stop_requested_for,
+    write_stop_request,
     write_daemon_pid,
     write_daemon_ready,
 )
@@ -290,6 +291,13 @@ class Daemon:
 
     def request_stop(self) -> None:
         self._stop.set()
+        pid = os.getpid()
+        if read_daemon_pid() != pid:
+            return
+        try:
+            write_stop_request(pid)
+        except Exception:  # noqa: BLE001 - the in-process event still stops us
+            logger.exception("failed to persist signal stop request")
 
     def _load_agent_cfg_cached(self, agent_id: str) -> AgentConfig:
         """Reuses a cached parse when (mtime_ns, size) is unchanged.
@@ -1343,6 +1351,11 @@ async def _existing_daemon_start_result() -> int | None:
     if not is_daemon_alive():
         return None
     pid = read_daemon_pid()
+    if pid is not None and is_daemon_startup_stalled(pid):
+        msg = f"puffo-agent daemon is alive but stalled during startup (pid={pid})"
+        logger.error(msg)
+        print(msg)
+        return 1
     startup = (
         await _observe_existing_daemon_startup(pid)
         if pid is not None
@@ -1354,11 +1367,6 @@ async def _existing_daemon_start_result() -> int | None:
         print(msg)
         return 0
     if startup is DaemonStartupState.STARTING:
-        if is_daemon_startup_stalled(pid):
-            msg = f"puffo-agent daemon is alive but stalled during startup (pid={pid})"
-            logger.error(msg)
-            print(msg)
-            return 1
         msg = f"puffo-agent daemon already starting (pid={pid})"
         logger.info(msg)
         print(msg)
@@ -1372,11 +1380,10 @@ async def _existing_daemon_start_result() -> int | None:
 async def run_daemon(
     external_stop_requested: threading.Event | None = None,
 ) -> int:
-    # Single-daemon enforcement. ``start`` against an already-running
-    # daemon exits 0 (the user wanted a running daemon; one exists) —
-    # exit 1 read as an error in upgrade flows. Enforcement is unchanged:
-    # we never spawn a second daemon. A different running version isn't
-    # discriminated here; ``stop && start`` is the version-swap path.
+    # Single-daemon enforcement. ``start`` against an already-running or
+    # recently-started daemon exits 0; a live process that stayed unready
+    # beyond the stall threshold returns 1 with diagnostics. We never spawn
+    # a second daemon. ``stop && start`` remains the version-swap path.
     if (existing := await _existing_daemon_start_result()) is not None:
         return existing
 

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -138,6 +138,7 @@ class Daemon:
         self,
         external_stop_requested: threading.Event | None = None,
     ) -> None:
+        startup_started = time.perf_counter()
         logger.info("puffo-agent portal starting; home=%s", home_dir())
         interval = max(0.5, self.daemon_cfg.reconcile_interval_seconds)
         pid = os.getpid()
@@ -149,6 +150,11 @@ class Daemon:
                 self._stop.set()
             else:
                 write_daemon_ready(pid)
+                logger.info(
+                    "startup: control plane ready; elapsed_ms=%d",
+                    int((time.perf_counter() - startup_started) * 1000),
+                )
+                await _prepare_workers_at_startup()
             await self._run_reconcile_loop(
                 pid,
                 interval,
@@ -198,7 +204,6 @@ class Daemon:
         runtime.runtime_tasks.append(
             asyncio.ensure_future(runtime.control_manager.run())
         )
-        _respawn_codex_on_mcp_change_at_startup()
 
     def _stop_was_requested(
         self,
@@ -850,13 +855,26 @@ def _mcp_fingerprint_path() -> Path:
     return home_dir() / "mcp_tool_fingerprint"
 
 
+async def _prepare_workers_at_startup() -> None:
+    """Finish worker prerequisites without blocking control-plane readiness."""
+    started = time.perf_counter()
+    try:
+        await asyncio.to_thread(_respawn_codex_on_mcp_change_at_startup)
+    except Exception:  # noqa: BLE001 - preparation is best-effort
+        logger.exception("startup: worker preparation failed; continuing")
+    logger.info(
+        "startup: worker preparation complete; elapsed_ms=%d",
+        int((time.perf_counter() - started) * 1000),
+    )
+
+
 def _respawn_codex_on_mcp_change_at_startup() -> None:
     """Rotate Codex sessions when their cached MCP surface changed."""
     import json
 
-    from ..mcp.puffo_core_server import mcp_tool_fingerprint
-
     try:
+        from ..mcp.puffo_core_server import mcp_tool_fingerprint
+
         current = mcp_tool_fingerprint()
     except Exception as exc:  # noqa: BLE001 - startup remains best-effort
         logger.warning("startup: mcp fingerprint failed: %s", exc)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -58,6 +58,7 @@ from .state import (
     home_dir,
     is_daemon_alive,
     is_daemon_ready,
+    is_daemon_startup_stalled,
     is_pid_alive,
     read_daemon_pid,
     refresh_model_flag_path,
@@ -1353,6 +1354,11 @@ async def _existing_daemon_start_result() -> int | None:
         print(msg)
         return 0
     if startup is DaemonStartupState.STARTING:
+        if is_daemon_startup_stalled(pid):
+            msg = f"puffo-agent daemon is alive but stalled during startup (pid={pid})"
+            logger.error(msg)
+            print(msg)
+            return 1
         msg = f"puffo-agent daemon already starting (pid={pid})"
         logger.info(msg)
         print(msg)

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -44,6 +44,7 @@ DAEMON_STARTUP_OBSERVATION_SECONDS = 10.0
 # Slow startup remains non-fatal; this only marks an old unready process
 # as diagnosably stalled when a later command inspects it.
 DAEMON_STARTUP_STALLED_SECONDS = 300.0
+DAEMON_STOP_STALLED_SECONDS = 60.0
 
 
 class DaemonStartupState(Enum):
@@ -1100,7 +1101,7 @@ def is_daemon_startup_stalled(
     threshold: float = DAEMON_STARTUP_STALLED_SECONDS,
 ) -> bool:
     """Whether the current daemon has stayed alive but unready too long."""
-    if read_daemon_pid() != pid:
+    if read_daemon_pid() != pid or is_daemon_ready(pid):
         return False
     try:
         started_at = daemon_pid_path().stat().st_mtime
@@ -1219,6 +1220,21 @@ def stop_requested_for(pid: int) -> bool:
     request, which targets whichever daemon is running."""
     kind, target_pid = _classify_stop_request()
     return (kind == "pid" and target_pid == pid) or kind == "legacy"
+
+
+def is_daemon_stop_stalled(
+    pid: int,
+    *,
+    threshold: float = DAEMON_STOP_STALLED_SECONDS,
+) -> bool:
+    """Whether an owned stop request has waited too long for process exit."""
+    if not stop_requested_for(pid):
+        return False
+    try:
+        requested_at = stop_request_path().stat().st_mtime
+    except OSError:
+        return False
+    return time.time() - requested_at >= threshold
 
 
 def write_stop_request(pid: int | None = None) -> None:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -41,6 +41,9 @@ logger = logging.getLogger(__name__)
 
 
 DAEMON_STARTUP_OBSERVATION_SECONDS = 10.0
+# Slow startup remains non-fatal; this only marks an old unready process
+# as diagnosably stalled when a later command inspects it.
+DAEMON_STARTUP_STALLED_SECONDS = 300.0
 
 
 class DaemonStartupState(Enum):
@@ -1089,6 +1092,21 @@ def write_daemon_pid(pid: int) -> None:
     path = daemon_pid_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(str(pid), encoding="utf-8")
+
+
+def is_daemon_startup_stalled(
+    pid: int,
+    *,
+    threshold: float = DAEMON_STARTUP_STALLED_SECONDS,
+) -> bool:
+    """Whether the current daemon has stayed alive but unready too long."""
+    if read_daemon_pid() != pid:
+        return False
+    try:
+        started_at = daemon_pid_path().stat().st_mtime
+    except OSError:
+        return False
+    return time.time() - started_at >= threshold
 
 
 def read_daemon_ready_pid() -> int | None:

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -81,7 +81,7 @@ def test_spawn_background_accepts_existing_daemon_still_starting(monkeypatch, ca
     assert "already starting (pid=4321)" in capsys.readouterr().out
 
 
-def test_spawn_background_reports_existing_daemon_stalled(monkeypatch, capsys):
+def test_headless_background_reports_existing_daemon_stalled(monkeypatch, capsys):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: True)
     monkeypatch.setattr(bg, "read_daemon_pid", lambda: 4321)
     monkeypatch.setattr(
@@ -227,6 +227,7 @@ def test_spawn_background_accepts_redundant_child_exit(
 ):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: True)
     monkeypatch.setattr(bg, "read_daemon_pid", lambda: 4321)
+    monkeypatch.setattr(bg, "is_pid_alive", lambda _pid: True)
     monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
     monkeypatch.setattr(
         bg,
@@ -268,10 +269,16 @@ def test_cmd_status_reports_stop_request(monkeypatch, capsys):
     monkeypatch.setattr(cli, "is_daemon_alive", lambda: True)
     monkeypatch.setattr(cli, "is_daemon_ready", lambda _pid: False)
     monkeypatch.setattr(cli, "stop_requested_for", lambda _pid: True)
+    stalled = False
+    monkeypatch.setattr(cli, "is_daemon_stop_stalled", lambda _pid: stalled)
     monkeypatch.setattr(cli, "discover_agents", lambda: [])
 
     assert cli.cmd_status(argparse.Namespace()) == 0
     assert "daemon: stopping (pid=4321)" in capsys.readouterr().out
+
+    stalled = True
+    assert cli.cmd_status(argparse.Namespace()) == 0
+    assert "daemon: stop stalled (pid=4321)" in capsys.readouterr().out
 
 
 # ── cmd_start routing ─────────────────────────────────────────────────────────

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -71,6 +71,7 @@ def test_spawn_background_accepts_existing_daemon_still_starting(monkeypatch, ca
         "_observe_pid_startup",
         lambda _pid: DaemonStartupState.STARTING,
     )
+    monkeypatch.setattr(bg, "is_daemon_startup_stalled", lambda _pid: False)
 
     def _no_spawn(*_args, **_kwargs):
         raise AssertionError("must not spawn over an existing daemon process")
@@ -78,6 +79,20 @@ def test_spawn_background_accepts_existing_daemon_still_starting(monkeypatch, ca
     monkeypatch.setattr(bg.subprocess, "Popen", _no_spawn)
     assert bg.spawn_background() == 0
     assert "already starting (pid=4321)" in capsys.readouterr().out
+
+
+def test_spawn_background_reports_existing_daemon_stalled(monkeypatch, capsys):
+    monkeypatch.setattr(bg, "is_daemon_alive", lambda: True)
+    monkeypatch.setattr(bg, "read_daemon_pid", lambda: 4321)
+    monkeypatch.setattr(
+        bg,
+        "_observe_pid_startup",
+        lambda _pid: DaemonStartupState.STARTING,
+    )
+    monkeypatch.setattr(bg, "is_daemon_startup_stalled", lambda _pid: True)
+
+    assert bg.spawn_headless_background() == 1
+    assert "stalled during startup" in capsys.readouterr().err
 
 
 def test_spawn_background_preflights_gui_before_detach(monkeypatch, capsys):
@@ -159,17 +174,26 @@ def test_spawn_background_keeps_a_live_child_after_observation_timeout(
     assert "still initializing" in capsys.readouterr().out
 
 
-def test_observation_timeout_classifies_live_child_as_starting(monkeypatch):
-    monkeypatch.setattr(bg, "is_daemon_ready", lambda _pid: False)
+def test_observation_prioritizes_ready_then_detects_exit_or_timeout(monkeypatch):
+    ready = True
+    monkeypatch.setattr(bg, "is_daemon_ready", lambda _pid: ready)
 
-    class _LiveProc:
+    class _Proc:
         pid = 9999
 
         def poll(self):
-            return None
+            return 0
+
+    proc = _Proc()
+    assert bg._observe_background_startup(proc, timeout=0) is DaemonStartupState.READY
+
+    ready = False
+    assert bg._observe_background_startup(proc, timeout=0) is DaemonStartupState.EXITED
+
+    proc.poll = lambda: None
 
     assert (
-        bg._observe_background_startup(_LiveProc(), timeout=0)
+        bg._observe_background_startup(proc, timeout=0)
         is DaemonStartupState.STARTING
     )
 
@@ -189,10 +213,38 @@ def test_spawn_background_reports_child_exit_before_ready(
     class _ExitedProc:
         pid = 9999
 
+        def poll(self):
+            return 1
+
     monkeypatch.setattr(bg.subprocess, "Popen", lambda *_a, **_kw: _ExitedProc())
 
     assert bg.spawn_background() == 1
     assert "exited before becoming ready" in capsys.readouterr().err
+
+
+def test_spawn_background_accepts_redundant_child_exit(
+    monkeypatch, tmp_path, capsys,
+):
+    monkeypatch.setattr(bg, "is_daemon_alive", lambda: True)
+    monkeypatch.setattr(bg, "read_daemon_pid", lambda: 4321)
+    monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
+    monkeypatch.setattr(
+        bg,
+        "_observe_background_startup",
+        lambda _proc: DaemonStartupState.EXITED,
+    )
+
+    class _RedundantProc:
+        pid = 9999
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(bg.subprocess, "Popen", lambda *_a, **_kw: _RedundantProc())
+    monkeypatch.setattr(bg, "_existing_daemon_result", lambda: None)
+
+    assert bg.spawn_headless_background() == 0
+    assert "already running or starting (pid=4321)" in capsys.readouterr().out
 
 
 def test_cmd_status_reports_live_unready_daemon_as_starting(monkeypatch, capsys):
@@ -201,10 +253,25 @@ def test_cmd_status_reports_live_unready_daemon_as_starting(monkeypatch, capsys)
     monkeypatch.setattr(cli, "read_daemon_pid", lambda: 4321)
     monkeypatch.setattr(cli, "is_daemon_alive", lambda: True)
     monkeypatch.setattr(cli, "is_daemon_ready", lambda _pid: False)
+    monkeypatch.setattr(cli, "is_daemon_startup_stalled", lambda _pid: False)
+    monkeypatch.setattr(cli, "stop_requested_for", lambda _pid: False)
     monkeypatch.setattr(cli, "discover_agents", lambda: [])
 
     assert cli.cmd_status(argparse.Namespace()) == 0
     assert "daemon: starting (pid=4321)" in capsys.readouterr().out
+
+
+def test_cmd_status_reports_stop_request(monkeypatch, capsys):
+    from puffo_agent.portal import cli
+
+    monkeypatch.setattr(cli, "read_daemon_pid", lambda: 4321)
+    monkeypatch.setattr(cli, "is_daemon_alive", lambda: True)
+    monkeypatch.setattr(cli, "is_daemon_ready", lambda _pid: False)
+    monkeypatch.setattr(cli, "stop_requested_for", lambda _pid: True)
+    monkeypatch.setattr(cli, "discover_agents", lambda: [])
+
+    assert cli.cmd_status(argparse.Namespace()) == 0
+    assert "daemon: stopping (pid=4321)" in capsys.readouterr().out
 
 
 # ── cmd_start routing ─────────────────────────────────────────────────────────
@@ -259,10 +326,10 @@ def test_cmd_start_routes_ui(monkeypatch):
 
 
 def test_cmd_start_routes_foreground_daemon(monkeypatch):
-    from puffo_agent.portal import cli
+    from puffo_agent.portal import cli, daemon
 
     async def fake_run_daemon():
         return 3
 
-    monkeypatch.setattr(cli, "run_daemon", fake_run_daemon)
+    monkeypatch.setattr(daemon, "run_daemon", fake_run_daemon)
     assert cli.cmd_start(_ns()) == 3

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -23,6 +23,60 @@ def test_daemon_run_calls_model_catalog_prefetch_at_startup():
     assert "model_catalog" in source and "prefetch" in source
 
 
+@pytest.mark.asyncio
+async def test_daemon_ready_precedes_worker_preparation_and_reconcile(
+    monkeypatch,
+):
+    """A slow MCP scan must not hide a usable control plane, while workers
+    must not reconcile until the scan has prepared their sessions."""
+    events = []
+
+    async def start_runtime(_self, _runtime):
+        events.append("control-plane")
+
+    async def prepare_workers():
+        events.append("worker-preparation")
+
+    async def reconcile(_self, _pid, _interval, _external_stop):
+        events.append("reconcile")
+
+    async def shutdown(_self, _runtime, _pid):
+        events.append("shutdown")
+
+    daemon = daemon_mod.Daemon.__new__(daemon_mod.Daemon)
+    daemon.daemon_cfg = DaemonConfig()
+    daemon._stop = asyncio.Event()
+    monkeypatch.setattr(daemon_mod.Daemon, "_start_runtime", start_runtime)
+    monkeypatch.setattr(daemon_mod.Daemon, "_run_reconcile_loop", reconcile)
+    monkeypatch.setattr(daemon_mod.Daemon, "_shutdown_runtime", shutdown)
+    monkeypatch.setattr(
+        daemon_mod.Daemon,
+        "_stop_was_requested",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        daemon_mod,
+        "_prepare_workers_at_startup",
+        prepare_workers,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        daemon_mod,
+        "write_daemon_ready",
+        lambda _pid: events.append("ready"),
+    )
+
+    await daemon.run()
+
+    assert events == [
+        "control-plane",
+        "ready",
+        "worker-preparation",
+        "reconcile",
+        "shutdown",
+    ]
+
+
 def test_capabilities_fetch_claude_catalog_after_late_login(monkeypatch):
     from puffo_agent.agent import cli_bin, model_catalog
     from puffo_agent.portal.control.client import build_capabilities

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -78,7 +78,7 @@ async def test_daemon_ready_precedes_worker_preparation_and_reconcile(
 
 
 @pytest.mark.asyncio
-async def test_worker_preparation_failure_does_not_stop_ready_daemon(
+async def test_worker_preparation_failure_is_best_effort(
     monkeypatch, caplog,
 ):
     def fail_preparation():

--- a/tests/test_daemon_catalog_prefetch.py
+++ b/tests/test_daemon_catalog_prefetch.py
@@ -77,6 +77,24 @@ async def test_daemon_ready_precedes_worker_preparation_and_reconcile(
     ]
 
 
+@pytest.mark.asyncio
+async def test_worker_preparation_failure_does_not_stop_ready_daemon(
+    monkeypatch, caplog,
+):
+    def fail_preparation():
+        raise RuntimeError("preparation failed")
+
+    monkeypatch.setattr(
+        daemon_mod,
+        "_respawn_codex_on_mcp_change_at_startup",
+        fail_preparation,
+    )
+
+    await daemon_mod._prepare_workers_at_startup()
+
+    assert "worker preparation failed; continuing" in caplog.text
+
+
 def test_capabilities_fetch_claude_catalog_after_late_login(monkeypatch):
     from puffo_agent.agent import cli_bin, model_catalog
     from puffo_agent.portal.control.client import build_capabilities

--- a/tests/test_daemon_signal_handlers.py
+++ b/tests/test_daemon_signal_handlers.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import threading
 
+from puffo_agent.portal import daemon as daemon_mod
 from puffo_agent.portal.daemon import _install_posix_stop_handlers
 from puffo_agent.portal.ui import daemon_thread as daemon_thread_mod
 from puffo_agent.portal.ui.daemon_thread import DaemonThread
@@ -37,6 +38,19 @@ def test_posix_stop_handlers_skipped_off_main_thread():
     # No RuntimeError from set_wakeup_fd, and nothing installed off-thread.
     assert "error" not in out, out.get("error")
     assert out["installed"] is False
+
+
+def test_daemon_signal_stop_publishes_owned_sentinel(monkeypatch):
+    daemon = daemon_mod.Daemon.__new__(daemon_mod.Daemon)
+    daemon._stop = asyncio.Event()
+    writes = []
+    monkeypatch.setattr(daemon_mod, "read_daemon_pid", lambda: os.getpid())
+    monkeypatch.setattr(daemon_mod, "write_stop_request", writes.append)
+
+    daemon.request_stop()
+
+    assert daemon._stop.is_set()
+    assert writes == [os.getpid()]
 
 
 def test_daemon_thread_runs_daemon_without_bridge_flag(monkeypatch):

--- a/tests/test_run_daemon_already_running.py
+++ b/tests/test_run_daemon_already_running.py
@@ -16,6 +16,7 @@ class TestRunDaemonAlreadyRunning:
     def test_returns_0_when_daemon_already_starting(self, caplog):
         with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
              patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
+             patch("puffo_agent.portal.daemon.is_daemon_startup_stalled", return_value=False), \
              patch(
                  "puffo_agent.portal.daemon._observe_existing_daemon_startup",
                  return_value=DaemonStartupState.STARTING,
@@ -23,6 +24,19 @@ class TestRunDaemonAlreadyRunning:
              caplog.at_level(logging.INFO):
             rc = asyncio.run(run_daemon())
         assert rc == 0
+
+    def test_returns_1_when_daemon_startup_is_stalled(self, caplog):
+        with patch("puffo_agent.portal.daemon.is_daemon_alive", return_value=True), \
+             patch("puffo_agent.portal.daemon.read_daemon_pid", return_value=4242), \
+             patch("puffo_agent.portal.daemon.is_daemon_startup_stalled", return_value=True), \
+             patch(
+                 "puffo_agent.portal.daemon._observe_existing_daemon_startup",
+                 return_value=DaemonStartupState.STARTING,
+             ), \
+             caplog.at_level(logging.ERROR):
+            rc = asyncio.run(run_daemon())
+        assert rc == 1
+        assert any("stalled during startup" in r.message for r in caplog.records)
 
     def test_logs_at_info_not_error_when_already_running(self, caplog):
         # An already-running daemon is the user's intent, not an error —

--- a/tests/test_slim_packaging_headless.py
+++ b/tests/test_slim_packaging_headless.py
@@ -62,6 +62,12 @@ def test_daemon_and_cli_import_without_pyside6(pyside6_blocked):
     assert hasattr(cli, "cmd_start")
 
 
+def test_cli_import_does_not_eagerly_import_daemon(pyside6_blocked):
+    importlib.import_module("puffo_agent.portal.cli")
+
+    assert "puffo_agent.portal.daemon" not in sys.modules
+
+
 def test_gui_command_without_extra_yields_actionable_hint(
     pyside6_blocked, capsys,
 ):


### PR DESCRIPTION
## Summary

- report daemon readiness once local WS/RPC/data/control services are initialized
- run the expensive MCP fingerprint scan off the event-loop thread, before the first worker reconcile
- lazily import the daemon in the CLI so detached startup does not import the daemon in both parent and child
- add stage timing logs and one lifecycle-order regression test

## Why this is stacked

This PR is based on #288, which fixes the correctness bug where a live daemon was killed after a fixed 10-second startup observation window. This follow-up reduces the actual cold-start wait without changing worker startup ordering.

## Ordering contract

`local control plane ready -> MCP/session worker preparation -> first worker reconcile`

The ready marker no longer waits for the MCP scan, but no worker can start before that scan completes. Worker preparation remains best-effort and logs failures instead of terminating an already-ready daemon.

## Evidence

- isolated detached cold start on macOS: 3.25s baseline -> 0.25s
- control-plane ready log: 6ms
- worker preparation log: 121ms
- focused startup/background/MCP tests: 33 passed
- full test suite: passed (1 existing Windows-only skip)
- `pre-commit run --all-files`: passed
- `python tools/check_python_structure.py`: passed

## Deferred

Windows tray startup still imports Qt before launching the daemon thread. That is a separate process/lifecycle change and is intentionally not included here.