### PR TITLE
fix(pi): surface assistant authentication failures in runtime health

### DIFF
--- a/src/puffo_agent/agent/_auth_markers.py
+++ b/src/puffo_agent/agent/_auth_markers.py
@@ -36,6 +36,7 @@ _PROVIDER_DIAGNOSTIC_AUTH_MARKERS: tuple[str, ...] = (
     "invalid token",
     "invalid credential",
     "token revoked",
+    "authentication token is expired",
 )
 
 

--- a/src/puffo_agent/agent/harness/drivers/pi.py
+++ b/src/puffo_agent/agent/harness/drivers/pi.py
@@ -194,6 +194,8 @@ class PiDriver(Driver):
         # agent_settled. Pi reports failures as separate events that do not end
         # the run, so the terminal outcome is only known when the run settles.
         self._turn_outcome = "succeeded"
+        self._assistant_failure = ""
+        self._turn_error_code = ""
         self._turn_usage: dict[str, int] = {}
         self._closed = False
 
@@ -558,8 +560,15 @@ class PiDriver(Driver):
         ):
             if event.type == HarnessEventType.CONTEXT_UPDATED:
                 self._turn_usage = dict(event.data)
+            if event.type == HarnessEventType.RUNTIME_WARNING:
+                code = event.data.get("code")
+                if code == "assistant_error":
+                    self._assistant_failure = str(event.data["failure_code"])
+                elif code == "auto_retry_end" and event.data.get("succeeded"):
+                    self._assistant_failure = ""
             if _is_failure_signal(event):
                 self._turn_outcome = "failed"
+                self._turn_error_code = str(event.data["failure_code"])
             await self._events.put(event)
 
     async def _resolve_response(self, frame: dict[str, Any]) -> None:
@@ -640,6 +649,11 @@ class PiDriver(Driver):
             )
             return
         data: dict[str, Any] = {"outcome": self._turn_outcome}
+        # An assistant error may still recover through Pi's automatic retry.
+        # Report it only at agent_settled, preserving explicit cancellation.
+        error_code = self._turn_error_code or self._assistant_failure
+        if error_code and self._turn_outcome != "cancelled":
+            data.update(outcome="failed", error_code=error_code)
         data.update(self._turn_usage)
         turn = self._active
         self._active = TurnRef("")
@@ -674,6 +688,8 @@ class PiDriver(Driver):
 
     def _reset_turn(self) -> None:
         self._turn_outcome = "succeeded"
+        self._assistant_failure = ""
+        self._turn_error_code = ""
         self._turn_usage = {}
 
     def _require_active(self, turn: TurnRef) -> None:

--- a/src/puffo_agent/agent/harness/drivers/pi_protocol.py
+++ b/src/puffo_agent/agent/harness/drivers/pi_protocol.py
@@ -187,6 +187,13 @@ def _normalize_pi_lifecycle(
     if type_ == "message_update":
         return _normalize_message_update(frame, event)
     if type_ == "message_end":
+        message = frame.get("message")
+        if isinstance(message, dict) and message.get("role") == "assistant":
+            if message.get("stopReason") == "error":
+                return (event(HarnessEventType.RUNTIME_WARNING, {
+                    "code": "assistant_error",
+                    "failure_code": _failure_code(message.get("errorMessage")),
+                }),)
         events: list[HarnessEvent] = [
             event(HarnessEventType.ASSISTANT_COMPLETED, {"block_id": ""})
         ]

--- a/tests/test_pi_driver.py
+++ b/tests/test_pi_driver.py
@@ -518,6 +518,89 @@ async def test_final_retry_failure_marks_the_settled_turn_failed():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("diagnostic", [
+    "OAuth refresh failed for anthropic: invalid_grant / Refresh token not found or invalid",
+    "Provided authentication token is expired",
+])
+async def test_assistant_auth_error_reaches_runtime_adapter(diagnostic):
+    """A Pi message error must raise auth failure, never return an empty success."""
+    from puffo_agent.agent.errors import AgentAPIError
+
+    proc = FakePiProcess()
+    driver = PiDriver(process_factory=_attesting_factory(proc))
+    manager = RuntimeManager(driver, _spec(task_timeout_seconds=2))
+    adapter = RuntimeManagerAdapter(manager)
+    opening = asyncio.create_task(manager.open())
+    await proc.answer_next()
+    await opening
+    task = asyncio.create_task(adapter.run_turn(TurnContext(
+        system_prompt="contract", messages=[{"role": "user", "content": "hello"}],
+    )))
+    await proc.answer_next()
+    proc.push({"type": "agent_start"})
+    proc.push({"type": "message_end", "message": {
+        "role": "assistant", "stopReason": "error", "content": [],
+        "errorMessage": diagnostic + " private-provider-detail",
+    }})
+    proc.push({"type": "agent_settled"})
+    try:
+        with pytest.raises(AgentAPIError) as caught:
+            await asyncio.wait_for(task, 2)
+        assert caught.value.is_auth
+        assert caught.value.error_code == "authentication"
+        assert "private-provider-detail" not in str(caught.value)
+    finally:
+        await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_assistant_error_recovered_by_retry_does_not_fail_turn():
+    """Intermediate failed attempts must not poison a successful retry."""
+    proc = FakePiProcess()
+    driver, _ = await _open(proc)
+    task = asyncio.create_task(driver.start_turn(TurnInput("hello")))
+    await proc.answer_next()
+    await task
+    for frame in (
+        {"type": "agent_start"},
+        {"type": "message_end", "message": {"role": "assistant",
+         "stopReason": "error", "errorMessage": "529 overloaded private-detail"}},
+        {"type": "auto_retry_end", "success": True, "attempt": 1},
+        {"type": "message_end", "message": {"role": "assistant", "stopReason": "stop"}},
+        {"type": "agent_settled"},
+    ):
+        proc.push(frame)
+    events = await _drain_events(driver, 5)
+    assert events[-1].data["outcome"] == "succeeded"
+    assert "error_code" not in events[-1].data
+    assert "private-detail" not in json.dumps([dict(e.data) for e in events])
+    assert events[1].type != HarnessEventType.ASSISTANT_COMPLETED
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_unretried_provider_error_fails_once_and_resets_for_next_turn():
+    """A non-auth error must fail the turn without contaminating later work."""
+    proc = FakePiProcess()
+    driver, _ = await _open(proc)
+    for failed in (True, False):
+        task = asyncio.create_task(driver.start_turn(TurnInput("hello")))
+        await proc.answer_next()
+        await task
+        proc.push({"type": "agent_start"})
+        proc.push({"type": "message_end", "message": {
+            "role": "assistant", "stopReason": "error" if failed else "stop",
+            "errorMessage": "unknown failure private-detail" if failed else "",
+        }})
+        proc.push({"type": "agent_settled"})
+        events = await _drain_events(driver, 3)
+        assert events[-1].data["outcome"] == ("failed" if failed else "succeeded")
+        assert events[-1].data.get("error_code") == ("provider_error" if failed else None)
+        assert "private-detail" not in json.dumps([dict(e.data) for e in events])
+    await driver.close()
+
+
+@pytest.mark.asyncio
 async def test_settled_run_without_an_active_turn_is_reported_autonomous():
     """A model wake the daemon did not start must not be dropped."""
     proc = FakePiProcess()


### PR DESCRIPTION
> [!NOTE]
> **评审已转移**:本 PR 已并入统一交付 [puffo-agent #328](https://github.com/puffo-ai/puffo-agent/pull/328)(agent 仓汇总,head `fcc1ddc7`;统一评审入口及 11→3 映射见其描述)。原评审正文与 head 保留如下,未改动。

Pi assistant messages ending with `stopReason: error` were normalized as successful completion. Invalid Anthropic refresh tokens and expired Codex tokens therefore produced empty successful turns and left runtime health green.

Normalize assistant errors into a warning carrying only the shared failure classification, retain it until `agent_settled`, and pass `error_code` on the failed terminal. This reaches the existing RuntimeManagerAdapter authentication exception and worker `auth_failed` handling. Preserve successful automatic retry recovery, explicit cancellation, and reset between turns. Also retain the failure classification for exhausted retries and recognize Codex’s explicit expired-authentication-token diagnostic.

Validation:
- Reproduced both observed authentication diagnostics against the old code; regression tests failed before the fix and passed afterwards.
- Pi driver and RPC contract tests: 72 passed, including retry recovery, safe diagnostics, generic failures and next-turn reset.
- Full suite with inherited CODEX_HOME removed: 3911 passed, 2 skipped (live OpenCode opt-in and Windows-only), 25 existing warnings.
- Pre-commit and Python structural checks passed.

The first full-suite run inherited CODEX_HOME and had eight host-configuration test failures; removing that inherited variable resolved all eight. Two test MCP blocks appended to the agent config during that run were removed after matching their exact test contents.

This fixes error reporting. It does not renew OAuth credentials or deploy/restart the running staging agents. The independent worker no-progress fallback is outside this change.

---

<!-- peter-pr-facts-20260909 -->
## PR 事实说明（2026-09-09，待交叉确认）

作者：Peter Steinberger。此节记录实现事实及待讨论问题，不代表跨 PR 建模方案已达成一致。

- PR：[puffo-agent #324](https://github.com/puffo-ai/puffo-agent/pull/324)
- 目标分支：`main`；查询时 base head：`54a0599d7700490a4fce7f60df5b88d8b6219705`
- 本文 head：`5d441ac2943ffa737f63615fe44af533f20714ad`
- 比较 merge base：`54a0599d7700490a4fce7f60df5b88d8b6219705`；[固定版本差异](https://github.com/puffo-ai/puffo-agent/compare/54a0599d7700490a4fce7f60df5b88d8b6219705...5d441ac2943ffa737f63615fe44af533f20714ad)
- 后续代码变更需重新确认本文，不自动继承复核结论。

### 1. 问题与行为变化

Pi 可以通过 assistant `message_end` 中的 `stopReason=error` 报错，而进程和回合仍正常结束。旧路径把这一消息归成 assistant completed；如果没有另一个失败信号，`agent_settled` 最终报 succeeded，认证过期因此无法进入上层故障处理。

改后：识别该 assistant 错误并暂存分类结果；若 Pi 自动重试成功则撤销暂存错误，否则在 settled 时给回合 failed/error_code。显式 cancelled 保留；下一回合清空缓存。新增过期令牌文案匹配只扩展既有认证分类。

### 2. 实现路径和代码依据

- `harness/drivers/pi_protocol.py::_normalize_pi_lifecycle`：在 message_end 分支输出 `RUNTIME_WARNING(code=assistant_error, failure_code=…)`，沿用 `_failure_code` 分类。公共事件不携带供应商原始 errorMessage。
- `harness/drivers/pi.py::_dispatch_frame`：保存 `_assistant_failure`；成功的 auto_retry_end 清空它；既有硬失败信号另存 `_turn_error_code`。
- `pi.py::_complete_turn`：settled 时取硬失败码优先、assistant 失败码次之；除 cancelled 外转 failed。
- `pi.py::_reset_turn`：清空两个新增字段，避免上一回合污染下一回合。
- `_auth_markers.py`：新增 authentication token is expired 字面匹配。

### 3. 复用、新增模型与改动范围

复用 HarnessEvent、ProviderFailure 分类、原 settled 生命周期和取消语义。新增两个回合内字段，分别表达可被重试消除的 assistant 错误和已经确定的失败；没有新增持久化 health 状态、重试队列或 UI 状态表。三个生产文件、一个测试文件。

删除整项改动会恢复“供应商拒绝但回合成功”的路径。两个字段能否由现有单个 outcome 字段替代，需要先证明能够保留“错误暂存、重试消除、硬失败优先、取消不覆盖”四种行为；这是待讨论的简化问题，尚未作合并建议。

### 4. 验证证据及边界

`tests/test_pi_driver.py` 覆盖 assistant error 无重试、自动重试恢复、取消、下回合重置与分类。作者本地全量记录 3911 passed / 2 skipped；本次只复读代码和刷新 CI，并未重跑该全量。该 head 的远端检查全部成功。

这里证明驱动能报告错误；不能单独证明部署中的 OAuth 已恢复，也不判断模型是否读取了 Inbox。与 #325 比较时，应对照“错误信号”和“读取进展”的输入证据。

### 5. 待共同确认的问题

驱动层保留两种失败缓存是否是当前事件协议下最小表达？分类结果到上层健康状态的对应由哪些现有入口负责？请先确认以上事实，再讨论是否与其他 PR 合并抽象。

### 固定版本代码入口

- [src/puffo_agent/agent/_auth_markers.py](https://github.com/puffo-ai/puffo-agent/blob/5d441ac2943ffa737f63615fe44af533f20714ad/src/puffo_agent/agent/_auth_markers.py)
- [src/puffo_agent/agent/harness/drivers/pi.py](https://github.com/puffo-ai/puffo-agent/blob/5d441ac2943ffa737f63615fe44af533f20714ad/src/puffo_agent/agent/harness/drivers/pi.py)
- [src/puffo_agent/agent/harness/drivers/pi_protocol.py](https://github.com/puffo-ai/puffo-agent/blob/5d441ac2943ffa737f63615fe44af533f20714ad/src/puffo_agent/agent/harness/drivers/pi_protocol.py)
