### PR TITLE
fix(docker): mount the puffo_agent package, not site-packages

### DIFF
--- a/src/puffo_agent/agent/harness/runtime/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/docker_runtime.py
@@ -568,8 +568,13 @@ class DockerRuntimePreparer:
         await run_cmd([self._docker_bin, "rm", self.container_name])
 
     async def _probe_container(self) -> tuple[bool | None, bool | None]:
+        # Import it for real: a file-existence check passes even when the
+        # mounted tree cannot actually load in-container (wrong-ABI native
+        # deps shadowing the image's), which is exactly how a mute fleet
+        # slipped through an upgrade.
         package = await self._probe_command(
-            "test -f /opt/puffoagent-pkg/puffo_agent/__init__.py"
+            "PYTHONPATH=/opt/puffoagent-pkg python3 -c "
+            "'import puffo_agent.mcp.puffo_core_server'"
         )
         harness = await self._probe_command(
             f"command -v {self._harness_executable()} >/dev/null"
@@ -657,7 +662,7 @@ class DockerRuntimePreparer:
             "-v",
             f"{self.shared_fs_dir}:/workspace/.shared",
             "-v",
-            f"{puffo_agent_pkg_dir()}:/opt/puffoagent-pkg:ro",
+            f"{puffo_agent_pkg_dir()}:/opt/puffoagent-pkg/puffo_agent:ro",
         ]
         default_memory = self.agent_home / "memory"
         if self.memory_dir.resolve() != default_memory.resolve():

--- a/src/puffo_agent/agent/harness/runtime/docker_support.py
+++ b/src/puffo_agent/agent/harness/runtime/docker_support.py
@@ -12,17 +12,29 @@ logger = logging.getLogger(__name__)
 
 
 def puffo_agent_pkg_dir() -> Path:
-    """Host package root mounted read-only for the in-container MCP server."""
+    """Host ``puffo_agent`` PACKAGE dir, mounted read-only for the
+    in-container MCP server.
+
+    Deliberately the package itself, not its parent. Under a regular
+    (non-editable) install the parent IS site-packages, and mounting that
+    puts the host's platform-specific builds — ``pydantic_core``,
+    ``cryptography``, ``PIL`` … — ahead of the image's own on ``PYTHONPATH``.
+    On a macOS or Windows host those are the wrong ABI entirely, so the MCP
+    server dies at import with ``No module named
+    'pydantic_core._pydantic_core'`` and every agent silently loses
+    ``send_message``. Mounting only the package (pure Python) lets the image
+    supply every dependency, which is what it already ships.
+    """
     import puffo_agent
 
-    return Path(puffo_agent.__file__).resolve().parent.parent
+    return Path(puffo_agent.__file__).resolve().parent
 
 
 # Bump both values when the bundled image or mount layout changes. The image
 # tag makes first use build new contents; the layout marker recreates existing
 # per-Agent containers that still point at an older image or mount set.
 DEFAULT_IMAGE = "puffo/agent-runtime:v20"
-CONTAINER_LAYOUT_VERSION = "23"
+CONTAINER_LAYOUT_VERSION = "24"
 
 CLAUDE_CODE_NPM_VERSION = "2.1.224"
 CODEX_NPM_VERSION = "0.147.0"

--- a/tests/test_docker_codex_driver.py
+++ b/tests/test_docker_codex_driver.py
@@ -131,7 +131,12 @@ def _assert_codex_mounts(preparer, run_cmd):
     assert f"{preparer.shared_fs_dir}:/workspace/shared" in run_cmd
     assert not (preparer.workspace_dir / "shared").is_symlink()
     assert any(":/workspace/.shared" in part for part in run_cmd)
-    assert any(str(part).endswith(":/opt/puffoagent-pkg:ro") for part in run_cmd)
+    # The PACKAGE dir, not its parent: mounting site-packages would shadow the
+    # image's Linux native deps with the host's (see puffo_agent_pkg_dir).
+    assert any(
+        str(part).endswith(":/opt/puffoagent-pkg/puffo_agent:ro") for part in run_cmd
+    )
+    assert not any(str(part).endswith(":/opt/puffoagent-pkg:ro") for part in run_cmd)
     assert not any(str(Path.home() / ".codex") in str(part) for part in run_cmd)
     assert [part for part in run_cmd if str(part).endswith(":/home/agent/.codex")] == [
         f"{preparer.codex_home}:/home/agent/.codex"

--- a/tests/test_docker_lifecycle_safety.py
+++ b/tests/test_docker_lifecycle_safety.py
@@ -59,3 +59,27 @@ def test_docker_child_is_killed_and_reaped(cancel):
         assert proc.reaped is True
 
     asyncio.run(scenario())
+
+
+def test_puffo_agent_pkg_dir_is_the_package_not_site_packages():
+    """Mount the package itself, never its parent.
+
+    Under a non-editable install the parent IS site-packages; mounting it puts
+    the host's platform-specific builds (pydantic_core, cryptography, PIL) ahead
+    of the image's own on PYTHONPATH. On a macOS/Windows host those are the
+    wrong ABI, the in-container MCP server dies at import, and every agent
+    silently loses send_message while still reporting healthy.
+    """
+    from pathlib import Path
+
+    import puffo_agent
+    from puffo_agent.agent.harness.runtime.docker_support import (
+        puffo_agent_pkg_dir,
+    )
+
+    pkg_dir = puffo_agent_pkg_dir()
+    assert pkg_dir.name == "puffo_agent"
+    assert (pkg_dir / "__init__.py").is_file()
+    assert pkg_dir == Path(puffo_agent.__file__).resolve().parent
+    # site-packages would contain sibling distributions; the package must not.
+    assert not (pkg_dir / "pydantic_core").exists()


### PR DESCRIPTION
## The bug

`puffo_agent_pkg_dir()` returns `.parent.parent`. Under a non-editable install that **is site-packages**, so the container mount put the host's platform-specific builds — `pydantic_core`, `cryptography`, `PIL` — ahead of the image's own on `PYTHONPATH`.

On a macOS or Windows host those are the wrong ABI entirely. The in-container MCP server dies at import:

```
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

**Every agent silently loses `send_message` while still reporting `runtime=running`.**

Observed live in a container, with the host's darwin build visible inside a Linux image:

```
$ docker exec puffo-<agent> ls /opt/puffoagent-pkg | head
PIL
_cffi_backend.cpython-313-darwin.so      <-- host macOS build
pydantic_core
...
```

## Why it went unnoticed

The container probe was a file-existence check:

```python
"test -f /opt/puffoagent-pkg/puffo_agent/__init__.py"
```

That passes against a tree that cannot actually load. A broken mount looked healthy, so the fleet went mute behind a green status. The probe now imports the module for real — the same check the runtime depends on.

## The fix

- **`docker_support.py`** — `puffo_agent_pkg_dir()` returns the package dir; docstring explains why it must never be the parent.
- **`docker_runtime.py`** — mount at `/opt/puffoagent-pkg/puffo_agent`; probe by import.
- **`CONTAINER_LAYOUT_VERSION` 23 → 24** so existing containers are recreated with the corrected mount. Without this the fix ships but no running fleet picks it up.
- `DEFAULT_IMAGE` unchanged (`puffo/agent-runtime:v20`) — the image already ships every dependency; this is purely a mount-layout fix.

## Tests

- `test_docker_codex_driver.py` — pins the new mount suffix and asserts the old one is **gone**.
- `test_docker_lifecycle_safety.py` — new regression guard on `puffo_agent_pkg_dir()`. Verified it fails on `.parent.parent` and passes on `.parent`.

```
3909 passed, 4 skipped
ruff check: All checks passed!
```

`ruff format` flags `docker_runtime.py`, but that is pre-existing on `main` (confirmed by stashing the change) — deliberately not reformatted here to keep the diff to the fix.

## Verified in production

A 32-agent fleet on macOS, all reporting healthy:

| | before | after |
|---|---|---|
| MCP import in containers | **0/28** | **28/28** |
| agents `runtime=running` | 32/32 | 32/32 |

The "before" column is the point: status was green in both.

## Note for reviewers

This was originally patched locally against 2.0.0 and lost during a version upgrade, which is how the fleet regressed. It is **still absent from `main`** — 2.0.1/2.0.2/2.0.3 all ship `.parent.parent`, layout `23`, and the `test -f` probe. Any host whose `puffo-agent` is a normal (non-editable) install is affected; an editable install happens to be safe because its package parent is `src/`, not site-packages, which is likely why this survived so long in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)