### PR TITLE
chore(release): prepare 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-08-25
+
+### Fixed
+
+- **Windows background daemons survive terminal closure.** Detached children
+  break away from the launcher's Job object instead of being terminated with
+  the PowerShell or Terminal window. Managed Windows machines whose App Control
+  policy blocks the pip/uv-generated `puffo-agent.exe` shim can use the new
+  equivalent `python -m puffo_agent` entry point. (#292)
+
 ## [2.0.1] - 2026-08-24
 
 ### Changed
@@ -4932,7 +4942,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.2
 [2.0.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.1
 [2.0.0]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0
 [2.0.0a2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.0a2

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python:
 ```bash
 uv tool install puffo-agent
 # pin to a specific version:
-uv tool install puffo-agent==2.0.1
+uv tool install puffo-agent==2.0.2
 ```
 
 Otherwise use pip:
@@ -70,10 +70,10 @@ Otherwise use pip:
 ```bash
 pip install puffo-agent
 # pin to a specific version:
-pip install puffo-agent==2.0.1
+pip install puffo-agent==2.0.2
 ```
 
-Agent Foundation `2.0.1` is the current stable release. It upgrades supported
+Agent Foundation `2.0.2` is the current stable release. It upgrades supported
 1.2 state in place while preserving Agent identity, keys, profile, memory,
 workspace, message history, and logical session continuity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.1"
+version = "2.0.2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the stable package version from `2.0.1` to `2.0.2`
- document the Windows background-daemon and App Control recovery fix from #292
- update pinned install examples and release comparison links

## Verification

- Windows close-the-terminal smoke test reported successful by the affected operator
- #292 CI: Python 3.11, Python 3.12, pre-commit, and CodeQL all passed
- release pre-commit: passed
- focused launcher tests: 25 passed
- built `puffo_agent-2.0.2.tar.gz` and `puffo_agent-2.0.2-py3-none-any.whl`
- smoke-installed the wheel under Python 3.11 and verified both `puffo-agent version` and `python -m puffo_agent version` report `2.0.2`

After this merges, publish GitHub Release `v2.0.2`; the existing trusted-publishing workflow will validate the tag/version match, rebuild, smoke-install, and publish to PyPI.
