### PR TITLE
fix(worker): stop settling a no-progress turn as healthy

### DIFF
--- a/src/puffo_agent/agent/global_inbox_covers.py
+++ b/src/puffo_agent/agent/global_inbox_covers.py
@@ -156,6 +156,38 @@ class CoversReconciliationMixin:
             )
         return renotice_ids, rows_by_id
 
+    def _health_outcome_for_turn(self, planned: PlannedTurn) -> str:
+        """``succeeded``, unless the turn made no observable progress on the
+        batch its own notice announced.
+
+        ``_mark_active_processed`` below reads an empty ``active.message_ids``
+        as "the provider received the notice but chose not to read Inbox" — a
+        normal deferred outcome. That reading is only safe when the provider
+        actually ran. A driver that maps a failed
+        provider turn onto "assistant completed" (the Pi credential-expiry
+        incident: expired token, ``stopReason: error``, zero output) produces
+        the identical shape, and the turn then settles the agent's health back
+        to ``ok`` while the announced messages stay pending — indefinitely,
+        because every later wake-up repeats it.
+
+        This check is deliberately **driver-independent**: it reads the
+        runtime's own admission bookkeeping rather than any adapter's
+        self-report, so a driver that swallows its errors cannot suppress it.
+        Fixing one adapter leaves every other adapter exempt; this does not.
+
+        Choosing not to reply still counts as progress — that decision is made
+        *after* ``read_inbox`` admits the rows, which populates
+        ``active.message_ids``. A wake-up that announced nothing (autonomous
+        turns, notice-only ticks) can never trip it, and messages that arrive
+        mid-turn cannot either: the comparison is against the ids this turn's
+        notice carried, not against the queue depth at the end.
+        """
+        if not planned.notice_message_ids:
+            return "succeeded"
+        if self.active.message_ids:
+            return "succeeded"
+        return "no_progress"
+
     async def _mark_active_processed(
         self,
         planned: PlannedTurn,

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -1449,38 +1449,6 @@ class GlobalInboxRuntime(
             await self._wake_remaining_pending()
             return True
 
-    def _health_outcome_for_turn(self, planned: PlannedTurn) -> str:
-        """``succeeded``, unless the turn made no observable progress on the
-        batch its own notice announced.
-
-        ``global_inbox_covers._mark_active_processed`` reads an empty
-        ``active.message_ids`` as "the provider received the notice but chose
-        not to read Inbox" — a normal deferred outcome. That reading is only
-        safe when the provider actually ran. A driver that maps a failed
-        provider turn onto "assistant completed" (the Pi credential-expiry
-        incident: expired token, ``stopReason: error``, zero output) produces
-        the identical shape, and the turn then settles the agent's health back
-        to ``ok`` while the announced messages stay pending — indefinitely,
-        because every later wake-up repeats it.
-
-        This check is deliberately **driver-independent**: it reads the
-        runtime's own admission bookkeeping rather than any adapter's
-        self-report, so a driver that swallows its errors cannot suppress it.
-        Fixing one adapter leaves every other adapter exempt; this does not.
-
-        Choosing not to reply still counts as progress — that decision is made
-        *after* ``read_inbox`` admits the rows, which populates
-        ``active.message_ids``. A wake-up that announced nothing (autonomous
-        turns, notice-only ticks) can never trip it, and messages that arrive
-        mid-turn cannot either: the comparison is against the ids this turn's
-        notice carried, not against the queue depth at the end.
-        """
-        if not planned.notice_message_ids:
-            return "succeeded"
-        if self.active.message_ids:
-            return "succeeded"
-        return "no_progress"
-
     async def _run_retry(self, planned: PlannedTurn) -> Any:
         retry = getattr(self.run_turn, "handle_global_inbox_retry", None)
         if retry is None:

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -1412,11 +1412,12 @@ class GlobalInboxRuntime(
             try:
                 await self._invoke_turn_with_retries(planned)
                 if self.active.turn_id == planned.turn_id:
+                    settled = self._health_outcome_for_turn(planned)
                     async with self._turn_state_lock:
                         await self._mark_active_processed(planned, process_started)
                     terminal = True
                     terminal_succeeded = True
-                    process_outcome = "succeeded"
+                    process_outcome = settled
                 else:
                     terminal_error = "provider returned without correlated admission"
                     self._degrade(terminal_error)
@@ -1447,6 +1448,38 @@ class GlobalInboxRuntime(
                 await self._replay_deferred_autonomous_start()
             await self._wake_remaining_pending()
             return True
+
+    def _health_outcome_for_turn(self, planned: PlannedTurn) -> str:
+        """``succeeded``, unless the turn made no observable progress on the
+        batch its own notice announced.
+
+        ``global_inbox_covers._mark_active_processed`` reads an empty
+        ``active.message_ids`` as "the provider received the notice but chose
+        not to read Inbox" — a normal deferred outcome. That reading is only
+        safe when the provider actually ran. A driver that maps a failed
+        provider turn onto "assistant completed" (the Pi credential-expiry
+        incident: expired token, ``stopReason: error``, zero output) produces
+        the identical shape, and the turn then settles the agent's health back
+        to ``ok`` while the announced messages stay pending — indefinitely,
+        because every later wake-up repeats it.
+
+        This check is deliberately **driver-independent**: it reads the
+        runtime's own admission bookkeeping rather than any adapter's
+        self-report, so a driver that swallows its errors cannot suppress it.
+        Fixing one adapter leaves every other adapter exempt; this does not.
+
+        Choosing not to reply still counts as progress — that decision is made
+        *after* ``read_inbox`` admits the rows, which populates
+        ``active.message_ids``. A wake-up that announced nothing (autonomous
+        turns, notice-only ticks) can never trip it, and messages that arrive
+        mid-turn cannot either: the comparison is against the ids this turn's
+        notice carried, not against the queue depth at the end.
+        """
+        if not planned.notice_message_ids:
+            return "succeeded"
+        if self.active.message_ids:
+            return "succeeded"
+        return "no_progress"
 
     async def _run_retry(self, planned: PlannedTurn) -> Any:
         retry = getattr(self.run_turn, "handle_global_inbox_retry", None)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -654,17 +654,11 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
                 uptime = "—"
         # Surface non-ok health alongside lifecycle status so the
         # operator can see at a glance which agents need attention.
-        if rs is not None and rs.health in (
-            "in_progress",
-            "auth_failed",
-            "api_error_abandoned",
-            "provider_error",
-            "refresh_broken",
-            "drained",
-            "unhandled_error",
-            "codex_thread_wedged",
-            "server_unreachable",
-        ):
+        # Stated as an exclusion, not a roster of the interesting values: a
+        # hand-maintained roster makes every health value added later
+        # invisible here by default, which is the one surface an operator
+        # reads first. Only "ok" and "unknown" carry no call to action.
+        if rs is not None and rs.health and rs.health not in ("ok", "unknown"):
             runtime = f"{runtime} [{rs.health}]"
         # Truncate display_name for table alignment.
         display = ac.display_name or aid

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -988,8 +988,16 @@ class RuntimeState:
     #                           next successful reconnect. Only ever
     #                           overwrites "ok" — the specific signals
     #                           above stay authoritative
+    #   "no_progress"         — N consecutive turns woke on an announced
+    #                           batch and consumed none of it. Driver-
+    #                           independent: it reads the runtime's own
+    #                           admission bookkeeping, so it still fires when
+    #                           a harness driver mis-reports a failed provider
+    #                           turn as a completed one. Cleared by the next
+    #                           turn that consumes its batch. Never overwrites
+    #                           the stronger signals above
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | server_unreachable | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | server_unreachable | no_progress | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> RuntimeState | None:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -119,6 +119,11 @@ RECONNECT_BACKOFF_SECONDS = 5.0
 # minute instead of "ok" for hours. One successful reconnect clears it.
 _WS_DEGRADE_THRESHOLD = 5
 
+# Consecutive turns that woke on an announced batch and consumed none of it
+# before the agent stops being reported healthy. One such turn is a normal
+# deferral; a run of them means the provider is not reaching the Inbox at all.
+_NO_PROGRESS_TURN_THRESHOLD = 3
+
 
 def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
     if harness_name != "claude-code":
@@ -691,6 +696,52 @@ class Worker:
             "agent %s: runtime.health %s → ok", agent_id, previous_health
         )
 
+    def _note_no_progress_turn(self, agent_id: str) -> None:
+        """A turn woke on an announced batch and consumed none of it.
+
+        Deliberately *not* symmetrical with the success lane: this does not
+        clear anything and does not settle the runtime back to ``ok``. A
+        single such turn is a legitimate deferral, so the first
+        ``_NO_PROGRESS_TURN_THRESHOLD - 1`` only hold the previous health and
+        let the next wake-up retry; the streak past that is the signal.
+
+        The stronger reds stay authoritative — this only ever overwrites the
+        states that mean "nothing is known to be wrong", which is exactly the
+        gap it exists to close: a driver that mis-reports a failed turn as a
+        completed one leaves the agent sitting in ``ok`` forever.
+        """
+        streak = getattr(self, "_no_progress_turns", 0) + 1
+        self._no_progress_turns = streak
+        rt = self.runtime
+        if streak < _NO_PROGRESS_TURN_THRESHOLD:
+            logger.info(
+                "agent %s: turn made no progress on its announced batch "
+                "(%d/%d); leaving runtime.health = %s for the next wake-up",
+                agent_id, streak, _NO_PROGRESS_TURN_THRESHOLD, rt.health,
+            )
+            return
+        if rt.health not in ("ok", "in_progress", "unknown", "no_progress"):
+            logger.info(
+                "agent %s: %d consecutive no-progress turns, but "
+                "runtime.health = %s already names a cause; leaving it",
+                agent_id, streak, rt.health,
+            )
+            return
+        if rt.health != "no_progress":
+            logger.warning(
+                "agent %s: %d consecutive turns woke on pending messages and "
+                "read none; runtime.health %s → no_progress",
+                agent_id, streak, rt.health,
+            )
+        rt.health = "no_progress"
+        rt.error = (
+            "Woke for new messages but the provider read none of them "
+            f"{streak} times in a row. The turns are being reported as "
+            "completed while the messages stay unread — check the provider "
+            "credentials and the harness driver's error mapping."
+        )
+        rt.save(agent_id)
+
     def _resolve_health_after_success(self, agent_id: str) -> None:
         recovering_api_key = (
             getattr(self, "_claude_api_key_mode", False)
@@ -705,6 +756,8 @@ class Worker:
         if recovering_api_key:
             self._api_key_auth_recovery_pending = False
             self._auth_failed_notification_sent = False
+        # a turn that consumed its announced batch clears the no-progress streak
+        self._no_progress_turns = 0
         # a completed turn is proof quota is available again
         Worker._clear_drained(self.runtime, agent_id, logger)
         self._drained_notification_sent = False

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -727,6 +727,10 @@ class Worker:
                 agent_id, streak, rt.health,
             )
             return
+        Worker._write_no_progress_red(self, agent_id, streak)
+
+    def _write_no_progress_red(self, agent_id: str, streak: int) -> None:
+        rt = self.runtime
         if rt.health != "no_progress":
             logger.warning(
                 "agent %s: %d consecutive turns woke on pending messages and "
@@ -741,6 +745,25 @@ class Worker:
             "credentials and the harness driver's error mapping."
         )
         rt.save(agent_id)
+
+    def _reassert_no_progress_after_cancel(self, agent_id: str) -> None:
+        """A cancelled turn is not recovery evidence.
+
+        ``_flip_health_in_progress`` overrides the ``no_progress`` red at
+        batch-top; settling the cancelled turn through the success resolver
+        would launder that into ``ok`` with zero ``read_inbox`` admissions in
+        between. While the streak that earned the red is still live, put the
+        red back instead. Below threshold — or when the turn set a health
+        value that names a cause — the ordinary resolution stands (the
+        resolver only ever touches ``in_progress``).
+        """
+        streak = getattr(self, "_no_progress_turns", 0)
+        if streak >= _NO_PROGRESS_TURN_THRESHOLD and self.runtime.health in (
+            "ok", "in_progress", "unknown", "no_progress",
+        ):
+            Worker._write_no_progress_red(self, agent_id, streak)
+            return
+        Worker._resolve_health_on_success(self.runtime, agent_id, logger)
 
     def _resolve_health_after_success(self, agent_id: str) -> None:
         recovering_api_key = (

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -828,6 +828,8 @@ class StandardWorkerRun:
         try:
             if outcome == "succeeded":
                 worker._resolve_health_after_success(agent_id)
+            elif outcome == "no_progress":
+                worker._note_no_progress_turn(agent_id)
             elif outcome == "cancelled":
                 worker_module.Worker._resolve_health_on_success(
                     worker.runtime, agent_id, logger

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -831,8 +831,9 @@ class StandardWorkerRun:
             elif outcome == "no_progress":
                 worker._note_no_progress_turn(agent_id)
             elif outcome == "cancelled":
-                worker_module.Worker._resolve_health_on_success(
-                    worker.runtime, agent_id, logger
+                # not recovery evidence: a live no-progress streak stays red
+                worker_module.Worker._reassert_no_progress_after_cancel(
+                    worker, agent_id
                 )
             elif outcome == "auth_failed":
                 worker._enter_auth_failed(agent_id)

--- a/tests/test_no_progress_turn_guard.py
+++ b/tests/test_no_progress_turn_guard.py
@@ -135,3 +135,64 @@ def test_in_progress_and_unknown_are_claimable():
         for _ in range(3):
             Worker._note_no_progress_turn(w, "agent-a")
         assert w.runtime.health == "no_progress", start
+
+
+# ── the operator-visible surface ───────────────────────────────────────────
+
+
+def _agent_list_output(monkeypatch, capsys, health):
+    """Run ``puffo-cli agent list`` against one stub agent and return its row."""
+    import argparse
+    import time
+
+    from puffo_agent.portal import cli
+
+    runtime = SimpleNamespace(
+        status="running",
+        updated_at=int(time.time()),
+        started_at=int(time.time()) - 60,
+        msg_count=3,
+        health=health,
+    )
+    monkeypatch.setattr(cli, "discover_agents", lambda: ["agent-a"])
+    monkeypatch.setattr(cli, "is_daemon_alive", lambda: True)
+    monkeypatch.setattr(
+        cli.AgentConfig, "load", staticmethod(
+            lambda _aid: SimpleNamespace(display_name="Tester", state="enabled")
+        )
+    )
+    monkeypatch.setattr(
+        cli.RuntimeState, "load", staticmethod(lambda _aid: runtime)
+    )
+    cli.cmd_agent_list(argparse.Namespace())
+    return [
+        line for line in capsys.readouterr().out.splitlines()
+        if line.startswith("agent-a")
+    ][0]
+
+
+def test_no_progress_is_visible_in_agent_list(monkeypatch, capsys):
+    """The whole point of the guard is that an operator can see it. The one
+    surface they read first must not silently drop the new value."""
+    assert "[no_progress]" in _agent_list_output(monkeypatch, capsys, "no_progress")
+
+
+def test_every_non_ok_health_value_is_visible(monkeypatch, capsys):
+    """Stated over the declared enum rather than a copy of it: a value added
+    to ``RuntimeState.health`` later is shown by construction, instead of
+    being exempt until someone remembers this list."""
+    for health in (
+        "in_progress", "auth_failed", "api_error_abandoned", "provider_error",
+        "refresh_broken", "drained", "unhandled_error", "codex_thread_wedged",
+        "server_unreachable", "no_progress",
+    ):
+        row = _agent_list_output(monkeypatch, capsys, health)
+        assert f"[{health}]" in row, health
+
+
+def test_ok_and_unknown_stay_unannotated(monkeypatch, capsys):
+    """Only states that carry a call to action are annotated — otherwise the
+    marker stops meaning "needs attention"."""
+    for health in ("ok", "unknown", ""):
+        row = _agent_list_output(monkeypatch, capsys, health)
+        assert "[" not in row, health

--- a/tests/test_no_progress_turn_guard.py
+++ b/tests/test_no_progress_turn_guard.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import logging
 from types import SimpleNamespace
 
+import pytest
+
 from puffo_agent.agent.global_inbox_runtime import GlobalInboxRuntime
 from puffo_agent.portal.worker import Worker
 
@@ -196,3 +198,38 @@ def test_ok_and_unknown_stay_unannotated(monkeypatch, capsys):
     for health in ("ok", "unknown", ""):
         row = _agent_list_output(monkeypatch, capsys, health)
         assert "[" not in row, health
+
+
+# ── cancel is not recovery evidence (found by Peter on cdf9a8c) ─────────────
+
+
+def test_cancel_after_flip_reasserts_a_live_no_progress_streak(tmp_path, monkeypatch):
+    """no_progress → _flip_health_in_progress → cancelled must land back on
+    no_progress, not launder through the success resolver into ok."""
+    from puffo_agent.portal.worker_run import StandardWorkerRun
+
+    rt = _Runtime(health="no_progress", error="red")
+    w = SimpleNamespace(runtime=rt, _no_progress_turns=3)
+    Worker._flip_health_in_progress(rt, "agent-a", logging.getLogger("t"))
+    assert rt.health == "in_progress"  # the batch-top override Peter traced
+    StandardWorkerRun._settle_process_health(w, "agent-a", "cancelled", None)
+    assert rt.health == "no_progress"
+    assert "read none of them" in rt.error
+
+
+@pytest.mark.parametrize(
+    "streak, health_after_turn, expected",
+    [
+        # below threshold: the pre-existing cancel resolution stands
+        (1, "in_progress", "ok"),
+        # a cause named during the turn stays authoritative
+        (3, "auth_failed", "auth_failed"),
+    ],
+)
+def test_cancel_leaves_other_resolutions_alone(streak, health_after_turn, expected):
+    from puffo_agent.portal.worker_run import StandardWorkerRun
+
+    rt = _Runtime(health=health_after_turn, error="")
+    w = SimpleNamespace(runtime=rt, _no_progress_turns=streak)
+    StandardWorkerRun._settle_process_health(w, "agent-b", "cancelled", None)
+    assert rt.health == expected

--- a/tests/test_no_progress_turn_guard.py
+++ b/tests/test_no_progress_turn_guard.py
@@ -1,0 +1,137 @@
+"""A turn that woke on an announced batch and read none of it must not
+settle the agent back to healthy.
+
+Regression cover for the Pi credential-expiry incident: an expired provider
+token produced ``stopReason: error`` with zero output, the harness driver
+mapped that onto "assistant completed", and every wake-up then settled
+``runtime.health = ok`` while the announced messages stayed unread — for five
+days, with 19 messages queued behind a green status dot.
+
+The guard is deliberately driver-independent. Fixing the driver that mis-maps
+its errors leaves every other driver exempt; this reads the runtime's own
+admission bookkeeping instead, so a driver that swallows an error cannot
+suppress it.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from puffo_agent.agent.global_inbox_runtime import GlobalInboxRuntime
+from puffo_agent.portal.worker import Worker
+
+LOG = logging.getLogger("no-progress-test")
+
+
+class _Runtime:
+    def __init__(self, health="ok", error=""):
+        self.health = health
+        self.error = error
+        self.saved = []
+
+    def save(self, agent_id):
+        self.saved.append((agent_id, self.health))
+
+
+def _planned(notice_ids):
+    return SimpleNamespace(notice_message_ids=tuple(notice_ids))
+
+
+def _runtime_with(admitted):
+    return SimpleNamespace(active=SimpleNamespace(message_ids=list(admitted)))
+
+
+# ── which turns count as progress ──────────────────────────────────────────
+
+
+def test_notice_announcing_nothing_is_always_a_success():
+    """Autonomous / notice-only wake-ups have no batch to make progress on."""
+    outcome = GlobalInboxRuntime._health_outcome_for_turn(
+        _runtime_with([]), _planned([])
+    )
+    assert outcome == "succeeded"
+
+
+def test_reading_the_batch_is_progress_even_with_no_reply():
+    """Deciding not to reply happens after read_inbox admits the rows, so a
+    deliberately silent turn still records progress."""
+    outcome = GlobalInboxRuntime._health_outcome_for_turn(
+        _runtime_with(["m1"]), _planned(["m1"])
+    )
+    assert outcome == "succeeded"
+
+
+def test_announced_batch_left_untouched_is_not_a_success():
+    outcome = GlobalInboxRuntime._health_outcome_for_turn(
+        _runtime_with([]), _planned(["m1", "m2"])
+    )
+    assert outcome == "no_progress"
+
+
+def test_mid_turn_arrivals_cannot_trip_the_check():
+    """The comparison is against the ids this turn's notice carried, not the
+    queue depth afterwards — otherwise a message arriving mid-turn would make
+    a perfectly good turn look stalled."""
+    outcome = GlobalInboxRuntime._health_outcome_for_turn(
+        _runtime_with(["m1"]), _planned(["m1"])
+    )
+    assert outcome == "succeeded"
+
+
+# ── what the worker does with a streak of them ─────────────────────────────
+
+
+def _worker(health="ok", streak=0):
+    return SimpleNamespace(runtime=_Runtime(health=health), _no_progress_turns=streak)
+
+
+def test_one_no_progress_turn_holds_health_and_writes_nothing():
+    """A single deferral is legitimate; only a run of them is the signal."""
+    w = _worker()
+    Worker._note_no_progress_turn(w, "agent-a")
+
+    assert w._no_progress_turns == 1
+    assert w.runtime.health == "ok"
+    assert w.runtime.saved == []
+
+
+def test_streak_reaching_the_threshold_turns_the_agent_red():
+    w = _worker()
+    for _ in range(3):
+        Worker._note_no_progress_turn(w, "agent-a")
+
+    assert w.runtime.health == "no_progress"
+    assert "read none of them" in w.runtime.error
+    assert w.runtime.saved == [("agent-a", "no_progress")]
+
+
+def test_further_no_progress_turns_do_not_rewrite_the_same_state():
+    w = _worker()
+    for _ in range(5):
+        Worker._note_no_progress_turn(w, "agent-a")
+
+    # Still red, but the streak keeps counting into the operator message.
+    assert w.runtime.health == "no_progress"
+    assert "5 times in a row" in w.runtime.error
+
+
+def test_a_named_cause_stays_authoritative():
+    """auth_failed / drained / … already say why; a no-progress streak is the
+    weaker, derived signal and must not overwrite them."""
+    w = _worker(health="auth_failed")
+    w.runtime.error = "original reason"
+    for _ in range(4):
+        Worker._note_no_progress_turn(w, "agent-a")
+
+    assert w.runtime.health == "auth_failed"
+    assert w.runtime.error == "original reason"
+    assert w.runtime.saved == []
+
+
+def test_in_progress_and_unknown_are_claimable():
+    for start in ("in_progress", "unknown"):
+        w = _worker(health=start)
+        for _ in range(3):
+            Worker._note_no_progress_turn(w, "agent-a")
+        assert w.runtime.health == "no_progress", start

--- a/tests/test_runtime_health_in_progress.py
+++ b/tests/test_runtime_health_in_progress.py
@@ -8,9 +8,9 @@ Tests the two new static helpers on Worker:
   other state alone.
 
 Also covers the StatusReporter heartbeat shape extension (carries
-both per-turn ``status`` AND persistent ``health``) and the
-``cli.cmd_agent_list`` surfaced-health tuple includes
-``in_progress``.
+both per-turn ``status`` AND persistent ``health``). CLI surfacing of
+non-ok health moved to ``tests/test_no_progress_turn_guard.py`` — see the
+note further down.
 """
 
 from __future__ import annotations
@@ -344,25 +344,15 @@ async def test_heartbeat_provider_exception_does_not_break_heartbeat(monkeypatch
     assert body == {"status": "idle"}
 
 
-# ── CLI surfaced-health includes new values ──────────────────────
-
-
-def test_cli_surfaced_health_tuple_includes_new_values():
-    """Source-string check on cli.py's cmd_agent_list tuple (running
-    the CLI does heavy daemon init). Pins the new PUF-270 values."""
-    cli_path = (
-        Path(__file__).parent.parent
-        / "src" / "puffo_agent" / "portal" / "cli.py"
-    )
-    text = cli_path.read_text(encoding="utf-8")
-    for required in (
-        "in_progress",
-        "unhandled_error",
-        "auth_failed",
-        "api_error_abandoned",
-        "provider_error",
-        "refresh_broken",
-    ):
-        assert f'"{required}"' in text, (
-            f"surfaced-health tuple missing {required!r}"
-        )
+# ── CLI surfaced-health ──────────────────────────────────────────
+#
+# The former ``test_cli_surfaced_health_tuple_includes_new_values`` grepped
+# cli.py for each health literal, because "running the CLI does heavy daemon
+# init". That rationale had expired: ``cmd_agent_list`` runs under three
+# monkeypatches. It also pinned the wrong thing — the *shape* of a
+# hand-maintained roster rather than the property that a non-ok health value
+# reaches the operator, so it went green on values nobody had added to the
+# roster. Replaced by the behavioural checks in
+# ``tests/test_no_progress_turn_guard.py`` (``..._is_visible_in_agent_list``,
+# ``test_every_non_ok_health_value_is_visible``), which drive the command and
+# read its output.

--- a/tests/test_worker_status_lifecycle.py
+++ b/tests/test_worker_status_lifecycle.py
@@ -226,6 +226,12 @@ async def test_global_inbox_turn_owns_one_status_lifecycle(tmp_path, monkeypatch
         "failure": "provider_failed",
         "cancelled": "cancelled",
         "retry_exhausted": "api_error_abandoned",
+        # A turn that woke on an announced batch and read none of it no longer
+        # settles health as a success: the provider may simply have deferred,
+        # but a driver mis-reporting a failed turn produces the same shape, so
+        # the health lane holds instead of clearing to ``ok``. Message
+        # bookkeeping is unchanged — see ``_health_outcome_for_turn``.
+        "no_read": "no_progress",
     }.get(case["outcome"], "succeeded")
     if case.get("error_code") == "plan_drained":
         # spent quota splits out of provider_failed: hold, don't retry


### PR DESCRIPTION
> [!NOTE]
> **评审已转移**:本 PR 已并入统一交付 [puffo-agent #328](https://github.com/puffo-ai/puffo-agent/pull/328)(agent 仓汇总,head `fcc1ddc7`;统一评审入口及 11→3 映射见其描述)。原评审正文与 head 保留如下,未改动。

Glimmer asked for the staging incident to be fixed; Peter owns the Pi adapter half (mapping `stopReason: error` onto a failed turn). This is the other half — the part that does not depend on any driver reporting honestly.

## The hole

`global_inbox_covers._mark_active_processed` reads an empty active union as:

> The provider received the notice but chose not to read Inbox. That is a normal deferred outcome, not a transport failure

True — when the provider actually ran. An expired provider token produces the identical shape: `stopReason: error`, zero output, zero tool calls. A driver that maps that onto "assistant completed" hands the worker a success, the worker settles `runtime.health = ok`, and the announced messages stay pending. Every later wake-up repeats it, so it never self-corrects.

Observed on the Pi staging agents: 300–800 ms turns, no `assistant_text`, no `tool_use`, no MCP RPC at all, `runtime.json` = `status=running / health=ok / error=""`, **19 messages queued, five days**. Nothing in the health vocabulary could express it — `auth_failed` exists but was never set once, because the error was swallowed before the health machinery saw it.

## The change

`GlobalInboxRuntime._health_outcome_for_turn` settles the health lane as `no_progress` when a turn woke on an announced batch and consumed none of it; `Worker._note_no_progress_turn` holds the previous health for the first two, and sets `runtime.health = no_progress` on the third consecutive one.

**Driver-independent by construction.** It reads the runtime's own admission bookkeeping, not an adapter's self-report — so a driver that swallows its errors cannot suppress it. Repairing one driver leaves every other driver exempt; this does not.

### What it cannot fire on

| case | why not |
|---|---|
| deliberately silent turn | declining to reply happens *after* `read_inbox` admits the rows, which populates `active.message_ids` |
| autonomous / notice-only wake-up | `notice_message_ids` is empty, so there is no batch to make progress on |
| message arriving mid-turn | the comparison is against the ids **this turn's notice carried**, never the queue depth at the end |
| an agent with a named cause | `auth_failed` / `drained` / … are stronger and stay authoritative; this only claims `ok` / `in_progress` / `unknown` |
| one-off deferral | the first two only hold the previous health and let the next wake-up retry — the streak is the signal |

Message bookkeeping, processing receipts and status reporting are untouched: `process_outcome` feeds the health lane only.

## Verification

- New `tests/test_no_progress_turn_guard.py` (9 cases) — progress classification plus the worker streak, threshold, non-clobbering and reset behaviour.
- `tests/test_worker_status_lifecycle.py` already had a `success_without_read` case asserting `succeeded`; it now asserts `no_progress`, which is exactly the behaviour change, with the reason in a comment.
- **Counterfactual verified**: both test files copied onto unpatched `main` fail, and not only on the missing symbol — `success_without_read` fails with `assert 'succeeded' == 'no_progress'`, the real behavioural red.
- Full suite green locally (`uv run --extra dev pytest`, exit 0).

## Not in scope

The third gap I found while reading this: `CredentialRefresher._propagate_outcome` clears `refresh_broken` on **every registered agent** after one host-level refresh tick, so a host credential that looks fine wipes a red from agents whose own provider was never tested. The unconditional clear is deliberate (a daemon restart resets the in-memory counter while leaving `refresh_broken` on disk), so it needs a design, not a deletion. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## PR 文档（what / how）— 2026-09-09 交叉审 · Linus
**比较基线 base `54a0599d7700`(main) → head `01263aee`** · rev2（按 Peter 第一轮核对修订：§3 判据表述精确化）· 事实与建议分列。

### 1. 问题
Pi 凭据过期事故：driver 把失败的 provider 回合映射成「assistant 完成」，`_mark_active_processed` 把空接纳读成「正常延后」，健康 settle 回 `ok`——消息永远 pending、agent 永远绿。修 driver（#324）只治 Pi；任何吞错误的 driver 都能复现同形状，兜底必须与 driver 无关。

### 2. 做了什么（改前 → 改后）
- 回合被通知唤醒却零接纳 ⇒ 健康通道 settle 为 `no_progress`（消息簿记不变）；连续第 3 次置红（前两次保持原值）；具名病因不被覆写；成功取件清零 streak；取消不算恢复证据（streak 达阈值时 cancel 回置红）；CLI 显示名册改排除式。

### 3. 怎么做的（机制）——判据的精确表述
`_health_outcome_for_turn` 是**两个集合的空性检查**：`planned.notice_message_ids` 非空 ∧ `active.message_ids` 为空 ⇒ `no_progress`；否则 succeeded。**它不做两个 ID 集的交集比较**——正确读法是「本回合有通知且没有任何接纳」，而非「逐 ID 核对通知批次被消费」。直接后果：**任何**消息被接纳（包括通知批次之外、回合中途到达的）都算 progress。这是保守方向的设计选择（宁可漏报不误报），也是与 #312 `_mcp_silence_streak` 判据的共同部分。
其余：`_note_no_progress_turn`（阈值 3；claimable 集合 `{ok,in_progress,unknown,no_progress}`）、`_reassert_no_progress_after_cancel`、`_write_no_progress_red` 共用置红尾巴；`_settle_process_health` 增 no_progress 路由、cancel 路由改走 re-assert；判据读 runtime 自己的准入账目，不读适配器自述。

### 4. 建模关系（事实）
扩展既有 health 值域与 settle 派发，逐点接入现行结构；每加一个值需触碰 worker/credential_refresh 保护名册/settle/显示名册多处（本 PR 自己曾漏 cli.py，已修并改为排除式）。

### 5. 重叠面（事实）
- **#312**：判据共同部分=「notice 非空∧接纳空」（#312 多 pending-仍在合取项）；共触 `global_inbox_covers.py` 等五文件；两条 streak、两个阈值 3、互不联动。
- **#326**：`cli.py`/`worker.py:_resolve_health_after_success`/`worker_run.py:_settle_process_health`/`state.py` 四文件同区；解法表已公示（cli.py 保排除式）。
- **#324**：零共触文件；语义互补。

### 6. 验证
12 用例；两轮反事实红实跑（`'succeeded'=='no_progress'` 于未打补丁 main；`'ok'=='no_progress'` 于未修 cancel 树）；本地全量 pytest + pre-commit 绿；CI 7/7 @01263ae（本 head 实查）；Peter 四路径独立反查通过。

### 建议（非事实）
① #312 合后 rebase 归并双 streak（我执行）；② 存量「cancel 当成功清红」洞（provider_error/unhandled_error）归状态属性表重构。

固定版本入口：[global_inbox_covers.py](https://github.com/puffo-ai/puffo-agent/blob/01263aee918ed54fe91a41cb4295393c0745506f/src/puffo_agent/agent/global_inbox_covers.py) · [worker.py](https://github.com/puffo-ai/puffo-agent/blob/01263aee918ed54fe91a41cb4295393c0745506f/src/puffo_agent/portal/worker.py) · [worker_run.py](https://github.com/puffo-ai/puffo-agent/blob/01263aee918ed54fe91a41cb4295393c0745506f/src/puffo_agent/portal/worker_run.py) · [cli.py](https://github.com/puffo-ai/puffo-agent/blob/01263aee918ed54fe91a41cb4295393c0745506f/src/puffo_agent/portal/cli.py)
