### PR TITLE
Expose OpenCode model reasoning variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **OpenCode reasoning variants follow each model's native catalog.** The
+  daemon now publishes the exact selectable inference levels advertised by
+  `opencode models --verbose`, keeps models that expose no variants explicit,
+  and passes the selected level to `opencode run --variant`. Older OpenCode
+  versions fall back to their non-verbose model list. (#316)
+
 ## 2.0.4a1 - 2026-09-03
 
 > Pre-release published to TestPyPI for staging validation only. It is not the

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -20,6 +20,7 @@ from typing import Any, Protocol
 from ....macos.keychain import is_macos
 from ....mcp.config import (
     INFERENCE_LEVELS,
+    OPENCODE_INFERENCE_LEVELS,
     default_python_executable,
     puffo_core_mcp_env,
     write_cli_mcp_config,
@@ -454,6 +455,13 @@ class LocalRuntimePreparer:
             and "--thinking" not in launch_args
         ):
             launch_args.extend(("--thinking", inference_level))
+        if (
+            self.harness_name == "opencode"
+            and inference_level in OPENCODE_INFERENCE_LEVELS
+            and "--variant" not in launch_args
+        ):
+            native_variant = "none" if inference_level == "off" else inference_level
+            launch_args.extend(("--variant", native_variant))
         return executable, launch_args
 
     def _prepare_executable_configuration(

--- a/src/puffo_agent/agent/model_catalog.py
+++ b/src/puffo_agent/agent/model_catalog.py
@@ -206,18 +206,30 @@ def _opencode_models(*, fetch: bool) -> tuple[ModelOption, ...]:
     if cached is not None or not fetch:
         return cached if cached is not None else _stale_models("opencode")
     from .cli_bin import resolve_opencode_bin
-    from .opencode_auth import OpenCodeProbeError, list_opencode_models
+    from .opencode_auth import OpenCodeProbeError, list_opencode_model_catalog
 
     executable = resolve_opencode_bin()
     if not executable:
         return _store_models("opencode", ())
     try:
-        model_ids = list_opencode_models(executable)
+        models = list_opencode_model_catalog(executable)
     except OpenCodeProbeError:
         return _stale_models("opencode")
+    from ..mcp.config import OPENCODE_INFERENCE_LEVELS
+
     options = tuple(
-        ModelOption(model_id, model_id)
-        for model_id in model_ids
+        ModelOption(
+            model.id,
+            model.id,
+            supported_inference_levels=tuple(
+                level for level in OPENCODE_INFERENCE_LEVELS
+                if (
+                    level in model.variants
+                    or (level == "off" and "none" in model.variants)
+                )
+            ),
+        )
+        for model in models
     )
     return _store_models("opencode", options)
 

--- a/src/puffo_agent/agent/model_catalog.py
+++ b/src/puffo_agent/agent/model_catalog.py
@@ -27,7 +27,9 @@ class ModelOption:
     id: str  # the ``--model`` value; "" means the daemon default
     label: str  # combo-box display text
     is_alias: bool = False
-    supported_inference_levels: tuple[str, ...] = ()
+    # None means the catalog makes no model-specific claim. An empty tuple is
+    # an explicit claim that this model exposes no selectable inference level.
+    supported_inference_levels: tuple[str, ...] | None = None
 
 
 _DAEMON_DEFAULT = ModelOption("", "(daemon default)")

--- a/src/puffo_agent/agent/opencode_auth.py
+++ b/src/puffo_agent/agent/opencode_auth.py
@@ -73,7 +73,33 @@ def _run_opencode_models(
 
 
 def _is_model_id(value: str) -> bool:
-    return "/" in value and not any(char.isspace() for char in value)
+    return (
+        "/" in value
+        and not any(char.isspace() or char in '{}[],"' for char in value)
+    )
+
+
+def _next_verbose_model_offset(output: str, offset: int) -> int:
+    """Recover at the next bare model-id line after malformed metadata."""
+    length = len(output)
+    line_start = offset
+    while line_start < length:
+        line_end = output.find("\n", line_start)
+        if line_end < 0:
+            line_end = length
+        raw_line = output[line_start:line_end]
+        candidate = raw_line.strip()
+        metadata_offset = line_end + 1
+        while metadata_offset < length and output[metadata_offset].isspace():
+            metadata_offset += 1
+        if (
+            raw_line == candidate
+            and _is_model_id(candidate)
+            and (metadata_offset == length or output[metadata_offset] == "{")
+        ):
+            return line_start
+        line_start = line_end + 1
+    return length
 
 
 def _parse_verbose_models(output: str) -> tuple[OpenCodeModel, ...]:
@@ -106,6 +132,7 @@ def _parse_verbose_models(output: str) -> tuple[OpenCodeModel, ...]:
                 metadata, offset = decoder.raw_decode(output, json_offset)
             except json.JSONDecodeError:
                 metadata = {}
+                offset = _next_verbose_model_offset(output, offset)
 
         variants = metadata.get("variants") if isinstance(metadata, dict) else {}
         variant_names = tuple(
@@ -149,12 +176,22 @@ def list_opencode_model_catalog(
     timeout_seconds: float = 5.0,
 ) -> tuple[OpenCodeModel, ...]:
     """Return visible models with their model-specific native variants."""
-    stdout = _run_opencode_models(
-        executable,
-        provider=provider,
-        verbose=True,
-        timeout_seconds=timeout_seconds,
-    )
+    try:
+        stdout = _run_opencode_models(
+            executable,
+            provider=provider,
+            verbose=True,
+            timeout_seconds=timeout_seconds,
+        )
+    except OpenCodeProbeError:
+        return tuple(
+            OpenCodeModel(model_id)
+            for model_id in list_opencode_models(
+                executable,
+                provider=provider,
+                timeout_seconds=timeout_seconds,
+            )
+        )
     return _parse_verbose_models(stdout)
 
 

--- a/src/puffo_agent/agent/opencode_auth.py
+++ b/src/puffo_agent/agent/opencode_auth.py
@@ -79,29 +79,6 @@ def _is_model_id(value: str) -> bool:
     )
 
 
-def _next_verbose_model_offset(output: str, offset: int) -> int:
-    """Recover at the next bare model-id line after malformed metadata."""
-    length = len(output)
-    line_start = offset
-    while line_start < length:
-        line_end = output.find("\n", line_start)
-        if line_end < 0:
-            line_end = length
-        raw_line = output[line_start:line_end]
-        candidate = raw_line.strip()
-        metadata_offset = line_end + 1
-        while metadata_offset < length and output[metadata_offset].isspace():
-            metadata_offset += 1
-        if (
-            raw_line == candidate
-            and _is_model_id(candidate)
-            and (metadata_offset == length or output[metadata_offset] == "{")
-        ):
-            return line_start
-        line_start = line_end + 1
-    return length
-
-
 def _parse_verbose_models(output: str) -> tuple[OpenCodeModel, ...]:
     """Parse ``models --verbose``'s repeated ``id`` + JSON blocks.
 
@@ -118,9 +95,10 @@ def _parse_verbose_models(output: str) -> tuple[OpenCodeModel, ...]:
         line_end = output.find("\n", offset)
         if line_end < 0:
             line_end = length
-        model_id = output[offset:line_end].strip()
+        raw_line = output[offset:line_end]
+        model_id = raw_line.strip()
         offset = line_end + 1
-        if not _is_model_id(model_id) or model_id in seen:
+        if raw_line != model_id or not _is_model_id(model_id) or model_id in seen:
             continue
 
         metadata: object = {}
@@ -132,7 +110,10 @@ def _parse_verbose_models(output: str) -> tuple[OpenCodeModel, ...]:
                 metadata, offset = decoder.raw_decode(output, json_offset)
             except json.JSONDecodeError:
                 metadata = {}
-                offset = _next_verbose_model_offset(output, offset)
+                # Continue line by line from the malformed block. Bare model-id
+                # lines remain authoritative even when they have no JSON block;
+                # punctuation and indentation keep JSON fragments from becoming
+                # phantom models.
 
         variants = metadata.get("variants") if isinstance(metadata, dict) else {}
         variant_names = tuple(

--- a/src/puffo_agent/agent/opencode_auth.py
+++ b/src/puffo_agent/agent/opencode_auth.py
@@ -10,8 +10,10 @@ runtime can actually launch.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
+from dataclasses import dataclass
 from typing import Literal
 
 from .harness.support.child_env import build_child_environment
@@ -29,16 +31,26 @@ OpenCodeModelStatus = Literal[
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
 
-def list_opencode_models(
+@dataclass(frozen=True, slots=True)
+class OpenCodeModel:
+    """One model and the native variants advertised by OpenCode."""
+
+    id: str
+    variants: tuple[str, ...] = ()
+
+
+def _run_opencode_models(
     executable: str,
     *,
-    provider: str = "",
-    timeout_seconds: float = 5.0,
-) -> tuple[str, ...]:
-    """Return model IDs visible to OpenCode's current native credential view."""
+    provider: str,
+    verbose: bool,
+    timeout_seconds: float,
+) -> str:
     command = [executable, "models"]
     if provider:
         command.append(provider)
+    if verbose:
+        command.append("--verbose")
     try:
         completed = subprocess.run(
             command,
@@ -51,22 +63,99 @@ def list_opencode_models(
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise OpenCodeProbeError("OpenCode model check could not complete") from exc
 
-    diagnostic = _ANSI_ESCAPE.sub("", completed.stdout + completed.stderr)
+    stdout = _ANSI_ESCAPE.sub("", completed.stdout)
+    diagnostic = stdout + _ANSI_ESCAPE.sub("", completed.stderr)
     if completed.returncode != 0:
         if provider and "Provider not found:" in diagnostic:
-            return ()
+            return ""
         raise OpenCodeProbeError("OpenCode model check failed")
+    return stdout
 
+
+def _is_model_id(value: str) -> bool:
+    return "/" in value and not any(char.isspace() for char in value)
+
+
+def _parse_verbose_models(output: str) -> tuple[OpenCodeModel, ...]:
+    """Parse ``models --verbose``'s repeated ``id`` + JSON blocks.
+
+    The model-id line is the launch authority. JSON is used only for optional
+    variant metadata, so a malformed/missing block degrades to no variants
+    without inventing support or dropping a runnable model.
+    """
+    decoder = json.JSONDecoder()
+    models: list[OpenCodeModel] = []
+    seen: set[str] = set()
+    offset = 0
+    length = len(output)
+    while offset < length:
+        line_end = output.find("\n", offset)
+        if line_end < 0:
+            line_end = length
+        model_id = output[offset:line_end].strip()
+        offset = line_end + 1
+        if not _is_model_id(model_id) or model_id in seen:
+            continue
+
+        metadata: object = {}
+        json_offset = offset
+        while json_offset < length and output[json_offset].isspace():
+            json_offset += 1
+        if json_offset < length and output[json_offset] == "{":
+            try:
+                metadata, offset = decoder.raw_decode(output, json_offset)
+            except json.JSONDecodeError:
+                metadata = {}
+
+        variants = metadata.get("variants") if isinstance(metadata, dict) else {}
+        variant_names = tuple(
+            key for key in variants
+            if isinstance(key, str) and key
+        ) if isinstance(variants, dict) else ()
+        seen.add(model_id)
+        models.append(OpenCodeModel(model_id, variant_names))
+    return tuple(models)
+
+
+def list_opencode_models(
+    executable: str,
+    *,
+    provider: str = "",
+    timeout_seconds: float = 5.0,
+) -> tuple[str, ...]:
+    """Return model IDs visible to OpenCode's current native credential view."""
+    stdout = _run_opencode_models(
+        executable,
+        provider=provider,
+        verbose=False,
+        timeout_seconds=timeout_seconds,
+    )
     models: list[str] = []
     seen: set[str] = set()
-    for line in completed.stdout.splitlines():
+    for line in stdout.splitlines():
         model = line.strip()
-        if "/" not in model or any(char.isspace() for char in model):
+        if not _is_model_id(model):
             continue
         if model not in seen:
             seen.add(model)
             models.append(model)
     return tuple(models)
+
+
+def list_opencode_model_catalog(
+    executable: str,
+    *,
+    provider: str = "",
+    timeout_seconds: float = 5.0,
+) -> tuple[OpenCodeModel, ...]:
+    """Return visible models with their model-specific native variants."""
+    stdout = _run_opencode_models(
+        executable,
+        provider=provider,
+        verbose=True,
+        timeout_seconds=timeout_seconds,
+    )
+    return _parse_verbose_models(stdout)
 
 
 def opencode_model_status(executable: str, model: str) -> OpenCodeModelStatus:

--- a/src/puffo_agent/mcp/config.py
+++ b/src/puffo_agent/mcp/config.py
@@ -38,6 +38,13 @@ PI_INFERENCE_LEVELS = (
     "off", "minimal", "low", "medium", "high", "xhigh", "max",
 )
 
+# OpenCode ``run --variant`` values that map to Puffo's shared reasoning
+# vocabulary. Individual models publish only the subset advertised by
+# ``opencode models --verbose``.
+OPENCODE_INFERENCE_LEVELS = (
+    "off", "minimal", "low", "medium", "high", "xhigh", "max",
+)
+
 
 def supported_inference_levels(harness: str) -> tuple[str, ...]:
     """Reasoning-effort values implemented by a specific harness."""
@@ -47,6 +54,8 @@ def supported_inference_levels(harness: str) -> tuple[str, ...]:
         return INFERENCE_LEVELS
     if harness == "pi":
         return PI_INFERENCE_LEVELS
+    if harness == "opencode":
+        return OPENCODE_INFERENCE_LEVELS
     return ()
 
 _TOML_BARE_KEY = re.compile(r"[A-Za-z0-9_-]+")

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -594,7 +594,7 @@ def build_capabilities() -> dict:
                                 o.supported_inference_levels
                             )
                         }
-                        if o.supported_inference_levels
+                        if o.supported_inference_levels is not None
                         else {}
                     ),
                 }

--- a/tests/test_harness_readiness.py
+++ b/tests/test_harness_readiness.py
@@ -136,3 +136,32 @@ def test_capabilities_publish_model_specific_pi_thinking_levels(monkeypatch):
             "supported_inference_levels": ["off", "low", "high"],
         }],
     }]
+
+
+def test_capabilities_publish_an_explicit_empty_opencode_variant_list(monkeypatch):
+    """No variants must not be mistaken for missing model-level metadata."""
+    _patch_hosts(monkeypatch, opencode_path="/bin/opencode")
+    monkeypatch.setattr(model_catalog, "KNOWN_HARNESSES", ("opencode",))
+    monkeypatch.setattr(
+        model_catalog,
+        "provider_models",
+        lambda harness, *, fetch=False: [
+            model_catalog.ModelOption(
+                "opencode/no-variants",
+                "opencode/no-variants",
+                supported_inference_levels=(),
+            )
+        ],
+    )
+
+    caps = build_capabilities()
+
+    assert caps["providers"] == [{
+        "provider": "opencode",
+        "models": [{
+            "id": "opencode/no-variants",
+            "label": "opencode/no-variants",
+            "alias": False,
+            "supported_inference_levels": [],
+        }],
+    }]

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -15,6 +15,7 @@ import pytest
 
 from puffo_agent.mcp.config import (
     INFERENCE_LEVELS,
+    OPENCODE_INFERENCE_LEVELS,
     REASONING_EFFORTS,
     write_codex_mcp_config,
 )
@@ -196,6 +197,7 @@ def test_supported_levels_are_per_harness():
     assert supported_inference_levels("pi") == (
         "off", "minimal", "low", "medium", "high", "xhigh", "max",
     )
+    assert supported_inference_levels("opencode") == OPENCODE_INFERENCE_LEVELS
     # codex has minimal but not xhigh; claude-code the reverse.
     assert "xhigh" not in supported_inference_levels("codex")
     assert "minimal" not in supported_inference_levels("claude-code")

--- a/tests/test_local_runtime_migration.py
+++ b/tests/test_local_runtime_migration.py
@@ -319,6 +319,37 @@ async def test_opencode_uses_shared_binary_resolver(puffo_home, monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("level", "native_variant"), [("high", "high"), ("off", "none")],
+)
+async def test_opencode_runtime_forwards_selected_variant(
+    puffo_home, monkeypatch, level, native_variant,
+):
+    """A model-advertised reasoning level must reach ``opencode run``."""
+    import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
+
+    monkeypatch.setattr(
+        local_runtime, "resolve_opencode_bin", lambda: "/opt/bin/opencode"
+    )
+    config = AgentConfig(
+        id="opencode-variant",
+        runtime=RuntimeConfig(
+            kind="cli-local",
+            provider="openai",
+            harness="opencode",
+            model="openai/gpt-5",
+            inference_level=level,
+        ),
+    )
+
+    prepared = await LocalRuntimePreparer(
+        DaemonConfig(), config
+    ).prepare(system_prompt="managed prompt")
+
+    assert prepared.spec.launch_args == ("--variant", native_variant)
+
+
+@pytest.mark.asyncio
 async def test_pi_uses_shared_binary_resolver(puffo_home, monkeypatch):
     import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -108,11 +108,16 @@ def test_unknown_harness_is_just_default():
 
 def test_opencode_catalog_uses_models_visible_to_native_cli(monkeypatch):
     """Authenticated OpenCode providers must not collapse to Custom model."""
+    from puffo_agent.agent.opencode_auth import OpenCodeModel
+
     monkeypatch.setattr(
-        "puffo_agent.agent.opencode_auth.list_opencode_models",
+        "puffo_agent.agent.opencode_auth.list_opencode_model_catalog",
         lambda executable: (
-            "opencode/big-pickle",
-            "deepseek/deepseek-v4-pro",
+            OpenCodeModel("opencode/big-pickle"),
+            OpenCodeModel(
+                "deepseek/deepseek-v4-pro",
+                ("none", "low", "medium", "high", "vendor-special"),
+            ),
         ),
     )
     monkeypatch.setattr(
@@ -120,10 +125,15 @@ def test_opencode_catalog_uses_models_visible_to_native_cli(monkeypatch):
         lambda: "/opt/bin/opencode",
     )
 
-    assert _ids(provider_models("opencode", fetch=True))[1:] == [
+    options = provider_models("opencode", fetch=True)
+    assert _ids(options)[1:] == [
         "opencode/big-pickle",
         "deepseek/deepseek-v4-pro",
     ]
+    assert options[1].supported_inference_levels == ()
+    assert options[2].supported_inference_levels == (
+        "off", "low", "medium", "high",
+    )
 
 
 def test_pi_catalog_uses_models_visible_to_native_cli(monkeypatch):
@@ -156,7 +166,7 @@ def test_opencode_catalog_drops_logged_out_provider_after_short_ttl(monkeypatch)
         (ModelOption("deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-pro"),),
     )
     monkeypatch.setattr(
-        "puffo_agent.agent.opencode_auth.list_opencode_models",
+        "puffo_agent.agent.opencode_auth.list_opencode_model_catalog",
         lambda executable: (),
     )
     monkeypatch.setattr(

--- a/tests/test_opencode_auth.py
+++ b/tests/test_opencode_auth.py
@@ -89,19 +89,51 @@ def test_verbose_model_probe_parses_native_variants(monkeypatch):
     assert "OPENAI_API_KEY" not in seen["kwargs"]["env"]
 
 
-def test_verbose_probe_keeps_model_when_metadata_is_malformed(monkeypatch):
+def test_verbose_probe_recovers_after_malformed_metadata_without_phantom_models(
+    monkeypatch,
+):
     monkeypatch.setattr(
         subprocess,
         "run",
         lambda *args, **kwargs: _completed(
             code=0,
-            stdout="opencode/big-pickle\n{not-json}\n",
+            stdout=(
+                "opencode/big-pickle\n"
+                '{"id":"a","api":{"npm":"@ai-sdk/openai-compatible"\n'
+                "opencode/second-model\n"
+                '{"variants":{"low":{}}}\n'
+            ),
         ),
     )
 
     assert list_opencode_model_catalog("/opt/bin/opencode") == (
         OpenCodeModel("opencode/big-pickle"),
+        OpenCodeModel("opencode/second-model", ("low",)),
     )
+
+
+def test_verbose_probe_falls_back_to_non_verbose_models(monkeypatch):
+    seen = []
+
+    def fake_run(command, **kwargs):
+        seen.append(command)
+        if "--verbose" in command:
+            return _completed(code=1, stderr="Unknown option: --verbose")
+        return _completed(
+            code=0,
+            stdout="opencode/big-pickle\ndeepseek/deepseek-v4-pro\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert list_opencode_model_catalog("/opt/bin/opencode") == (
+        OpenCodeModel("opencode/big-pickle"),
+        OpenCodeModel("deepseek/deepseek-v4-pro"),
+    )
+    assert seen == [
+        ["/opt/bin/opencode", "models", "--verbose"],
+        ["/opt/bin/opencode", "models"],
+    ]
 
 
 def test_selected_model_uses_provider_filtered_native_catalog(monkeypatch):

--- a/tests/test_opencode_auth.py
+++ b/tests/test_opencode_auth.py
@@ -7,7 +7,9 @@ import subprocess
 import pytest
 
 from puffo_agent.agent.opencode_auth import (
+    OpenCodeModel,
     OpenCodeProbeError,
+    list_opencode_model_catalog,
     list_opencode_models,
     opencode_model_is_available,
     opencode_model_status,
@@ -55,6 +57,51 @@ def test_missing_provider_is_a_clean_not_ready_result(monkeypatch):
     assert list_opencode_models(
         "/opt/bin/opencode", provider="deepseek",
     ) == ()
+
+
+def test_verbose_model_probe_parses_native_variants(monkeypatch):
+    seen = {}
+
+    def fake_run(command, **kwargs):
+        seen.update(command=command, kwargs=kwargs)
+        return _completed(
+            code=0,
+            stdout=(
+                "opencode/no-variants\n"
+                '{"id":"no-variants","variants":{}}\n'
+                "openai/gpt-5\n"
+                '{"id":"gpt-5","variants":{'
+                '"minimal":{"reasoningEffort":"minimal"},'
+                '"high":{"reasoningEffort":"high"}}}\n'
+            ),
+        )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-probe")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert list_opencode_model_catalog("/opt/bin/opencode") == (
+        OpenCodeModel("opencode/no-variants"),
+        OpenCodeModel("openai/gpt-5", ("minimal", "high")),
+    )
+    assert seen["command"] == [
+        "/opt/bin/opencode", "models", "--verbose",
+    ]
+    assert "OPENAI_API_KEY" not in seen["kwargs"]["env"]
+
+
+def test_verbose_probe_keeps_model_when_metadata_is_malformed(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(
+            code=0,
+            stdout="opencode/big-pickle\n{not-json}\n",
+        ),
+    )
+
+    assert list_opencode_model_catalog("/opt/bin/opencode") == (
+        OpenCodeModel("opencode/big-pickle"),
+    )
 
 
 def test_selected_model_uses_provider_filtered_native_catalog(monkeypatch):

--- a/tests/test_opencode_auth.py
+++ b/tests/test_opencode_auth.py
@@ -9,6 +9,7 @@ import pytest
 from puffo_agent.agent.opencode_auth import (
     OpenCodeModel,
     OpenCodeProbeError,
+    _is_model_id,
     list_opencode_model_catalog,
     list_opencode_models,
     opencode_model_is_available,
@@ -20,6 +21,21 @@ def _completed(*, code: int, stdout: str = "", stderr: str = ""):
     return subprocess.CompletedProcess(
         args=[], returncode=code, stdout=stdout, stderr=stderr,
     )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("opencode/gpt-5.6", True),
+        ("openrouter/qwen/qwen3-max", True),
+        ('{"id":"a/b"}', False),
+        ('"npm":"@ai-sdk/openai-compatible"', False),
+        (" opencode/indented", False),
+        ("opencode/x,y", False),
+    ],
+)
+def test_model_id_requires_a_bare_non_json_line(value, expected):
+    assert _is_model_id(value) is expected
 
 
 def test_native_model_probe_scrubs_ambient_keys(monkeypatch):
@@ -109,6 +125,31 @@ def test_verbose_probe_recovers_after_malformed_metadata_without_phantom_models(
     assert list_opencode_model_catalog("/opt/bin/opencode") == (
         OpenCodeModel("opencode/big-pickle"),
         OpenCodeModel("opencode/second-model", ("low",)),
+    )
+
+
+def test_verbose_probe_keeps_blockless_models_after_malformed_metadata(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(
+            code=0,
+            stdout=(
+                "opencode/a\n"
+                '{"id":"a","api":{"npm":"x"\n'
+                "opencode/b\n"
+                "opencode/c\n"
+                '{"variants":{"low":{}}}\n'
+            ),
+        ),
+    )
+
+    assert list_opencode_model_catalog("/opt/bin/opencode") == (
+        OpenCodeModel("opencode/a"),
+        OpenCodeModel("opencode/b"),
+        OpenCodeModel("opencode/c", ("low",)),
     )
 
 

--- a/tests/test_opencode_protocol.py
+++ b/tests/test_opencode_protocol.py
@@ -25,7 +25,6 @@ def test_run_command_resumes_by_session_and_keeps_prompt_positional():
         launch_args=("--title", "Puffo"),
         permission_mode="bypassPermissions",
     )
-
     command = build_opencode_run_command(
         spec,
         prompt="one semantic input",
@@ -48,6 +47,19 @@ def test_run_command_resumes_by_session_and_keeps_prompt_positional():
         "Puffo",
         "one semantic input",
     )
+
+
+def test_run_command_forwards_model_variant_before_prompt():
+    spec = RuntimeSpec(
+        workspace_dir="/workspace",
+        model="openai/gpt-5",
+        executable="/bin/opencode",
+        launch_args=("--variant", "high"),
+    )
+
+    command = build_opencode_run_command(spec, prompt="hello")
+
+    assert command[-3:] == ("--variant", "high", "hello")
 
 
 def test_text_frame_emits_one_completed_output_block():


### PR DESCRIPTION
## Summary

- discover model-specific reasoning variants from OpenCode native verbose model metadata
- publish only supported Puffo inference levels, mapping native none to off
- forward selected inference levels to `opencode run` via `--variant`
- fall back to the ordinary model list when older OpenCode versions reject `models --verbose`
- recover from malformed verbose metadata without dropping runnable models or inventing phantom IDs

## Verification

- focused OpenCode and catalog tests: 28 passed
- full suite: 3,902 passed, 2 skipped
- Ruff and `git diff --check`: passed
- real OpenCode 1.18.16 catalog: 36 models discovered, 23 with published inference levels

No live model turn was sent; command construction and native catalog metadata were verified locally.
