### PR TITLE
fix: report remote agent startup readiness

### DIFF
--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -44,9 +44,11 @@ HTTP_TIMEOUT = aiohttp.ClientTimeout(total=30)
 HEARTBEAT_INTERVAL_SECONDS = 30.0
 # Remote create waits for the daemon's durable worker lifecycle instead of
 # acknowledging as soon as agent.yml exists. Docker's first image build may
-# legitimately take several minutes.
+# legitimately take several minutes. The server's Portal machine-command TTL
+# is 24 hours; this shorter bound is a UI/operator feedback budget, not the
+# command-expiry budget used by Runtime permission/cancel commands.
 AGENT_START_TIMEOUT_SECONDS = 10 * 60.0
-AGENT_START_POLL_SECONDS = 0.1
+AGENT_START_POLL_SECONDS = 0.5
 
 
 class _DuplicateDelivery(ControlError):
@@ -229,7 +231,9 @@ async def _wait_for_agent_start(agent_id: str) -> dict | None:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + AGENT_START_TIMEOUT_SECONDS
     while loop.time() < deadline:
-        runtime = RuntimeState.load(agent_id)
+        # RuntimeState.load performs filesystem I/O. Keep repeated startup
+        # observation off the single control event loop.
+        runtime = await asyncio.to_thread(RuntimeState.load, agent_id)
         if runtime is not None:
             if runtime.status == "running":
                 return None
@@ -247,8 +251,9 @@ async def _wait_for_agent_start(agent_id: str) -> dict | None:
     return {
         "error_code": "agent_start_timeout",
         "error": (
-            f"agent worker did not finish starting within "
-            f"{AGENT_START_TIMEOUT_SECONDS:g}s"
+            f"agent worker has not reached running within "
+            f"{AGENT_START_TIMEOUT_SECONDS:g}s; it remains configured and "
+            "may still finish starting, so check its status before retrying"
         ),
     }
 
@@ -624,6 +629,7 @@ class MachineControlClient:
     def __init__(self, machine) -> None:
         self.machine = machine
         self._seen_nonces: dict[str, int] = {}  # nonce -> ts; pruned to the ts window
+        self._command_tasks: set[asyncio.Future] = set()
         # Serialize WS writes — acks (receive loop) + heartbeat/capabilities
         # (sender task) share one socket; concurrent send_json would interleave.
         self._send_lock = asyncio.Lock()
@@ -686,7 +692,7 @@ class MachineControlClient:
                                     "control: WS connected; agent.status sender ready"
                                 )
                         elif frame.get("type") == "command":
-                            await self._handle(ws, frame)
+                            await self._handle(ws, frame, background_create=True)
                         elif frame.get("type") == "error":
                             log.warning("control: server rejected ws: %s", frame.get("reason"))
                             break
@@ -716,10 +722,15 @@ class MachineControlClient:
                 await self._send(ws, {"type": "capabilities", "capabilities": caps})
                 last_caps = caps
 
-    async def _handle(self, ws: aiohttp.ClientWebSocketResponse, frame: dict) -> None:
+    async def _handle(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        frame: dict,
+        *,
+        background_create: bool = False,
+    ) -> None:
         command_id = frame.get("command_id")
         operator_slug = frame.get("operator_slug")
-        result: dict = {"ok": False, "error_code": "command_failed"}
         try:
             pairing = load_pairings().get(operator_slug)
             if pairing is None:
@@ -739,19 +750,6 @@ class MachineControlClient:
                     n: t for n, t in self._seen_nonces.items() if t > cutoff
                 }
                 self._seen_nonces[nonce] = int(envelope.get("ts", now_ms()))
-            result = await execute_command(
-                decrypted["op"],
-                decrypted["agent_slug"],
-                decrypted["params"],
-                server_url=pairing.server_url,
-                paired_root_pubkey=pairing.operator_root_pubkey,
-                command_id=str(command_id or ""),
-            )
-            if isinstance(result, dict) and not result.get("ok", True):
-                log.warning(
-                    "control: command %s op=%s failed: %s",
-                    command_id, decrypted["op"], result.get("error"),
-                )
         except _DuplicateDelivery:
             log.debug(
                 "control: duplicate delivery suppressed for command %s",
@@ -765,14 +763,73 @@ class MachineControlClient:
         except Exception as exc:  # noqa: BLE001
             log.warning("control: command %s failed: %s", command_id, exc)
             result = {"ok": False, "error_code": "command_failed"}
-        if command_id:
-            try:
-                await self._send(
-                    ws,
-                    {"type": "ack", "command_id": command_id, "result": result},
+        else:
+            execution = self._execute_and_ack(
+                ws,
+                command_id,
+                decrypted,
+                pairing,
+            )
+            if background_create and command_id and decrypted["op"] == "create":
+                # A first Docker image build can take minutes. Keep that wait
+                # out of the one machine-control receive loop so pause/resume,
+                # runtime decisions, and other operators remain responsive.
+                task = spawn(execution, name=f"control.create:{command_id}")
+                self._command_tasks.add(task)
+                task.add_done_callback(self._command_tasks.discard)
+                return
+            await execution
+            return
+
+        await self._send_ack(ws, command_id, result)
+
+    async def _execute_and_ack(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        command_id: str | None,
+        decrypted: dict,
+        pairing,
+    ) -> None:
+        result: dict = {"ok": False, "error_code": "command_failed"}
+        try:
+            result = await execute_command(
+                decrypted["op"],
+                decrypted["agent_slug"],
+                decrypted["params"],
+                server_url=pairing.server_url,
+                paired_root_pubkey=pairing.operator_root_pubkey,
+                command_id=str(command_id or ""),
+            )
+            if isinstance(result, dict) and not result.get("ok", True):
+                log.warning(
+                    "control: command %s op=%s failed: %s",
+                    command_id,
+                    decrypted["op"],
+                    result.get("error"),
                 )
-            except Exception as exc:  # noqa: BLE001
-                log.debug("control: ack %s failed: %s", command_id, exc)
+        except ControlError as exc:
+            log.warning("control: rejected command %s: %s", command_id, exc)
+            result = {"ok": False, "error_code": "command_rejected"}
+        except Exception as exc:  # noqa: BLE001
+            log.warning("control: command %s failed: %s", command_id, exc)
+            result = {"ok": False, "error_code": "command_failed"}
+        await self._send_ack(ws, command_id, result)
+
+    async def _send_ack(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        command_id: str | None,
+        result: dict,
+    ) -> None:
+        if not command_id:
+            return
+        try:
+            await self._send(
+                ws,
+                {"type": "ack", "command_id": command_id, "result": result},
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug("control: ack %s failed: %s", command_id, exc)
 
 
 class ControlManager:

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -42,6 +42,11 @@ HTTP_TIMEOUT = aiohttp.ClientTimeout(total=30)
 # Control-WS heartbeat: liveness ping + capability re-check cadence. Must stay
 # well under the server's HEARTBEAT_TIMEOUT (90s) or the server culls us.
 HEARTBEAT_INTERVAL_SECONDS = 30.0
+# Remote create waits for the daemon's durable worker lifecycle instead of
+# acknowledging as soon as agent.yml exists. Docker's first image build may
+# legitimately take several minutes.
+AGENT_START_TIMEOUT_SECONDS = 10 * 60.0
+AGENT_START_POLL_SECONDS = 0.1
 
 
 class _DuplicateDelivery(ControlError):
@@ -193,8 +198,8 @@ async def _create_agent_command(
     async def _materialize(_ctx: dict) -> None:
         await _materialize_slug_binding(server_url, pending_token, slug_binding)
 
-    def _preflight(context: dict) -> None:
-        preflight_runtime(context["runtime"], agent_id=context["agent_id"])
+    async def _preflight(context: dict) -> None:
+        await preflight_runtime(context["runtime"], agent_id=context["agent_id"])
 
     try:
         result = await provision_agent_from_bundle(
@@ -207,7 +212,45 @@ async def _create_agent_command(
         return {"ok": False, "error": exc.reason, **exc.fields}
     except ControlError as exc:
         return {"ok": False, "error": str(exc)}
+    startup = await _wait_for_agent_start(result["agent_id"])
+    if startup is not None:
+        return {
+            "ok": False,
+            "agent_slug": result["agent_id"],
+            **startup,
+        }
     return {"ok": True, "agent_slug": result["agent_id"]}
+
+
+async def _wait_for_agent_start(agent_id: str) -> dict | None:
+    """Return ``None`` once the worker is running, else a structured failure."""
+    from ..state import RuntimeState
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + AGENT_START_TIMEOUT_SECONDS
+    while loop.time() < deadline:
+        runtime = RuntimeState.load(agent_id)
+        if runtime is not None:
+            if runtime.status == "running":
+                return None
+            if runtime.status == "error":
+                return {
+                    "error_code": "agent_start_failed",
+                    "error": runtime.error or "agent worker failed to start",
+                }
+            if runtime.status == "stopped":
+                return {
+                    "error_code": "agent_start_failed",
+                    "error": "agent worker stopped before startup completed",
+                }
+        await asyncio.sleep(AGENT_START_POLL_SECONDS)
+    return {
+        "error_code": "agent_start_timeout",
+        "error": (
+            f"agent worker did not finish starting within "
+            f"{AGENT_START_TIMEOUT_SECONDS:g}s"
+        ),
+    }
 
 
 async def post_usage_snapshot(machine, base: str) -> bool:

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -630,9 +630,15 @@ class MachineControlClient:
         self.machine = machine
         self._seen_nonces: dict[str, int] = {}  # nonce -> ts; pruned to the ts window
         self._command_tasks: set[asyncio.Future] = set()
+        self._inflight_command_ids: set[str] = set()
+        self._nonce_commands: dict[str, str] = {}
+        self._completed_results: dict[str, dict] = {}
+        self._pending_acks: dict[str, dict] = {}
+        self._active_ws: aiohttp.ClientWebSocketResponse | None = None
         # Serialize WS writes — acks (receive loop) + heartbeat/capabilities
         # (sender task) share one socket; concurrent send_json would interleave.
         self._send_lock = asyncio.Lock()
+        self._ack_flush_lock = asyncio.Lock()
 
     async def run(self, stop: asyncio.Event) -> None:
         while not stop.is_set():
@@ -686,6 +692,8 @@ class MachineControlClient:
                             continue
                         if frame.get("type") == "connected":
                             if not reporter_ready:
+                                self._active_ws = ws
+                                await self._flush_pending_acks(ws)
                                 reporter.set_sender(_report)
                                 reporter_ready = True
                                 log.info(
@@ -697,6 +705,8 @@ class MachineControlClient:
                             log.warning("control: server rejected ws: %s", frame.get("reason"))
                             break
                 finally:
+                    if self._active_ws is ws:
+                        self._active_ws = None
                     if reporter_ready:
                         reporter.set_sender(None)
                     sender.cancel()
@@ -746,13 +756,43 @@ class MachineControlClient:
                 # Bound the replay set: a nonce older than the ts window is
                 # already rejected by decrypt_command, so it's safe to forget.
                 cutoff = now_ms() - TS_WINDOW_MS
-                self._seen_nonces = {
-                    n: t for n, t in self._seen_nonces.items() if t > cutoff
+                expired_command_ids = {
+                    command
+                    for n, t in self._seen_nonces.items()
+                    if t <= cutoff
+                    if (command := self._nonce_commands.get(n)) is not None
+                    if command not in self._inflight_command_ids
                 }
+                self._seen_nonces = {
+                    n: t
+                    for n, t in self._seen_nonces.items()
+                    if t > cutoff
+                    or self._nonce_commands.get(n) in self._inflight_command_ids
+                }
+                self._nonce_commands = {
+                    n: command
+                    for n, command in self._nonce_commands.items()
+                    if n in self._seen_nonces
+                }
+                for expired_command_id in expired_command_ids:
+                    self._completed_results.pop(expired_command_id, None)
                 self._seen_nonces[nonce] = int(envelope.get("ts", now_ms()))
+                if command_id:
+                    self._nonce_commands[nonce] = str(command_id)
         except _DuplicateDelivery:
+            cached = self._completed_results.get(str(command_id or ""))
+            if cached is not None:
+                log.info("control: re-acking completed command %s", command_id)
+                await self._send_ack(command_id, cached, ws=ws)
+                return
+            if command_id and str(command_id) in self._inflight_command_ids:
+                log.info(
+                    "control: duplicate delivery suppressed while command %s is running",
+                    command_id,
+                )
+                return
             log.debug(
-                "control: duplicate delivery suppressed for command %s",
+                "control: duplicate delivery suppressed for unknown command %s",
                 command_id,
             )
             result = {"ok": False, "error_code": "command_rejected"}
@@ -765,11 +805,18 @@ class MachineControlClient:
             result = {"ok": False, "error_code": "command_failed"}
         else:
             execution = self._execute_and_ack(
-                ws,
+                (
+                    None
+                    if background_create and command_id and decrypted["op"] == "create"
+                    else ws
+                ),
                 command_id,
                 decrypted,
                 pairing,
+                nonce=str(nonce) if nonce else None,
             )
+            if command_id:
+                self._inflight_command_ids.add(str(command_id))
             if background_create and command_id and decrypted["op"] == "create":
                 # A first Docker image build can take minutes. Keep that wait
                 # out of the one machine-control receive loop so pause/resume,
@@ -781,14 +828,16 @@ class MachineControlClient:
             await execution
             return
 
-        await self._send_ack(ws, command_id, result)
+        await self._send_ack(command_id, result, ws=ws)
 
     async def _execute_and_ack(
         self,
-        ws: aiohttp.ClientWebSocketResponse,
+        ws: aiohttp.ClientWebSocketResponse | None,
         command_id: str | None,
         decrypted: dict,
         pairing,
+        *,
+        nonce: str | None,
     ) -> None:
         result: dict = {"ok": False, "error_code": "command_failed"}
         try:
@@ -813,23 +862,60 @@ class MachineControlClient:
         except Exception as exc:  # noqa: BLE001
             log.warning("control: command %s failed: %s", command_id, exc)
             result = {"ok": False, "error_code": "command_failed"}
-        await self._send_ack(ws, command_id, result)
+        finally:
+            if command_id:
+                command_key = str(command_id)
+                self._inflight_command_ids.discard(command_key)
+                self._completed_results[command_key] = result
+            if nonce:
+                # Retain the nonce for a full window after completion too, so
+                # an ambiguous/disconnected ack can only replay the result,
+                # never the side effect.
+                self._seen_nonces[nonce] = now_ms()
+        await self._send_ack(command_id, result, ws=ws)
 
     async def _send_ack(
         self,
-        ws: aiohttp.ClientWebSocketResponse,
         command_id: str | None,
         result: dict,
+        *,
+        ws: aiohttp.ClientWebSocketResponse | None = None,
     ) -> None:
         if not command_id:
             return
-        try:
-            await self._send(
-                ws,
-                {"type": "ack", "command_id": command_id, "result": result},
-            )
-        except Exception as exc:  # noqa: BLE001
-            log.debug("control: ack %s failed: %s", command_id, exc)
+        command_key = str(command_id)
+        self._pending_acks[command_key] = result
+        target = self._active_ws or ws
+        if target is not None:
+            await self._flush_pending_acks(target)
+
+    async def _flush_pending_acks(
+        self, ws: aiohttp.ClientWebSocketResponse
+    ) -> None:
+        """Send durable-in-memory results on the current authenticated socket.
+
+        A failed write leaves the result queued for the next connection. A
+        server redelivery after an ambiguous successful write is handled from
+        ``_completed_results`` and re-queues the same result.
+        """
+        async with self._ack_flush_lock:
+            if self._active_ws is not None and ws is not self._active_ws:
+                return
+            for command_id, result in list(self._pending_acks.items()):
+                try:
+                    await self._send(
+                        ws,
+                        {"type": "ack", "command_id": command_id, "result": result},
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log.warning(
+                        "control: ack %s failed; queued for reconnect: %s",
+                        command_id,
+                        exc,
+                    )
+                    return
+                if self._pending_acks.get(command_id) is result:
+                    self._pending_acks.pop(command_id, None)
 
 
 class ControlManager:

--- a/src/puffo_agent/portal/control/envelope.py
+++ b/src/puffo_agent/portal/control/envelope.py
@@ -27,8 +27,11 @@ from ...crypto.primitives import ed25519_verify, hpke_open
 from .store import MachineControlIdentity
 
 PORTAL_CMD_INFO = b"puffo/portal-cmd/v1"
-# Commands older than this (or this far in the future) are rejected.
-TS_WINDOW_MS = 5 * 60 * 1000
+# Commands older than this (or this far in the future) are rejected. Keep a
+# margin above the control client's ten-minute create budget: a valid command
+# must remain recognizable while its first Docker build is still running and
+# while its result is being re-acked after an ordinary reconnect.
+TS_WINDOW_MS = 15 * 60 * 1000
 
 
 class ControlError(Exception):

--- a/src/puffo_agent/portal/control/preflight.py
+++ b/src/puffo_agent/portal/control/preflight.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ...agent.cli_bin import resolve_opencode_bin, resolve_pi_bin
+from ...agent.cli_bin import resolve_docker_bin, resolve_opencode_bin, resolve_pi_bin
+from ...agent.harness.runtime.docker_support import container_state
 from ...agent.opencode_auth import OpenCodeProbeError, opencode_model_status
 from ...agent.pi_auth import PiAuthProbeError, check_pi_auth, pi_auth_target
 from ..runtime_matrix import (
+    RUNTIME_CLI_DOCKER,
     RUNTIME_CLI_LOCAL,
     resolve_effective_harness,
     resolve_effective_provider,
@@ -16,6 +18,7 @@ from ..state import RuntimeConfig, agent_dir, select_pi_auth_home
 from .provision import ProvisionError
 
 _MAX_NATIVE_REASON_CHARS = 200
+_DOCKER_PREFLIGHT_CONTAINER = "puffo-runtime-preflight"
 
 
 def _not_ready(
@@ -41,8 +44,44 @@ def _not_ready(
     return ProvisionError(message, **fields)
 
 
-def preflight_runtime(runtime: RuntimeConfig, *, agent_id: str = "") -> None:
-    """Reject an unusable Pi/OpenCode selection before provisioning state."""
+def _docker_not_ready(reason: str) -> ProvisionError:
+    message = {
+        "not_installed": (
+            "Docker is not installed; install Docker Desktop or docker-ce "
+            "and retry"
+        ),
+        "daemon_unavailable": (
+            "Docker is installed but its daemon is unavailable; start Docker "
+            "and retry"
+        ),
+    }[reason]
+    return ProvisionError(
+        message,
+        error_code="runtime_not_ready",
+        runtime_kind=RUNTIME_CLI_DOCKER,
+        reason=reason,
+    )
+
+
+async def preflight_runtime(runtime: RuntimeConfig, *, agent_id: str = "") -> None:
+    """Reject an unusable runtime before identity materialization."""
+    if runtime.kind == RUNTIME_CLI_DOCKER:
+        docker_bin = resolve_docker_bin()
+        if docker_bin is None:
+            raise _docker_not_ready("not_installed")
+        probe_name = (
+            f"{_DOCKER_PREFLIGHT_CONTAINER}-{agent_id}"
+            if agent_id
+            else _DOCKER_PREFLIGHT_CONTAINER
+        )
+        try:
+            state = await container_state(docker_bin, probe_name)
+        except (OSError, RuntimeError) as exc:
+            raise _docker_not_ready("daemon_unavailable") from exc
+        if state is None:
+            raise _docker_not_ready("daemon_unavailable")
+        return
+
     provider = resolve_effective_provider(runtime.kind, runtime.provider)
     harness = resolve_effective_harness(runtime.kind, provider, runtime.harness)
     if runtime.kind != RUNTIME_CLI_LOCAL or harness not in {"pi", "opencode"}:

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -341,7 +341,7 @@ async def provision_agent_from_bundle(
 ) -> dict:
     context = verify_agent_bundle(payload, operator_root_key_b64)
     if preflight is not None:
-        preflight(context)
+        await preflight(context)
     if materialize is not None:
         await materialize(context)
     result = write_agent_from_context(context)

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -376,7 +376,7 @@ class Daemon:
                     # the persisted session into Node's heap, so N
                     # parallel warms can OOM the host. Awaiting one at
                     # a time keeps peak RSS bounded.
-                    await worker.wait_warm(timeout=self._warm_serialise_timeout)
+                    await self._observe_worker_start(agent_id, worker)
                 elif (
                     worker.restart_required
                     or _worker_needs_restart(worker.agent_cfg, agent_cfg)
@@ -400,7 +400,7 @@ class Daemon:
                     self.workers[agent_id] = worker
                     self._register_with_refresher(agent_cfg, worker)
                     worker.start()
-                    await worker.wait_warm(timeout=self._warm_serialise_timeout)
+                    await self._observe_worker_start(agent_id, worker)
                 else:
                     worker.agent_cfg = agent_cfg
             elif desired_state == "paused":
@@ -418,6 +418,16 @@ class Daemon:
                         self._paused_reported.add(agent_id)
             else:
                 logger.warning("agent %s: unknown state %r", agent_id, desired_state)
+
+    async def _observe_worker_start(self, agent_id: str, worker: Worker) -> None:
+        if await worker.wait_warm(timeout=self._warm_serialise_timeout):
+            return
+        logger.warning(
+            "agent %s: worker did not reach running during the startup "
+            "observation window (status=%s)",
+            agent_id,
+            worker.runtime.status,
+        )
 
     async def _stop_removed_agents(self, on_disk: set[str]) -> None:
         for stale_id in list(self._agent_cfg_cache.keys() - on_disk):

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -942,7 +942,7 @@ class RuntimeState:
     worker deadlocked).
     """
 
-    status: str = "stopped"  # running | paused | error | stopped
+    status: str = "stopped"  # starting | running | paused | error | stopped
     started_at: int = 0
     updated_at: int = 0
     msg_count: int = 0

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -359,6 +359,8 @@ class Worker:
                 logger,
                 api_key_mode=getattr(self, "_claude_api_key_mode", False),
             )
+        self.runtime.status = "running"
+        self.runtime.save(agent_id)
         self._warm_done.set()
 
     @staticmethod
@@ -804,7 +806,7 @@ class Worker:
         )
         self._api_key_auth_recovery_pending = False
         self.runtime = RuntimeState(
-            status="running",
+            status="starting",
             started_at=int(time.time()),
             msg_count=0,
         )
@@ -903,6 +905,9 @@ class Worker:
     def start(self) -> asyncio.Task:
         if self._task is not None and not self._task.done():
             return self._task
+        self.runtime.status = "starting"
+        self.runtime.error = ""
+        self.runtime.save(self.agent_cfg.id)
         self._task = spawn(self._run(), name="run")
         return self._task
 
@@ -917,10 +922,10 @@ class Worker:
 
     async def wait_warm(self, timeout: float | None = None) -> bool:
         """Block until warm() finishes or the worker exits early.
-        Returns True on completion, False on timeout."""
+        Returns True only when startup reached ``running``."""
         try:
             await asyncio.wait_for(self._warm_done.wait(), timeout=timeout)
-            return True
+            return self.runtime.status == "running"
         except asyncio.TimeoutError:
             return False
 

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -206,6 +206,75 @@ async def test_duplicate_delivery_is_debug_not_rejection_warning(
     )
 
 
+@pytest.mark.asyncio
+async def test_completed_redelivery_reacks_exact_result_without_reexecution(monkeypatch):
+    result = {"ok": False, "error_code": "agent_start_timeout"}
+    executions = 0
+
+    async def fake_exec(*args, **kwargs):
+        nonlocal executions
+        executions += 1
+        return result
+
+    monkeypatch.setattr(cc, "execute_command", fake_exec)
+    monkeypatch.setattr(
+        cc,
+        "load_pairings",
+        lambda: {
+            "op": types.SimpleNamespace(
+                operator_root_pubkey="ROOT", server_url="https://s"
+            )
+        },
+    )
+    monkeypatch.setattr(
+        cc,
+        "decrypt_command",
+        lambda *args: {"op": "create", "agent_slug": "a1", "params": {}},
+    )
+    monkeypatch.setattr(cc, "now_ms", lambda: 1_000_000)
+    client = MachineControlClient(machine=object())
+    ws = _FakeWS()
+    frame = {
+        "command_id": "create-1",
+        "operator_slug": "op",
+        "envelope": {"nonce": "N1", "ts": 1_000_000},
+    }
+
+    await client._handle(ws, frame)
+    await client._handle(ws, frame)
+
+    assert executions == 1
+    assert ws.acks == [
+        {"type": "ack", "command_id": "create-1", "result": result},
+        {"type": "ack", "command_id": "create-1", "result": result},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_ack_is_warned_and_retried(monkeypatch, caplog):
+    class FailingWS:
+        async def send_json(self, obj):
+            raise ConnectionError("socket closed")
+
+    client = MachineControlClient(machine=object())
+    client._active_ws = FailingWS()
+    caplog.set_level(logging.WARNING, logger=cc.log.name)
+
+    result = {"ok": True}
+    await client._send_ack("create-1", result)
+
+    assert client._pending_acks == {"create-1": result}
+    assert "queued for reconnect" in caplog.text
+
+    recovered_ws = _FakeWS()
+    client._active_ws = recovered_ws
+    await client._flush_pending_acks(recovered_ws)
+    assert client._pending_acks == {}
+    assert recovered_ws.acks == [
+        {"type": "ack", "command_id": "create-1", "result": result}
+    ]
+
+
 @pytest.fixture
 def home(monkeypatch):
     h = isolated_home()
@@ -516,11 +585,108 @@ async def test_create_wait_does_not_block_followup_machine_command(monkeypatch):
 
     release_create.set()
     await asyncio.gather(*client._command_tasks)
-    assert ws.acks[-1] == {
+    assert [sent for sent in ws.acks if sent.get("command_id") == "create-1"] == []
+
+    # The create finished after the first socket's context exited. Its result
+    # is held and sent on the next authenticated connection, never on the stale
+    # socket captured when the command arrived.
+    reconnect_ws = _StreamingWS([{"type": "connected"}])
+    monkeypatch.setattr(
+        cc,
+        "create_remote_http_session",
+        lambda *args, **kwargs: _ControlSession(reconnect_ws),
+    )
+    await client._connect_once(asyncio.Event())
+    assert reconnect_ws.acks[-1] == {
         "type": "ack",
         "command_id": "create-1",
         "result": {"ok": True, "op": "create"},
     }
+
+
+@pytest.mark.asyncio
+async def test_create_redelivery_after_five_minutes_is_not_reexecuted(monkeypatch):
+    """A long first build remains deduped beyond the former five-minute window."""
+    clock = [1_000_000]
+    create_started = asyncio.Event()
+    release_create = asyncio.Event()
+    executed = []
+
+    async def fake_exec(op, *args, **kwargs):
+        executed.append(op)
+        if op == "create":
+            create_started.set()
+            await release_create.wait()
+        return {"ok": True, "op": op}
+
+    monkeypatch.setattr(cc, "execute_command", fake_exec)
+    monkeypatch.setattr(cc, "now_ms", lambda: clock[0])
+    monkeypatch.setattr(
+        cc,
+        "load_pairings",
+        lambda: {
+            "op": types.SimpleNamespace(
+                operator_root_pubkey="ROOT", server_url="https://s"
+            )
+        },
+    )
+    monkeypatch.setattr(
+        cc,
+        "decrypt_command",
+        lambda envelope, *args: {
+            "op": envelope["op"],
+            "agent_slug": envelope.get("agent_slug"),
+            "params": {},
+        },
+    )
+    monkeypatch.setattr(cc.machine_auth, "ws_connect_frame", lambda machine: {})
+    monkeypatch.setattr(cc, "build_capabilities", lambda: {})
+
+    def frame(command_id, nonce, op):
+        return {
+            "type": "command",
+            "command_id": command_id,
+            "operator_slug": "op",
+            "envelope": {
+                "nonce": nonce,
+                "ts": 1_000_000,
+                "op": op,
+            },
+        }
+
+    client = MachineControlClient(machine=object())
+    first_ws = _StreamingWS([
+        {"type": "connected"},
+        frame("create-1", "nonce-create", "create"),
+    ])
+    monkeypatch.setattr(
+        cc,
+        "create_remote_http_session",
+        lambda *args, **kwargs: _ControlSession(first_ws),
+    )
+    await client._connect_once(asyncio.Event())
+    await asyncio.wait_for(create_started.wait(), timeout=0.5)
+
+    # A different command forces replay-cache pruning after five minutes,
+    # followed by server redelivery of the still-running create.
+    clock[0] += 5 * 60 * 1000 + 1
+    second_ws = _StreamingWS([
+        {"type": "connected"},
+        frame("pause-1", "nonce-pause", "pause"),
+        frame("create-1", "nonce-create", "create"),
+    ])
+    monkeypatch.setattr(
+        cc,
+        "create_remote_http_session",
+        lambda *args, **kwargs: _ControlSession(second_ws),
+    )
+    await client._connect_once(asyncio.Event())
+    assert executed == ["create", "pause"]
+    assert not any(sent.get("command_id") == "create-1" for sent in second_ws.acks)
+
+    release_create.set()
+    await asyncio.gather(*client._command_tasks)
+    assert cc.TS_WINDOW_MS >= cc.AGENT_START_TIMEOUT_SECONDS * 1000
 
 
 # ── usage-report snapshot loop ─────────────────────────────────────

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -23,6 +23,43 @@ class _FakeWS:
         self.acks.append(obj)
 
 
+class _StreamingWS(_FakeWS):
+    def __init__(self, frames):
+        super().__init__()
+        self.frames = frames
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self.frames:
+            raise StopAsyncIteration
+        return types.SimpleNamespace(
+            type=cc.aiohttp.WSMsgType.TEXT,
+            data=json.dumps(self.frames.pop(0)),
+        )
+
+
+class _ControlSession:
+    def __init__(self, socket):
+        self.socket = socket
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def ws_connect(self, *args, **kwargs):
+        return self.socket
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("server_frame", "connected_logged"),
@@ -355,7 +392,11 @@ async def test_start_waiter_returns_structured_timeout(home, monkeypatch):
 
     assert await cc._wait_for_agent_start("helper-1") == {
         "error_code": "agent_start_timeout",
-        "error": "agent worker did not finish starting within 0s",
+        "error": (
+            "agent worker has not reached running within 0s; it remains "
+            "configured and may still finish starting, so check its status "
+            "before retrying"
+        ),
     }
 
 
@@ -397,6 +438,89 @@ async def test_handle_ack_carries_the_exact_command_result(monkeypatch):
     assert ws.acks == [
         {"type": "ack", "command_id": "create-1", "result": result}
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_wait_does_not_block_followup_machine_command(monkeypatch):
+    create_started = asyncio.Event()
+    release_create = asyncio.Event()
+
+    async def fake_exec(op, *args, **kwargs):
+        if op == "create":
+            create_started.set()
+            await release_create.wait()
+        return {"ok": True, "op": op}
+
+    monkeypatch.setattr(cc, "execute_command", fake_exec)
+    monkeypatch.setattr(
+        cc,
+        "load_pairings",
+        lambda: {
+            "op": types.SimpleNamespace(
+                operator_root_pubkey="ROOT", server_url="https://s"
+            )
+        },
+    )
+    monkeypatch.setattr(
+        cc,
+        "decrypt_command",
+        lambda envelope, *args: {
+            "op": envelope["op"],
+            "agent_slug": envelope.get("agent_slug"),
+            "params": {},
+        },
+    )
+    def frame(command_id, nonce, op, agent_slug=None):
+        return {
+            "type": "command",
+            "command_id": command_id,
+            "operator_slug": "op",
+            "envelope": {
+                "nonce": nonce,
+                "ts": cc.now_ms(),
+                "op": op,
+                "agent_slug": agent_slug,
+            },
+        }
+
+    ws = _StreamingWS([
+        {"type": "connected"},
+        frame("create-1", "nonce-create", "create"),
+        frame("pause-1", "nonce-pause", "pause", "existing-agent"),
+    ])
+    monkeypatch.setattr(
+        cc,
+        "create_remote_http_session",
+        lambda *args, **kwargs: _ControlSession(ws),
+    )
+    monkeypatch.setattr(cc.machine_auth, "ws_connect_frame", lambda machine: {})
+    monkeypatch.setattr(cc, "build_capabilities", lambda: {})
+    client = MachineControlClient(machine=object())
+
+    # Exercise the real receive loop. Removing its background-create dispatch
+    # makes this wait forever on the first command and never ack the second.
+    await asyncio.wait_for(
+        client._connect_once(asyncio.Event()),
+        timeout=0.5,
+    )
+    assert len(client._command_tasks) == 1, ws.acks
+    await asyncio.wait_for(create_started.wait(), timeout=0.5)
+    acks = [sent for sent in ws.acks if sent.get("type") == "ack"]
+    assert acks == [
+        {
+            "type": "ack",
+            "command_id": "pause-1",
+            "result": {"ok": True, "op": "pause"},
+        }
+    ]
+
+    release_create.set()
+    await asyncio.gather(*client._command_tasks)
+    assert ws.acks[-1] == {
+        "type": "ack",
+        "command_id": "create-1",
+        "result": {"ok": True, "op": "create"},
+    }
 
 
 # ── usage-report snapshot loop ─────────────────────────────────────

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -12,7 +12,7 @@ import pytest
 from _portal_support import isolated_home, write_test_agent
 from puffo_agent.portal.control import client as cc
 from puffo_agent.portal.control.client import MachineControlClient, execute_command
-from puffo_agent.portal.state import AgentConfig
+from puffo_agent.portal.state import AgentConfig, RuntimeState
 
 
 class _FakeWS:
@@ -250,6 +250,11 @@ async def test_create_delegates_to_control_provisioner(home, monkeypatch):
         "puffo_agent.portal.control.provision.provision_agent_from_bundle",
         fake_provision,
     )
+
+    async def started(_agent_id):
+        return None
+
+    monkeypatch.setattr(cc, "_wait_for_agent_start", started)
     params = {
         "pending_token": "pending_1",
         "identity_bundle": {"slug_binding": {}},
@@ -265,6 +270,93 @@ async def test_create_delegates_to_control_provisioner(home, monkeypatch):
     assert result == {"ok": True, "agent_slug": "helper-1"}
     assert seen["operator_key"] == "operator-key"
     assert seen["params"]["puffo_core"]["server_url"] == "https://relay.example"
+
+
+@pytest.mark.asyncio
+async def test_create_reports_worker_start_failure(home, monkeypatch):
+    async def fake_provision(*args, **kwargs):
+        return {"agent_id": "helper-1"}
+
+    async def failed(_agent_id):
+        return {
+            "error_code": "agent_start_failed",
+            "error": "docker run failed",
+        }
+
+    monkeypatch.setattr(
+        "puffo_agent.portal.control.provision.provision_agent_from_bundle",
+        fake_provision,
+    )
+    monkeypatch.setattr(cc, "_wait_for_agent_start", failed)
+    params = {
+        "pending_token": "pending_1",
+        "identity_bundle": {"slug_binding": {}},
+        "puffo_core": {},
+    }
+
+    result = await execute_command(
+        "create",
+        None,
+        params,
+        server_url="https://relay.example",
+        paired_root_pubkey="operator-key",
+    )
+
+    assert result == {
+        "ok": False,
+        "agent_slug": "helper-1",
+        "error_code": "agent_start_failed",
+        "error": "docker run failed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_waiter_ignores_starting_then_returns_running(
+    home, monkeypatch,
+):
+    states = iter(
+        [
+            RuntimeState(status="starting"),
+            RuntimeState(status="running"),
+        ]
+    )
+    monkeypatch.setattr(
+        RuntimeState,
+        "load",
+        classmethod(lambda cls, agent_id: next(states)),
+    )
+    monkeypatch.setattr(cc, "AGENT_START_POLL_SECONDS", 0)
+
+    assert await cc._wait_for_agent_start("helper-1") is None
+
+
+@pytest.mark.asyncio
+async def test_start_waiter_returns_persisted_worker_error(home, monkeypatch):
+    monkeypatch.setattr(
+        RuntimeState,
+        "load",
+        classmethod(
+            lambda cls, agent_id: RuntimeState(
+                status="error",
+                error="Docker daemon stopped",
+            )
+        ),
+    )
+
+    assert await cc._wait_for_agent_start("helper-1") == {
+        "error_code": "agent_start_failed",
+        "error": "Docker daemon stopped",
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_waiter_returns_structured_timeout(home, monkeypatch):
+    monkeypatch.setattr(cc, "AGENT_START_TIMEOUT_SECONDS", 0)
+
+    assert await cc._wait_for_agent_start("helper-1") == {
+        "error_code": "agent_start_timeout",
+        "error": "agent worker did not finish starting within 0s",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_control_envelope.py
+++ b/tests/test_control_envelope.py
@@ -132,9 +132,9 @@ def test_stale_command_rejected(home):
     op_root = base64url_encode(operator.public_key_bytes())
     ts = store.now_ms()
     env = _command(operator, machine, "cmd_3", "pause", ts)
-    # 10 minutes later → outside the ±5min window.
+    # 20 minutes later → outside the ±15min window.
     with pytest.raises(ControlError):
-        decrypt_command(env, machine, op_root, ts + 10 * 60 * 1000)
+        decrypt_command(env, machine, op_root, ts + 20 * 60 * 1000)
 
 
 def test_pairing_persist_round_trip(home):

--- a/tests/test_control_preflight.py
+++ b/tests/test_control_preflight.py
@@ -26,11 +26,12 @@ def _runtime(
     )
 
 
-def test_pi_preflight_reports_missing_binary(monkeypatch):
+@pytest.mark.asyncio
+async def test_pi_preflight_reports_missing_binary(monkeypatch):
     monkeypatch.setattr(preflight, "resolve_pi_bin", lambda: None)
 
     with pytest.raises(ProvisionError) as caught:
-        preflight.preflight_runtime(_runtime())
+        await preflight.preflight_runtime(_runtime())
 
     assert caught.value.reason == "Pi is not installed"
     assert caught.value.fields == {
@@ -40,7 +41,8 @@ def test_pi_preflight_reports_missing_binary(monkeypatch):
     }
 
 
-def test_pi_preflight_uses_qualified_model_as_authoritative_target(
+@pytest.mark.asyncio
+async def test_pi_preflight_uses_qualified_model_as_authoritative_target(
     tmp_path, monkeypatch,
 ):
     seen = {}
@@ -53,7 +55,7 @@ def test_pi_preflight_uses_qualified_model_as_authoritative_target(
 
     monkeypatch.setattr(preflight, "check_pi_auth", fake_check)
 
-    preflight.preflight_runtime(
+    await preflight.preflight_runtime(
         _runtime(provider="anthropic", model="openai/gpt-5.5")
     )
 
@@ -65,7 +67,10 @@ def test_pi_preflight_uses_qualified_model_as_authoritative_target(
     }
 
 
-def test_pi_preflight_returns_machine_readable_login_reason(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_pi_preflight_returns_machine_readable_login_reason(
+    tmp_path, monkeypatch,
+):
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     monkeypatch.setattr(preflight, "resolve_pi_bin", lambda: "/opt/bin/pi")
     monkeypatch.setattr(
@@ -79,7 +84,7 @@ def test_pi_preflight_returns_machine_readable_login_reason(tmp_path, monkeypatc
     )
 
     with pytest.raises(ProvisionError) as caught:
-        preflight.preflight_runtime(_runtime())
+        await preflight.preflight_runtime(_runtime())
 
     assert caught.value.reason == "Pi sign-in required"
     assert caught.value.fields == {
@@ -90,7 +95,10 @@ def test_pi_preflight_returns_machine_readable_login_reason(tmp_path, monkeypatc
     }
 
 
-def test_pi_preflight_bounds_native_reason_from_harness(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_pi_preflight_bounds_native_reason_from_harness(
+    tmp_path, monkeypatch,
+):
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     monkeypatch.setattr(preflight, "resolve_pi_bin", lambda: "/opt/bin/pi")
     monkeypatch.setattr(
@@ -104,12 +112,15 @@ def test_pi_preflight_bounds_native_reason_from_harness(tmp_path, monkeypatch):
     )
 
     with pytest.raises(ProvisionError) as caught:
-        preflight.preflight_runtime(_runtime())
+        await preflight.preflight_runtime(_runtime())
 
     assert caught.value.fields["native_reason"] == "x" * 200
 
 
-def test_opencode_preflight_rejects_model_missing_from_native_catalog(monkeypatch):
+@pytest.mark.asyncio
+async def test_opencode_preflight_rejects_model_missing_from_native_catalog(
+    monkeypatch,
+):
     """A stale private model choice must fail before agent files are written."""
     monkeypatch.setattr(
         preflight, "resolve_opencode_bin", lambda: "/opt/bin/opencode",
@@ -123,7 +134,7 @@ def test_opencode_preflight_rejects_model_missing_from_native_catalog(monkeypatc
     )
 
     with pytest.raises(ProvisionError) as caught:
-        preflight.preflight_runtime(
+        await preflight.preflight_runtime(
             _runtime(
                 provider="deepseek",
                 harness="opencode",
@@ -142,7 +153,8 @@ def test_opencode_preflight_rejects_model_missing_from_native_catalog(monkeypatc
     )
 
 
-def test_opencode_preflight_accepts_model_in_native_catalog(monkeypatch):
+@pytest.mark.asyncio
+async def test_opencode_preflight_accepts_model_in_native_catalog(monkeypatch):
     monkeypatch.setattr(
         preflight, "resolve_opencode_bin", lambda: "/opt/bin/opencode",
     )
@@ -152,7 +164,7 @@ def test_opencode_preflight_accepts_model_in_native_catalog(monkeypatch):
         lambda executable, model: "ready",
     )
 
-    preflight.preflight_runtime(
+    await preflight.preflight_runtime(
         _runtime(
             provider="deepseek",
             harness="opencode",
@@ -161,7 +173,8 @@ def test_opencode_preflight_accepts_model_in_native_catalog(monkeypatch):
     )
 
 
-def test_opencode_preflight_reports_missing_provider_as_login(monkeypatch):
+@pytest.mark.asyncio
+async def test_opencode_preflight_reports_missing_provider_as_login(monkeypatch):
     monkeypatch.setattr(
         preflight, "resolve_opencode_bin", lambda: "/opt/bin/opencode",
     )
@@ -172,7 +185,7 @@ def test_opencode_preflight_reports_missing_provider_as_login(monkeypatch):
     )
 
     with pytest.raises(ProvisionError) as caught:
-        preflight.preflight_runtime(
+        await preflight.preflight_runtime(
             _runtime(
                 provider="deepseek",
                 harness="opencode",
@@ -182,3 +195,55 @@ def test_opencode_preflight_reports_missing_provider_as_login(monkeypatch):
 
     assert caught.value.fields["reason"] == "need_login"
     assert str(caught.value) == "OpenCode sign-in required"
+
+
+@pytest.mark.asyncio
+async def test_docker_preflight_rejects_missing_binary(monkeypatch):
+    monkeypatch.setattr(preflight, "resolve_docker_bin", lambda: None)
+    runtime = RuntimeConfig(kind="cli-docker", harness="claude-code")
+
+    with pytest.raises(ProvisionError) as caught:
+        await preflight.preflight_runtime(runtime, agent_id="docker-agent")
+
+    assert caught.value.fields == {
+        "error_code": "runtime_not_ready",
+        "runtime_kind": "cli-docker",
+        "reason": "not_installed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_docker_preflight_rejects_unavailable_daemon(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(preflight, "resolve_docker_bin", lambda: "/opt/docker")
+
+    async def unavailable(docker_bin, container_name):
+        seen.update(docker_bin=docker_bin, container_name=container_name)
+        return None
+
+    monkeypatch.setattr(preflight, "container_state", unavailable)
+    runtime = RuntimeConfig(kind="cli-docker", harness="claude-code")
+
+    with pytest.raises(ProvisionError) as caught:
+        await preflight.preflight_runtime(runtime, agent_id="docker-agent")
+
+    assert caught.value.fields["reason"] == "daemon_unavailable"
+    assert seen == {
+        "docker_bin": "/opt/docker",
+        "container_name": "puffo-runtime-preflight-docker-agent",
+    }
+
+
+@pytest.mark.asyncio
+async def test_docker_preflight_reuses_container_probe(monkeypatch):
+    monkeypatch.setattr(preflight, "resolve_docker_bin", lambda: "/opt/docker")
+
+    async def available(_docker_bin, _container_name):
+        return ""
+
+    monkeypatch.setattr(preflight, "container_state", available)
+
+    await preflight.preflight_runtime(
+        RuntimeConfig(kind="cli-docker", harness="claude-code"),
+        agent_id="docker-agent",
+    )

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -372,7 +372,7 @@ async def test_provision_preflight_rejects_before_materialization_or_write(
     payload, operator_public = _payload()
     events = []
 
-    def preflight(context):
+    async def preflight(context):
         events.append(("preflight", context["agent_id"]))
         raise ProvisionError(
             "Pi sign-in required",

--- a/tests/test_daemon_catchup_config.py
+++ b/tests/test_daemon_catchup_config.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 import yaml
@@ -178,6 +181,26 @@ def test_real_reconcile_initializes_multiple_ws_local_workers(
             tmp_path, monkeypatch,
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_daemon_observes_worker_start_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    daemon = Daemon(DaemonConfig())
+    worker = SimpleNamespace(
+        wait_warm=AsyncMock(return_value=False),
+        runtime=SimpleNamespace(status="error"),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await daemon._observe_worker_start("broken-agent", worker)
+
+    worker.wait_warm.assert_awaited_once_with(
+        timeout=daemon._warm_serialise_timeout,
+    )
+    assert "broken-agent: worker did not reach running" in caplog.text
+    assert "status=error" in caplog.text
 
 
 async def _assert_reconcile_replaces_post_start_fatal_worker(

--- a/tests/test_worker_health_probe_gate.py
+++ b/tests/test_worker_health_probe_gate.py
@@ -13,9 +13,10 @@ from unittest.mock import AsyncMock, Mock, patch
 class _Runtime:
     """Stand-in for RuntimeState — records save() calls instead of
     hitting disk."""
-    def __init__(self, health="ok", error=""):
+    def __init__(self, health="ok", error="", status="starting"):
         self.health = health
         self.error = error
+        self.status = status
         self.saved = []
 
     def save(self, agent_id):
@@ -136,13 +137,17 @@ def test_warm_done_only_flips_after_probe_completes():
         gate_task = asyncio.create_task(w._run_post_warm_gate("agent-a"))
         await started.wait()
         captured["mid_probe"] = w._warm_done.is_set()
+        captured["mid_probe_status"] = w.runtime.status
         release.set()
         await gate_task
         captured["post_gate"] = w._warm_done.is_set()
+        captured["post_gate_status"] = w.runtime.status
 
     asyncio.run(_run())
     assert captured["mid_probe"] is False
+    assert captured["mid_probe_status"] == "starting"
     assert captured["post_gate"] is True
+    assert captured["post_gate_status"] == "running"
 
 
 def test_warm_done_only_flips_after_reassert_when_probe_fails():


### PR DESCRIPTION
## Summary
- fail remote `cli-docker` create before identity materialization when Docker is missing or the daemon is unavailable, reusing the existing Docker binary resolver and container-state probe
- persist `starting` until the worker completes runtime warm-up and its post-warm health gate
- keep the machine command open until durable runtime state reaches `running`, `error`, `stopped`, or the 10-minute create deadline
- make daemon startup serialization observe and log a failed startup result instead of ignoring `wait_warm()`

## Contract
The create ack remains `{ok: true, agent_slug}` on success. Startup failures now return `ok: false` with `agent_start_failed` or `agent_start_timeout`. Docker preflight failures use the existing `runtime_not_ready` family with `reason=not_installed|daemon_unavailable`.

## Verification
- `env -u CODEX_HOME uv run pytest -q` (full suite passed; 2 expected skips)
- focused runtime/control group passed
- `uv run pre-commit run --all-files`
- `git diff --check`
- mutation checks proved the regression tests fail when Docker preflight, create-result propagation, running transition, or daemon startup observation is removed

The ambient Puffo agent process sets `CODEX_HOME`; the first full-suite run exposed 7 unrelated host-MCP isolation tests. Re-running those tests and the full suite with that ambient variable removed passed.