### PR TITLE
fix(harness): echo driver authority call IDs

### DIFF
--- a/src/puffo_agent/agent/harness/driver_authority_server.py
+++ b/src/puffo_agent/agent/harness/driver_authority_server.py
@@ -166,6 +166,16 @@ class DriverAuthorityServer:
             while True:
                 request = self._recv_frame(record)
                 response, child = self._handle_request(record, request)
+                # Correlation is stamped here, at the one point every response
+                # passes through on its way to the wire. A peer that matches
+                # responses to requests by call_id rejects any reply that omits
+                # it, and this server has ten leaf response paths; threading a
+                # parameter through each one means a path added later can drop
+                # the echo silently. Only a request that correlates gets a
+                # correlation key back.
+                request_call_id = request.get("call_id")
+                if isinstance(request_call_id, str):
+                    response["call_id"] = request_call_id
                 try:
                     self._send_frame(record.server_socket, response, child=child)
                 finally:
@@ -218,15 +228,12 @@ class DriverAuthorityServer:
                 self._claim_probe()
             record.state = _LeaseState.CLAIMED
             binding = record.binding
-        response = {
+        return {
             "version": PROTOCOL_VERSION,
             "role": binding.role,
             "launch_id": binding.launch_id,
             "capability": binding.capability,
         }
-        if call_id is not None:
-            response["call_id"] = call_id
-        return response
 
     def _authorize_derived_launch(
         self, record: _EndpointRecord, request: dict[str, Any], *, call_id: str | None = None
@@ -336,15 +343,12 @@ class DriverAuthorityServer:
                 call_id,
             )
         )
-        response = {
+        return {
             "version": PROTOCOL_VERSION,
             "state": state,
             "reason_code": reason_code,
             "audit_id": audit_id,
         }
-        if call_id is not None:
-            response["call_id"] = call_id
-        return response
 
     @staticmethod
     def _send_frame(

--- a/src/puffo_agent/agent/harness/driver_authority_server.py
+++ b/src/puffo_agent/agent/harness/driver_authority_server.py
@@ -187,43 +187,49 @@ class DriverAuthorityServer:
         self, record: _EndpointRecord, request: dict[str, Any]
     ) -> tuple[dict[str, Any], socket.socket | None]:
         operation = request.get("op")
+        call_id = request.get("call_id")
+        if not isinstance(call_id, str):
+            call_id = None
         if request.get("version") != PROTOCOL_VERSION or not isinstance(operation, str):
             return self._decision(
-                record, "malformed", "indeterminate", "malformed_request"
+                record, "malformed", "indeterminate", "malformed_request", call_id=call_id
             ), None
         if operation == "hello":
-            return self._claim(record), None
+            return self._claim(record, call_id=call_id), None
         with self._lock:
             claimed = record.state is _LeaseState.CLAIMED
         if not claimed:
-            return self._mismatch(record, operation), None
+            return self._mismatch(record, operation, call_id=call_id), None
         if operation == "authorize_derived_launch":
-            return self._authorize_derived_launch(record, request)
+            return self._authorize_derived_launch(record, request, call_id=call_id)
         if operation == "authorize_provider_call":
             return self._authorize_provider_call(record, request), None
         return self._decision(
-            record, operation, "indeterminate", "unsupported_operation"
+            record, operation, "indeterminate", "unsupported_operation", call_id=call_id
         ), None
 
-    def _claim(self, record: _EndpointRecord) -> dict[str, Any]:
+    def _claim(self, record: _EndpointRecord, *, call_id: str | None = None) -> dict[str, Any]:
         with self._lock:
             if record.state is not _LeaseState.ISSUED:
                 return self._record_decision_locked(
-                    record, "hello", "denied", "endpoint_already_claimed"
+                    record, "hello", "denied", "endpoint_already_claimed", call_id=call_id
                 )
             if self._claim_probe is not None:
                 self._claim_probe()
             record.state = _LeaseState.CLAIMED
             binding = record.binding
-        return {
+        response = {
             "version": PROTOCOL_VERSION,
             "role": binding.role,
             "launch_id": binding.launch_id,
             "capability": binding.capability,
         }
+        if call_id is not None:
+            response["call_id"] = call_id
+        return response
 
     def _authorize_derived_launch(
-        self, record: _EndpointRecord, request: dict[str, Any]
+        self, record: _EndpointRecord, request: dict[str, Any], *, call_id: str | None = None
     ) -> tuple[dict[str, Any], socket.socket | None]:
         binding = record.binding
         if binding.role != "root":
@@ -232,13 +238,14 @@ class DriverAuthorityServer:
                 "authorize_derived_launch",
                 "denied",
                 "nested_derived_launch_denied",
+                call_id=call_id,
             ), None
         capability = request.get("capability")
         if request.get("launch_id") != binding.launch_id or capability not in {
             "daemon",
             "avatar",
         }:
-            return self._mismatch(record, "authorize_derived_launch"), None
+            return self._mismatch(record, "authorize_derived_launch", call_id=call_id), None
         child_binding = _EndpointBinding(
             launch_id=f"launch_{uuid.uuid4().hex}",
             role="derived",
@@ -249,7 +256,7 @@ class DriverAuthorityServer:
         child_record, child_endpoint = self._issue_endpoint(child_binding)
         self._start_record(child_record)
         response = self._decision(
-            record, "authorize_derived_launch", "granted", "allowed"
+            record, "authorize_derived_launch", "granted", "allowed", call_id=call_id
         )
         response["admission_id"] = f"admission_{uuid.uuid4().hex}"
         return response, child_endpoint
@@ -329,12 +336,15 @@ class DriverAuthorityServer:
                 call_id,
             )
         )
-        return {
+        response = {
             "version": PROTOCOL_VERSION,
             "state": state,
             "reason_code": reason_code,
             "audit_id": audit_id,
         }
+        if call_id is not None:
+            response["call_id"] = call_id
+        return response
 
     @staticmethod
     def _send_frame(

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -518,10 +518,13 @@ _ROOT_LAUNCH_ID = "root-echo"
 
 
 def _paths_on_a_fresh_root(launch_id: str) -> list[dict[str, Any]]:
-    """Requests answered on a root endpoint, in order; hello claims it.
+    """Requests answered on a root endpoint, in order; the first hello claims it.
 
-    The second entry deliberately runs before any hello elsewhere in the
-    suite: ``_unclaimed_endpoint_request`` covers the pre-claim branch.
+    Every entry after that runs against a claimed endpoint, so this list
+    reaches eight of the ten leaf response paths. The pre-claim branch and
+    the nested-derived denial need different endpoint state and are covered
+    by ``test_unclaimed_endpoint_response_echoes_call_id`` and
+    ``test_nested_derived_launch_denial_echoes_call_id``.
     """
     return [
         {"version": 1, "op": "hello"},

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -488,3 +488,104 @@ async def test_constrained_lingtai_rejects_spawn_paths_that_cannot_pass_fds() ->
                 )
             )
         )
+
+
+def _root_client(server: DriverAuthorityServer, launch_id: str) -> socket.socket:
+    return _client(server.issue_root(launch_id=launch_id))
+
+
+def _every_answered_request(launch_id: str) -> list[dict[str, Any]]:
+    """One request per response path the server can take, hello first."""
+    return [
+        {"version": 1, "op": "hello"},
+        # Second hello: the endpoint is single-use, so this is the denied path.
+        {"version": 1, "op": "hello"},
+        {"version": 99, "op": "hello"},  # malformed_request
+        {"version": 1, "op": "no_such_operation"},  # unsupported_operation
+        {
+            "version": 1,
+            "op": "authorize_provider_call",
+            "launch_id": launch_id,
+            "provider": "llm",
+            "capability": "root",
+        },  # granted
+        {
+            "version": 1,
+            "op": "authorize_provider_call",
+            "launch_id": "not-the-binding",
+            "provider": "llm",
+            "capability": "root",
+        },  # endpoint_binding_mismatch
+        {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "launch_id": launch_id,
+            "capability": "daemon",
+        },  # granted, carries a child descriptor
+        {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "launch_id": "not-the-binding",
+            "capability": "daemon",
+        },  # mismatch
+    ]
+
+
+def test_every_response_echoes_the_request_call_id() -> None:
+    """A correlating peer rejects any response that drops its ``call_id``.
+
+    Asserted over every response path rather than the two that happened to
+    break LingTai, so a response constructor added later cannot reintroduce
+    the omission on a path nobody enumerated.
+    """
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-echo")
+    try:
+        for request in _every_answered_request("root-echo"):
+            call_id = str(uuid.uuid4())
+            response, fds = _request(client, {**request, "call_id": call_id})
+            _close_fds(fds)
+            assert response.get("call_id") == call_id, (
+                f"op={request['op']} version={request['version']} "
+                f"dropped call_id; response keys={sorted(response)}"
+            )
+    finally:
+        client.close()
+        server.close()
+
+
+def test_response_omits_call_id_when_the_request_did_not_correlate() -> None:
+    """Requests that send no ``call_id`` keep their existing response shape."""
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-uncorrelated")
+    try:
+        for request in _every_answered_request("root-uncorrelated"):
+            response, fds = _request(client, request)
+            _close_fds(fds)
+            assert "call_id" not in response, (
+                f"op={request['op']} invented a call_id the caller never sent: "
+                f"{response!r}"
+            )
+    finally:
+        client.close()
+        server.close()
+
+
+def test_lingtai_hello_correlation_is_accepted_end_to_end() -> None:
+    """The exact exchange LingTai performs before it will bind authority."""
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-lingtai")
+    try:
+        call_id = str(uuid.uuid4())
+        response, fds = _request(
+            client, {"version": 1, "op": "hello", "call_id": call_id}
+        )
+        assert fds == []
+        # LingTai's driver_authority client raises
+        # DriverAuthorityTransportError unless this comparison holds.
+        assert response.get("call_id") == call_id
+        assert response["role"] == "root"
+        assert response["launch_id"] == "root-lingtai"
+    finally:
+        client.close()
+        server.close()

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -494,12 +494,38 @@ def _root_client(server: DriverAuthorityServer, launch_id: str) -> socket.socket
     return _client(server.issue_root(launch_id=launch_id))
 
 
-def _every_answered_request(launch_id: str) -> list[dict[str, Any]]:
-    """One request per response path the server can take, hello first."""
+def _derived_client(server: DriverAuthorityServer, root: socket.socket) -> socket.socket:
+    """A claimed derived (non-root) endpoint, for the nested-denial path."""
+    _hello(root)  # the root endpoint must be claimed before it can derive
+    grant, fds = _request(
+        root,
+        {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "call_id": str(uuid.uuid4()),
+            "launch_id": _ROOT_LAUNCH_ID,
+            "capability": "daemon",
+        },
+    )
+    assert grant["state"] == "granted", grant
+    assert len(fds) == 1, fds
+    child = socket.socket(fileno=fds[0])
+    _hello(child)
+    return child
+
+
+_ROOT_LAUNCH_ID = "root-echo"
+
+
+def _paths_on_a_fresh_root(launch_id: str) -> list[dict[str, Any]]:
+    """Requests answered on a root endpoint, in order; hello claims it.
+
+    The second entry deliberately runs before any hello elsewhere in the
+    suite: ``_unclaimed_endpoint_request`` covers the pre-claim branch.
+    """
     return [
         {"version": 1, "op": "hello"},
-        # Second hello: the endpoint is single-use, so this is the denied path.
-        {"version": 1, "op": "hello"},
+        {"version": 1, "op": "hello"},  # endpoint_already_claimed
         {"version": 99, "op": "hello"},  # malformed_request
         {"version": 1, "op": "no_such_operation"},  # unsupported_operation
         {
@@ -534,14 +560,23 @@ def _every_answered_request(launch_id: str) -> list[dict[str, Any]]:
 def test_every_response_echoes_the_request_call_id() -> None:
     """A correlating peer rejects any response that drops its ``call_id``.
 
-    Asserted over every response path rather than the two that happened to
-    break LingTai, so a response constructor added later cannot reintroduce
-    the omission on a path nobody enumerated.
+    Ten leaf response paths reach the wire. Eight are reachable on a fresh
+    root endpoint; the other two need different endpoint state, so they get
+    their own cases below rather than being quietly absent:
+    ``test_unclaimed_endpoint_response_echoes_call_id`` (a non-hello request
+    before the endpoint is claimed) and
+    ``test_nested_derived_launch_denial_echoes_call_id`` (a derived endpoint
+    asking to derive again).
+
+    The guarantee itself does not come from this enumeration: the echo is
+    stamped once in ``_serve`` before ``_send_frame``, so a response path
+    added later is covered by construction. These cases prove that stamp is
+    live on every path we can name.
     """
     server = DriverAuthorityServer()
-    client = _root_client(server, "root-echo")
+    client = _root_client(server, _ROOT_LAUNCH_ID)
     try:
-        for request in _every_answered_request("root-echo"):
+        for request in _paths_on_a_fresh_root(_ROOT_LAUNCH_ID):
             call_id = str(uuid.uuid4())
             response, fds = _request(client, {**request, "call_id": call_id})
             _close_fds(fds)
@@ -554,12 +589,69 @@ def test_every_response_echoes_the_request_call_id() -> None:
         server.close()
 
 
+def test_unclaimed_endpoint_response_echoes_call_id() -> None:
+    """A non-hello request before the endpoint is claimed is still a response."""
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-unclaimed")
+    try:
+        call_id = str(uuid.uuid4())
+        response, fds = _request(
+            client,
+            {
+                "version": 1,
+                "op": "authorize_provider_call",
+                "call_id": call_id,
+                "launch_id": "root-unclaimed",
+                "provider": "llm",
+                "capability": "root",
+            },
+        )
+        _close_fds(fds)
+        assert response["reason_code"] == "endpoint_binding_mismatch"
+        assert response.get("call_id") == call_id, response
+    finally:
+        client.close()
+        server.close()
+
+
+def test_nested_derived_launch_denial_echoes_call_id() -> None:
+    """A derived endpoint asking to derive again is denied -- and correlated."""
+    server = DriverAuthorityServer()
+    root = _root_client(server, _ROOT_LAUNCH_ID)
+    child = None
+    try:
+        child = _derived_client(server, root)
+        call_id = str(uuid.uuid4())
+        response, fds = _request(
+            child,
+            {
+                "version": 1,
+                "op": "authorize_derived_launch",
+                "call_id": call_id,
+                "launch_id": "anything",
+                "capability": "daemon",
+            },
+        )
+        _close_fds(fds)
+        assert response["reason_code"] == "nested_derived_launch_denied"
+        assert response.get("call_id") == call_id, response
+    finally:
+        if child is not None:
+            child.close()
+        root.close()
+        server.close()
+
+
 def test_response_omits_call_id_when_the_request_did_not_correlate() -> None:
-    """Requests that send no ``call_id`` keep their existing response shape."""
+    """Requests that send no ``call_id`` keep their existing response shape.
+
+    An uncorrelated request must not receive an invented or null correlation
+    key; two existing tests assert hello responses by exact dict equality.
+    """
     server = DriverAuthorityServer()
     client = _root_client(server, "root-uncorrelated")
     try:
-        for request in _every_answered_request("root-uncorrelated"):
+        for request in _paths_on_a_fresh_root("root-uncorrelated"):
             response, fds = _request(client, request)
             _close_fds(fds)
             assert "call_id" not in response, (

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -255,6 +255,63 @@ def test_provider_calls_are_adjudicated_independently_with_readable_audit_ids() 
         server.close()
 
 
+def test_protocol_responses_echo_request_call_id() -> None:
+    """LingTai correlates every authority response to its request."""
+
+    server = DriverAuthorityServer()
+    root = _client(server.issue_root(launch_id="root-call-id"))
+    child: socket.socket | None = None
+    try:
+        root_hello_id = uuid.uuid4().hex
+        root_hello, fds = _request(
+            root, {"version": 1, "op": "hello", "call_id": root_hello_id}
+        )
+        assert fds == []
+        assert root_hello["call_id"] == root_hello_id
+
+        launch_id = uuid.uuid4().hex
+        launch, child_fds = _request(
+            root,
+            {
+                "version": 1,
+                "op": "authorize_derived_launch",
+                "call_id": launch_id,
+                "launch_id": "root-call-id",
+                "capability": "daemon",
+            },
+        )
+        assert launch["call_id"] == launch_id
+        child = socket.socket(fileno=child_fds.pop())
+
+        child_hello_id = uuid.uuid4().hex
+        child_hello, fds = _request(
+            child, {"version": 1, "op": "hello", "call_id": child_hello_id}
+        )
+        assert fds == []
+        assert child_hello["call_id"] == child_hello_id
+
+        provider_id = uuid.uuid4().hex
+        provider, fds = _request(
+            child,
+            {
+                "version": 1,
+                "op": "authorize_provider_call",
+                "call_id": provider_id,
+                "launch_id": child_hello["launch_id"],
+                "provider": "llm",
+                "capability": "daemon",
+            },
+        )
+        assert fds == []
+        assert provider["call_id"] == provider_id
+    finally:
+        _close_fds(child_fds if "child_fds" in locals() else [])
+        if child is not None:
+            child.close()
+        root.close()
+        server.close()
+
+
 def test_root_can_issue_one_hop_but_derived_cannot_issue_nested_child() -> None:
     server = DriverAuthorityServer()
     root = _client(server.issue_root(launch_id="root-parent"))


### PR DESCRIPTION
## Summary
- echo a request `call_id` from every driver-authority response path
- preserve compatibility for legacy requests without a `call_id`
- add a root → derived → provider regression covering all correlated exchanges

## Verification
- `uv run --extra dev pytest -q tests/test_driver_authority_server.py`
- `uv run --extra dev ruff check src/puffo_agent/agent/harness/driver_authority_server.py tests/test_driver_authority_server.py`
- actual Puffo server + LingTai main client: root hello → derived launch → child hello → provider call

This is intended to be merged into #304 before #304 is merged to `main`.