### PR TITLE
Surface swallowed worker-task exceptions via universal spawn helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   them too. Quota-exhausted refresh probes no longer count toward the
   `refresh_broken` streak. (#228)
 
+### Fixed
+
+- **Worker tasks no longer die unclaimed.** Every background task the daemon
+  spawns now carries a done-callback that logs `worker task died: <name>` with
+  the full traceback when the task ends on an unhandled exception, instead of
+  the exception vanishing into the event loop. Shutdown cancellation stays
+  silent. A start-up failure such as an unreadable message-backup key now
+  surfaces on the first restart rather than presenting as a silent hang.
+
 ## [2.0.2] - 2026-08-25
 
 ### Fixed

--- a/src/puffo_agent/agent/adapters/cli_session.py
+++ b/src/puffo_agent/agent/adapters/cli_session.py
@@ -48,6 +48,7 @@ from ..context_controller import (
     ToolResultAdmission,
     normalize_context_snapshot,
 )
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -899,13 +900,14 @@ class ClaudeSession:
                 self.agent_id,
                 INIT_TIMEOUT_SECONDS,
             )
-            self._stderr_drain_task = asyncio.ensure_future(
-                self._drain_stderr(self._proc)
+            self._stderr_drain_task = spawn(
+                self._drain_stderr(self._proc),
+                name="drain_stderr",
             )
             return
         if sid and sid != self._session_id:
             self._save_session_id(sid)
-        self._stderr_drain_task = asyncio.ensure_future(self._drain_stderr(self._proc))
+        self._stderr_drain_task = spawn(self._drain_stderr(self._proc), name="drain_stderr")
 
     async def _read_init(self, proc: asyncio.subprocess.Process) -> str:
         while True:
@@ -1347,8 +1349,9 @@ class ClaudeSession:
             text = block.get("text", "") or ""
             state.reply_parts.append(text)
             if text and not is_silent(text):
-                asyncio.ensure_future(
-                    reporter.emit(self.agent_id, "assistant_text", {"text": text})
+                spawn(
+                    reporter.emit(self.agent_id, "assistant_text", {"text": text}),
+                    name="reporter.emit:assistant_text",
                 )
             if self.audit is not None and text:
                 self.audit.write("assistant.text", text=text)
@@ -1368,7 +1371,10 @@ class ClaudeSession:
         tool_event = {"tool": name}
         if "send_message" in name and isinstance(tool_input.get("text"), str):
             tool_event["content"] = tool_input["text"][:STATUS_PREVIEW_CHARS]
-        asyncio.ensure_future(reporter.emit(self.agent_id, "tool_use", tool_event))
+        spawn(
+            reporter.emit(self.agent_id, "tool_use", tool_event),
+            name="reporter.emit:tool_use",
+        )
         if name == "mcp__puffo__send_message":
             state.send_message_targets.append(
                 {

--- a/src/puffo_agent/agent/bridge_client.py
+++ b/src/puffo_agent/agent/bridge_client.py
@@ -26,6 +26,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 import aiohttp
 
 from ..limits import MAX_INBOUND_ATTACHMENT_BYTES
+from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +153,7 @@ class CloudBridgeClient:
         logger.info("cloud bridge: WS connected (slug=%s)", self._slug)
         # Start the heartbeat only after a clean handshake so no failure
         # path leaves a live heartbeat task behind.
-        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        self._heartbeat_task = spawn(self._heartbeat_loop(), name="heartbeat_loop")
         for callback in tuple(self._connected_callbacks):
             try:
                 await callback()

--- a/src/puffo_agent/agent/bridge_transport.py
+++ b/src/puffo_agent/agent/bridge_transport.py
@@ -82,6 +82,7 @@ from .message_context import (
     maybe_redact_long_text,
 )
 from .message_store import ReceiptDisposition, ReceiptWriteStatus
+from ..tasks import spawn
 
 KEYLESS_DM_REPLY_REASON = "handled keyless dm approval reply"
 KEYLESS_INVITATION_REPLY_REASON = "handled keyless invitation reply"
@@ -155,8 +156,9 @@ def _arm_keyless_invite_poller(client) -> None:
     task = getattr(client, "_keyless_invite_poll_task", None)
     if task is not None and not task.done():
         return
-    client._keyless_invite_poll_task = asyncio.create_task(
-        keyless_invite_poll_loop(client)
+    client._keyless_invite_poll_task = spawn(
+        keyless_invite_poll_loop(client),
+        name="keyless_invite_poll_loop",
     )
 
 
@@ -240,14 +242,14 @@ async def dispatch_bridge_frame(
         # pump is live — never from ``connect()`` or a connected callback.
         _track_bridge_task(
             client,
-            asyncio.create_task(resume_pending_approvals(client)),
+            spawn(resume_pending_approvals(client), name="resume_pending_approvals"),
         )
         # Seed the channel→space map for every channel we're already a
         # member of, so a proactive post to a pre-existing channel works
         # from boot (not only after the first inbound message there).
         # Scheduled async — awaiting send_list_spaces inline would deadlock
         # frames(), which must keep receiving to deliver the 'spaces' reply.
-        task = asyncio.create_task(client._refresh_bridge_spaces())
+        task = spawn(client._refresh_bridge_spaces(), name="client.refresh_bridge_spaces")
         client._ack_tasks.add(task)
         task.add_done_callback(client._ack_tasks.discard)
         # Keep draining pages on this connection. Awaiting a correlated
@@ -257,7 +259,7 @@ async def dispatch_bridge_frame(
         if more is True and isinstance(count, int) and not isinstance(count, bool):
             if count > 0:
                 client._bridge_pending_nonprogress = False
-                task = asyncio.create_task(client._bridge.send_fetch_pending())
+                task = spawn(client._bridge.send_fetch_pending(), name="bridge.send_fetch_pending")
                 client._ack_tasks.add(task)
                 task.add_done_callback(client._ack_tasks.discard)
             elif not client._bridge_pending_nonprogress:
@@ -280,7 +282,7 @@ async def dispatch_bridge_frame(
             "bridge: added to space %s — refreshing spaces",
             space_id or "<missing space_id>",
         )
-        task = asyncio.create_task(client._refresh_bridge_spaces(space_id))
+        task = spawn(client._refresh_bridge_spaces(space_id), name="client.refresh_bridge_spaces")
         client._ack_tasks.add(task)
         task.add_done_callback(client._ack_tasks.discard)
     elif kind == "error":
@@ -349,7 +351,10 @@ async def _handle_bridge_message_frame(client, frame: dict) -> None:
         if acknowledge:
             _track_bridge_task(
                 client,
-                asyncio.create_task(client._ack_bridge_envelope([payload.envelope_id])),
+                spawn(
+                    client._ack_bridge_envelope([payload.envelope_id]),
+                    name="client.ack_bridge_envelope",
+                ),
             )
     except Exception:  # noqa: BLE001 - poison frames must not stop delivery
         client._log.exception(
@@ -593,13 +598,14 @@ def _reschedule_sequence_less_control_reply(client, payload, stored) -> bool:
             return False
         _track_bridge_task(
             client,
-            asyncio.create_task(
+            spawn(
                 _finish_keyless_dm_operator_reply(
                     client,
                     thread_root_id=thread_root_id,
                     text=text,
                     envelope_id=payload.envelope_id,
-                )
+                ),
+                name="finish_keyless_dm_operator_reply",
             ),
         )
         return True
@@ -614,14 +620,15 @@ def _reschedule_sequence_less_control_reply(client, payload, stored) -> bool:
             return False
         _track_bridge_task(
             client,
-            asyncio.create_task(
+            spawn(
                 _finish_keyless_invitation_reply(
                     client,
                     flow,
                     thread_root_id=thread_root_id,
                     text=text,
                     envelope_id=payload.envelope_id,
-                )
+                ),
+                name="finish_keyless_invitation_reply",
             ),
         )
         return True
@@ -641,13 +648,14 @@ def _reschedule_keyless_gated_record(client, payload, stored) -> None:
         return
     _track_bridge_task(
         client,
-        asyncio.create_task(
+        spawn(
             record_gated_dm(
                 client,
                 envelope_id=payload.envelope_id,
                 sender_slug=payload.sender_slug,
                 server_seq=None,
-            )
+            ),
+            name="record_gated_dm",
         ),
     )
 
@@ -783,13 +791,14 @@ async def _keyless_operator_reply_gate(client, payload, row) -> GateVerdict | No
         return None
     _track_bridge_task(
         client,
-        asyncio.create_task(
+        spawn(
             _finish_keyless_dm_operator_reply(
                 client,
                 thread_root_id=thread_root_id,
                 text=text,
                 envelope_id=payload.envelope_id,
-            )
+            ),
+            name="finish_keyless_dm_operator_reply",
         ),
     )
     return GateVerdict(
@@ -855,14 +864,15 @@ async def _keyless_invitation_reply_gate(client, payload, row) -> GateVerdict | 
         return None
     _track_bridge_task(
         client,
-        asyncio.create_task(
+        spawn(
             _finish_keyless_invitation_reply(
                 client,
                 flow,
                 thread_root_id=thread_root_id,
                 text=text,
                 envelope_id=payload.envelope_id,
-            )
+            ),
+            name="finish_keyless_invitation_reply",
         ),
     )
     return GateVerdict(
@@ -932,13 +942,14 @@ async def _commit_bridge_verdict(
     ):
         _track_bridge_task(
             client,
-            asyncio.create_task(
+            spawn(
                 record_gated_dm(
                     client,
                     envelope_id=payload.envelope_id,
                     sender_slug=payload.sender_slug,
                     server_seq=server_seq,
-                )
+                ),
+                name="record_gated_dm",
             ),
         )
     runtime = getattr(client, "global_runtime", None)

--- a/src/puffo_agent/agent/core.py
+++ b/src/puffo_agent/agent/core.py
@@ -1,4 +1,3 @@
-import asyncio
 
 from ._auth_markers import looks_like_auth_error
 from ._logging import agent_logger
@@ -9,6 +8,7 @@ from .adapters.base import STATUS_PREVIEW_CHARS, is_silent
 from .errors import AgentAPIError
 from .message_projection import model_attachment_path
 from .memory import MemoryManager
+from ..tasks import spawn
 
 MAX_LOG_ENTRIES = 60
 
@@ -395,12 +395,13 @@ class PuffoAgent:
         # → turn_complete (tokens). Best-effort; no-ops if the owner isn't linked.
         from ..portal.control.reporter import get_reporter
 
-        asyncio.ensure_future(
+        spawn(
             get_reporter().emit(
                 self.agent_id,
                 "turn_start",
                 {"message": _user_message_preview(ctx.messages)},
-            )
+            ),
+            name="reporter.emit:turn_start",
         )
         result = await self.adapter.run_turn(ctx)
 
@@ -427,12 +428,13 @@ class PuffoAgent:
         context_measured_at = result.metadata.get("context_measured_at")
         if isinstance(context_measured_at, str) and context_measured_at:
             turn_complete_payload["context_measured_at"] = context_measured_at
-        asyncio.ensure_future(
+        spawn(
             get_reporter().emit(
                 self.agent_id,
                 "turn_complete",
                 turn_complete_payload,
-            )
+            ),
+            name="reporter.emit:turn_complete",
         )
 
         return self._route_turn_result(
@@ -500,12 +502,13 @@ class PuffoAgent:
             f"send_message and [SILENT] markers; posting "
             f"{len(text_parts) or 1}-frame fallback"
         )
-        asyncio.ensure_future(
+        spawn(
             get_reporter().emit(
                 self.agent_id,
                 "tool_use",
                 {"tool": "fallback", "content": fallback[:STATUS_PREVIEW_CHARS]},
-            )
+            ),
+            name="reporter.emit:tool_use",
         )
         self._append_assistant(channel_name, fallback)
         return fallback

--- a/src/puffo_agent/agent/directory_cache.py
+++ b/src/puffo_agent/agent/directory_cache.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from . import disk_cache
+from ..tasks import spawn
 
 PROFILE_CACHE_TTL_SECONDS = 10 * 60
 PROFILE_FETCH_CHUNK_SIZE = 50
@@ -76,7 +77,7 @@ async def fetch_user_profile(
     owner_cache[slug] = (owner_slug, now)
     disk_cache.persist_profile(slug, name, avatar_url)
     if avatar_url:
-        asyncio.create_task(fetch_avatar(avatar_url))
+        spawn(fetch_avatar(avatar_url), name="fetch_avatar")
     return name, avatar_url
 
 
@@ -123,8 +124,8 @@ async def warm_member_caches(
         return
 
     async def warm_one(space_id: str) -> set[str]:
-        members_task = asyncio.create_task(get_members(space_id))
-        channels_task = asyncio.create_task(warm_channels(space_id))
+        members_task = spawn(get_members(space_id), name="get_members")
+        channels_task = spawn(warm_channels(space_id), name="warm_channels")
         members = await members_task
         await channels_task
         return set(members)
@@ -223,7 +224,7 @@ async def bulk_fetch_profiles(
             profile_cache[slug] = (name, avatar_url, now)
             disk_cache.persist_profile(slug, name, avatar_url)
             if avatar_url:
-                asyncio.create_task(fetch_avatar(avatar_url))
+                spawn(fetch_avatar(avatar_url), name="fetch_avatar")
 
 
 async def fetch_and_cache_avatar(

--- a/src/puffo_agent/agent/directory_cache.py
+++ b/src/puffo_agent/agent/directory_cache.py
@@ -124,14 +124,19 @@ async def warm_member_caches(
         return
 
     async def warm_one(space_id: str) -> set[str]:
-        members_task = spawn(
-            get_members(space_id), name="get_members", report_failure=False
+        # These failures are intentionally tolerated by the outer cache warm,
+        # so the tasks retain their reporters as the sole authoritative log.
+        # Gather both results before re-raising one: a failed member lookup
+        # must not leave the channel warmer's exception unobserved.
+        members_task = spawn(get_members(space_id), name="get_members")
+        channels_task = spawn(warm_channels(space_id), name="warm_channels")
+        members, channels = await asyncio.gather(
+            members_task, channels_task, return_exceptions=True
         )
-        channels_task = spawn(
-            warm_channels(space_id), name="warm_channels", report_failure=False
-        )
-        members = await members_task
-        await channels_task
+        if isinstance(members, BaseException):
+            raise members
+        if isinstance(channels, BaseException):
+            raise channels
         return set(members)
 
     all_slugs: set[str] = set()

--- a/src/puffo_agent/agent/directory_cache.py
+++ b/src/puffo_agent/agent/directory_cache.py
@@ -124,8 +124,12 @@ async def warm_member_caches(
         return
 
     async def warm_one(space_id: str) -> set[str]:
-        members_task = spawn(get_members(space_id), name="get_members")
-        channels_task = spawn(warm_channels(space_id), name="warm_channels")
+        members_task = spawn(
+            get_members(space_id), name="get_members", report_failure=False
+        )
+        channels_task = spawn(
+            warm_channels(space_id), name="warm_channels", report_failure=False
+        )
         members = await members_task
         await channels_task
         return set(members)

--- a/src/puffo_agent/agent/global_inbox_admission.py
+++ b/src/puffo_agent/agent/global_inbox_admission.py
@@ -27,6 +27,7 @@ from .message_store import (
     ReceiptDisposition,
     StoredMessage,
 )
+from ..tasks import spawn
 
 # Existing operators and tests subscribe to the runtime logger, not this
 # implementation module.
@@ -371,10 +372,10 @@ class InboxAdmissionMixin:
         if self._busy_notice_task is not None and not self._busy_notice_task.done():
             return
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
             return
-        self._busy_notice_task = loop.create_task(
+        self._busy_notice_task = spawn(
             self._deliver_busy_notices(turn_id),
             name=f"inbox-notice-{turn_id}",
         )

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -393,7 +393,6 @@ class GlobalInboxRuntime(
         reminder_task = spawn(
             self.reminder_scheduler.run(),
             name="reminder_scheduler.run",
-            report_failure=False,
         )
         try:
             await self.recover_current_turn()
@@ -412,7 +411,6 @@ class GlobalInboxRuntime(
                 burst_task = spawn(
                     self.coalescer.wait_for_burst(),
                     name="coalescer.wait_for_burst",
-                    report_failure=False,
                 )
                 done, _pending = await asyncio.wait(
                     {burst_task, reminder_task},
@@ -421,10 +419,11 @@ class GlobalInboxRuntime(
                 if reminder_task in done:
                     if not burst_task.done():
                         burst_task.cancel()
-                        try:
-                            await burst_task
-                        except asyncio.CancelledError:
-                            pass
+                    # Settle the sibling even when both tasks completed in the
+                    # same event-loop turn.  Otherwise a simultaneous burst
+                    # failure can escape inspection while the scheduler error
+                    # is propagated below.
+                    await asyncio.gather(burst_task, return_exceptions=True)
                     # A scheduler error is an owning-runtime error, never a
                     # silently disabled timer loop.
                     await reminder_task

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -58,6 +58,7 @@ from .message_projection import (
 from .reminder_scheduler import ReminderScheduler
 from .shared_content import INBOX_TURN_CUE
 from .provider_failures import operator_failure_text
+from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -389,7 +390,7 @@ class GlobalInboxRuntime(
         )
 
     async def run(self) -> None:
-        reminder_task = asyncio.create_task(self.reminder_scheduler.run())
+        reminder_task = spawn(self.reminder_scheduler.run(), name="reminder_scheduler.run")
         try:
             await self.recover_current_turn()
             await self.recover_orphaned_turns()
@@ -404,7 +405,10 @@ class GlobalInboxRuntime(
                 ):
                     self.notify()
             while not self._stopping:
-                burst_task = asyncio.create_task(self.coalescer.wait_for_burst())
+                burst_task = spawn(
+                    self.coalescer.wait_for_burst(),
+                    name="coalescer.wait_for_burst",
+                )
                 done, _pending = await asyncio.wait(
                     {burst_task, reminder_task},
                     return_when=asyncio.FIRST_COMPLETED,

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -390,7 +390,11 @@ class GlobalInboxRuntime(
         )
 
     async def run(self) -> None:
-        reminder_task = spawn(self.reminder_scheduler.run(), name="reminder_scheduler.run")
+        reminder_task = spawn(
+            self.reminder_scheduler.run(),
+            name="reminder_scheduler.run",
+            report_failure=False,
+        )
         try:
             await self.recover_current_turn()
             await self.recover_orphaned_turns()
@@ -408,6 +412,7 @@ class GlobalInboxRuntime(
                 burst_task = spawn(
                     self.coalescer.wait_for_burst(),
                     name="coalescer.wait_for_burst",
+                    report_failure=False,
                 )
                 done, _pending = await asyncio.wait(
                     {burst_task, reminder_task},

--- a/src/puffo_agent/agent/global_inbox_types.py
+++ b/src/puffo_agent/agent/global_inbox_types.py
@@ -7,6 +7,7 @@ from typing import Any, Awaitable, Callable, Protocol, Sequence
 from .context_controller import AdmissionCandidate
 from .message_projection import canonical_target_parts, format_message_group
 from .message_store import MessageStore, StoredMessage
+from ..tasks import spawn
 
 OUTPUT_TOOL_RESERVE_TOKENS = 4_096
 CURRENT_TURN_VERSION = 2
@@ -24,7 +25,7 @@ async def await_listener_with_runtime(
     label: str,
 ) -> Any:
     """Stop a transport listener as soon as its Inbox consumer exits."""
-    listener_task = asyncio.ensure_future(listener)
+    listener_task = spawn(listener, name="listener")
     try:
         done, _pending = await asyncio.wait(
             {listener_task, runtime_task},

--- a/src/puffo_agent/agent/global_inbox_types.py
+++ b/src/puffo_agent/agent/global_inbox_types.py
@@ -25,7 +25,7 @@ async def await_listener_with_runtime(
     label: str,
 ) -> Any:
     """Stop a transport listener as soon as its Inbox consumer exits."""
-    listener_task = spawn(listener, name="listener", report_failure=False)
+    listener_task = spawn(listener, name="listener")
     try:
         done, _pending = await asyncio.wait(
             {listener_task, runtime_task},

--- a/src/puffo_agent/agent/global_inbox_types.py
+++ b/src/puffo_agent/agent/global_inbox_types.py
@@ -25,7 +25,7 @@ async def await_listener_with_runtime(
     label: str,
 ) -> Any:
     """Stop a transport listener as soon as its Inbox consumer exits."""
-    listener_task = spawn(listener, name="listener")
+    listener_task = spawn(listener, name="listener", report_failure=False)
     try:
         done, _pending = await asyncio.wait(
             {listener_task, runtime_task},

--- a/src/puffo_agent/agent/harness/claude_code_driver.py
+++ b/src/puffo_agent/agent/harness/claude_code_driver.py
@@ -41,6 +41,7 @@ from .driver import (
     UnsupportedCapability,
 )
 from .subprocess_io import drain_subprocess_stream_keeping_tail
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -209,9 +210,10 @@ class ClaudeCodeCliDriver(Driver):
             if asyncio.iscoroutine(self._proc):
                 self._proc = await self._proc
         self._init = asyncio.get_running_loop().create_future()
-        self._reader = asyncio.create_task(self._read_loop())
-        self._stderr_reader = asyncio.create_task(
-            drain_subprocess_stream_keeping_tail(getattr(self._proc, "stderr", None))
+        self._reader = spawn(self._read_loop(), name="read_loop")
+        self._stderr_reader = spawn(
+            drain_subprocess_stream_keeping_tail(getattr(self._proc, "stderr", None)),
+            name="drain_subprocess_stream_keeping_tail",
         )
         # Older CLI builds and test doubles may emit init eagerly.  Give the
         # reader one scheduling opportunity while keeping current CLI startup

--- a/src/puffo_agent/agent/harness/codex_driver.py
+++ b/src/puffo_agent/agent/harness/codex_driver.py
@@ -46,6 +46,7 @@ from .driver import (
     TurnStarted,
 )
 from .subprocess_io import drain_subprocess_stream
+from ...tasks import spawn
 
 CODEX_CAPABILITIES = DriverCapabilities(
     session_resume=True,
@@ -278,9 +279,10 @@ class CodexAppServerDriver(Driver):
         if self._closed:
             self._prepare_reopen()
         await self._start_process(spec)
-        self._reader = asyncio.create_task(self._read_loop())
-        self._stderr_reader = asyncio.create_task(
-            drain_subprocess_stream(getattr(self._proc, "stderr", None))
+        self._reader = spawn(self._read_loop(), name="read_loop")
+        self._stderr_reader = spawn(
+            drain_subprocess_stream(getattr(self._proc, "stderr", None)),
+            name="drain_subprocess_stream",
         )
         await self._initialize_app_server()
         result, resumed = await self._open_thread(spec, resume)

--- a/src/puffo_agent/agent/harness/docker_support.py
+++ b/src/puffo_agent/agent/harness/docker_support.py
@@ -165,7 +165,11 @@ async def communicate_with_timeout(
     timeout_seconds: float,
     operation: str,
 ) -> tuple[bytes, bytes]:
-    communicate_task = spawn(proc.communicate(input_data), name="proc.communicate")
+    communicate_task = spawn(
+        proc.communicate(input_data),
+        name="proc.communicate",
+        report_failure=False,
+    )
     try:
         return await asyncio.wait_for(
             asyncio.shield(communicate_task),

--- a/src/puffo_agent/agent/harness/docker_support.py
+++ b/src/puffo_agent/agent/harness/docker_support.py
@@ -168,7 +168,6 @@ async def communicate_with_timeout(
     communicate_task = spawn(
         proc.communicate(input_data),
         name="proc.communicate",
-        report_failure=False,
     )
     try:
         return await asyncio.wait_for(

--- a/src/puffo_agent/agent/harness/docker_support.py
+++ b/src/puffo_agent/agent/harness/docker_support.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
+from ...tasks import spawn
 
 
 logger = logging.getLogger(__name__)
@@ -164,7 +165,7 @@ async def communicate_with_timeout(
     timeout_seconds: float,
     operation: str,
 ) -> tuple[bytes, bytes]:
-    communicate_task = asyncio.create_task(proc.communicate(input_data))
+    communicate_task = spawn(proc.communicate(input_data), name="proc.communicate")
     try:
         return await asyncio.wait_for(
             asyncio.shield(communicate_task),

--- a/src/puffo_agent/agent/harness/local_runtime.py
+++ b/src/puffo_agent/agent/harness/local_runtime.py
@@ -9,7 +9,6 @@ those responsibilities belong to :mod:`codex_driver`,
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -75,6 +74,7 @@ from .driver import (
     SessionRef,
 )
 from .runtime_manager import RuntimeManager, RuntimeManagerAdapter
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -673,7 +673,7 @@ def _normalized_tool_label(label: str) -> str:
 def _emit_status(agent_id: str, event: str, payload: dict[str, Any]) -> None:
     from ...portal.control.reporter import get_reporter
 
-    asyncio.ensure_future(get_reporter().emit(agent_id, event, payload))
+    spawn(get_reporter().emit(agent_id, event, payload), name="reporter.emit")
 
 
 class _LegacyStatusProjector:

--- a/src/puffo_agent/agent/harness/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime_manager.py
@@ -46,6 +46,7 @@ from .driver import (
     TurnRef,
     UnsupportedCapability,
 )
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -278,7 +279,7 @@ class RuntimeManager:
             opened.resumed
             and opened.native_session_id != self._confirmed_native_session_id
         )
-        self._reader = asyncio.create_task(self._consume_events())
+        self._reader = spawn(self._consume_events(), name="consume_events")
         if self.agent_id:
             register_runtime_manager(self.agent_id, self)
         return self.opened

--- a/src/puffo_agent/agent/inbox_scheduler.py
+++ b/src/puffo_agent/agent/inbox_scheduler.py
@@ -10,6 +10,7 @@ from typing import Awaitable, Callable, Iterable
 
 from .message_projection import canonical_target_parts
 from .message_store import StoredMessage
+from ..tasks import spawn
 
 MAX_MESSAGES = 50
 MAX_ESTIMATED_TOKENS = 32_000
@@ -247,8 +248,8 @@ class InboxCoalescer:
 
     async def _sleep_or_pull(self, remaining: float) -> bool:
         """Sleep ``remaining``; report whether a pulled deadline cut it short."""
-        sleeper = asyncio.ensure_future(self._sleep(remaining))
-        pull = asyncio.ensure_future(self._pulled.wait())
+        sleeper = spawn(self._sleep(remaining), name="sleep")
+        pull = spawn(self._pulled.wait(), name="pulled.wait")
         try:
             done, _pending = await asyncio.wait(
                 {sleeper, pull}, return_when=asyncio.FIRST_COMPLETED,

--- a/src/puffo_agent/agent/inbox_scheduler.py
+++ b/src/puffo_agent/agent/inbox_scheduler.py
@@ -248,12 +248,8 @@ class InboxCoalescer:
 
     async def _sleep_or_pull(self, remaining: float) -> bool:
         """Sleep ``remaining``; report whether a pulled deadline cut it short."""
-        sleeper = spawn(
-            self._sleep(remaining), name="sleep", report_failure=False
-        )
-        pull = spawn(
-            self._pulled.wait(), name="pulled.wait", report_failure=False
-        )
+        sleeper = spawn(self._sleep(remaining), name="sleep")
+        pull = spawn(self._pulled.wait(), name="pulled.wait")
         try:
             done, _pending = await asyncio.wait(
                 {sleeper, pull}, return_when=asyncio.FIRST_COMPLETED,
@@ -262,10 +258,7 @@ class InboxCoalescer:
             for task in (sleeper, pull):
                 if not task.done():
                     task.cancel()
-                    try:
-                        await task
-                    except asyncio.CancelledError:
-                        pass
+            await asyncio.gather(sleeper, pull, return_exceptions=True)
         return sleeper not in done
 
     async def wait_for_burst(self) -> None:

--- a/src/puffo_agent/agent/inbox_scheduler.py
+++ b/src/puffo_agent/agent/inbox_scheduler.py
@@ -248,8 +248,12 @@ class InboxCoalescer:
 
     async def _sleep_or_pull(self, remaining: float) -> bool:
         """Sleep ``remaining``; report whether a pulled deadline cut it short."""
-        sleeper = spawn(self._sleep(remaining), name="sleep")
-        pull = spawn(self._pulled.wait(), name="pulled.wait")
+        sleeper = spawn(
+            self._sleep(remaining), name="sleep", report_failure=False
+        )
+        pull = spawn(
+            self._pulled.wait(), name="pulled.wait", report_failure=False
+        )
         try:
             done, _pending = await asyncio.wait(
                 {sleeper, pull}, return_when=asyncio.FIRST_COMPLETED,

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -28,6 +28,7 @@ from ..limits import (
 from . import disk_cache as _disk_cache
 from . import inbound_attachments as _attachment_helpers
 from . import message_context as _message_context
+from ..tasks import spawn
 
 if TYPE_CHECKING:
     from .bridge_client import CloudBridgeClient
@@ -269,7 +270,7 @@ class PuffoCoreMessageClient:
             read_plaintext=read_plaintext_message,
         )
 
-        invite_poll_task = asyncio.ensure_future(self._invite_poll_loop())
+        invite_poll_task = spawn(self._invite_poll_loop(), name="invite_poll_loop")
         self._ws = PuffoCoreWsClient(
             server_url=self.keystore.load_identity(self.slug).server_url,
             keystore=self.keystore,
@@ -866,13 +867,14 @@ class PuffoCoreMessageClient:
 
     async def _on_ws_connect(self) -> None:
         """Fire-and-forget re-warm; handle kept (asyncio weak-refs tasks)."""
-        self._warm_task = asyncio.ensure_future(
+        self._warm_task = spawn(
             asyncio.gather(
                 self._warm_member_caches(),
                 # Allow/block hydration rides the same tick so a restart
                 # doesn't re-gate already-allowlisted senders.
                 self._contacts.refresh(),
-            )
+            ),
+            name="warm_after_ws_connect",
         )
         await self._notify_connected_callbacks()
 

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -868,12 +868,8 @@ class PuffoCoreMessageClient:
     async def _on_ws_connect(self) -> None:
         """Fire-and-forget re-warm; handle kept (asyncio weak-refs tasks)."""
         self._warm_task = spawn(
-            asyncio.gather(
-                self._warm_member_caches(),
-                # Allow/block hydration rides the same tick so a restart
-                # doesn't re-gate already-allowlisted senders.
-                self._contacts.refresh(),
-            ),
+            # allow/block hydration same tick: restart must not re-gate
+            asyncio.gather(self._warm_member_caches(), self._contacts.refresh()),
             name="warm_after_ws_connect",
         )
         await self._notify_connected_callbacks()

--- a/src/puffo_agent/agent/send_coordinator.py
+++ b/src/puffo_agent/agent/send_coordinator.py
@@ -45,6 +45,7 @@ from .send_response_validation import (
     validate_keyless_response,
 )
 from .shared_content import HELD_SEND_RECONSIDERATION_GUIDANCE
+from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
 CHANNEL_SEND_PATH = "/v2/agent-runtime/messages:send"
@@ -1048,14 +1049,12 @@ class SendCoordinator:
                     "sent message but could not advance local boundary"
                 )
         if result.missing_devices:
-            asyncio.create_task(
+            spawn(
                 self._supplement_channel(
-                    envelope,
-                    content_key,
-                    resolved["recipient_slugs"],
-                    result.missing_devices,
-                    freshness,
-                )
+                    envelope, content_key, resolved["recipient_slugs"],
+                    result.missing_devices, freshness,
+                ),
+                name="supplement_channel",
             )
 
     async def _finish_held_channel_send(
@@ -1192,14 +1191,12 @@ class SendCoordinator:
             if missing:
                 from ..mcp.puffo_core_tools import _supplement_missing_devices
 
-                asyncio.create_task(
+                spawn(
                     _supplement_missing_devices(
-                        self.http_client,
-                        envelope,
-                        content_key,
-                        resolved["recipient_slugs"],
-                        list(missing),
-                    )
+                        self.http_client, envelope, content_key,
+                        resolved["recipient_slugs"], list(missing),
+                    ),
+                    name="supplement_missing_devices",
                 )
             return SendResult(
                 state="sent",

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -12,6 +12,7 @@ from typing import Any, Awaitable, Callable, Optional
 
 from ..crypto.http_client import HttpError, PuffoCoreHttpClient
 from .processing_receipts import ProcessingReportDispatcher
+from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,7 @@ class StatusReporter:
         self._run_stop = stop
         replay_task = None
         if self._processing_reports is not None:
-            replay_task = asyncio.create_task(self._processing_reports.run())
+            replay_task = spawn(self._processing_reports.run(), name="processing_reports.run")
         try:
             await self._send_heartbeat()
             while not stop.is_set():

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -17,6 +17,7 @@ from .http_client import PuffoCoreHttpClient
 from .http_session import create_remote_ssl_context
 from .keystore import KeyStore, decode_secret
 from .primitives import Ed25519KeyPair
+from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -416,4 +417,4 @@ class PuffoCoreWsClient:
     def stop(self) -> None:
         self._running = False
         if self._ws:
-            asyncio.ensure_future(self._ws.close())
+            spawn(self._ws.close(), name="ws.close")

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -29,6 +29,7 @@ from . import machine_auth
 from .envelope import TS_WINDOW_MS, ControlError, decrypt_command
 from .store import load_or_create_machine, load_pairings, now_ms
 from .usage_snapshot import apply_drained_health, collect_usage_snapshot
+from ...tasks import spawn
 
 log = logging.getLogger("puffo_agent.control")
 
@@ -552,7 +553,7 @@ class MachineControlClient:
                 # Initial capability snapshot on connect.
                 last_caps = await asyncio.to_thread(build_capabilities)
                 await self._send(ws, {"type": "capabilities", "capabilities": last_caps})
-                sender = asyncio.create_task(self._heartbeat_loop(ws, stop, last_caps))
+                sender = spawn(self._heartbeat_loop(ws, stop, last_caps), name="heartbeat_loop")
 
                 # Register the reverse-channel sender on this live socket.
                 from .reporter import get_reporter
@@ -678,9 +679,9 @@ class ControlManager:
                     machine = load_or_create_machine()
                 if pairings and ws_task is None:
                     client = MachineControlClient(machine)
-                    ws_task = asyncio.create_task(client.run(self._stop))
-                    me_task = asyncio.create_task(self._me_loop(machine))
-                    usage_task = asyncio.create_task(self._usage_loop(machine))
+                    ws_task = spawn(client.run(self._stop), name="client.run")
+                    me_task = spawn(self._me_loop(machine), name="me_loop")
+                    usage_task = spawn(self._usage_loop(machine), name="usage_loop")
                 if not pairings and ws_task is not None:
                     ws_task.cancel()
                     me_task.cancel()

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1146,8 +1146,14 @@ class CredentialRefresher:
             self._detect_external_rotation()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
-        stop_task = spawn(stop_event.wait(), name="stop_event.wait")
-        refresh_task = spawn(self._refresh_request.wait(), name="refresh_request.wait")
+        stop_task = spawn(
+            stop_event.wait(), name="stop_event.wait", report_failure=False
+        )
+        refresh_task = spawn(
+            self._refresh_request.wait(),
+            name="refresh_request.wait",
+            report_failure=False,
+        )
         try:
             await asyncio.wait(
                 {stop_task, refresh_task},

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -50,6 +50,7 @@ from .state import (
     sync_host_codex_auth_view,
     sync_host_claude_code_auth_view,
 )
+from ..tasks import spawn
 
 
 logger = logging.getLogger(__name__)
@@ -1086,8 +1087,9 @@ class CredentialRefresher:
         # don't import the macos module up here.
         external_poll_task: asyncio.Task | None = None
         if hasattr(self.backend, "poll_external_rotation"):
-            external_poll_task = asyncio.ensure_future(
+            external_poll_task = spawn(
                 self._external_rotation_loop(stop_event),
+                name="external_rotation_loop",
             )
 
         try:
@@ -1144,8 +1146,8 @@ class CredentialRefresher:
             self._detect_external_rotation()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
-        stop_task = asyncio.create_task(stop_event.wait())
-        refresh_task = asyncio.create_task(self._refresh_request.wait())
+        stop_task = spawn(stop_event.wait(), name="stop_event.wait")
+        refresh_task = spawn(self._refresh_request.wait(), name="refresh_request.wait")
         try:
             await asyncio.wait(
                 {stop_task, refresh_task},
@@ -1334,7 +1336,7 @@ class CredentialRefresher:
 
         coro = _retry()
         try:
-            self._rate_limit_retry_task = asyncio.create_task(coro)
+            self._rate_limit_retry_task = spawn(coro, name="rate_limit_retry")
         except RuntimeError:
             # No running loop (sync test path) — fall back to natural poll.
             coro.close()

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1146,13 +1146,10 @@ class CredentialRefresher:
             self._detect_external_rotation()
 
     async def _sleep_until_next_tick(self, stop_event: asyncio.Event) -> None:
-        stop_task = spawn(
-            stop_event.wait(), name="stop_event.wait", report_failure=False
-        )
+        stop_task = spawn(stop_event.wait(), name="stop_event.wait")
         refresh_task = spawn(
             self._refresh_request.wait(),
             name="refresh_request.wait",
-            report_failure=False,
         )
         try:
             await asyncio.wait(
@@ -1161,8 +1158,10 @@ class CredentialRefresher:
                 return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
-            stop_task.cancel()
-            refresh_task.cancel()
+            for task in (stop_task, refresh_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(stop_task, refresh_task, return_exceptions=True)
 
     def _current_credential_revision(self) -> CredentialRevision | None:
         fingerprint = getattr(self.backend, "fingerprint", None)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -80,6 +80,7 @@ from .workspace_layout import (
     prepare_workspace_shared_access,
 )
 from .worker import Worker
+from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -170,16 +171,25 @@ class Daemon:
 
     async def _start_runtime(self, runtime: _DaemonRuntime) -> None:
         runtime.startup_tasks.append(
-            asyncio.ensure_future(_log_outdated_version_warning())
+            spawn(_log_outdated_version_warning(), name="log_outdated_version_warning")
         )
         from ..agent.model_catalog import prefetch as _prefetch_model_catalog
 
         _prefetch_model_catalog()
         runtime.startup_tasks.extend(
             (
-                asyncio.ensure_future(_sweep_archived_pending_revokes_at_startup()),
-                asyncio.ensure_future(_migrate_linked_agents_at_startup()),
-                asyncio.ensure_future(_full_sync_all_owned_agents_at_startup()),
+                spawn(
+                    _sweep_archived_pending_revokes_at_startup(),
+                    name="sweep_archived_pending_revokes_at_startup",
+                ),
+                spawn(
+                    _migrate_linked_agents_at_startup(),
+                    name="migrate_linked_agents_at_startup",
+                ),
+                spawn(
+                    _full_sync_all_owned_agents_at_startup(),
+                    name="full_sync_all_owned_agents_at_startup",
+                ),
             )
         )
         runtime.ws_local_runner = await start_ws_local_server(
@@ -199,15 +209,15 @@ class Daemon:
         )
         runtime.runtime_tasks.extend(
             (
-                asyncio.ensure_future(self.refresher.run_loop(self._stop)),
-                asyncio.ensure_future(self.codex_refresher.run_loop(self._stop)),
+                spawn(self.refresher.run_loop(self._stop), name="refresher.run_loop"),
+                spawn(self.codex_refresher.run_loop(self._stop), name="codex_refresher.run_loop"),
             )
         )
         from .control.client import ControlManager
 
         runtime.control_manager = ControlManager()
         runtime.runtime_tasks.append(
-            asyncio.ensure_future(runtime.control_manager.run())
+            spawn(runtime.control_manager.run(), name="control_manager.run")
         )
 
     def _stop_was_requested(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -51,6 +51,7 @@ from .state import (
     claude_cli_api_key,
     docker_shared_dir as docker_shared_dir,
 )
+from ..tasks import spawn
 
 
 def _rebuild_managed_system_prompt(
@@ -409,7 +410,10 @@ class Worker:
             self._api_key_auth_recovery_pending = True
         self._auth_failed_notification_sent = True
         try:
-            asyncio.create_task(self._notify_operator_of_auth_failed_oauth())
+            spawn(
+                self._notify_operator_of_auth_failed_oauth(),
+                name="notify_operator_of_auth_failed_oauth",
+            )
         except Exception as exc:  # noqa: BLE001
             # Re-arm so a schedule failure retries on the next ENTER.
             self._auth_failed_notification_sent = False
@@ -510,7 +514,7 @@ class Worker:
             return
         self._drained_notification_sent = True
         try:
-            asyncio.create_task(self._notify_operator_of_drained())
+            spawn(self._notify_operator_of_drained(), name="notify_operator_of_drained")
         except Exception as exc:  # noqa: BLE001
             self._drained_notification_sent = False  # re-arm
             logger.warning(
@@ -835,7 +839,7 @@ class Worker:
     def start(self) -> asyncio.Task:
         if self._task is not None and not self._task.done():
             return self._task
-        self._task = asyncio.ensure_future(self._run())
+        self._task = spawn(self._run(), name="run")
         return self._task
 
     @property
@@ -1128,7 +1132,7 @@ class Worker:
                     "agent %s: ws-local profile sync failed: %s", agent_id, exc
                 )
 
-        asyncio.ensure_future(_ws_local_profile_sync())
+        spawn(_ws_local_profile_sync(), name="ws_local_profile_sync")
         logger.info("agent %s: ws-local idle, awaiting tool attach", agent_id)
         try:
             await self._stop.wait()

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -861,7 +861,11 @@ class StandardWorkerRun:
             ),
         )
         reminder_sync = await self._prepare_reminder_sync(context, global_runtime)
-        global_task = spawn(global_runtime.run(), name="global_runtime.run")
+        global_task = spawn(
+            global_runtime.run(),
+            name="global_runtime.run",
+            report_failure=False,
+        )
         reminder_task = None
         if reminder_sync is not None:
             reminder_task = spawn(

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -864,7 +864,6 @@ class StandardWorkerRun:
         global_task = spawn(
             global_runtime.run(),
             name="global_runtime.run",
-            report_failure=False,
         )
         reminder_task = None
         if reminder_sync is not None:

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -24,6 +24,7 @@ from .workspace_layout import (
 from ..agent.errors import ProviderFailureError
 from ..agent.processing_receipts import processing_run_id
 from ..agent._usage_markers import parse_reset_epoch
+from ..tasks import spawn
 
 if TYPE_CHECKING:
     from .worker import Worker
@@ -215,7 +216,10 @@ class StandardWorkerRun:
         context = await self._initialize()
         if context is None or not await self._warm(context):
             return
-        asyncio.ensure_future(self._sync_profile_after_warm(context.paths.agent_id))
+        spawn(
+            self._sync_profile_after_warm(context.paths.agent_id),
+            name="sync_profile_after_warm",
+        )
         services = await self._start_services(context)
         try:
             await self._listen(context, services)
@@ -857,21 +861,23 @@ class StandardWorkerRun:
             ),
         )
         reminder_sync = await self._prepare_reminder_sync(context, global_runtime)
-        global_task = asyncio.ensure_future(global_runtime.run())
+        global_task = spawn(global_runtime.run(), name="global_runtime.run")
         reminder_task = None
         if reminder_sync is not None:
-            reminder_task = asyncio.ensure_future(
-                reminder_sync.run(request_snapshot_on_start=False)
+            reminder_task = spawn(
+                reminder_sync.run(request_snapshot_on_start=False),
+                name="reminder_sync.run",
             )
-        heartbeat_task = asyncio.ensure_future(self._heartbeat(context.paths.agent_id))
-        status_task = asyncio.ensure_future(reporter.run_heartbeat_loop())
-        watch_task = asyncio.ensure_future(
+        heartbeat_task = spawn(self._heartbeat(context.paths.agent_id), name="heartbeat")
+        status_task = spawn(reporter.run_heartbeat_loop(), name="reporter.run_heartbeat_loop")
+        watch_task = spawn(
             worker._refresh_watcher_loop(
                 context.paths.refresh_flags,
                 lambda: self._apply_refresh(context),
-            )
+            ),
+            name="worker.refresh_watcher_loop",
         )
-        upload_task = asyncio.ensure_future(self._upload_runtime_events(uploader))
+        upload_task = spawn(self._upload_runtime_events(uploader), name="upload_runtime_events")
         return WorkerRunServices(
             global_runtime=global_runtime,
             global_runtime_task=global_task,

--- a/src/puffo_agent/portal/ws_local/endpoint.py
+++ b/src/puffo_agent/portal/ws_local/endpoint.py
@@ -109,8 +109,14 @@ async def _run_attached(
     async def on_message(root_id, batch, channel_meta):
         await bridge.dispatch(session, root_id, batch, channel_meta)
 
-    session_task = spawn(session.run(), name="session.run")
-    consumer_task = spawn(start_consumer(authed, on_message), name="start_consumer")
+    session_task = spawn(
+        session.run(), name="session.run", report_failure=False
+    )
+    consumer_task = spawn(
+        start_consumer(authed, on_message),
+        name="start_consumer",
+        report_failure=False,
+    )
     try:
         await asyncio.wait(
             {session_task, consumer_task}, return_when=asyncio.FIRST_COMPLETED

--- a/src/puffo_agent/portal/ws_local/endpoint.py
+++ b/src/puffo_agent/portal/ws_local/endpoint.py
@@ -26,6 +26,7 @@ from .bridge import WsLocalBridge
 from .protocol import Connect, Connected, Error, ProtocolError, decode_inbound, encode
 from .registry import SessionRegistry
 from .session import Transport, WsLocalSession
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +109,8 @@ async def _run_attached(
     async def on_message(root_id, batch, channel_meta):
         await bridge.dispatch(session, root_id, batch, channel_meta)
 
-    session_task = asyncio.ensure_future(session.run())
-    consumer_task = asyncio.ensure_future(start_consumer(authed, on_message))
+    session_task = spawn(session.run(), name="session.run")
+    consumer_task = spawn(start_consumer(authed, on_message), name="start_consumer")
     try:
         await asyncio.wait(
             {session_task, consumer_task}, return_when=asyncio.FIRST_COMPLETED

--- a/src/puffo_agent/portal/ws_local/endpoint.py
+++ b/src/puffo_agent/portal/ws_local/endpoint.py
@@ -109,13 +109,12 @@ async def _run_attached(
     async def on_message(root_id, batch, channel_meta):
         await bridge.dispatch(session, root_id, batch, channel_meta)
 
-    session_task = spawn(
-        session.run(), name="session.run", report_failure=False
-    )
+    # Cleanup below only records diagnostic DEBUG context.  Keep the central
+    # reporter as the single alertable, traceback-bearing failure record.
+    session_task = spawn(session.run(), name="session.run")
     consumer_task = spawn(
         start_consumer(authed, on_message),
         name="start_consumer",
-        report_failure=False,
     )
     try:
         await asyncio.wait(

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -31,6 +31,7 @@ from .protocol import Error, encode
 from .session import Transport, WsLocalSession
 from .tool_dispatch import build_dispatch as _build_dispatch
 from ..state import shared_fs_dir
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -421,7 +422,7 @@ async def _start_ws_consumer(
 
     point, client = hub.get(authed.slug), hub.get(authed.slug).client
     owned = connection.get("owned_runtime")
-    heartbeat = asyncio.ensure_future(point.reporter.run_heartbeat_loop())
+    heartbeat = spawn(point.reporter.run_heartbeat_loop(), name="reporter.run_heartbeat_loop")
     reminder_sync = None
     reminder_task = None
     runtime_task = None
@@ -430,10 +431,11 @@ async def _start_ws_consumer(
             # First statement of the scope whose ``finally`` unwinds it.
             _install_owned_runtime(client, owned)
             reminder_sync = await _prepare_owned_reminder_sync(point, client, owned)
-            reminder_task = asyncio.ensure_future(
-                reminder_sync.run(request_snapshot_on_start=False)
+            reminder_task = spawn(
+                reminder_sync.run(request_snapshot_on_start=False),
+                name="reminder_sync.run",
             )
-            runtime_task = asyncio.ensure_future(owned.run())
+            runtime_task = spawn(owned.run(), name="owned.run")
             await await_listener_with_runtime(
                 client.listen(on_message),
                 runtime_task,

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -435,7 +435,9 @@ async def _start_ws_consumer(
                 reminder_sync.run(request_snapshot_on_start=False),
                 name="reminder_sync.run",
             )
-            runtime_task = spawn(owned.run(), name="owned.run")
+            runtime_task = spawn(
+                owned.run(), name="owned.run", report_failure=False
+            )
             await await_listener_with_runtime(
                 client.listen(on_message),
                 runtime_task,

--- a/src/puffo_agent/portal/ws_local/route.py
+++ b/src/puffo_agent/portal/ws_local/route.py
@@ -435,9 +435,7 @@ async def _start_ws_consumer(
                 reminder_sync.run(request_snapshot_on_start=False),
                 name="reminder_sync.run",
             )
-            runtime_task = spawn(
-                owned.run(), name="owned.run", report_failure=False
-            )
+            runtime_task = spawn(owned.run(), name="owned.run")
             await await_listener_with_runtime(
                 client.listen(on_message),
                 runtime_task,

--- a/src/puffo_agent/portal/ws_local/session.py
+++ b/src/puffo_agent/portal/ws_local/session.py
@@ -39,6 +39,7 @@ from .protocol import (
     decode_inbound,
     encode,
 )
+from ...tasks import spawn
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +172,7 @@ class WsLocalSession:
         rolls back any in-flight bundle on the way out."""
         self._last_rx = self._now()
         await self._pump()
-        watchdog = asyncio.ensure_future(self._watchdog())
+        watchdog = spawn(self._watchdog(), name="watchdog")
         try:
             while self._alive:
                 raw = await self._transport.recv()
@@ -210,7 +211,7 @@ class WsLocalSession:
         try:
             from ..control.reporter import get_reporter
 
-            asyncio.ensure_future(get_reporter().emit(self.slug, event, payload))
+            spawn(get_reporter().emit(self.slug, event, payload), name="reporter.emit")
         except Exception:  # noqa: BLE001
             pass
 

--- a/src/puffo_agent/tasks.py
+++ b/src/puffo_agent/tasks.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any, Awaitable
+from weakref import WeakSet
 
 logger = logging.getLogger(__name__)
+
+# ``ensure_future`` returns an existing Task/Future unchanged.  Keeping the
+# registration set weak makes ``spawn(existing_task)`` idempotent without
+# extending the task's lifetime.
+_reported_tasks: WeakSet[asyncio.Future[Any]] = WeakSet()
 
 
 def _task_label(task: asyncio.Future[Any]) -> str:
@@ -24,8 +30,18 @@ def _report_task_death(task: asyncio.Future[Any]) -> None:
     logger.error("worker task died: %s", _task_label(task), exc_info=error)
 
 
-def spawn(coro: Awaitable[Any], *, name: str | None = None) -> asyncio.Future[Any]:
-    """Schedule ``coro`` with a done-callback that surfaces its exception."""
+def spawn(
+    coro: Awaitable[Any],
+    *,
+    name: str | None = None,
+    report_failure: bool = True,
+) -> asyncio.Future[Any]:
+    """Schedule ``coro`` and optionally report an otherwise detached failure.
+
+    Pass ``report_failure=False`` when an owning path promptly awaits or
+    otherwise inspects the returned future.  That owner remains responsible
+    for surfacing the failure with its richer context.
+    """
     if asyncio.iscoroutine(coro):
         # running-loop only: preserves create_task's RuntimeError contract
         task: asyncio.Future[Any] = asyncio.get_running_loop().create_task(coro, name=name)
@@ -33,5 +49,7 @@ def spawn(coro: Awaitable[Any], *, name: str | None = None) -> asyncio.Future[An
         task = asyncio.ensure_future(coro)
         if name is not None and isinstance(task, asyncio.Task):
             task.set_name(name)
-    task.add_done_callback(_report_task_death)
+    if report_failure and task not in _reported_tasks:
+        _reported_tasks.add(task)
+        task.add_done_callback(_report_task_death)
     return task

--- a/src/puffo_agent/tasks.py
+++ b/src/puffo_agent/tasks.py
@@ -35,11 +35,15 @@ def spawn(
     *,
     name: str | None = None,
 ) -> asyncio.Future[Any]:
-    """Schedule ``coro`` and report every failed task exactly once.
+    """Schedule ``coro`` and centrally report every failed task exactly once.
 
     Callers may still own cancellation and settlement of the returned future,
     but failure reporting is deliberately not optional: an awaiter propagating
     an exception is not itself an alertable, traceback-bearing record.
+
+    A supervisor may also emit its own authoritative record for the same
+    failure. Incident counts must therefore deduplicate by exception rather
+    than treating ``puffo_agent.tasks`` ERROR log lines as distinct failures.
     """
     if asyncio.iscoroutine(coro):
         # running-loop only: preserves create_task's RuntimeError contract

--- a/src/puffo_agent/tasks.py
+++ b/src/puffo_agent/tasks.py
@@ -34,14 +34,12 @@ def spawn(
     coro: Awaitable[Any],
     *,
     name: str | None = None,
-    report_failure: bool = True,
 ) -> asyncio.Future[Any]:
-    """Schedule ``coro`` and optionally report an otherwise detached failure.
+    """Schedule ``coro`` and report every failed task exactly once.
 
-    Pass ``report_failure=False`` only when an owning path is guaranteed to
-    await or inspect the returned future and emit exactly one alertable,
-    traceback-bearing failure record.  Merely intending to inspect it, or
-    logging at DEBUG, is not sufficient.
+    Callers may still own cancellation and settlement of the returned future,
+    but failure reporting is deliberately not optional: an awaiter propagating
+    an exception is not itself an alertable, traceback-bearing record.
     """
     if asyncio.iscoroutine(coro):
         # running-loop only: preserves create_task's RuntimeError contract
@@ -50,7 +48,7 @@ def spawn(
         task = asyncio.ensure_future(coro)
         if name is not None and isinstance(task, asyncio.Task):
             task.set_name(name)
-    if report_failure and task not in _reported_tasks:
+    if task not in _reported_tasks:
         _reported_tasks.add(task)
         task.add_done_callback(_report_task_death)
     return task

--- a/src/puffo_agent/tasks.py
+++ b/src/puffo_agent/tasks.py
@@ -1,0 +1,37 @@
+"""Spawn helper: a worker task that dies unclaimed logs instead of vanishing."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable
+
+logger = logging.getLogger(__name__)
+
+
+def _task_label(task: asyncio.Future[Any]) -> str:
+    get_name = getattr(task, "get_name", None)
+    return get_name() if get_name is not None else repr(task)
+
+
+def _report_task_death(task: asyncio.Future[Any]) -> None:
+    # cancelled: shutdown path, not a failure
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is None:
+        return
+    logger.error("worker task died: %s", _task_label(task), exc_info=error)
+
+
+def spawn(coro: Awaitable[Any], *, name: str | None = None) -> asyncio.Future[Any]:
+    """Schedule ``coro`` with a done-callback that surfaces its exception."""
+    if asyncio.iscoroutine(coro):
+        # running-loop only: preserves create_task's RuntimeError contract
+        task: asyncio.Future[Any] = asyncio.get_running_loop().create_task(coro, name=name)
+    else:
+        task = asyncio.ensure_future(coro)
+        if name is not None and isinstance(task, asyncio.Task):
+            task.set_name(name)
+    task.add_done_callback(_report_task_death)
+    return task

--- a/src/puffo_agent/tasks.py
+++ b/src/puffo_agent/tasks.py
@@ -38,9 +38,10 @@ def spawn(
 ) -> asyncio.Future[Any]:
     """Schedule ``coro`` and optionally report an otherwise detached failure.
 
-    Pass ``report_failure=False`` when an owning path promptly awaits or
-    otherwise inspects the returned future.  That owner remains responsible
-    for surfacing the failure with its richer context.
+    Pass ``report_failure=False`` only when an owning path is guaranteed to
+    await or inspect the returned future and emit exactly one alertable,
+    traceback-bearing failure record.  Merely intending to inspect it, or
+    logging at DEBUG, is not sufficient.
     """
     if asyncio.iscoroutine(coro):
         # running-loop only: preserves create_task's RuntimeError contract

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -63,14 +63,14 @@ def test_oauth_copy_degrades_when_display_name_missing():
 
 
 class _StubLoop:
-    """Stand-in for asyncio.create_task that records the call but
+    """Stand-in for the spawn helper that records the call but
     doesn't actually schedule. Used to verify the dedup gate
     semantics without spinning a real event loop."""
     def __init__(self):
         self.calls = 0
         self.tasks = []
 
-    def create_task(self, coro):
+    def spawn(self, coro, *, name=None):
         self.calls += 1
         self.tasks.append(coro)
         # Close the coro so it doesn't warn "never awaited."
@@ -82,9 +82,7 @@ def test_worker_dedup_gate_fires_once(monkeypatch):
     from puffo_agent.portal import worker as worker_module
 
     stub_loop = _StubLoop()
-    monkeypatch.setattr(
-        worker_module.asyncio, "create_task", stub_loop.create_task,
-    )
+    monkeypatch.setattr(worker_module, "spawn", stub_loop.spawn)
 
     class _StubWorker:
         agent_cfg = type("A", (), {"id": "t-agent"})()
@@ -112,9 +110,7 @@ def test_worker_reset_arms_next_notify(monkeypatch):
     from puffo_agent.portal import worker as worker_module
 
     stub_loop = _StubLoop()
-    monkeypatch.setattr(
-        worker_module.asyncio, "create_task", stub_loop.create_task,
-    )
+    monkeypatch.setattr(worker_module, "spawn", stub_loop.spawn)
 
     class _StubWorker:
         agent_cfg = type("A", (), {"id": "t-agent"})()
@@ -245,7 +241,7 @@ def test_create_task_failure_broadly_caught(monkeypatch):
     arrives, masking a legitimate retry opportunity."""
     from puffo_agent.portal import worker as worker_module
 
-    def crash(_coro):
+    def crash(_coro, *, name=None):
         # close coro so it doesn't warn "never awaited"
         try:
             _coro.close()
@@ -253,7 +249,7 @@ def test_create_task_failure_broadly_caught(monkeypatch):
             pass
         raise OSError("unexpected scheduler failure")
 
-    monkeypatch.setattr(worker_module.asyncio, "create_task", crash)
+    monkeypatch.setattr(worker_module, "spawn", crash)
 
     class _StubWorker:
         agent_cfg = type("A", (), {"id": "t-agent"})()
@@ -278,9 +274,7 @@ def test_workers_have_independent_dedup_flags(monkeypatch):
     from puffo_agent.portal import worker as worker_module
 
     stub_loop = _StubLoop()
-    monkeypatch.setattr(
-        worker_module.asyncio, "create_task", stub_loop.create_task,
-    )
+    monkeypatch.setattr(worker_module, "spawn", stub_loop.spawn)
 
     class _StubWorker:
         _client = None

--- a/tests/test_credential_refresher.py
+++ b/tests/test_credential_refresher.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from pathlib import Path
+
+import pytest
 
 
 from puffo_agent.portal import credential_refresh
@@ -267,6 +270,36 @@ def test_run_loop_wakes_early_on_refresh_request(tmp_path, monkeypatch):
     wake_latency = refreshes[0] - started
     # Conservative bound: should wake within 1s of the event.
     assert wake_latency < 1.0, f"wake_latency={wake_latency:.3f}s — event didn't short-circuit poll"
+
+
+@pytest.mark.asyncio
+async def test_tick_wait_failures_are_reported_once_each_with_tracebacks(
+    tmp_path, caplog,
+):
+    class BrokenEvent:
+        def __init__(self, message):
+            self._message = message
+
+        async def wait(self):
+            raise ValueError(self._message)
+
+    refresher = CredentialRefresher(host_home=tmp_path)
+    refresher._refresh_request = BrokenEvent("refresh wait failed")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        await refresher._sleep_until_next_tick(BrokenEvent("stop wait failed"))
+        await asyncio.sleep(0)
+
+    records = [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert sorted(record.getMessage() for record in records) == [
+        "worker task died: refresh_request.wait",
+        "worker task died: stop_event.wait",
+    ]
+    assert all(record.exc_info is not None for record in records)
+    assert {str(record.exc_info[1]) for record in records} == {
+        "stop wait failed",
+        "refresh wait failed",
+    }
 
 
 # ── refresh-token flag round-trip (CLI ↔ daemon sentinel) ──────

--- a/tests/test_drained_state.py
+++ b/tests/test_drained_state.py
@@ -678,13 +678,13 @@ def test_local_warm_still_holds_on_auth_and_on_programming_errors():
 
 
 class _StubLoop:
-    """Stand-in for asyncio.create_task that records the call but doesn't
+    """Stand-in for the spawn helper that records the call but doesn't
     schedule, so the dedup gate is observable without an event loop."""
 
     def __init__(self):
         self.calls = 0
 
-    def create_task(self, coro):
+    def spawn(self, coro, *, name=None):
         self.calls += 1
         coro.close()
         return None
@@ -696,7 +696,7 @@ def _stub_create_task(monkeypatch):
     from puffo_agent.portal import worker as worker_module
 
     stub = _StubLoop()
-    monkeypatch.setattr(worker_module.asyncio, "create_task", stub.create_task)
+    monkeypatch.setattr(worker_module, "spawn", stub.spawn)
     return stub
 
 
@@ -781,11 +781,11 @@ def test_scheduling_failure_re_arms_the_notification(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_HOME", str(tmp_path))
     from puffo_agent.portal import worker as worker_module
 
-    def boom(coro):
+    def boom(coro, *, name=None):
         coro.close()
         raise RuntimeError("no running loop")
 
-    monkeypatch.setattr(worker_module.asyncio, "create_task", boom)
+    monkeypatch.setattr(worker_module, "spawn", boom)
     w = _drained_worker("agent-cb-raises")
     w._enter_drained("agent-cb-raises")
     assert w.runtime.health == "drained"

--- a/tests/test_global_inbox_runtime.py
+++ b/tests/test_global_inbox_runtime.py
@@ -42,6 +42,7 @@ from puffo_agent.agent.runtime_event_outbox import RuntimeEventOutbox
 from puffo_agent.agent.runtime_events import RuntimeEvent
 from puffo_agent.crypto.message import MessagePayload
 from puffo_agent.crypto.ws_client import TransportOutcome
+from puffo_agent.tasks import spawn
 from _global_inbox_support import Adapter, ToolReturnAdapter, make_store, receipt
 
 
@@ -753,9 +754,10 @@ async def test_listener_guard_stops_transport_when_runtime_crashes():
 
 
 @pytest.mark.asyncio
-async def test_listener_guard_observes_simultaneous_listener_failure():
+async def test_listener_guard_reports_both_simultaneous_failures_once(caplog):
     release = asyncio.Event()
     listener_started = asyncio.Event()
+    loop_contexts = []
 
     async def fail_listener():
         listener_started.set()
@@ -767,22 +769,44 @@ async def test_listener_guard_observes_simultaneous_listener_failure():
         await release.wait()
         raise ValueError("runtime boom")
 
-    runtime_task = asyncio.create_task(fail_runtime())
-    guarded = asyncio.create_task(
-        await_listener_with_runtime(
-            fail_listener(),
-            runtime_task,
-            label="global inbox",
-        )
-    )
-    await listener_started.wait()
-    release.set()
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+    try:
+        with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+            runtime_task = spawn(fail_runtime(), name="global_runtime.run")
+            guarded = asyncio.create_task(
+                await_listener_with_runtime(
+                    fail_listener(),
+                    runtime_task,
+                    label="global inbox",
+                )
+            )
+            await listener_started.wait()
+            release.set()
 
-    with pytest.raises(
-        RuntimeError,
-        match="runtime boom; listener also failed: listener boom",
-    ):
-        await guarded
+            with pytest.raises(
+                RuntimeError,
+                match="runtime boom; listener also failed: listener boom",
+            ):
+                await guarded
+            for _ in range(3):
+                await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    records = [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert len(records) == 2
+    assert {record.getMessage() for record in records} == {
+        "worker task died: listener",
+        "worker task died: global_runtime.run",
+    }
+    assert all(record.exc_info is not None for record in records)
+    assert {type(record.exc_info[1]) for record in records} == {
+        OSError,
+        ValueError,
+    }
+    assert loop_contexts == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_global_inbox_runtime_held_and_reminders.py
+++ b/tests/test_global_inbox_runtime_held_and_reminders.py
@@ -974,6 +974,63 @@ async def test_runtime_surfaces_owned_reminder_scheduler_failure(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_runtime_reports_and_settles_simultaneous_owned_failures(
+    tmp_path, caplog,
+):
+    store = await make_store(tmp_path)
+    release = asyncio.Event()
+    unhandled = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+
+    class FailingScheduler:
+        async def run(self):
+            await release.wait()
+            raise RuntimeError("reminder failed")
+
+        def stop(self):
+            return None
+
+    async def fail_burst():
+        await release.wait()
+        raise ValueError("burst failed")
+
+    runtime = GlobalInboxRuntime(
+        store=store,
+        adapter=Adapter(),
+        run_turn=lambda _planned: None,
+        workspace=tmp_path,
+        reminder_scheduler=FailingScheduler(),
+    )
+    runtime.coalescer.wait_for_burst = fail_burst
+    caplog.set_level(logging.ERROR, logger="puffo_agent.tasks")
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+    try:
+        running = asyncio.create_task(runtime.run())
+        await asyncio.sleep(0)
+        release.set()
+        with pytest.raises(RuntimeError, match="reminder failed"):
+            await running
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+        await store.close()
+
+    failures = [
+        record
+        for record in caplog.records
+        if record.name == "puffo_agent.tasks"
+        and record.levelno == logging.ERROR
+    ]
+    assert sorted(str(record.exc_info[1]) for record in failures) == [
+        "burst failed",
+        "reminder failed",
+    ]
+    assert all(record.exc_info is not None for record in failures)
+    assert unhandled == []
+
+
+@pytest.mark.asyncio
 async def test_changed_pending_generation_replaces_accepted_notice_without_losing_unread_rows(
     tmp_path,
 ):

--- a/tests/test_inbox_scheduler.py
+++ b/tests/test_inbox_scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import sys
 from dataclasses import FrozenInstanceError
@@ -215,6 +216,24 @@ async def test_coalescer_deadline_starts_at_notify_before_delayed_waiter():
     coalescer.notify()
     await coalescer.wait_for_burst()
     assert sleeps == [pytest.approx(2.920)]
+
+
+@pytest.mark.asyncio
+async def test_coalescer_sleep_failure_is_reported_once_with_traceback(caplog):
+    async def broken_sleep(_delay):
+        raise ValueError("coalescer sleep failed")
+
+    coalescer = InboxCoalescer(sleep=broken_sleep, monotonic=lambda: 20.0)
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        assert not await coalescer._sleep_or_pull(3.0)
+        await asyncio.sleep(0)
+
+    records = [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert len(records) == 1
+    assert records[0].getMessage() == "worker task died: sleep"
+    assert records[0].exc_info is not None
+    assert isinstance(records[0].exc_info[1], ValueError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_spawn.py
+++ b/tests/test_task_spawn.py
@@ -3,6 +3,7 @@ done-callback, and no bare ensure_future/create_task remains in the tree."""
 
 import ast
 import asyncio
+import inspect
 import logging
 from pathlib import Path
 
@@ -152,17 +153,25 @@ async def test_existing_done_callback_still_runs(caplog):
 
 
 @pytest.mark.asyncio
-async def test_owned_companion_leaves_reporting_to_awaiter(caplog):
+async def test_owned_companion_is_still_reported_once(caplog):
     async def boom():
         raise ValueError("claimed")
 
     with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
-        task = spawn(boom(), name="claimed", report_failure=False)
+        task = spawn(boom(), name="claimed")
         with pytest.raises(ValueError):
             await task
         await _settle()
 
-    assert _errors(caplog) == []
+    records = _errors(caplog)
+    assert len(records) == 1
+    assert records[0].getMessage() == "worker task died: claimed"
+    assert records[0].exc_info is not None
+    assert isinstance(records[0].exc_info[1], ValueError)
+
+
+def test_failure_reporting_cannot_be_disabled():
+    assert "report_failure" not in inspect.signature(spawn).parameters
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_spawn.py
+++ b/tests/test_task_spawn.py
@@ -172,6 +172,11 @@ async def test_owned_companion_is_still_reported_once(caplog):
 
 def test_failure_reporting_cannot_be_disabled():
     assert "report_failure" not in inspect.signature(spawn).parameters
+    # Supervised paths can add another authoritative record for the same
+    # exception, so incident counters must not equate ERROR lines with faults.
+    doc = inspect.getdoc(spawn)
+    assert doc is not None
+    assert "deduplicate by exception" in doc
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_spawn.py
+++ b/tests/test_task_spawn.py
@@ -50,10 +50,25 @@ async def test_unclaimed_exception_is_logged_with_name_and_traceback(caplog):
     records = _errors(caplog)
     assert len(records) == 1
     record = records[0]
-    assert "reminder_sync.run" in record.getMessage()
+    assert record.getMessage() == "worker task died: reminder_sync.run"
     assert record.exc_info is not None
     assert isinstance(record.exc_info[1], ValueError)
     assert "message backup key has invalid length" in str(record.exc_info[1])
+
+
+@pytest.mark.asyncio
+async def test_pre_built_task_is_renamed_before_reporting(caplog):
+    async def boom():
+        raise ValueError("prebuilt")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        task = asyncio.get_running_loop().create_task(boom(), name="original")
+        returned = spawn(task, name="renamed")
+        await _settle()
+
+    assert returned is task
+    assert task.get_name() == "renamed"
+    assert _errors(caplog)[0].getMessage() == "worker task died: renamed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_spawn.py
+++ b/tests/test_task_spawn.py
@@ -1,0 +1,208 @@
+"""Worker tasks must not die unclaimed: spawn attaches an exception-logging
+done-callback, and no bare ensure_future/create_task remains in the tree."""
+
+import ast
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.tasks import spawn
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "puffo_agent"
+_HELPER = _SRC / "tasks.py"
+_SPAWNERS = {"ensure_future", "create_task"}
+_SPAWNER_OWNERS = {"asyncio", "loop"}
+
+
+async def _settle():
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+def _errors(caplog):
+    return [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+@pytest.mark.asyncio
+async def test_clean_completion_logs_nothing(caplog):
+    async def ok():
+        return 7
+
+    with caplog.at_level(logging.DEBUG, logger="puffo_agent.tasks"):
+        task = spawn(ok(), name="ok")
+        assert await task == 7
+        await _settle()
+
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_unclaimed_exception_is_logged_with_name_and_traceback(caplog):
+    async def boom():
+        raise ValueError("message backup key has invalid length")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        spawn(boom(), name="reminder_sync.run")
+        await _settle()
+
+    records = _errors(caplog)
+    assert len(records) == 1
+    record = records[0]
+    assert "reminder_sync.run" in record.getMessage()
+    assert record.exc_info is not None
+    assert isinstance(record.exc_info[1], ValueError)
+    assert "message backup key has invalid length" in str(record.exc_info[1])
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_is_not_reported(caplog):
+    started = asyncio.Event()
+
+    async def sleeper():
+        started.set()
+        await asyncio.sleep(3600)
+
+    with caplog.at_level(logging.DEBUG, logger="puffo_agent.tasks"):
+        task = spawn(sleeper(), name="sleeper")
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await _settle()
+
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_returned_task_is_named_and_awaitable():
+    async def ok():
+        return "value"
+
+    task = spawn(ok(), name="named")
+    assert isinstance(task, asyncio.Task)
+    assert task.get_name() == "named"
+    assert await task == "value"
+
+
+@pytest.mark.asyncio
+async def test_spawn_without_name_still_reports(caplog):
+    async def boom():
+        raise RuntimeError("nameless")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        spawn(boom())
+        await _settle()
+
+    records = _errors(caplog)
+    assert len(records) == 1
+    assert isinstance(records[0].exc_info[1], RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_plain_future_is_reported_without_set_name(caplog):
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        returned = spawn(future, name="ignored-on-future")
+        assert returned is future
+        future.set_exception(OSError("disk"))
+        await _settle()
+
+    records = _errors(caplog)
+    assert len(records) == 1
+    assert isinstance(records[0].exc_info[1], OSError)
+
+
+@pytest.mark.asyncio
+async def test_existing_done_callback_still_runs(caplog):
+    tasks: set[asyncio.Future] = set()
+
+    async def boom():
+        raise ValueError("both callbacks")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        task = spawn(boom(), name="housekept")
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+        await _settle()
+
+    assert tasks == set()
+    assert len(_errors(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_awaited_companion_still_receives_the_exception(caplog):
+    async def boom():
+        raise ValueError("claimed")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        task = spawn(boom(), name="claimed")
+        with pytest.raises(ValueError):
+            await task
+        await _settle()
+
+    assert len(_errors(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_services_shaped_failure_surfaces(caplog):
+    """Prof-Puffo shape: bring-up spawns a service task nobody awaits."""
+    ready = asyncio.Event()
+
+    async def prepare_reminder_sync():
+        raise ValueError("message backup key has invalid length")
+
+    async def start_services():
+        spawn(prepare_reminder_sync(), name="reminder_sync.run")
+        ready.set()
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        await start_services()
+        await ready.wait()
+        await _settle()
+
+    records = _errors(caplog)
+    assert len(records) == 1
+    assert "reminder_sync.run" in records[0].getMessage()
+
+
+def test_spawn_without_running_loop_raises():
+    async def never():
+        return None
+
+    coro = never()
+    try:
+        with pytest.raises(RuntimeError):
+            spawn(coro, name="no-loop")
+    finally:
+        coro.close()
+
+
+def _bare_spawn_sites(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in _SPAWNERS:
+            continue
+        if isinstance(func.value, ast.Name) and func.value.id in _SPAWNER_OWNERS:
+            hits.append(f"{path}:{node.lineno} {func.value.id}.{func.attr}")
+    return hits
+
+
+def test_no_bare_task_spawn_remains_in_tree():
+    sources = sorted(p for p in _SRC.rglob("*.py") if p != _HELPER)
+    assert sources, "source sweep found no files"
+    hits = [site for path in sources for site in _bare_spawn_sites(path)]
+    assert hits == []
+
+
+def test_helper_is_the_only_ensure_future_owner():
+    hits = _bare_spawn_sites(_HELPER)
+    assert len(hits) == 1
+    assert "asyncio.ensure_future" in hits[0]

--- a/tests/test_task_spawn.py
+++ b/tests/test_task_spawn.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from puffo_agent.agent.directory_cache import warm_member_caches
 from puffo_agent.tasks import spawn
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "puffo_agent"
@@ -186,6 +187,40 @@ async def test_start_services_shaped_failure_surfaces(caplog):
     assert "reminder_sync.run" in records[0].getMessage()
 
 
+@pytest.mark.asyncio
+async def test_cache_warm_reports_both_failed_siblings_once(caplog):
+    class Http:
+        async def get(self, path):
+            assert path == "/spaces"
+            return {"spaces": [{"space_id": "sp_1", "name": "One"}]}
+
+    async def get_members(_space_id):
+        raise ValueError("members failed")
+
+    async def warm_channels(_space_id):
+        await asyncio.sleep(0)
+        raise RuntimeError("channels failed")
+
+    async def fetch_profiles(_slugs):
+        raise AssertionError("no profiles should be fetched")
+
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        await warm_member_caches(
+            http=Http(),
+            log=logging.getLogger("test.directory_cache"),
+            space_name_cache={},
+            profile_cache={},
+            get_members=get_members,
+            warm_channels=warm_channels,
+            fetch_profiles=fetch_profiles,
+        )
+        await _settle()
+
+    records = _errors(caplog)
+    assert len(records) == 2
+    assert {type(record.exc_info[1]) for record in records} == {ValueError, RuntimeError}
+
+
 def test_spawn_without_running_loop_raises():
     async def never():
         return None
@@ -200,15 +235,74 @@ def test_spawn_without_running_loop_raises():
 
 def _bare_spawn_sites(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"))
+    asyncio_modules: set[str] = set()
+    direct_spawners: set[str] = set()
+    task_group_factories: set[str] = set()
+    task_group_owners: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "asyncio":
+                    asyncio_modules.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "asyncio":
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                if alias.name in _SPAWNERS:
+                    direct_spawners.add(local_name)
+                elif alias.name == "TaskGroup":
+                    task_group_factories.add(local_name)
+
+    def is_task_group_factory(expr: ast.expr) -> bool:
+        if isinstance(expr, ast.Name):
+            return expr.id in task_group_factories
+        return (
+            isinstance(expr, ast.Attribute)
+            and expr.attr == "TaskGroup"
+            and isinstance(expr.value, ast.Name)
+            and expr.value.id in asyncio_modules
+        )
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.With, ast.AsyncWith)):
+            continue
+        for item in node.items:
+            context = item.context_expr
+            if (
+                isinstance(context, ast.Call)
+                and is_task_group_factory(context.func)
+                and isinstance(item.optional_vars, ast.Name)
+            ):
+                task_group_owners.add(item.optional_vars.id)
+
+    def is_loop_owner(expr: ast.expr) -> bool:
+        if isinstance(expr, ast.Name):
+            return expr.id in asyncio_modules or "loop" in expr.id.lower()
+        if isinstance(expr, ast.Attribute):
+            return "loop" in expr.attr.lower()
+        if not isinstance(expr, ast.Call) or not isinstance(expr.func, ast.Attribute):
+            return False
+        return (
+            expr.func.attr in {"get_running_loop", "get_event_loop"}
+            and isinstance(expr.func.value, ast.Name)
+            and expr.func.value.id in asyncio_modules
+        )
+
     hits = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if isinstance(func, ast.Attribute) and func.attr in _SPAWNERS:
-            hits.append(f"{path}:{node.lineno} attribute.{func.attr}")
-        elif isinstance(func, ast.Name) and func.id in _SPAWNERS:
+        if isinstance(func, ast.Name) and func.id in direct_spawners:
             hits.append(f"{path}:{node.lineno} name.{func.id}")
+        elif isinstance(func, ast.Attribute) and func.attr == "ensure_future":
+            if isinstance(func.value, ast.Name) and func.value.id in asyncio_modules:
+                hits.append(f"{path}:{node.lineno} attribute.{func.attr}")
+        elif isinstance(func, ast.Attribute) and func.attr == "create_task":
+            if isinstance(func.value, ast.Name) and func.value.id in task_group_owners:
+                continue
+            if is_loop_owner(func.value):
+                hits.append(f"{path}:{node.lineno} attribute.{func.attr}")
     return hits
 
 
@@ -229,13 +323,29 @@ def test_helper_owns_both_low_level_spawn_shapes():
 @pytest.mark.parametrize(
     "source",
     [
-        "asyncio.get_running_loop().create_task(work())",
-        "self._loop.create_task(work())",
-        "create_task(work())",
-        "aio.ensure_future(work())",
+        "import asyncio\nasyncio.get_running_loop().create_task(work())",
+        "import asyncio\nloop = asyncio.get_running_loop()\nloop.create_task(work())",
+        "import asyncio\nself._loop.create_task(work())",
+        "from asyncio import create_task\ncreate_task(work())",
+        "from asyncio import create_task as schedule\nschedule(work())",
+        "import asyncio as aio\naio.ensure_future(work())",
     ],
 )
 def test_fleet_lint_detects_indirect_spawn_shapes(tmp_path, source):
     path = tmp_path / "indirect.py"
     path.write_text(source, encoding="utf-8")
     assert len(_bare_spawn_sites(path)) == 1
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import asyncio\nasync with asyncio.TaskGroup() as tg:\n    tg.create_task(work())",
+        "from asyncio import TaskGroup as Group\nasync with Group() as owner:\n    owner.create_task(work())",
+        "domain.create_task(record())",
+    ],
+)
+def test_fleet_lint_allows_supervised_and_unrelated_create_task(tmp_path, source):
+    path = tmp_path / "owned.py"
+    path.write_text(source, encoding="utf-8")
+    assert _bare_spawn_sites(path) == []

--- a/tests/test_task_spawn.py
+++ b/tests/test_task_spawn.py
@@ -13,7 +13,6 @@ from puffo_agent.tasks import spawn
 _SRC = Path(__file__).resolve().parent.parent / "src" / "puffo_agent"
 _HELPER = _SRC / "tasks.py"
 _SPAWNERS = {"ensure_future", "create_task"}
-_SPAWNER_OWNERS = {"asyncio", "loop"}
 
 
 async def _settle():
@@ -57,18 +56,21 @@ async def test_unclaimed_exception_is_logged_with_name_and_traceback(caplog):
 
 
 @pytest.mark.asyncio
-async def test_pre_built_task_is_renamed_before_reporting(caplog):
+async def test_pre_built_task_is_renamed_before_reporting_once(caplog):
     async def boom():
         raise ValueError("prebuilt")
 
     with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
         task = asyncio.get_running_loop().create_task(boom(), name="original")
         returned = spawn(task, name="renamed")
+        returned_again = spawn(task, name="renamed-again")
         await _settle()
 
     assert returned is task
-    assert task.get_name() == "renamed"
-    assert _errors(caplog)[0].getMessage() == "worker task died: renamed"
+    assert returned_again is task
+    assert task.get_name() == "renamed-again"
+    assert len(_errors(caplog)) == 1
+    assert _errors(caplog)[0].getMessage() == "worker task died: renamed-again"
 
 
 @pytest.mark.asyncio
@@ -149,17 +151,17 @@ async def test_existing_done_callback_still_runs(caplog):
 
 
 @pytest.mark.asyncio
-async def test_awaited_companion_still_receives_the_exception(caplog):
+async def test_owned_companion_leaves_reporting_to_awaiter(caplog):
     async def boom():
         raise ValueError("claimed")
 
     with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
-        task = spawn(boom(), name="claimed")
+        task = spawn(boom(), name="claimed", report_failure=False)
         with pytest.raises(ValueError):
             await task
         await _settle()
 
-    assert len(_errors(caplog)) == 1
+    assert _errors(caplog) == []
 
 
 @pytest.mark.asyncio
@@ -203,10 +205,10 @@ def _bare_spawn_sites(path: Path) -> list[str]:
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr not in _SPAWNERS:
-            continue
-        if isinstance(func.value, ast.Name) and func.value.id in _SPAWNER_OWNERS:
-            hits.append(f"{path}:{node.lineno} {func.value.id}.{func.attr}")
+        if isinstance(func, ast.Attribute) and func.attr in _SPAWNERS:
+            hits.append(f"{path}:{node.lineno} attribute.{func.attr}")
+        elif isinstance(func, ast.Name) and func.id in _SPAWNERS:
+            hits.append(f"{path}:{node.lineno} name.{func.id}")
     return hits
 
 
@@ -217,7 +219,23 @@ def test_no_bare_task_spawn_remains_in_tree():
     assert hits == []
 
 
-def test_helper_is_the_only_ensure_future_owner():
+def test_helper_owns_both_low_level_spawn_shapes():
     hits = _bare_spawn_sites(_HELPER)
-    assert len(hits) == 1
-    assert "asyncio.ensure_future" in hits[0]
+    assert len(hits) == 2
+    assert any("attribute.create_task" in hit for hit in hits)
+    assert any("attribute.ensure_future" in hit for hit in hits)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "asyncio.get_running_loop().create_task(work())",
+        "self._loop.create_task(work())",
+        "create_task(work())",
+        "aio.ensure_future(work())",
+    ],
+)
+def test_fleet_lint_detects_indirect_spawn_shapes(tmp_path, source):
+    path = tmp_path / "indirect.py"
+    path.write_text(source, encoding="utf-8")
+    assert len(_bare_spawn_sites(path)) == 1

--- a/tests/test_ws_local_endpoint.py
+++ b/tests/test_ws_local_endpoint.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 import pytest
 
@@ -154,7 +155,7 @@ async def test_release_and_close_on_error_after_acquire():
 
 
 @pytest.mark.asyncio
-async def test_consumer_exception_torn_down_cleanly():
+async def test_consumer_exception_has_one_authoritative_failure_record(caplog):
     reg: SessionRegistry = SessionRegistry()
     t = FakeTransport()
     t.feed({"type": "connect", "bundle": "Yg==", "password": "pw"})
@@ -163,8 +164,18 @@ async def test_consumer_exception_torn_down_cleanly():
         raise RuntimeError("server stream died")
 
     coro, _ = _serve(t, registry=reg, consumer=consumer)
-    await coro  # exception is logged, not propagated
+    with caplog.at_level(logging.ERROR, logger="puffo_agent.tasks"):
+        await coro  # exception is logged, not propagated
+        await asyncio.sleep(0)
     assert reg.current("puffotest") is None
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "puffo_agent.tasks" and record.levelno >= logging.ERROR
+    ]
+    assert len(records) == 1
+    assert records[0].getMessage() == "worker task died: start_consumer"
+    assert isinstance(records[0].exc_info[1], RuntimeError)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Every `asyncio.ensure_future` / `asyncio.create_task` in the daemon now
routes through a single helper (`puffo_agent.tasks.spawn`) that attaches a
universal done-callback. Unhandled exceptions in worker tasks are logged
with the full traceback (`worker task died: <name>`) instead of vanishing
into the event loop. Shutdown cancellation stays silent; awaited-companion
paths do not double-surface.

Motivating incident: the 2026-08-26 Prof-Puffo restart hang. A
`ValueError: message backup key has invalid length` fired at
`keystore.py:149` on every startup and was swallowed by an unmonitored
`reminder_task`, producing zero log output. Diagnosis took a full day and
six misdirected stages. With this helper in place, that failure surfaces
on restart #1.

## Change shape

- **New helper** — `src/puffo_agent/tasks.py` (37 lines):
  - `spawn(coro, *, name=None)` — `get_running_loop().create_task(coro, name=name)`
    for coroutines (preserves the `RuntimeError("no running event loop")`
    contract callers already rely on); `asyncio.ensure_future(awaitable)` +
    conditional `set_name` for non-coroutine awaitables.
  - `_report_task_death(task)` — `Task.done()` callback. Skips
    `task.cancelled()` and `task.exception() is None`. Logs
    `ERROR "worker task died: %s"` with `exc_info=<exception>`.
- **Sweep** — 26 modules migrated from bare `asyncio.ensure_future` /
  `asyncio.create_task` to `tasks.spawn`. `bridge_transport.py` layers
  `_report_task_death` alongside its existing `client._ack_tasks.discard`
  housekeeping callback (housekeeping preserved).
- **Fleet-lint** — two AST tests
  (`test_no_bare_task_spawn_remains_in_tree`,
  `test_helper_is_the_only_ensure_future_owner`) walk
  `src/puffo_agent/**/*.py` (excluding `tasks.py`) and fail on any
  `asyncio.ensure_future` / `asyncio.create_task` / `loop.create_task` /
  `loop.ensure_future` call outside the helper. Guards future regressions.

## Test coverage

- **New unit tests** — `tests/test_task_spawn.py`, 13 tests:
  - Happy path spawn + await.
  - Unhandled exception surfaces via logger at ERROR with full traceback
    and task name.
  - `CancelledError` from cooperative shutdown stays silent.
  - `exception() is None` (normal completion) stays silent.
  - `name=` propagates to callback log.
  - Pre-built Task / plain Future path (non-coroutine `ensure_future`).
  - No-running-loop → `RuntimeError` (contract preserved).
  - Awaited-companion double-surface guard (caller `await` still raises
    once; callback logs once; no duplicate ERROR).
  - Two AST fleet-lint tests as described above.
- **Updated tests** —
  `tests/test_auth_failed_dm_notification.py`,
  `tests/test_drained_state.py`: adjusted where the previous
  `asyncio.create_task` call-site was patched or asserted.
- **Full suite** — 3341 passed, 0 failed, 0 error, 1 skipped
  (pre-existing Windows-only skip), exit 0.

## Race / concurrency coverage

Explicitly tested:
- Callback FIFO ordering with pre-existing housekeeping callback
  (bridge_transport) — housekeeping and death-log both fire; order does
  not swap.
- Awaited path — a caller that awaits the returned task still receives
  the exception normally; the callback still logs; no double-report of
  the same exception on the same task.
- Shutdown-cancel path — `Task.cancel()` mid-run does not trigger the
  ERROR log.
- Non-coroutine awaitable path — plain `asyncio.Future` handled without
  attempting `set_name` on objects that lack it.

## Non-changes

- No wire protocol change; no schema change; no persisted-state change.
- No dependency change.
- No behavioral change on any happy path — successful task completion is
  untouched. Only silently-swallowed exceptions are now surfaced as
  `ERROR` log lines.

## Fleet numbering

Fleet PUF-454 · Linear PUF-353.
