### PR TITLE
fix(daemon): recover wedged MCP transports after reload

### DIFF
--- a/src/puffo_agent/agent/global_inbox_covers.py
+++ b/src/puffo_agent/agent/global_inbox_covers.py
@@ -15,6 +15,8 @@ from .message_store import ProcessingState
 # implementation module.
 logger = logging.getLogger("puffo_agent.agent.global_inbox_runtime")
 
+MCP_SILENCE_WARNING_EVERY_TURNS = 3
+
 
 class CoversReconciliationMixin:
     """Cover reconciliation + completion for ``GlobalInboxRuntime``.
@@ -179,6 +181,7 @@ class CoversReconciliationMixin:
             # That is a normal deferred outcome, not a transport failure and
             # therefore must not create another generation for the same set.
             await self.store.finalize_empty_turn(turn_id=planned.turn_id)
+        await self._observe_mcp_read_progress()
         renotice_set = set(renotice_ids)
         for item_id in self.active.message_ids:
             row = rows_by_id.get(item_id)
@@ -209,4 +212,28 @@ class CoversReconciliationMixin:
             state=ProcessingState.PROCESSED.value,
             message_count=len(self.active.message_ids),
             duration_ms=int((time.monotonic() - process_started) * 1000),
+        )
+
+    async def _observe_mcp_read_progress(self) -> None:
+        """Warn when repeated notice turns never reach ``read_inbox``.
+
+        One empty notice turn is a supported deferral. Repeated empty turns
+        while messages remain pending are also the daemon-visible signature
+        of a provider whose MCP client is wedged, so surface that ambiguity
+        without claiming a transport root cause we cannot observe here.
+        """
+        if not self.active.notice_message_ids:
+            return
+        if self.active.message_ids or not await self.store.get_pending(limit=1):
+            self._mcp_silence_streak = 0
+            return
+        self._mcp_silence_streak += 1
+        if self._mcp_silence_streak % MCP_SILENCE_WARNING_EVERY_TURNS:
+            return
+        logger.warning(
+            "agent %s: possible MCP control-plane failure — %d consecutive "
+            "Inbox notice turns completed without read_inbox admission while "
+            "messages remain pending",
+            self.agent_id,
+            self._mcp_silence_streak,
         )

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -190,6 +190,7 @@ class GlobalInboxRuntime(
         self._turn_state_lock = asyncio.Lock()
         self._stopping = False
         self._init_recovery_gates(drained_check)
+        self._mcp_silence_streak = 0
         self._defer_requeued_recovery = False
         self.max_context_decisions = max_context_decisions
         self.max_api_retries = max_api_retries

--- a/src/puffo_agent/agent/harness/driver.py
+++ b/src/puffo_agent/agent/harness/driver.py
@@ -155,6 +155,10 @@ class RuntimeSpec:
     task_timeout_seconds: float = 1800.0
     auto_compact_threshold_pct: float | None = None
     auto_compact_threshold_tokens: int | None = None
+    # Identity of the MCP config this spec was prepared with; the puffo
+    # MCP subprocess echoes it back over loopback RPC so the worker can
+    # prove the transport is reachable ("" = no handshake expected).
+    mcp_generation: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/puffo_agent/agent/harness/runtime/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/docker_runtime.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -277,13 +278,21 @@ class DockerRuntimePreparer:
                 inference,
             )
         mcp_env = self._container_puffo_mcp_env()
+        mcp_generation = ""
         if mcp_env:
+            # Minted per config write; the subprocess echoes it back over
+            # RPC (mcp-hello) so the worker's transport probe can tell
+            # "this spec's MCP reached us" from a stale predecessor.
+            mcp_generation = uuid.uuid4().hex
             config_host = self.workspace_dir / ".puffo-agent" / "mcp-config.json"
             write_cli_mcp_config(
                 config_host,
                 command="python3",
                 args=["-m", "puffo_agent.mcp.puffo_core_server"],
-                env=mcp_env,
+                env={
+                    **mcp_env,
+                    "PUFFO_MCP_GENERATION": mcp_generation,
+                },
             )
             launch_args.extend(
                 ["--mcp-config", "/workspace/.puffo-agent/mcp-config.json"]
@@ -331,6 +340,7 @@ class DockerRuntimePreparer:
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
             auto_compact_threshold_pct=compact_pct,
             auto_compact_threshold_tokens=compact_tokens,
+            mcp_generation=mcp_generation,
         )
 
     def _codex_gateway_provider(self) -> dict[str, str] | None:

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -668,12 +669,20 @@ class LocalRuntimePreparer:
                     inference,
                 )
         mcp_path = agent_dir(self.agent_id) / "mcp-config.json"
+        mcp_generation = ""
         if self._puffo_core_env:
+            # Minted per config write; the subprocess echoes it back over
+            # RPC (mcp-hello) so the worker's transport probe can tell
+            # "this spec's MCP reached us" from a stale predecessor.
+            mcp_generation = uuid.uuid4().hex
             write_cli_mcp_config(
                 mcp_path,
                 command=default_python_executable(),
                 args=["-m", "puffo_agent.mcp.puffo_core_server"],
-                env=self._puffo_core_env,
+                env={
+                    **self._puffo_core_env,
+                    "PUFFO_MCP_GENERATION": mcp_generation,
+                },
             )
             launch_args.extend(["--mcp-config", str(mcp_path)])
         else:
@@ -720,6 +729,7 @@ class LocalRuntimePreparer:
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
             auto_compact_threshold_pct=compact_pct,
             auto_compact_threshold_tokens=compact_tokens,
+            mcp_generation=mcp_generation,
         )
 
     def _prepare_codex_spec(self, system_prompt: str) -> RuntimeSpec:

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -982,6 +982,7 @@ def build_local_runtime_adapter(
     logical_session_ref: str,
     driver: Driver | None = None,
     cleanup: Callable[[], Awaitable[None]] | None = None,
+    generation_sink: Callable[[str], None] | None = None,
 ) -> RuntimeManagerAdapter:
     """Bind a prepared Driver runtime to the durable Runtime Manager.
 
@@ -1065,6 +1066,7 @@ def build_local_runtime_adapter(
         manager,
         spec_reloader=reload_spec,
         post_close=cleanup,
+        generation_sink=generation_sink,
     )
 
 

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import time
 import uuid
 import weakref
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
@@ -226,6 +227,9 @@ class RuntimeManager:
         # input reached the transcript (accepted start receipt only)
         self._input_admitted = False
         self._resume_failure_streak = 0
+        # When the current runtime process was (re)opened; the worker's
+        # MCP transport probe compares hello timestamps against it.
+        self.last_open_monotonic: float | None = None
 
     async def open(self, *, resume: bool = True) -> RuntimeOpened:
         async with self._command_lock:
@@ -285,6 +289,7 @@ class RuntimeManager:
                 )
         self.native_session_id = opened.native_session_id
         self._resume_failure_streak = 0
+        self.last_open_monotonic = time.monotonic()
         # Preserve the durable Puffo logical reference independently of the
         # native provider session ID.
         self.opened = replace(opened, session_ref=self.session_ref)

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -245,6 +245,7 @@ class RuntimeManager:
             if resume and self.native_session_id
             else None
         )
+        self.last_open_monotonic = time.monotonic()
         try:
             opened = await self.driver.open(self.spec, native_resume)
         except BaseException as exc:
@@ -276,6 +277,7 @@ class RuntimeManager:
             )
             self._clear_native_session()
             try:
+                self.last_open_monotonic = time.monotonic()
                 opened = await self.driver.open(self.spec, None)
             except BaseException as exc:
                 errors = [exc]
@@ -289,7 +291,6 @@ class RuntimeManager:
                 )
         self.native_session_id = opened.native_session_id
         self._resume_failure_streak = 0
-        self.last_open_monotonic = time.monotonic()
         # Preserve the durable Puffo logical reference independently of the
         # native provider session ID.
         self.opened = replace(opened, session_ref=self.session_ref)

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -1167,6 +1167,7 @@ class RuntimeManagerAdapter(Adapter):
         spec_reloader: Callable[[str], Awaitable[RuntimeSpec]] | None = None,
         compaction_wait_seconds: float = COMPACTION_WAIT_SECONDS,
         post_close: Callable[[], Awaitable[None]] | None = None,
+        generation_sink: Callable[[str], None] | None = None,
     ):
         self.manager = manager
         self.spec_reloader = spec_reloader
@@ -1175,6 +1176,11 @@ class RuntimeManagerAdapter(Adapter):
         # (and its Driver) close. Used by the Docker Codex runtime to stop
         # the per-agent container once the exec transport has terminated.
         self.post_close = post_close
+        # Observes a freshly minted mcp generation between the spec
+        # reload and the reopen (the daemon pins it against registry
+        # trimming before the new subprocess can hello). Observation
+        # only; failures never reach the runtime.
+        self.generation_sink = generation_sink
         self.assistant_text_parts: list[str] = []
         self._latest_context_limits: tuple[int | None, int | None] = (
             None,
@@ -1475,6 +1481,22 @@ class RuntimeManagerAdapter(Adapter):
             await self.spec_reloader(new_system_prompt)
             if self.spec_reloader is not None else None
         )
+        if (
+            spec is not None
+            and spec.mcp_generation
+            and self.generation_sink is not None
+        ):
+            # Pin the minted generation BEFORE the reopen: the reopened
+            # subprocess hellos immediately, and until the caller's
+            # post-reload pin lands, registry trimming under zombie
+            # beacon pressure could evict that hello and fake a
+            # never-seen probe result.
+            try:
+                self.generation_sink(spec.mcp_generation)
+            except Exception:
+                logger.exception(
+                    "generation sink failed; reload continues"
+                )
         await self.manager.reload_resources(
             preserve_session=not with_session,
             spec=spec,

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -46,6 +46,11 @@ class PuffoRpcClient:
             await self._session.close()
             self._session = None
 
+    async def hello(self, generation: str) -> str:
+        """Startup handshake: prove this subprocess can reach the daemon's
+        RPC service, tagged with the mcp-config generation that spawned it."""
+        return await self._post("mcp-hello", {"generation": generation})
+
     async def _post(self, route: str, body: dict[str, Any]) -> str:
         """POST + return the ``message`` field. Raises on transport or non-2xx."""
         path = (

--- a/src/puffo_agent/mcp/_host_mcp.py
+++ b/src/puffo_agent/mcp/_host_mcp.py
@@ -46,10 +46,17 @@ class PuffoRpcClient:
             await self._session.close()
             self._session = None
 
-    async def hello(self, generation: str) -> str:
-        """Startup handshake: prove this subprocess can reach the daemon's
-        RPC service, tagged with the mcp-config generation that spawned it."""
-        return await self._post("mcp-hello", {"generation": generation})
+    async def hello(
+        self, generation: str, *, beacon_interval: float | None = None,
+    ) -> str:
+        """Hello beacon: prove this subprocess can reach the daemon's
+        RPC service, tagged with the mcp-config generation that spawned
+        it. ``beacon_interval`` declares the re-hello cadence so the
+        daemon may read sustained silence as a wedged transport."""
+        body: dict[str, Any] = {"generation": generation}
+        if beacon_interval is not None:
+            body["beacon_interval"] = beacon_interval
+        return await self._post("mcp-hello", body)
 
     async def _post(self, route: str, body: dict[str, Any]) -> str:
         """POST + return the ``message`` field. Raises on transport or non-2xx."""

--- a/src/puffo_agent/mcp/_lifespan.py
+++ b/src/puffo_agent/mcp/_lifespan.py
@@ -12,6 +12,8 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Awaitable, Callable, Protocol
 
+from ..tasks import spawn
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,9 +34,9 @@ def make_lifespan(
 
     @asynccontextmanager
     async def _lifespan(_app: Any) -> AsyncIterator[None]:
-        startup_task: asyncio.Task | None = None
+        startup_task: asyncio.Future[Any] | None = None
         if startup is not None:
-            startup_task = asyncio.ensure_future(startup())
+            startup_task = spawn(startup(), name="mcp.startup")
         try:
             yield
         finally:

--- a/src/puffo_agent/mcp/_lifespan.py
+++ b/src/puffo_agent/mcp/_lifespan.py
@@ -7,9 +7,10 @@ pulling in ``mcp.server.fastmcp`` (the SDK is optional in dev).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Protocol
+from typing import Any, AsyncIterator, Awaitable, Callable, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -22,15 +23,23 @@ def make_lifespan(
     data: _AsyncCloseable,
     rpc_client: _AsyncCloseable | None,
     http: _AsyncCloseable,
+    startup: Callable[[], Awaitable[None]] | None = None,
 ):
     """Async context manager FastMCP wraps around its serve loop;
-    closes every adapter session while the loop is still alive."""
+    closes every adapter session while the loop is still alive.
+    ``startup`` (optional) runs as a background task so a slow or
+    failing hook can never delay or break tool serving."""
 
     @asynccontextmanager
     async def _lifespan(_app: Any) -> AsyncIterator[None]:
+        startup_task: asyncio.Task | None = None
+        if startup is not None:
+            startup_task = asyncio.ensure_future(startup())
         try:
             yield
         finally:
+            if startup_task is not None and not startup_task.done():
+                startup_task.cancel()
             # Per-adapter try so one close() raising can't strand the rest.
             for label, closer in (
                 ("DataClient", data.close),

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -394,34 +394,66 @@ def build_server(
 
 _HELLO_ATTEMPTS = 3
 _HELLO_RETRY_DELAY_SECONDS = 2.0
+_HELLO_BEACON_INTERVAL_SECONDS = 60.0
 
 
 def _make_hello_startup(rpc_client):
-    """Startup handshake coroutine factory. ``None`` when the handshake
-    is not applicable (no RPC client wired, or the daemon predates
-    ``PUFFO_MCP_GENERATION``) so older daemons see zero new traffic."""
+    """Hello-beacon coroutine factory: one prompt startup burst, then a
+    steady re-hello every ``_HELLO_BEACON_INTERVAL_SECONDS``. The declared
+    interval travels in the payload, so the daemon-side probe reads
+    sustained silence from this subprocess as a wedged transport — not
+    just "never came up". ``None`` when the handshake is not applicable
+    (no RPC client wired, or the daemon predates ``PUFFO_MCP_GENERATION``)
+    so older daemons see zero new traffic."""
     generation = os.environ.get("PUFFO_MCP_GENERATION", "")
     if rpc_client is None or not generation:
         return None
 
-    async def _hello() -> None:
-        for attempt in range(1, _HELLO_ATTEMPTS + 1):
-            try:
-                await rpc_client.hello(generation)
-                return
-            except Exception as exc:  # noqa: BLE001
-                if attempt == _HELLO_ATTEMPTS:
-                    # The daemon-side probe recycles on missing hellos;
-                    # this line is the subprocess-side half of the story.
-                    logger.warning(
-                        "mcp-hello failed after %d attempts "
-                        "(generation=%s): %s",
-                        attempt, generation, exc,
-                    )
-                    return
-                await asyncio.sleep(_HELLO_RETRY_DELAY_SECONDS)
+    async def _try_hello() -> Exception | None:
+        try:
+            await rpc_client.hello(
+                generation,
+                beacon_interval=_HELLO_BEACON_INTERVAL_SECONDS,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001
+            return exc
 
-    return _hello
+    async def _beacon() -> None:
+        failing = False
+        for attempt in range(1, _HELLO_ATTEMPTS + 1):
+            exc = await _try_hello()
+            if exc is None:
+                break
+            if attempt == _HELLO_ATTEMPTS:
+                failing = True
+                # The daemon-side probe recycles on missing hellos;
+                # this line is the subprocess-side half of the story.
+                logger.warning(
+                    "mcp-hello failed after %d attempts "
+                    "(generation=%s): %s",
+                    attempt, generation, exc,
+                )
+            else:
+                await asyncio.sleep(_HELLO_RETRY_DELAY_SECONDS)
+        while True:
+            await asyncio.sleep(_HELLO_BEACON_INTERVAL_SECONDS)
+            exc = await _try_hello()
+            if exc is None:
+                if failing:
+                    logger.info(
+                        "mcp-hello beacon recovered (generation=%s)",
+                        generation,
+                    )
+                failing = False
+            elif not failing:
+                failing = True
+                logger.warning(
+                    "mcp-hello beacon failed (generation=%s): %s",
+                    generation, exc,
+                )
+
+    return _beacon
 
 
 def _cfg_from_env() -> dict[str, str]:

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -9,6 +9,7 @@ Entry point: ``python -m puffo_agent.mcp.puffo_core_server``
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -368,7 +369,12 @@ def build_server(
     # silencing the ``Unclosed client session`` gc warning.
     mcp = FastMCP(
         "puffo-core",
-        lifespan=make_lifespan(data, rpc_client, http),
+        lifespan=make_lifespan(
+            data,
+            rpc_client,
+            http,
+            startup=_make_hello_startup(rpc_client),
+        ),
     )
     register_core_tools(mcp, core_cfg)
     _register_local_tools(mcp, workspace, runtime_kind, harness)
@@ -384,6 +390,38 @@ def build_server(
     )
     register_memory_tools(mcp, mem_cfg)
     return mcp
+
+
+_HELLO_ATTEMPTS = 3
+_HELLO_RETRY_DELAY_SECONDS = 2.0
+
+
+def _make_hello_startup(rpc_client):
+    """Startup handshake coroutine factory. ``None`` when the handshake
+    is not applicable (no RPC client wired, or the daemon predates
+    ``PUFFO_MCP_GENERATION``) so older daemons see zero new traffic."""
+    generation = os.environ.get("PUFFO_MCP_GENERATION", "")
+    if rpc_client is None or not generation:
+        return None
+
+    async def _hello() -> None:
+        for attempt in range(1, _HELLO_ATTEMPTS + 1):
+            try:
+                await rpc_client.hello(generation)
+                return
+            except Exception as exc:  # noqa: BLE001
+                if attempt == _HELLO_ATTEMPTS:
+                    # The daemon-side probe recycles on missing hellos;
+                    # this line is the subprocess-side half of the story.
+                    logger.warning(
+                        "mcp-hello failed after %d attempts "
+                        "(generation=%s): %s",
+                        attempt, generation, exc,
+                    )
+                    return
+                await asyncio.sleep(_HELLO_RETRY_DELAY_SECONDS)
+
+    return _hello
 
 
 def _cfg_from_env() -> dict[str, str]:

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -664,6 +664,7 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
             "unhandled_error",
             "codex_thread_wedged",
             "server_unreachable",
+            "mcp_unreachable",
         ):
             runtime = f"{runtime} [{rs.health}]"
         # Truncate display_name for table alignment.

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -10,8 +10,10 @@ by mutating the filesystem — no IPC needed.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import random
 import shutil
 import signal
 import threading
@@ -61,6 +63,7 @@ from .state import (
     is_daemon_ready,
     is_daemon_startup_stalled,
     is_pid_alive,
+    PROVIDER_AUTH_RELOAD_JITTER_MAX_SECONDS,
     read_daemon_pid,
     refresh_model_flag_path,
     refresh_provider_auth_flag_path,
@@ -83,6 +86,11 @@ from .worker import Worker
 from ..tasks import spawn
 
 logger = logging.getLogger(__name__)
+
+
+def _provider_auth_reload_jitter_seconds() -> float:
+    """Spread fleet-wide provider reopen requests across a short window."""
+    return random.uniform(0.0, PROVIDER_AUTH_RELOAD_JITTER_MAX_SECONDS)
 
 
 class _DaemonRuntime:
@@ -512,13 +520,23 @@ class Daemon:
                     agent_cfg.resolve_workspace_dir()
                 )
                 flag.parent.mkdir(parents=True, exist_ok=True)
+                jitter_seconds = _provider_auth_reload_jitter_seconds()
                 flag.write_text(
-                    '{"source":"credential_replaced"}', encoding="utf-8"
+                    json.dumps({
+                        "source": "credential_replaced",
+                        "jitter_seconds": jitter_seconds,
+                        "not_before_unix_ms": int(
+                            (time.time() + jitter_seconds) * 1000
+                        ),
+                    }),
+                    encoding="utf-8",
                 )
                 worker.notify_refresh()
                 logger.info(
-                    "agent %s: credential replaced — provider reload requested",
+                    "agent %s: credential replaced — provider reload requested "
+                    "with %.3fs jitter",
                     agent_id,
+                    jitter_seconds,
                 )
             except OSError as exc:
                 logger.warning(

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -8,6 +8,7 @@ it via ``host.docker.internal`` → host's 127.0.0.1."""
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Awaitable, Callable, Optional
 
 from aiohttp import web
@@ -38,6 +39,47 @@ def set_rpc_resolver(fn: Optional[RpcResolver]) -> None:
     """Daemon-side hook. ``None`` clears it; routes 503 while unset."""
     global _RPC_RESOLVER
     _RPC_RESOLVER = fn
+
+
+# Per-agent (generation, monotonic-arrival) of the last MCP subprocess
+# that reached this service. The worker's transport probe compares both
+# against the generation it minted for the current spec and the runtime's
+# open time — reachability is proven by the subprocess itself (the same
+# process a real tool call would come from), not inferred from our side.
+_MCP_HELLO_SEEN: dict[str, tuple[str, float]] = {}
+
+
+def record_mcp_hello(agent_id: str, generation: str) -> None:
+    _MCP_HELLO_SEEN[agent_id] = (generation, time.monotonic())
+
+
+def mcp_hello_state(agent_id: str) -> tuple[str, float]:
+    """Last (generation, monotonic arrival); ("", 0.0) when never seen."""
+    return _MCP_HELLO_SEEN.get(agent_id, ("", 0.0))
+
+
+def clear_mcp_hello(agent_id: str) -> None:
+    _MCP_HELLO_SEEN.pop(agent_id, None)
+
+
+async def mcp_hello_route(request: web.Request) -> web.Response:
+    """POST /v1/rpc/{agent_id}/mcp-hello — ``{generation}``.
+
+    Deliberately resolver-free: the handshake may arrive while the
+    worker is still warming, and recording it must not depend on a
+    warm ``HostMcpContext``."""
+    agent_id = request.match_info["agent_id"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "body must be JSON"}, status=400)
+    generation = body.get("generation") if isinstance(body, dict) else None
+    if not isinstance(generation, str) or not generation:
+        return web.json_response(
+            {"error": "generation must be a non-empty string"}, status=400,
+        )
+    record_mcp_hello(agent_id, generation)
+    return web.json_response({"message": "ok"})
 
 
 async def _dispatch(
@@ -671,6 +713,10 @@ def build_app(cfg: RpcServiceConfig) -> web.Application:
     app.router.add_post(
         "/v1/rpc/{agent_id}/replace-reminder",
         replace_reminder_route,
+    )
+    app.router.add_post(
+        "/v1/rpc/{agent_id}/mcp-hello",
+        mcp_hello_route,
     )
     return app
 

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -53,10 +53,16 @@ def set_rpc_resolver(fn: Optional[RpcResolver]) -> None:
 # evidence and drive false recycles. beacon-interval is the
 # subprocess's self-declared re-hello cadence (None for a startup-only
 # sender): the probe enforces freshness only where the capability was
-# declared. Per-agent generations are bounded: dead generations stop
-# re-recording, so trimming the oldest arrival keeps live ones and a
-# leaking predecessor cannot grow the map without bound.
+# declared. Per-agent generations are bounded, but surviving old
+# subprocesses keep re-recording their generations: with more live
+# senders than slots, a pure least-recently-heard trim would
+# periodically evict the current generation (whichever beaconed
+# longest ago) and fake a never-seen probe result. The probe is the
+# only reader, and it only ever asks about the generation it minted —
+# so the last-probed generation is pinned and never trimmed; zombie
+# generations are never probed and stay evictable.
 _MCP_HELLO_SEEN: dict[str, dict[str, tuple[float, float | None]]] = {}
+_MCP_HELLO_PROBED: dict[str, str] = {}
 _MCP_HELLO_MAX_GENERATIONS = 4
 
 
@@ -65,8 +71,10 @@ def record_mcp_hello(
 ) -> None:
     slots = _MCP_HELLO_SEEN.setdefault(agent_id, {})
     slots[generation] = (time.monotonic(), beacon_interval)
+    pinned = _MCP_HELLO_PROBED.get(agent_id)
     while len(slots) > _MCP_HELLO_MAX_GENERATIONS:
-        oldest = min(slots, key=lambda gen: slots[gen][0])
+        evictable = [gen for gen in slots if gen != pinned]
+        oldest = min(evictable, key=lambda gen: slots[gen][0])
         del slots[oldest]
 
 
@@ -75,6 +83,7 @@ def mcp_hello_state(
 ) -> tuple[float, float | None]:
     """Last (monotonic arrival, declared beacon interval) of a hello
     from exactly this generation; (0.0, None) when never seen."""
+    _MCP_HELLO_PROBED[agent_id] = generation
     slots = _MCP_HELLO_SEEN.get(agent_id)
     if not slots:
         return (0.0, None)
@@ -83,6 +92,7 @@ def mcp_hello_state(
 
 def clear_mcp_hello(agent_id: str) -> None:
     _MCP_HELLO_SEEN.pop(agent_id, None)
+    _MCP_HELLO_PROBED.pop(agent_id, None)
 
 
 async def mcp_hello_route(request: web.Request) -> web.Response:

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -41,21 +41,29 @@ def set_rpc_resolver(fn: Optional[RpcResolver]) -> None:
     _RPC_RESOLVER = fn
 
 
-# Per-agent (generation, monotonic-arrival) of the last MCP subprocess
-# that reached this service. The worker's transport probe compares both
-# against the generation it minted for the current spec and the runtime's
-# open time — reachability is proven by the subprocess itself (the same
-# process a real tool call would come from), not inferred from our side.
-_MCP_HELLO_SEEN: dict[str, tuple[str, float]] = {}
+# Per-agent (generation, monotonic-arrival, beacon-interval) of the last
+# MCP subprocess that reached this service. The worker's transport probe
+# compares generation and arrival against the generation it minted for
+# the current spec and the runtime's open time — reachability is proven
+# by the subprocess itself (the same process a real tool call would come
+# from), not inferred from our side. beacon-interval is the subprocess's
+# self-declared re-hello cadence (None for a startup-only sender): the
+# probe enforces freshness only where the capability was declared.
+_MCP_HELLO_SEEN: dict[str, tuple[str, float, float | None]] = {}
 
 
-def record_mcp_hello(agent_id: str, generation: str) -> None:
-    _MCP_HELLO_SEEN[agent_id] = (generation, time.monotonic())
+def record_mcp_hello(
+    agent_id: str, generation: str, beacon_interval: float | None = None,
+) -> None:
+    _MCP_HELLO_SEEN[agent_id] = (
+        generation, time.monotonic(), beacon_interval,
+    )
 
 
-def mcp_hello_state(agent_id: str) -> tuple[str, float]:
-    """Last (generation, monotonic arrival); ("", 0.0) when never seen."""
-    return _MCP_HELLO_SEEN.get(agent_id, ("", 0.0))
+def mcp_hello_state(agent_id: str) -> tuple[str, float, float | None]:
+    """Last (generation, monotonic arrival, declared beacon interval);
+    ("", 0.0, None) when never seen."""
+    return _MCP_HELLO_SEEN.get(agent_id, ("", 0.0, None))
 
 
 def clear_mcp_hello(agent_id: str) -> None:
@@ -63,7 +71,8 @@ def clear_mcp_hello(agent_id: str) -> None:
 
 
 async def mcp_hello_route(request: web.Request) -> web.Response:
-    """POST /v1/rpc/{agent_id}/mcp-hello — ``{generation}``.
+    """POST /v1/rpc/{agent_id}/mcp-hello — ``{generation,
+    beacon_interval?}``.
 
     Deliberately resolver-free: the handshake may arrive while the
     worker is still warming, and recording it must not depend on a
@@ -78,7 +87,21 @@ async def mcp_hello_route(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "generation must be a non-empty string"}, status=400,
         )
-    record_mcp_hello(agent_id, generation)
+    interval = body.get("beacon_interval")
+    if interval is not None and (
+        isinstance(interval, bool)
+        or not isinstance(interval, (int, float))
+        or interval <= 0
+    ):
+        return web.json_response(
+            {"error": "beacon_interval must be a positive number"},
+            status=400,
+        )
+    record_mcp_hello(
+        agent_id,
+        generation,
+        float(interval) if interval is not None else None,
+    )
     return web.json_response({"message": "ok"})
 
 

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -78,6 +78,17 @@ def record_mcp_hello(
         del slots[oldest]
 
 
+def pin_mcp_generation(agent_id: str, generation: str) -> None:
+    """Trim-protect this generation starting now.
+
+    Must be called where a generation is minted or switched (prepare,
+    recycle, refresh reload), not just from the probe: between the
+    mint and the first probe the registry would otherwise still pin
+    the predecessor, and zombie beacon pressure inside that window
+    could evict the new generation's hello and fake never-seen."""
+    _MCP_HELLO_PROBED[agent_id] = generation
+
+
 def mcp_hello_state(
     agent_id: str, generation: str,
 ) -> tuple[float, float | None]:

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -41,29 +41,43 @@ def set_rpc_resolver(fn: Optional[RpcResolver]) -> None:
     _RPC_RESOLVER = fn
 
 
-# Per-agent (generation, monotonic-arrival, beacon-interval) of the last
-# MCP subprocess that reached this service. The worker's transport probe
-# compares generation and arrival against the generation it minted for
-# the current spec and the runtime's open time — reachability is proven
-# by the subprocess itself (the same process a real tool call would come
-# from), not inferred from our side. beacon-interval is the subprocess's
-# self-declared re-hello cadence (None for a startup-only sender): the
-# probe enforces freshness only where the capability was declared.
-_MCP_HELLO_SEEN: dict[str, tuple[str, float, float | None]] = {}
+# Per-(agent, generation) (monotonic-arrival, beacon-interval) of the
+# last hello from that exact subprocess generation. The worker's
+# transport probe queries only the generation it minted for the current
+# spec — reachability is proven by the subprocess itself (the same
+# process a real tool call would come from), not inferred from our
+# side. Keying by generation matters: an old CLI's MCP subprocess is
+# not guaranteed to die with its parent, and a single per-agent slot
+# would let its surviving beacon overwrite the new generation's healthy
+# evidence and drive false recycles. beacon-interval is the
+# subprocess's self-declared re-hello cadence (None for a startup-only
+# sender): the probe enforces freshness only where the capability was
+# declared. Per-agent generations are bounded: dead generations stop
+# re-recording, so trimming the oldest arrival keeps live ones and a
+# leaking predecessor cannot grow the map without bound.
+_MCP_HELLO_SEEN: dict[str, dict[str, tuple[float, float | None]]] = {}
+_MCP_HELLO_MAX_GENERATIONS = 4
 
 
 def record_mcp_hello(
     agent_id: str, generation: str, beacon_interval: float | None = None,
 ) -> None:
-    _MCP_HELLO_SEEN[agent_id] = (
-        generation, time.monotonic(), beacon_interval,
-    )
+    slots = _MCP_HELLO_SEEN.setdefault(agent_id, {})
+    slots[generation] = (time.monotonic(), beacon_interval)
+    while len(slots) > _MCP_HELLO_MAX_GENERATIONS:
+        oldest = min(slots, key=lambda gen: slots[gen][0])
+        del slots[oldest]
 
 
-def mcp_hello_state(agent_id: str) -> tuple[str, float, float | None]:
-    """Last (generation, monotonic arrival, declared beacon interval);
-    ("", 0.0, None) when never seen."""
-    return _MCP_HELLO_SEEN.get(agent_id, ("", 0.0, None))
+def mcp_hello_state(
+    agent_id: str, generation: str,
+) -> tuple[float, float | None]:
+    """Last (monotonic arrival, declared beacon interval) of a hello
+    from exactly this generation; (0.0, None) when never seen."""
+    slots = _MCP_HELLO_SEEN.get(agent_id)
+    if not slots:
+        return (0.0, None)
+    return slots.get(generation, (0.0, None))
 
 
 def clear_mcp_hello(agent_id: str) -> None:

--- a/src/puffo_agent/portal/rpc_service.py
+++ b/src/puffo_agent/portal/rpc_service.py
@@ -8,6 +8,7 @@ it via ``host.docker.internal`` → host's 127.0.0.1."""
 from __future__ import annotations
 
 import logging
+import math
 import time
 from typing import Any, Awaitable, Callable, Optional
 
@@ -102,13 +103,17 @@ async def mcp_hello_route(request: web.Request) -> web.Response:
             {"error": "generation must be a non-empty string"}, status=400,
         )
     interval = body.get("beacon_interval")
+    # Python's json parser admits the non-standard Infinity/NaN literals;
+    # an infinite cadence would make the staleness window infinite and
+    # silently disable mid-life wedge detection, so require finite.
     if interval is not None and (
         isinstance(interval, bool)
         or not isinstance(interval, (int, float))
+        or not math.isfinite(interval)
         or interval <= 0
     ):
         return web.json_response(
-            {"error": "beacon_interval must be a positive number"},
+            {"error": "beacon_interval must be a positive finite number"},
             status=400,
         )
     record_mcp_hello(

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -237,6 +237,8 @@ def delete_flag_path(agent_id: str) -> Path:
 # All under ``<workspace>/.puffo-agent/`` so the location is reachable
 # from both the worker and the MCP subprocess in cli-docker.
 
+PROVIDER_AUTH_RELOAD_JITTER_MAX_SECONDS = 30.0
+
 
 def refresh_agent_flag_path(workspace: Path) -> Path:
     return workspace / ".puffo-agent" / "refresh_agent.flag"
@@ -256,7 +258,9 @@ def refresh_provider_auth_flag_path(workspace: Path) -> Path:
     Unlike ``refresh_session.flag``, this preserves the Puffo logical session
     and asks the harness to resume its native session with the replacement
     credential. The runtime manager falls back to a fresh native session only
-    when that saved session is explicitly unavailable.
+    when that saved session is explicitly unavailable. Daemon-authored payloads
+    include ``not_before_unix_ms`` so simultaneous fleet reloads can be spread
+    across a bounded jitter window without losing the durable request.
     """
     return workspace / ".puffo-agent" / "refresh_provider_auth.flag"
 

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -988,8 +988,15 @@ class RuntimeState:
     #                           next successful reconnect. Only ever
     #                           overwrites "ok" — the specific signals
     #                           above stay authoritative
+    #   "mcp_unreachable"     — the puffo MCP subprocess never reached the
+    #                           loopback RPC service (mcp-hello handshake)
+    #                           after a runtime open AND one automatic
+    #                           recycle; tool calls are likely timing out.
+    #                           Set only from ok/unknown; cleared by the
+    #                           probe when a current-generation hello
+    #                           arrives.
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | server_unreachable | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | server_unreachable | mcp_unreachable | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> RuntimeState | None:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -126,6 +126,11 @@ _WS_DEGRADE_THRESHOLD = 5
 # plus the subprocess's own 3×2s hello retry budget.
 _MCP_PROBE_GRACE_SECONDS = 30.0
 
+# A beacon-capable subprocess may miss this many of its own declared
+# re-hello intervals before its last hello stops counting as evidence
+# of a live transport.
+_MCP_BEACON_STALE_FACTOR = 3.0
+
 # Consecutive failed adapter reloads tolerated before the pending
 # refresh flags are abandoned and the failure becomes a health state.
 _REFRESH_RELOAD_FAILURE_CAP = 3
@@ -398,23 +403,45 @@ class Worker:
         """Heartbeat-cadence transport probe: the current runtime's puffo
         MCP subprocess must have reached the loopback RPC service
         (``mcp-hello`` with this spec's generation, after this runtime's
-        open). One miss past the grace window recycles the runtime —
-        the respawned subprocess re-fires hello; a second miss flips
-        ``mcp_unreachable`` so the wedge is visible instead of an
-        agent that wakes turns but can never read them (8/30-class
-        incident: alive worker, dead MCP, health ok for 51 min)."""
+        open) — and, when the subprocess declared a beacon cadence,
+        recently enough that the hello still stands for a live transport.
+        One miss past the grace window recycles the runtime through the
+        adapter (the rebuilt spec mints a fresh generation, so a
+        surviving pre-recycle subprocess can never impersonate the new
+        runtime's health); a second miss flips ``mcp_unreachable`` so
+        the wedge is visible instead of an agent that wakes turns but
+        can never read them (8/30-class incident: alive worker, dead
+        MCP, health ok for 51 min)."""
         from ..agent.harness.runtime.runtime_manager import get_runtime_manager
         from . import rpc_service
 
+        adapter = self._adapter
         mgr = get_runtime_manager(agent_id)
-        if mgr is None:
+        if adapter is None or mgr is None:
             return
-        spec_gen = getattr(mgr.spec, "mcp_generation", "")
-        opened_at = getattr(mgr, "last_open_monotonic", None)
+        # Direct attribute access on purpose: these are required contract
+        # fields, and producer/consumer drift must raise here instead of
+        # silently disabling recovery. Only value-level absence is
+        # legitimate (no puffo_core → empty generation; never opened →
+        # None) and returns quietly.
+        spec_gen = mgr.spec.mcp_generation
+        opened_at = mgr.last_open_monotonic
         if not spec_gen or opened_at is None:
             return
-        seen_gen, seen_at = rpc_service.mcp_hello_state(agent_id)
-        if seen_gen == spec_gen and seen_at >= opened_at:
+        now = time.monotonic()
+        seen_gen, seen_at, beacon_interval = rpc_service.mcp_hello_state(
+            agent_id
+        )
+        current = seen_gen == spec_gen and seen_at >= opened_at
+        # Freshness is only enforced against a subprocess that declared
+        # its own re-hello cadence; a startup-only predecessor (older
+        # package in a lagging Docker image) keeps handshake semantics
+        # and is never recycle-looped for going quiet.
+        stale = (
+            beacon_interval is not None
+            and now - seen_at > beacon_interval * _MCP_BEACON_STALE_FACTOR
+        )
+        if current and not stale:
             if self._mcp_probe_strikes:
                 logger.info(
                     "agent %s: puffo MCP transport recovered "
@@ -426,21 +453,33 @@ class Worker:
                 self.runtime.error = ""
                 self.runtime.save(agent_id)
             return
-        if time.monotonic() - opened_at < _MCP_PROBE_GRACE_SECONDS:
+        if now - opened_at < _MCP_PROBE_GRACE_SECONDS:
             return
         if self._turn_active:
             # A reload would raise mid-turn; check again next beat.
             return
         self._mcp_probe_strikes += 1
         if self._mcp_probe_strikes == 1:
+            if current:
+                cause = (
+                    f"hello beacon silent for {now - seen_at:.0f}s "
+                    f"(declared interval {beacon_interval:.0f}s)"
+                )
+            else:
+                cause = (
+                    "no hello from this spec's subprocess since runtime "
+                    f"open ({now - opened_at:.0f}s ago)"
+                )
             logger.error(
-                "agent %s: puffo MCP subprocess has not reached the RPC "
-                "service %.0fs after runtime open (generation=%s); "
-                "recycling the provider runtime",
-                agent_id, _MCP_PROBE_GRACE_SECONDS, spec_gen,
+                "agent %s: puffo MCP transport unhealthy — %s "
+                "(generation=%s); recycling the provider runtime with a "
+                "fresh mcp generation",
+                agent_id, cause, spec_gen,
             )
             try:
-                await mgr.reload_resources(preserve_session=True)
+                await adapter.reload(
+                    mgr.spec.system_prompt, with_session=False,
+                )
             except Exception as exc:  # noqa: BLE001
                 # Includes a turn racing us; keep the strike for next beat.
                 self._mcp_probe_strikes -= 1

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -429,10 +429,14 @@ class Worker:
         if not spec_gen or opened_at is None:
             return
         now = time.monotonic()
-        seen_gen, seen_at, beacon_interval = rpc_service.mcp_hello_state(
-            agent_id
+        # Query exactly this spec's generation: hello state is keyed per
+        # (agent, generation), so a surviving pre-recycle subprocess's
+        # beacon can neither impersonate this runtime nor overwrite its
+        # healthy evidence.
+        seen_at, beacon_interval = rpc_service.mcp_hello_state(
+            agent_id, spec_gen
         )
-        current = seen_gen == spec_gen and seen_at >= opened_at
+        current = seen_at > 0.0 and seen_at >= opened_at
         # Freshness is only enforced against a subprocess that declared
         # its own re-hello cadence; a startup-only predecessor (older
         # package in a lagging Docker image) keeps handshake semantics
@@ -470,22 +474,9 @@ class Worker:
                     "no hello from this spec's subprocess since runtime "
                     f"open ({now - opened_at:.0f}s ago)"
                 )
-            logger.error(
-                "agent %s: puffo MCP transport unhealthy — %s "
-                "(generation=%s); recycling the provider runtime with a "
-                "fresh mcp generation",
-                agent_id, cause, spec_gen,
+            await self._recycle_wedged_mcp(
+                agent_id, adapter, mgr, cause=cause, spec_gen=spec_gen,
             )
-            try:
-                await adapter.reload(
-                    mgr.spec.system_prompt, with_session=False,
-                )
-            except Exception as exc:  # noqa: BLE001
-                # Includes a turn racing us; keep the strike for next beat.
-                self._mcp_probe_strikes -= 1
-                logger.warning(
-                    "agent %s: MCP-probe recycle failed: %s", agent_id, exc,
-                )
             return
         if self.runtime.health in ("ok", "unknown"):
             self.runtime.health = "mcp_unreachable"
@@ -498,6 +489,28 @@ class Worker:
             logger.error(
                 "agent %s: MCP transport still unreachable after recycle; "
                 "runtime.health = mcp_unreachable", agent_id,
+            )
+
+    async def _recycle_wedged_mcp(
+        self, agent_id: str, adapter, mgr, *, cause: str, spec_gen: str,
+    ) -> None:
+        """First-strike response: recycle through the adapter-level
+        reload so the rebuilt spec mints a fresh mcp generation."""
+        logger.error(
+            "agent %s: puffo MCP transport unhealthy — %s "
+            "(generation=%s); recycling the provider runtime with a "
+            "fresh mcp generation",
+            agent_id, cause, spec_gen,
+        )
+        try:
+            await adapter.reload(
+                mgr.spec.system_prompt, with_session=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Includes a turn racing us; keep the strike for next beat.
+            self._mcp_probe_strikes -= 1
+            logger.warning(
+                "agent %s: MCP-probe recycle failed: %s", agent_id, exc,
             )
 
     def _note_refresh_reload(

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -119,6 +119,15 @@ RECONNECT_BACKOFF_SECONDS = 5.0
 # minute instead of "ok" for hours. One successful reconnect clears it.
 _WS_DEGRADE_THRESHOLD = 5
 
+# How long after a runtime open the MCP subprocess gets to say hello
+# before the probe treats the transport as wedged. Covers a slow spawn
+# plus the subprocess's own 3×2s hello retry budget.
+_MCP_PROBE_GRACE_SECONDS = 30.0
+
+# Consecutive failed adapter reloads tolerated before the pending
+# refresh flags are abandoned and the failure becomes a health state.
+_REFRESH_RELOAD_FAILURE_CAP = 3
+
 
 def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
     if harness_name != "claude-code":
@@ -362,6 +371,105 @@ class Worker:
         self.runtime.status = "running"
         self.runtime.save(agent_id)
         self._warm_done.set()
+
+    async def probe_mcp_transport(self, agent_id: str) -> None:
+        """Heartbeat-cadence transport probe: the current runtime's puffo
+        MCP subprocess must have reached the loopback RPC service
+        (``mcp-hello`` with this spec's generation, after this runtime's
+        open). One miss past the grace window recycles the runtime —
+        the respawned subprocess re-fires hello; a second miss flips
+        ``mcp_unreachable`` so the wedge is visible instead of an
+        agent that wakes turns but can never read them (8/30-class
+        incident: alive worker, dead MCP, health ok for 51 min)."""
+        from ..agent.harness.runtime.runtime_manager import get_runtime_manager
+        from . import rpc_service
+
+        mgr = get_runtime_manager(agent_id)
+        if mgr is None:
+            return
+        spec_gen = getattr(mgr.spec, "mcp_generation", "")
+        opened_at = getattr(mgr, "last_open_monotonic", None)
+        if not spec_gen or opened_at is None:
+            return
+        seen_gen, seen_at = rpc_service.mcp_hello_state(agent_id)
+        if seen_gen == spec_gen and seen_at >= opened_at:
+            if self._mcp_probe_strikes:
+                logger.info(
+                    "agent %s: puffo MCP transport recovered "
+                    "(generation=%s)", agent_id, spec_gen,
+                )
+            self._mcp_probe_strikes = 0
+            if self.runtime.health == "mcp_unreachable":
+                self.runtime.health = "ok"
+                self.runtime.error = ""
+                self.runtime.save(agent_id)
+            return
+        if time.monotonic() - opened_at < _MCP_PROBE_GRACE_SECONDS:
+            return
+        if self._turn_active:
+            # A reload would raise mid-turn; check again next beat.
+            return
+        self._mcp_probe_strikes += 1
+        if self._mcp_probe_strikes == 1:
+            logger.error(
+                "agent %s: puffo MCP subprocess has not reached the RPC "
+                "service %.0fs after runtime open (generation=%s); "
+                "recycling the provider runtime",
+                agent_id, _MCP_PROBE_GRACE_SECONDS, spec_gen,
+            )
+            try:
+                await mgr.reload_resources(preserve_session=True)
+            except Exception as exc:  # noqa: BLE001
+                # Includes a turn racing us; keep the strike for next beat.
+                self._mcp_probe_strikes -= 1
+                logger.warning(
+                    "agent %s: MCP-probe recycle failed: %s", agent_id, exc,
+                )
+            return
+        if self.runtime.health in ("ok", "unknown"):
+            self.runtime.health = "mcp_unreachable"
+            self.runtime.error = (
+                "puffo MCP subprocess never reached the daemon RPC "
+                "service after a runtime recycle; tool calls are likely "
+                "timing out. Restart this worker."
+            )
+            self.runtime.save(agent_id)
+            logger.error(
+                "agent %s: MCP transport still unreachable after recycle; "
+                "runtime.health = mcp_unreachable", agent_id,
+            )
+
+    def _note_refresh_reload(
+        self, ok: bool, flags: tuple[Path, ...], agent_id: str
+    ) -> None:
+        """Give-up policy for ``_process_refresh_flags`` failures: the
+        flags survive ``_REFRESH_RELOAD_FAILURE_CAP`` consecutive failed
+        reloads (each turn-start / watcher tick retries), then they are
+        abandoned into an explicit health state — a worker must not spin
+        on a reload that will never succeed, and it must not pretend the
+        refresh was applied either."""
+        if ok:
+            self._refresh_reload_failures = 0
+            return
+        self._refresh_reload_failures += 1
+        if self._refresh_reload_failures < _REFRESH_RELOAD_FAILURE_CAP:
+            return
+        self._refresh_reload_failures = 0
+        _unlink_refresh_flags(*flags)
+        logger.error(
+            "agent %s: adapter reload failed %d consecutive times; "
+            "abandoning pending refresh flags — the provider runtime is "
+            "still on its pre-refresh state",
+            agent_id, _REFRESH_RELOAD_FAILURE_CAP,
+        )
+        if self.runtime.health in ("ok", "unknown"):
+            self.runtime.health = "provider_error"
+            self.runtime.error = (
+                "provider runtime reload kept failing after a refresh "
+                "(credentials/profile may not be applied). Restart this "
+                "worker."
+            )
+            self.runtime.save(agent_id)
 
     @staticmethod
     def _reassert_auth_failed_after_failed_probe(
@@ -832,6 +940,11 @@ class Worker:
         self._reload_lock = asyncio.Lock()
         self._turn_active = False
         self._refresh_now = asyncio.Event()
+        # MCP transport probe state (see ``probe_mcp_transport``): missed
+        # handshakes since the last confirmed one, and how many consecutive
+        # adapter reloads failed before their flags were abandoned.
+        self._mcp_probe_strikes = 0
+        self._refresh_reload_failures = 0
 
     def notify_refresh(self) -> None:
         """Wake the proactive refresh watcher now (sub-poll latency).
@@ -1235,18 +1348,24 @@ async def _process_refresh_flags(
     role_short: str = "",
     puffo_handle: str = "",
     workspace_shared_status: str = "existing",
-) -> None:
+) -> bool:
     """Consume worker refresh flags in one idle-boundary adapter reload.
 
     Resource and credential changes preserve session identity. Only an explicit
     session refresh starts a new logical and native provider conversation.
+
+    Returns whether the reload succeeded. On failure the flag files are
+    kept byte-for-byte (their content may carry scheduling fields owned
+    by the daemon) so the next turn-start or watcher tick retries; the
+    caller owns the give-up policy (``Worker._note_refresh_reload``).
+    Everything that runs before the reload is idempotent re-run work.
     """
-    host_sync_seen = refresh_host_sync_flag.exists()
-    agent_seen = refresh_agent_flag.exists()
-    session_seen = refresh_session_flag.exists()
-    provider_auth_seen = refresh_provider_auth_flag.exists()
+    host_sync_seen = _refresh_flag_is_pending(refresh_host_sync_flag)
+    agent_seen = _refresh_flag_is_pending(refresh_agent_flag)
+    session_seen = _refresh_flag_is_pending(refresh_session_flag)
+    provider_auth_seen = _refresh_flag_is_pending(refresh_provider_auth_flag)
     if not (host_sync_seen or agent_seen or session_seen or provider_auth_seen):
-        return
+        return True
 
     if host_sync_seen:
         _sync_refresh_host_assets(agent_id)
@@ -1293,17 +1412,32 @@ async def _process_refresh_flags(
             )
     except Exception as exc:
         logger.warning(
-            "agent %s: adapter.reload after refresh failed: %s",
+            "agent %s: adapter.reload after refresh failed "
+            "(flags kept for retry): %s",
             agent_id,
             exc,
         )
+        return False
 
-    for flag in (
+    _unlink_refresh_flags(
         refresh_host_sync_flag,
         refresh_agent_flag,
         refresh_session_flag,
         refresh_provider_auth_flag,
-    ):
+    )
+    return True
+
+
+def _refresh_flag_is_pending(flag: Path) -> bool:
+    """Whether a refresh flag is due for consumption. Existence-only
+    here; the credential-reload jitter branch supersedes this body with
+    the ``not_before_unix_ms``-aware variant (a flag persisted with a
+    future not-before is "recorded but not yet pending")."""
+    return flag.exists()
+
+
+def _unlink_refresh_flags(*flags: Path) -> None:
+    for flag in flags:
         try:
             flag.unlink()
         except OSError:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -792,8 +792,8 @@ class Worker:
         agent_id: str,
         log: logging.Logger,
     ) -> None:
-        """Override any sticky red with ``in_progress`` at batch-top."""
-        if runtime.health == "in_progress":
+        """Mark batch work without hiding an independently probed MCP wedge."""
+        if runtime.health in {"in_progress", "mcp_unreachable"}:
             return
         runtime.health = "in_progress"
         runtime.error = ""
@@ -1451,14 +1451,6 @@ async def _process_refresh_flags(
         refresh_provider_auth_flag,
     )
     return True
-
-
-def _refresh_flag_is_pending(flag: Path) -> bool:
-    """Whether a refresh flag is due for consumption. Existence-only
-    here; the credential-reload jitter branch supersedes this body with
-    the ``not_before_unix_ms``-aware variant (a flag persisted with a
-    future not-before is "recorded but not yet pending")."""
-    return flag.exists()
 
 
 def _unlink_refresh_flags(*flags: Path) -> None:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -131,8 +131,8 @@ _MCP_PROBE_GRACE_SECONDS = 30.0
 _REFRESH_RELOAD_FAILURE_CAP = 3
 
 
-def _provider_auth_reload_delay_seconds(flag: Path) -> float:
-    """Return the bounded remaining delay from a credential-reload request."""
+def _refresh_flag_delay_seconds(flag: Path) -> float:
+    """Return a bounded remaining delay encoded in a refresh flag."""
     try:
         request = json.loads(flag.read_text(encoding="utf-8"))
         if not isinstance(request, dict):
@@ -146,19 +146,9 @@ def _provider_auth_reload_delay_seconds(flag: Path) -> float:
         return 0.0
 
 
-async def _wait_for_provider_auth_reload_jitter(
-    agent_id: str, flag: Path,
-) -> None:
-    delay_seconds = _provider_auth_reload_delay_seconds(flag)
-    if not delay_seconds:
-        return
-    logger.info(
-        "agent %s: delaying provider reload %.3fs to stagger "
-        "credential-refresh fan-out",
-        agent_id,
-        delay_seconds,
-    )
-    await asyncio.sleep(delay_seconds)
+def _refresh_flag_is_pending(flag: Path) -> bool:
+    """A future-dated durable request exists but is not pending yet."""
+    return flag.exists() and _refresh_flag_delay_seconds(flag) <= 0.0
 
 
 def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
@@ -998,7 +988,7 @@ class Worker:
         if self._turn_active:
             # A turn owns flag consumption; never apply mid-turn.
             return False
-        if not any(p.exists() for p in flag_paths):
+        if not any(_refresh_flag_is_pending(p) for p in flag_paths):
             # Cheap exists() check before taking the lock.
             return False
         async with self._reload_lock:
@@ -1395,14 +1385,12 @@ async def _process_refresh_flags(
     host_sync_seen = _refresh_flag_is_pending(refresh_host_sync_flag)
     agent_seen = _refresh_flag_is_pending(refresh_agent_flag)
     session_seen = _refresh_flag_is_pending(refresh_session_flag)
+    provider_auth_exists = refresh_provider_auth_flag.exists()
     provider_auth_seen = _refresh_flag_is_pending(refresh_provider_auth_flag)
+    if provider_auth_exists and (host_sync_seen or agent_seen or session_seen):
+        provider_auth_seen = True
     if not (host_sync_seen or agent_seen or session_seen or provider_auth_seen):
         return True
-
-    if provider_auth_seen and not (host_sync_seen or agent_seen or session_seen):
-        await _wait_for_provider_auth_reload_jitter(
-            agent_id, refresh_provider_auth_flag
-        )
 
     if host_sync_seen:
         _sync_refresh_host_assets(agent_id)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -512,6 +512,16 @@ class Worker:
             logger.warning(
                 "agent %s: MCP-probe recycle failed: %s", agent_id, exc,
             )
+            return
+        from . import rpc_service
+
+        # Pin the freshly minted generation at the switch, not at the
+        # next probe: zombie beacon pressure inside that window could
+        # trim its hello and fake never-seen (a recycle loop on a
+        # healthy runtime).
+        new_gen = mgr.spec.mcp_generation
+        if new_gen:
+            rpc_service.pin_mcp_generation(agent_id, new_gen)
 
     def _note_refresh_reload(
         self, ok: bool, flags: tuple[Path, ...], agent_id: str
@@ -1496,13 +1506,24 @@ async def _process_refresh_flags(
         )
         return False
 
+    _pin_refreshed_generation(agent_id)
     _unlink_refresh_flags(
-        refresh_host_sync_flag,
-        refresh_agent_flag,
-        refresh_session_flag,
-        refresh_provider_auth_flag,
+        refresh_host_sync_flag, refresh_agent_flag,
+        refresh_session_flag, refresh_provider_auth_flag,
     )
     return True
+
+
+def _pin_refreshed_generation(agent_id: str) -> None:
+    """The refresh reload rebuilt the spec and minted a fresh mcp
+    generation: pin it at the switch (see
+    ``rpc_service.pin_mcp_generation``)."""
+    from ..agent.harness.runtime.runtime_manager import get_runtime_manager
+    from . import rpc_service
+
+    mgr = get_runtime_manager(agent_id)
+    if mgr is not None and mgr.spec.mcp_generation:
+        rpc_service.pin_mcp_generation(agent_id, mgr.spec.mcp_generation)
 
 
 def _unlink_refresh_flags(*flags: Path) -> None:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -7,6 +7,7 @@ into runtime.json so the CLI can read live stats without IPC.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -43,6 +44,7 @@ from ..agent.shared_content import rebuild_agent_claude_md, rebuild_agent_codex_
 from .state import (
     AgentConfig,
     DaemonConfig,
+    PROVIDER_AUTH_RELOAD_JITTER_MAX_SECONDS,
     RuntimeState,
     agent_claude_user_dir,
     agent_codex_user_dir,
@@ -127,6 +129,36 @@ _MCP_PROBE_GRACE_SECONDS = 30.0
 # Consecutive failed adapter reloads tolerated before the pending
 # refresh flags are abandoned and the failure becomes a health state.
 _REFRESH_RELOAD_FAILURE_CAP = 3
+
+
+def _provider_auth_reload_delay_seconds(flag: Path) -> float:
+    """Return the bounded remaining delay from a credential-reload request."""
+    try:
+        request = json.loads(flag.read_text(encoding="utf-8"))
+        if not isinstance(request, dict):
+            return 0.0
+        not_before_ms = request.get("not_before_unix_ms")
+        if not isinstance(not_before_ms, (int, float)):
+            return 0.0
+        remaining = (float(not_before_ms) / 1000.0) - time.time()
+        return min(max(remaining, 0.0), PROVIDER_AUTH_RELOAD_JITTER_MAX_SECONDS)
+    except (OSError, ValueError, TypeError):
+        return 0.0
+
+
+async def _wait_for_provider_auth_reload_jitter(
+    agent_id: str, flag: Path,
+) -> None:
+    delay_seconds = _provider_auth_reload_delay_seconds(flag)
+    if not delay_seconds:
+        return
+    logger.info(
+        "agent %s: delaying provider reload %.3fs to stagger "
+        "credential-refresh fan-out",
+        agent_id,
+        delay_seconds,
+    )
+    await asyncio.sleep(delay_seconds)
 
 
 def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
@@ -1366,6 +1398,11 @@ async def _process_refresh_flags(
     provider_auth_seen = _refresh_flag_is_pending(refresh_provider_auth_flag)
     if not (host_sync_seen or agent_seen or session_seen or provider_auth_seen):
         return True
+
+    if provider_auth_seen and not (host_sync_seen or agent_seen or session_seen):
+        await _wait_for_provider_auth_reload_jitter(
+            agent_id, refresh_provider_auth_flag
+        )
 
     if host_sync_seen:
         _sync_refresh_host_assets(agent_id)

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -622,7 +622,7 @@ class StandardWorkerRun:
         ) = context.paths.refresh_flags
         paths = context.paths
         worker = self.worker
-        await worker_module._process_refresh_flags(
+        ok = await worker_module._process_refresh_flags(
             agent_id=paths.agent_id,
             harness_name=paths.effective_harness,
             shared_path=paths.shared_path,
@@ -640,6 +640,11 @@ class StandardWorkerRun:
             refresh_host_sync_flag=refresh_host,
             refresh_session_flag=refresh_session,
             refresh_provider_auth_flag=refresh_provider_auth,
+        )
+        worker._note_refresh_reload(
+            ok,
+            (refresh_agent, refresh_host, refresh_session, refresh_provider_auth),
+            paths.agent_id,
         )
 
     async def _execute_global_turn(self, context: WorkerRunContext, planned):
@@ -785,6 +790,14 @@ class StandardWorkerRun:
         interval = max(1.0, worker.daemon_cfg.runtime_heartbeat_seconds)
         while not worker._stop.is_set():
             worker.runtime.save(agent_id)
+            try:
+                await worker.probe_mcp_transport(agent_id)
+            except Exception:  # noqa: BLE001
+                # The probe must never take the heartbeat down with it.
+                logger.warning(
+                    "agent %s: MCP transport probe raised", agent_id,
+                    exc_info=True,
+                )
             try:
                 await asyncio.wait_for(worker._stop.wait(), timeout=interval)
             except asyncio.TimeoutError:

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -399,22 +399,29 @@ class StandardWorkerRun:
                 process_factory=preparer.process_factory,
             )
             cleanup = preparer.aclose
+        from . import rpc_service
+
+        agent_id = prepared.preparer.agent_id
+
+        def pin_generation(generation: str) -> None:
+            # Runs between the spec reload minting a fresh generation
+            # and the reopen: the pin must move before the new
+            # subprocess can hello, or zombie beacon pressure inside
+            # that window trims the hello and fakes never-seen.
+            rpc_service.pin_mcp_generation(agent_id, generation)
+
         worker._adapter = build_local_runtime_adapter(
             prepared,
             outbox=outbox,
             logical_session_ref=session_ref,
             driver=driver,
             cleanup=cleanup,
+            generation_sink=pin_generation,
         )
         # Pin the initial mcp generation at the mint, not at the first
-        # probe: zombie beacon pressure inside that window could trim
-        # its hello and fake never-seen (see rpc_service).
+        # probe (same window as above, prepare-time edition).
         if prepared.spec.mcp_generation:
-            from . import rpc_service
-
-            rpc_service.pin_mcp_generation(
-                prepared.preparer.agent_id, prepared.spec.mcp_generation
-            )
+            pin_generation(prepared.spec.mcp_generation)
         return outbox, session_ref, prepared
 
     async def _abort_docker_preparation(self, preparer: Any) -> None:

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -406,6 +406,15 @@ class StandardWorkerRun:
             driver=driver,
             cleanup=cleanup,
         )
+        # Pin the initial mcp generation at the mint, not at the first
+        # probe: zombie beacon pressure inside that window could trim
+        # its hello and fake never-seen (see rpc_service).
+        if prepared.spec.mcp_generation:
+            from . import rpc_service
+
+            rpc_service.pin_mcp_generation(
+                prepared.preparer.agent_id, prepared.spec.mcp_generation
+            )
         return outbox, session_ref, prepared
 
     async def _abort_docker_preparation(self, preparer: Any) -> None:

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -678,13 +678,8 @@ def test_process_refresh_flags_honors_provider_reload_not_before(
         '{"source":"credential_replaced","not_before_unix_ms":10500}',
         encoding="utf-8",
     )
-    delays = []
-
-    async def record_sleep(delay):
-        delays.append(delay)
-
-    monkeypatch.setattr(worker_mod.time, "time", lambda: 10.0)
-    monkeypatch.setattr(worker_mod.asyncio, "sleep", record_sleep)
+    now = {"value": 10.0}
+    monkeypatch.setattr(worker_mod.time, "time", lambda: now["value"])
     _run(worker_mod._process_refresh_flags(
         agent_id="t",
         harness_name="claude-code",
@@ -700,15 +695,30 @@ def test_process_refresh_flags_honors_provider_reload_not_before(
         refresh_provider_auth_flag=provider_flag,
     ))
 
-    assert delays == [0.5]
+    assert adapter.reload_calls == []
+    assert provider_flag.exists()
+
+    now["value"] = 10.5
+    _run(worker_mod._process_refresh_flags(
+        agent_id="t", harness_name="claude-code",
+        shared_path=tmp_path / "shared", profile_path=str(tmp_path / "profile.md"),
+        memory_path=str(tmp_path / "memory"), workspace_path=str(tmp_path),
+        puffo=_FakePuffo(prompt="preserved"), adapter=adapter,
+        refresh_agent_flag=tmp_path / "refresh_agent.flag",
+        refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
+        refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=provider_flag,
+    ))
     assert adapter.reload_calls == [("preserved", False)]
+    assert not provider_flag.exists()
 
     # An explicit user/session refresh already spreads naturally and should
     # not inherit the daemon's background credential jitter.
     provider_flag.write_text(
-        '{"source":"credential_replaced","not_before_unix_ms":10500}',
+        '{"source":"credential_replaced","not_before_unix_ms":11000}',
         encoding="utf-8",
     )
+    now["value"] = 10.5
     session_flag = tmp_path / "refresh_session.flag"
     session_flag.write_text("{}", encoding="utf-8")
     _run(worker_mod._process_refresh_flags(
@@ -721,8 +731,8 @@ def test_process_refresh_flags_honors_provider_reload_not_before(
         refresh_session_flag=session_flag,
         refresh_provider_auth_flag=provider_flag,
     ))
-    assert delays == [0.5]
     assert adapter.reload_calls[-1] == ("preserved", True)
+    assert not provider_flag.exists()
 
 
 def test_process_refresh_flags_deletes_flags_after_processing(tmp_path, monkeypatch):

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -666,6 +666,65 @@ def test_process_refresh_flags_provider_auth_preserves_session(tmp_path):
     assert not provider_flag.exists()
 
 
+def test_process_refresh_flags_honors_provider_reload_not_before(
+    tmp_path, monkeypatch,
+):
+    """Fleet credential fan-out waits for each persisted jitter deadline."""
+    from puffo_agent.portal import worker as worker_mod
+
+    adapter = _FakeAdapter()
+    provider_flag = tmp_path / "refresh_provider_auth.flag"
+    provider_flag.write_text(
+        '{"source":"credential_replaced","not_before_unix_ms":10500}',
+        encoding="utf-8",
+    )
+    delays = []
+
+    async def record_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(worker_mod.time, "time", lambda: 10.0)
+    monkeypatch.setattr(worker_mod.asyncio, "sleep", record_sleep)
+    _run(worker_mod._process_refresh_flags(
+        agent_id="t",
+        harness_name="claude-code",
+        shared_path=tmp_path / "shared",
+        profile_path=str(tmp_path / "profile.md"),
+        memory_path=str(tmp_path / "memory"),
+        workspace_path=str(tmp_path),
+        puffo=_FakePuffo(prompt="preserved"),
+        adapter=adapter,
+        refresh_agent_flag=tmp_path / "refresh_agent.flag",
+        refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
+        refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=provider_flag,
+    ))
+
+    assert delays == [0.5]
+    assert adapter.reload_calls == [("preserved", False)]
+
+    # An explicit user/session refresh already spreads naturally and should
+    # not inherit the daemon's background credential jitter.
+    provider_flag.write_text(
+        '{"source":"credential_replaced","not_before_unix_ms":10500}',
+        encoding="utf-8",
+    )
+    session_flag = tmp_path / "refresh_session.flag"
+    session_flag.write_text("{}", encoding="utf-8")
+    _run(worker_mod._process_refresh_flags(
+        agent_id="t", harness_name="claude-code",
+        shared_path=tmp_path / "shared", profile_path=str(tmp_path / "profile.md"),
+        memory_path=str(tmp_path / "memory"), workspace_path=str(tmp_path),
+        puffo=_FakePuffo(prompt="preserved"), adapter=adapter,
+        refresh_agent_flag=tmp_path / "refresh_agent.flag",
+        refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
+        refresh_session_flag=session_flag,
+        refresh_provider_auth_flag=provider_flag,
+    ))
+    assert delays == [0.5]
+    assert adapter.reload_calls[-1] == ("preserved", True)
+
+
 def test_process_refresh_flags_deletes_flags_after_processing(tmp_path, monkeypatch):
     from puffo_agent.portal import worker as worker_mod
     monkeypatch.setattr(

--- a/tests/test_credential_external_rotation.py
+++ b/tests/test_credential_external_rotation.py
@@ -277,6 +277,24 @@ def test_on_refresh_success_reloads_healthy_agent(tmp_path, monkeypatch):
     assert w.refresh_notifications == 1
 
 
+def test_on_refresh_success_persists_bounded_reload_jitter(tmp_path, monkeypatch):
+    from puffo_agent.portal import daemon as daemon_module
+
+    d, _w, flag = _daemon_harness(monkeypatch, tmp_path, "ok")
+    monkeypatch.setattr(
+        daemon_module, "_provider_auth_reload_jitter_seconds", lambda: 17.5
+    )
+    monkeypatch.setattr(daemon_module.time, "time", lambda: 100.0)
+
+    d.refresher.callback()
+
+    assert json.loads(flag.read_text(encoding="utf-8")) == {
+        "source": "credential_replaced",
+        "jitter_seconds": 17.5,
+        "not_before_unix_ms": 117500,
+    }
+
+
 # ── new message while auth_failed wakes the refresher ──────────────
 
 

--- a/tests/test_global_inbox_runtime.py
+++ b/tests/test_global_inbox_runtime.py
@@ -1657,6 +1657,51 @@ async def test_success_without_inbox_read_leaves_messages_pending(
 
 
 @pytest.mark.asyncio
+async def test_repeated_empty_notice_turns_warn_of_possible_mcp_failure(
+    tmp_path, caplog,
+):
+    """A wedged MCP lane must not leave repeated empty turns log-silent."""
+    caplog.set_level(logging.WARNING)
+    store = await make_store(tmp_path)
+    adapter = Adapter()
+    should_read = False
+
+    async def ignore_notice(_planned):
+        if should_read:
+            await adapter.admit()
+            await runtime.read_inbox(limit=50)
+        return None
+
+    runtime = GlobalInboxRuntime(
+        store=store,
+        adapter=adapter,
+        run_turn=ignore_notice,
+        workspace=tmp_path,
+        agent_id="agent-stuck",
+    )
+
+    for seq in range(1, 4):
+        await receipt(store, f"pending-{seq}", seq)
+        assert await runtime.process_once()
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if "possible MCP control-plane failure" in record.getMessage()
+    ]
+    assert warnings == [
+        "agent agent-stuck: possible MCP control-plane failure — 3 "
+        "consecutive Inbox notice turns completed without read_inbox "
+        "admission while messages remain pending"
+    ]
+    should_read = True
+    await receipt(store, "pending-4", 4)
+    assert await runtime.process_once()
+    assert runtime._mcp_silence_streak == 0
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_held_watermark_sync_proof_returns_local_semantic_rows_without_admission(
     tmp_path,
 ):

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -6,12 +6,22 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from puffo_agent.agent.harness.driver import (
+    ProtocolDiagnostics,
+    RuntimeOpened,
+    RuntimeRef,
+    RuntimeSpec,
+    SessionRef,
+)
+from puffo_agent.agent.harness.drivers.codex import CODEX_CAPABILITIES
+from puffo_agent.agent.harness.runtime.runtime_manager import RuntimeManager
 from puffo_agent.portal import rpc_service
 from puffo_agent.portal.state import (
     AgentConfig,
@@ -56,17 +66,24 @@ def _flags_kwargs(tmp_path: Path, adapter) -> dict:
     )
 
 
-def test_failed_reload_keeps_flags_byte_for_byte(tmp_path):
+def test_failed_reload_keeps_scheduled_flag_byte_for_byte(tmp_path, monkeypatch):
     """A failed reload must not consume the refresh intent: the flag
     files survive unmodified (their content may carry daemon-owned
     scheduling fields) and the call reports failure."""
+    from puffo_agent.portal import worker as worker_mod
+
     provider_flag = tmp_path / "refresh_provider_auth.flag"
-    provider_flag.write_text('{"not_before": 123.0}', encoding="utf-8")
+    payload = (
+        '{"source":"credential_replaced",'
+        '"not_before_unix_ms":500}'
+    )
+    provider_flag.write_text(payload, encoding="utf-8")
+    monkeypatch.setattr(worker_mod.time, "time", lambda: 1.0)
 
     ok = _run(_process_refresh_flags(**_flags_kwargs(tmp_path, _FailingAdapter())))
 
     assert ok is False
-    assert provider_flag.read_text(encoding="utf-8") == '{"not_before": 123.0}'
+    assert provider_flag.read_text(encoding="utf-8") == payload
 
 
 def _seed_worker(health: str = "ok") -> Worker:
@@ -160,6 +177,53 @@ def test_probe_recycles_then_flips_health(registered_manager, saved_states):
     assert ("t", "mcp_unreachable", worker.runtime.error) in saved_states
 
 
+def test_runtime_open_watermark_precedes_current_generation_hello():
+    """A hello emitted during driver.open belongs to the runtime being opened."""
+    class _HelloDuringOpenDriver:
+        def __init__(self):
+            self.queue: asyncio.Queue = asyncio.Queue()
+
+        async def open(self, _spec, _resume=None):
+            rpc_service.record_mcp_hello("opening", "g-current")
+            return RuntimeOpened(
+                RuntimeRef("runtime"),
+                SessionRef("session"),
+                "native",
+                False,
+                CODEX_CAPABILITIES,
+                ProtocolDiagnostics(),
+            )
+
+        def events(self):
+            async def iterate():
+                while True:
+                    event = await self.queue.get()
+                    if event is None:
+                        return
+                    yield event
+            return iterate()
+
+        async def close(self):
+            await self.queue.put(None)
+
+    async def scenario():
+        rpc_service.clear_mcp_hello("opening")
+        manager = RuntimeManager(
+            _HelloDuringOpenDriver(),
+            RuntimeSpec("/tmp", mcp_generation="g-current"),
+        )
+        try:
+            await manager.open()
+            generation, seen_at = rpc_service.mcp_hello_state("opening")
+            assert generation == "g-current"
+            assert seen_at >= manager.last_open_monotonic
+        finally:
+            await manager.close()
+            rpc_service.clear_mcp_hello("opening")
+
+    _run(scenario())
+
+
 def test_probe_hello_clears_wedge_state(registered_manager, saved_states):
     opened_at = time.monotonic() - 120
     registered_manager(_FakeManager("g1", opened_at))
@@ -171,6 +235,20 @@ def test_probe_hello_clears_wedge_state(registered_manager, saved_states):
 
     assert worker._mcp_probe_strikes == 0
     assert worker.runtime.health == "ok"
+
+
+def test_empty_turn_cannot_clear_mcp_unreachable(saved_states):
+    """Only a current-generation hello proves that the MCP lane recovered."""
+    worker = _seed_worker(health="mcp_unreachable")
+    worker.runtime.error = "puffo MCP subprocess never reached the daemon RPC service"
+
+    log = logging.getLogger(__name__)
+    Worker._flip_health_in_progress(worker.runtime, "t", log)
+    Worker._resolve_health_on_success(worker.runtime, "t", log)
+
+    assert worker.runtime.health == "mcp_unreachable"
+    assert "never reached" in worker.runtime.error
+    assert saved_states == []
 
 
 def test_probe_ignores_stale_generation_hello(registered_manager):

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -1,0 +1,306 @@
+"""MCP transport wedge fixes (2026-09-03 incident): the generation
+handshake probe, the hello RPC route, per-spawn config generations, and
+refresh flags surviving a failed reload."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.portal import rpc_service
+from puffo_agent.portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    PuffoCoreConfig,
+    RuntimeConfig,
+    RuntimeState,
+)
+from puffo_agent.portal.worker import (
+    Worker,
+    _REFRESH_RELOAD_FAILURE_CAP,
+    _process_refresh_flags,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── refresh flags survive a failed reload ──────────────────────────────
+
+
+class _FailingAdapter:
+    async def reload(self, new_system_prompt, *, with_session=False):
+        raise RuntimeError("cannot reload while a turn is active")
+
+
+def _flags_kwargs(tmp_path: Path, adapter) -> dict:
+    return dict(
+        agent_id="t",
+        harness_name="claude-code",
+        shared_path=tmp_path / "shared",
+        profile_path=str(tmp_path / "profile.md"),
+        memory_path=str(tmp_path / "memory"),
+        workspace_path=str(tmp_path),
+        puffo=SimpleNamespace(system_prompt="p"),
+        adapter=adapter,
+        refresh_agent_flag=tmp_path / "refresh_agent.flag",
+        refresh_host_sync_flag=tmp_path / "refresh_host_sync.flag",
+        refresh_session_flag=tmp_path / "refresh_session.flag",
+        refresh_provider_auth_flag=tmp_path / "refresh_provider_auth.flag",
+    )
+
+
+def test_failed_reload_keeps_flags_byte_for_byte(tmp_path):
+    """A failed reload must not consume the refresh intent: the flag
+    files survive unmodified (their content may carry daemon-owned
+    scheduling fields) and the call reports failure."""
+    provider_flag = tmp_path / "refresh_provider_auth.flag"
+    provider_flag.write_text('{"not_before": 123.0}', encoding="utf-8")
+
+    ok = _run(_process_refresh_flags(**_flags_kwargs(tmp_path, _FailingAdapter())))
+
+    assert ok is False
+    assert provider_flag.read_text(encoding="utf-8") == '{"not_before": 123.0}'
+
+
+def _seed_worker(health: str = "ok") -> Worker:
+    worker = object.__new__(Worker)
+    worker.runtime = RuntimeState(status="running", health=health)
+    worker._turn_active = False
+    worker._mcp_probe_strikes = 0
+    worker._refresh_reload_failures = 0
+    return worker
+
+
+@pytest.fixture
+def saved_states(monkeypatch):
+    saves: list[tuple[str, str, str]] = []
+    def _save(self, agent_id):
+        saves.append((agent_id, self.health, self.error))
+    monkeypatch.setattr(RuntimeState, "save", _save)
+    return saves
+
+
+def test_reload_failure_cap_abandons_flags_into_health(tmp_path, saved_states):
+    worker = _seed_worker()
+    flags = tuple(
+        tmp_path / name
+        for name in ("a.flag", "b.flag", "c.flag", "d.flag")
+    )
+    for flag in flags:
+        flag.write_text("{}", encoding="utf-8")
+
+    for _ in range(_REFRESH_RELOAD_FAILURE_CAP - 1):
+        worker._note_refresh_reload(False, flags, "t")
+    assert all(flag.exists() for flag in flags)
+    assert worker.runtime.health == "ok"
+
+    worker._note_refresh_reload(False, flags, "t")
+    assert not any(flag.exists() for flag in flags)
+    assert worker.runtime.health == "provider_error"
+    assert "reload" in worker.runtime.error
+    assert saved_states
+
+    # A success resets the streak so unrelated later failures re-count.
+    worker._refresh_reload_failures = 1
+    worker._note_refresh_reload(True, flags, "t")
+    assert worker._refresh_reload_failures == 0
+
+
+# ── generation handshake probe ─────────────────────────────────────────
+
+
+class _FakeManager:
+    def __init__(self, generation: str, opened_at: float):
+        self.spec = SimpleNamespace(mcp_generation=generation)
+        self.last_open_monotonic = opened_at
+        self.reload_calls: list[bool] = []
+
+    async def reload_resources(self, *, preserve_session, spec=None):
+        self.reload_calls.append(preserve_session)
+        self.last_open_monotonic = time.monotonic()
+
+
+@pytest.fixture
+def registered_manager(monkeypatch):
+    def _register(manager):
+        import puffo_agent.agent.harness.runtime.runtime_manager as rm
+
+        monkeypatch.setattr(rm, "get_runtime_manager", lambda _aid: manager)
+        return manager
+    yield _register
+    rpc_service.clear_mcp_hello("t")
+
+
+def test_probe_recycles_then_flips_health(registered_manager, saved_states):
+    """No hello past the grace window → one recycle; still none → the
+    wedge becomes a visible health state instead of 51 silent minutes."""
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker()
+
+    _run(worker.probe_mcp_transport("t"))
+    assert mgr.reload_calls == [True]
+    assert worker._mcp_probe_strikes == 1
+    assert worker.runtime.health == "ok"
+
+    # Freshly recycled: within grace, the probe must not double-punish.
+    _run(worker.probe_mcp_transport("t"))
+    assert mgr.reload_calls == [True]
+
+    mgr.last_open_monotonic = time.monotonic() - 120
+    _run(worker.probe_mcp_transport("t"))
+    assert worker.runtime.health == "mcp_unreachable"
+    assert ("t", "mcp_unreachable", worker.runtime.error) in saved_states
+
+
+def test_probe_hello_clears_wedge_state(registered_manager, saved_states):
+    opened_at = time.monotonic() - 120
+    registered_manager(_FakeManager("g1", opened_at))
+    rpc_service.record_mcp_hello("t", "g1")
+    worker = _seed_worker(health="mcp_unreachable")
+    worker._mcp_probe_strikes = 2
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker._mcp_probe_strikes == 0
+    assert worker.runtime.health == "ok"
+
+
+def test_probe_ignores_stale_generation_hello(registered_manager):
+    """A hello from the previous config generation is not proof the
+    current spawn's transport works."""
+    mgr = registered_manager(_FakeManager("g2", time.monotonic() - 120))
+    rpc_service.record_mcp_hello("t", "g1")
+    worker = _seed_worker()
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert mgr.reload_calls == [True]
+
+
+def test_probe_defers_while_turn_active(registered_manager):
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker()
+    worker._turn_active = True
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert mgr.reload_calls == []
+    assert worker._mcp_probe_strikes == 0
+
+
+# ── hello plumbing ─────────────────────────────────────────────────────
+
+
+def test_mcp_hello_route_records_generation():
+    from aiohttp.test_utils import TestServer
+    from aiohttp.test_utils import TestClient as AiohttpTestClient
+
+    from puffo_agent.portal.local_service_auth import (
+        issue_local_service_token,
+        local_service_headers,
+    )
+
+    async def _exercise():
+        cfg = rpc_service.RpcServiceConfig(enabled=True, port=0)
+        app = rpc_service.build_app(cfg)
+        client = AiohttpTestClient(TestServer(app))
+        await client.start_server()
+        try:
+            headers = local_service_headers(issue_local_service_token("t"))
+            resp = await client.post(
+                "/v1/rpc/t/mcp-hello",
+                json={"generation": "gen-42"},
+                headers=headers,
+            )
+            assert resp.status == 200
+            bad = await client.post(
+                "/v1/rpc/t/mcp-hello", json={}, headers=headers,
+            )
+            assert bad.status == 400
+        finally:
+            await client.close()
+
+    rpc_service.clear_mcp_hello("t")
+    _run(_exercise())
+    generation, seen_at = rpc_service.mcp_hello_state("t")
+    assert generation == "gen-42"
+    assert seen_at > 0.0
+    rpc_service.clear_mcp_hello("t")
+
+
+def test_hello_startup_absent_without_generation(monkeypatch):
+    from puffo_agent.mcp import puffo_core_server
+
+    monkeypatch.delenv("PUFFO_MCP_GENERATION", raising=False)
+    assert puffo_core_server._make_hello_startup(object()) is None
+    monkeypatch.setenv("PUFFO_MCP_GENERATION", "g")
+    assert puffo_core_server._make_hello_startup(None) is None
+
+
+def test_hello_startup_retries_then_succeeds(monkeypatch):
+    from puffo_agent.mcp import puffo_core_server
+
+    monkeypatch.setenv("PUFFO_MCP_GENERATION", "g7")
+    monkeypatch.setattr(
+        puffo_core_server, "_HELLO_RETRY_DELAY_SECONDS", 0.0,
+    )
+    calls: list[str] = []
+
+    class _Client:
+        async def hello(self, generation):
+            calls.append(generation)
+            if len(calls) < 3:
+                raise RuntimeError("rpc mcp-hello transport error")
+            return "ok"
+
+    startup = puffo_core_server._make_hello_startup(_Client())
+    _run(startup())
+    assert calls == ["g7", "g7", "g7"]
+
+
+# ── per-spawn config generation ────────────────────────────────────────
+
+
+def test_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
+    import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
+    from puffo_agent.agent.harness.runtime.local_runtime import (
+        LocalRuntimePreparer,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
+    monkeypatch.setattr(
+        local_runtime, "resolve_claude_bin", lambda: "/bin/claude",
+    )
+    monkeypatch.setattr(local_runtime, "is_macos", lambda: False)
+    config = AgentConfig(
+        id="gen-test",
+        runtime=RuntimeConfig(
+            kind="cli-local", provider="anthropic", harness="claude-code",
+        ),
+        puffo_core=PuffoCoreConfig(
+            slug="bot-gen", device_id="d1", space_id="sp1",
+        ),
+    )
+    preparer = LocalRuntimePreparer(DaemonConfig(), config)
+
+    first = preparer._prepare_claude_spec("prompt")
+    config_doc = json.loads(
+        (tmp_path / "puffo" / "agents" / "gen-test" / "mcp-config.json")
+        .read_text(encoding="utf-8")
+    )
+    written = config_doc["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]
+    second = preparer._prepare_claude_spec("prompt")
+
+    assert first.mcp_generation and second.mcp_generation
+    assert first.mcp_generation != second.mcp_generation
+    assert written == first.mcp_generation

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -261,6 +261,46 @@ def test_recycled_generation_survives_zombie_pressure_before_first_probe(
     assert rpc_service.mcp_hello_state("t", new_gen)[0] > 0.0
 
 
+def test_reload_pins_minted_generation_before_reopen():
+    """The post-reload pins land only after ``adapter.reload``
+    returns, but the reopened subprocess hellos immediately — zombie
+    beacon pressure inside that window can evict the new hello while
+    the pin still names the predecessor. The adapter must push the
+    minted generation through its generation sink after the spec
+    reloader and BEFORE ``reload_resources`` reopens."""
+    from puffo_agent.agent.harness.runtime.runtime_manager import (
+        RuntimeManagerAdapter,
+    )
+
+    rpc_service.clear_mcp_hello("t")
+    try:
+        rpc_service.pin_mcp_generation("t", "g-old")
+        pin_at_reopen: list[str | None] = []
+
+        class _Mgr:
+            spec = SimpleNamespace(mcp_generation="g-old", system_prompt="p")
+
+            async def reload_resources(self, *, preserve_session, spec):
+                pin_at_reopen.append(rpc_service._MCP_HELLO_PROBED.get("t"))
+                self.spec = spec
+
+        async def reloader(prompt):
+            return SimpleNamespace(mcp_generation="g-new", system_prompt=prompt)
+
+        adapter = RuntimeManagerAdapter(
+            _Mgr(),
+            spec_reloader=reloader,
+            generation_sink=lambda gen: rpc_service.pin_mcp_generation(
+                "t", gen
+            ),
+        )
+        _run(adapter.reload("p2", with_session=False))
+
+        assert pin_at_reopen == ["g-new"]
+    finally:
+        rpc_service.clear_mcp_hello("t")
+
+
 def test_initial_prepare_pins_generation_before_first_probe(
     tmp_path, monkeypatch,
 ):
@@ -294,10 +334,14 @@ def test_initial_prepare_pins_generation_before_first_probe(
             legacy_session_path=tmp_path / "legacy.json",
             preparer=_StubPreparer(),
         )
+        captured_kwargs: dict = {}
+
+        def fake_builder(prepared, **kw):
+            captured_kwargs.update(kw)
+            return SimpleNamespace()
+
         monkeypatch.setattr(
-            local_runtime,
-            "build_local_runtime_adapter",
-            lambda prepared, **kw: SimpleNamespace(),
+            local_runtime, "build_local_runtime_adapter", fake_builder,
         )
         runner = StandardWorkerRun(SimpleNamespace())
         outbox = SimpleNamespace(set_active_turn=lambda *a, **kw: None)
@@ -313,6 +357,11 @@ def test_initial_prepare_pins_generation_before_first_probe(
         seen_at, interval = rpc_service.mcp_hello_state("t", "g-new")
         assert seen_at > 0.0
         assert interval == 60.0
+
+        # The bind also hands the adapter a generation sink wired to
+        # this agent, so reload-minted generations pin the same way.
+        captured_kwargs["generation_sink"]("g-reloaded")
+        assert rpc_service._MCP_HELLO_PROBED["t"] == "g-reloaded"
     finally:
         rpc_service.clear_mcp_hello("t")
 

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -226,6 +226,62 @@ def test_recycle_mints_new_generation_and_late_old_hello_stays_red(
     assert worker.runtime.health == "mcp_unreachable"
 
 
+def test_recycled_generation_survives_zombie_pressure_before_first_probe(
+    registered_manager, saved_states,
+):
+    """The pin must move at the generation switch, not at the first
+    probe: after a recycle the registry would otherwise still pin the
+    predecessor, and zombie beacons landing inside the mint->probe
+    window would evict the new generation's hello — the next probe
+    reads never-seen and a healthy runtime gets recycle-looped."""
+    mgr = registered_manager(_FakeManager("g-old", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker()
+    adapter = _wire(worker, mgr)
+
+    # Probe 1 pins g-old (query) and recycles the silent runtime; the
+    # recycle mints a fresh generation and must re-pin at the switch.
+    _run(worker.probe_mcp_transport("t"))
+    assert adapter.reload_calls == [False]
+    new_gen = mgr.spec.mcp_generation
+    assert new_gen != "g-old"
+
+    # The new subprocess says hello, then zombie pressure fills the
+    # slots before any probe has asked about the new generation.
+    rpc_service.record_mcp_hello("t", new_gen, 60.0)
+    for zombie in ("g-old", "g-z1", "g-z2", "g-z3"):
+        rpc_service.record_mcp_hello("t", zombie, 60.0)
+
+    # Probe 2: with the switch-time pin the new hello survived the
+    # trim and reads healthy — strikes reset, no second reload.
+    _run(worker.probe_mcp_transport("t"))
+    assert worker._mcp_probe_strikes == 0
+    assert adapter.reload_calls == [False]
+    assert worker.runtime.health == "ok"
+    assert rpc_service.mcp_hello_state("t", new_gen)[0] > 0.0
+
+
+def test_refresh_reload_pins_the_new_generation(
+    tmp_path, registered_manager,
+):
+    """The refresh-flag reload also rebuilds the spec and mints a
+    fresh generation; the pin must move with it (same window as the
+    probe-driven recycle)."""
+    mgr = registered_manager(_FakeManager("g-before", time.monotonic()))
+    rpc_service.clear_mcp_hello("t")
+    adapter = _RecyclingAdapter(mgr)
+    (tmp_path / "refresh_session.flag").write_text("{}", encoding="utf-8")
+    try:
+        ok = _run(_process_refresh_flags(**_flags_kwargs(tmp_path, adapter)))
+        assert ok is True
+        assert mgr.spec.mcp_generation != "g-before"
+        assert (
+            rpc_service._MCP_HELLO_PROBED["t"] == mgr.spec.mcp_generation
+        )
+    finally:
+        rpc_service.clear_mcp_hello("t")
+
+
 def test_runtime_open_watermark_precedes_current_generation_hello():
     """A hello emitted during driver.open belongs to the runtime being opened."""
     class _HelloDuringOpenDriver:

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -263,8 +263,8 @@ def test_runtime_open_watermark_precedes_current_generation_hello():
         )
         try:
             await manager.open()
-            generation, seen_at, _ = rpc_service.mcp_hello_state("opening")
-            assert generation == "g-current"
+            seen_at, _ = rpc_service.mcp_hello_state("opening", "g-current")
+            assert seen_at > 0.0
             assert seen_at >= manager.last_open_monotonic
         finally:
             await manager.close()
@@ -292,7 +292,7 @@ def test_beacon_silence_recycles(registered_manager):
     silent is a wedge (the incident's 51-min RPC silence signature),
     even though its startup hello matched this generation."""
     mgr = registered_manager(_FakeManager("g1", time.monotonic() - 400))
-    rpc_service._MCP_HELLO_SEEN["t"] = ("g1", time.monotonic() - 400, 60.0)
+    rpc_service._MCP_HELLO_SEEN["t"] = {"g1": (time.monotonic() - 400, 60.0)}
     worker = _seed_worker()
     adapter = _wire(worker, mgr)
 
@@ -307,7 +307,7 @@ def test_startup_only_hello_never_goes_stale(registered_manager):
     keeps handshake semantics: an aged hello stays valid and the probe
     must not recycle-loop the runtime for silence."""
     mgr = registered_manager(_FakeManager("g1", time.monotonic() - 5000))
-    rpc_service._MCP_HELLO_SEEN["t"] = ("g1", time.monotonic() - 4000, None)
+    rpc_service._MCP_HELLO_SEEN["t"] = {"g1": (time.monotonic() - 4000, None)}
     worker = _seed_worker()
     adapter = _wire(worker, mgr)
 
@@ -315,6 +315,43 @@ def test_startup_only_hello_never_goes_stale(registered_manager):
 
     assert adapter.reload_calls == []
     assert worker._mcp_probe_strikes == 0
+
+
+def test_surviving_old_beacon_cannot_evict_new_generation_health(
+    registered_manager,
+):
+    """Hello state is keyed per (agent, generation): a surviving
+    pre-recycle subprocess that keeps beaconing its old generation must
+    not overwrite the current generation's healthy evidence — a single
+    per-agent slot here recycled healthy runtimes in a loop."""
+    mgr = registered_manager(_FakeManager("g-new", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker()
+    adapter = _wire(worker, mgr)
+
+    rpc_service.record_mcp_hello("t", "g-new", 60.0)
+    rpc_service.record_mcp_hello("t", "g-old", 60.0)
+    _run(worker.probe_mcp_transport("t"))
+
+    assert adapter.reload_calls == []
+    assert worker._mcp_probe_strikes == 0
+    assert worker.runtime.health == "ok"
+
+
+def test_hello_state_bounds_generations_per_agent():
+    """Dead generations stop re-recording, so trimming by oldest
+    arrival keeps the live ones and a leaking predecessor cannot grow
+    the per-agent map without bound."""
+    rpc_service.clear_mcp_hello("t")
+    try:
+        for n in range(rpc_service._MCP_HELLO_MAX_GENERATIONS + 1):
+            rpc_service.record_mcp_hello("t", f"g{n}", 60.0)
+        slots = rpc_service._MCP_HELLO_SEEN["t"]
+        assert len(slots) == rpc_service._MCP_HELLO_MAX_GENERATIONS
+        assert "g0" not in slots
+        assert rpc_service.mcp_hello_state("t", "g1")[0] > 0.0
+    finally:
+        rpc_service.clear_mcp_hello("t")
 
 
 def test_empty_turn_cannot_clear_mcp_unreachable(saved_states):
@@ -382,7 +419,7 @@ def test_mcp_hello_route_records_generation():
                 headers=headers,
             )
             assert resp.status == 200
-            assert rpc_service.mcp_hello_state("t")[2] is None
+            assert rpc_service.mcp_hello_state("t", "gen-42")[1] is None
             beacon = await client.post(
                 "/v1/rpc/t/mcp-hello",
                 json={"generation": "gen-42", "beacon_interval": 60},
@@ -404,8 +441,7 @@ def test_mcp_hello_route_records_generation():
 
     rpc_service.clear_mcp_hello("t")
     _run(_exercise())
-    generation, seen_at, interval = rpc_service.mcp_hello_state("t")
-    assert generation == "gen-42"
+    seen_at, interval = rpc_service.mcp_hello_state("t", "gen-42")
     assert seen_at > 0.0
     assert interval == 60.0
     rpc_service.clear_mcp_hello("t")

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -369,6 +369,32 @@ def test_hello_state_bounds_generations_per_agent():
         rpc_service.clear_mcp_hello("t")
 
 
+def test_probed_generation_survives_zombie_beacon_pressure():
+    """More live senders than slots must never evict the probed
+    generation. With four surviving zombie subprocesses beaconing
+    alongside the current one, a pure least-recently-heard trim
+    periodically dropped the current generation (whichever beaconed
+    longest ago), so the next probe read never-seen and recycled a
+    healthy runtime."""
+    rpc_service.clear_mcp_hello("t")
+    try:
+        rpc_service.record_mcp_hello("t", "g-current", 60.0)
+        # The worker probe only ever queries the generation it minted;
+        # that query pins it against the trim.
+        assert rpc_service.mcp_hello_state("t", "g-current")[0] > 0.0
+        # Four zombies beacon after the current generation, making it
+        # the least recently heard entry when the trim fires.
+        for n in range(4):
+            rpc_service.record_mcp_hello("t", f"g-zombie{n}", 60.0)
+        slots = rpc_service._MCP_HELLO_SEEN["t"]
+        assert len(slots) == rpc_service._MCP_HELLO_MAX_GENERATIONS
+        seen_at, interval = rpc_service.mcp_hello_state("t", "g-current")
+        assert seen_at > 0.0
+        assert interval == 60.0
+    finally:
+        rpc_service.clear_mcp_hello("t")
+
+
 def test_empty_turn_cannot_clear_mcp_unreachable(saved_states):
     """Only a current-generation hello proves that the MCP lane recovered."""
     worker = _seed_worker(health="mcp_unreachable")

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import time
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -92,6 +93,7 @@ def _seed_worker(health: str = "ok") -> Worker:
     worker._turn_active = False
     worker._mcp_probe_strikes = 0
     worker._refresh_reload_failures = 0
+    worker._adapter = None
     return worker
 
 
@@ -135,13 +137,34 @@ def test_reload_failure_cap_abandons_flags_into_health(tmp_path, saved_states):
 
 class _FakeManager:
     def __init__(self, generation: str, opened_at: float):
-        self.spec = SimpleNamespace(mcp_generation=generation)
+        self.spec = SimpleNamespace(
+            mcp_generation=generation, system_prompt="p",
+        )
         self.last_open_monotonic = opened_at
+
+
+class _RecyclingAdapter:
+    """Mimics the adapter-level reload chain the probe must use: the
+    spec_reloader rebuilds the spec (minting a fresh generation) and the
+    reopen stamps a new open watermark."""
+
+    def __init__(self, mgr: _FakeManager):
+        self.mgr = mgr
         self.reload_calls: list[bool] = []
 
-    async def reload_resources(self, *, preserve_session, spec=None):
-        self.reload_calls.append(preserve_session)
-        self.last_open_monotonic = time.monotonic()
+    async def reload(self, new_system_prompt, *, with_session=False):
+        self.reload_calls.append(with_session)
+        self.mgr.spec = SimpleNamespace(
+            mcp_generation=uuid.uuid4().hex,
+            system_prompt=new_system_prompt,
+        )
+        self.mgr.last_open_monotonic = time.monotonic()
+
+
+def _wire(worker: Worker, mgr: _FakeManager) -> _RecyclingAdapter:
+    adapter = _RecyclingAdapter(mgr)
+    worker._adapter = adapter
+    return adapter
 
 
 @pytest.fixture
@@ -161,20 +184,46 @@ def test_probe_recycles_then_flips_health(registered_manager, saved_states):
     mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
     rpc_service.clear_mcp_hello("t")
     worker = _seed_worker()
+    adapter = _wire(worker, mgr)
 
     _run(worker.probe_mcp_transport("t"))
-    assert mgr.reload_calls == [True]
+    assert adapter.reload_calls == [False]
     assert worker._mcp_probe_strikes == 1
     assert worker.runtime.health == "ok"
 
     # Freshly recycled: within grace, the probe must not double-punish.
     _run(worker.probe_mcp_transport("t"))
-    assert mgr.reload_calls == [True]
+    assert adapter.reload_calls == [False]
 
     mgr.last_open_monotonic = time.monotonic() - 120
     _run(worker.probe_mcp_transport("t"))
     assert worker.runtime.health == "mcp_unreachable"
     assert ("t", "mcp_unreachable", worker.runtime.error) in saved_states
+
+
+def test_recycle_mints_new_generation_and_late_old_hello_stays_red(
+    registered_manager, saved_states,
+):
+    """The automatic recycle must rotate the config generation: an old
+    CLI's MCP subprocess is not guaranteed to die with its parent, and
+    its late hello (same old generation, arriving after the new open
+    watermark) must never read as the new runtime's health."""
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker()
+    adapter = _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+    assert adapter.reload_calls == [False]
+    assert mgr.spec.mcp_generation != "g1"
+
+    # The pre-recycle subprocess reports in late: fresh arrival, old
+    # generation. Past the new grace window this is a miss, not health.
+    rpc_service.record_mcp_hello("t", "g1")
+    mgr.last_open_monotonic = time.monotonic() - 120
+    _run(worker.probe_mcp_transport("t"))
+    assert worker._mcp_probe_strikes == 2
+    assert worker.runtime.health == "mcp_unreachable"
 
 
 def test_runtime_open_watermark_precedes_current_generation_hello():
@@ -214,7 +263,7 @@ def test_runtime_open_watermark_precedes_current_generation_hello():
         )
         try:
             await manager.open()
-            generation, seen_at = rpc_service.mcp_hello_state("opening")
+            generation, seen_at, _ = rpc_service.mcp_hello_state("opening")
             assert generation == "g-current"
             assert seen_at >= manager.last_open_monotonic
         finally:
@@ -226,15 +275,46 @@ def test_runtime_open_watermark_precedes_current_generation_hello():
 
 def test_probe_hello_clears_wedge_state(registered_manager, saved_states):
     opened_at = time.monotonic() - 120
-    registered_manager(_FakeManager("g1", opened_at))
+    mgr = registered_manager(_FakeManager("g1", opened_at))
     rpc_service.record_mcp_hello("t", "g1")
     worker = _seed_worker(health="mcp_unreachable")
+    _wire(worker, mgr)
     worker._mcp_probe_strikes = 2
 
     _run(worker.probe_mcp_transport("t"))
 
     assert worker._mcp_probe_strikes == 0
     assert worker.runtime.health == "ok"
+
+
+def test_beacon_silence_recycles(registered_manager):
+    """A subprocess that declared a re-hello cadence and then went
+    silent is a wedge (the incident's 51-min RPC silence signature),
+    even though its startup hello matched this generation."""
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 400))
+    rpc_service._MCP_HELLO_SEEN["t"] = ("g1", time.monotonic() - 400, 60.0)
+    worker = _seed_worker()
+    adapter = _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert adapter.reload_calls == [False]
+    assert worker._mcp_probe_strikes == 1
+
+
+def test_startup_only_hello_never_goes_stale(registered_manager):
+    """No declared cadence (older package, e.g. a lagging Docker image)
+    keeps handshake semantics: an aged hello stays valid and the probe
+    must not recycle-loop the runtime for silence."""
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 5000))
+    rpc_service._MCP_HELLO_SEEN["t"] = ("g1", time.monotonic() - 4000, None)
+    worker = _seed_worker()
+    adapter = _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert adapter.reload_calls == []
+    assert worker._mcp_probe_strikes == 0
 
 
 def test_empty_turn_cannot_clear_mcp_unreachable(saved_states):
@@ -257,21 +337,23 @@ def test_probe_ignores_stale_generation_hello(registered_manager):
     mgr = registered_manager(_FakeManager("g2", time.monotonic() - 120))
     rpc_service.record_mcp_hello("t", "g1")
     worker = _seed_worker()
+    adapter = _wire(worker, mgr)
 
     _run(worker.probe_mcp_transport("t"))
 
-    assert mgr.reload_calls == [True]
+    assert adapter.reload_calls == [False]
 
 
 def test_probe_defers_while_turn_active(registered_manager):
     mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
     rpc_service.clear_mcp_hello("t")
     worker = _seed_worker()
+    adapter = _wire(worker, mgr)
     worker._turn_active = True
 
     _run(worker.probe_mcp_transport("t"))
 
-    assert mgr.reload_calls == []
+    assert adapter.reload_calls == []
     assert worker._mcp_probe_strikes == 0
 
 
@@ -300,18 +382,32 @@ def test_mcp_hello_route_records_generation():
                 headers=headers,
             )
             assert resp.status == 200
+            assert rpc_service.mcp_hello_state("t")[2] is None
+            beacon = await client.post(
+                "/v1/rpc/t/mcp-hello",
+                json={"generation": "gen-42", "beacon_interval": 60},
+                headers=headers,
+            )
+            assert beacon.status == 200
             bad = await client.post(
                 "/v1/rpc/t/mcp-hello", json={}, headers=headers,
             )
             assert bad.status == 400
+            bad_interval = await client.post(
+                "/v1/rpc/t/mcp-hello",
+                json={"generation": "gen-42", "beacon_interval": 0},
+                headers=headers,
+            )
+            assert bad_interval.status == 400
         finally:
             await client.close()
 
     rpc_service.clear_mcp_hello("t")
     _run(_exercise())
-    generation, seen_at = rpc_service.mcp_hello_state("t")
+    generation, seen_at, interval = rpc_service.mcp_hello_state("t")
     assert generation == "gen-42"
     assert seen_at > 0.0
+    assert interval == 60.0
     rpc_service.clear_mcp_hello("t")
 
 
@@ -324,6 +420,19 @@ def test_hello_startup_absent_without_generation(monkeypatch):
     assert puffo_core_server._make_hello_startup(None) is None
 
 
+async def _drive_beacon(startup, calls, target: int, ticks: int = 500):
+    task = asyncio.ensure_future(startup())
+    for _ in range(ticks):
+        if len(calls) >= target:
+            break
+        await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
 def test_hello_startup_retries_then_succeeds(monkeypatch):
     from puffo_agent.mcp import puffo_core_server
 
@@ -331,18 +440,42 @@ def test_hello_startup_retries_then_succeeds(monkeypatch):
     monkeypatch.setattr(
         puffo_core_server, "_HELLO_RETRY_DELAY_SECONDS", 0.0,
     )
-    calls: list[str] = []
+    calls: list[tuple[str, float]] = []
 
     class _Client:
-        async def hello(self, generation):
-            calls.append(generation)
+        async def hello(self, generation, *, beacon_interval=None):
+            calls.append((generation, beacon_interval))
             if len(calls) < 3:
                 raise RuntimeError("rpc mcp-hello transport error")
             return "ok"
 
     startup = puffo_core_server._make_hello_startup(_Client())
-    _run(startup())
-    assert calls == ["g7", "g7", "g7"]
+    _run(_drive_beacon(startup, calls, target=3))
+    expected = ("g7", puffo_core_server._HELLO_BEACON_INTERVAL_SECONDS)
+    assert calls == [expected, expected, expected]
+
+
+def test_hello_beacon_refires_after_interval(monkeypatch):
+    """After the startup burst the sender keeps re-helloing on its
+    declared cadence — the daemon side reads sustained silence as a
+    wedge, so a one-shot sender would defeat mid-life detection."""
+    from puffo_agent.mcp import puffo_core_server
+
+    monkeypatch.setenv("PUFFO_MCP_GENERATION", "g8")
+    monkeypatch.setattr(
+        puffo_core_server, "_HELLO_BEACON_INTERVAL_SECONDS", 0.0,
+    )
+    calls: list[tuple[str, float]] = []
+
+    class _Client:
+        async def hello(self, generation, *, beacon_interval=None):
+            calls.append((generation, beacon_interval))
+            return "ok"
+
+    startup = puffo_core_server._make_hello_startup(_Client())
+    _run(_drive_beacon(startup, calls, target=4))
+    assert len(calls) >= 4
+    assert all(call == ("g8", 0.0) for call in calls)
 
 
 # ── per-spawn config generation ────────────────────────────────────────
@@ -374,6 +507,40 @@ def test_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
     first = preparer._prepare_claude_spec("prompt")
     config_doc = json.loads(
         (tmp_path / "puffo" / "agents" / "gen-test" / "mcp-config.json")
+        .read_text(encoding="utf-8")
+    )
+    written = config_doc["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]
+    second = preparer._prepare_claude_spec("prompt")
+
+    assert first.mcp_generation and second.mcp_generation
+    assert first.mcp_generation != second.mcp_generation
+    assert written == first.mcp_generation
+
+
+def test_docker_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
+    """cli-docker Claude gets the same per-write generation as
+    cli-local — without it the transport probe exits early and Docker
+    agents have no wedge recovery at all."""
+    from puffo_agent.agent.harness.runtime.docker_runtime import (
+        DockerRuntimePreparer,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
+    config = AgentConfig(
+        id="gen-docker",
+        runtime=RuntimeConfig(
+            kind="cli-docker", provider="anthropic", harness="claude-code",
+        ),
+        puffo_core=PuffoCoreConfig(
+            slug="bot-gen-d", device_id="d1", space_id="sp1",
+        ),
+    )
+    preparer = DockerRuntimePreparer(DaemonConfig(), config)
+
+    first = preparer._prepare_claude_spec("prompt")
+    config_doc = json.loads(
+        (preparer.workspace_dir / ".puffo-agent" / "mcp-config.json")
         .read_text(encoding="utf-8")
     )
     written = config_doc["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -287,12 +287,26 @@ def test_probe_hello_clears_wedge_state(registered_manager, saved_states):
     assert worker.runtime.health == "ok"
 
 
-def test_beacon_silence_recycles(registered_manager):
+@pytest.fixture
+def pinned_clock(monkeypatch):
+    """Fixed monotonic value for tests that fabricate large past
+    offsets: on a freshly booted CI runner ``time.monotonic()`` is
+    small, so ``monotonic() - 4000`` goes negative and reads as
+    never-seen."""
+    from puffo_agent.portal import worker as worker_mod
+
+    now = 1_000_000.0
+    monkeypatch.setattr(worker_mod.time, "monotonic", lambda: now)
+    return now
+
+
+def test_beacon_silence_recycles(registered_manager, pinned_clock):
     """A subprocess that declared a re-hello cadence and then went
     silent is a wedge (the incident's 51-min RPC silence signature),
     even though its startup hello matched this generation."""
-    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 400))
-    rpc_service._MCP_HELLO_SEEN["t"] = {"g1": (time.monotonic() - 400, 60.0)}
+    now = pinned_clock
+    mgr = registered_manager(_FakeManager("g1", now - 400))
+    rpc_service._MCP_HELLO_SEEN["t"] = {"g1": (now - 400, 60.0)}
     worker = _seed_worker()
     adapter = _wire(worker, mgr)
 
@@ -302,12 +316,13 @@ def test_beacon_silence_recycles(registered_manager):
     assert worker._mcp_probe_strikes == 1
 
 
-def test_startup_only_hello_never_goes_stale(registered_manager):
+def test_startup_only_hello_never_goes_stale(registered_manager, pinned_clock):
     """No declared cadence (older package, e.g. a lagging Docker image)
     keeps handshake semantics: an aged hello stays valid and the probe
     must not recycle-loop the runtime for silence."""
-    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 5000))
-    rpc_service._MCP_HELLO_SEEN["t"] = {"g1": (time.monotonic() - 4000, None)}
+    now = pinned_clock
+    mgr = registered_manager(_FakeManager("g1", now - 5000))
+    rpc_service._MCP_HELLO_SEEN["t"] = {"g1": (now - 4000, None)}
     worker = _seed_worker()
     adapter = _wire(worker, mgr)
 
@@ -430,12 +445,13 @@ def test_mcp_hello_route_records_generation():
                 "/v1/rpc/t/mcp-hello", json={}, headers=headers,
             )
             assert bad.status == 400
-            bad_interval = await client.post(
-                "/v1/rpc/t/mcp-hello",
-                json={"generation": "gen-42", "beacon_interval": 0},
-                headers=headers,
-            )
-            assert bad_interval.status == 400
+            for bad_value in (0, float("inf"), float("nan")):
+                bad_interval = await client.post(
+                    "/v1/rpc/t/mcp-hello",
+                    json={"generation": "gen-42", "beacon_interval": bad_value},
+                    headers=headers,
+                )
+                assert bad_interval.status == 400, bad_value
         finally:
             await client.close()
 

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -261,6 +261,62 @@ def test_recycled_generation_survives_zombie_pressure_before_first_probe(
     assert rpc_service.mcp_hello_state("t", new_gen)[0] > 0.0
 
 
+def test_initial_prepare_pins_generation_before_first_probe(
+    tmp_path, monkeypatch,
+):
+    """The third pin seam: binding a freshly prepared runtime must
+    re-pin its minted generation immediately. A daemon-internal
+    restart can leave the previous run's generation pinned; without
+    the bind-time pin, zombie pressure between warm and the first
+    probe evicts the new hello and the probe reads never-seen.
+    Removing only the ``worker_run`` pin turns this red."""
+    import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
+    from puffo_agent.agent.harness.driver import RuntimeSpec
+    from puffo_agent.agent.harness.runtime.local_runtime import (
+        PreparedLocalRuntime,
+    )
+    from puffo_agent.portal.worker_run import StandardWorkerRun
+
+    rpc_service.clear_mcp_hello("t")
+    try:
+        # The previous worker run's generation is still pinned.
+        rpc_service.record_mcp_hello("t", "g-old", 60.0)
+        assert rpc_service.mcp_hello_state("t", "g-old")[0] > 0.0
+
+        class _StubPreparer:
+            agent_id = "t"
+
+        prepared = PreparedLocalRuntime(
+            harness_name="codex",
+            spec=RuntimeSpec(str(tmp_path), mcp_generation="g-new"),
+            native_session_id="",
+            migration_source="fresh",
+            legacy_session_path=tmp_path / "legacy.json",
+            preparer=_StubPreparer(),
+        )
+        monkeypatch.setattr(
+            local_runtime,
+            "build_local_runtime_adapter",
+            lambda prepared, **kw: SimpleNamespace(),
+        )
+        runner = StandardWorkerRun(SimpleNamespace())
+        outbox = SimpleNamespace(set_active_turn=lambda *a, **kw: None)
+
+        _run(runner._bind_driver_runtime(outbox, prepared, {}))
+
+        # New hello lands, then zombie pressure fills the slots before
+        # any probe has asked about the new generation.
+        rpc_service.record_mcp_hello("t", "g-new", 60.0)
+        for zombie in ("g-z1", "g-z2", "g-z3", "g-z4"):
+            rpc_service.record_mcp_hello("t", zombie, 60.0)
+
+        seen_at, interval = rpc_service.mcp_hello_state("t", "g-new")
+        assert seen_at > 0.0
+        assert interval == 60.0
+    finally:
+        rpc_service.clear_mcp_hello("t")
+
+
 def test_refresh_reload_pins_the_new_generation(
     tmp_path, registered_manager,
 ):


### PR DESCRIPTION
> [!NOTE]
> **评审已转移**:本 PR 已并入统一交付 [puffo-agent #328](https://github.com/puffo-ai/puffo-agent/pull/328)(agent 仓汇总,head `fcc1ddc7`;统一评审入口及 11→3 映射见其描述)。原评审正文与 head 保留如下,未改动。

> 原描述曾被文档追加脚本误覆盖；Peter 已于 2026-09-09 从此前保存的 PR 描述快照恢复。下面保留原描述及 Linus 新增事实文档。

## Incident

After a fleet-wide credential replacement reloaded 17 provider runtimes in the
same second, one worker stayed alive for 51 minutes while its CLI MCP subsystem
was unreachable. Turns kept waking without `read_inbox` admission, every MCP
call timed out, and `runtime.json` continued to report healthy. Restarting the
worker recovered it.

The observed facts support an MCP transport wedge after runtime reload. They do
not by themselves prove one internal CLI root cause.

## Changes

### Active, generation-bound MCP liveness (beacon)

- Claude runtime specs — **cli-local and cli-docker** — mint a per-config-write
  `PUFFO_MCP_GENERATION`; the Puffo MCP subprocess reports that generation
  through a loopback `mcp-hello` RPC.
- The hello is a **beacon**, not a one-shot handshake: a prompt startup burst
  (3×2s), then a steady re-hello every 60 seconds. The payload declares the
  cadence (`beacon_interval`), and the worker enforces freshness only against
  subprocesses that declared one — a hello older than 3× the declared interval
  stops counting as evidence of a live transport. A startup-only sender (older
  package, e.g. a lagging Docker image) keeps handshake semantics and is never
  recycle-looped for silence.
- The worker accepts only a matching generation whose arrival is after the
  current runtime-open watermark. The watermark is captured before
  `driver.open`, so a valid hello emitted during startup is not rejected.
- One miss past the 30-second grace window recycles the provider runtime while
  preserving the session. The recycle goes through the adapter-level reload
  (`spec_reloader` → `preparer.refresh_spec`), which rebuilds the config and
  **mints a fresh generation** — a surviving pre-recycle subprocess reporting
  its old generation late can never read as the new runtime's health. A second
  miss sets `mcp_unreachable`.
- `mcp_unreachable` remains sticky across otherwise successful turns and clears
  only when a current, fresh hello arrives.
- The probe reads `mgr.spec.mcp_generation` and `mgr.last_open_monotonic`
  directly: these are required contract fields, and producer/consumer drift
  must raise instead of silently disabling recovery. Only value-level absence
  (no puffo_core → empty generation; never opened → None) returns quietly.
- The beacon task uses Puffo's supervised `spawn` helper via the MCP lifespan,
  so it is cancelled cleanly at teardown and a failure is logged instead of
  producing an unclaimed Future exception.

### Declared scope

Covered failure classes: (a) the subprocess never reaches the RPC service
after a runtime open; (b) the subprocess reached it and later went silent —
the incident's observed signature (51 minutes of RPC silence). Explicitly out
of scope: a wedge confined to the CLI↔subprocess stdio lane while the
subprocess itself keeps beaconing normally; nothing on our side of the
process boundary can witness that lane, and no such case has been observed.

### Credential-reload resilience

- A successful credential replacement persists a durable provider-auth refresh
  flag with a randomized 0–30 second `not_before_unix_ms`, spreading fleet
  reloads rather than synchronizing them.
- Future-dated flags are recorded but not consumed until due. An explicit
  session/profile/host refresh may fold the provider-auth refresh in immediately.
- Failed adapter reloads preserve every refresh flag byte-for-byte for bounded
  retries. Three consecutive failures surface `provider_error` instead of
  silently claiming success.

### Fail-loud Inbox diagnostics

- Three consecutive Inbox-notice turns that finish without any `read_inbox`
  admission while messages remain pending emit a possible MCP control-plane
  failure warning.
- A successful Inbox read resets the streak; autonomous turns do not affect it.

## Verification

- 19 tests in `test_mcp_transport_probe.py` pass, including the review-driven
  regressions: Docker spec generation minting, recycle rotates the generation
  and a late old-generation hello stays red, beacon silence recycles, a
  startup-only hello never goes stale, and the beacon re-fires after its
  interval, a surviving old-generation beacon cannot evict the new
  generation's health (hello state keyed per (agent, generation)), and the
  per-agent generation map is bounded.
- Four temporary mutations were each observed failing the intended regression
  test: existence-only flag admission, deleting a scheduled flag after failed
  reload, post-open watermarking, and clearing `mcp_unreachable` on an empty
  successful turn.
- The full suite passes locally (pytest exit 0) with the two PySide6-import
  modules excluded (GUI extra not installed in the verification env; identical
  collection failure on main). Expected platform/live tests skip.
- Ruff, Python structure limits, and pre-commit pass.

Integration branch: `peter/mcp-reload-wedge-integration`

---

## PR 文档（what / how）— 2026-09-09 交叉审 · Linus
**比较基线 base `3e2db43b0845`(main) → head `67a13a64`** · rev2（按 Peter 第一轮核对修订：补 reload/flag 半边、收窄探测边界、事故归因改引用）· 事实与建议分列。

### 1. 问题（没有它什么坏）
凭据替换/网络闪断后，CLI 的 MCP 子系统可能不可达而 worker 仍存活、`runtime.json` 照常健康——回合不断唤醒却无 `read_inbox` 接纳，MCP 调用全部超时（见上方原描述 Incident 节：51 分钟无恢复，重启立愈）。**引用**：2026-09-09 Jeremy 主机断网事件的 QA 报告呈现了同形状（WS 自愈、MCP 直到全员重启才恢复）；其因果归属以该报告的有限结论为准，本文不加码。

### 2. 做了什么（改前 → 改后）
- 改前：上述故障零观测、零自愈。
- 改后（四件事）：① MCP 子进程 hello + 60s 信标，daemon 判 stale；② 凭据替换落 durable refresh flag（0–30s 有界延迟），reload 失败**不消费 flag**（下次重试仍有依据）；③ 连续 `_REFRESH_RELOAD_FAILURE_CAP=3` 次 reload 失败 ⇒ 弃 flag（`_unlink_refresh_flags`，计数归零），**仅当 health ∈ {ok, unknown} 时才置 `provider_error`**——已有的其他 health（含 in_progress）不覆写，具名病因保持权威（`_note_refresh_reload`）；④ runtime 侧「连续空通知回合」告警。
- **探测边界（保留原描述的限制，勿放大）**：hello/信标证明的是**子进程→daemon 本地 RPC 可达**；「子进程仍正常 beacon、但 CLI↔子进程 stdio 卡死」被明确排除在可探测范围外。信标 ≠ 端到端 MCP 健康证明。

### 3. 怎么做的（机制）
- `mcp/puffo_core_server.py` `_make_hello_startup`：hello 3 次×2s → 60s 信标循环。
- `portal/worker.py`：stale = `now-seen_at > beacon_interval × _MCP_BEACON_STALE_FACTOR(3.0)`，无 beacon_interval 的旧客户端不判（能力门控）；`_MCP_PROBE_GRACE_SECONDS=30`；`_refresh_flag_delay_seconds`（上限 `PROVIDER_AUTH_RELOAD_JITTER_MAX_SECONDS`）/`_refresh_flag_is_pending`；失败计数达 3 → 弃 flag + provider_error。
- `harness/runtime/{local,docker}_runtime.py`+`runtime_manager.py`：reload 经 `adapter.reload` 换 generation，generation 于重开前铸好 pin（review 轮实测淘汰过 registry-shield 方案——「淘汰再上报」不可区分）。
- `global_inbox_covers.py` `_observe_mcp_read_progress`：`_mcp_silence_streak`（notice 非空∧接纳空∧pending 仍在）每 3 次 WARN。

### 4. 建模关系（事实）
扩展既有 RPC/lifecycle 握手与 refresh-flag 机制；信标是新增观察通道，观察对象（stdio 子进程链路）与 WS 心跳（daemon 链路）不同。

### 5. 重叠面（事实）
与 **#325** 共触 `global_inbox_covers.py`/`global_inbox_runtime.py`/`worker.py`/`state.py`/`cli.py`；`_observe_mcp_read_progress` 与 #325 `_health_outcome_for_turn` 的判据同为「notice 非空∧接纳空」的集合空性检查（#312 多 pending-仍在合取项），输出分别为 log warn / health 值，阈值各为 3、互不联动。

### 6. 验证
`tests/test_mcp_transport_probe.py`（790 行）+ `test_credential_external_rotation.py` + `test_global_inbox_runtime.py` 告警用例。**历史结果（非本轮重跑）**：三轮交叉审闭卷、CI 7/7 @67a13a64。本文档轮未重跑全量。

### 建议（非事实，待跨 PR 讨论）
① 「信标是必要的新建通道」属判断，依据=观察对象不同，交叉轮裁；② 双 streak 归并为一次回合观测两个消费者（#312 先合，#325 rebase 执行，已共识）。

（存档记录：原描述曾于 07:09Z 被我的追加脚本误覆盖，07:15Z 由 Peter 快照恢复并回读一致。）

固定版本入口：[puffo_core_server.py](https://github.com/puffo-ai/puffo-agent/blob/67a13a646667a2b6bf7227390fe78409a0a93fd7/src/puffo_agent/mcp/puffo_core_server.py) · [worker.py](https://github.com/puffo-ai/puffo-agent/blob/67a13a646667a2b6bf7227390fe78409a0a93fd7/src/puffo_agent/portal/worker.py) · [global_inbox_covers.py](https://github.com/puffo-ai/puffo-agent/blob/67a13a646667a2b6bf7227390fe78409a0a93fd7/src/puffo_agent/agent/global_inbox_covers.py) · [runtime_manager.py](https://github.com/puffo-ai/puffo-agent/blob/67a13a646667a2b6bf7227390fe78409a0a93fd7/src/puffo_agent/agent/harness/runtime/runtime_manager.py)

