### PR TITLE
Prepare Agent 2.0.4a1 TestPyPI release

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -15,7 +15,7 @@
 #
 # Verify after a run with:
 #   pip install -i https://test.pypi.org/simple/ \
-#     --extra-index-url https://pypi.org/simple/ puffo-agent
+#     --extra-index-url https://pypi.org/simple/ puffo-agent==2.0.4a1
 # (the extra index lets test-pypi resolve real deps from real PyPI).
 
 name: Publish to TestPyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [2.0.4a1] - 2026-09-03
+## 2.0.4a1 - 2026-09-03
 
 > Pre-release published to TestPyPI for staging validation only. It is not the
 > stable `2.0.4` release. Because TestPyPI already contains an earlier build
@@ -5028,8 +5028,7 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.4a1...HEAD
-[2.0.4a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.4a1
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.3...HEAD
 [2.0.3]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.3
 [2.0.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.2
 [2.0.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [2.0.4] - 2026-09-01
+## [2.0.4a1] - 2026-09-03
+
+> Pre-release published to TestPyPI for staging validation only. It is not the
+> stable `2.0.4` release. Because TestPyPI already contains an earlier build
+> numbered `2.0.4`, install this candidate with an explicit `==2.0.4a1` pin.
 
 ### Added
 
@@ -15,6 +19,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   exact models before provisioning identity state, and discovers standard
   per-user OpenCode installations even under a narrow daemon `PATH`. Existing
   ACP-over-OpenCode configurations continue to load unchanged. (#305)
+- **Generic Monid paid-data tools.** Native agents can prepare arbitrary
+  allowlisted provider capabilities for free, inspect their input schema and
+  quoted price, then execute a budget-gated spend without holding vendor keys
+  or funds. Results carry provenance, failures require honest fallback
+  labeling, and retry keys prevent accidental duplicate charges. (#308)
+- **Cross-platform daemon autostart.** `puffo-agent autostart
+  enable|disable|status` installs per-user launchd, systemd, or Windows startup
+  registration. Machine linking enables it by default, with an explicit
+  opt-out, safe persisted environments, and actionable status or failure
+  reporting. (#309)
 
 ### Fixed
 
@@ -24,6 +38,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - **OpenCode tool activity reaches the UI.** Tool frames now project both
   start and completion status, and unavailable selected models are reported
   separately from missing provider authentication. (#305)
+- **Sleep/wake transport recovery.** A background daemon now heals an event
+  loop executor that died during macOS sleep before sending new traffic,
+  avoids replaying requests with ambiguous outcomes, and reports sustained
+  reconnect failure as `server_unreachable`. The tray also requests a
+  best-effort App Nap exemption. (#310)
+- **Remote creates report real startup readiness.** Docker availability is
+  checked before identity materialization, create commands wait for durable
+  runtime readiness, slow startup does not block unrelated machine commands,
+  and terminal acknowledgements survive reconnects. (#313)
+- **Large Codex sessions resume without replaying full history.** Codex resume
+  now declares the required experimental API capability and requests a
+  metadata-only response, preserving the native thread and provider-side
+  context without overflowing the Agent's stdout frame limit. (#314)
 
 ## [2.0.3] - 2026-08-27
 
@@ -5001,8 +5028,8 @@ First public PyPI release.
   future server-side regression that echoes the same cursor back
   bails instead of spinning.
 
-[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.4...HEAD
-[2.0.4]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.4
+[Unreleased]: https://github.com/puffo-ai/puffo-agent/compare/v2.0.4a1...HEAD
+[2.0.4a1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.4a1
 [2.0.3]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.3
 [2.0.2]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.2
 [2.0.1]: https://github.com/puffo-ai/puffo-agent/releases/tag/v2.0.1

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Python:
 ```bash
 uv tool install puffo-agent
 # pin to a specific version:
-uv tool install puffo-agent==2.0.4
+uv tool install puffo-agent==2.0.3
 ```
 
 Otherwise use pip:
@@ -70,10 +70,10 @@ Otherwise use pip:
 ```bash
 pip install puffo-agent
 # pin to a specific version:
-pip install puffo-agent==2.0.4
+pip install puffo-agent==2.0.3
 ```
 
-Agent Foundation `2.0.4` is the current stable release. It upgrades supported
+Agent Foundation `2.0.3` is the current stable release. It upgrades supported
 1.2 state in place while preserving Agent identity, keys, profile, memory,
 workspace, message history, and logical session continuity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.4"
+version = "2.0.4a1"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.4"
+version = "2.0.4a1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- set the package and lockfile version to the prerelease `2.0.4a1`
- document every user-visible change merged since v2.0.3: #305, #308, #309, #310, #313, and #314
- restore README stable-install guidance to production PyPI latest `2.0.3`
- explicitly document that this candidate is for TestPyPI staging only

## Important TestPyPI state

TestPyPI already contains an earlier artifact numbered `2.0.4` from the September 1 dry run. The new `2.0.4a1` artifact is still unique and publishable, but testers must install it with an explicit `==2.0.4a1` pin because package resolution otherwise prefers `2.0.4`. Production PyPI remains at `2.0.3`; no production release or tag has been created.

## Validation

- `git diff --check`
- `uv lock`
- `env -u CODEX_HOME uv run --extra dev pre-commit run --all-files`
- built sdist + wheel; wheel metadata is `Version: 2.0.4a1`
- installed the wheel in a clean Python 3.11 environment and verified `puffo-agent version` reports `2.0.4a1`
- first-parent history from v2.0.3 checked against merged PR metadata

After exact-head review and green CI, merge this PR and manually dispatch `publish-testpypi.yml` from `main`. Do not create a GitHub Release: that would trigger the production-only workflow.