### PR TITLE
chore(release): prepare 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-24
+
 ### Changed
 
 - **Channel sends follow the channel's format policy.** The channel's
@@ -29,6 +31,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - Detached startup reports success when a concurrently launched child exits
   because another daemon won startup, and avoids redundant daemon imports in
   the parent CLI process.
+- The daemon publishes control-plane readiness before worker preparation, so
+  background startup returns promptly while preserving bounded stalled-start
+  and stalled-stop diagnostics.
+- Windows background Agents now launch Claude Code, Codex, and memory Git
+  subprocesses without opening visible console windows.
 
 ## [2.0.0] - 2026-08-23
 
@@ -4925,7 +4932,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.1
 [2.0.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0
 [2.0.0a2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a2
 [2.0.0a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a1

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python:
 ```bash
 uv tool install puffo-agent
 # pin to a specific version:
-uv tool install puffo-agent==2.0.0
+uv tool install puffo-agent==2.0.1
 ```
 
 Otherwise use pip:
@@ -70,10 +70,10 @@ Otherwise use pip:
 ```bash
 pip install puffo-agent
 # pin to a specific version:
-pip install puffo-agent==2.0.0
+pip install puffo-agent==2.0.1
 ```
 
-Agent Foundation `2.0.0` is the current stable release. It upgrades supported
+Agent Foundation `2.0.1` is the current stable release. It upgrades supported
 1.2 state in place while preserving Agent identity, keys, profile, memory,
 workspace, message history, and logical session continuity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.0"
+version = "2.0.1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- release the current stable main as `puffo-agent 2.0.1`
- include channel-format enforcement (#212), Windows background subprocess fixes (#286), resilient background startup (#288/#289), and Codex resume recovery (#290)
- update package metadata, lockfile, README, and changelog
- make no runtime-code changes in the release commit

## Validation

- `uv lock --check`
- `SKIP=no-commit-to-branch uv run --extra dev pre-commit run --all-files`
- `QT_QPA_PLATFORM=offscreen uv run --extra dev pytest -q -p no:warnings` (pass; one expected Windows-only skip)
- built `puffo_agent-2.0.1.tar.gz` and `puffo_agent-2.0.1-py3-none-any.whl`
- installed the wheel into a fresh Python 3.11 environment
- verified wheel metadata and `puffo-agent --help`
- `git diff --check`

## Publish

After merge, publish GitHub release `v2.0.1`. The production workflow validates the stable version/tag pair, rebuilds and smoke-installs the artifacts, then publishes through the protected `pypi` environment.