### PR TITLE
Reconcile release/2.0.3 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.3] - 2026-08-27
+
 ### Added
+
+- **Generic ACP v1 harness foundation.** ACP and OpenCode Drivers now share
+  validated launch plans, bounded lifecycle handling, per-turn protocol
+  support, and explicit process-tree cleanup semantics. (#297)
 
 - **Invite-link channel joins are announced to the agent.** When someone
   joins channels by redeeming an invite link, the server's synthetic
@@ -28,6 +34,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `refresh_broken` streak. (#228)
 
 ### Fixed
+
+- **Autonomous-turn admission race.** Autonomous runs reserve admission
+  atomically and settle losing or orphaned runs instead of wedging the Agent.
+  (#296)
 
 - **Worker tasks no longer die unclaimed.** Every background task the daemon
   spawns now carries a done-callback that logs `worker task died: <name>` with

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python:
 ```bash
 uv tool install puffo-agent
 # pin to a specific version:
-uv tool install puffo-agent==2.0.2
+uv tool install puffo-agent==2.0.3
 ```
 
 Otherwise use pip:
@@ -70,10 +70,10 @@ Otherwise use pip:
 ```bash
 pip install puffo-agent
 # pin to a specific version:
-pip install puffo-agent==2.0.2
+pip install puffo-agent==2.0.3
 ```
 
-Agent Foundation `2.0.2` is the current stable release. It upgrades supported
+Agent Foundation `2.0.3` is the current stable release. It upgrades supported
 1.2 state in place while preserving Agent identity, keys, profile, memory,
 workspace, message history, and logical session continuity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.2"
+version = "2.0.3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- reconcile the published `release/2.0.3` history back into `main`
- preserve the release merge ancestry with `main` first and `release/2.0.3` second
- update only release metadata and documentation: `CHANGELOG.md`, `README.md`, `pyproject.toml`, and `uv.lock`
- leave runtime source, tests, and all five driver implementations unchanged

## Review gate

- exact reviewed SHA: `125e544adac9b7b3a80a89a8e19e245ba8d60a1d`
- parent 1: `c1db306e7112fdd05777559526ca6689a3fe522b` (`main`)
- parent 2: `06f2e1cd895bf8bf268d0894d857b3639d1c0300` (`release/2.0.3`)
- independent reviews: Linus PASS on the reconciliation; Jeff PASS on this exact amended SHA

## Verification

- `git diff --check`
- `uv lock --check`
- `uv run --extra dev ruff check .`
- `env -u CODEX_HOME uv run --extra dev pytest -q`
- Python compileall
- `uv build`

Full pytest completed successfully with only the two established platform/opt-in skips.