### PR TITLE
feat(exa): add exa_search agent tool routed through the server gateway

### DIFF
--- a/src/puffo_agent/mcp/core_exa_tools.py
+++ b/src/puffo_agent/mcp/core_exa_tools.py
@@ -135,10 +135,19 @@ def _register_exa_search(mcp: FastMCP, cfg: Any) -> None:
 def _format_search_result(data: dict[str, Any]) -> str:
     """Render a `/v2/exa/search` response for the model.
 
-    An idempotent retry of an already-settled search returns the accounting with
-    null results (results are never stored, so they cannot be replayed) — report
-    that rather than pretending there are fresh results.
+    A 202 is not an HTTP error to the client, but it means a prior search under
+    this idempotency key is still resolving and an owner will reconcile it —
+    there is no result yet. An idempotent retry of an already-settled search
+    returns the accounting with null results (results are never stored, so they
+    cannot be replayed).
     """
+    if data.get("error") == "PENDING_RECONCILE":
+        return (
+            "This search is still resolving upstream; your operator will "
+            f"reconcile it (ledger {data.get('ledger_id', '?')}). No result yet — "
+            f"do not retry with the same idempotency key. {_LABEL_NON_EXA}"
+        )
+
     cost = data.get("cost_micro")
     status = data.get("provider_http_status")
     results = data.get("results")

--- a/src/puffo_agent/mcp/core_exa_tools.py
+++ b/src/puffo_agent/mcp/core_exa_tools.py
@@ -1,0 +1,158 @@
+"""exa search MCP tool registration.
+
+One generic tool lets an agent run a web search through exa with the server as
+the spend-control middle layer:
+
+* ``exa_search`` — PAID. Search the web; the server holds the exa key, checks
+  the budget, pays exa at a fixed per-call price, and returns the results.
+
+The agent never holds the exa key or money: it forwards to the server via the
+native signed client, and the server calls exa and settles the charge. exa's
+plain-search price is fixed and known before the call, so there is no separate
+"prepare" step (unlike Monid). Native (key-holding) agents only: the keyless
+bridge transport is unsigned and cannot reach the subkey-gated route.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from ..crypto.http_client import HttpError
+
+logger = logging.getLogger(__name__)
+
+# Comfortably covers a full search (up to 100 results costs ~97_000 micro-
+# dollars); the operator's per-agent cap is the real limit, so the model does not
+# have to reason about micro-dollars for an ordinary search.
+_DEFAULT_MAX_COST_MICRO = 100_000
+
+# Provenance is mandatory. A successful `exa_search` result is stamped as
+# exa-sourced (paid, real web search) so the model can attribute it; on any
+# failure we tell it that if it falls back to its own knowledge it MUST label
+# that as non-exa — never pass it off as an exa search result.
+_LABEL_NON_EXA = (
+    "If you answer from your own knowledge instead, you MUST clearly label it as "
+    "NOT an exa search result — never present non-exa data as an exa result."
+)
+
+
+def _exa_error_message(exc: HttpError) -> str:
+    """Pull the server's human-readable ``message`` out of a failed exa response
+    body (JSON ``{error, message}``), falling back to a terse ``HTTP <status>``.
+    Keeps the tool's error clean instead of a raw blob.
+    """
+    try:
+        parsed = json.loads(exc.body)
+        if isinstance(parsed, dict) and parsed.get("message"):
+            return str(parsed["message"])
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+    return f"HTTP {exc.status}"
+
+
+def register_exa_tools(mcp: FastMCP, cfg: Any) -> None:
+    # Native-only tool. A keyless (bridge) agent holds no subkey and cannot reach
+    # the subkey-gated `/v2/exa/search` route, so the tool is simply not
+    # registered for it — the same conditional-registration pattern the Monid
+    # tools use.
+    if getattr(cfg, "keyless", False):
+        return
+    _register_exa_search(mcp, cfg)
+
+
+def _register_exa_search(mcp: FastMCP, cfg: Any) -> None:
+    @mcp.tool()
+    async def exa_search(
+        query: str,
+        num_results: int = 10,
+        type: str = "auto",
+        max_cost_micro: int = _DEFAULT_MAX_COST_MICRO,
+        idempotency_key: str = "",
+    ) -> str:
+        """Search the web through exa — PAID.
+
+        Puffo is the middle layer: it holds the exa key, checks your spend
+        budget, pays exa, and returns the results. You never see the key and
+        never hold money. The charge comes out of the shared balance, and your
+        operator must have enabled paid tools for you and set a cap first.
+
+        This tool is the ONLY way to reach exa: never install or run an exa CLI,
+        and never ask for or hold your own exa key (the server holds it).
+
+        Args:
+            query: What to search for, in natural language.
+            num_results: How many results to return (1-100). More results cost
+                slightly more; the price is fixed and known before the call.
+            type: Search mode — one of "auto", "neural", "keyword", "fast".
+                Leave as "auto" unless you have a reason to change it.
+            max_cost_micro: Your hard ceiling for THIS one call, in micro-dollars
+                (1_000_000 = $1). The default covers an ordinary search; if the
+                fixed price is above it, the call is rejected before any spend.
+            idempotency_key: Optional. Pass a stable value to make a retried call
+                safe — it reports the earlier result instead of charging twice.
+
+        Returns the search results and what the call cost, stamped
+        `via exa · search · <cost>` — mark data you got this way as exa-sourced.
+        Anything you instead answer from your own knowledge MUST be labeled as
+        NOT an exa result; never present non-exa data as an exa result.
+        """
+        if not query.strip():
+            raise RuntimeError("query is required")
+        if max_cost_micro <= 0:
+            raise RuntimeError(
+                "max_cost_micro must be a positive integer in micro-dollars "
+                "(1_000_000 = $1)"
+            )
+
+        body: dict[str, Any] = {
+            "query": query,
+            "num_results": num_results,
+            "type": type,
+            "max_cost_micro": max_cost_micro,
+        }
+        if idempotency_key:
+            body["idempotency_key"] = idempotency_key
+
+        try:
+            data = await cfg.http_client.post("/v2/exa/search", body)
+        except HttpError as exc:
+            # A search failure (budget, rate limit, upstream error) means the data
+            # was not reached through exa, so it must not be passed off as an exa
+            # result. Answering from elsewhere is allowed if labeled non-exa.
+            raise RuntimeError(
+                f"exa search failed: {_exa_error_message(exc)}\n{_LABEL_NON_EXA}"
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise RuntimeError(f"unexpected exa response: {data!r}")
+        return _format_search_result(data)
+
+
+def _format_search_result(data: dict[str, Any]) -> str:
+    """Render a `/v2/exa/search` response for the model.
+
+    An idempotent retry of an already-settled search returns the accounting with
+    null results (results are never stored, so they cannot be replayed) — report
+    that rather than pretending there are fresh results.
+    """
+    cost = data.get("cost_micro")
+    status = data.get("provider_http_status")
+    results = data.get("results")
+
+    if data.get("already_settled") and results is None:
+        return (
+            f"via exa · search · cost {cost} micro-dollars (already settled)\n"
+            "This search was already run and charged under this idempotency key; "
+            "its results are not stored and cannot be replayed. Run a new search "
+            "for fresh results."
+        )
+
+    # Provenance stamp: this is paid, real exa web-search data.
+    header = f"via exa · search · cost {cost} micro-dollars"
+    if status is not None:
+        header += f", provider status {status}"
+    return header + "\nresults:\n" + json.dumps(results, indent=2, ensure_ascii=False)

--- a/src/puffo_agent/mcp/puffo_core_tools.py
+++ b/src/puffo_agent/mcp/puffo_core_tools.py
@@ -708,6 +708,7 @@ def register_core_tools(
     from .core_host_tools import register_host_tools
     from .core_identity_tools import register_identity_tools
     from .core_inbox_tools import register_inbox_tools
+    from .core_exa_tools import register_exa_tools
     from .core_message_tools import register_message_tools
     from .core_monid_tools import register_monid_tools
     register_inbox_tools(mcp, cfg, result_surface=result_surface)
@@ -716,6 +717,7 @@ def register_core_tools(
     register_history_tools(mcp, cfg)
     register_host_tools(mcp, cfg)
     register_monid_tools(mcp, cfg)
+    register_exa_tools(mcp, cfg)
 
     if cfg.bridge_client is not None:
         from .lifecycle_tools import register_lifecycle_tools

--- a/tests/test_exa_tools.py
+++ b/tests/test_exa_tools.py
@@ -1,0 +1,151 @@
+"""``exa_search`` forwards to the server gateway and formats its result. The
+tool holds no key and does no budgeting itself — the server holds the exa key,
+enforces the cap, and settles the charge; the tool's checks are UX pre-guards
+and its errors are the server's own mapped messages.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from puffo_agent.crypto.http_client import HttpError
+from puffo_agent.mcp.core_exa_tools import register_exa_tools
+
+
+class _FakeHttp:
+    def __init__(self, *, response=None, post_error: Exception | None = None) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self.keyless = False
+        self._response = response if response is not None else {"ok": True}
+        self._post_error = post_error
+
+    async def post(self, path, body=None):
+        self.calls.append(("POST", path, body))
+        if self._post_error is not None:
+            raise self._post_error
+        return self._response
+
+
+def _tools(http):
+    cfg = SimpleNamespace(http_client=http, keyless=http.keyless)
+    mcp = FastMCP("test")
+    register_exa_tools(mcp, cfg)
+    return mcp
+
+
+async def _call(mcp, name, args):
+    result = await mcp.call_tool(name, args)
+    if isinstance(result, tuple):
+        result = result[0]
+    return "".join(getattr(item, "text", str(item)) for item in result)
+
+
+@pytest.mark.asyncio
+async def test_search_forwards_and_formats_result():
+    http = _FakeHttp(
+        response={
+            "ledger_id": "led_1",
+            "cost_micro": 7000,
+            "provider_http_status": 200,
+            "results": [{"title": "t", "url": "https://x"}],
+        }
+    )
+    mcp = _tools(http)
+    text = await _call(
+        mcp,
+        "exa_search",
+        {"query": "weather in tokyo", "num_results": 5, "max_cost_micro": 20000},
+    )
+    # Provenance stamp: a settled search is marked exa-sourced so the model can
+    # attribute it and not conflate it with its own answers.
+    assert "via exa · search" in text
+    assert "cost 7000 micro-dollars" in text
+    assert "provider status 200" in text
+    assert "https://x" in text
+    assert http.calls[-1][0] == "POST"
+    assert http.calls[-1][1] == "/v2/exa/search"
+    body = http.calls[-1][2]
+    assert body["query"] == "weather in tokyo"
+    assert body["num_results"] == 5
+    assert body["type"] == "auto"
+    assert body["max_cost_micro"] == 20000
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_empty_query_without_calling_server():
+    http = _FakeHttp()
+    mcp = _tools(http)
+    with pytest.raises(Exception):
+        await _call(mcp, "exa_search", {"query": "   "})
+    assert not [c for c in http.calls if c[1] == "/v2/exa/search"]
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_non_positive_ceiling_without_calling_server():
+    http = _FakeHttp()
+    mcp = _tools(http)
+    with pytest.raises(Exception):
+        await _call(mcp, "exa_search", {"query": "x", "max_cost_micro": 0})
+    assert not [c for c in http.calls if c[1] == "/v2/exa/search"]
+
+
+@pytest.mark.asyncio
+async def test_search_surfaces_server_error_and_labels_non_exa():
+    http = _FakeHttp(
+        post_error=HttpError(
+            402,
+            json.dumps(
+                {"error": "BUDGET_EXCEEDED", "message": "agent spend cap reached"}
+            ),
+        )
+    )
+    mcp = _tools(http)
+    with pytest.raises(Exception) as excinfo:
+        await _call(mcp, "exa_search", {"query": "x", "max_cost_micro": 20000})
+    msg = str(excinfo.value)
+    assert "agent spend cap reached" in msg
+    # A search failure carries the label rule: if the model gives up and answers
+    # from elsewhere, it must mark that non-exa.
+    assert "NOT an exa search result" in msg
+    # Only the mapped message + directive surface — never a raw upstream body.
+    assert "BUDGET_EXCEEDED" not in msg
+
+
+@pytest.mark.asyncio
+async def test_already_settled_replay_reports_no_fresh_results():
+    http = _FakeHttp(
+        response={
+            "ledger_id": "led_1",
+            "cost_micro": 7000,
+            "results": None,
+            "already_settled": True,
+        }
+    )
+    mcp = _tools(http)
+    text = await _call(
+        mcp,
+        "exa_search",
+        {"query": "x", "max_cost_micro": 20000, "idempotency_key": "k1"},
+    )
+    assert "already settled" in text
+    assert "cannot be replayed" in text
+
+
+@pytest.mark.asyncio
+async def test_tool_not_registered_for_keyless_agents():
+    # A keyless bridge agent cannot reach the subkey-gated route, so the tool is
+    # not exposed for it — not registered, no error path.
+    http = _FakeHttp()
+    http.keyless = True
+    mcp = _tools(http)
+    tool_names = {t.name for t in await mcp.list_tools()}
+    assert "exa_search" not in tool_names
+
+    # Native agents DO get it.
+    native = _tools(_FakeHttp())
+    native_names = {t.name for t in await native.list_tools()}
+    assert "exa_search" in native_names

--- a/tests/test_exa_tools.py
+++ b/tests/test_exa_tools.py
@@ -136,6 +136,29 @@ async def test_already_settled_replay_reports_no_fresh_results():
 
 
 @pytest.mark.asyncio
+async def test_pending_reconcile_202_is_reported_not_treated_as_results():
+    # A 202 (prior attempt under this key still resolving) comes back as a
+    # success body, not an HttpError — the tool reports it as pending, not as
+    # search results.
+    http = _FakeHttp(
+        response={
+            "error": "PENDING_RECONCILE",
+            "message": "still resolving",
+            "ledger_id": "led_pending",
+        }
+    )
+    mcp = _tools(http)
+    text = await _call(
+        mcp,
+        "exa_search",
+        {"query": "x", "max_cost_micro": 20000, "idempotency_key": "k1"},
+    )
+    assert "still resolving" in text
+    assert "led_pending" in text
+    assert "do not retry with the same idempotency key" in text
+
+
+@pytest.mark.asyncio
 async def test_tool_not_registered_for_keyless_agents():
     # A keyless bridge agent cannot reach the subkey-gated route, so the tool is
     # not exposed for it — not registered, no error path.


### PR DESCRIPTION
## Background

Agents fetch paid external data through the server's spend gateway rather than holding vendor keys themselves (as with the existing `monid_spend` tool). This adds an `exa_search` tool so an agent can run an Exa web search; the tool forwards to the server's `/v2/exa/search` endpoint, which holds the Exa key, prices the call, enforces budget caps, and meters it.

## What changed

- New `core_exa_tools.py` with `register_exa_tools`, shaped after `core_monid_tools`: a thin `exa_search` tool that forwards `query` / `type` / `numResults` to the server's `POST /v2/exa/search`.
  - The agent **never holds the Exa key** and **never reports its own identity slug** (the server derives it).
  - Errors surface the server's plain message, not raw vendor output; the `202 pending` and already-settled responses are handled.

## Scope / non-goals

- The agent side is **transport only** — all pricing, budget caps, idempotency, and metering live on the server. Search results are returned to the agent in the moment and are **not stored or logged**.
- This PR targets `main`; it has no git dependency on the server gateway branch. The tool talks to `/v2/exa/search` over HTTP at runtime, which ships in the companion server PR — so Exa search only functions once that server PR is deployed.

## Verification

- Unit tests (7) cover the tool's request shaping, that it never carries a key or a self-reported slug, native-only behavior, plain error surfacing, and the pending / already-settled paths. `ruff` is clean; the full suite (3,839+) is unaffected.
- Local: with the server running, `EXA_API_KEY` set, and a seeded budget, invoke `exa_search` from an agent and confirm results return and the key never reaches the agent process logs.

## Release note

Internal / not user-facing yet.
