### PR TITLE
fix(transport): recover from sleep/wake executor death and report honest health

### DIFF
--- a/src/puffo_agent/agent/dm_gate.py
+++ b/src/puffo_agent/agent/dm_gate.py
@@ -2,9 +2,95 @@
 
 from __future__ import annotations
 
+import time
+
 from ..crypto.ws_client import TransportOutcome
 from .client_support import DM_GATE_SENDER_ACK
 from .permission_prompt import format_permission_prompt
+
+
+async def maybe_send_dm_notice(client, sender_slug: str) -> None:
+    """Operator FYI for every non-trusted sender (contacts included):
+    first DM immediately, then one per 72h; persisted."""
+    if not client.operator_slug:
+        return
+    try:
+        last = await client.store.get_dm_notice(sender_slug)
+    except Exception:
+        last = None
+    now_ms = int(time.time() * 1000)
+    if last is not None and now_ms - last < client._DM_NOTICE_INTERVAL_MS:
+        return
+    display = await client._fetch_display_name(sender_slug)
+    label = f"**{display}** ({sender_slug})" if display else f"@{sender_slug}"
+    try:
+        await client._send_dm(
+            client.operator_slug,
+            f"FYI, {label} is sending direct messages to me.",
+            root_id="",
+        )
+    except Exception as exc:
+        client._log.warning(
+            "dm_notice: failed to notify operator about %s: %s",
+            sender_slug,
+            exc,
+        )
+        return
+    try:
+        await client.store.set_dm_notice(sender_slug, now_ms)
+    except Exception as exc:
+        client._log.warning("dm_notice: failed to persist ts: %s", exc)
+
+
+async def maybe_allowlist_outbound_dm(client, recipient_slug: str) -> None:
+    """Agent DM'd a foreign peer first → allowlist them; best-effort."""
+    if not recipient_slug:
+        return
+    # Never allowlist a sender we're currently gating — the ack DM
+    # echoes back here and would pre-empt the operator's y/n.
+    if any(
+        m.get("sender_slug") == recipient_slug
+        for m in client._pending_dm_approvals.values()
+    ):
+        return
+    # Replying is not consent — only a genuinely agent-initiated
+    # first DM allowlists. A stored inbound DM means they wrote first.
+    try:
+        if await client.store.has_dm_from(recipient_slug):
+            return
+    except Exception:
+        return
+    # Trusted short-circuit before is_allowed can hit the network
+    # (the daemon DMs the operator constantly).
+    if not await client._is_foreign_dm_sender(recipient_slug):
+        return
+    if await client._contacts.is_allowed(recipient_slug):
+        return
+    try:
+        await client.http.post("/allowlists", {"slugs": [recipient_slug]})
+    except Exception as exc:
+        client._log.warning(
+            "dm_gate: outbound allowlist for %s failed: %s",
+            recipient_slug,
+            exc,
+        )
+        return
+    client._contacts.note_allowed(recipient_slug)
+    if not client.operator_slug:
+        return
+    display = await client._fetch_display_name(recipient_slug)
+    label = f"**{display}**(@{recipient_slug})" if display else f"@{recipient_slug}"
+    try:
+        await client._send_dm(
+            client.operator_slug,
+            f"Allowlisted {label} — I messaged them first, so their "
+            "replies won't need approval.",
+            root_id="",
+        )
+    except Exception:
+        client._log.exception(
+            "dm_gate: failed to notify operator of outbound allowlist",
+        )
 
 
 async def maybe_gate_foreign_dm(

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -191,6 +191,9 @@ class PuffoCoreMessageClient:
                 bridge_client=bridge_client,
             )
         )
+        # Assignable post-construction (the Worker owns the health policy);
+        # picked up when ``run()`` builds the WS client.
+        self.transport_state_listener: Callable[[bool, int], None] | None = None
         bridge_connected = getattr(self._bridge, "add_connected_callback", None)
         if callable(bridge_connected):
             bridge_connected(self._notify_connected_callbacks)
@@ -283,6 +286,14 @@ class PuffoCoreMessageClient:
         self._ws.on_channel_update = self._handle_channel_update
         # Re-warms caches on every (re)connect, first connect included.
         self._ws.on_connect = self._on_ws_connect
+        # Worker-installed observer (see Worker._transport_state_listener):
+        # feeds reconnect-failure streaks into runtime.json health so a
+        # dead transport stops reporting "ok" (8/30 App Nap incident).
+        # getattr: legacy test seeds construct this client without
+        # __init__, same tolerance as the bridge callback above.
+        self._ws.on_transport_state = getattr(
+            self, "transport_state_listener", None
+        )
         await self.store.open()
         try:
             await self._ws.run()

--- a/src/puffo_agent/agent/puffo_core_client.py
+++ b/src/puffo_agent/agent/puffo_core_client.py
@@ -1448,86 +1448,14 @@ class PuffoCoreMessageClient:
     _DM_NOTICE_INTERVAL_MS = 72 * 3600 * 1000
 
     async def _maybe_send_dm_notice(self, sender_slug: str) -> None:
-        """Operator FYI for every non-trusted sender (contacts included):
-        first DM immediately, then one per 72h; persisted."""
-        if not self.operator_slug:
-            return
-        try:
-            last = await self.store.get_dm_notice(sender_slug)
-        except Exception:
-            last = None
-        now_ms = int(time.time() * 1000)
-        if last is not None and now_ms - last < self._DM_NOTICE_INTERVAL_MS:
-            return
-        display = await self._fetch_display_name(sender_slug)
-        label = f"**{display}** ({sender_slug})" if display else f"@{sender_slug}"
-        try:
-            await self._send_dm(
-                self.operator_slug,
-                f"FYI, {label} is sending direct messages to me.",
-                root_id="",
-            )
-        except Exception as exc:
-            self._log.warning(
-                "dm_notice: failed to notify operator about %s: %s",
-                sender_slug,
-                exc,
-            )
-            return
-        try:
-            await self.store.set_dm_notice(sender_slug, now_ms)
-        except Exception as exc:
-            self._log.warning("dm_notice: failed to persist ts: %s", exc)
+        from . import dm_gate
+
+        await dm_gate.maybe_send_dm_notice(self, sender_slug)
 
     async def _maybe_allowlist_outbound_dm(self, recipient_slug: str) -> None:
-        """Agent DM'd a foreign peer first → allowlist them; best-effort."""
-        if not recipient_slug:
-            return
-        # Never allowlist a sender we're currently gating — the ack DM
-        # echoes back here and would pre-empt the operator's y/n.
-        if any(
-            m.get("sender_slug") == recipient_slug
-            for m in self._pending_dm_approvals.values()
-        ):
-            return
-        # Replying is not consent — only a genuinely agent-initiated
-        # first DM allowlists. A stored inbound DM means they wrote first.
-        try:
-            if await self.store.has_dm_from(recipient_slug):
-                return
-        except Exception:
-            return
-        # Trusted short-circuit before is_allowed can hit the network
-        # (the daemon DMs the operator constantly).
-        if not await self._is_foreign_dm_sender(recipient_slug):
-            return
-        if await self._contacts.is_allowed(recipient_slug):
-            return
-        try:
-            await self.http.post("/allowlists", {"slugs": [recipient_slug]})
-        except Exception as exc:
-            self._log.warning(
-                "dm_gate: outbound allowlist for %s failed: %s",
-                recipient_slug,
-                exc,
-            )
-            return
-        self._contacts.note_allowed(recipient_slug)
-        if not self.operator_slug:
-            return
-        display = await self._fetch_display_name(recipient_slug)
-        label = f"**{display}**(@{recipient_slug})" if display else f"@{recipient_slug}"
-        try:
-            await self._send_dm(
-                self.operator_slug,
-                f"Allowlisted {label} — I messaged them first, so their "
-                "replies won't need approval.",
-                root_id="",
-            )
-        except Exception:
-            self._log.exception(
-                "dm_gate: failed to notify operator of outbound allowlist",
-            )
+        from . import dm_gate
+
+        await dm_gate.maybe_allowlist_outbound_dm(self, recipient_slug)
 
     async def _maybe_gate_foreign_dm(
         self, *, sender_slug: str, text: str

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -60,8 +60,8 @@ def heal_if_dead_executor(exc: BaseException) -> bool:
     """Heal the loop's default executor iff ``exc`` is the dead-executor
     RuntimeError; returns whether it healed.
 
-    Shared by the HTTP retry wrapper and the WS reconnect loop: with a
-    valid subkey ``connect_once`` reaches ``websockets.connect`` (and its
+    Shared by the HTTP wrapper and the WS reconnect loop: with a valid
+    subkey ``connect_once`` reaches ``websockets.connect`` (and its
     ``loop.getaddrinfo``) without a single prior HTTP request, so the WS
     path cannot rely on an HTTP-side heal having happened first.
     """
@@ -71,13 +71,36 @@ def heal_if_dead_executor(exc: BaseException) -> bool:
     return True
 
 
-class _HealedRequest:
-    """One aiohttp request attempt with a single dead-executor heal.
+async def _probe_default_executor() -> bool:
+    """Run a no-op through the loop's default executor; heal if dead.
 
-    The dead-executor RuntimeError fires in the pre-connection stage
-    (threaded DNS / netrc lookup), before any bytes reach the wire, so
-    the one retry cannot double-send a request. Any other error — and a
-    second dead-executor failure after healing — propagates untouched.
+    ``run_in_executor(None, ...)`` is the same scheduling call aiohttp
+    makes for threaded DNS and ``trust_env`` netrc lookups, so a passing
+    probe means this request's own executor hops cannot raise the
+    shutdown error — short of a concurrent shutdown mid-request, which
+    is surfaced to the caller, never retried. Returns whether it healed.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        await loop.run_in_executor(None, lambda: None)
+        return False
+    except RuntimeError as exc:
+        if not heal_if_dead_executor(exc):
+            raise
+        return True
+
+
+class _HealedRequest:
+    """One aiohttp request attempt, healed *before* any bytes go out.
+
+    A dead default executor is detected by a no-op probe and replaced
+    prior to sending; the pooled connections from before the suspension
+    are dropped with it. A dead-executor RuntimeError that still fires
+    mid-request is healed so the caller's next attempt works, then
+    re-raised — never replayed: aiohttp re-enters the executor on every
+    automatic-redirect hop, so past the first hop the original request
+    is already on the wire and a replay double-sends it (reproduced
+    live: POST → 307, hop-2 executor death, replayed POST).
     """
 
     def __init__(self, client: PuffoCoreHttpClient, method: str, url: str, kwargs: dict):
@@ -87,19 +110,17 @@ class _HealedRequest:
         self._kwargs = kwargs
         self._ctx = None
 
-    async def _enter_once(self):
-        http = await self._client._get_session()
-        self._ctx = http.request(self._method, self._url, **self._kwargs)
-        return await self._ctx.__aenter__()
-
     async def __aenter__(self):
-        try:
-            return await self._enter_once()
-        except RuntimeError as exc:
-            if not heal_if_dead_executor(exc):
-                raise
+        if await _probe_default_executor():
             await self._client.close()
-            return await self._enter_once()
+        try:
+            http = await self._client._get_session()
+            self._ctx = http.request(self._method, self._url, **self._kwargs)
+            return await self._ctx.__aenter__()
+        except RuntimeError as exc:
+            if heal_if_dead_executor(exc):
+                await self._client.close()
+            raise
 
     async def __aexit__(self, *exc_info):
         return await self._ctx.__aexit__(*exc_info)

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -154,9 +154,12 @@ class PuffoCoreHttpClient:
         return _HealedRequest(self, method, url, kwargs)
 
     async def close(self) -> None:
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        # Detach before awaiting: a concurrent _get_session() during the
+        # await may install a fresh session, which a post-await
+        # ``self._session = None`` would orphan with a live connector.
+        session, self._session = self._session, None
+        if session is not None and not session.closed:
+            await session.close()
 
     def _load_signing_key(self) -> tuple[Ed25519KeyPair, str]:
         sess = self.keystore.load_session(self.slug)

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -52,8 +52,23 @@ def _heal_dead_default_executor() -> None:
     )
     logger.warning(
         "default executor was shut down while the loop kept running; "
-        "installed a fresh one and rebuilding the HTTP session"
+        "installed a fresh one"
     )
+
+
+def heal_if_dead_executor(exc: BaseException) -> bool:
+    """Heal the loop's default executor iff ``exc`` is the dead-executor
+    RuntimeError; returns whether it healed.
+
+    Shared by the HTTP retry wrapper and the WS reconnect loop: with a
+    valid subkey ``connect_once`` reaches ``websockets.connect`` (and its
+    ``loop.getaddrinfo``) without a single prior HTTP request, so the WS
+    path cannot rely on an HTTP-side heal having happened first.
+    """
+    if _DEAD_EXECUTOR_MESSAGE not in str(exc):
+        return False
+    _heal_dead_default_executor()
+    return True
 
 
 class _HealedRequest:
@@ -81,9 +96,8 @@ class _HealedRequest:
         try:
             return await self._enter_once()
         except RuntimeError as exc:
-            if _DEAD_EXECUTOR_MESSAGE not in str(exc):
+            if not heal_if_dead_executor(exc):
                 raise
-            _heal_dead_default_executor()
             await self._client.close()
             return await self._enter_once()
 

--- a/src/puffo_agent/crypto/http_client.py
+++ b/src/puffo_agent/crypto/http_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import json
 import logging
 import os
@@ -22,6 +24,71 @@ class HttpError(Exception):
         self.status = status
         self.body = body
         super().__init__(f"HTTP {status}: {body}")
+
+
+_DEAD_EXECUTOR_MESSAGE = "cannot schedule new futures after shutdown"
+
+
+def _heal_dead_default_executor() -> None:
+    """Install a fresh default executor on the running loop.
+
+    Every aiohttp request rides the loop's default ThreadPoolExecutor
+    (threaded DNS, netrc lookup under ``trust_env``), and
+    ``websockets.connect`` does through ``loop.getaddrinfo``. After a
+    long process suspension (macOS App Nap — see the 8/30 incident) that
+    executor has been observed shut down while the loop itself keeps
+    running, which turns every subsequent request into
+    ``RuntimeError: cannot schedule new futures after shutdown`` forever;
+    nothing else ever recreates it. Replacing it is loop-global, so one
+    heal here also revives WS reconnects and any other transport on the
+    loop. The distinct 'Executor shutdown has been called' /
+    'after interpreter shutdown' errors mean an intentional teardown and
+    are deliberately not healed.
+    """
+    asyncio.get_running_loop().set_default_executor(
+        concurrent.futures.ThreadPoolExecutor(
+            thread_name_prefix="puffo-healed-executor"
+        )
+    )
+    logger.warning(
+        "default executor was shut down while the loop kept running; "
+        "installed a fresh one and rebuilding the HTTP session"
+    )
+
+
+class _HealedRequest:
+    """One aiohttp request attempt with a single dead-executor heal.
+
+    The dead-executor RuntimeError fires in the pre-connection stage
+    (threaded DNS / netrc lookup), before any bytes reach the wire, so
+    the one retry cannot double-send a request. Any other error — and a
+    second dead-executor failure after healing — propagates untouched.
+    """
+
+    def __init__(self, client: PuffoCoreHttpClient, method: str, url: str, kwargs: dict):
+        self._client = client
+        self._method = method
+        self._url = url
+        self._kwargs = kwargs
+        self._ctx = None
+
+    async def _enter_once(self):
+        http = await self._client._get_session()
+        self._ctx = http.request(self._method, self._url, **self._kwargs)
+        return await self._ctx.__aenter__()
+
+    async def __aenter__(self):
+        try:
+            return await self._enter_once()
+        except RuntimeError as exc:
+            if _DEAD_EXECUTOR_MESSAGE not in str(exc):
+                raise
+            _heal_dead_default_executor()
+            await self._client.close()
+            return await self._enter_once()
+
+    async def __aexit__(self, *exc_info):
+        return await self._ctx.__aexit__(*exc_info)
 
 
 class PuffoCoreHttpClient:
@@ -47,6 +114,9 @@ class PuffoCoreHttpClient:
         if self._session is None or self._session.closed:
             self._session = create_remote_http_session(self.server_url)
         return self._session
+
+    def _healed_request(self, method: str, url: str, **kwargs):
+        return _HealedRequest(self, method, url, kwargs)
 
     async def close(self) -> None:
         if self._session and not self._session.closed:
@@ -81,8 +151,8 @@ class PuffoCoreHttpClient:
             "POST", "/devices/subkeys", body,
         )
 
-        http = await self._get_session()
-        async with http.post(
+        async with self._healed_request(
+            "POST",
             f"{self.server_url}/devices/subkeys",
             data=body,
             headers=auth.to_dict(),
@@ -135,8 +205,9 @@ class PuffoCoreHttpClient:
         headers = auth.to_dict()
         url = f"{self.server_url}{path}"
 
-        http = await self._get_session()
-        async with http.request(method, url, data=body or None, headers=headers) as resp:
+        async with self._healed_request(
+            method, url, data=body or None, headers=headers
+        ) as resp:
             text = await resp.text()
             try:
                 data = json.loads(text)
@@ -171,8 +242,7 @@ class PuffoCoreHttpClient:
         auth = sign_request(signing_key, self.slug, signer_id, method, path, b"")
         headers = auth.to_dict()
         url = f"{self.server_url}{path}"
-        http = await self._get_session()
-        async with http.request(method, url, headers=headers) as resp:
+        async with self._healed_request(method, url, headers=headers) as resp:
             if resp.status == 401:
                 # Caller retries after a rotation.
                 raise HttpError(401, await resp.text())
@@ -244,8 +314,8 @@ class PuffoCoreHttpClient:
 
     async def post_unsigned(self, path: str, body: dict | None = None) -> Any:
         raw = json.dumps(body).encode() if body else b""
-        http = await self._get_session()
-        async with http.post(
+        async with self._healed_request(
+            "POST",
             f"{self.server_url}{path}",
             data=raw,
             headers=self._egress_headers({"content-type": "application/json"}),
@@ -266,8 +336,8 @@ class PuffoCoreHttpClient:
         request path in a scheduler or tool.
         """
         raw = json.dumps(body).encode() if body else b""
-        http = await self._get_session()
-        async with http.put(
+        async with self._healed_request(
+            "PUT",
             f"{self.server_url}{path}",
             data=raw,
             headers=self._egress_headers({"content-type": "application/json"}),
@@ -285,8 +355,8 @@ class PuffoCoreHttpClient:
         ``post_unsigned`` but carries an ``application/octet-stream`` body
         and no signature — the egress proxy supplies auth via
         ``x-sandbox-token``."""
-        http = await self._get_session()
-        async with http.post(
+        async with self._healed_request(
+            "POST",
             f"{self.server_url}{path}",
             data=body,
             headers=self._egress_headers(
@@ -302,8 +372,8 @@ class PuffoCoreHttpClient:
                 return text
 
     async def get_unsigned(self, path: str) -> Any:
-        http = await self._get_session()
-        async with http.get(
+        async with self._healed_request(
+            "GET",
             f"{self.server_url}{path}",
             headers=self._egress_headers(),
         ) as resp:

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -13,7 +13,7 @@ import websockets
 import websockets.exceptions  # websockets>=16 lazy-loads submodules; bare `import websockets` doesn't bind `.exceptions`
 
 from .encoding import base64url_encode, generate_nonce
-from .http_client import PuffoCoreHttpClient
+from .http_client import PuffoCoreHttpClient, heal_if_dead_executor
 from .http_session import create_remote_ssl_context
 from .keystore import KeyStore, decode_secret
 from .primitives import Ed25519KeyPair
@@ -410,6 +410,24 @@ class PuffoCoreWsClient:
                     "[%s] WS reconnect category=transport exception=%s "
                     "retry_delay=%ds",
                     self.slug, type(exc).__name__, backoff,
+                )
+                self._note_reconnect_failure()
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, MAX_BACKOFF)
+            except RuntimeError as exc:
+                if not self._running:
+                    break
+                # A valid subkey means connect_once() made no HTTP request
+                # before ``websockets.connect`` hit ``loop.getaddrinfo``,
+                # so the dead default executor must be healed here — the
+                # HTTP wrapper's heal never ran (8/30 incident).
+                healed = heal_if_dead_executor(exc)
+                logger.warning(
+                    "[%s] WS reconnect category=%s exception=%s "
+                    "retry_delay=%ds",
+                    self.slug,
+                    "dead_executor_healed" if healed else "unexpected",
+                    type(exc).__name__, backoff,
                 )
                 self._note_reconnect_failure()
                 await asyncio.sleep(backoff)

--- a/src/puffo_agent/crypto/ws_client.py
+++ b/src/puffo_agent/crypto/ws_client.py
@@ -86,6 +86,12 @@ class PuffoCoreWsClient:
         self.on_channel_update: Callable[[dict], Coroutine[Any, Any, None]] | None = None
         # Fires after every (re)connect handshake, before catch-up.
         self.on_connect: Callable[[], Coroutine[Any, Any, None]] | None = None
+        # Sync observer for reconnect health: (healthy, consecutive_failures).
+        # Fired on every failed reconnect attempt and once on the reconnect
+        # that ends a failure streak. Policy (thresholds, health writes)
+        # belongs to the listener; this client only counts.
+        self.on_transport_state: Callable[[bool, int], None] | None = None
+        self._reconnect_failures = 0
         self._catchup_lock = asyncio.Lock()
 
     def _build_connect_frame(self) -> str:
@@ -346,6 +352,9 @@ class PuffoCoreWsClient:
             self._ws = ws
             self.session_id = await self._handshake(ws)
             logger.info("[%s] WS connected, session=%s", self.slug, self.session_id)
+            if self._reconnect_failures:
+                self._reconnect_failures = 0
+                self._notify_transport_state(healthy=True)
             if self.on_connect:
                 try:
                     await self.on_connect()
@@ -369,6 +378,7 @@ class PuffoCoreWsClient:
                     "retry_delay=%ds",
                     self.slug, type(exc).__name__, backoff,
                 )
+                self._note_reconnect_failure()
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             except asyncio.TimeoutError as exc:
@@ -379,6 +389,7 @@ class PuffoCoreWsClient:
                     "retry_delay=%ds",
                     self.slug, type(exc).__name__, backoff,
                 )
+                self._note_reconnect_failure()
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             except ConnectionError as exc:
@@ -389,6 +400,7 @@ class PuffoCoreWsClient:
                     "retry_delay=%ds",
                     self.slug, type(exc).__name__, backoff,
                 )
+                self._note_reconnect_failure()
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             except OSError as exc:
@@ -399,6 +411,7 @@ class PuffoCoreWsClient:
                     "retry_delay=%ds",
                     self.slug, type(exc).__name__, backoff,
                 )
+                self._note_reconnect_failure()
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             except Exception as exc:
@@ -409,10 +422,23 @@ class PuffoCoreWsClient:
                     "retry_delay=%ds",
                     self.slug, type(exc).__name__, backoff,
                 )
+                self._note_reconnect_failure()
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, MAX_BACKOFF)
         self._ws = None
         self.session_id = None
+
+    def _note_reconnect_failure(self) -> None:
+        self._reconnect_failures += 1
+        self._notify_transport_state(healthy=False)
+
+    def _notify_transport_state(self, *, healthy: bool) -> None:
+        if self.on_transport_state is None:
+            return
+        try:
+            self.on_transport_state(healthy, self._reconnect_failures)
+        except Exception:
+            logger.exception("on_transport_state callback failed")
 
     def stop(self) -> None:
         self._running = False

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -644,6 +644,7 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
             "drained",
             "unhandled_error",
             "codex_thread_wedged",
+            "server_unreachable",
         ):
             runtime = f"{runtime} [{rs.health}]"
         # Truncate display_name for table alignment.

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -982,8 +982,14 @@ class RuntimeState:
     #                           cleared on next successful turn. Does
     #                           NOT overwrite the stronger downstream
     #                           signals above.
+    #   "server_unreachable"  — N consecutive WS reconnect failures; the
+    #                           process is alive but the server has not
+    #                           been reachable for minutes. Cleared by the
+    #                           next successful reconnect. Only ever
+    #                           overwrites "ok" — the specific signals
+    #                           above stay authoritative
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | server_unreachable | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> RuntimeState | None:

--- a/src/puffo_agent/portal/ui/tray.py
+++ b/src/puffo_agent/portal/ui/tray.py
@@ -17,6 +17,72 @@ from .log_buffer import install_log_buffer
 
 logger = logging.getLogger(__name__)
 
+# Token from NSProcessInfo.beginActivityWithOptions: — held for the process
+# lifetime; releasing it would re-enable App Nap.
+_app_nap_activity_token = None
+
+
+def _exempt_from_app_nap() -> None:
+    """Best-effort macOS App Nap exemption for the tray process.
+
+    The daemon runs as a thread of this windowless Qt application, and
+    macOS suspends napping GUI apps wholesale — in the 8/30 incident the
+    daemon froze for whole hours on an awake machine, resuming only when
+    the user touched the computer. NSActivityUserInitiatedAllowingIdle-
+    SystemSleep keeps the process running without preventing normal
+    system sleep. No-op off macOS; any failure is logged and ignored —
+    a missing exemption degrades to today's behavior, never worse.
+    """
+    global _app_nap_activity_token
+    if sys.platform != "darwin":
+        return
+    try:
+        import ctypes
+        import ctypes.util
+
+        objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
+        ctypes.cdll.LoadLibrary(ctypes.util.find_library("Foundation"))
+        objc.objc_getClass.restype = ctypes.c_void_p
+        objc.objc_getClass.argtypes = [ctypes.c_char_p]
+        objc.sel_registerName.restype = ctypes.c_void_p
+        objc.sel_registerName.argtypes = [ctypes.c_char_p]
+        send = objc.objc_msgSend
+        send.restype = ctypes.c_void_p
+
+        send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        info = send(
+            objc.objc_getClass(b"NSProcessInfo"),
+            objc.sel_registerName(b"processInfo"),
+        )
+        send.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+        reason = send(
+            objc.objc_getClass(b"NSString"),
+            objc.sel_registerName(b"stringWithUTF8String:"),
+            b"Puffo agents serve messages while unattended",
+        )
+        # NSActivityUserInitiated minus NSActivityIdleSystemSleepDisabled
+        # (1 << 20): defeat App Nap, still allow the system to sleep.
+        options = ctypes.c_uint64(0x00FFFFFF & ~(1 << 20))
+        send.argtypes = [
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p,
+        ]
+        token = send(
+            info,
+            objc.sel_registerName(b"beginActivityWithOptions:reason:"),
+            options,
+            reason,
+        )
+        send.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        send(token, objc.sel_registerName(b"retain"))
+        _app_nap_activity_token = token
+        logger.info("App Nap exemption active for the tray-hosted daemon")
+    except Exception:
+        logger.warning(
+            "could not exempt the tray from App Nap; the daemon may be "
+            "suspended while the machine is unattended",
+            exc_info=True,
+        )
+
 
 def run_tray() -> int:
     logging.basicConfig(
@@ -32,6 +98,7 @@ def run_tray() -> int:
 
     app = QApplication(sys.argv)
     app.setApplicationName("Puffo Agent")
+    _exempt_from_app_nap()
     # The tray icon is the only UI — without this the app would exit the
     # moment it's created (no windows means "last window closed").
     app.setQuitOnLastWindowClosed(False)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -111,6 +111,13 @@ logger = logging.getLogger(__name__)
 
 RECONNECT_BACKOFF_SECONDS = 5.0
 
+# Consecutive WS reconnect failures before runtime.json health flips to
+# "server_unreachable". At the WS client's capped backoff this is a few
+# minutes of provable unreachability — late enough to skip network blips,
+# early enough that a wedged transport can't impersonate a healthy agent
+# for hours.
+_WS_DEGRADE_THRESHOLD = 5
+
 
 def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
     if harness_name != "claude-code":
@@ -376,6 +383,46 @@ class Worker:
             "runtime.health = auth_failed",
             agent_id,
         )
+
+    def _transport_state_listener(self, agent_id: str):
+        """Feed WS reconnect streaks into runtime.json health.
+
+        Before this, a dead transport kept reporting health="ok" with a
+        fresh local heartbeat for hours (the 8/30 App Nap incident):
+        "process alive" was standing in for "server reachable". Only the
+        ok state is overwritten — auth_failed and the other specific
+        signals stay authoritative — and only the transport-set state is
+        cleared on recovery.
+        """
+
+        def note(healthy: bool, streak: int) -> None:
+            rt = self.runtime
+            if healthy:
+                if rt.health == "server_unreachable":
+                    rt.health = "ok"
+                    rt.error = ""
+                    rt.save(agent_id)
+                    logger.info(
+                        "agent %s: transport recovered; runtime.health "
+                        "server_unreachable → ok",
+                        agent_id,
+                    )
+                return
+            if streak < _WS_DEGRADE_THRESHOLD or rt.health != "ok":
+                return
+            rt.health = "server_unreachable"
+            rt.error = (
+                f"server unreachable: {streak} consecutive WS reconnect "
+                "failures"
+            )
+            rt.save(agent_id)
+            logger.warning(
+                "agent %s: %s; runtime.health ok → server_unreachable",
+                agent_id,
+                rt.error,
+            )
+
+        return note
 
     def _enter_auth_failed(self, agent_id: str) -> None:
         """Flip ``auth_failed`` + fire recovery (refresher kick + operator
@@ -1086,6 +1133,9 @@ class Worker:
                 self.agent_cfg,
                 agent_id,
                 daemon_cfg=self.daemon_cfg,
+            )
+            client.transport_state_listener = self._transport_state_listener(
+                agent_id
             )
             self._client = client
             reporter = self._build_status_reporter(client)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -112,10 +112,11 @@ logger = logging.getLogger(__name__)
 RECONNECT_BACKOFF_SECONDS = 5.0
 
 # Consecutive WS reconnect failures before runtime.json health flips to
-# "server_unreachable". At the WS client's capped backoff this is a few
-# minutes of provable unreachability — late enough to skip network blips,
-# early enough that a wedged transport can't impersonate a healthy agent
-# for hours.
+# "server_unreachable". With the WS client's 1s→30s doubling backoff the
+# fifth failure lands ~15s into an outage (~40s when each attempt burns a
+# connect timeout): a blip surviving one or two reconnects never flips,
+# while an operator checking `agent list` sees the truth within the
+# minute instead of "ok" for hours. One successful reconnect clears it.
 _WS_DEGRADE_THRESHOLD = 5
 
 
@@ -383,6 +384,22 @@ class Worker:
             "runtime.health = auth_failed",
             agent_id,
         )
+
+    def _build_wired_client(self):
+        """Construct the core client with the worker's observers attached.
+
+        Every runtime path must obtain its client here: one built straight
+        from ``_build_puffo_core_client`` carries no transport-state
+        listener, so WS reconnect streaks reach nobody and runtime.json
+        keeps saying "ok" while the agent is offline — the 8/30 incident's
+        health symptom.
+        """
+        agent_id = self.agent_cfg.id
+        client = _build_puffo_core_client(
+            self.agent_cfg, agent_id, daemon_cfg=self.daemon_cfg
+        )
+        client.transport_state_listener = self._transport_state_listener(agent_id)
+        return client
 
     def _transport_state_listener(self, agent_id: str):
         """Feed WS reconnect streaks into runtime.json health.
@@ -1129,14 +1146,7 @@ class Worker:
                 raise RuntimeError(
                     f"agent {agent_id!r}: puffo_core block in agent.yml is incomplete"
                 )
-            client = _build_puffo_core_client(
-                self.agent_cfg,
-                agent_id,
-                daemon_cfg=self.daemon_cfg,
-            )
-            client.transport_state_listener = self._transport_state_listener(
-                agent_id
-            )
+            client = self._build_wired_client()
             self._client = client
             reporter = self._build_status_reporter(client)
             identity = client.keystore.load_identity(client.slug)

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -444,9 +444,7 @@ class StandardWorkerRun:
                 claude_dir=paths.claude_path,
                 agent_id=agent_id,
             )
-            client = worker_module._build_puffo_core_client(
-                worker.agent_cfg, agent_id, daemon_cfg=worker.daemon_cfg
-            )
+            client = worker._build_wired_client()
             worker._client = client
             return WorkerRunContext(
                 paths=paths,

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -77,15 +77,72 @@ async def test_dead_default_executor_heals_and_request_succeeds(monkeypatch):
     assert loop._default_executor is not None
 
 
+@pytest.mark.asyncio
+async def test_ws_dns_dead_executor_heals_without_http(monkeypatch):
+    """Valid subkey: connect_once() makes no HTTP request before
+    websockets.connect hits loop.getaddrinfo, so the reconnect loop
+    itself must heal the dead executor for the next attempt to work."""
+    from puffo_agent.crypto import ws_client as ws_module
+
+    client = ws_module.PuffoCoreWsClient.__new__(ws_module.PuffoCoreWsClient)
+    client.slug = "s"
+    client.ws_url = "ws://x/subscribe"
+    client._ws = None
+    client.session_id = None
+    client.on_transport_state = None
+    client._reconnect_failures = 0
+
+    class _ValidSubkeyHttp:
+        async def _ensure_subkey(self):
+            return None
+
+    client.http_client = _ValidSubkeyHttp()
+
+    calls = {"n": 0}
+
+    def fake_connect(url, ssl=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("cannot schedule new futures after shutdown")
+        client._running = False
+        raise ConnectionError("stop the loop")
+
+    monkeypatch.setattr(ws_module.websockets, "connect", fake_connect)
+    monkeypatch.setattr(ws_module, "INITIAL_BACKOFF", 0)
+
+    loop = asyncio.get_running_loop()
+    executor_before = loop._default_executor
+    await client.run()
+
+    assert calls["n"] == 2
+    assert client._reconnect_failures >= 1
+    assert loop._default_executor is not None
+    assert loop._default_executor is not executor_before
+
+
 def test_ws_streaks_flip_health_to_server_unreachable_and_back(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from types import SimpleNamespace
+
+    from puffo_agent.portal import worker as worker_module
     from puffo_agent.portal.state import RuntimeState, agent_dir
     from puffo_agent.portal.worker import _WS_DEGRADE_THRESHOLD, Worker
 
     agent_dir("a1").mkdir(parents=True)
     worker = Worker.__new__(Worker)
     worker.runtime = RuntimeState(status="running", health="ok")
-    note = worker._transport_state_listener("a1")
+    worker.agent_cfg = SimpleNamespace(id="a1")
+    worker.daemon_cfg = None
+    monkeypatch.setattr(
+        worker_module,
+        "_build_puffo_core_client",
+        lambda cfg, agent_id, daemon_cfg=None: SimpleNamespace(),
+    )
+    # Through the wiring seam both runtime paths use — a client built
+    # here must arrive with the listener attached, or streaks reach
+    # nobody (the standard daemon path shipped exactly that hole once).
+    note = worker._build_wired_client().transport_state_listener
+    assert note is not None
 
     for streak in range(1, _WS_DEGRADE_THRESHOLD):
         note(False, streak)

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -1,9 +1,11 @@
 """Transport self-heal + honest health (8/30 App Nap incident).
 
-Two key behaviors:
+Key behaviors:
 - a dead default executor (RuntimeError: cannot schedule new futures
-  after shutdown) heals in-place: fresh executor + rebuilt session +
-  one retry, instead of failing every request forever;
+  after shutdown) is healed by a pre-send probe, so requests succeed
+  instead of failing forever — and a death mid-request is healed for
+  the next attempt but surfaced, never replayed (redirect hops mean
+  bytes may already be on the wire);
 - WS reconnect-failure streaks flip runtime.json health to
   "server_unreachable" and back, instead of reporting "ok" while the
   server is unreachable for hours.
@@ -43,19 +45,19 @@ class _FakeSession:
     def __init__(self, fail: bool):
         self._fail = fail
         self.closed = False
+        self.requests = 0
 
     def request(self, method, url, **kwargs):
+        self.requests += 1
         return _RequestCtx(self._fail)
 
     async def close(self):
         self.closed = True
 
 
-@pytest.mark.asyncio
-async def test_dead_default_executor_heals_and_request_succeeds(monkeypatch):
+def _fake_http_client(monkeypatch, sessions):
     client = PuffoCoreHttpClient.__new__(PuffoCoreHttpClient)
     client.server_url = "https://x"
-    sessions = [_FakeSession(fail=True), _FakeSession(fail=False)]
 
     async def fake_get_session():
         return sessions[0] if not sessions[0].closed else sessions[1]
@@ -63,15 +65,51 @@ async def test_dead_default_executor_heals_and_request_succeeds(monkeypatch):
     monkeypatch.setattr(client, "_get_session", fake_get_session)
     client._session = sessions[0]
     monkeypatch.setattr(client, "_egress_headers", lambda base=None: dict(base or {}))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_dead_default_executor_heals_before_the_request(monkeypatch):
+    """The 8/30 shape: executor already dead when the request starts.
+    The pre-send probe heals it and the request goes through — no retry
+    involved, so nothing can double-send."""
+    import concurrent.futures
+
+    sessions = [_FakeSession(fail=False), _FakeSession(fail=False)]
+    client = _fake_http_client(monkeypatch, sessions)
 
     loop = asyncio.get_running_loop()
-    executor_before = loop._default_executor
+    dead = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    dead.shutdown()
+    loop.set_default_executor(dead)
 
     result = await client.get_unsigned("/ping")
 
     assert result == {"healed": True}
-    # The broken session was replaced, and the loop-global executor was
-    # renewed — that is what also revives WS reconnects.
+    # The pre-suspension session pool was dropped with the executor, and
+    # the loop-global executor was renewed — which also revives WS.
+    assert sessions[0].closed
+    assert sessions[1].requests == 1
+    assert loop._default_executor is not dead
+    assert loop._default_executor is not None
+
+
+@pytest.mark.asyncio
+async def test_mid_request_executor_death_heals_but_never_replays(monkeypatch):
+    """A dead-executor error after the request started means bytes may
+    already be on the wire (aiohttp redirect hops re-enter the executor),
+    so it must surface to the caller — healed for next time, not replayed."""
+    sessions = [_FakeSession(fail=True), _FakeSession(fail=False)]
+    client = _fake_http_client(monkeypatch, sessions)
+
+    loop = asyncio.get_running_loop()
+    executor_before = loop._default_executor
+
+    with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+        await client.get_unsigned("/ping")
+
+    assert sessions[0].requests == 1
+    assert sessions[1].requests == 0
     assert sessions[0].closed
     assert loop._default_executor is not executor_before
     assert loop._default_executor is not None

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -182,6 +182,11 @@ def test_ws_streaks_flip_health_to_server_unreachable_and_back(tmp_path, monkeyp
     note = worker._build_wired_client().transport_state_listener
     assert note is not None
 
+    # The threshold is policy, not plumbing: 5 failures ≈ 15-40s of
+    # backoff before `agent list` stops claiming "ok". Restated here so
+    # a drive-by change has to touch a test that says so.
+    assert _WS_DEGRADE_THRESHOLD == 5
+
     for streak in range(1, _WS_DEGRADE_THRESHOLD):
         note(False, streak)
     assert worker.runtime.health == "ok"
@@ -203,3 +208,57 @@ def test_ws_streaks_flip_health_to_server_unreachable_and_back(tmp_path, monkeyp
     assert worker.runtime.health == "auth_failed"
     note(True, 0)
     assert worker.runtime.health == "auth_failed"
+
+
+def test_heal_only_fires_on_the_designated_dead_executor_message():
+    """Intentional-teardown RuntimeErrors must not heal: installing a
+    fresh executor there would fight a shutdown in progress. Only the
+    suspended-loop shape ("after shutdown") is treated."""
+    from puffo_agent.crypto.http_client import heal_if_dead_executor
+
+    assert not heal_if_dead_executor(
+        RuntimeError("Executor shutdown has been called")
+    )
+    assert not heal_if_dead_executor(
+        RuntimeError("cannot schedule new futures after interpreter shutdown")
+    )
+    assert not heal_if_dead_executor(RuntimeError("boom"))
+
+
+@pytest.mark.asyncio
+async def test_concurrent_close_keeps_a_mid_close_replacement_session(monkeypatch):
+    """close() detaches its session before awaiting: a _get_session()
+    racing the await installs a replacement, and a post-await
+    ``self._session = None`` would orphan it with a live connector."""
+
+    class _SlowCloseSession:
+        def __init__(self):
+            self.closed = False
+            self.close_started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def close(self):
+            # aiohttp reads as closed from the start of close(), before
+            # the connector teardown awaits.
+            self.closed = True
+            self.close_started.set()
+            await self.release.wait()
+
+    old = _SlowCloseSession()
+    replacement = _FakeSession(fail=False)
+    monkeypatch.setattr(
+        "puffo_agent.crypto.http_client.create_remote_http_session",
+        lambda url: replacement,
+    )
+    client = PuffoCoreHttpClient.__new__(PuffoCoreHttpClient)
+    client.server_url = "https://x"
+    client._session = old
+
+    close_task = asyncio.create_task(client.close())
+    await old.close_started.wait()
+    assert await client._get_session() is replacement
+    old.release.set()
+    await close_task
+
+    assert client._session is replacement
+    assert not replacement.closed

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -1,0 +1,110 @@
+"""Transport self-heal + honest health (8/30 App Nap incident).
+
+Two key behaviors:
+- a dead default executor (RuntimeError: cannot schedule new futures
+  after shutdown) heals in-place: fresh executor + rebuilt session +
+  one retry, instead of failing every request forever;
+- WS reconnect-failure streaks flip runtime.json health to
+  "server_unreachable" and back, instead of reporting "ok" while the
+  server is unreachable for hours.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from puffo_agent.crypto.http_client import PuffoCoreHttpClient
+
+
+class _FakeResponse:
+    status = 200
+
+    async def text(self) -> str:
+        return json.dumps({"healed": True})
+
+
+class _RequestCtx:
+    def __init__(self, fail: bool):
+        self._fail = fail
+
+    async def __aenter__(self):
+        if self._fail:
+            raise RuntimeError("cannot schedule new futures after shutdown")
+        return _FakeResponse()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, fail: bool):
+        self._fail = fail
+        self.closed = False
+
+    def request(self, method, url, **kwargs):
+        return _RequestCtx(self._fail)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_dead_default_executor_heals_and_request_succeeds(monkeypatch):
+    client = PuffoCoreHttpClient.__new__(PuffoCoreHttpClient)
+    client.server_url = "https://x"
+    sessions = [_FakeSession(fail=True), _FakeSession(fail=False)]
+
+    async def fake_get_session():
+        return sessions[0] if not sessions[0].closed else sessions[1]
+
+    monkeypatch.setattr(client, "_get_session", fake_get_session)
+    client._session = sessions[0]
+    monkeypatch.setattr(client, "_egress_headers", lambda base=None: dict(base or {}))
+
+    loop = asyncio.get_running_loop()
+    executor_before = loop._default_executor
+
+    result = await client.get_unsigned("/ping")
+
+    assert result == {"healed": True}
+    # The broken session was replaced, and the loop-global executor was
+    # renewed — that is what also revives WS reconnects.
+    assert sessions[0].closed
+    assert loop._default_executor is not executor_before
+    assert loop._default_executor is not None
+
+
+def test_ws_streaks_flip_health_to_server_unreachable_and_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    from puffo_agent.portal.state import RuntimeState, agent_dir
+    from puffo_agent.portal.worker import _WS_DEGRADE_THRESHOLD, Worker
+
+    agent_dir("a1").mkdir(parents=True)
+    worker = Worker.__new__(Worker)
+    worker.runtime = RuntimeState(status="running", health="ok")
+    note = worker._transport_state_listener("a1")
+
+    for streak in range(1, _WS_DEGRADE_THRESHOLD):
+        note(False, streak)
+    assert worker.runtime.health == "ok"
+
+    note(False, _WS_DEGRADE_THRESHOLD)
+    assert worker.runtime.health == "server_unreachable"
+    assert "consecutive WS reconnect failures" in worker.runtime.error
+    on_disk = json.loads((agent_dir("a1") / "runtime.json").read_text())
+    assert on_disk["health"] == "server_unreachable"
+
+    # Recovery clears only the transport-set state...
+    note(True, 0)
+    assert worker.runtime.health == "ok"
+    assert worker.runtime.error == ""
+
+    # ...and stronger signals are never clobbered in either direction.
+    worker.runtime.health = "auth_failed"
+    note(False, _WS_DEGRADE_THRESHOLD + 1)
+    assert worker.runtime.health == "auth_failed"
+    note(True, 0)
+    assert worker.runtime.health == "auth_failed"


### PR DESCRIPTION
**Root cause (8/30 incident)**: `--background` runs the daemon as a thread of the windowless Qt tray process, which macOS App Nap suspends wholesale. After resume the loop's default ThreadPoolExecutor is dead; aiohttp rides it for DNS/netrc on every request and `websockets.connect` uses `loop.getaddrinfo` on the same pool, so one dead executor killed all HTTP + WS forever (`cannot schedule new futures after shutdown` ×9136) while runtime.json health said "ok" for 14.5h.

**Fixes**
- `http_client`: pre-send no-op executor probe heals a dead pool (and drops the pre-suspension session) before any bytes go out; a dead-executor error mid-request is healed for the next attempt but re-raised, never replayed (aiohttp redirect hops re-enter the executor after the request is on the wire — double-send reproduced live during review).
- `ws_client` + `worker`: reconnect-failure streaks flow through a transport-state listener wired via the single `Worker._build_wired_client()` seam (both standard and ws-local paths); ≥5 consecutive failures flip runtime.json health `ok → server_unreachable` (~15–40s into an outage), one successful reconnect clears it, stronger signals never clobbered. WS loop heals the same dead-executor error itself (valid subkey ⇒ no prior HTTP call to heal it). `agent list` shows the new state.
- `tray`: best-effort NSProcessInfo `beginActivityWithOptions:` App Nap exemption (still allows system sleep); failure degrades to today's behavior.

**Review**: two rounds by @Peter (exact SHAs a043b4c → f2a0c73 → 56fbaa0), findings verified with live aiohttp-server repros; both incident paths re-run on final SHA with exactly one POST observed. All tests red-first; full suite exit 0; ruff clean.

**Deferred**: structural split (daemon out of the GUI process) → follow-up PR; #232 (refresh_broken can't self-clear) is the same "no recovery path" class, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
