### PR TITLE
fix: treat provider model catalog as advisory

### DIFF
--- a/src/puffo_agent/agent/harness/driver.py
+++ b/src/puffo_agent/agent/harness/driver.py
@@ -144,6 +144,7 @@ class McpServerSpec:
 class RuntimeSpec:
     workspace_dir: str
     model: str = ""
+    inference_level: str = ""
     system_prompt: str = ""
     executable: str = ""
     launch_args: tuple[str, ...] = ()

--- a/src/puffo_agent/agent/harness/drivers/codex.py
+++ b/src/puffo_agent/agent/harness/drivers/codex.py
@@ -174,6 +174,27 @@ def _is_invalid_resume_error(message: str) -> bool:
     return any(marker in lowered for marker in _INVALID_RESUME_MARKERS)
 
 
+def _selection_ack_warnings(
+    spec: RuntimeSpec, thread: dict[str, Any],
+) -> tuple[str, ...]:
+    warnings: list[str] = []
+    acknowledged_model = thread.get("model")
+    if spec.model and acknowledged_model != spec.model:
+        warnings.append(
+            "model_ack_unavailable"
+            if acknowledged_model is None
+            else "model_ack_mismatch"
+        )
+    acknowledged_level = thread.get("reasoningEffort")
+    if spec.inference_level and acknowledged_level != spec.inference_level:
+        warnings.append(
+            "inference_level_ack_unavailable"
+            if acknowledged_level is None
+            else "inference_level_ack_mismatch"
+        )
+    return tuple(warnings)
+
+
 def _classify_jsonrpc_error(error: Any) -> Exception:
     """Translate a Codex JSON-RPC error into Global Inbox recovery semantics."""
     error_obj = error if isinstance(error, dict) else {}
@@ -304,6 +325,12 @@ class CodexAppServerDriver(Driver):
             raise RuntimeError("Codex thread response omitted native thread id")
         self._native_session_id = native
         self._session_ref = SessionRef(native)
+        selection_warnings = _selection_ack_warnings(spec, thread)
+        if selection_warnings:
+            logger.warning(
+                "codex runtime selection not fully acknowledged: %s",
+                ", ".join(selection_warnings),
+            )
         await self._emit(
             HarnessEventType.SESSION_RESUMED
             if resumed
@@ -325,6 +352,7 @@ class CodexAppServerDriver(Driver):
                     "thread/compact/start",
                     "permission_bridge",
                 ),
+                warnings=selection_warnings,
             ),
         )
 

--- a/src/puffo_agent/agent/harness/runtime/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/docker_runtime.py
@@ -443,6 +443,7 @@ class DockerRuntimePreparer:
         return RuntimeSpec(
             workspace_dir="/workspace",
             model=self.model,
+            inference_level=self.agent_cfg.runtime.inference_level,
             system_prompt=system_prompt,
             environment=environment,
             permission_mode=self.permission_mode,

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -399,6 +399,7 @@ class LocalRuntimePreparer:
         return RuntimeSpec(
             workspace_dir=str(self.workspace_dir),
             model=self.model,
+            inference_level=self.agent_cfg.runtime.inference_level,
             system_prompt=system_prompt,
             executable=executable,
             launch_args=tuple(launch_args),
@@ -789,6 +790,7 @@ class LocalRuntimePreparer:
         return RuntimeSpec(
             workspace_dir=str(self.workspace_dir),
             model=self.model,
+            inference_level=self.agent_cfg.runtime.inference_level,
             system_prompt=system_prompt,
             executable=executable,
             environment=environment,

--- a/src/puffo_agent/agent/model_catalog.py
+++ b/src/puffo_agent/agent/model_catalog.py
@@ -65,8 +65,9 @@ _CLAUDE_STATIC: tuple[ModelOption, ...] = (
     ModelOption("claude-sonnet-4-6", "Claude Sonnet 4.6"),
 )
 
-# codex reads its own local model cache (see _codex_models); these are
-# the fallback when that cache is unreadable.
+# codex reads its own local model cache (see _codex_models); these are the
+# fallback only when the cache is unreadable and no persisted last-known-good
+# catalog exists for this account and source home.
 _CODEX_STATIC: tuple[ModelOption, ...] = (
     ModelOption("gpt-5.5", "GPT-5.5"),
     ModelOption("gpt-5.4", "GPT-5.4"),

--- a/src/puffo_agent/agent/model_catalog.py
+++ b/src/puffo_agent/agent/model_catalog.py
@@ -10,8 +10,11 @@ OpenCode query their installed CLIs; the rest are static.
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import logging
+import os
 import threading
 import time
 import urllib.error
@@ -94,10 +97,171 @@ _ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models"
 _CACHE_TTL_S = 3600.0
 _FETCH_TIMEOUT_S = 6.0
 _DYNAMIC_CACHE_TTL_S = 20.0
+_CATALOG_REMOVAL_MISSES = 3
+_CATALOG_REMOVAL_GRACE_S = 15 * 60.0
+MAX_CUSTOM_MODEL_ID_LENGTH = 128
 
 # "claude-code" -> (fetched_at, concrete_models). Guarded by _lock.
 _cache: dict[str, tuple[float, tuple[ModelOption, ...]]] = {}
 _lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _CatalogObservation:
+    models: tuple[ModelOption, ...]
+    revision: str
+
+
+@dataclass(frozen=True)
+class _MissingEvidence:
+    model_id: str
+    successful_misses: int
+    first_missing_at: float
+
+
+@dataclass(frozen=True)
+class _CatalogState:
+    models: tuple[ModelOption, ...]
+    last_observation: str
+    missing: tuple[_MissingEvidence, ...] = ()
+
+
+@dataclass(frozen=True)
+class CatalogStabilizer:
+    """Persist and de-flake one account-scoped discovery catalog.
+
+    Discovery is advisory: additions appear immediately, while removals need
+    repeated, time-separated evidence. Failed and empty observations never
+    erase the last-known-good list.
+    """
+
+    harness: str
+    account_fingerprint: str
+    fallback: tuple[ModelOption, ...]
+    removal_misses: int = _CATALOG_REMOVAL_MISSES
+    removal_grace_seconds: float = _CATALOG_REMOVAL_GRACE_S
+
+    def stabilize(
+        self, observation: _CatalogObservation | None,
+    ) -> tuple[ModelOption, ...]:
+        with _lock:
+            state = self._load()
+            if observation is None or not observation.models:
+                return state.models if state is not None else self.fallback
+            if state is not None and observation.revision == state.last_observation:
+                return state.models
+            updated = self._reconcile(state, observation, now=time.time())
+            self._save(updated)
+            return updated.models
+
+    def _reconcile(
+        self,
+        state: _CatalogState | None,
+        observation: _CatalogObservation,
+        *,
+        now: float,
+    ) -> _CatalogState:
+        if state is None:
+            return _CatalogState(observation.models, observation.revision)
+        observed_ids = {model.id for model in observation.models}
+        prior_missing = {item.model_id: item for item in state.missing}
+        retained: list[ModelOption] = []
+        missing: list[_MissingEvidence] = []
+        for model in state.models:
+            if model.id in observed_ids:
+                continue
+            evidence = prior_missing.get(model.id)
+            evidence = _MissingEvidence(
+                model.id,
+                (evidence.successful_misses + 1) if evidence else 1,
+                evidence.first_missing_at if evidence else now,
+            )
+            old_enough = now - evidence.first_missing_at >= self.removal_grace_seconds
+            if evidence.successful_misses >= self.removal_misses and old_enough:
+                continue
+            retained.append(model)
+            missing.append(evidence)
+        return _CatalogState(
+            (*observation.models, *retained),
+            observation.revision,
+            tuple(missing),
+        )
+
+    def _path(self) -> Path:
+        from ..portal.state import home_dir
+
+        name = f"{self.harness}-{self.account_fingerprint}.json"
+        return home_dir() / "cache" / "model-catalogs" / name
+
+    def _load(self) -> _CatalogState | None:
+        try:
+            raw = json.loads(self._path().read_text(encoding="utf-8"))
+            if raw.get("version") != 1:
+                return None
+            models = tuple(_model_option_from_json(item) for item in raw["models"])
+            missing = tuple(
+                _MissingEvidence(
+                    str(item["model_id"]),
+                    int(item["successful_misses"]),
+                    float(item["first_missing_at"]),
+                )
+                for item in raw.get("missing", [])
+            )
+            return _CatalogState(models, str(raw["last_observation"]), missing)
+        except (KeyError, OSError, TypeError, ValueError):
+            return None
+
+    def _save(self, state: _CatalogState) -> None:
+        from ..portal.host_assets import _atomic_write_private
+
+        body = {
+            "version": 1,
+            "harness": self.harness,
+            "account_fingerprint": self.account_fingerprint,
+            "last_observation": state.last_observation,
+            "models": [_model_option_to_json(model) for model in state.models],
+            "missing": [
+                {
+                    "model_id": item.model_id,
+                    "successful_misses": item.successful_misses,
+                    "first_missing_at": item.first_missing_at,
+                }
+                for item in state.missing
+            ],
+        }
+        try:
+            _atomic_write_private(self._path(), json.dumps(body, indent=2))
+        except OSError as exc:
+            logger.debug("could not persist %s model catalog: %s", self.harness, exc)
+
+
+def _model_option_to_json(model: ModelOption) -> dict[str, object]:
+    return {
+        "id": model.id,
+        "label": model.label,
+        "is_alias": model.is_alias,
+        "supported_inference_levels": (
+            list(model.supported_inference_levels)
+            if model.supported_inference_levels is not None
+            else None
+        ),
+    }
+
+
+def _model_option_from_json(raw: object) -> ModelOption:
+    if not isinstance(raw, dict):
+        raise ValueError("model option must be an object")
+    levels = raw.get("supported_inference_levels")
+    if levels is not None and not isinstance(levels, list):
+        raise ValueError("supported_inference_levels must be a list or null")
+    return ModelOption(
+        id=str(raw["id"]),
+        label=str(raw["label"]),
+        is_alias=bool(raw.get("is_alias", False)),
+        supported_inference_levels=(
+            tuple(str(level) for level in levels) if levels is not None else None
+        ),
+    )
 
 
 def _anthropic_oauth_token() -> str | None:
@@ -154,28 +318,127 @@ def _claude_concrete(*, fetch: bool) -> tuple[ModelOption, ...]:
     return cached[1] if cached else _CLAUDE_STATIC
 
 
-def _codex_models() -> tuple[ModelOption, ...]:
-    """The codex CLI's own local model cache. ``visibility == "list"``
-    drops internal entries (e.g. codex-auto-review); the CLI's
-    ``priority`` sets the order. Falls back to the static list when the
-    cache is missing / unreadable. No block-list needed — ``visibility``
-    does the filtering."""
+def _jwt_account_identity(token: object) -> str:
+    if not isinstance(token, str) or token.count(".") < 2:
+        return ""
+    try:
+        payload = token.split(".", 2)[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, TypeError):
+        return ""
+    provider_claims = claims.get("https://api.openai.com/auth") or {}
+    if not isinstance(provider_claims, dict):
+        provider_claims = {}
+    return str(
+        provider_claims.get("chatgpt_account_id")
+        or provider_claims.get("account_id")
+        or claims.get("sub")
+        or ""
+    )
+
+
+def _codex_account_fingerprint() -> str:
+    """Opaque scope for persisted discovery, never exposed or logged."""
+    source_home = Path.home()
+    path = source_home / ".codex" / "auth.json"
+    try:
+        auth = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError):
+        auth = {}
+    tokens = auth.get("tokens") or {}
+    if not isinstance(tokens, dict):
+        tokens = {}
+    identity = str(tokens.get("account_id") or "")
+    if not identity:
+        identity = _jwt_account_identity(tokens.get("id_token"))
+    if not identity:
+        identity = str(
+            auth.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY") or ""
+        )
+    source = "\0".join((
+        "puffo-model-catalog-v1",
+        "codex",
+        str(source_home.resolve()),
+        str(auth.get("auth_mode") or "unknown"),
+        identity or "unauthenticated",
+    ))
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()[:24]
+
+
+def _codex_model_option(raw: dict) -> ModelOption:
+    levels = raw.get("supported_reasoning_levels")
+    supported: tuple[str, ...] | None = None
+    if isinstance(levels, list):
+        from ..mcp.config import REASONING_EFFORTS
+
+        advertised = {
+            str(item.get("effort"))
+            for item in levels
+            if isinstance(item, dict) and item.get("effort")
+        }
+        supported = tuple(
+            level for level in REASONING_EFFORTS if level in advertised
+        )
+    return ModelOption(
+        raw["slug"],
+        raw.get("display_name") or raw["slug"],
+        supported_inference_levels=supported,
+    )
+
+
+def _codex_observation() -> _CatalogObservation | None:
+    """Parse one successful, non-empty Codex discovery snapshot."""
     path = Path.home() / ".codex" / "models_cache.json"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return _CODEX_STATIC
+    except (OSError, TypeError, ValueError):
+        return None
     listed = sorted(
         (
             m for m in data.get("models", [])
-            if m.get("slug") and m.get("visibility") == "list"
+            if isinstance(m, dict)
+            and m.get("slug")
+            and m.get("visibility") == "list"
         ),
         key=lambda m: m.get("priority", 9999),
     )
-    out = tuple(
-        ModelOption(m["slug"], m.get("display_name") or m["slug"]) for m in listed
-    )
-    return out or _CODEX_STATIC
+    models = tuple(_codex_model_option(model) for model in listed)
+    if not models:
+        return None
+    revision_body = {
+        "etag": data.get("etag"),
+        "fetched_at": data.get("fetched_at"),
+        "models": [_model_option_to_json(model) for model in models],
+    }
+    revision = hashlib.sha256(
+        json.dumps(revision_body, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return _CatalogObservation(models, revision)
+
+
+def _codex_models() -> tuple[ModelOption, ...]:
+    """Stable advisory view over the Codex CLI's volatile local cache."""
+    return CatalogStabilizer(
+        harness="codex",
+        account_fingerprint=_codex_account_fingerprint(),
+        fallback=_CODEX_STATIC,
+    ).stabilize(_codex_observation())
+
+
+def validate_model_id(model: str) -> str:
+    """Validate only transport-safe model syntax; discovery is advisory."""
+    if not isinstance(model, str):
+        raise ValueError("model must be a string")
+    if not model or model != model.strip():
+        raise ValueError("model must be a non-empty trimmed string")
+    if len(model) > MAX_CUSTOM_MODEL_ID_LENGTH:
+        raise ValueError(
+            f"model must be at most {MAX_CUSTOM_MODEL_ID_LENGTH} characters"
+        )
+    if any(ord(char) < 32 or ord(char) == 127 for char in model):
+        raise ValueError("model must not contain control characters")
+    return model
 
 
 def _cached_models(

--- a/src/puffo_agent/agent/provider_failures.py
+++ b/src/puffo_agent/agent/provider_failures.py
@@ -31,6 +31,13 @@ PROVIDER_FAILURES: Mapping[str, ProviderFailure] = MappingProxyType(
             "The requested operation was not permitted.",
             runtime_event_code="permission_denied",
         ),
+        "model_not_found": ProviderFailure(
+            "The selected provider model was not found; choose another model ID.",
+        ),
+        "not_entitled": ProviderFailure(
+            "This provider account is not entitled to use the selected model.",
+            runtime_event_code="permission_denied",
+        ),
         "plan_drained": ProviderFailure(
             "The provider plan's usage quota is spent; wait for the "
             "usage window to reset.",
@@ -127,6 +134,31 @@ def runtime_event_failure_code(error_code: str) -> str:
     return provider_failure(error_code).runtime_event_code
 
 
+def _looks_like_model_not_found(diagnostic: str) -> bool:
+    return (
+        "model_not_found" in diagnostic
+        or "model not found" in diagnostic
+        or "unknown model" in diagnostic
+        or re.search(r"\bmodel\b.*\bdoes not exist\b", diagnostic) is not None
+    )
+
+
+def _looks_like_model_entitlement_failure(diagnostic: str) -> bool:
+    if "model" not in diagnostic:
+        return False
+    return any(
+        marker in diagnostic
+        for marker in (
+            "not_entitled",
+            "not entitled",
+            "do not have access",
+            "does not have access",
+            "not available for your account",
+            "not permitted to use",
+        )
+    )
+
+
 def classify_provider_failure(*, status: int | None, diagnostic: str) -> str:
     """Classify an explicit provider diagnostic into the shared vocabulary."""
     normalized = diagnostic.lower()
@@ -147,6 +179,10 @@ def classify_provider_failure(*, status: int | None, diagnostic: str) -> str:
         or re.search(r"\bquota\b", normalized) is not None
     ):
         return "quota_exhausted"
+    if _looks_like_model_not_found(normalized):
+        return "model_not_found"
+    if _looks_like_model_entitlement_failure(normalized):
+        return "not_entitled"
     if looks_like_provider_auth_error(normalized):
         return "authentication"
     if status == 429 or any(

--- a/src/puffo_agent/agent/provider_failures.py
+++ b/src/puffo_agent/agent/provider_failures.py
@@ -134,7 +134,7 @@ def runtime_event_failure_code(error_code: str) -> str:
     return provider_failure(error_code).runtime_event_code
 
 
-def _looks_like_model_not_found(diagnostic: str) -> bool:
+def _diagnostic_mentions_model_not_found(diagnostic: str) -> bool:
     return (
         "model_not_found" in diagnostic
         or "model not found" in diagnostic
@@ -179,7 +179,7 @@ def classify_provider_failure(*, status: int | None, diagnostic: str) -> str:
         or re.search(r"\bquota\b", normalized) is not None
     ):
         return "quota_exhausted"
-    if _looks_like_model_not_found(normalized):
+    if _diagnostic_mentions_model_not_found(normalized):
         return "model_not_found"
     if _looks_like_model_entitlement_failure(normalized):
         return "not_entitled"

--- a/src/puffo_agent/mcp/puffo_core_server.py
+++ b/src/puffo_agent/mcp/puffo_core_server.py
@@ -57,13 +57,12 @@ def _validate_refresh_model(harness: str, model: Optional[str]) -> None:
             f"harness={harness!r} not installed on host — the CLI "
             "binary is missing from PATH."
         )
-    from ..agent.model_catalog import provider_models
-    supported = [m.id for m in provider_models(harness) if m.id]
-    if (model or "") not in supported:
-        raise RuntimeError(
-            f"model={model!r} not supported by harness={harness!r}; "
-            f"supported: {supported}"
-        )
+    from ..agent.model_catalog import validate_model_id
+
+    try:
+        validate_model_id(model or "")
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
 
 
 def _validate_refresh_inference_level(harness: str, level: str) -> None:

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -1075,14 +1075,9 @@ def _validate_daemon_refresh_model(harness: str, model: str) -> None:
     }[harness]
     if resolver() is None:
         raise ValueError(f"harness={harness!r} CLI not installed on host")
-    from ..agent.model_catalog import provider_models
+    from ..agent.model_catalog import validate_model_id
 
-    supported = [m.id for m in provider_models(harness) if m.id]
-    if model not in supported:
-        raise ValueError(
-            f"model={model!r} not supported by harness={harness!r}; "
-            f"supported: {supported}"
-        )
+    validate_model_id(model)
 
 
 def _validate_daemon_inference_level(harness: str, level: str) -> None:

--- a/tests/test_codex_driver_jsonrpc_errors.py
+++ b/tests/test_codex_driver_jsonrpc_errors.py
@@ -13,8 +13,38 @@ from puffo_agent.agent.errors import ProviderFailureError
 from puffo_agent.agent.harness.drivers.codex import (
     CodexAppServerDriver,
     _classify_jsonrpc_error,
+    _selection_ack_warnings,
 )
-from puffo_agent.agent.harness.driver import PermissionDecision, PermissionRef
+from puffo_agent.agent.harness.driver import (
+    PermissionDecision,
+    PermissionRef,
+    RuntimeSpec,
+)
+
+
+def test_unlisted_model_and_level_are_explicitly_unvalidated_without_ack():
+    """A successful thread open must not imply its requested tier took effect."""
+    spec = RuntimeSpec(
+        "/workspace", model="gpt-6-astra", inference_level="high",
+    )
+
+    assert _selection_ack_warnings(spec, {"id": "thread-1"}) == (
+        "model_ack_unavailable",
+        "inference_level_ack_unavailable",
+    )
+
+
+def test_matching_harness_ack_validates_model_and_level():
+    """An exact app-server echo is positive evidence for the selected config."""
+    spec = RuntimeSpec(
+        "/workspace", model="gpt-6-astra", inference_level="high",
+    )
+
+    assert _selection_ack_warnings(spec, {
+        "id": "thread-1",
+        "model": "gpt-6-astra",
+        "reasoningEffort": "high",
+    }) == ()
 
 
 @pytest.mark.parametrize(
@@ -55,6 +85,30 @@ def test_jsonrpc_retryable_provider_errors_requeue(error):
     assert isinstance(exc, AgentAPIError)
     assert exc.is_auth is False
     assert exc.error_code in {"rate_limit", "provider_unavailable"}
+
+
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        (
+            {"code": -32000, "message": "model_not_found: gpt-future"},
+            "model_not_found",
+        ),
+        (
+            {
+                "code": 403,
+                "message": "Your account is not entitled to use model gpt-future",
+            },
+            "not_entitled",
+        ),
+    ],
+)
+def test_jsonrpc_model_selection_failures_keep_actionable_class(error, expected):
+    """A real model rejection must not collapse into generic provider failure."""
+    exc = _classify_jsonrpc_error(error)
+
+    assert isinstance(exc, ProviderFailureError)
+    assert exc.error_code == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_codex_driver_selection_ack.py
+++ b/tests/test_codex_driver_selection_ack.py
@@ -1,0 +1,67 @@
+"""Integration coverage for Codex runtime-selection acknowledgments."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from puffo_agent.agent.harness.driver import RuntimeSpec
+from puffo_agent.agent.harness.drivers.codex import CodexAppServerDriver
+
+
+class _ResponsiveStdin:
+    def __init__(self, process: _ResponsiveProcess) -> None:
+        self._process = process
+
+    def write(self, value: bytes) -> None:
+        frame = json.loads(value)
+        if frame.get("method") == "initialize":
+            self._process.feed({"id": frame["id"], "result": {"server": "fake"}})
+        elif frame.get("method") == "thread/start":
+            self._process.feed({
+                "id": frame["id"],
+                "result": {"thread": {"id": "th_1"}},
+            })
+
+    async def drain(self) -> None:
+        await asyncio.sleep(0)
+
+
+class _ResponsiveProcess:
+    def __init__(self) -> None:
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.stdin = _ResponsiveStdin(self)
+        self.returncode: int | None = None
+
+    def feed(self, frame: dict) -> None:
+        self.stdout.feed_data(json.dumps(frame).encode() + b"\n")
+
+    def terminate(self) -> None:
+        self.returncode = 0
+        self.stdout.feed_eof()
+
+    def kill(self) -> None:
+        self.terminate()
+
+    async def wait(self) -> int:
+        return int(self.returncode or 0)
+
+
+@pytest.mark.asyncio
+async def test_codex_open_reports_unacknowledged_model_and_inference_level():
+    """A provider response without selection echoes must never look validated."""
+    process = _ResponsiveProcess()
+    driver = CodexAppServerDriver(lambda _spec: process)
+
+    opened = await driver.open(RuntimeSpec(
+        "/workspace", model="gpt-6-astra", inference_level="high",
+    ))
+
+    assert opened.diagnostics.warnings == (
+        "model_ack_unavailable",
+        "inference_level_ack_unavailable",
+    )
+    await driver.close()

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -855,6 +855,22 @@ def _codex_protocol_driver():
     return proc, CodexAppServerDriver(lambda _spec: proc)
 
 
+@pytest.mark.asyncio
+async def test_codex_open_reports_unacknowledged_model_and_inference_level():
+    """A provider response without selection echoes must never look validated."""
+    proc, driver = _codex_protocol_driver()
+
+    opened = await driver.open(RuntimeSpec(
+        "/workspace", model="gpt-6-astra", inference_level="high",
+    ))
+
+    assert opened.diagnostics.warnings == (
+        "model_ack_unavailable",
+        "inference_level_ack_unavailable",
+    )
+    await driver.close()
+
+
 async def _open_codex_protocol_driver(proc, driver):
     opened = await driver.open(RuntimeSpec("/workspace", model="gpt"))
     assert opened.native_session_id == "th_1"

--- a/tests/test_harness_driver.py
+++ b/tests/test_harness_driver.py
@@ -855,22 +855,6 @@ def _codex_protocol_driver():
     return proc, CodexAppServerDriver(lambda _spec: proc)
 
 
-@pytest.mark.asyncio
-async def test_codex_open_reports_unacknowledged_model_and_inference_level():
-    """A provider response without selection echoes must never look validated."""
-    proc, driver = _codex_protocol_driver()
-
-    opened = await driver.open(RuntimeSpec(
-        "/workspace", model="gpt-6-astra", inference_level="high",
-    ))
-
-    assert opened.diagnostics.warnings == (
-        "model_ack_unavailable",
-        "inference_level_ack_unavailable",
-    )
-    await driver.close()
-
-
 async def _open_codex_protocol_driver(proc, driver):
     opened = await driver.open(RuntimeSpec("/workspace", model="gpt"))
     assert opened.native_session_id == "th_1"

--- a/tests/test_inference_level.py
+++ b/tests/test_inference_level.py
@@ -183,10 +183,12 @@ def test_docker_claude_argv_skips_invalid(tmp_path, monkeypatch):
 from puffo_agent.mcp.config import supported_inference_levels  # noqa: E402
 from puffo_agent.mcp.puffo_core_server import (  # noqa: E402
     _validate_refresh_inference_level,
+    _validate_refresh_model,
 )
 from puffo_agent.portal.daemon import (  # noqa: E402
     _process_daemon_refresh_flags,
     _validate_daemon_inference_level,
+    _validate_daemon_refresh_model,
 )
 from puffo_agent.portal.state import refresh_model_flag_path  # noqa: E402
 
@@ -230,6 +232,45 @@ def test_daemon_validator_rejects_codex_xhigh():
     with pytest.raises(ValueError):
         _validate_daemon_inference_level("codex", "xhigh")
     _validate_daemon_inference_level("codex", "high")  # no raise
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [_validate_refresh_model, _validate_daemon_refresh_model],
+)
+def test_refresh_model_catalog_is_advisory(monkeypatch, validator):
+    """A syntactically valid custom model must survive a catalog miss."""
+    from puffo_agent.agent import cli_bin, model_catalog
+
+    monkeypatch.setattr(cli_bin, "resolve_codex_bin", lambda: "/bin/codex")
+    monkeypatch.setattr(
+        model_catalog,
+        "provider_models",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("refresh validation must not consult discovery")
+        ),
+    )
+
+    validator("codex", "gpt-6-astra")
+
+
+@pytest.mark.parametrize(
+    "validator,error_type",
+    [
+        (_validate_refresh_model, RuntimeError),
+        (_validate_daemon_refresh_model, ValueError),
+    ],
+)
+@pytest.mark.parametrize("model", ["", "x" * 129, "bad\nmodel"])
+def test_refresh_model_keeps_syntax_gate(
+    monkeypatch, validator, error_type, model,
+):
+    """Removing catalog admission must not let malformed CLI arguments through."""
+    from puffo_agent.agent import cli_bin
+
+    monkeypatch.setattr(cli_bin, "resolve_codex_bin", lambda: "/bin/codex")
+    with pytest.raises(error_type):
+        validator("codex", model)
 
 
 def _codex_agent(tmp_path, monkeypatch, aid="codex-refresh", level=""):

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -201,6 +201,22 @@ def test_codex_catalog_removes_only_after_three_distinct_misses_over_window(
     assert "gpt-6-astra" not in _ids(provider_models("codex"))
 
 
+def test_codex_catalog_keeps_model_after_three_fast_misses(monkeypatch, tmp_path):
+    """Three misses inside the grace window must not remove a model."""
+    now = {"value": 1_000.0}
+    monkeypatch.setattr(mc.time, "time", lambda: now["value"])
+    monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo-home"))
+    _write_codex_auth(tmp_path, "account-a")
+    _write_codex_cache(tmp_path, ["gpt-6-astra", "gpt-5.6-sol"], revision="a")
+    provider_models("codex")
+
+    for revision, elapsed in (("b1", 0), ("b2", 100), ("b3", 200)):
+        now["value"] = 1_000.0 + elapsed
+        _write_codex_cache(tmp_path, ["gpt-5.6-sol"], revision=revision)
+        assert "gpt-6-astra" in _ids(provider_models("codex"))
+
+
 def test_codex_catalog_persistence_is_scoped_by_account(monkeypatch, tmp_path):
     """Switching accounts must neither leak nor destroy another account's LKG."""
     monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -23,6 +23,35 @@ def _ids(opts):
     return [o.id for o in opts]
 
 
+def _write_codex_cache(
+    root, model_ids: list[str], *, revision: str = "snapshot-1",
+):
+    cache = root / ".codex" / "models_cache.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({
+        "etag": revision,
+        "fetched_at": revision,
+        "models": [
+            {
+                "slug": model_id,
+                "display_name": model_id,
+                "visibility": "list",
+                "priority": index,
+            }
+            for index, model_id in enumerate(model_ids)
+        ],
+    }), encoding="utf-8")
+
+
+def _write_codex_auth(root, account_id: str):
+    auth = root / ".codex" / "auth.json"
+    auth.parent.mkdir(parents=True, exist_ok=True)
+    auth.write_text(json.dumps({
+        "auth_mode": "chatgpt",
+        "tokens": {"account_id": account_id},
+    }), encoding="utf-8")
+
+
 def test_claude_code_default_and_aliases_offline(monkeypatch):
     monkeypatch.setattr(mc, "_fetch_anthropic_models", lambda: None)  # offline
     opts = provider_models("claude-code", fetch=True)
@@ -78,7 +107,17 @@ def test_codex_reads_local_cache(monkeypatch, tmp_path):
     cache.parent.mkdir(parents=True)
     cache.write_text(json.dumps({"models": [
         {"slug": "gpt-5.4", "display_name": "GPT-5.4", "visibility": "list", "priority": 16},
-        {"slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list", "priority": 9},
+        {
+            "slug": "gpt-5.5",
+            "display_name": "GPT-5.5",
+            "visibility": "list",
+            "priority": 9,
+            "supported_reasoning_levels": [
+                {"effort": "low"},
+                {"effort": "medium"},
+                {"effort": "vendor-special"},
+            ],
+        },
         {"slug": "codex-auto-review", "display_name": "Codex Auto Review",
          "visibility": "hide", "priority": 43},
     ]}), encoding="utf-8")
@@ -87,6 +126,9 @@ def test_codex_reads_local_cache(monkeypatch, tmp_path):
     assert ids[0] == ""  # daemon default
     # visibility=hide excluded; ordered by priority (gpt-5.5 before gpt-5.4)
     assert ids[1:] == ["gpt-5.5", "gpt-5.4"]
+    assert provider_models("codex")[1].supported_inference_levels == (
+        "low", "medium",
+    )
 
 
 def test_codex_fallback_when_cache_missing(monkeypatch, tmp_path):
@@ -100,6 +142,80 @@ def test_codex_fallback_on_bad_json(monkeypatch, tmp_path):
     cache.write_text("not json", encoding="utf-8")
     monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)
     assert _ids(provider_models("codex"))[1:] == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]
+
+
+def test_codex_catalog_keeps_models_across_alternating_snapshots(
+    monkeypatch, tmp_path,
+):
+    """A model that alternates in account discovery must not flicker out."""
+    monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo-home"))
+    _write_codex_auth(tmp_path, "account-a")
+    _write_codex_cache(tmp_path, ["gpt-6-astra", "gpt-5.6-sol"], revision="a1")
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+
+    _write_codex_cache(tmp_path, ["gpt-5.6-sol"], revision="b1")
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+    _write_codex_cache(tmp_path, ["gpt-6-astra", "gpt-5.6-sol"], revision="a2")
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+
+
+def test_codex_catalog_errors_and_empty_results_keep_last_known_good(
+    monkeypatch, tmp_path,
+):
+    """Unreadable or empty provider snapshots must not clear the catalog."""
+    monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo-home"))
+    _write_codex_auth(tmp_path, "account-a")
+    _write_codex_cache(tmp_path, ["gpt-6-astra"], revision="good")
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+
+    _write_codex_cache(tmp_path, [], revision="empty")
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+    (tmp_path / ".codex" / "models_cache.json").write_text(
+        "not json", encoding="utf-8",
+    )
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+
+
+def test_codex_catalog_removes_only_after_three_distinct_misses_over_window(
+    monkeypatch, tmp_path,
+):
+    """A genuinely withdrawn model needs three refreshes spanning 15 minutes."""
+    now = {"value": 1_000.0}
+    monkeypatch.setattr(mc.time, "time", lambda: now["value"])
+    monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo-home"))
+    _write_codex_auth(tmp_path, "account-a")
+    _write_codex_cache(tmp_path, ["gpt-6-astra", "gpt-5.6-sol"], revision="a")
+    provider_models("codex")
+
+    for revision, elapsed in (("b1", 0), ("b2", 450)):
+        now["value"] = 1_000.0 + elapsed
+        _write_codex_cache(tmp_path, ["gpt-5.6-sol"], revision=revision)
+        assert "gpt-6-astra" in _ids(provider_models("codex"))
+
+    now["value"] = 1_901.0
+    assert "gpt-6-astra" in _ids(provider_models("codex"))
+    _write_codex_cache(tmp_path, ["gpt-5.6-sol"], revision="b3")
+    assert "gpt-6-astra" not in _ids(provider_models("codex"))
+
+
+def test_codex_catalog_persistence_is_scoped_by_account(monkeypatch, tmp_path):
+    """Switching accounts must neither leak nor destroy another account's LKG."""
+    monkeypatch.setattr(mc.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo-home"))
+    _write_codex_auth(tmp_path, "account-a")
+    _write_codex_cache(tmp_path, ["account-a-model"], revision="a")
+    assert "account-a-model" in _ids(provider_models("codex"))
+
+    _write_codex_auth(tmp_path, "account-b")
+    _write_codex_cache(tmp_path, ["account-b-model"], revision="b")
+    assert "account-a-model" not in _ids(provider_models("codex"))
+
+    _write_codex_auth(tmp_path, "account-a")
+    _write_codex_cache(tmp_path, [], revision="a-empty")
+    assert "account-a-model" in _ids(provider_models("codex"))
 
 
 def test_unknown_harness_is_just_default():


### PR DESCRIPTION
## Summary

- persist a last-known-good provider model catalog per account and source-home fingerprint
- accept catalog additions immediately, but require three distinct successful observations over at least 15 minutes before removing a model
- treat empty/failed catalog refreshes as non-authoritative and treat the catalog as advisory rather than an allowlist
- keep model syntax validation while surfacing execution acknowledgments and classified provider failures

Linus cross-reviewed and passed the exact daemon head `e975987d`.

## Verification

- full daemon test suite passed with 2 expected skips
- focused model catalog, harness, inference-level, and Codex JSON-RPC error coverage passed
- mutation checks confirmed unlisted models remain selectable and catalog removals require the stabilization window

## Merge policy

- owner approval required
- do not self-merge
- if CI or a rebase changes the reviewed head, obtain a fresh Linus review before merge
