### PR TITLE
feat(mcp): monid_spend tool to fetch paid external data via the server

### DIFF
--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -74,6 +74,7 @@ PUFFO_CORE_TOOL_NAMES = (
     "add_dm_allowlist",
     "update_dm_blocklist",
     "refresh",
+    "monid_spend",
     # M3 memory tools (registered by mcp.memory_tools).
     "create_note",
     "patch_note",

--- a/src/puffo_agent/mcp/core_monid_tools.py
+++ b/src/puffo_agent/mcp/core_monid_tools.py
@@ -1,0 +1,127 @@
+"""Monid spend MCP tool registration.
+
+One generic tool, ``monid_spend``, lets an agent fetch paid, read-only
+external data through Monid with the server as the spend-control middle
+layer. The agent never holds the Monid key or money: it forwards to
+``POST /v2/monid/spend`` via the native signed client, and the server
+discovers a capability, checks the budget, pays Monid, and returns the
+result. Step one targets native (key-holding) agents; the keyless bridge
+transport is out of scope here (that path is unsigned and could not reach
+the subkey-gated spend route).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ..crypto.http_client import HttpError
+
+logger = logging.getLogger(__name__)
+
+
+def _monid_error_message(exc: HttpError) -> str:
+    """Pull the server's human-readable ``message`` out of a failed monid
+    response body (JSON ``{error, message}``), falling back to a terse
+    ``HTTP <status>``. Keeps the tool's error clean instead of a raw blob.
+    """
+    try:
+        parsed = json.loads(exc.body)
+        if isinstance(parsed, dict) and parsed.get("message"):
+            return str(parsed["message"])
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+    return f"HTTP {exc.status}"
+
+
+def register_monid_tools(mcp: FastMCP, cfg: Any) -> None:
+    # Native-only tool. A keyless (T23 bridge) agent authenticates via the
+    # unsigned `/v2/cloud-agents/*` proxy and holds no subkey, so it cannot
+    # reach the subkey-gated `/v2/monid/spend`. Rather than expose a tool that
+    # would only ever error there (and to avoid opening any second auth path),
+    # it is simply not registered for keyless agents — the same conditional-
+    # registration pattern `register_core_tools` uses for the bridge lifecycle
+    # tools. Cloud/keyless Monid is out of scope for step one.
+    if getattr(cfg, "keyless", False):
+        return
+
+    @mcp.tool()
+    async def monid_spend(
+        query: str,
+        input: Optional[dict[str, Any]] = None,
+        max_cost_micro: int = 0,
+        limit: int = 5,
+        idempotency_key: str = "",
+    ) -> str:
+        """Fetch paid, read-only external data through Monid.
+
+        Puffo is the middle layer: it holds the Monid key, checks your
+        spend budget, pays Monid, and returns the result. You never see the
+        key and never hold money. The spend comes out of the shared Monid
+        balance, and your operator must have enabled Monid for you and set a
+        cap first (otherwise this returns a "not enabled" error).
+
+        Args:
+            query: What data you want, in natural language. Puffo discovers a
+                matching read-only capability for it.
+            input: The structured parameters for that capability (e.g. the
+                search terms or ids it needs).
+            max_cost_micro: Your hard ceiling for THIS one call, in
+                micro-dollars (1_000_000 = $1). Must be positive. If the
+                quoted price is above it, the call is rejected before any
+                money is spent.
+            limit: How many candidate capabilities to consider (1-25).
+            idempotency_key: Optional. Pass a stable value to make a retried
+                call safe — it reconciles the earlier attempt instead of
+                paying a second time.
+
+        Returns the provider's result and what the call cost.
+        """
+        if not query.strip():
+            raise RuntimeError("query is required")
+        if max_cost_micro <= 0:
+            raise RuntimeError(
+                "max_cost_micro must be a positive integer in micro-dollars "
+                "(1_000_000 = $1)"
+            )
+
+        body: dict[str, Any] = {
+            "query": query,
+            "input": input if input is not None else {},
+            "max_cost_micro": max_cost_micro,
+            "limit": limit,
+        }
+        if idempotency_key:
+            body["idempotency_key"] = idempotency_key
+
+        try:
+            data = await cfg.http_client.post("/v2/monid/spend", body)
+        except HttpError as exc:
+            raise RuntimeError(
+                f"monid spend failed: {_monid_error_message(exc)}"
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise RuntimeError(f"unexpected monid response: {data!r}")
+
+        # A 202 is not an HTTP error to the client, but it means the spend is
+        # still resolving upstream and an owner will reconcile it — there is no
+        # result yet, so report that rather than a settled cost.
+        if data.get("error") == "PENDING_RECONCILE" or (
+            "cost_micro" not in data and data.get("ledger_id")
+        ):
+            return (
+                "monid spend is still resolving upstream; your operator will "
+                f"reconcile it (ledger {data.get('ledger_id', '?')}). No result yet."
+            )
+
+        cost = data.get("cost_micro")
+        status = data.get("provider_http_status")
+        output = data.get("output")
+        header = f"monid spend settled: cost {cost} micro-dollars"
+        if status is not None:
+            header += f", provider status {status}"
+        return header + "\nresult:\n" + json.dumps(output, indent=2, ensure_ascii=False)

--- a/src/puffo_agent/mcp/core_monid_tools.py
+++ b/src/puffo_agent/mcp/core_monid_tools.py
@@ -75,11 +75,9 @@ def register_monid_tools(mcp: FastMCP, cfg: Any) -> None:
         balance, and your operator must have enabled Monid for you and set a
         cap first (otherwise this returns a "not enabled" error).
 
-        This tool is the ONLY way to reach Monid. Do NOT install or run a
-        Monid CLI, and never ask anyone for — or try to hold — your own Monid
-        API key: you neither have nor need one, the server holds it. If a call
-        fails, fix your `input` or ask the operator to raise the cap; do not
-        route around this tool.
+        This tool is the ONLY way to reach Monid: never install or run a Monid
+        CLI, and never ask for or hold your own Monid key (the server holds it).
+        If a call fails, fix `input` or ask the operator to raise the cap.
 
         Args:
             query: What data you want, in natural language. Puffo discovers a

--- a/src/puffo_agent/mcp/core_monid_tools.py
+++ b/src/puffo_agent/mcp/core_monid_tools.py
@@ -75,6 +75,12 @@ def register_monid_tools(mcp: FastMCP, cfg: Any) -> None:
         balance, and your operator must have enabled Monid for you and set a
         cap first (otherwise this returns a "not enabled" error).
 
+        This tool is the ONLY way to reach Monid. Do NOT install or run a
+        Monid CLI, and never ask anyone for — or try to hold — your own Monid
+        API key: you neither have nor need one, the server holds it. If a call
+        fails, fix your `input` or ask the operator to raise the cap; do not
+        route around this tool.
+
         Args:
             query: What data you want, in natural language. Puffo discovers a
                 matching read-only capability for it.

--- a/src/puffo_agent/mcp/core_monid_tools.py
+++ b/src/puffo_agent/mcp/core_monid_tools.py
@@ -25,13 +25,24 @@ logger = logging.getLogger(__name__)
 
 def _monid_error_message(exc: HttpError) -> str:
     """Pull the server's human-readable ``message`` out of a failed monid
-    response body (JSON ``{error, message}``), falling back to a terse
-    ``HTTP <status>``. Keeps the tool's error clean instead of a raw blob.
+    response body (JSON ``{error, message, input_schema?}``), falling back to a
+    terse ``HTTP <status>``. Keeps the tool's error clean instead of a raw blob.
+
+    When the server rejects the ``input`` before spending it returns the
+    capability's own ``input_schema``; that is appended so the model can rebuild
+    ``input`` to match and retry.
     """
     try:
         parsed = json.loads(exc.body)
         if isinstance(parsed, dict) and parsed.get("message"):
-            return str(parsed["message"])
+            message = str(parsed["message"])
+            schema = parsed.get("input_schema")
+            if schema is not None:
+                return (
+                    f"{message}\nRebuild `input` to match this schema and call "
+                    f"again:\n{json.dumps(schema, ensure_ascii=False)}"
+                )
+            return message
     except (json.JSONDecodeError, ValueError, TypeError):
         pass
     return f"HTTP {exc.status}"
@@ -67,8 +78,15 @@ def register_monid_tools(mcp: FastMCP, cfg: Any) -> None:
         Args:
             query: What data you want, in natural language. Puffo discovers a
                 matching read-only capability for it.
-            input: The structured parameters for that capability (e.g. the
-                search terms or ids it needs).
+            input: The parameters for the chosen capability, in Monid's run
+                envelope: wrap them under `body` (Puffo forwards `input`
+                verbatim), i.e. `{"body": { ... }}`. For example, an Amazon
+                search takes an `input` array of query objects:
+                `{"body": {"input": [{"keyword": "Men Shoes", "domainCode":
+                "com", "sortBy": "recent", "maxPages": 1, "category":
+                "aps"}]}}`. If the shape does not match the capability's schema,
+                the error returns that schema — rebuild `input` to match it and
+                call again.
             max_cost_micro: Your hard ceiling for THIS one call, in
                 micro-dollars (1_000_000 = $1). Must be positive. If the
                 quoted price is above it, the call is rejected before any

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -709,11 +709,13 @@ def register_core_tools(
     from .core_identity_tools import register_identity_tools
     from .core_inbox_tools import register_inbox_tools
     from .core_message_tools import register_message_tools
+    from .core_monid_tools import register_monid_tools
     register_inbox_tools(mcp, cfg, result_surface=result_surface)
     register_identity_tools(mcp, cfg)
     register_message_tools(mcp, cfg, result_surface=result_surface)
     register_history_tools(mcp, cfg)
     register_host_tools(mcp, cfg)
+    register_monid_tools(mcp, cfg)
 
     if cfg.bridge_client is not None:
         from .lifecycle_tools import register_lifecycle_tools

--- a/tests/test_monid_tools.py
+++ b/tests/test_monid_tools.py
@@ -117,6 +117,51 @@ async def test_surfaces_server_error_message():
 
 
 @pytest.mark.asyncio
+async def test_surfaces_input_schema_so_the_model_can_retry():
+    # When the server rejects the input before spending, it returns the
+    # capability's own schema; the tool hands it back so the model can rebuild
+    # `input` and retry.
+    http = _FakeHttp(
+        post_error=HttpError(
+            400,
+            json.dumps(
+                {
+                    "error": "INVALID_INPUT",
+                    "message": (
+                        'input.body is required: Monid wraps a run\'s input as '
+                        '{"body": { … }}'
+                    ),
+                    "input_schema": {
+                        "body": {
+                            "type": "object",
+                            "required": ["input"],
+                            "properties": {
+                                "input": {
+                                    "type": "array",
+                                    "prefill": [
+                                        {"keyword": "Men Shoes", "domainCode": "com"}
+                                    ],
+                                }
+                            },
+                        },
+                        "bodyType": "json",
+                    },
+                }
+            ),
+        )
+    )
+    mcp = _tools(http)
+    with pytest.raises(Exception) as excinfo:
+        await _call(
+            mcp, {"query": "x", "input": {"keyword": "y"}, "max_cost_micro": 5000}
+        )
+    msg = str(excinfo.value)
+    assert "input.body is required" in msg
+    assert "Rebuild `input`" in msg  # the schema is included for a retry
+    assert '"required"' in msg
+
+
+@pytest.mark.asyncio
 async def test_not_registered_for_keyless_agents():
     # A keyless bridge agent cannot reach the subkey-gated spend route, so the
     # tool is simply not exposed for it — not registered, no error path.

--- a/tests/test_monid_tools.py
+++ b/tests/test_monid_tools.py
@@ -1,0 +1,132 @@
+"""``monid_spend`` forwards to the server spend gateway and formats its
+result. The tool holds no key and does no budgeting itself — the server
+enforces the cap (PR-1 reserve); the tool's checks are UX pre-guards and
+its errors are the server's own mapped messages.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from puffo_agent.crypto.http_client import HttpError
+from puffo_agent.mcp.core_monid_tools import register_monid_tools
+
+
+class _FakeHttp:
+    def __init__(self, *, response=None, post_error: Exception | None = None) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.keyless = False
+        self._response = response if response is not None else {"ok": True}
+        self._post_error = post_error
+
+    async def post(self, path, body=None):
+        self.calls.append(("POST", path, body))
+        if self._post_error is not None:
+            raise self._post_error
+        return self._response
+
+
+def _tools(http):
+    cfg = SimpleNamespace(http_client=http, keyless=http.keyless)
+    mcp = FastMCP("test")
+    register_monid_tools(mcp, cfg)
+    return mcp
+
+
+async def _call(mcp, args):
+    result = await mcp.call_tool("monid_spend", args)
+    if isinstance(result, tuple):
+        result = result[0]
+    return "".join(getattr(item, "text", str(item)) for item in result)
+
+
+@pytest.mark.asyncio
+async def test_forwards_and_formats_result():
+    http = _FakeHttp(
+        response={
+            "ledger_id": "led_1",
+            "provider": "amazon",
+            "endpoint": "product_search",
+            "cost_micro": 3000,
+            "provider_http_status": 200,
+            "output": {"items": ["a", "b"]},
+        }
+    )
+    mcp = _tools(http)
+    text = await _call(
+        mcp,
+        {"query": "find widgets", "input": {"q": "widgets"}, "max_cost_micro": 10000},
+    )
+    assert "cost 3000 micro-dollars" in text
+    assert "provider status 200" in text
+    assert "items" in text
+    assert http.calls[-1][0] == "POST"
+    assert http.calls[-1][1] == "/v2/monid/spend"
+    body = http.calls[-1][2]
+    assert body["query"] == "find widgets"
+    assert body["input"] == {"q": "widgets"}
+    assert body["max_cost_micro"] == 10000
+
+
+@pytest.mark.asyncio
+async def test_reports_pending_reconcile():
+    http = _FakeHttp(
+        response={
+            "error": "PENDING_RECONCILE",
+            "message": "still resolving",
+            "ledger_id": "led_pending",
+        }
+    )
+    mcp = _tools(http)
+    text = await _call(
+        mcp, {"query": "x", "input": {"q": "x"}, "max_cost_micro": 5000}
+    )
+    assert "still resolving upstream" in text
+    assert "led_pending" in text
+
+
+@pytest.mark.asyncio
+async def test_rejects_bad_input_without_calling_server():
+    http = _FakeHttp()
+    mcp = _tools(http)
+    with pytest.raises(Exception):
+        await _call(mcp, {"query": "x", "input": {"q": "x"}, "max_cost_micro": 0})
+    with pytest.raises(Exception):
+        await _call(mcp, {"query": "   ", "input": {"q": "x"}, "max_cost_micro": 5000})
+    assert not [c for c in http.calls if c[1] == "/v2/monid/spend"]
+
+
+@pytest.mark.asyncio
+async def test_surfaces_server_error_message():
+    http = _FakeHttp(
+        post_error=HttpError(
+            403,
+            json.dumps(
+                {"error": "FORBIDDEN", "message": "monid is not enabled for this agent"}
+            ),
+        )
+    )
+    mcp = _tools(http)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, {"query": "x", "input": {"q": "x"}, "max_cost_micro": 5000})
+    assert "not enabled for this agent" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_not_registered_for_keyless_agents():
+    # A keyless bridge agent cannot reach the subkey-gated spend route, so the
+    # tool is simply not exposed for it — not registered, no error path.
+    http = _FakeHttp()
+    http.keyless = True
+    mcp = _tools(http)
+    tool_names = {t.name for t in await mcp.list_tools()}
+    assert "monid_spend" not in tool_names
+
+    # Native agents DO get it.
+    native = _tools(_FakeHttp())
+    native_names = {t.name for t in await native.list_tools()}
+    assert "monid_spend" in native_names


### PR DESCRIPTION
## Goal

Give an agent one generic tool to fetch paid, read-only external data through Monid, with the server acting as the spend-control middle layer. The agent never holds the Monid API key or money.

This is the agent-side piece of the Monid spend gateway; the server-side endpoint it forwards to is a separate change.

## Why

- An agent should be able to buy external data (e.g. product data, reviews) without ever holding the paid API key or an unbounded budget.
- The budget, the key, and the receipt all live on the server; the agent just asks and gets a result plus what it cost.

## Scope

Adds one MCP tool, `monid_spend`, in its own registrar module `core_monid_tools` wired into `register_core_tools` (matching the per-domain tool-module layout), and registers it in the tool allowlist (`config.py`):

- The agent calls it with a natural-language `query`, the structured `input` for the capability, and a hard per-call `max_cost_micro` ceiling (micro-dollars, 1,000,000 = $1). The server discovers a matching read-only capability, checks the agent's budget, pays Monid, and returns the result.
- It forwards to `POST /v2/monid/spend` via the **native signed client** — no new auth path. The agent authenticates as itself (subkey signature); the server resolves the agent from that identity. The keyless bridge transport is out of scope here (that path is unsigned and could not reach the subkey-gated spend route).
- It validates the query and the positive cost ceiling before any network call — a UX pre-guard; the real cap is enforced server-side. It reports a still-resolving (pending reconcile) spend clearly instead of as a fake result, and surfaces the server's own mapped error message on failure rather than a raw HTTP blob.

## How to verify

Needs Python ≥ 3.11 and the `mcp` v1 SDK (the code uses `FastMCP`; `mcp` v2 renamed it, so pin `mcp<2`):

```
pytest tests/test_monid_tools.py
pytest
```

Result on my run: **`tests/test_monid_tools.py` 5 passed** (forwards-and-formats-result, reports-pending-reconcile, rejects-bad-input-without-calling-the-server, surfaces-server-error-message, keyless-unsupported). Full suite **3786 passed, 4 skipped**. No linter/type-checker is configured in this repo; the tests are the gate.

This branch is based on current `main`. The real-money end-to-end run is done separately on the maintainer's own machine with the key set locally; this branch is built and tested against a fake client.

**This is a draft and is not intended to merge as-is** — pending code-level review.
