### PR TITLE
feat(agent): hold extra usage failures separately from subscription quota

### DIFF
--- a/src/puffo_agent/agent/_failure_outcomes.py
+++ b/src/puffo_agent/agent/_failure_outcomes.py
@@ -10,12 +10,14 @@ from .errors import AgentAPIError, ProviderFailureError
 
 def failure_outcome(exc: Exception) -> str:
     """``drained`` | ``auth_failed`` | ``api_error_abandoned`` |
-    ``provider_failed`` | ``failed``. Quota before auth."""
+    ``extra_usage_required`` | ``provider_failed`` | ``failed``. Quota before auth."""
     if isinstance(exc, AgentAPIError):
         if exc.is_drained:
             return "drained"
         return "auth_failed" if exc.is_auth else "api_error_abandoned"
     if isinstance(exc, ProviderFailureError):
+        if exc.error_code == "extra_usage_required":
+            return "extra_usage_required"
         # plan_drained only — quota_exhausted includes per-model limits
         return (
             "drained"
@@ -34,8 +36,8 @@ def crash_resume_terminal(exc: Exception) -> tuple[str, str] | None:
             if isinstance(exc, AgentAPIError)
             else str(exc)
         ), "drained"
-    if outcome == "provider_failed":
-        return str(exc), "provider_failed"
+    if outcome in {"provider_failed", "extra_usage_required"}:
+        return str(exc), outcome
     if outcome == "auth_failed":
         return "crash resume auth failure", "auth_failed"
     if not isinstance(exc, AgentAPIError):

--- a/src/puffo_agent/agent/global_inbox_degraded.py
+++ b/src/puffo_agent/agent/global_inbox_degraded.py
@@ -40,12 +40,14 @@ class DegradedRecoveryMixin:
         # wake rides the existing coalescer — no extra task/timer/thread
         self.coalescer.notify(delay_seconds=backoff)
 
-    def _park_drained(self) -> None:
+    def _park_drained(self, outcome: str = "drained") -> None:
         """Hold, don't retry — backoff can't refill a quota. Rows stay
         pending; unpark = ``drained_check`` clear + a wake."""
         self.health = RuntimeHealth(
             "degraded",
-            "provider quota exhausted; parked until the usage window resets",
+            "extra usage unavailable; parked until operator retry"
+            if outcome == "extra_usage_required"
+            else "provider quota exhausted; parked until the usage window resets",
         )
         self._parked_drained = True
 

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -1343,8 +1343,8 @@ class GlobalInboxRuntime(
                 planned, process_started, "provider_error"
             )
         terminal_error = operator_failure_text(exc)
-        if process_outcome == "drained":
-            self._park_drained()
+        if process_outcome in {"drained", "extra_usage_required"}:
+            self._park_drained(process_outcome)
         else:
             self._degrade(
                 "turn failed and was requeued"
@@ -1681,7 +1681,7 @@ class GlobalInboxRuntime(
                 activated=activated,
             )
         self.health = RuntimeHealth(state, diagnostic)
-        if state == "drained":
+        if state in {"drained", "extra_usage_required"}:
             # crash-resume drained: same park as the live path
             self._parked_drained = True
         self._defer_requeued_recovery = defer_requeued_recovery and requeued
@@ -1707,6 +1707,7 @@ class GlobalInboxRuntime(
                     "api_error_abandoned",
                     "provider_failed",
                     "drained",
+                    "extra_usage_required",
                 }
                 else "failed"
             )

--- a/src/puffo_agent/agent/provider_failures.py
+++ b/src/puffo_agent/agent/provider_failures.py
@@ -43,6 +43,12 @@ PROVIDER_FAILURES: Mapping[str, ProviderFailure] = MappingProxyType(
             "usage window to reset.",
             runtime_event_code="provider_unavailable",
         ),
+        "extra_usage_required": ProviderFailure(
+            "Extra usage is unavailable. Check extra usage settings, balance, "
+            "or spending limits at https://claude.ai/settings/usage, then restart "
+            "the agent to retry pending messages.",
+            runtime_event_code="provider_unavailable",
+        ),
         "quota_exhausted": ProviderFailure(
             "The selected provider model has reached its usage limit; "
             "switch models or wait for the limit to reset.",
@@ -168,6 +174,13 @@ def classify_provider_failure(*, status: int | None, diagnostic: str) -> str:
     # order: hard 401 -> plan quota -> broad quota -> auth substrings
     if status == 401:
         return "authentication"
+    # A specific provider refusal, not a general mention of usage or limits.
+    # Subscription snapshots cannot prove that this separate budget recovered.
+    if (
+        "third-party apps now draw from your extra usage" in normalized
+        and "add more at claude.ai/settings/usage" in normalized
+    ):
+        return "extra_usage_required"
     if looks_like_usage_limit(normalized):
         return "plan_drained"
     if (

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -661,6 +661,7 @@ def cmd_agent_list(args: argparse.Namespace) -> int:
             "provider_error",
             "refresh_broken",
             "drained",
+            "extra_usage_required",
             "unhandled_error",
             "codex_thread_wedged",
             "server_unreachable",

--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -1372,7 +1372,7 @@ class CredentialRefresher:
                 continue
             if rs.health in (
                 "auth_failed", "api_error_abandoned", "provider_error",
-                "refresh_broken", "drained", "in_progress", "unhandled_error",
+                "refresh_broken", "drained", "extra_usage_required", "in_progress", "unhandled_error",
             ):
                 continue
             rs.health = "refresh_broken"
@@ -1433,7 +1433,7 @@ class CredentialRefresher:
             if rs is None:
                 continue
             if rs.health in (
-                "auth_failed", "api_error_abandoned", "drained", "in_progress",
+                "auth_failed", "api_error_abandoned", "drained", "extra_usage_required", "in_progress",
             ):
                 continue
             rs.health = "auth_failed"

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -969,6 +969,7 @@ class RuntimeState:
     #                           refresh outcomes; cleared by next
     #                           REFRESHED. Does not overwrite the stronger
     #                           provider and authentication signals above.
+    #   "extra_usage_required" — extra usage refused; operator action + model success
     #   "drained"             — plan quota spent; hold-no-retry until the
     #                           usage window resets. Not a credential
     #                           failure: re-login does not recover it
@@ -989,7 +990,7 @@ class RuntimeState:
     #                           overwrites "ok" — the specific signals
     #                           above stay authoritative
     #   "unknown"             — no probe yet
-    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | unhandled_error | codex_thread_wedged | server_unreachable | unknown
+    health: str = "unknown"  # ok | in_progress | auth_failed | api_error_abandoned | provider_error | refresh_broken | drained | extra_usage_required | unhandled_error | codex_thread_wedged | server_unreachable | unknown
 
     @classmethod
     def load(cls, agent_id: str) -> RuntimeState | None:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -560,6 +560,44 @@ class Worker:
             )
         return provider_failure_message("authentication")
 
+    def _enter_extra_usage_required(self, agent_id: str) -> None:
+        """Extra usage needs operator action; subscription refresh cannot clear it."""
+        self.runtime.health = "extra_usage_required"
+        self.runtime.error = provider_failure_message("extra_usage_required")
+        self.runtime.save(agent_id)
+        if self._extra_usage_notification_sent:
+            return
+        self._extra_usage_notification_sent = True
+        coro = self._notify_operator_of_extra_usage()
+        try:
+            spawn(coro, name="notify_operator_of_extra_usage")
+        except Exception:
+            coro.close()
+            self._extra_usage_notification_sent = False
+            logger.exception("could not schedule extra-usage notification")
+
+    async def _notify_operator_of_extra_usage(self) -> None:
+        client = self._client
+        if client is None:
+            self._extra_usage_notification_sent = False
+            return
+        operator_slug = client.operator_slug or ""
+        if not operator_slug:
+            return
+        name = self.agent_cfg.display_name or self.agent_cfg.id
+        text = (
+            f"{name}: 额度不可用（额外用量）。请检查 Claude 的额外用量设置、"
+            "余额或花费上限：https://claude.ai/settings/usage 。"
+            "处理后重启此 Agent，以重试待处理消息。\n\n"
+            f"{name}: Quota unavailable (extra usage). "
+            + provider_failure_message("extra_usage_required")
+        )
+        try:
+            await client._send_dm(operator_slug, text, root_id="")
+        except Exception:
+            self._extra_usage_notification_sent = False
+            logger.exception("could not send extra-usage notification")
+
     def _enter_drained(self, agent_id: str, resets_at: int | None = None) -> None:
         """``drained`` + one operator DM per episode. No refresher kick."""
         from ..agent._usage_markers import DRAINED_RUNTIME_ERROR
@@ -663,7 +701,7 @@ class Worker:
         log: logging.Logger,
     ) -> None:
         """Override any sticky red with ``in_progress`` at batch-top."""
-        if runtime.health == "in_progress":
+        if runtime.health in {"in_progress", "extra_usage_required"}:
             return
         runtime.health = "in_progress"
         runtime.error = ""
@@ -705,6 +743,12 @@ class Worker:
         if recovering_api_key:
             self._api_key_auth_recovery_pending = False
             self._auth_failed_notification_sent = False
+        # Transport readiness, refresh and cancellation are not model success.
+        if self.runtime.health == "extra_usage_required":
+            self.runtime.health = "ok"
+            self.runtime.error = ""
+            self.runtime.save(agent_id)
+        self._extra_usage_notification_sent = False
         # a completed turn is proof quota is available again
         Worker._clear_drained(self.runtime, agent_id, logger)
         self._drained_notification_sent = False
@@ -794,6 +838,7 @@ class Worker:
         # on_refresh_success) and on a failed send.
         self._auth_failed_notification_sent = False
         self._drained_notification_sent = False
+        self._extra_usage_notification_sent = False
         self._drained_resets_at: int | None = None
         self._claude_api_key_mode = (
             agent_cfg.runtime.kind in {RUNTIME_CLI_LOCAL, RUNTIME_CLI_DOCKER}
@@ -810,6 +855,11 @@ class Worker:
             started_at=int(time.time()),
             msg_count=0,
         )
+        # A restart permits a fresh attempt, but is not proof billing recovered.
+        previous = RuntimeState.load(agent_cfg.id)
+        if previous is not None and previous.health == "extra_usage_required":
+            self.runtime.health = previous.health
+            self.runtime.error = provider_failure_message("extra_usage_required")
         self._stop = asyncio.Event()
         self._task: asyncio.Task | None = None
         self._restart_required = False

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -464,7 +464,10 @@ class StandardWorkerRun:
         worker = self.worker
         logger.error("agent %s: failed to initialise: %s", agent_id, exc, exc_info=True)
         worker.runtime.status = "error"
-        worker.runtime.error = str(exc)
+        if isinstance(exc, ProviderFailureError) and exc.error_code == "extra_usage_required":
+            worker._enter_extra_usage_required(agent_id)
+        else:
+            worker.runtime.error = str(exc)
         worker.runtime.save(agent_id)
         worker._warm_done.set()
         if worker._adapter is not None:
@@ -521,7 +524,7 @@ class StandardWorkerRun:
             return not exc.is_auth and not exc.is_drained
         if isinstance(exc, ProviderFailureError):
             # plan quota arrives here, not as AgentAPIError
-            return exc.error_code != "plan_drained"
+            return exc.error_code not in {"plan_drained", "extra_usage_required"}
         return not isinstance(
             exc,
             (
@@ -572,7 +575,10 @@ class StandardWorkerRun:
             exc_info=True,
         )
         worker.runtime.status = "error"
-        worker.runtime.error = str(exc)
+        if isinstance(exc, ProviderFailureError) and exc.error_code == "extra_usage_required":
+            worker._enter_extra_usage_required(agent_id)
+        else:
+            worker.runtime.error = str(exc)
         worker.runtime.save(agent_id)
         worker._warm_done.set()
         try:
@@ -743,8 +749,11 @@ class StandardWorkerRun:
             covers_renotice_enabled=(
                 True if worker.daemon_cfg.covers_renotice else None
             ),
-            # unpark = snapshot-cleared health + a wake
-            drained_check=lambda: worker.runtime.health == "drained",
+            # Plan quota can unpark after a snapshot; extra usage requires
+            # an operator restart (new runtime) or a successful model turn.
+            drained_check=lambda: worker.runtime.health in {
+                "drained", "extra_usage_required",
+            },
         )
         coordinator = SendCoordinator(
             slug=client.slug,
@@ -838,6 +847,8 @@ class StandardWorkerRun:
                 worker._enter_drained(
                     agent_id, parse_reset_epoch(error_text or "")
                 )
+            elif outcome == "extra_usage_required":
+                worker._enter_extra_usage_required(agent_id)
             elif outcome == "api_error_abandoned":
                 worker_module.Worker._mark_api_error_abandoned_if_in_progress(
                     worker.runtime, agent_id, error_text, logger

--- a/tests/test_drained_state.py
+++ b/tests/test_drained_state.py
@@ -1368,3 +1368,90 @@ def test_codex_dm_names_codex_not_claude():
     text = format_codex_drained("agent-1", "Testy")
     assert "Codex usage limit" in text
     assert "Claude Code usage limit" not in text
+
+
+EXTRA_USAGE_DIAGNOSTIC = (
+    '400 {"type":"error","error":{"type":"invalid_request_error",'
+    '"message":"Third-party apps now draw from your extra usage, not your '
+    'plan limits. Add more at claude.ai/settings/usage"}}'
+)
+
+
+def test_extra_usage_is_distinct_from_plan_quota_and_holds_warm():
+    """The reported Pi 400 must not become a generic retry or a plan reset."""
+    code = classify_provider_failure(status=None, diagnostic=EXTRA_USAGE_DIAGNOSTIC)
+    assert code == "extra_usage_required"
+    exc = ProviderFailureError("extra usage unavailable", error_code=code)
+    assert failure_outcome(exc) == "extra_usage_required"
+    assert crash_resume_terminal(exc) == (str(exc), "extra_usage_required")
+    assert not StandardWorkerRun._retryable_local_warm_error(exc)
+    assert classify_provider_failure(
+        status=400, diagnostic=EXTRA_USAGE_DIAGNOSTIC + " usage limit reached"
+    ) == code
+    assert classify_provider_failure(status=429, diagnostic="Too Many Requests") == "rate_limit"
+    assert classify_provider_failure(status=400, diagnostic="extra usage documentation") == "provider_error"
+
+
+def test_extra_usage_survives_snapshots_and_refresh_until_success(tmp_path, monkeypatch):
+    """Only a successful model turn can clear the extra-usage failure."""
+    from puffo_agent.portal.credential_refresh import CredentialRefresher, RefreshOutcome
+
+    monkeypatch.setenv("PUFFO_HOME", str(tmp_path))
+    loop = _stub_create_task(monkeypatch)
+    w = _drained_worker("extra")
+    w._extra_usage_notification_sent = False
+    StandardWorkerRun._settle_process_health(w, "extra", "extra_usage_required", "raw private text")
+    assert w.runtime.health == "extra_usage_required"
+    assert "raw private text" not in w.runtime.error
+    assert loop.calls == 1
+    StandardWorkerRun._settle_process_health(w, "extra", "extra_usage_required", None)
+    assert loop.calls == 1
+    _stub_agents(monkeypatch, {"extra": "pi"})
+    for workers in ({"extra": w}, {}):
+        _stub_live_workers(monkeypatch, workers)
+        for used in (0, 100):
+            apply_drained_health({"pi": {"session": {"used_pct": used}}})
+            assert RuntimeState.load("extra").health == "extra_usage_required"
+    refresher = CredentialRefresher(host_home=tmp_path)
+    refresher._agent_homes = {str(tmp_path / "extra")}
+    refresher._flip_refresh_broken(RefreshOutcome.FAILED)
+    refresher._flip_auth_failed()
+    refresher._clear_refresh_broken()
+    assert RuntimeState.load("extra").health == "extra_usage_required"
+    Worker._clear_auth_failed_if_recoverable(w.runtime, "extra", logging.getLogger())
+    Worker._flip_health_in_progress(w.runtime, "extra", logging.getLogger())
+    assert w.runtime.health == "extra_usage_required"
+    StandardWorkerRun._settle_process_health(w, "extra", "cancelled", None)
+    assert w.runtime.health == "extra_usage_required"
+    w._resolve_health_after_success("extra")
+    assert w.runtime.health == "ok"
+    assert not w._extra_usage_notification_sent
+
+
+@pytest.mark.asyncio
+async def test_extra_usage_notifies_operator_with_recovery_action():
+    """Extra-usage alerts must not direct the operator to re-login or wait."""
+    client = _StubClient()
+    w = _drained_worker(client=client)
+    w._extra_usage_notification_sent = True
+    await w._notify_operator_of_extra_usage()
+    assert len(client.sent) == 1
+    text = client.sent[0][1]
+    assert "https://claude.ai/settings/usage" in text
+    assert "restart" in text.lower()
+    assert "login" not in text.lower()
+    assert "window resets" not in text.lower()
+
+
+def test_restart_preserves_extra_usage_until_a_real_turn_succeeds(tmp_path, monkeypatch):
+    """A new Worker may retry, but a process restart must not erase the red state."""
+    from puffo_agent.portal.state import AgentConfig, DaemonConfig
+
+    monkeypatch.setenv("PUFFO_HOME", str(tmp_path))
+    RuntimeState(status="running", health="extra_usage_required", error="extra usage").save("extra")
+    w = Worker(DaemonConfig(), AgentConfig(id="extra"))
+    assert w.runtime.health == "extra_usage_required"
+    Worker._reassert_auth_failed_after_failed_probe(w.runtime, "extra", logging.getLogger())
+    assert w.runtime.health == "extra_usage_required"
+    w._resolve_health_after_success("extra")
+    assert RuntimeState.load("extra").health == "ok"

--- a/tests/test_global_inbox_session_retry.py
+++ b/tests/test_global_inbox_session_retry.py
@@ -277,3 +277,47 @@ async def test_turn_session_transfer_store_contract(tmp_path, case):
     else:
         await _assert_transfer_rejected(store, case)
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_extra_usage_parks_pending_messages_across_new_wakes(tmp_path):
+    """New inbound messages must not turn a billing hold into repeated API calls."""
+    from puffo_agent.agent.errors import ProviderFailureError
+    from puffo_agent.agent.provider_failures import provider_failure_message
+
+    store = await make_store(tmp_path)
+    adapter = Adapter()
+    calls = 0
+    blocked = False
+
+    async def run(planned):
+        nonlocal calls
+        calls += 1
+        await adapter.admit()
+        raise ProviderFailureError(
+            provider_failure_message("extra_usage_required"),
+            error_code="extra_usage_required",
+        )
+
+    def settle(outcome, error):
+        nonlocal blocked
+        assert outcome == "extra_usage_required"
+        blocked = True
+
+    runtime = GlobalInboxRuntime(
+        agent_id="extra", store=store, adapter=adapter, run_turn=run,
+        workspace=tmp_path, drained_check=lambda: blocked, process_outcome=settle,
+    )
+    try:
+        await receipt(store, "extra-1", 1)
+        await runtime.process_once()
+        assert calls == 1
+        assert blocked
+        assert runtime._parked_drained
+        await receipt(store, "extra-2", 2)
+        runtime.notify()
+        assert not await runtime.process_once()
+        assert calls == 1
+        assert len(await store.get_pending(limit=10)) == 2
+    finally:
+        await store.close()

--- a/tests/test_pi_driver.py
+++ b/tests/test_pi_driver.py
@@ -579,7 +579,12 @@ async def test_assistant_error_recovered_by_retry_does_not_fail_turn():
 
 
 @pytest.mark.asyncio
-async def test_unretried_provider_error_fails_once_and_resets_for_next_turn():
+@pytest.mark.parametrize("diagnostic, expected", [
+    ("unknown failure private-detail", "provider_error"),
+    ("Third-party apps now draw from your extra usage, not your plan limits. "
+     "Add more at claude.ai/settings/usage", "extra_usage_required"),
+])
+async def test_unretried_provider_error_fails_once_and_resets_for_next_turn(diagnostic, expected):
     """A non-auth error must fail the turn without contaminating later work."""
     proc = FakePiProcess()
     driver, _ = await _open(proc)
@@ -590,12 +595,12 @@ async def test_unretried_provider_error_fails_once_and_resets_for_next_turn():
         proc.push({"type": "agent_start"})
         proc.push({"type": "message_end", "message": {
             "role": "assistant", "stopReason": "error" if failed else "stop",
-            "errorMessage": "unknown failure private-detail" if failed else "",
+            "errorMessage": diagnostic if failed else "",
         }})
         proc.push({"type": "agent_settled"})
         events = await _drain_events(driver, 3)
         assert events[-1].data["outcome"] == ("failed" if failed else "succeeded")
-        assert events[-1].data.get("error_code") == ("provider_error" if failed else None)
+        assert events[-1].data.get("error_code") == (expected if failed else None)
         assert "private-detail" not in json.dumps([dict(e.data) for e in events])
     await driver.close()
 


### PR DESCRIPTION
> [!NOTE]
> **评审已转移**:本 PR 已并入统一交付 [puffo-agent #328](https://github.com/puffo-ai/puffo-agent/pull/328)(agent 仓汇总,head `fcc1ddc7`;统一评审入口及 11→3 映射见其描述)。原评审正文与 head 保留如下,未改动。

Pi can return an HTTP 400 saying third-party apps require Claude extra usage. Treating it as a generic provider error hides the recovery action; treating it as subscription exhaustion lets unrelated usage snapshots clear the failure.

Add `extra_usage_required` as a separate provider failure and runtime health state. Match the explicit diagnostic before general quota wording, retain pending messages without automatic retry, notify the operator with the usage settings link, and keep the state through subscription snapshots, credential refresh, cancellation and restart. An operator restart permits another attempt; only a successful model turn clears the state. CLI output includes the new health value. `drained` retains its existing subscription reset behavior.

This PR is stacked on #324 (Pi assistant error propagation); merge #324 first, then retarget this PR to main. Companion web PR https://github.com/puffo-ai/puffo-core-han-group/pull/923 maps both quota states to the same localized label while retaining separate recovery behavior.

Validation:
- Observed the reported diagnostic regression fail before implementation.
- Full Python suite: 3917 passed, 2 skipped; pre-commit and structural checks passed.
- Coverage includes Pi terminal classification, warm/crash recovery outcomes, durable pending-message parking, snapshot/credential protection, operator notification and restart/success transitions.
- One intermediate full run had an ACP SDK stream test fail under concurrent test load. It passed alone and the final full run passed.

No live OAuth credentials or agent deployments were changed. The matcher deliberately covers the supplied refusal, not arbitrary mentions of extra usage.

---

<!-- peter-pr-facts-20260909 -->
## PR 事实说明（2026-09-09，待交叉确认）

作者：Peter Steinberger。此节记录实现事实及待讨论问题，不代表跨 PR 建模方案已达成一致。

- PR：[puffo-agent #326](https://github.com/puffo-ai/puffo-agent/pull/326)
- 目标分支：`fix/pi-assistant-error-outcome`；查询时 base head：`5d441ac2943ffa737f63615fe44af533f20714ad`
- 本文 head：`e68319850346897b80fd05133d98ae0b0c23d712`
- 比较 merge base：`5d441ac2943ffa737f63615fe44af533f20714ad`；[固定版本差异](https://github.com/puffo-ai/puffo-agent/compare/5d441ac2943ffa737f63615fe44af533f20714ad...e68319850346897b80fd05133d98ae0b0c23d712)
- 后续代码变更需重新确认本文，不自动继承复核结论。

### 1. 问题与行为变化

供应商明确拒绝第三方应用使用订阅额度、要求额外用量时，订阅使用率快照和刷新凭据不能证明该独立预算恢复。原分类没有这一原因；与一般额度耗尽混同，会采用错误恢复证据。

改后新增内部 `extra_usage_required`：精确拒绝文案进入该原因；待处理 Inbox 保留并停止自动尝试；提示用户检查额外用量设置、余额和花费上限。重启允许一次新的模型尝试，但持久化故障仍保留，成功模型回合才清除。普通 drained 的订阅快照恢复规则保留。

### 2. 实现路径和代码依据

- `provider_failures.py::classify_provider_failure`：硬 401 判断之后、宽泛 quota 判断之前匹配两段指定文案；注册安全恢复提示。
- `_failure_outcomes.py::failure_outcome/crash_resume_terminal`：保留独立失败原因，包含崩溃恢复路径。
- `global_inbox_runtime.py` + `global_inbox_degraded.py::_park_drained`：复用已存在的 parked gate 和待处理行；增加原因参数，没有另建重试器。
- `portal/worker_run.py`：warm/init 失败和 settle 都可进入该 health；warm 不再把它当可自动重试错误；`drained_check` 接纳两种额度原因。
- `portal/worker.py::_enter_extra_usage_required`：保存 health/error，发送中英双语操作者提示；进程内标志限制重复提示。构造时从 RuntimeState 恢复该故障；`_flip_health_in_progress` 保留它；`_resolve_health_after_success` 才清除。
- `portal/credential_refresh.py`：两处保护集合加入该状态，防止被刷新故障或认证故障覆写。已有订阅快照只清 drained，本 PR 以测试约束 extra 不受其清除。
- `portal/state.py` 与 `portal/cli.py`：文档及终端显示名册同步扩展。

### 3. 复用、新增模型与改动范围

新增的是失败原因和恢复政策，复用 ProviderFailure、RuntimeState、drained parking、原通知通道；没有新增数据库 schema、后台计时器或第二套 Inbox。新增通知布尔值属于 Worker 生命周期，重启后可能再次通知，不应称为跨重启严格 exactly-once。

九个生产文件、三个测试文件。该 PR 基于 #324，其 assistant 错误归一化属于父 PR，不应重复计入本项实现量。Web 展示在 #923。

### 4. 验证证据及边界

`test_drained_state.py` 覆盖 extra 状态、实际订阅快照与凭据刷新、取消/成功、重启保留与通知；`test_global_inbox_session_retry.py` 用持久化 Inbox 验证新消息到来仍不重试且 pending 保留；`test_pi_driver.py` 检查精确文案的安全分类。作者最后一次本地全量 3917 passed / 2 skipped，pre-commit/结构检查通过；该 head 三项远端检查通过。本次文档工作未重跑全量。

匹配是供应商给定的具体文案，不保证将来的所有账单拒绝文案都归此类；取消和凭据刷新不构成额外预算可用的证据。重启是放行尝试，并非恢复证明。

### 5. 待共同确认的问题

为何普通 drained 与 extra 不能仅用同一个健康值？需共同确认各自恢复证据。新增状态需改多个保护集合和显示名册，是否应扩展已有状态属性结构来收口？讨论须涵盖 worker、settle、credential_refresh、CLI 和 Web，不能只移一张表。

与 #325 组合时 `cli.py` 有实现冲突：#325 已改为排除普通状态，本项当前仍为列举故障值。最终处理方案需以两份文档及合并差异核对，不能机械叠加名册。

### 固定版本代码入口

- [src/puffo_agent/agent/_failure_outcomes.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/agent/_failure_outcomes.py)
- [src/puffo_agent/agent/global_inbox_degraded.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/agent/global_inbox_degraded.py)
- [src/puffo_agent/agent/global_inbox_runtime.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/agent/global_inbox_runtime.py)
- [src/puffo_agent/agent/provider_failures.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/agent/provider_failures.py)
- [src/puffo_agent/portal/cli.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/portal/cli.py)
- [src/puffo_agent/portal/credential_refresh.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/portal/credential_refresh.py)
- [src/puffo_agent/portal/state.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/portal/state.py)
- [src/puffo_agent/portal/worker.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/portal/worker.py)
- [src/puffo_agent/portal/worker_run.py](https://github.com/puffo-ai/puffo-agent/blob/e68319850346897b80fd05133d98ae0b0c23d712/src/puffo_agent/portal/worker_run.py)
