### PR TITLE
feat(acp): forward the projected Puffo MCP server into session/new

### DIFF
--- a/src/puffo_agent/agent/context_controller.py
+++ b/src/puffo_agent/agent/context_controller.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
+import hashlib
 import json
 from typing import Any, Awaitable, Callable, Mapping, Protocol, runtime_checkable
 
@@ -165,6 +166,25 @@ class ToolResultAdmission:
             f"[{MODEL_VISIBLE_READ_RECEIPT_PREFIX}"
             f"{self.correlation_receipt}]"
         )
+
+    def binding_for_tool_call(self, tool_call_id: str) -> str:
+        """Bind one provider call id to this result's private receipt.
+
+        ACP keeps tool arguments and results off its public wire.  A
+        post-commit producer can still prove that the exact receipt-bearing
+        result was committed by hashing its native tool-call id together with
+        the receipt.  Including the id prevents a parallel call's binding from
+        being replayed under a different call while the random receipt keeps
+        the binding unique to this staged continuation.
+        """
+        if not tool_call_id or not self.correlation_receipt:
+            return ""
+        payload = (
+            str(tool_call_id).encode("utf-8")
+            + b"\x00"
+            + self.correlation_receipt.encode("utf-8")
+        )
+        return hashlib.sha256(payload).hexdigest()
 
     def matches(self, tool_name: str, arguments: Mapping[str, Any]) -> bool:
         semantic_tool_name = normalize_tool_name(tool_name)

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -302,14 +302,20 @@ class AcpDriver(Driver):
             await self._conn.load_session(
                 cwd=launch.plan.cwd,
                 session_id=str(resume),
-                mcp_servers=list(launch.plan.mcp_servers),
+                mcp_servers=[
+                    _to_acp_stdio_server(server)
+                    for server in launch.plan.mcp_servers
+                ],
             )
             native_session_id = str(resume)
             resumed = True
         else:
             session = await self._conn.new_session(
                 cwd=launch.plan.cwd,
-                mcp_servers=list(launch.plan.mcp_servers),
+                mcp_servers=[
+                    _to_acp_stdio_server(server)
+                    for server in launch.plan.mcp_servers
+                ],
             )
             native_session_id = session.session_id
             resumed = False
@@ -377,13 +383,21 @@ class AcpDriver(Driver):
             environment=MappingProxyType(dict(spec.environment)),
             cwd=spec.workspace_dir,
             # The Driver is transport, not policy: it forwards whatever
-            # the runtime projected into ``spec.mcp_servers``, converted to
-            # the ACP wire shape. Which profiles receive Puffo's server —
-            # and that puffo-v0 stays empty, since it rejects a non-empty
-            # ``mcpServers`` at ``session/new`` — is decided by
-            # ``_project_protocol_mcp`` in the runtime.
+            # the runtime projected into ``spec.mcp_servers``. Which
+            # profiles receive Puffo's server — and that puffo-v0 stays
+            # empty, since it rejects a non-empty ``mcpServers`` at
+            # ``session/new`` — is decided by ``_project_protocol_mcp``
+            # in the runtime. The sealed plan carries deep-frozen copies;
+            # conversion to the mutable ACP wire objects happens only at
+            # the session call, so nothing validated here can change
+            # between validation and the wire.
             mcp_servers=tuple(
-                _to_acp_stdio_server(server)
+                McpServerSpec(
+                    name=server.name,
+                    command=server.command,
+                    args=tuple(server.args),
+                    environment=MappingProxyType(dict(server.environment)),
+                )
                 for server in spec.mcp_servers
             ),
         )
@@ -934,15 +948,17 @@ def _lingtai_constrained_profile(command: tuple[str, ...]) -> str:
     except ValueError:
         return ""
     profile_args = command[acp_index + 1 :]
+    # argparse takes the LAST occurrence of a repeated flag; classify by
+    # the same effective value or a duplicated ``--profile`` would launch
+    # under a different profile than Puffo prepared it for.
+    candidate = ""
     for index, arg in enumerate(profile_args):
         if arg == "--profile" and index + 1 < len(profile_args):
             candidate = profile_args[index + 1]
         elif arg.startswith("--profile="):
             candidate = arg.removeprefix("--profile=")
-        else:
-            continue
-        if candidate in _LINGTAI_CONSTRAINED_PROFILES:
-            return candidate
+    if candidate in _LINGTAI_CONSTRAINED_PROFILES:
+        return candidate
     return ""
 
 

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -205,7 +205,8 @@ class _PuffoAcpClient:
 class AcpDriver(Driver):
     """Persistent ACP agent process with negotiated session semantics.
 
-    This is the only trusted entrypoint for ``puffo-v0`` identity binding.
+    This is the only trusted entrypoint for constrained LingTai
+    (``puffo-v0`` / ``puffo-v1``) identity binding.
     The complete process/session launch plan is validated immediately before
     spawn; the separate OpenCode driver is explicitly outside that contract.
     """
@@ -918,26 +919,52 @@ def _to_acp_stdio_server(spec: McpServerSpec) -> McpServerStdio:
     )
 
 
-def _uses_lingtai_driver_authority(command: tuple[str, ...]) -> bool:
-    """Select only LingTai's constrained ACP profile, independent of argv[0]."""
+_LINGTAI_CONSTRAINED_PROFILES = frozenset({"puffo-v0", "puffo-v1"})
+
+
+def _lingtai_constrained_profile(command: tuple[str, ...]) -> str:
+    """The constrained LingTai profile argv selects, or "" for none.
+
+    Independent of argv[0]; both ``--profile X`` and ``--profile=X``
+    spellings after the ``acp`` token are recognised.
+    """
 
     try:
         acp_index = command.index("acp")
     except ValueError:
-        return False
+        return ""
     profile_args = command[acp_index + 1 :]
-    return any(
-        (
-            arg == "--profile"
-            and index + 1 < len(profile_args)
-            and profile_args[index + 1] == "puffo-v0"
-        )
-        or arg == "--profile=puffo-v0"
-        for index, arg in enumerate(profile_args)
-    )
+    for index, arg in enumerate(profile_args):
+        if arg == "--profile" and index + 1 < len(profile_args):
+            candidate = profile_args[index + 1]
+        elif arg.startswith("--profile="):
+            candidate = arg.removeprefix("--profile=")
+        else:
+            continue
+        if candidate in _LINGTAI_CONSTRAINED_PROFILES:
+            return candidate
+    return ""
+
+
+def _uses_lingtai_driver_authority(command: tuple[str, ...]) -> bool:
+    """True for every constrained LingTai profile, independent of argv[0].
+
+    Both ``puffo-v0`` and ``puffo-v1`` refuse to start without a
+    successful Driver authority handshake (LingTai #1624), so both get
+    the authority FD and the guarded POSIX spawn path. This is a wider
+    predicate than ``selects_puffo_v0_profile``, which only controls
+    the empty MCP projection.
+    """
+
+    return bool(_lingtai_constrained_profile(command))
 
 
 def selects_puffo_v0_profile(command: tuple[str, ...]) -> bool:
-    """True when argv selects LingTai's constrained ``puffo-v0`` profile."""
+    """True when argv selects LingTai's ``puffo-v0`` profile.
 
-    return _uses_lingtai_driver_authority(command)
+    v0 rejects a non-empty ``mcpServers`` at ``session/new``, so only
+    this profile keeps the MCP projection empty; ``puffo-v1`` receives
+    Puffo's server while still using the Driver authority spawn path.
+    """
+
+    return _lingtai_constrained_profile(command) == "puffo-v0"

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -20,8 +20,10 @@ from acp.schema import (
     ClientCapabilities,
     CreateTerminalResponse,
     DeniedOutcome,
+    EnvVariable,
     FileSystemCapabilities,
     Implementation,
+    McpServerStdio,
     PermissionOption,
     ReadTextFileResponse,
     ReleaseTerminalResponse,
@@ -51,6 +53,7 @@ from ..driver import (
     DriverCapabilities,
     HarnessEvent,
     HarnessEventType,
+    McpServerSpec,
     PermissionDecision,
     PermissionReceipt,
     PermissionRef,
@@ -298,14 +301,14 @@ class AcpDriver(Driver):
             await self._conn.load_session(
                 cwd=launch.plan.cwd,
                 session_id=str(resume),
-                mcp_servers=launch.plan.mcp_servers,
+                mcp_servers=list(launch.plan.mcp_servers),
             )
             native_session_id = str(resume)
             resumed = True
         else:
             session = await self._conn.new_session(
                 cwd=launch.plan.cwd,
-                mcp_servers=launch.plan.mcp_servers,
+                mcp_servers=list(launch.plan.mcp_servers),
             )
             native_session_id = session.session_id
             resumed = False
@@ -372,9 +375,16 @@ class AcpDriver(Driver):
             argv=argv,
             environment=MappingProxyType(dict(spec.environment)),
             cwd=spec.workspace_dir,
-            # puffo-v0 uses the Puffo-projected tool surface, never an
-            # independently supplied ACP MCP server list.
-            mcp_servers=(),
+            # The Driver is transport, not policy: it forwards whatever
+            # the runtime projected into ``spec.mcp_servers``, converted to
+            # the ACP wire shape. Which profiles receive Puffo's server —
+            # and that puffo-v0 stays empty, since it rejects a non-empty
+            # ``mcpServers`` at ``session/new`` — is decided by
+            # ``_project_protocol_mcp`` in the runtime.
+            mcp_servers=tuple(
+                _to_acp_stdio_server(server)
+                for server in spec.mcp_servers
+            ),
         )
         if self.launch_validator is not None:
             self.launch_validator(plan)
@@ -890,6 +900,24 @@ def model_launch_args(executable: str, model: str) -> tuple[str, ...]:
     return (flag, model)
 
 
+def _to_acp_stdio_server(spec: McpServerSpec) -> McpServerStdio:
+    """Convert Puffo's provider-neutral MCP spec to the ACP wire shape.
+
+    The two shapes correspond field for field; only the container types
+    differ (tuple/mapping here, list/``EnvVariable`` rows on the wire).
+    """
+
+    return McpServerStdio(
+        name=spec.name,
+        command=spec.command,
+        args=list(spec.args),
+        env=[
+            EnvVariable(name=key, value=value)
+            for key, value in spec.environment.items()
+        ],
+    )
+
+
 def _uses_lingtai_driver_authority(command: tuple[str, ...]) -> bool:
     """Select only LingTai's constrained ACP profile, independent of argv[0]."""
 
@@ -907,3 +935,9 @@ def _uses_lingtai_driver_authority(command: tuple[str, ...]) -> bool:
         or arg == "--profile=puffo-v0"
         for index, arg in enumerate(profile_args)
     )
+
+
+def selects_puffo_v0_profile(command: tuple[str, ...]) -> bool:
+    """True when argv selects LingTai's constrained ``puffo-v0`` profile."""
+
+    return _uses_lingtai_driver_authority(command)

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -965,11 +965,12 @@ def _lingtai_constrained_profile(command: tuple[str, ...]) -> str:
 def _uses_lingtai_driver_authority(command: tuple[str, ...]) -> bool:
     """True for every constrained LingTai profile, independent of argv[0].
 
-    Both ``puffo-v0`` and ``puffo-v1`` refuse to start without a
-    successful Driver authority handshake (LingTai #1624), so both get
-    the authority FD and the guarded POSIX spawn path. This is a wider
-    predicate than ``selects_puffo_v0_profile``, which only controls
-    the empty MCP projection.
+    Both profiles must fail closed without a successful Driver authority
+    handshake, so both get the authority FD and guarded POSIX spawn path.
+    ``puffo-v1`` enforces that contract at startup; ``puffo-v0`` starts with
+    an unavailable adapter and denies the first authority-controlled action.
+    This is a wider predicate than ``selects_puffo_v0_profile``, which only
+    controls the empty MCP projection.
     """
 
     return bool(_lingtai_constrained_profile(command))

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -242,6 +242,9 @@ class AcpDriver(Driver):
             tuple[asyncio.Future[PermissionDecision], list[PermissionOption]],
         ] = {}
         self._output_blocks: set[str] = set()
+        self._tool_names: dict[str, str] = {}
+        self._completed_tool_calls: set[str] = set()
+        self._admitted_tool_calls: set[str] = set()
         self._fallback_block_id = ""
         self._capabilities = acp_capabilities(session_resume=False)
         self._model_selection = ""
@@ -480,6 +483,9 @@ class AcpDriver(Driver):
         self._active = turn
         self._active_native_turn_id = native_turn
         self._output_blocks.clear()
+        self._tool_names.clear()
+        self._completed_tool_calls.clear()
+        self._admitted_tool_calls.clear()
         self._fallback_block_id = f"assistant_{uuid.uuid4().hex}"
         self._prompt_sent = asyncio.get_running_loop().create_future()
         prompt_sent = self._prompt_sent
@@ -592,6 +598,9 @@ class AcpDriver(Driver):
         self._prompt_sent = None
         self._prompt_task = None
         self._output_blocks.clear()
+        self._tool_names.clear()
+        self._completed_tool_calls.clear()
+        self._admitted_tool_calls.clear()
         await self._events.put(terminal)
 
     async def steer_turn(self, turn: TurnRef, input: TurnInput):
@@ -679,6 +688,9 @@ class AcpDriver(Driver):
             authority.close()
         self._active = TurnRef("")
         self._active_native_turn_id = ""
+        self._tool_names.clear()
+        self._completed_tool_calls.clear()
+        self._admitted_tool_calls.clear()
         await collect_cleanup_errors(
             self._events.put(None), errors, timeout=CLEANUP_TIMEOUT_SECONDS
         )
@@ -724,6 +736,7 @@ class AcpDriver(Driver):
             )
             return
         if isinstance(update, ToolCallStart):
+            self._tool_names[update.tool_call_id] = update.title
             await self._emit(
                 HarnessEventType.TOOL_STARTED,
                 turn=turn,
@@ -735,6 +748,20 @@ class AcpDriver(Driver):
             )
             return
         if isinstance(update, ToolCallProgress):
+            admission = self._post_commit_admission(update)
+            if admission is not None:
+                self._admitted_tool_calls.add(update.tool_call_id)
+                await self._emit(
+                    HarnessEventType.TOOL_COMPLETED,
+                    turn=turn,
+                    data={
+                        "tool_call_ref": update.tool_call_id,
+                        "label": admission["tool_name"],
+                        "outcome": "succeeded",
+                    },
+                    native_payload=admission,
+                )
+                return
             status = str(update.status or "in_progress")
             if status in {"completed", "failed"}:
                 type_ = HarnessEventType.TOOL_COMPLETED
@@ -743,6 +770,10 @@ class AcpDriver(Driver):
                     "label": update.title or "",
                     "outcome": "succeeded" if status == "completed" else "failed",
                 }
+                if status == "completed":
+                    self._completed_tool_calls.add(update.tool_call_id)
+                else:
+                    self._completed_tool_calls.discard(update.tool_call_id)
             else:
                 type_ = HarnessEventType.TOOL_UPDATED
                 data = {
@@ -769,6 +800,47 @@ class AcpDriver(Driver):
             data={"record_type": getattr(update, "session_update", "unknown")},
             native_payload=update,
         )
+
+    def _post_commit_admission(
+        self, update: ToolCallProgress
+    ) -> dict[str, Any] | None:
+        """Normalize LingTai's private, post-commit ACP extension.
+
+        Ordinary ACP ``completed`` only proves that a handler returned; it is
+        emitted before LingTai commits tool results to provider context.  The
+        namespaced extension is accepted only on a later update for a tool we
+        already saw complete successfully.  Its binding stays in the opaque
+        native diagnostic and never enters the public event projection.
+        """
+        metadata = getattr(update, "field_meta", None)
+        if not isinstance(metadata, Mapping):
+            return None
+        fact = metadata.get("puffo.admission/1")
+        if not isinstance(fact, Mapping):
+            return None
+        tool_call_id = update.tool_call_id
+        binding = fact.get("binding")
+        nested_id = fact.get("toolCallId")
+        tool_name = self._tool_names.get(tool_call_id, "")
+        if (
+            update.status is not None
+            or tool_call_id not in self._completed_tool_calls
+            or tool_call_id in self._admitted_tool_calls
+            or nested_id != tool_call_id
+            or not tool_name
+            or not isinstance(binding, str)
+            or len(binding) != 64
+            or any(char not in "0123456789abcdef" for char in binding)
+        ):
+            return None
+        return {
+            "_puffo_internal": "tool_result",
+            "provider_context_committed": True,
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "admission_binding": binding,
+            "is_error": False,
+        }
 
     async def _request_permission(
         self,

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -73,6 +73,7 @@ from ...runtime_event_outbox import (
 from ...runtime_events import RuntimeEventProjector, TrustedScope
 from .. import SUPPORTED_LOCAL_DRIVERS, UnsupportedDriver, build_driver
 from ..support.child_env import build_child_environment
+from ..drivers.acp import selects_puffo_v0_profile
 from ..drivers.pi_bridge import (
     build_bridge_environment,
     install_pi_tool_bridge,
@@ -389,7 +390,7 @@ class LocalRuntimePreparer:
             executable, system_prompt
         )
         mcp_servers = self._project_protocol_mcp(
-            controlled, opencode_config
+            controlled, opencode_config, tuple(launch_args)
         )
         if opencode_config:
             controlled["OPENCODE_CONFIG_CONTENT"] = json.dumps(
@@ -483,19 +484,20 @@ class LocalRuntimePreparer:
         self,
         controlled: dict[str, str],
         opencode_config: dict[str, Any],
+        launch_args: tuple[str, ...],
     ) -> tuple[McpServerSpec, ...]:
         """Project Puffo tools according to the selected Driver protocol.
 
         Native OpenCode receives its inline MCP configuration and must not
         also receive the generic projection.
 
-        The ACP Driver does not honour ``RuntimeSpec.mcp_servers``: it seals
-        an empty list into every launch plan, because ``puffo-v0`` rejects a
-        non-empty ``mcpServers`` at ``session/new``. So an ACP runtime opens
-        a session but gets no Puffo tools, and the server built here is
-        dropped downstream. Carrying it to an ACP agent needs an audited
-        profile and a fixed bridge, not a forward from this tuple. See
-        ``test_spec_mcp_servers_never_reach_the_acp_launch_plan``.
+        The ACP Driver forwards this tuple into ``session/new`` verbatim
+        (converted to the ACP wire shape), so this method is the single
+        policy point for which tools an ACP agent can discover. LingTai's
+        constrained ``puffo-v0`` profile rejects a non-empty ``mcpServers``
+        at ``session/new`` and therefore keeps an empty projection until
+        the agent is re-provisioned under ``puffo-v1``. See
+        ``test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan``.
         """
         mcp_servers: tuple[McpServerSpec, ...] = ()
         if self._puffo_core_env:
@@ -512,6 +514,12 @@ class LocalRuntimePreparer:
                 # only Puffo's core server; keeping mcp_servers empty is part
                 # of the Driver admission contract.
                 controlled.update(self._prepare_pi_bridge(puffo_server))
+            elif self.harness_name == "acp" and selects_puffo_v0_profile(
+                launch_args
+            ):
+                # puffo-v0 fails session/new on any server list; the empty
+                # projection is a LingTai-side contract, not a default.
+                mcp_servers = ()
             else:
                 mcp_servers = (puffo_server,)
             if self.harness_name == "opencode":

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -486,9 +486,16 @@ class LocalRuntimePreparer:
     ) -> tuple[McpServerSpec, ...]:
         """Project Puffo tools according to the selected Driver protocol.
 
-        Native OpenCode receives its inline MCP configuration. ACP-over-
-        OpenCode carries the same server through ``RuntimeSpec.mcp_servers``
-        and must not receive the native inline projection.
+        Native OpenCode receives its inline MCP configuration and must not
+        also receive the generic projection.
+
+        The ACP Driver does not honour ``RuntimeSpec.mcp_servers``: it seals
+        an empty list into every launch plan, because ``puffo-v0`` rejects a
+        non-empty ``mcpServers`` at ``session/new``. So an ACP runtime opens
+        a session but gets no Puffo tools, and the server built here is
+        dropped downstream. Carrying it to an ACP agent needs an audited
+        profile and a fixed bridge, not a forward from this tuple. See
+        ``test_spec_mcp_servers_never_reach_the_acp_launch_plan``.
         """
         mcp_servers: tuple[McpServerSpec, ...] = ()
         if self._puffo_core_env:

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -21,6 +21,7 @@ from ...context_controller import (
     RolloverResult,
     ToolResultAdmission,
     normalize_context_snapshot,
+    normalize_tool_name,
 )
 from ...errors import AgentAPIError, ProviderFailureError
 from ...provider_failures import (
@@ -1078,6 +1079,33 @@ class RuntimeManager:
         ):
             return
         tool_name = str(fact.get("tool_name") or "")
+        tool_call_id = str(fact.get("tool_call_id") or "")
+        admission_binding = fact.get("admission_binding")
+        if fact.get("provider_context_committed") is True:
+            candidates = [
+                (index, admission)
+                for index, admission in enumerate(self._continuation_admissions)
+                if admission.provider_turn_id == event.native_turn_id
+                and admission.tool_names
+                and normalize_tool_name(tool_name) in admission.tool_names
+                and isinstance(admission_binding, str)
+                and admission.binding_for_tool_call(tool_call_id)
+                == admission_binding
+            ]
+            if not candidates:
+                return
+            index, admission = max(
+                candidates, key=lambda value: value[1].match_specificity
+            )
+            self._continuation_admissions.pop(index)
+            await admission.callback(ProviderAdmissionEvent(
+                planning_cycle_key=admission.planning_cycle_key,
+                provider_session_id=self.native_session_id,
+                provider_turn_id=event.native_turn_id,
+                tool_call_id=tool_call_id,
+                admitted_at=datetime.now(timezone.utc),
+            ))
+            return
         arguments = fact.get("arguments")
         if not isinstance(arguments, dict):
             return

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -576,6 +576,10 @@ async def _wait_for_path(path) -> None:
             ("acp", "--runtime-id", "rt_x", "--profile", "puffo-v0"),
             id="puffo-v0",
         ),
+        pytest.param(
+            ("acp", "--runtime-id", "rt_x", "--profile", "puffo-v1"),
+            id="puffo-v1",
+        ),
         pytest.param(("acp", "--agent-dir", "/agent"), id="generic-acp"),
     ],
 )

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -15,6 +15,7 @@ from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
     InitializeResponse,
+    McpServerStdio,
     NewSessionResponse,
     PermissionOption,
     PromptResponse,
@@ -333,7 +334,13 @@ async def test_launch_validator_sees_complete_immutable_plan_at_spawn_boundary()
         assert plan.argv == ("agent", "acp", "--agent-dir", "/agent")
         assert plan.environment["ACP_TOKEN"] == "secret"
         assert plan.cwd == "/workspace"
-        assert plan.mcp_servers == ()
+        (server,) = plan.mcp_servers
+        assert server.name == "puffo"
+        assert server.command == "/usr/bin/python3"
+        assert server.args == ["-m", "puffo_agent.mcp.puffo_core_server"]
+        assert [(e.name, e.value) for e in server.env] == [
+            ("PUFFO_AGENT_ID", "agent_test")
+        ]
         with pytest.raises(TypeError):
             plan.environment["ACP_TOKEN"] = "changed"
 
@@ -573,11 +580,14 @@ async def _wait_for_path(path) -> None:
     ],
 )
 @pytest.mark.asyncio
-async def test_spec_mcp_servers_never_reach_the_acp_launch_plan(launch_args):
-    """puffo-v0 rejects a non-empty ``mcpServers`` outright, so the Driver
-    drops whatever the runtime projected rather than forwarding it. Pinned
-    for the generic profile too: the drop is unconditional today, and a
-    future per-profile forward must not reintroduce it for puffo-v0."""
+async def test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan(
+    launch_args,
+):
+    """The Driver is transport, not policy: whatever the runtime projected
+    into ``spec.mcp_servers`` is converted to the ACP wire shape and sealed
+    into the plan, for the constrained and the generic profile alike.
+    Keeping puffo-v0 empty is the runtime projection's job — pinned in
+    ``test_puffo_v0_projection_keeps_mcp_servers_empty``."""
     seen = []
     driver = AcpDriver(
         launch_validator=lambda plan: seen.append(plan.mcp_servers)
@@ -588,19 +598,26 @@ async def test_spec_mcp_servers_never_reach_the_acp_launch_plan(launch_args):
         launch_args=launch_args,
         mcp_servers=(_PUFFO_CORE,),
     )
-    assert spec.mcp_servers == (_PUFFO_CORE,), "spec must carry the server"
 
     with contextlib.suppress(Exception):
         # The plan is sealed and validated before any spawn is attempted.
         await driver.open(spec)
 
-    assert seen == [()]
+    assert len(seen) == 1
+    (server,) = seen[0]
+    assert server.name == "puffo"
+    assert server.command == "/usr/bin/python3"
+    assert server.args == ["-m", "puffo_agent.mcp.puffo_core_server"]
+    assert [(e.name, e.value) for e in server.env] == [
+        ("PUFFO_AGENT_ID", "agent_test")
+    ]
 
 
 @pytest.mark.asyncio
-async def test_session_new_is_sent_an_empty_mcp_server_list():
-    """The wire value, not just the plan: an empty list is what makes
-    ``session/new`` succeed under puffo-v0."""
+async def test_session_new_receives_the_projected_mcp_servers():
+    """The wire value, not just the plan: ``session/new`` carries the
+    converted server list, which is what lets an ACP agent discover
+    Puffo's tools at all."""
     harness = _Harness(can_load=False)
     driver = AcpDriver(
         harness.process_factory,
@@ -613,6 +630,14 @@ async def test_session_new_is_sent_an_empty_mcp_server_list():
         mcp_servers=(_PUFFO_CORE,),
     ))
 
-    calls = dict(harness.conn.calls)
-    assert calls["new_session"]["mcp_servers"] == ()
+    sent = dict(harness.conn.calls)["new_session"]["mcp_servers"]
+    assert isinstance(sent, list)
+    (server,) = sent
+    assert isinstance(server, McpServerStdio)
+    assert server.name == "puffo"
+    assert server.command == "/usr/bin/python3"
+    assert server.args == ["-m", "puffo_agent.mcp.puffo_core_server"]
+    assert [(e.name, e.value) for e in server.env] == [
+        ("PUFFO_AGENT_ID", "agent_test")
+    ]
     await driver.close()

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import sys
 import time
@@ -32,6 +33,7 @@ from puffo_agent.agent.harness.drivers.acp import (
 )
 from puffo_agent.agent.harness.driver import (
     HarnessEventType,
+    McpServerSpec,
     PermissionDecision,
     PermissionRef,
     RuntimeLifecycle,
@@ -132,6 +134,14 @@ class _Harness:
             can_load=self.can_load,
         )
         return self.conn
+
+
+_PUFFO_CORE = McpServerSpec(
+    name="puffo",
+    command="/usr/bin/python3",
+    args=("-m", "puffo_agent.mcp.puffo_core_server"),
+    environment={"PUFFO_AGENT_ID": "agent_test"},
+)
 
 
 async def _collect_through(stream, type_):
@@ -342,6 +352,9 @@ async def test_launch_validator_sees_complete_immutable_plan_at_spawn_boundary()
         executable="agent",
         launch_args=("acp", "--agent-dir", "/agent"),
         environment={"ACP_TOKEN": "secret"},
+        # A spec that actually carries a server: with the default empty
+        # tuple the plan assertion above passes whatever the Driver does.
+        mcp_servers=(_PUFFO_CORE,),
     ))
 
     assert [name for name, _ in events] == ["validate", "spawn"]
@@ -547,3 +560,59 @@ async def _wait_for_path(path) -> None:
             return
         await asyncio.sleep(0.01)
     raise AssertionError(f"child did not create {path}")
+
+
+@pytest.mark.parametrize(
+    "launch_args",
+    [
+        pytest.param(
+            ("acp", "--runtime-id", "rt_x", "--profile", "puffo-v0"),
+            id="puffo-v0",
+        ),
+        pytest.param(("acp", "--agent-dir", "/agent"), id="generic-acp"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_spec_mcp_servers_never_reach_the_acp_launch_plan(launch_args):
+    """puffo-v0 rejects a non-empty ``mcpServers`` outright, so the Driver
+    drops whatever the runtime projected rather than forwarding it. Pinned
+    for the generic profile too: the drop is unconditional today, and a
+    future per-profile forward must not reintroduce it for puffo-v0."""
+    seen = []
+    driver = AcpDriver(
+        launch_validator=lambda plan: seen.append(plan.mcp_servers)
+    )
+    spec = RuntimeSpec(
+        "/workspace",
+        executable="lingtai-agent",
+        launch_args=launch_args,
+        mcp_servers=(_PUFFO_CORE,),
+    )
+    assert spec.mcp_servers == (_PUFFO_CORE,), "spec must carry the server"
+
+    with contextlib.suppress(Exception):
+        # The plan is sealed and validated before any spawn is attempted.
+        await driver.open(spec)
+
+    assert seen == [()]
+
+
+@pytest.mark.asyncio
+async def test_session_new_is_sent_an_empty_mcp_server_list():
+    """The wire value, not just the plan: an empty list is what makes
+    ``session/new`` succeed under puffo-v0."""
+    harness = _Harness(can_load=False)
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(RuntimeSpec(
+        "/workspace",
+        executable="agent",
+        launch_args=("acp", "--agent-dir", "/agent"),
+        mcp_servers=(_PUFFO_CORE,),
+    ))
+
+    calls = dict(harness.conn.calls)
+    assert calls["new_session"]["mcp_servers"] == ()
+    await driver.close()

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -337,10 +337,13 @@ async def test_launch_validator_sees_complete_immutable_plan_at_spawn_boundary()
         (server,) = plan.mcp_servers
         assert server.name == "puffo"
         assert server.command == "/usr/bin/python3"
-        assert server.args == ["-m", "puffo_agent.mcp.puffo_core_server"]
-        assert [(e.name, e.value) for e in server.env] == [
-            ("PUFFO_AGENT_ID", "agent_test")
-        ]
+        assert server.args == ("-m", "puffo_agent.mcp.puffo_core_server")
+        assert dict(server.environment) == {"PUFFO_AGENT_ID": "agent_test"}
+        # Sealed means sealed for the nested carriers too: what the
+        # validator saw is byte-for-byte what the wire call will convert.
+        assert isinstance(server.args, tuple)
+        with pytest.raises(TypeError):
+            server.environment["PUFFO_AGENT_ID"] = "changed"
         with pytest.raises(TypeError):
             plan.environment["ACP_TOKEN"] = "changed"
 
@@ -611,30 +614,43 @@ async def test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan(
     (server,) = seen[0]
     assert server.name == "puffo"
     assert server.command == "/usr/bin/python3"
-    assert server.args == ["-m", "puffo_agent.mcp.puffo_core_server"]
-    assert [(e.name, e.value) for e in server.env] == [
-        ("PUFFO_AGENT_ID", "agent_test")
-    ]
+    assert server.args == ("-m", "puffo_agent.mcp.puffo_core_server")
+    assert dict(server.environment) == {"PUFFO_AGENT_ID": "agent_test"}
+    assert isinstance(server.args, tuple)
+    with pytest.raises(TypeError):
+        server.environment["INJECTED"] = "value"
 
 
+@pytest.mark.parametrize(
+    "resume, expected_call",
+    [
+        pytest.param(None, "new_session", id="session-new"),
+        pytest.param(SessionRef("existing"), "load_session", id="session-load"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_session_new_receives_the_projected_mcp_servers():
-    """The wire value, not just the plan: ``session/new`` carries the
-    converted server list, which is what lets an ACP agent discover
-    Puffo's tools at all."""
-    harness = _Harness(can_load=False)
+async def test_session_calls_receive_the_projected_mcp_servers(
+    resume, expected_call
+):
+    """The wire value, not just the plan: both ``session/new`` and
+    ``session/load`` carry the converted server list — resuming an agent
+    must not silently drop its tools."""
+    harness = _Harness(can_load=True)
     driver = AcpDriver(
         harness.process_factory,
         connection_factory=harness.connection_factory,
     )
-    await driver.open(RuntimeSpec(
-        "/workspace",
-        executable="agent",
-        launch_args=("acp", "--agent-dir", "/agent"),
-        mcp_servers=(_PUFFO_CORE,),
-    ))
+    await driver.open(
+        RuntimeSpec(
+            "/workspace",
+            executable="agent",
+            launch_args=("acp", "--agent-dir", "/agent"),
+            mcp_servers=(_PUFFO_CORE,),
+        ),
+        resume,
+    )
 
-    sent = dict(harness.conn.calls)["new_session"]["mcp_servers"]
+    sent = dict(harness.conn.calls)[expected_call]["mcp_servers"]
     assert isinstance(sent, list)
     (server,) = sent
     assert isinstance(server, McpServerStdio)

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import os
 import sys
 import time
@@ -586,8 +585,7 @@ async def _wait_for_path(path) -> None:
         pytest.param(("acp", "--agent-dir", "/agent"), id="generic-acp"),
     ],
 )
-@pytest.mark.asyncio
-async def test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan(
+def test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan(
     launch_args,
 ):
     """The Driver is transport, not policy: whatever the runtime projected
@@ -606,9 +604,10 @@ async def test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan(
         mcp_servers=(_PUFFO_CORE,),
     )
 
-    with contextlib.suppress(Exception):
-        # The plan is sealed and validated before any spawn is attempted.
-        await driver.open(spec)
+    # Inspect the final pre-spawn seam directly. Reaching into this local
+    # object is intentional: this test guards plan construction and must not
+    # start a real provider when ``lingtai-agent`` happens to be installed.
+    driver._validate_launch_plan(spec)
 
     assert len(seen) == 1
     (server,) = seen[0]

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -250,6 +250,153 @@ async def test_prompt_admission_updates_and_response_form_one_terminal():
 
 
 @pytest.mark.asyncio
+async def test_post_commit_admission_extension_is_private_and_normalized():
+    harness = _Harness()
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(RuntimeSpec("/workspace", executable="agent"))
+    stream = driver.events()
+    await driver.start_turn(TurnInput("hello"))
+
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallStart(
+            session_update="tool_call",
+            tool_call_id="tool_1",
+            title="mcp__puffo__read_inbox",
+            status="in_progress",
+        ),
+    )
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallProgress(
+            session_update="tool_call_update",
+            tool_call_id="tool_1",
+            status="completed",
+        ),
+    )
+    binding = "a" * 64
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallProgress(
+            session_update="tool_call_update",
+            tool_call_id="tool_1",
+            field_meta={
+                "puffo.admission/1": {
+                    "toolCallId": "tool_1",
+                    "binding": binding,
+                },
+            },
+        ),
+    )
+    # A duplicate fact is ignored, so one commit cannot fire twice.
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallProgress(
+            session_update="tool_call_update",
+            tool_call_id="tool_1",
+            field_meta={
+                "puffo.admission/1": {
+                    "toolCallId": "tool_1",
+                    "binding": binding,
+                },
+            },
+        ),
+    )
+    harness.conn.prompt_result.set_result(PromptResponse(stop_reason="end_turn"))
+
+    events = await asyncio.wait_for(
+        _collect_through(stream, HarnessEventType.TURN_COMPLETED), timeout=1
+    )
+    admissions = [
+        event for event in events
+        if isinstance(event.native_diagnostic, dict)
+        and event.native_diagnostic.get("provider_context_committed") is True
+    ]
+    assert len(admissions) == 1
+    admission = admissions[0]
+    assert admission.data == {
+        "tool_call_ref": "tool_1",
+        "label": "mcp__puffo__read_inbox",
+        "outcome": "succeeded",
+    }
+    assert binding not in repr(admission.data)
+    assert admission.native_diagnostic == {
+        "_puffo_internal": "tool_result",
+        "provider_context_committed": True,
+        "tool_call_id": "tool_1",
+        "tool_name": "mcp__puffo__read_inbox",
+        "admission_binding": binding,
+        "is_error": False,
+    }
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_post_commit_admission_requires_prior_success_and_matching_id():
+    harness = _Harness()
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(RuntimeSpec("/workspace", executable="agent"))
+    stream = driver.events()
+    await driver.start_turn(TurnInput("hello"))
+    extension = {
+        "puffo.admission/1": {
+            "toolCallId": "tool_1",
+            "binding": "b" * 64,
+        },
+    }
+
+    # Metadata before a successful terminal cannot witness a future commit.
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallProgress(
+            session_update="tool_call_update",
+            tool_call_id="tool_1",
+            field_meta=extension,
+        ),
+    )
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallStart(
+            session_update="tool_call",
+            tool_call_id="tool_1",
+            title="read_inbox",
+        ),
+    )
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallProgress(
+            session_update="tool_call_update",
+            tool_call_id="tool_1",
+            status="failed",
+        ),
+    )
+    await harness.client.session_update(
+        "acp_session",
+        ToolCallProgress(
+            session_update="tool_call_update",
+            tool_call_id="tool_1",
+            field_meta=extension,
+        ),
+    )
+    harness.conn.prompt_result.set_result(PromptResponse(stop_reason="end_turn"))
+    events = await asyncio.wait_for(
+        _collect_through(stream, HarnessEventType.TURN_COMPLETED), timeout=1
+    )
+    assert not any(
+        isinstance(event.native_diagnostic, dict)
+        and event.native_diagnostic.get("provider_context_committed") is True
+        for event in events
+    )
+    await driver.close()
+
+
+@pytest.mark.asyncio
 async def test_permission_request_waits_for_typed_driver_resolution():
     harness = _Harness()
     driver = AcpDriver(

--- a/tests/test_acp_mcp_projection.py
+++ b/tests/test_acp_mcp_projection.py
@@ -1,0 +1,101 @@
+"""ACP MCP projection policy.
+
+The ACP Driver forwards ``RuntimeSpec.mcp_servers`` into ``session/new``
+verbatim (``test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan``),
+so ``_project_protocol_mcp`` is the single policy point for which tools an
+ACP agent can discover. These tests pin that policy:
+
+  * LingTai's constrained ``puffo-v0`` profile rejects a non-empty
+    ``mcpServers`` at ``session/new``, so its projection must stay empty —
+    an existing imported v0 agent must keep starting after the Driver
+    became a pass-through;
+  * every other ACP launch (``puffo-v1``, generic agents) receives
+    Puffo's core server, which is what makes the imported agent a full
+    platform member.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from puffo_agent.portal.state import (
+    AgentConfig,
+    DaemonConfig,
+    PuffoCoreConfig,
+    RuntimeConfig,
+)
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+
+
+def _preparer():
+    from puffo_agent.agent.harness.runtime.local_runtime import (
+        LocalRuntimePreparer,
+    )
+
+    cfg = AgentConfig(
+        id="acp-projection",
+        runtime=RuntimeConfig(
+            kind="cli-local",
+            harness="acp",
+            harness_command=["lingtai-agent", "acp"],
+        ),
+        puffo_core=PuffoCoreConfig(
+            server_url="http://localhost:3000",
+            slug="bot-0001",
+            device_id="dev_1",
+            space_id="sp_test",
+        ),
+    )
+    return LocalRuntimePreparer(DaemonConfig(), cfg)
+
+
+def _project(launch_args):
+    preparer = _preparer()
+    assert preparer._puffo_core_env, "fixture must yield a configured core env"
+    return preparer._project_protocol_mcp({}, {}, tuple(launch_args))
+
+
+@pytest.mark.parametrize(
+    "launch_args",
+    [
+        pytest.param(
+            ("acp", "--runtime-id", "rt_x", "--profile", "puffo-v0"),
+            id="flag-pair",
+        ),
+        pytest.param(
+            ("acp", "--profile=puffo-v0"),
+            id="flag-equals",
+        ),
+    ],
+)
+def test_puffo_v0_projection_keeps_mcp_servers_empty(launch_args):
+    """puffo-v0 fails ``session/new`` on any server list; with the Driver
+    now a pass-through, this projection is the only thing keeping an
+    imported v0 agent bootable."""
+    assert _project(launch_args) == ()
+
+
+@pytest.mark.parametrize(
+    "launch_args",
+    [
+        pytest.param(
+            ("acp", "--runtime-id", "rt_x", "--profile", "puffo-v1"),
+            id="puffo-v1",
+        ),
+        pytest.param(("acp", "--agent-dir", "/agent"), id="generic-acp"),
+    ],
+)
+def test_non_v0_acp_projection_carries_the_puffo_server(launch_args):
+    (server,) = _project(launch_args)
+    assert server.name == "puffo"
+    assert server.args == ("-m", "puffo_agent.mcp.puffo_core_server")
+    assert server.environment.get("PUFFO_CORE_SLUG") == "bot-0001"

--- a/tests/test_acp_mcp_projection.py
+++ b/tests/test_acp_mcp_projection.py
@@ -99,3 +99,15 @@ def test_non_v0_acp_projection_carries_the_puffo_server(launch_args):
     assert server.name == "puffo"
     assert server.args == ("-m", "puffo_agent.mcp.puffo_core_server")
     assert server.environment.get("PUFFO_CORE_SLUG") == "bot-0001"
+
+
+def test_duplicate_profile_flags_classify_by_the_last_occurrence():
+    """LingTai's argparse takes the LAST ``--profile``; Puffo must
+    classify by the same effective value or a duplicated flag launches
+    the child under a different profile than the one prepared for it —
+    both mismatch directions pinned."""
+    v0_then_v1 = ("acp", "--profile", "puffo-v0", "--profile", "puffo-v1")
+    v1_then_v0 = ("acp", "--profile", "puffo-v1", "--profile=puffo-v0")
+    (server,) = _project(v0_then_v1)  # effective v1 → carries the server
+    assert server.name == "puffo"
+    assert _project(v1_then_v0) == ()  # effective v0 → stays empty

--- a/tests/test_acp_mcp_projection.py
+++ b/tests/test_acp_mcp_projection.py
@@ -99,6 +99,7 @@ def test_non_v0_acp_projection_carries_the_puffo_server(launch_args):
     assert server.name == "puffo"
     assert server.args == ("-m", "puffo_agent.mcp.puffo_core_server")
     assert server.environment.get("PUFFO_CORE_SLUG") == "bot-0001"
+    assert server.environment.get("PUFFO_LOCAL_SERVICE_TOKEN")
 
 
 def test_duplicate_profile_flags_classify_by_the_last_occurrence():

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -383,9 +383,10 @@ def test_malformed_frames_disconnect_without_a_decision(payload: bytes) -> None:
         server.close()
 
 
+@pytest.mark.parametrize("profile", ["puffo-v0", "puffo-v1"])
 @pytest.mark.asyncio
 async def test_constrained_lingtai_spawn_gets_only_the_issued_endpoint(
-    monkeypatch,
+    monkeypatch, profile,
 ) -> None:
     captured: dict[str, Any] = {}
 
@@ -405,7 +406,7 @@ async def test_constrained_lingtai_spawn_gets_only_the_issued_endpoint(
                 launch_args=(
                     "acp",
                     "--profile",
-                    "puffo-v0",
+                    profile,
                     "--runtime-id",
                     "r1",
                 ),
@@ -422,7 +423,7 @@ async def test_constrained_lingtai_spawn_gets_only_the_issued_endpoint(
             "lingtai",
             "acp",
             "--profile",
-            "puffo-v0",
+            profile,
             "--runtime-id",
             "r1",
         )
@@ -474,8 +475,11 @@ async def test_generic_acp_spawn_cannot_inherit_a_caller_supplied_authority(
         await driver.close()
 
 
+@pytest.mark.parametrize("profile_arg", ["--profile=puffo-v0", "--profile=puffo-v1"])
 @pytest.mark.asyncio
-async def test_constrained_lingtai_rejects_spawn_paths_that_cannot_pass_fds() -> None:
+async def test_constrained_lingtai_rejects_spawn_paths_that_cannot_pass_fds(
+    profile_arg,
+) -> None:
     driver = AcpDriver(lambda _command, _spec: object())
 
     with pytest.raises(RuntimeError, match="POSIX local spawn path"):
@@ -484,7 +488,7 @@ async def test_constrained_lingtai_rejects_spawn_paths_that_cannot_pass_fds() ->
                 RuntimeSpec(
                     "/workspace",
                     executable="lingtai",
-                    launch_args=("acp", "--profile=puffo-v0"),
+                    launch_args=("acp", profile_arg),
                 )
             )
         )

--- a/tests/test_runtime_manager_failures.py
+++ b/tests/test_runtime_manager_failures.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from types import SimpleNamespace
 
 import pytest
@@ -1470,6 +1471,92 @@ async def test_context_rollover_preserves_logical_session_and_opens_fresh_native
     assert manager.session_ref == SessionRef("logical-session")
     assert manager.opened is not None and manager.opened.resumed is False
     assert adapter.get_context_capabilities().rollover is True
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_acp_post_commit_binding_admits_exact_call_and_rejects_wrong_id():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(driver, RuntimeSpec("/tmp"), driver_name="acp")
+    await manager.open()
+    await manager.start_turn(TurnInput("notice"))
+    admitted = []
+
+    async def admit(event):
+        admitted.append(event)
+
+    def event(call_id, receipt, *, bound_id=None, tool_name="read_inbox"):
+        binding = hashlib.sha256(
+            f"{bound_id or call_id}\x00{receipt}".encode("utf-8")
+        ).hexdigest()
+        return HarnessEvent.normalized(
+            type="turn.tool_completed",
+            driver="acp",
+            session_ref=SessionRef(manager.native_session_id),
+            turn_ref=driver.turn,
+            native_session_id=manager.native_session_id,
+            native_turn_id=manager.native_turn_id,
+            data={
+                "tool_call_ref": call_id,
+                "label": tool_name,
+                "outcome": "succeeded",
+            },
+            native_payload={
+                "_puffo_internal": "tool_result",
+                "provider_context_committed": True,
+                "tool_call_id": call_id,
+                "tool_name": tool_name,
+                "admission_binding": binding,
+                "is_error": False,
+            },
+        )
+
+    manager.register_continuation(
+        admit,
+        "exact",
+        tool_names=("read_inbox",),
+        tool_arguments={"limit": 1},
+        correlation_receipt="receipt-exact",
+    )
+    await manager._admit_matching_tool_result(
+        event("call-exact", "receipt-exact")
+    )
+    assert len(admitted) == 1
+    assert admitted[0].planning_cycle_key == "exact"
+    assert admitted[0].tool_call_id == "call-exact"
+
+    admitted.clear()
+    manager.register_continuation(
+        admit,
+        "wrong-id",
+        tool_names=("read_inbox",),
+        tool_arguments={"limit": 2},
+        correlation_receipt="receipt-wrong-id",
+    )
+    await manager._admit_matching_tool_result(
+        event(
+            "call-tampered",
+            "receipt-wrong-id",
+            bound_id="call-actually-committed",
+        )
+    )
+    assert admitted == []
+
+    manager.register_continuation(
+        admit,
+        "wrong-tool",
+        tool_names=("read_inbox",),
+        tool_arguments={"limit": 3},
+        correlation_receipt="receipt-wrong-tool",
+    )
+    await manager._admit_matching_tool_result(
+        event(
+            "call-wrong-tool",
+            "receipt-wrong-tool",
+            tool_name="send_message",
+        )
+    )
+    assert admitted == []
     await manager.close()
 
 


### PR DESCRIPTION
> [!NOTE]
> **评审已转移**:本 PR 已并入统一交付 [puffo-agent #328](https://github.com/puffo-ai/puffo-agent/pull/328)(agent 仓汇总,head `fcc1ddc7`;统一评审入口及 11→3 映射见其描述)。原评审正文与 head 保留如下,未改动。

## What

An imported LingTai agent could chat but never discover Puffo's tools: the ACP driver sealed an empty `mcp_servers` list into every launch plan (`acp.py`, old line 377), dropping the server the runtime had already projected into `RuntimeSpec.mcp_servers`.

This PR makes the driver pure transport and moves the policy to the single point that already builds the projection:

- **`drivers/acp.py`** — convert each projected `McpServerSpec` to the ACP wire shape (`McpServerStdio` + `EnvVariable` rows, a field-for-field mapping) and forward the list through `session/new` and `session/load`. New public `selects_puffo_v0_profile` predicate.
- **`runtime/local_runtime.py`** — `_project_protocol_mcp` now sees the launch args and keeps the projection **empty for LingTai's constrained `puffo-v0` profile**, which rejects any non-empty `mcpServers` at `session/new` — existing imported v0 agents keep booting. `puffo-v1` and generic ACP launches receive the full core server.

Counterpart: LingTai adds a `puffo-v1` profile accepting exactly one injected `puffo` stdio server (name + `-m puffo_agent.mcp.puffo_core_server` args pinned, interpreter path not pinned). Decision thread: Lingtai <> Puffo #General, approved by Glimmer 2026-09-04.

## Tests

- The two regression tests that pinned the old drop contract are flipped into forwarding tests (plan and wire level, both `--profile` spellings).
- New `tests/test_acp_mcp_projection.py` pins the policy: v0 stays empty; v1/generic carry the server.
- **Negative controls ran red first**: resealing the empty list broke 4 driver tests; removing the v0 gate broke both v0 projection tests.
- Full suite on this tree (`12c69a7d…`, Python 3.12 repo venv): 100% progress, exit 0, only 2 environment skips (live-opencode e2e, Windows-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- peter-pr-facts-20260909 -->
## PR 事实说明（2026-09-09，待交叉确认）

作者：Peter Steinberger。此节记录实现事实及待讨论问题，不代表跨 PR 建模方案已达成一致。

- PR：[puffo-agent #319](https://github.com/puffo-ai/puffo-agent/pull/319)
- 目标分支：`dev`；查询时 base head：`0c050f88fb4a2ad0e9638fdfa83027c5fae51f53`
- 本文 head：`1c19a266ba03336a10d5d2aaaf8cc5d32c5e2165`
- 比较 merge base：`0c050f88fb4a2ad0e9638fdfa83027c5fae51f53`；[固定版本差异](https://github.com/puffo-ai/puffo-agent/compare/0c050f88fb4a2ad0e9638fdfa83027c5fae51f53...1c19a266ba03336a10d5d2aaaf8cc5d32c5e2165)
- 后续代码变更需重新确认本文，不自动继承复核结论。

### 1. 问题与行为变化

本 PR 实际包含两条行为链，原有简短描述主要解释第一条。

A. 工具发现：RuntimeSpec 已投影 MCP server，但 ACP launch plan 固定为空，new/load session 接收不到。改后 driver 保留不可变投影并在 session 调用时转成 ACP wire 对象。LingTai puffo-v0 仍要求空投影；puffo-v1/通用 ACP 可收到 Puffo server。

B. 结果接纳：普通 ACP tool completed 只表明 handler 完成，不能证明结果已提交给模型上下文。改后识别 LingTai 后续的 `puffo.admission/1` 扩展，并和既有 staged continuation 关联后触发 admission callback。

### 2. 实现路径和代码依据

- `harness/runtime/local_runtime.py::_project_protocol_mcp` 根据实际 launch_args 为 v0 保持空投影，其他路径沿用现有 McpServerSpec。环境来源仍经 `_build_puffo_core_env` 到既有 `mcp/config.py::puffo_core_mcp_env`；本 PR 没另写凭据构造。
- `harness/drivers/acp.py::_validate_launch_plan` 深冻结 MCP args/environment；`_to_acp_stdio_server` 只把 tuple/mapping 转成 ACP list/EnvVariable，new_session/load_session 均使用。
- `_lingtai_constrained_profile` 解析两种 --profile 写法，并按最后一次参数确定生效值；authority 的受约束范围扩为 v0/v1，空 MCP 条件只针对 v0。
- `acp.py::_session_update/_post_commit_admission` 记住工具名称、已成功完成集合和已接纳集合。后续扩展必须匹配同一调用、满足成功完成前置条件且未重复接纳；私有绑定进入 native payload，公共投影不带绑定。
- `context_controller.py::ToolResultAdmission.binding_for_tool_call` 把既有私有 receipt 与原生调用 ID 关联；`runtime_manager.py::_admit_matching_tool_result` 校验当前 turn、工具名称和绑定，取最具体候选并从等待列表移除，执行既有 callback。
- 新增的三份调用追踪容器在 start/finish/close 清理；原 arguments 匹配路径继续供其他结果使用。

### 3. 复用、新增模型与改动范围

复用 RuntimeSpec/McpServerSpec、已有环境构造、Driver authority、ToolResultAdmission、ProviderAdmissionEvent 和 continuation 等待列表。新增协议转换函数、profile 条件、ACP 结果提交扩展适配及回合内追踪集合。四个生产文件、四个测试文件。

工具是否可被发现、调用是否获准、结果是否进入模型上下文是三个可分别失败的步骤；以上是实现输入输出说明，尚不据此认定最终抽象一定合理。#304 的文档需对照 authority 具体责任后再讨论重复。

### 4. 验证证据及边界

`test_acp_mcp_projection.py` 检查 v0 空、v1/通用非空；`test_acp_driver.py` 检查 plan/wire 转换、profile 与 admission 事件；`test_runtime_manager_failures.py` 检查提交绑定接纳；authority 测试同步更新。当前 head 三项 CI 成功。本轮未独立跑完整 Python suite；原 PR 描述中的早期全量结果不能替代后来增加 admission 逻辑后的版本证据。

对端必须实现并正确发出 post-commit 扩展；仅转发工具不证明真实端到端接纳已发生。目标分支为 dev，和其他 main PR 的依赖不能只按编号排序。

### 5. 待共同确认的问题

两条行为链是否应该作为同一交付原子，还是分别描述/交付更易验证？三份追踪容器是否可依托已有工具生命周期记录；若可，是否拥有相同清理和去重保证？需要与 #304 的原有 authority 和 admission 边界共同核对，不能仅凭 ACP 文件重叠断言重复。

### 固定版本代码入口

- [src/puffo_agent/agent/context_controller.py](https://github.com/puffo-ai/puffo-agent/blob/1c19a266ba03336a10d5d2aaaf8cc5d32c5e2165/src/puffo_agent/agent/context_controller.py)
- [src/puffo_agent/agent/harness/drivers/acp.py](https://github.com/puffo-ai/puffo-agent/blob/1c19a266ba03336a10d5d2aaaf8cc5d32c5e2165/src/puffo_agent/agent/harness/drivers/acp.py)
- [src/puffo_agent/agent/harness/runtime/local_runtime.py](https://github.com/puffo-ai/puffo-agent/blob/1c19a266ba03336a10d5d2aaaf8cc5d32c5e2165/src/puffo_agent/agent/harness/runtime/local_runtime.py)
- [src/puffo_agent/agent/harness/runtime/runtime_manager.py](https://github.com/puffo-ai/puffo-agent/blob/1c19a266ba03336a10d5d2aaaf8cc5d32c5e2165/src/puffo_agent/agent/harness/runtime/runtime_manager.py)
