### PR TITLE
fix(codex): preserve large session resume

### DIFF
--- a/src/puffo_agent/agent/harness/drivers/codex.py
+++ b/src/puffo_agent/agent/harness/drivers/codex.py
@@ -391,6 +391,13 @@ class CodexAppServerDriver(Driver):
                 "thread/resume",
                 {
                     "threadId": str(resume),
+                    # Puffo already persists its own visible event history and
+                    # only needs Codex to restore the provider-side context.
+                    # Returning every reconstructed turn can turn a large
+                    # rollout into one enormous JSONL response before a new
+                    # turn even starts. Codex still resumes the full thread;
+                    # this only keeps that history out of the response.
+                    "excludeTurns": True,
                     **thread_config,
                 },
             )

--- a/src/puffo_agent/agent/harness/drivers/codex.py
+++ b/src/puffo_agent/agent/harness/drivers/codex.py
@@ -356,7 +356,10 @@ class CodexAppServerDriver(Driver):
             "initialize",
             {
                 "clientInfo": {"name": "puffo-agent", "version": "1"},
-                "capabilities": {},
+                # Codex gates thread/resume.excludeTurns behind this client
+                # capability. Without it, supported app-server versions reject
+                # every resume request before attempting to load the thread.
+                "capabilities": {"experimentalApi": True},
             },
         )
         await self._write({"method": "initialized", "params": {}})

--- a/tests/test_codex_resume.py
+++ b/tests/test_codex_resume.py
@@ -1,0 +1,25 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from puffo_agent.agent.harness.drivers.codex import CodexAppServerDriver
+
+
+@pytest.mark.asyncio
+async def test_initialize_enables_api_required_by_exclude_turns():
+    driver = CodexAppServerDriver()
+    driver._request = AsyncMock(return_value={})
+    driver._write = AsyncMock()
+
+    await driver._initialize_app_server()
+
+    driver._request.assert_awaited_once_with(
+        "initialize",
+        {
+            "clientInfo": {"name": "puffo-agent", "version": "1"},
+            "capabilities": {"experimentalApi": True},
+        },
+    )
+    driver._write.assert_awaited_once_with(
+        {"method": "initialized", "params": {}}
+    )

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -1084,7 +1084,7 @@ async def test_claude_driver_emits_compaction_boundary_and_clears_tool_calls():
 
 
 @pytest.mark.asyncio
-async def test_codex_driver_resumes_with_native_session_id_after_handshake():
+async def test_codex_driver_resumes_without_returning_full_turn_history():
     holder = {}
 
     def on_frame(frame):
@@ -1094,7 +1094,7 @@ async def test_codex_driver_resumes_with_native_session_id_after_handshake():
         elif frame.get("method") == "thread/resume":
             assert frame["params"] == {
                 "threadId": "native-thread",
-                "cwd": "/workspace",
+                "excludeTurns": True, "cwd": "/workspace",
                 "approvalPolicy": "never",
                 "sandbox": "danger-full-access",
                 "model": "gpt",


### PR DESCRIPTION
## Summary

- request Codex `thread/resume` with `excludeTurns: true`
- preserve the native thread and provider-side context while preventing full reconstructed history from becoming one oversized stdout JSONL frame
- pin the request contract with a regression test

## Why

A real Codex session with a 278 MB rollout could no longer resume because the default full-history response exceeded Puffo Agent’s 16 MiB stdout frame limit before `turn/start`. Codex 0.145.0-alpha.18 already supports its metadata-only resume response: the thread is fully restored, but historical turns are not serialized back to the client.

## Verification

- mutation: removing `excludeTurns` makes the regression test fail
- targeted driver/transport suite: 67 passed, 1 skipped
- full suite: 3883 passed, 2 skipped
- pre-commit: all hooks passed
- Python structure check: passed