### PR TITLE
Prepare Agent 2.0.4 test release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.4] - 2026-09-01
+
+### Added
+
+- **Truthful Pi and OpenCode creation preflight.** The daemon reports native
+  harness readiness and live model catalogs, rejects unavailable providers or
+  exact models before provisioning identity state, and discovers standard
+  per-user OpenCode installations even under a narrow daemon `PATH`. Existing
+  ACP-over-OpenCode configurations continue to load unchanged. (#305)
+
+### Fixed
+
+- **Pi concurrent replies keep their admission identity across sub-turns.**
+  Stable native turn IDs now survive `agent_end` / `agent_start` boundaries so
+  competing held replies are not silently dropped. (#305)
+- **OpenCode tool activity reaches the UI.** Tool frames now project both
+  start and completion status, and unavailable selected models are reported
+  separately from missing provider authentication. (#305)
+
 ## [2.0.3] - 2026-08-27
 
 ### Added
@@ -4982,7 +5001,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.3...HEAD
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.4...HEAD
+[2.0.4]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.4
 [2.0.3]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.3
 [2.0.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.2
 [2.0.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.1

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python:
 ```bash
 uv tool install puffo-agent
 # pin to a specific version:
-uv tool install puffo-agent==2.0.3
+uv tool install puffo-agent==2.0.4
 ```
 
 Otherwise use pip:
@@ -70,10 +70,10 @@ Otherwise use pip:
 ```bash
 pip install puffo-agent
 # pin to a specific version:
-pip install puffo-agent==2.0.3
+pip install puffo-agent==2.0.4
 ```
 
-Agent Foundation `2.0.3` is the current stable release. It upgrades supported
+Agent Foundation `2.0.4` is the current stable release. It upgrades supported
 1.2 state in place while preserving Agent identity, keys, profile, memory,
 workspace, message history, and logical session continuity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.3"
+version = "2.0.4"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- bump the Agent package and lockfile to `2.0.4`
- update pinned installation examples
- publish focused release notes for truthful Pi/OpenCode preflight, Pi held-send correlation, and OpenCode tool status

## Verification
- #305 merged to `main` as `86f1da3c` after independent cross-review and green CI/CodeQL
- `uv lock --check` and `git diff --check` pass
- full suite completed with one transient ACP loopback failure; the isolated test then passed 5/5 and GitHub CI already passed on Python 3.11 and 3.12
- sdist and wheel build successfully
- clean wheel install reports `2.0.4` and contains all five drivers: Claude Code, Codex, ACP, OpenCode, and Pi

After CI passes, merge this PR and dispatch the existing TestPyPI workflow from `main`.