### PR TITLE
feat(cli): add cross-platform daemon autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,14 +208,17 @@ through the **Agent Portal**, without a direct connection to the machine.
 
 | Command | What it does |
 | --- | --- |
-| `puffo-agent machine link [--server-url <url>] [--name <name>]` | Register the machine + mint a link code, then wait for an operator to approve it in the web app |
+| `puffo-agent machine link [--server-url <url>] [--name <name>] [--no-autostart]` | Register the machine + mint a link code, then wait for an operator to approve it in the web app |
 | `puffo-agent machine unlink --operator <slug> [--server-url <url>]` | Revoke a pairing + pause that operator's agents (`--server-url` refuses if the pairing is on a different server) |
 
 `machine link` registers the machine (a self-minted ed25519 identity; the
 private key never leaves disk), mints a short code, and waits for an operator to
 approve it in the web app (My Agents → Link machine). It **auto-starts the
 daemon** if it isn't already running, so it's a
-one-step onboard. The default server is `chat.puffo.ai/relay`.
+one-step onboard. After linking succeeds, it also enables per-user login-time
+autostart by default; pass `--no-autostart` to skip that registration. A
+platform registration failure is reported but does not undo the successful
+link. The default server is `chat.puffo.ai/relay`.
 
 ### 4.1 Agent Portal control plane
 

--- a/src/puffo_agent/portal/autostart.py
+++ b/src/puffo_agent/portal/autostart.py
@@ -66,7 +66,15 @@ def _service_env() -> dict[str, str]:
     # shell export the user enabled from, and "defaulted at enable time,
     # different default at boot" is exactly the class of silent
     # divergence this feature must not introduce.
-    return {"PUFFO_AGENT_HOME": str(home_dir())}
+    env = {"PUFFO_AGENT_HOME": str(home_dir())}
+    # Login services get a minimal PATH. Known harness CLIs ride
+    # cli_bin's broader-than-PATH resolver, but generic/ACP runtime
+    # configs spawn bare commands (``opencode acp``, ...) exactly as
+    # written — persist the enable-time PATH so those still resolve.
+    path = os.environ.get("PATH")
+    if path:
+        env["PATH"] = path
+    return env
 
 
 # ── result / status types ────────────────────────────────────────────────────
@@ -411,16 +419,36 @@ def windows_run_command() -> list[str]:
     return command
 
 
+def _windows_login_home() -> Path:
+    """The PUFFO_AGENT_HOME a login-started daemon will see: the
+    persisted per-user value if any (where ``setx`` writes), else the
+    default. Comparing against the current effective home — not against
+    "is the variable set" — is what keeps ``setx`` + re-run from being
+    refused forever."""
+    winreg = _load_winreg()
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment") as key:
+            value, _ = winreg.QueryValueEx(key, "PUFFO_AGENT_HOME")
+    except (FileNotFoundError, OSError):
+        value = ""
+    if str(value):
+        return Path(str(value)).expanduser()
+    return Path.home() / ".puffo-agent"
+
+
 def enable_windows() -> ActionResult:
-    if os.environ.get("PUFFO_AGENT_HOME"):
-        # Run-key entries carry no per-entry environment; an override
-        # enabled here would silently start the daemon against the
-        # default home at next login. Refuse rather than diverge.
+    login_home = _windows_login_home()
+    if login_home != home_dir():
+        # Run-key entries carry no per-entry environment; enabling under
+        # a session-only override would silently start the daemon
+        # against a different home at next login. Refuse rather than
+        # diverge.
         return ActionResult(
             False,
             [
-                "PUFFO_AGENT_HOME is overridden in this environment; a Run-key "
-                "entry cannot carry it. Persist it first (`setx "
+                f"PUFFO_AGENT_HOME resolves to {home_dir()} here but would "
+                f"resolve to {login_home} at login; a Run-key entry cannot "
+                "carry the override. Persist it first (`setx "
                 "PUFFO_AGENT_HOME ...`) or unset it, then re-run "
                 "`puffo-agent autostart enable`."
             ],

--- a/src/puffo_agent/portal/autostart.py
+++ b/src/puffo_agent/portal/autostart.py
@@ -92,7 +92,14 @@ Runner = Callable[[list[str]], subprocess.CompletedProcess]
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        # No launchctl/systemctl on this box (e.g. a non-systemd distro):
+        # report it like any failed call instead of tracebacking.
+        return subprocess.CompletedProcess(
+            cmd, 127, stdout="", stderr=f"{cmd[0]}: command not found"
+        )
 
 
 def _failure_detail(proc: subprocess.CompletedProcess) -> str:
@@ -212,7 +219,11 @@ def status_macos(run: Runner = _run) -> AutostartStatus:
 
 
 def systemd_unit_path() -> Path:
-    return Path.home() / ".config" / "systemd" / "user" / SYSTEMD_UNIT_NAME
+    # systemd reads user units from $XDG_CONFIG_HOME/systemd/user and,
+    # like systemd itself, a non-absolute XDG_CONFIG_HOME is ignored.
+    xdg = os.environ.get("XDG_CONFIG_HOME", "")
+    base = Path(xdg) if os.path.isabs(xdg) else Path.home() / ".config"
+    return base / "systemd" / "user" / SYSTEMD_UNIT_NAME
 
 
 def systemd_unit(command: list[str], env: dict[str, str]) -> str:
@@ -254,14 +265,26 @@ def enable_linux(run: Runner = _run, *, linger: bool = False) -> ActionResult:
     path = systemd_unit_path()
     content = systemd_unit(daemon_command(), _service_env())
     changed = not (path.exists() and path.read_text() == content)
+    # Queried before `enable --now` can start anything: an already-running
+    # service keeps executing the old definition until restarted below.
+    was_active = (
+        changed
+        and run(["systemctl", "--user", "is-active", SYSTEMD_UNIT_NAME]).returncode == 0
+    )
     if changed:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content)
     lines = [f"wrote {path}" if changed else f"unit unchanged at {path}"]
-    for cmd in (
+    commands: list[list[str]] = [
         ["systemctl", "--user", "daemon-reload"],
         ["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT_NAME],
-    ):
+    ]
+    if was_active:
+        # `enable --now` only starts an inactive unit — the launchd
+        # branch's bootout/bootstrap equivalent for a changed definition.
+        commands.append(["systemctl", "--user", "restart", SYSTEMD_UNIT_NAME])
+        lines.append("restarting the running service to apply the changed definition")
+    for cmd in commands:
         proc = run(cmd)
         if proc.returncode != 0:
             lines.append(
@@ -285,9 +308,26 @@ def enable_linux(run: Runner = _run, *, linger: bool = False) -> ActionResult:
 def disable_linux(run: Runner = _run) -> ActionResult:
     path = systemd_unit_path()
     if not path.exists():
-        # Nothing configured; a failing systemctl here (e.g. no user
-        # manager at all) leaves nothing behind to report.
-        return ActionResult(True, ["autostart was not enabled"])
+        # The unit file can be gone while systemd still runs the service
+        # (deleted by hand, an earlier config root, ...). "Not enabled"
+        # over a live daemon would be a lie — stop it. A failing
+        # is-active (including: no user manager at all) means nothing is
+        # running and nothing is left behind to report.
+        if run(["systemctl", "--user", "is-active", SYSTEMD_UNIT_NAME]).returncode != 0:
+            return ActionResult(True, ["autostart was not enabled"])
+        proc = run(["systemctl", "--user", "stop", SYSTEMD_UNIT_NAME])
+        if proc.returncode != 0:
+            return ActionResult(
+                False,
+                [
+                    f"no unit file at {path}, but the service is running and "
+                    f"`systemctl --user stop` failed: {_failure_detail(proc)}"
+                ],
+            )
+        return ActionResult(
+            True,
+            [f"no unit file at {path}; stopped the still-loaded service"],
+        )
     proc = run(["systemctl", "--user", "disable", "--now", SYSTEMD_UNIT_NAME])
     if proc.returncode != 0:
         # Deleting the unit anyway would orphan a still-running /

--- a/src/puffo_agent/portal/autostart.py
+++ b/src/puffo_agent/portal/autostart.py
@@ -71,9 +71,15 @@ def _service_env() -> dict[str, str]:
     # cli_bin's broader-than-PATH resolver, but generic/ACP runtime
     # configs spawn bare commands (``opencode acp``, ...) exactly as
     # written — persist the enable-time PATH so those still resolve.
-    path = os.environ.get("PATH")
-    if path:
-        env["PATH"] = path
+    # Absolute entries only: an empty or relative entry resolves from
+    # the cwd, which an interactive shell controls but a daemon doesn't.
+    entries = [
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if entry and os.path.isabs(entry)
+    ]
+    if entries:
+        env["PATH"] = os.pathsep.join(entries)
     return env
 
 

--- a/src/puffo_agent/portal/autostart.py
+++ b/src/puffo_agent/portal/autostart.py
@@ -1,0 +1,452 @@
+"""Login-time autostart registration for the puffo-agent daemon.
+
+``puffo-agent autostart enable`` registers the daemon to start
+automatically after the user logs in; ``disable`` removes the
+registration; ``status`` reports both what is configured on disk and
+what the platform's service manager currently has loaded — the two can
+diverge (file present but never loaded, interpreter upgraded away, ...)
+and conflating them would report an autostart that will not fire.
+
+This is deliberately per-user, login-session autostart — not a
+pre-login system service. Credentials the daemon needs (Keychain
+entries, ``~/.pi``, OpenCode auth) live in the user session, so a
+system-level service would start into an environment where every
+harness reports signed-out. On Linux, ``--linger`` optionally upgrades
+to boot-time start via ``loginctl enable-linger`` (best-effort; not all
+systems permit it).
+
+Platform mechanisms:
+
+- macOS: a LaunchAgent plist. launchd supervises the foreground
+  ``start`` directly; ``KeepAlive.SuccessfulExit=false`` restarts the
+  daemon after a crash but not after a clean ``puffo-agent stop`` (and
+  not after the pid-lock "already running" no-op, which exits 0).
+- Linux: a systemd user unit with ``Restart=on-failure``.
+- Windows: an ``HKCU`` Run key. Windows offers no supervision on this
+  path — the daemon starts at login and is not restarted on crash;
+  ``status`` says so rather than implying launchd/systemd semantics.
+
+Every registration embeds the absolute interpreter path
+(``sys.executable -m puffo_agent.portal.cli start`` — the repo's
+established PATH-free re-invocation) and the effective
+``PUFFO_AGENT_HOME``, because login-time environments have neither the
+user's shell PATH nor its exports.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shlex
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .state import home_dir
+
+LAUNCHD_LABEL = "ai.puffo.agent"
+WINDOWS_RUN_VALUE = "PuffoAgent"
+_WINDOWS_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+SYSTEMD_UNIT_NAME = "puffo-agent.service"
+
+
+def daemon_command() -> list[str]:
+    """The exact argv a service manager should supervise."""
+    return [sys.executable, "-m", "puffo_agent.portal.cli", "start"]
+
+
+def autostart_log_path() -> Path:
+    return home_dir() / "logs" / "autostart.log"
+
+
+def _service_env() -> dict[str, str]:
+    # Always explicit: a login-time environment does not inherit the
+    # shell export the user enabled from, and "defaulted at enable time,
+    # different default at boot" is exactly the class of silent
+    # divergence this feature must not introduce.
+    return {"PUFFO_AGENT_HOME": str(home_dir())}
+
+
+# ── result / status types ────────────────────────────────────────────────────
+
+
+@dataclass
+class ActionResult:
+    ok: bool
+    lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AutostartStatus:
+    """``configured`` is what's on disk; ``active`` is what the service
+    manager currently has loaded. Both false ⇒ disabled."""
+
+    configured: bool
+    active: bool
+    lines: list[str] = field(default_factory=list)
+
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess]
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _failure_detail(proc: subprocess.CompletedProcess) -> str:
+    detail = (proc.stderr or proc.stdout or "").strip()
+    return detail.splitlines()[0] if detail else f"exit code {proc.returncode}"
+
+
+# ── macOS (launchd LaunchAgent) ──────────────────────────────────────────────
+
+
+def launchagent_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+
+
+def launchagent_plist(
+    command: list[str], log_path: Path, env: dict[str, str]
+) -> bytes:
+    return plistlib.dumps(
+        {
+            "Label": LAUNCHD_LABEL,
+            "ProgramArguments": command,
+            "RunAtLoad": True,
+            "KeepAlive": {"SuccessfulExit": False},
+            "StandardOutPath": str(log_path),
+            "StandardErrorPath": str(log_path),
+            "EnvironmentVariables": env,
+        },
+        sort_keys=True,
+    )
+
+
+def _launchd_domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _launchd_loaded(run: Runner) -> bool:
+    return run(["launchctl", "print", f"{_launchd_domain()}/{LAUNCHD_LABEL}"]).returncode == 0
+
+
+def enable_macos(run: Runner = _run) -> ActionResult:
+    path = launchagent_path()
+    log_path = autostart_log_path()
+    content = launchagent_plist(daemon_command(), log_path, _service_env())
+    if path.exists() and path.read_bytes() == content and _launchd_loaded(run):
+        return ActionResult(True, ["already enabled (LaunchAgent loaded, definition current)"])
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    lines = [f"wrote {path}"]
+    if _launchd_loaded(run):
+        # Definition changed while loaded: launchd only re-reads a plist
+        # across bootout/bootstrap. This restarts a launchd-run daemon.
+        run(["launchctl", "bootout", f"{_launchd_domain()}/{LAUNCHD_LABEL}"])
+        lines.append("reloading changed LaunchAgent definition")
+    proc = run(["launchctl", "bootstrap", _launchd_domain(), str(path)])
+    if proc.returncode != 0:
+        # Older macOS has no bootstrap subcommand.
+        proc = run(["launchctl", "load", "-w", str(path)])
+    if proc.returncode != 0:
+        lines.append(
+            "launchctl could not load the LaunchAgent: "
+            f"{_failure_detail(proc)}. The file is in place; it will "
+            "load at next login, or run `launchctl bootstrap "
+            f"{_launchd_domain()} {path}` manually."
+        )
+        return ActionResult(False, lines)
+    lines.append("daemon will start automatically after login (supervised by launchd)")
+    return ActionResult(True, lines)
+
+
+def disable_macos(run: Runner = _run) -> ActionResult:
+    path = launchagent_path()
+    lines: list[str] = []
+    if _launchd_loaded(run):
+        proc = run(["launchctl", "bootout", f"{_launchd_domain()}/{LAUNCHD_LABEL}"])
+        if proc.returncode != 0:
+            return ActionResult(
+                False,
+                [f"launchctl bootout failed: {_failure_detail(proc)}; LaunchAgent left in place"],
+            )
+        lines.append("unloaded LaunchAgent (a launchd-run daemon is stopped by this)")
+    if path.exists():
+        path.unlink()
+        lines.append(f"removed {path}")
+    if not lines:
+        lines.append("autostart was not enabled")
+    return ActionResult(True, lines)
+
+
+def status_macos(run: Runner = _run) -> AutostartStatus:
+    path = launchagent_path()
+    if not path.exists():
+        return AutostartStatus(False, False, ["disabled (no LaunchAgent)"])
+    lines = [f"configured: {path}"]
+    configured = True
+    try:
+        interpreter = plistlib.loads(path.read_bytes())["ProgramArguments"][0]
+        if not Path(interpreter).exists():
+            configured = False
+            lines.append(
+                f"stale: interpreter {interpreter} no longer exists "
+                "(re-run `puffo-agent autostart enable` from the current install)"
+            )
+    except Exception:
+        configured = False
+        lines.append("stale: plist unreadable; re-run `puffo-agent autostart enable`")
+    active = _launchd_loaded(run)
+    lines.append(
+        "loaded in launchd (will start after login)"
+        if active
+        else "not loaded in launchd (takes effect at next login, or enable again)"
+    )
+    return AutostartStatus(configured, active, lines)
+
+
+# ── Linux (systemd user unit) ────────────────────────────────────────────────
+
+
+def systemd_unit_path() -> Path:
+    return Path.home() / ".config" / "systemd" / "user" / SYSTEMD_UNIT_NAME
+
+
+def systemd_unit(command: list[str], env: dict[str, str]) -> str:
+    exec_start = " ".join(_systemd_quote(part) for part in command)
+    env_lines = "".join(
+        f"Environment={name}={value}\n" for name, value in sorted(env.items())
+    )
+    return (
+        "[Unit]\n"
+        "Description=Puffo.ai agent daemon\n"
+        "After=network-online.target\n"
+        "\n"
+        "[Service]\n"
+        f"ExecStart={exec_start}\n"
+        f"{env_lines}"
+        "Restart=on-failure\n"
+        "RestartSec=5\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def _systemd_quote(part: str) -> str:
+    if not part or any(ch.isspace() or ch == '"' for ch in part):
+        escaped = part.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return part
+
+
+def enable_linux(run: Runner = _run, *, linger: bool = False) -> ActionResult:
+    path = systemd_unit_path()
+    content = systemd_unit(daemon_command(), _service_env())
+    changed = not (path.exists() and path.read_text() == content)
+    if changed:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    lines = [f"wrote {path}" if changed else f"unit unchanged at {path}"]
+    for cmd in (
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT_NAME],
+    ):
+        proc = run(cmd)
+        if proc.returncode != 0:
+            lines.append(
+                f"`{' '.join(cmd)}` failed: {_failure_detail(proc)}. "
+                "The unit file is in place; on systems without a systemd "
+                "user session, autostart is not available this way."
+            )
+            return ActionResult(False, lines)
+    lines.append("daemon will start automatically after login (supervised by systemd)")
+    if linger:
+        proc = run(["loginctl", "enable-linger"])
+        lines.append(
+            "lingering enabled: the daemon also starts at boot, before login"
+            if proc.returncode == 0
+            else f"could not enable lingering ({_failure_detail(proc)}); "
+            "autostart remains login-time only"
+        )
+    return ActionResult(True, lines)
+
+
+def disable_linux(run: Runner = _run) -> ActionResult:
+    path = systemd_unit_path()
+    lines: list[str] = []
+    proc = run(["systemctl", "--user", "disable", "--now", SYSTEMD_UNIT_NAME])
+    if proc.returncode == 0:
+        lines.append("disabled systemd unit (a systemd-run daemon is stopped by this)")
+    if path.exists():
+        path.unlink()
+        run(["systemctl", "--user", "daemon-reload"])
+        lines.append(f"removed {path}")
+    if not lines:
+        lines.append("autostart was not enabled")
+    return ActionResult(True, lines)
+
+
+def status_linux(run: Runner = _run) -> AutostartStatus:
+    path = systemd_unit_path()
+    if not path.exists():
+        return AutostartStatus(False, False, ["disabled (no systemd user unit)"])
+    lines = [f"configured: {path}"]
+    configured = True
+    interpreter = _unit_interpreter(path.read_text())
+    if interpreter is not None and not Path(interpreter).exists():
+        configured = False
+        lines.append(
+            f"stale: interpreter {interpreter} no longer exists "
+            "(re-run `puffo-agent autostart enable` from the current install)"
+        )
+    enabled = run(["systemctl", "--user", "is-enabled", SYSTEMD_UNIT_NAME]).returncode == 0
+    running = run(["systemctl", "--user", "is-active", SYSTEMD_UNIT_NAME]).returncode == 0
+    lines.append(
+        "enabled in systemd (will start after login)"
+        if enabled
+        else "unit file present but not enabled in systemd"
+    )
+    lines.append("service currently active" if running else "service not currently active")
+    return AutostartStatus(configured, enabled, lines)
+
+
+def _unit_interpreter(unit_text: str) -> str | None:
+    for line in unit_text.splitlines():
+        if line.startswith("ExecStart="):
+            rest = line[len("ExecStart=") :].strip()
+            try:
+                # _systemd_quote emits shell-compatible double-quoting,
+                # so shlex round-trips it (spaces, escaped quotes).
+                return shlex.split(rest)[0]
+            except (ValueError, IndexError):
+                return None
+    return None
+
+
+# ── Windows (HKCU Run key) ───────────────────────────────────────────────────
+
+
+def _load_winreg():
+    import winreg
+
+    return winreg
+
+
+def windows_run_command() -> list[str]:
+    """Prefer the venv's ``pythonw.exe`` so login doesn't flash (or
+    leave) a console window; fall back to the console interpreter."""
+    command = daemon_command()
+    interpreter = Path(command[0])
+    windowless = interpreter.with_name("pythonw.exe")
+    if interpreter.name.lower() == "python.exe" and windowless.exists():
+        command[0] = str(windowless)
+    return command
+
+
+def enable_windows() -> ActionResult:
+    if os.environ.get("PUFFO_AGENT_HOME"):
+        # Run-key entries carry no per-entry environment; an override
+        # enabled here would silently start the daemon against the
+        # default home at next login. Refuse rather than diverge.
+        return ActionResult(
+            False,
+            [
+                "PUFFO_AGENT_HOME is overridden in this environment; a Run-key "
+                "entry cannot carry it. Persist it first (`setx "
+                "PUFFO_AGENT_HOME ...`) or unset it, then re-run "
+                "`puffo-agent autostart enable`."
+            ],
+        )
+    winreg = _load_winreg()
+    command = windows_run_command()
+    value = subprocess.list2cmdline(command)
+    with winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER, _WINDOWS_RUN_KEY, 0, winreg.KEY_SET_VALUE
+    ) as key:
+        winreg.SetValueEx(key, WINDOWS_RUN_VALUE, 0, winreg.REG_SZ, value)
+    lines = [f"registered Run entry: {value}"]
+    if Path(command[0]).name.lower() != "pythonw.exe":
+        lines.append("note: no pythonw.exe next to the interpreter; a console window will open at login")
+    lines.append(
+        "daemon will start automatically after login "
+        "(Windows Run entries are unsupervised: no restart after a crash)"
+    )
+    return ActionResult(True, lines)
+
+
+def disable_windows() -> ActionResult:
+    winreg = _load_winreg()
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, _WINDOWS_RUN_KEY, 0, winreg.KEY_SET_VALUE
+        ) as key:
+            winreg.DeleteValue(key, WINDOWS_RUN_VALUE)
+    except FileNotFoundError:
+        return ActionResult(True, ["autostart was not enabled"])
+    return ActionResult(True, ["removed Run entry"])
+
+
+def status_windows() -> AutostartStatus:
+    winreg = _load_winreg()
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _WINDOWS_RUN_KEY) as key:
+            value, _ = winreg.QueryValueEx(key, WINDOWS_RUN_VALUE)
+    except FileNotFoundError:
+        return AutostartStatus(False, False, ["disabled (no Run entry)"])
+    lines = [f"configured: Run entry {value!r}"]
+    configured = True
+    interpreter = value.split('"')[1] if value.startswith('"') else value.split(" ", 1)[0]
+    if not Path(interpreter).exists():
+        configured = False
+        lines.append(
+            f"stale: interpreter {interpreter} no longer exists "
+            "(re-run `puffo-agent autostart enable` from the current install)"
+        )
+    # A Run entry has no loaded/unloaded state distinct from the file:
+    # it fires at every login while present.
+    lines.append(
+        "will start after login (unsupervised: no restart after a crash)"
+    )
+    return AutostartStatus(configured, configured, lines)
+
+
+# ── platform dispatch ────────────────────────────────────────────────────────
+
+
+def _platform() -> str:
+    if sys.platform == "darwin":
+        return "macos"
+    if os.name == "nt":
+        return "windows"
+    return "linux"
+
+
+def enable(*, linger: bool = False, platform: str | None = None) -> ActionResult:
+    platform = platform or _platform()
+    if platform == "macos":
+        return enable_macos()
+    if platform == "windows":
+        return enable_windows()
+    return enable_linux(linger=linger)
+
+
+def disable(*, platform: str | None = None) -> ActionResult:
+    platform = platform or _platform()
+    if platform == "macos":
+        return disable_macos()
+    if platform == "windows":
+        return disable_windows()
+    return disable_linux()
+
+
+def status(*, platform: str | None = None) -> AutostartStatus:
+    platform = platform or _platform()
+    if platform == "macos":
+        return status_macos()
+    if platform == "windows":
+        return status_windows()
+    return status_linux()

--- a/src/puffo_agent/portal/autostart.py
+++ b/src/puffo_agent/portal/autostart.py
@@ -217,8 +217,12 @@ def systemd_unit_path() -> Path:
 
 def systemd_unit(command: list[str], env: dict[str, str]) -> str:
     exec_start = " ".join(_systemd_quote(part) for part in command)
+    # The whole NAME=value assignment is one quoted token: an unquoted
+    # value with whitespace gets split into separate (broken)
+    # assignments by systemd.
     env_lines = "".join(
-        f"Environment={name}={value}\n" for name, value in sorted(env.items())
+        f"Environment={_systemd_quote(f'{name}={value}')}\n"
+        for name, value in sorted(env.items())
     )
     return (
         "[Unit]\n"
@@ -237,7 +241,10 @@ def systemd_unit(command: list[str], env: dict[str, str]) -> str:
 
 
 def _systemd_quote(part: str) -> str:
-    if not part or any(ch.isspace() or ch == '"' for ch in part):
+    # % first: it is a systemd specifier everywhere in a unit file
+    # (ExecStart and Environment alike) and would otherwise expand.
+    part = part.replace("%", "%%")
+    if not part or any(ch.isspace() or ch in '"\\' for ch in part):
         escaped = part.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
     return part
@@ -277,16 +284,32 @@ def enable_linux(run: Runner = _run, *, linger: bool = False) -> ActionResult:
 
 def disable_linux(run: Runner = _run) -> ActionResult:
     path = systemd_unit_path()
-    lines: list[str] = []
+    if not path.exists():
+        # Nothing configured; a failing systemctl here (e.g. no user
+        # manager at all) leaves nothing behind to report.
+        return ActionResult(True, ["autostart was not enabled"])
     proc = run(["systemctl", "--user", "disable", "--now", SYSTEMD_UNIT_NAME])
-    if proc.returncode == 0:
-        lines.append("disabled systemd unit (a systemd-run daemon is stopped by this)")
-    if path.exists():
-        path.unlink()
-        run(["systemctl", "--user", "daemon-reload"])
-        lines.append(f"removed {path}")
-    if not lines:
-        lines.append("autostart was not enabled")
+    if proc.returncode != 0:
+        # Deleting the unit anyway would orphan a still-running /
+        # still-wanted service while reporting success.
+        return ActionResult(
+            False,
+            [
+                f"`systemctl --user disable --now` failed: {_failure_detail(proc)}; "
+                f"unit left in place at {path}"
+            ],
+        )
+    lines = ["disabled systemd unit (a systemd-run daemon is stopped by this)"]
+    path.unlink()
+    lines.append(f"removed {path}")
+    proc = run(["systemctl", "--user", "daemon-reload"])
+    if proc.returncode != 0:
+        lines.append(
+            f"`systemctl --user daemon-reload` failed: {_failure_detail(proc)}. "
+            "The unit is disabled and its file removed; run the reload "
+            "manually so systemd forgets the stale definition."
+        )
+        return ActionResult(False, lines)
     return ActionResult(True, lines)
 
 
@@ -320,8 +343,9 @@ def _unit_interpreter(unit_text: str) -> str | None:
             rest = line[len("ExecStart=") :].strip()
             try:
                 # _systemd_quote emits shell-compatible double-quoting,
-                # so shlex round-trips it (spaces, escaped quotes).
-                return shlex.split(rest)[0]
+                # so shlex round-trips it (spaces, escaped quotes); the
+                # %-specifier doubling is ours to undo.
+                return shlex.split(rest)[0].replace("%%", "%")
             except (ValueError, IndexError):
                 return None
     return None

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -1289,17 +1289,41 @@ def cmd_link(args: argparse.Namespace) -> int:
     name = args.name or friendly_device_name()
     server_url = args.server_url or DEFAULT_SERVER_URL
     try:
-        return asyncio.run(
+        link_rc = asyncio.run(
             run_link(
                 server_url,
                 name,
                 open_browser=not args.not_open,
-                code=getattr(args, "code", None),
+                code=args.code,
             )
         )
     except KeyboardInterrupt:
         print("\nlink: cancelled.")
         return 1
+    if link_rc == 0 and not args.no_autostart:
+        _enable_autostart_after_link()
+    return link_rc
+
+
+def _enable_autostart_after_link() -> None:
+    from . import autostart
+
+    try:
+        result = autostart.enable()
+    except Exception as exc:  # noqa: BLE001
+        result = autostart.ActionResult(False, [str(exc)])
+    if result.ok:
+        print("link: autostart enabled.")
+        for line in result.lines:
+            print(line)
+        return
+    print("warning: link succeeded, but autostart could not be enabled.", file=sys.stderr)
+    for line in result.lines:
+        print(line, file=sys.stderr)
+    print(
+        "Run `puffo-agent autostart enable` manually to retry.",
+        file=sys.stderr,
+    )
 
 
 def cmd_unlink(args: argparse.Namespace) -> int:

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -382,6 +382,25 @@ def cmd_stop(args: argparse.Namespace) -> int:
     return 1
 
 
+def cmd_autostart(args: argparse.Namespace) -> int:
+    """Register / unregister / inspect after-login daemon autostart."""
+    from . import autostart
+
+    if args.autostart_cmd == "enable":
+        result = autostart.enable(linger=getattr(args, "linger", False))
+    elif args.autostart_cmd == "disable":
+        result = autostart.disable()
+    else:
+        state = autostart.status()
+        for line in state.lines:
+            print(line)
+        return 0
+    stream = sys.stdout if result.ok else sys.stderr
+    for line in result.lines:
+        print(line, file=stream)
+    return 0 if result.ok else 1
+
+
 def cmd_version(args: argparse.Namespace) -> int:
     """Print installed version + install mode."""
     local = get_local_version()

--- a/src/puffo_agent/portal/cli_parser.py
+++ b/src/puffo_agent/portal/cli_parser.py
@@ -102,6 +102,29 @@ def _add_core_commands(sub, handlers: CommandHandlers) -> None:
         "check-update",
         help="Compare installed version against latest GitHub release",
     ).set_defaults(func=handlers["cmd_check_update"])
+    autostart = sub.add_parser(
+        "autostart",
+        help="Start the daemon automatically after login (per-user)",
+    )
+    autostart_sub = autostart.add_subparsers(dest="autostart_cmd", required=True)
+    autostart_enable = autostart_sub.add_parser(
+        "enable", help="Register the daemon to start after login"
+    )
+    autostart_enable.add_argument(
+        "--linger",
+        action="store_true",
+        help=(
+            "Linux only: also try `loginctl enable-linger` so the daemon "
+            "starts at boot, before login (best-effort)"
+        ),
+    )
+    autostart_enable.set_defaults(func=handlers["cmd_autostart"])
+    autostart_sub.add_parser(
+        "disable", help="Remove the after-login start registration"
+    ).set_defaults(func=handlers["cmd_autostart"])
+    autostart_sub.add_parser(
+        "status", help="Show what is configured and what is currently loaded"
+    ).set_defaults(func=handlers["cmd_autostart"])
 
 
 def _add_agent_create_commands(sub, handlers: CommandHandlers):

--- a/src/puffo_agent/portal/cli_parser.py
+++ b/src/puffo_agent/portal/cli_parser.py
@@ -519,6 +519,11 @@ def _add_machine_commands(sub, handlers: CommandHandlers) -> None:
         action="store_true",
         help="Don't auto-open the link page in your browser.",
     )
+    machine_link.add_argument(
+        "--no-autostart",
+        action="store_true",
+        help="Do not register the daemon to start automatically after login.",
+    )
     machine_link.set_defaults(func=handlers["cmd_link"])
 
     machine_unlink = machine_sub.add_parser(

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -204,6 +204,54 @@ def test_linux_disable_removes_unit_and_reloads():
     assert ["systemctl", "--user", "daemon-reload"] in run.calls
 
 
+def test_linux_disable_failure_keeps_unit_and_reports():
+    """A failed `disable --now` must not delete the unit and claim
+    success — that leaves a running service reported as removed."""
+    autostart.enable_linux(FakeRunner())
+    run = FakeRunner(
+        fail_prefixes=[["systemctl", "--user", "disable"]]
+    )
+    result = autostart.disable_linux(run)
+    assert not result.ok
+    assert autostart.systemd_unit_path().exists()
+    assert any("fake failure" in line for line in result.lines)
+
+
+def test_linux_disable_surfaces_daemon_reload_failure():
+    autostart.enable_linux(FakeRunner())
+    run = FakeRunner(
+        fail_prefixes=[["systemctl", "--user", "daemon-reload"]]
+    )
+    result = autostart.disable_linux(run)
+    assert not result.ok
+    # The unit itself was disabled and removed; the message must say
+    # what remains to be done rather than fail opaquely.
+    assert not autostart.systemd_unit_path().exists()
+    assert any("daemon-reload" in line for line in result.lines)
+
+
+def test_linux_disable_absent_unit_is_ok_even_without_user_manager():
+    run = FakeRunner(fail_prefixes=[["systemctl"]])
+    result = autostart.disable_linux(run)
+    assert result.ok
+    assert any("not enabled" in line for line in result.lines)
+
+
+def test_systemd_env_assignment_is_quoted_and_specifier_safe(tmp_path):
+    unit = autostart.systemd_unit(
+        ["/opt/py%thon", "-m", "puffo_agent.portal.cli", "start"],
+        {"PUFFO_AGENT_HOME": '/home/A User/di"r\\.puffo-agent'},
+    )
+    assert (
+        'Environment="PUFFO_AGENT_HOME=/home/A User/di\\"r\\\\.puffo-agent"'
+        in unit
+    )
+    # % is a systemd specifier in unit files; it must be doubled in
+    # both Environment and ExecStart or systemd expands it.
+    assert "py%%thon" in unit
+    assert autostart._unit_interpreter(unit) == "/opt/py%thon"
+
+
 def test_linux_status_distinguishes_enabled_active_and_stale():
     autostart.enable_linux(FakeRunner())
     state = autostart.status_linux(FakeRunner())

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -22,6 +22,8 @@ from puffo_agent.portal import autostart
 def isolated_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / ".puffo-agent"))
+    # A host XDG_CONFIG_HOME would point the unit path at the real config.
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     # Path.home() reads HOME on POSIX but USERPROFILE on Windows.
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     return tmp_path
@@ -250,6 +252,61 @@ def test_systemd_env_assignment_is_quoted_and_specifier_safe(tmp_path):
     # both Environment and ExecStart or systemd expands it.
     assert "py%%thon" in unit
     assert autostart._unit_interpreter(unit) == "/opt/py%thon"
+
+
+def test_linux_enable_restarts_a_running_service_only_on_change():
+    """`enable --now` does not restart an active unit, so a changed
+    definition needs an explicit restart — and an unchanged one must
+    not bounce the running daemon."""
+    restart = ["systemctl", "--user", "restart", "puffo-agent.service"]
+
+    run = FakeRunner()  # is-active → 0: service already running
+    result = autostart.enable_linux(run)
+    assert result.ok
+    # Ordering: the restart must come after daemon-reload re-read the
+    # changed unit, or systemd restarts into the old definition.
+    assert run.calls.index(["systemctl", "--user", "daemon-reload"]) < run.calls.index(restart)
+
+    run = FakeRunner()
+    result = autostart.enable_linux(run)  # second run: definition unchanged
+    assert result.ok
+    assert restart not in run.calls
+
+
+def test_linux_disable_stops_a_loaded_service_despite_missing_unit_file():
+    """A hand-deleted unit file with the service still running must not
+    report "not enabled" over a live daemon."""
+    run = FakeRunner()  # is-active → 0: still running
+    result = autostart.disable_linux(run)
+    assert result.ok
+    assert ["systemctl", "--user", "stop", "puffo-agent.service"] in run.calls
+    assert any("stopped" in line for line in result.lines)
+
+    run = FakeRunner(fail_prefixes=[["systemctl", "--user", "stop"]])
+    result = autostart.disable_linux(run)
+    assert not result.ok
+    assert any("stop" in line and "failed" in line for line in result.lines)
+
+
+def test_missing_systemctl_reports_instead_of_tracebacking(monkeypatch):
+    def raise_missing(cmd, **kwargs):
+        raise FileNotFoundError(cmd[0])
+
+    monkeypatch.setattr(subprocess, "run", raise_missing)
+    result = autostart.enable_linux(autostart._run)
+    assert not result.ok
+    assert any("command not found" in line for line in result.lines)
+
+
+def test_systemd_unit_path_honors_absolute_xdg_config_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    assert autostart.systemd_unit_path() == (
+        tmp_path / "xdg" / "systemd" / "user" / "puffo-agent.service"
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", "relative/config")  # ignored, like systemd
+    assert autostart.systemd_unit_path() == (
+        tmp_path / ".config" / "systemd" / "user" / "puffo-agent.service"
+    )
 
 
 def test_linux_status_distinguishes_enabled_active_and_stale():

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -8,7 +8,6 @@ user session.
 
 from __future__ import annotations
 
-import os
 import plistlib
 import subprocess
 import sys
@@ -87,7 +86,11 @@ def test_systemd_unit_quotes_interpreter_and_restarts_on_failure(tmp_path):
 # ── macOS ────────────────────────────────────────────────────────────────────
 
 
-def test_macos_enable_writes_plist_and_bootstraps():
+def test_macos_enable_writes_plist_and_bootstraps(monkeypatch):
+    # A deliberately dirty PATH: empty entries and a relative one mean
+    # "resolve from the cwd" — a planting vector for a daemon whose cwd
+    # the user doesn't control. Only absolute entries may persist.
+    monkeypatch.setenv("PATH", "/usr/bin::relative/bin:/opt/tools/bin:")
     run = FakeRunner()
     result = autostart.enable_macos(run)
     assert result.ok
@@ -100,7 +103,7 @@ def test_macos_enable_writes_plist_and_bootstraps():
     # ACP runtimes spawn bare commands that skip the CLI resolver).
     env = plistlib.loads(path.read_bytes())["EnvironmentVariables"]
     assert env["PUFFO_AGENT_HOME"] == str(autostart.home_dir())
-    assert env["PATH"] == os.environ["PATH"]
+    assert env["PATH"] == "/usr/bin:/opt/tools/bin"
 
 
 def test_macos_enable_is_idempotent_when_loaded_and_current():

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -8,6 +8,7 @@ user session.
 
 from __future__ import annotations
 
+import os
 import plistlib
 import subprocess
 import sys
@@ -94,6 +95,12 @@ def test_macos_enable_writes_plist_and_bootstraps():
     assert path.exists()
     assert ["launchctl", "bootstrap"] == run.calls[-1][:2]
     assert str(path) in run.calls[-1]
+    # The wiring, not just the formatter: what enable actually wrote
+    # must carry the effective home and the enable-time PATH (generic /
+    # ACP runtimes spawn bare commands that skip the CLI resolver).
+    env = plistlib.loads(path.read_bytes())["EnvironmentVariables"]
+    assert env["PUFFO_AGENT_HOME"] == str(autostart.home_dir())
+    assert env["PATH"] == os.environ["PATH"]
 
 
 def test_macos_enable_is_idempotent_when_loaded_and_current():
@@ -175,6 +182,11 @@ def test_linux_enable_writes_unit_and_enables_now():
     assert ["systemctl", "--user", "daemon-reload"] in run.calls
     assert ["systemctl", "--user", "enable", "--now", "puffo-agent.service"] in run.calls
     assert not any(cmd[0] == "loginctl" for cmd in run.calls)
+    # As on macOS: the unit enable actually wrote must carry the
+    # effective home and the enable-time PATH.
+    unit = autostart.systemd_unit_path().read_text()
+    assert f"PUFFO_AGENT_HOME={autostart.home_dir()}" in unit
+    assert "PATH=" in unit
 
 
 def test_linux_enable_linger_is_best_effort():
@@ -385,11 +397,30 @@ def test_windows_enable_registers_quoted_command(monkeypatch, fake_winreg):
     assert any("console window" in line for line in result.lines)
 
 
-def test_windows_enable_refuses_unpersistable_home_override(fake_winreg):
+def test_windows_enable_refuses_only_a_diverging_home_override(monkeypatch, fake_winreg):
+    # A session-only override that login won't see → refuse, actionably.
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(Path.home() / "elsewhere"))
     result = autostart.enable_windows()
     assert not result.ok
     assert any("setx" in line for line in result.lines)
     assert autostart.WINDOWS_RUN_VALUE not in fake_winreg.values
+
+    # After the suggested `setx`, the variable still exists in every
+    # shell — the persisted value matching the effective one must
+    # enable, not repeat the refusal forever.
+    fake_winreg.values["PUFFO_AGENT_HOME"] = str(Path.home() / "elsewhere")
+    result = autostart.enable_windows()
+    assert result.ok
+    assert autostart.WINDOWS_RUN_VALUE in fake_winreg.values
+
+
+def test_windows_enable_accepts_override_equal_to_login_default(fake_winreg):
+    # The autouse fixture sets PUFFO_AGENT_HOME to <tmp>/.puffo-agent —
+    # present, but identical to what login resolves. "Is the variable
+    # set" would refuse this; only actual divergence may.
+    result = autostart.enable_windows()
+    assert result.ok
+    assert autostart.WINDOWS_RUN_VALUE in fake_winreg.values
 
 
 def test_windows_prefers_pythonw_sibling(tmp_path, monkeypatch):

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,346 @@
+"""After-login autostart registration (`puffo-agent autostart`).
+
+All three platform branches run on any host: launchctl/systemctl are
+replaced by a recording fake runner, winreg by an in-memory fake, and
+HOME / PUFFO_AGENT_HOME point into tmp_path so nothing touches the real
+user session.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from puffo_agent.portal import autostart
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / ".puffo-agent"))
+    # Path.home() reads HOME on POSIX but USERPROFILE on Windows.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+class FakeRunner:
+    """Records commands; per-prefix return codes, default failure for
+    `launchctl print` (= not loaded) and success otherwise."""
+
+    def __init__(self, fail_prefixes=(), loaded=False):
+        self.calls: list[list[str]] = []
+        self.fail_prefixes = [list(p) for p in fail_prefixes]
+        self.loaded = loaded
+
+    def __call__(self, cmd: list[str]) -> subprocess.CompletedProcess:
+        self.calls.append(cmd)
+        if cmd[:2] == ["launchctl", "print"]:
+            return _proc(cmd, 0 if self.loaded else 113)
+        for prefix in self.fail_prefixes:
+            if cmd[: len(prefix)] == prefix:
+                return _proc(cmd, 1, stderr="fake failure")
+        return _proc(cmd, 0)
+
+
+def _proc(cmd, code, stderr="") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(cmd, code, stdout="", stderr=stderr)
+
+
+# ── definitions embed absolute interpreter + explicit home ───────────────────
+
+
+def test_launchagent_definition_is_supervised_and_env_explicit(tmp_path):
+    content = autostart.launchagent_plist(
+        autostart.daemon_command(),
+        tmp_path / "autostart.log",
+        {"PUFFO_AGENT_HOME": str(tmp_path)},
+    )
+    data = plistlib.loads(content)
+    assert data["ProgramArguments"][0] == sys.executable
+    assert data["ProgramArguments"][1:] == ["-m", "puffo_agent.portal.cli", "start"]
+    assert data["RunAtLoad"] is True
+    # Crash ⇒ relaunch; clean `stop` (and the pid-lock "already
+    # running" exit 0) ⇒ stay down.
+    assert data["KeepAlive"] == {"SuccessfulExit": False}
+    assert data["EnvironmentVariables"]["PUFFO_AGENT_HOME"] == str(tmp_path)
+
+
+def test_systemd_unit_quotes_interpreter_and_restarts_on_failure(tmp_path):
+    unit = autostart.systemd_unit(
+        ["/opt/some dir/python", "-m", "puffo_agent.portal.cli", "start"],
+        {"PUFFO_AGENT_HOME": str(tmp_path)},
+    )
+    assert 'ExecStart="/opt/some dir/python" -m puffo_agent.portal.cli start' in unit
+    assert f"Environment=PUFFO_AGENT_HOME={tmp_path}" in unit
+    assert "Restart=on-failure" in unit
+    assert "WantedBy=default.target" in unit
+    assert autostart._unit_interpreter(unit) == "/opt/some dir/python"
+
+
+# ── macOS ────────────────────────────────────────────────────────────────────
+
+
+def test_macos_enable_writes_plist_and_bootstraps():
+    run = FakeRunner()
+    result = autostart.enable_macos(run)
+    assert result.ok
+    path = autostart.launchagent_path()
+    assert path.exists()
+    assert ["launchctl", "bootstrap"] == run.calls[-1][:2]
+    assert str(path) in run.calls[-1]
+
+
+def test_macos_enable_is_idempotent_when_loaded_and_current():
+    autostart.enable_macos(FakeRunner())
+    run = FakeRunner(loaded=True)
+    result = autostart.enable_macos(run)
+    assert result.ok
+    assert any("already enabled" in line for line in result.lines)
+    assert not any(cmd[:2] == ["launchctl", "bootstrap"] for cmd in run.calls)
+
+
+def test_macos_enable_reloads_changed_definition_via_bootout():
+    autostart.enable_macos(FakeRunner())
+    path = autostart.launchagent_path()
+    data = plistlib.loads(path.read_bytes())
+    data["ProgramArguments"][0] = "/old/venv/python"
+    path.write_bytes(plistlib.dumps(data, sort_keys=True))
+
+    run = FakeRunner(loaded=True)
+    result = autostart.enable_macos(run)
+    assert result.ok
+    ops = [cmd[1] for cmd in run.calls if cmd[0] == "launchctl"]
+    assert ops.index("bootout") < ops.index("bootstrap")
+
+
+def test_macos_enable_falls_back_to_load_and_reports_total_failure():
+    run = FakeRunner(fail_prefixes=[["launchctl", "bootstrap"]])
+    result = autostart.enable_macos(run)
+    assert result.ok
+    assert ["launchctl", "load", "-w"] == run.calls[-1][:3]
+
+    run = FakeRunner(
+        fail_prefixes=[["launchctl", "bootstrap"], ["launchctl", "load"]]
+    )
+    result = autostart.enable_macos(run)
+    assert not result.ok
+    # The failure message must be actionable: file location + manual step.
+    assert any("launchctl bootstrap" in line for line in result.lines)
+
+
+def test_macos_disable_removes_and_reports_not_enabled():
+    autostart.enable_macos(FakeRunner())
+    result = autostart.disable_macos(FakeRunner(loaded=True))
+    assert result.ok
+    assert not autostart.launchagent_path().exists()
+
+    again = autostart.disable_macos(FakeRunner())
+    assert again.ok
+    assert any("not enabled" in line for line in again.lines)
+
+
+def test_macos_status_distinguishes_configured_loaded_and_stale():
+    assert autostart.status_macos(FakeRunner()).configured is False
+
+    autostart.enable_macos(FakeRunner())
+    state = autostart.status_macos(FakeRunner(loaded=True))
+    assert state.configured and state.active
+
+    state = autostart.status_macos(FakeRunner(loaded=False))
+    assert state.configured and not state.active
+
+    path = autostart.launchagent_path()
+    data = plistlib.loads(path.read_bytes())
+    data["ProgramArguments"][0] = "/gone/python"
+    path.write_bytes(plistlib.dumps(data, sort_keys=True))
+    state = autostart.status_macos(FakeRunner(loaded=True))
+    assert not state.configured
+    assert any("stale" in line for line in state.lines)
+
+
+# ── Linux ────────────────────────────────────────────────────────────────────
+
+
+def test_linux_enable_writes_unit_and_enables_now():
+    run = FakeRunner()
+    result = autostart.enable_linux(run)
+    assert result.ok
+    assert autostart.systemd_unit_path().exists()
+    assert ["systemctl", "--user", "daemon-reload"] in run.calls
+    assert ["systemctl", "--user", "enable", "--now", "puffo-agent.service"] in run.calls
+    assert not any(cmd[0] == "loginctl" for cmd in run.calls)
+
+
+def test_linux_enable_linger_is_best_effort():
+    run = FakeRunner()
+    result = autostart.enable_linux(run, linger=True)
+    assert result.ok
+    assert ["loginctl", "enable-linger"] in run.calls
+    assert any("before login" in line for line in result.lines)
+
+    run = FakeRunner(fail_prefixes=[["loginctl"]])
+    result = autostart.enable_linux(run, linger=True)
+    assert result.ok  # linger failure must not fail the enable
+    assert any("login-time only" in line for line in result.lines)
+
+
+def test_linux_enable_reports_missing_user_session():
+    run = FakeRunner(fail_prefixes=[["systemctl"]])
+    result = autostart.enable_linux(run)
+    assert not result.ok
+    assert any("systemd" in line for line in result.lines)
+
+
+def test_linux_disable_removes_unit_and_reloads():
+    autostart.enable_linux(FakeRunner())
+    run = FakeRunner()
+    result = autostart.disable_linux(run)
+    assert result.ok
+    assert not autostart.systemd_unit_path().exists()
+    assert ["systemctl", "--user", "daemon-reload"] in run.calls
+
+
+def test_linux_status_distinguishes_enabled_active_and_stale():
+    autostart.enable_linux(FakeRunner())
+    state = autostart.status_linux(FakeRunner())
+    assert state.configured and state.active
+
+    state = autostart.status_linux(FakeRunner(fail_prefixes=[["systemctl", "--user", "is-active"]]))
+    assert state.configured
+    assert any("not currently active" in line for line in state.lines)
+
+    path = autostart.systemd_unit_path()
+    path.write_text(path.read_text().replace(sys.executable, "/gone/python"))
+    state = autostart.status_linux(FakeRunner())
+    assert not state.configured
+    assert any("stale" in line for line in state.lines)
+
+
+# ── Windows ──────────────────────────────────────────────────────────────────
+
+
+class _FakeKey:
+    """Stands in for a winreg handle; the fake module functions below
+    receive it back, mirroring the real module-level winreg API."""
+
+    def __init__(self, reg):
+        self.reg = reg
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeWinreg:
+    HKEY_CURRENT_USER = object()
+    KEY_SET_VALUE = 2
+    REG_SZ = 1
+
+    def __init__(self):
+        self.values: dict[str, str] = {}
+
+    def OpenKey(self, hive, path, *args):
+        return _FakeKey(self)
+
+    def SetValueEx(self, key, name, reserved, kind, value):
+        key.reg.values[name] = value
+
+    def DeleteValue(self, key, name):
+        if name not in key.reg.values:
+            raise FileNotFoundError(name)
+        del key.reg.values[name]
+
+    def QueryValueEx(self, key, name):
+        if name not in key.reg.values:
+            raise FileNotFoundError(name)
+        return key.reg.values[name], self.REG_SZ
+
+
+@pytest.fixture()
+def fake_winreg(monkeypatch):
+    reg = FakeWinreg()
+    monkeypatch.setattr(autostart, "_load_winreg", lambda: reg)
+    return reg
+
+
+def test_windows_enable_registers_quoted_command(monkeypatch, fake_winreg):
+    monkeypatch.delenv("PUFFO_AGENT_HOME")
+    result = autostart.enable_windows()
+    assert result.ok
+    value = fake_winreg.values[autostart.WINDOWS_RUN_VALUE]
+    assert "puffo_agent.portal.cli" in value and value.endswith("start")
+    # Console interpreter without a pythonw sibling ⇒ the console-window
+    # caveat must be stated, not hidden.
+    assert any("console window" in line for line in result.lines)
+
+
+def test_windows_enable_refuses_unpersistable_home_override(fake_winreg):
+    result = autostart.enable_windows()
+    assert not result.ok
+    assert any("setx" in line for line in result.lines)
+    assert autostart.WINDOWS_RUN_VALUE not in fake_winreg.values
+
+
+def test_windows_prefers_pythonw_sibling(tmp_path, monkeypatch):
+    python = tmp_path / "python.exe"
+    python.touch()
+    (tmp_path / "pythonw.exe").touch()
+    monkeypatch.setattr(autostart.sys, "executable", str(python))
+    command = autostart.windows_run_command()
+    assert command[0].endswith("pythonw.exe")
+
+
+def test_windows_disable_and_status(monkeypatch, fake_winreg):
+    monkeypatch.delenv("PUFFO_AGENT_HOME")
+    assert autostart.status_windows().configured is False
+
+    autostart.enable_windows()
+    state = autostart.status_windows()
+    assert state.configured
+    assert any("unsupervised" in line for line in state.lines)
+
+    fake_winreg.values[autostart.WINDOWS_RUN_VALUE] = '"C:\\gone\\python.exe" -m x start'
+    state = autostart.status_windows()
+    assert not state.configured
+    assert any("stale" in line for line in state.lines)
+
+    result = autostart.disable_windows()
+    assert result.ok
+    assert autostart.WINDOWS_RUN_VALUE not in fake_winreg.values
+    again = autostart.disable_windows()
+    assert again.ok
+    assert any("not enabled" in line for line in again.lines)
+
+
+# ── CLI wiring ───────────────────────────────────────────────────────────────
+
+
+def test_cli_autostart_status_prints_lines(monkeypatch, capsys):
+    from puffo_agent.portal import cli
+
+    monkeypatch.setattr(
+        autostart,
+        "status",
+        lambda **_: autostart.AutostartStatus(True, True, ["configured: X", "loaded"]),
+    )
+    assert cli.main(["autostart", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "configured: X" in out and "loaded" in out
+
+
+def test_cli_autostart_enable_failure_exits_nonzero(monkeypatch, capsys):
+    from puffo_agent.portal import cli
+
+    monkeypatch.setattr(
+        autostart,
+        "enable",
+        lambda **_: autostart.ActionResult(False, ["it broke, do Y"]),
+    )
+    assert cli.main(["autostart", "enable"]) == 1
+    assert "it broke" in capsys.readouterr().err

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -9,6 +9,7 @@ def test_top_level_commands_remain_on_the_public_parser():
 
     assert set(command_action.choices) == {
         "agent",
+        "autostart",
         "check-update",
         "config",
         "machine",

--- a/tests/test_portal_onboarding.py
+++ b/tests/test_portal_onboarding.py
@@ -213,10 +213,13 @@ def test_cmd_link_no_autostart_flag_skips_registration(monkeypatch):
     parser = cli.build_parser()
     args = parser.parse_args(["machine", "link", "--no-autostart", "--not-open"])
     monkeypatch.setattr(cli, "is_daemon_ready", lambda: True)
+    # Record instead of raise: _enable_autostart_after_link swallows any
+    # exception into a warning, so a raising probe cannot fail this test.
+    called = []
     monkeypatch.setattr(
         autostart,
         "enable",
-        lambda: (_ for _ in ()).throw(AssertionError("autostart must stay disabled")),
+        lambda: called.append(True) or autostart.ActionResult(True),
     )
 
     async def _fake_run_link(url, name, open_browser=True, code=None):
@@ -224,6 +227,7 @@ def test_cmd_link_no_autostart_flag_skips_registration(monkeypatch):
 
     monkeypatch.setattr(link, "run_link", _fake_run_link)
     assert args.func(args) == 0
+    assert called == []
 
 
 def test_cmd_link_autostart_failure_keeps_link_successful(monkeypatch, capsys):

--- a/tests/test_portal_onboarding.py
+++ b/tests/test_portal_onboarding.py
@@ -121,8 +121,14 @@ async def test_migrate_survives_one_agent_failing(monkeypatch):
 
 # ── F3: link auto-starts the daemon ─────────────────────────────────
 
-def _link_ns(code=None):
-    return argparse.Namespace(name=None, server_url="https://x", not_open=True, code=code)
+def _link_ns(code=None, *, no_autostart=False):
+    return argparse.Namespace(
+        name=None,
+        server_url="https://x",
+        not_open=True,
+        code=code,
+        no_autostart=no_autostart,
+    )
 
 
 def test_cmd_link_autostarts_when_daemon_down(monkeypatch):
@@ -176,6 +182,70 @@ def test_cmd_link_skips_autostart_when_daemon_running(monkeypatch):
     monkeypatch.setattr(link, "run_link", _fake_run_link)
     cli.cmd_link(_link_ns())
     assert spawned == []
+
+
+def test_cmd_link_enables_login_autostart_after_success(monkeypatch, capsys):
+    from puffo_agent.portal import autostart, cli
+    from puffo_agent.portal.control import link
+
+    enabled = []
+    monkeypatch.setattr(cli, "is_daemon_ready", lambda: True)
+    monkeypatch.setattr(
+        autostart,
+        "enable",
+        lambda: enabled.append(True) or autostart.ActionResult(True),
+    )
+
+    async def _fake_run_link(url, name, open_browser=True, code=None):
+        return 0
+
+    monkeypatch.setattr(link, "run_link", _fake_run_link)
+
+    assert cli.cmd_link(_link_ns()) == 0
+    assert enabled == [True]
+    assert "autostart enabled" in capsys.readouterr().out
+
+
+def test_cmd_link_no_autostart_flag_skips_registration(monkeypatch):
+    from puffo_agent.portal import autostart, cli
+    from puffo_agent.portal.control import link
+
+    parser = cli.build_parser()
+    args = parser.parse_args(["machine", "link", "--no-autostart", "--not-open"])
+    monkeypatch.setattr(cli, "is_daemon_ready", lambda: True)
+    monkeypatch.setattr(
+        autostart,
+        "enable",
+        lambda: (_ for _ in ()).throw(AssertionError("autostart must stay disabled")),
+    )
+
+    async def _fake_run_link(url, name, open_browser=True, code=None):
+        return 0
+
+    monkeypatch.setattr(link, "run_link", _fake_run_link)
+    assert args.func(args) == 0
+
+
+def test_cmd_link_autostart_failure_keeps_link_successful(monkeypatch, capsys):
+    from puffo_agent.portal import autostart, cli
+    from puffo_agent.portal.control import link
+
+    monkeypatch.setattr(cli, "is_daemon_ready", lambda: True)
+    monkeypatch.setattr(
+        autostart,
+        "enable",
+        lambda: autostart.ActionResult(False, ["platform refused registration"]),
+    )
+
+    async def _fake_run_link(url, name, open_browser=True, code=None):
+        return 0
+
+    monkeypatch.setattr(link, "run_link", _fake_run_link)
+
+    assert cli.cmd_link(_link_ns()) == 0
+    captured = capsys.readouterr()
+    assert "platform refused registration" in captured.err
+    assert "puffo-agent autostart enable" in captured.err
 
 
 # ── lifecycle give-up (daemon._report_lifecycle) ────────────────────


### PR DESCRIPTION
## Summary
- add `puffo-agent autostart enable|disable|status`
- register per-user startup with launchd on macOS, systemd user units on Linux, and HKCU Run on Windows
- support optional Linux linger and preserve actionable disable/reload failures
- quote and escape systemd environment and executable values safely

## Validation
- `env -u CODEX_HOME uv run --extra dev pytest -q tests/test_autostart.py tests/test_cli_parser.py` (24 passed)
- `env -u CODEX_HOME uv run --extra dev ruff check src/puffo_agent/portal/autostart.py src/puffo_agent/portal/cli.py src/puffo_agent/portal/cli_parser.py tests/test_autostart.py tests/test_cli_parser.py`
- `env -u CODEX_HOME uv run --extra dev python tools/check_python_structure.py`
- `git diff --check f0691564..af31e9f`
- `env -u CODEX_HOME uv run --extra dev pytest -q` (100% passed, 2 expected skips)
