### PR TITLE
fix: make a gateway budget cap terminal instead of a retry storm (PUF-382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A gateway budget cap no longer turns into a retry storm.** LiteLLM's
+  `Budget has been exceeded!` 429 was classified as a transient rate limit and
+  retried — by the harness and by the `claude` CLI's own backoff loop — at up
+  to ~180 requests a minute per fleet, which the gateway counted against the
+  same budget. The wording is now a drain: the runtime parks on a timed hold
+  (5 → 30 min, reset by a completed turn) and probes once when it expires,
+  the operator gets a DM that names the cap rather than a quota window that
+  will "reset", the host's usage snapshot no longer clears it, and agents
+  routed through a gateway launch the CLI with `CLAUDE_CODE_MAX_RETRIES=2`.
+  (PUF-382)
+
 ### Added
 
 - **OpenCode reasoning variants follow each model's native catalog.** The

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -256,3 +256,33 @@ def format_codex_oauth_expired(
         "3. 按浏览器提示用你的 Codex 账户登录。\n"
         "4. 登录完成后回到这里发一条消息即可恢复。"
     )
+
+
+def format_budget_exceeded(agent_id: str, agent_display_name: str = "") -> str:
+    """Bilingual gateway-budget DM. Unlike a plan window there is nothing to
+    wait for: the cap is raised or the wallet is topped up, or it stays."""
+    label = (
+        f"**{agent_display_name}** (`{agent_id}`)"
+        if agent_display_name
+        else f"`{agent_id}`"
+    )
+    return (
+        f"🪫 {label} — the spending cap on the account behind my key is "
+        "exhausted, so the LLM gateway is refusing my requests. I'm holding "
+        "your messages and will re-check every 5–30 minutes; nothing is lost.\n"
+        "\n"
+        "**Your options:**\n"
+        "1. Top up the wallet or raise the cap for this account.\n"
+        "2. Switch me to a cheaper model (`/config`, or the model field on my agent card).\n"
+        "\n"
+        "**This is not a sign-in problem, and it will not reset on its own.**\n"
+        "\n"
+        f"🪫 {label} — 我这把密钥所属账户的消费上限已经用完，网关正在拒绝我的请求。"
+        "我会先把你的消息存住，每隔 5–30 分钟再试一次，不会丢。\n"
+        "\n"
+        "**你可以：**\n"
+        "1. 给这个账户充值，或提高消费上限。\n"
+        "2. 把我换成更便宜的模型（`/config`，或 agent 卡片上的 model 字段）。\n"
+        "\n"
+        "**这不是登录问题，也不会自己恢复。**"
+    )

--- a/src/puffo_agent/agent/_usage_markers.py
+++ b/src/puffo_agent/agent/_usage_markers.py
@@ -9,6 +9,16 @@ from __future__ import annotations
 import re
 
 # shipped plan-budget spellings; stable cores — full sentences drift per release
+# A gateway (LiteLLM) refusing on a spend cap. Unambiguous: nothing else says
+# "budget". Unlike a plan window it has no reset time — it clears when someone
+# raises the cap or tops up the wallet — so callers pair it with a timed hold
+# rather than a reset epoch (see ``looks_like_budget_cap``).
+BUDGET_CAP_MARKERS: tuple[str, ...] = (
+    "budget has been exceeded",
+    "max budget limit reached",
+    "max budget:",
+)
+
 PLAN_LIMIT_MARKERS: tuple[str, ...] = (
     "usage limit reached",
     "hour limit reached",
@@ -16,6 +26,7 @@ PLAN_LIMIT_MARKERS: tuple[str, ...] = (
     "limit will reset at",
     "you've hit your usage limit",
     "you have hit your usage limit",
+    *BUDGET_CAP_MARKERS,
 )
 
 # ambiguous alone: also fired for per-model / per-project ceilings
@@ -54,6 +65,27 @@ DRAINED_RUNTIME_ERROR = (
     "Usage limit reached — the plan's quota for this account is spent. "
     "Holding messages until the window resets. Not a sign-in problem."
 )
+
+
+BUDGET_EXCEEDED_RUNTIME_ERROR = (
+    "Budget exceeded at the LLM gateway — the wallet or team cap behind this "
+    "agent's key is spent. Holding messages and re-checking on a timer; "
+    "raise the cap or top up to release it. Not a sign-in problem."
+)
+
+
+def looks_like_budget_cap(text: str) -> bool:
+    """A gateway spend-cap refusal (LiteLLM ``Budget has been exceeded!``).
+
+    Subset of ``looks_like_usage_limit`` — every budget-cap text is also a
+    drain — split out because the recovery differs: no window resets, so
+    the runtime holds on a timer and probes, instead of waiting for a
+    usage snapshot that a gateway-routed agent can never produce.
+    """
+    if not text:
+        return False
+    low = text.lower()
+    return any(marker in low for marker in BUDGET_CAP_MARKERS)
 
 
 def looks_like_usage_limit(text: str) -> bool:

--- a/src/puffo_agent/agent/global_inbox_degraded.py
+++ b/src/puffo_agent/agent/global_inbox_degraded.py
@@ -10,6 +10,11 @@ from .global_inbox_types import RuntimeHealth
 # re-arms its own bounded backoff so retries don't depend on unrelated ingress
 DEGRADED_RECOVERY_BASE_SECONDS = 5.0
 DEGRADED_RECOVERY_MAX_SECONDS = 300.0
+# budget-cap park: no reset window exists, so hold, then probe once. Doubles
+# per consecutive cap hit; a completed turn resets it. Bounded so a wallet
+# topped up at minute 31 is not ignored until the next day.
+BUDGET_PARK_BASE_SECONDS = 300.0
+BUDGET_PARK_MAX_SECONDS = 1800.0
 
 
 class DegradedRecoveryMixin:
@@ -22,6 +27,9 @@ class DegradedRecoveryMixin:
         # drained park (see _park_drained); notify() never clears it
         self.drained_check = drained_check
         self._parked_drained = False
+        # timed hold for a budget-cap park; None = wait for drained_check
+        self._drained_park_until: float | None = None
+        self._budget_park_attempts = 0
 
     def _clear_degraded_backoff(self) -> None:
         self._degraded = False
@@ -40,19 +48,62 @@ class DegradedRecoveryMixin:
         # wake rides the existing coalescer — no extra task/timer/thread
         self.coalescer.notify(delay_seconds=backoff)
 
-    def _park_drained(self, outcome: str = "drained") -> None:
+    def _park_drained(
+        self,
+        outcome: str = "drained",
+        *,
+        hold_seconds: float | None = None,
+        diagnostic: str | None = None,
+    ) -> None:
         """Hold, don't retry — backoff can't refill a quota. Rows stay
-        pending; unpark = ``drained_check`` clear + a wake."""
+        pending; unpark = ``drained_check`` clear + a wake.
+
+        With ``hold_seconds`` the park is timed instead: nothing runs until
+        the hold expires, then ONE probe turn is allowed regardless of
+        ``drained_check``. That is the only exit a gateway-routed agent has
+        — the usage snapshot that clears a plan drain comes from the host's
+        own ``claude /usage``, which a sandbox cannot produce.
+        """
         self.health = RuntimeHealth(
             "degraded",
-            "extra usage unavailable; parked until operator retry"
-            if outcome == "extra_usage_required"
-            else "provider quota exhausted; parked until the usage window resets",
+            diagnostic
+            or (
+                "extra usage unavailable; parked until operator retry"
+                if outcome == "extra_usage_required"
+                else "provider quota exhausted; parked until the usage window resets"
+            ),
         )
         self._parked_drained = True
+        if hold_seconds is not None:
+            self._drained_park_until = time.monotonic() + hold_seconds
+            # the wake rides the coalescer, like the degraded backoff
+            self.coalescer.notify(delay_seconds=hold_seconds)
+        else:
+            self._drained_park_until = None
+
+    def next_budget_park_hold(self) -> float:
+        """Escalating hold for consecutive budget-cap parks (5 → 30 min)."""
+        self._budget_park_attempts += 1
+        return min(
+            BUDGET_PARK_BASE_SECONDS * 2 ** (self._budget_park_attempts - 1),
+            BUDGET_PARK_MAX_SECONDS,
+        )
+
+    def _clear_budget_park_backoff(self) -> None:
+        self._budget_park_attempts = 0
 
     def _drained_park_allows_processing(self) -> bool:
         if self._parked_drained:
+            if self._drained_park_until is not None:
+                remaining = self._drained_park_until - time.monotonic()
+                if remaining > 0:
+                    # a wake arrived inside the hold; re-arm and keep holding
+                    self.coalescer.notify(delay_seconds=remaining)
+                    return False
+                # hold expired: one probe, whatever the snapshot says
+                self._drained_park_until = None
+                self._parked_drained = False
+                return True
             if self.drained_check is not None and self.drained_check():
                 return False
             self._parked_drained = False

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -32,6 +32,7 @@ from .context_controller import (
 )
 from .errors import AgentAPIError
 from ._failure_outcomes import crash_resume_terminal, failure_outcome
+from ._usage_markers import looks_like_budget_cap
 from .inbox_scheduler import (
     COALESCE_SECONDS,
     MAX_ESTIMATED_TOKENS,
@@ -1345,7 +1346,17 @@ class GlobalInboxRuntime(
             )
         terminal_error = operator_failure_text(exc)
         if process_outcome in {"drained", "extra_usage_required"}:
-            self._park_drained(process_outcome)
+            if process_outcome == "drained" and looks_like_budget_cap(terminal_error):
+                hold = self.next_budget_park_hold()
+                self._park_drained(
+                    hold_seconds=hold,
+                    diagnostic=(
+                        "gateway budget cap; holding "
+                        f"{int(hold)}s then probing once — {terminal_error[:160]}"
+                    ),
+                )
+            else:
+                self._park_drained(process_outcome)
         else:
             self._degrade(
                 "turn failed and was requeued"
@@ -1419,6 +1430,8 @@ class GlobalInboxRuntime(
                     terminal = True
                     terminal_succeeded = True
                     process_outcome = settled
+                    if settled == "succeeded":
+                        self._clear_budget_park_backoff()
                 else:
                     terminal_error = "provider returned without correlated admission"
                     self._degrade(terminal_error)

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -95,6 +95,11 @@ from ....tasks import spawn
 
 logger = logging.getLogger(__name__)
 
+# claude-code reads this to bound its own transient-status retry loop
+# (429/529/5xx). Set only when the agent is routed through a budgeted gateway.
+GATEWAY_CLI_MAX_RETRIES_ENV = "CLAUDE_CODE_MAX_RETRIES"
+GATEWAY_CLI_MAX_RETRIES = "2"
+
 VALID_PERMISSION_MODES = frozenset({"bypassPermissions"})
 VALID_SANDBOX_MODES = frozenset({
     "read-only",
@@ -711,6 +716,11 @@ class LocalRuntimePreparer:
         llm_env = anthropic_base_url_env(runtime.llm_base_url)
         if llm_env and runtime.api_key:
             llm_env["ANTHROPIC_API_KEY"] = runtime.api_key
+            # Behind a budgeted gateway a 429 is usually the cap, not load.
+            # The CLI treats every 429 as transient and retries with backoff;
+            # under a cap that is a storm the gateway counts against the same
+            # budget. Cap the CLI's retries; the runtime parks on the drain.
+            llm_env[GATEWAY_CLI_MAX_RETRIES_ENV] = GATEWAY_CLI_MAX_RETRIES
         else:
             configured_key = claude_cli_api_key(self.daemon_cfg)
             if configured_key:

--- a/src/puffo_agent/portal/control/usage_snapshot.py
+++ b/src/puffo_agent/portal/control/usage_snapshot.py
@@ -192,6 +192,10 @@ def _apply_to_live_worker(worker, agent_id: str, spent_reset) -> None:
         if worker.runtime.health in ("ok", "unknown", ""):
             worker._enter_drained(agent_id, resets_at)
     elif worker.runtime.health == "drained":
+        if getattr(worker, "_drained_budget_cap", False):
+            # plan headroom says nothing about a gateway cap; the runtime's
+            # timed probe owns that exit
+            return
         worker._clear_drained(worker.runtime, agent_id, logger)
 
 

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -795,15 +795,32 @@ class Worker:
             self._extra_usage_notification_sent = False
             logger.exception("could not send extra-usage notification")
 
-    def _enter_drained(self, agent_id: str, resets_at: int | None = None) -> None:
-        """``drained`` + one operator DM per episode. No refresher kick."""
-        from ..agent._usage_markers import DRAINED_RUNTIME_ERROR
+    def _enter_drained(
+        self,
+        agent_id: str,
+        resets_at: int | None = None,
+        *,
+        budget_cap: bool = False,
+    ) -> None:
+        """``drained`` + one operator DM per episode. No refresher kick.
+
+        ``budget_cap``: a gateway spend cap, not a plan window — no reset time
+        exists and the usage snapshot must not clear it (unrelated signal).
+        The runtime holds on a timer and probes; see ``_park_drained``.
+        """
+        from ..agent._usage_markers import (
+            BUDGET_EXCEEDED_RUNTIME_ERROR,
+            DRAINED_RUNTIME_ERROR,
+        )
 
         rt = self.runtime
         was_ok = rt.health != "drained"
         rt.health = "drained"
-        rt.error = DRAINED_RUNTIME_ERROR
+        rt.error = (
+            BUDGET_EXCEEDED_RUNTIME_ERROR if budget_cap else DRAINED_RUNTIME_ERROR
+        )
         rt.save(agent_id)
+        self._drained_budget_cap = budget_cap
         if resets_at is not None:
             self._drained_resets_at = resets_at
         if was_ok:
@@ -847,19 +864,25 @@ class Worker:
         display_name = getattr(self.agent_cfg, "display_name", "") or self.agent_cfg.id
         runtime = getattr(self.agent_cfg, "runtime", None)
         harness = getattr(runtime, "harness", "") if runtime is not None else ""
-        resets_at = getattr(self, "_drained_resets_at", None)
-        if resets_at is None:
-            # error bodies rarely carry a time — predict from /usage, best-effort
-            from .control.usage_snapshot import predicted_reset_epoch
+        if getattr(self, "_drained_budget_cap", False):
+            # a gateway cap: no window, no /usage prediction — say what it is
+            from ..agent._invite_strings import format_budget_exceeded
 
-            try:
-                resets_at = await predicted_reset_epoch(harness or "claude-code")
-            except Exception:  # noqa: BLE001
-                resets_at = None
-            if resets_at is not None:
-                self._drained_resets_at = resets_at
-        formatter = format_codex_drained if harness == "codex" else format_drained
-        text = formatter(self.agent_cfg.id, display_name, resets_at=resets_at)
+            text = format_budget_exceeded(self.agent_cfg.id, display_name)
+        else:
+            resets_at = getattr(self, "_drained_resets_at", None)
+            if resets_at is None:
+                # error bodies rarely carry a time — predict from /usage, best-effort
+                from .control.usage_snapshot import predicted_reset_epoch
+
+                try:
+                    resets_at = await predicted_reset_epoch(harness or "claude-code")
+                except Exception:  # noqa: BLE001
+                    resets_at = None
+                if resets_at is not None:
+                    self._drained_resets_at = resets_at
+            formatter = format_codex_drained if harness == "codex" else format_drained
+            text = formatter(self.agent_cfg.id, display_name, resets_at=resets_at)
         try:
             await client._send_dm(operator_slug, text, root_id="")
         except Exception as exc:
@@ -1025,6 +1048,7 @@ class Worker:
         Worker._clear_drained(self.runtime, agent_id, logger)
         self._drained_notification_sent = False
         self._drained_resets_at = None
+        self._drained_budget_cap = False
 
     @staticmethod
     def _fallback_unhandled_error_if_stuck_in_progress(
@@ -1112,6 +1136,7 @@ class Worker:
         self._drained_notification_sent = False
         self._extra_usage_notification_sent = False
         self._drained_resets_at: int | None = None
+        self._drained_budget_cap = False
         self._claude_api_key_mode = (
             agent_cfg.runtime.kind in {RUNTIME_CLI_LOCAL, RUNTIME_CLI_DOCKER}
             and bool(

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -23,7 +23,7 @@ from .workspace_layout import (
 )
 from ..agent.errors import ProviderFailureError
 from ..agent.processing_receipts import processing_run_id
-from ..agent._usage_markers import parse_reset_epoch
+from ..agent._usage_markers import looks_like_budget_cap, parse_reset_epoch
 from ..tasks import spawn
 
 if TYPE_CHECKING:
@@ -920,7 +920,9 @@ class StandardWorkerRun:
                 worker._enter_auth_failed(agent_id)
             elif outcome == "drained":
                 worker._enter_drained(
-                    agent_id, parse_reset_epoch(error_text or "")
+                    agent_id,
+                    parse_reset_epoch(error_text or ""),
+                    budget_cap=looks_like_budget_cap(error_text or ""),
                 )
             elif outcome == "extra_usage_required":
                 worker._enter_extra_usage_required(agent_id)

--- a/tests/test_claude_api_key_policy.py
+++ b/tests/test_claude_api_key_policy.py
@@ -237,3 +237,28 @@ def test_successful_key_retry_clears_auth_failure(tmp_path, monkeypatch):
     assert worker.runtime.health == "ok"
     assert worker._api_key_auth_recovery_pending is False
     assert worker._auth_failed_notification_sent is False
+
+
+def test_local_gateway_caps_the_cli_retry_loop(tmp_path, monkeypatch):
+    """Behind a budgeted gateway a 429 is the cap, not load. The CLI retries
+    every 429 as transient; capping it keeps a cap hit to a handful of
+    requests instead of a storm the gateway bills against the same budget."""
+    preparer = _local_preparer(
+        tmp_path,
+        monkeypatch,
+        runtime_key="gateway-key",
+        base_url="https://gateway.example/v1",
+    )
+    spec = preparer._prepare_claude_spec("prompt")
+    assert spec.environment["CLAUDE_CODE_MAX_RETRIES"] == "2"
+
+
+def test_local_direct_provider_leaves_cli_retries_alone(tmp_path, monkeypatch):
+    preparer = _local_preparer(
+        tmp_path,
+        monkeypatch,
+        daemon_key="daemon-key",
+        key_enabled=True,
+    )
+    spec = preparer._prepare_claude_spec("prompt")
+    assert "CLAUDE_CODE_MAX_RETRIES" not in spec.environment

--- a/tests/test_drained_state.py
+++ b/tests/test_drained_state.py
@@ -565,8 +565,9 @@ def test_settle_routes_drained_into_enter_drained_with_the_epoch():
     entered = []
 
     class _EnterRecorder:
-        def _enter_drained(self, agent_id, resets_at=None):
+        def _enter_drained(self, agent_id, resets_at=None, *, budget_cap=False):
             entered.append((agent_id, resets_at))
+            assert budget_cap is False, "a plan window is not a gateway cap"
 
     StandardWorkerRun._settle_process_health(
         _EnterRecorder(), "agent-1", "drained",
@@ -1455,3 +1456,290 @@ def test_restart_preserves_extra_usage_until_a_real_turn_succeeds(tmp_path, monk
     assert w.runtime.health == "extra_usage_required"
     w._resolve_health_after_success("extra")
     assert RuntimeState.load("extra").health == "ok"
+
+
+def _worker_for_health_tests(tmp_path, monkeypatch):
+    """A Worker with a saveable RuntimeState; nothing else wired."""
+    from puffo_agent.portal.state import AgentConfig, RuntimeConfig, RuntimeState
+    from puffo_agent.portal.worker import Worker
+
+    cfg = AgentConfig(
+        id="agent-1",
+        runtime=RuntimeConfig(
+            kind="cli-local", provider="anthropic", harness="claude-code"
+        ),
+    )
+    worker = Worker.__new__(Worker)
+    worker.agent_cfg = cfg
+    worker.runtime = RuntimeState()
+    worker._drained_notification_sent = True  # no DM task in tests
+    worker._drained_resets_at = None
+    worker._drained_budget_cap = False
+    worker._client = None
+    return worker
+
+
+# ── Gateway budget caps (LiteLLM) ─────────────────────────────────────
+# Wording LiteLLM 1.93 actually emits: the team check, the key check, and the
+# user-level pre-call limiter. None carries a reset time.
+
+LITELLM_TEAM_CAP = (
+    "API Error: Request rejected (429) · Budget has been exceeded! "
+    "Team=team-5a46ddd9dc5a4febbe154487fa1b8048 "
+    "Current cost: 44.46579, Max budget: 43.86"
+)
+LITELLM_KEY_CAP = (
+    "Budget has been exceeded! Key=agent-finagle-4306-d55f080d-e4d8f1dc "
+    "(sk-...nWoA) Current cost: 10.0, Max budget: 10.0"
+)
+LITELLM_USER_CAP = "429 Max budget limit reached."
+
+
+def test_litellm_budget_caps_are_drained_not_rate_limited():
+    """A gateway spend cap is terminal for the turn: retrying cannot refill
+    a wallet, and every retry is a request the gateway counts. Before this,
+    the text matched nothing and fell through to ``rate_limit`` (retryable),
+    which is how four agents produced 1,359 rejections in a day."""
+    from puffo_agent.agent._usage_markers import looks_like_budget_cap
+    from puffo_agent.agent.provider_failures import classify_provider_failure
+
+    for text in (LITELLM_TEAM_CAP, LITELLM_KEY_CAP, LITELLM_USER_CAP):
+        assert looks_like_budget_cap(text) is True, text
+        assert looks_like_usage_limit(text) is True, text
+        is_auth, is_drained, _label = _classify_api_error(text)
+        assert (is_auth, is_drained) == (False, True), text
+        assert classify_provider_failure(status=429, diagnostic=text) == "plan_drained"
+        assert failure_outcome(AgentAPIError(text, is_drained=True)) == "drained"
+
+
+def test_budget_cap_is_a_strict_subset_of_drained():
+    """A plan window is drained but not a cap — the two recover differently
+    (snapshot-cleared vs timed probe), so the narrower predicate must not
+    swallow the wider one."""
+    from puffo_agent.agent._usage_markers import looks_like_budget_cap
+
+    assert looks_like_budget_cap("Claude AI usage limit reached|1780000000") is False
+    assert looks_like_budget_cap("API Error: Request rejected (429)") is False
+    assert looks_like_budget_cap("rate limit reached — please retry") is False
+
+
+def test_settle_routes_a_budget_cap_into_enter_drained_as_a_cap():
+    entered = []
+
+    class _EnterRecorder:
+        def _enter_drained(self, agent_id, resets_at=None, *, budget_cap=False):
+            entered.append((agent_id, resets_at, budget_cap))
+
+    StandardWorkerRun._settle_process_health(
+        _EnterRecorder(),
+        "agent-1",
+        "drained",
+        LITELLM_TEAM_CAP,
+    )
+    assert entered == [("agent-1", None, True)]
+
+
+def test_enter_drained_as_a_cap_says_so_and_marks_the_episode(tmp_path, monkeypatch):
+    """The status line must name the gateway cap, not a plan window that
+    will 'reset' — an operator reading the old text would wait for nothing."""
+    from puffo_agent.agent._usage_markers import (
+        BUDGET_EXCEEDED_RUNTIME_ERROR,
+        DRAINED_RUNTIME_ERROR,
+    )
+
+    monkeypatch.setenv("PUFFO_HOME", str(tmp_path))
+    worker = _worker_for_health_tests(tmp_path, monkeypatch)
+    worker._enter_drained("agent-1", None, budget_cap=True)
+    assert worker.runtime.health == "drained"
+    assert worker.runtime.error == BUDGET_EXCEEDED_RUNTIME_ERROR
+    assert worker._drained_budget_cap is True
+
+    worker.runtime.health = "ok"
+    worker._enter_drained("agent-1", 1780000000)
+    assert worker.runtime.error == DRAINED_RUNTIME_ERROR
+    assert worker._drained_budget_cap is False
+
+
+def test_usage_snapshot_does_not_clear_a_budget_cap():
+    """Plan headroom on the host says nothing about a gateway cap. A
+    recovered snapshot used to flip every drained worker back to ok; for a
+    cap that just re-probes a wall every snapshot cycle."""
+    from puffo_agent.portal.control.usage_snapshot import _apply_to_live_worker
+
+    cleared = []
+
+    class _Worker:
+        _drained_budget_cap = True
+        runtime = type("RT", (), {"health": "drained"})()
+
+        @staticmethod
+        def _clear_drained(runtime, agent_id, log):
+            cleared.append(agent_id)
+
+    _apply_to_live_worker(_Worker(), "agent-1", (False, None))
+    assert cleared == []
+
+    class _PlanWorker(_Worker):
+        _drained_budget_cap = False
+
+    _apply_to_live_worker(_PlanWorker(), "agent-2", (False, None))
+    assert cleared == ["agent-2"]
+
+
+# ── Timed hold on the runtime ──────────────────────────────────────────
+
+
+class _Coalescer:
+    def __init__(self):
+        self.delays: list[float] = []
+
+    def notify(self, delay_seconds=0.0):
+        self.delays.append(delay_seconds)
+
+
+def _gated_runtime(drained_check=None):
+    from puffo_agent.agent.global_inbox_degraded import DegradedRecoveryMixin
+
+    class _Gated(DegradedRecoveryMixin):
+        pass
+
+    rt = _Gated()
+    rt.coalescer = _Coalescer()
+    rt._init_recovery_gates(drained_check)
+    return rt
+
+
+def test_budget_park_holds_through_wakes_then_probes_once(monkeypatch):
+    """A cap has no window to wait for and no snapshot will clear it on a
+    sandbox, so the hold IS the exit: swallow wakes until it expires, then
+    let exactly one turn through regardless of the snapshot's opinion."""
+    from puffo_agent.agent import global_inbox_degraded as mod
+
+    now = [1000.0]
+    monkeypatch.setattr(mod.time, "monotonic", lambda: now[0])
+    rt = _gated_runtime(drained_check=lambda: True)  # snapshot still says spent
+
+    rt._park_drained(hold_seconds=300.0, diagnostic="gateway budget cap")
+    assert rt.health.state == "degraded"
+    assert "budget cap" in rt.health.diagnostic
+    assert rt.coalescer.delays == [300.0]
+
+    now[0] += 120.0
+    assert rt._drained_park_allows_processing() is False
+    assert rt.coalescer.delays[-1] == 180.0  # re-armed for the remainder
+
+    now[0] += 200.0
+    assert rt._drained_park_allows_processing() is True  # the probe
+    assert rt._parked_drained is False
+    assert rt._drained_park_until is None
+
+
+def test_plan_park_still_waits_for_the_snapshot():
+    """The untimed park is unchanged: a plan drain is cleared by the host's
+    usage snapshot, not a timer."""
+    rt = _gated_runtime(drained_check=lambda: True)
+    rt._park_drained()
+    assert rt._drained_park_until is None
+    assert rt._drained_park_allows_processing() is False
+    rt.drained_check = lambda: False
+    assert rt._drained_park_allows_processing() is True
+
+
+def test_budget_hold_escalates_and_resets_on_success():
+    rt = _gated_runtime()
+    assert [rt.next_budget_park_hold() for _ in range(5)] == [
+        300.0,
+        600.0,
+        1200.0,
+        1800.0,
+        1800.0,
+    ]
+    rt._clear_budget_park_backoff()
+    assert rt.next_budget_park_hold() == 300.0
+
+
+def test_notify_does_not_release_a_budget_hold(monkeypatch):
+    """``notify()`` clears the degraded backoff on every wake — an inbound
+    message must not turn into a probe while the hold is running."""
+    from puffo_agent.agent import global_inbox_degraded as mod
+
+    now = [5000.0]
+    monkeypatch.setattr(mod.time, "monotonic", lambda: now[0])
+    rt = _gated_runtime()
+    rt._park_drained(hold_seconds=300.0)
+    rt._clear_degraded_backoff()  # what notify() does
+    assert rt._parked_drained is True
+    assert rt._drained_park_allows_processing() is False
+
+
+def _failure_runtime(monkeypatch, now):
+    """A GlobalInboxRuntime with just enough wired for the failure path."""
+    from puffo_agent.agent import global_inbox_degraded as mod
+    from puffo_agent.agent.global_inbox_runtime import GlobalInboxRuntime
+
+    monkeypatch.setattr(mod.time, "monotonic", lambda: now[0])
+    rt = GlobalInboxRuntime.__new__(GlobalInboxRuntime)
+    rt.agent_id = "agent-1"
+    rt.coalescer = _Coalescer()
+    rt._turn_state_lock = asyncio.Lock()
+    rt.active = type(
+        "Active", (), {"provider_session_id": "s", "provider_turn_id": "t"}
+    )()
+    rt._init_recovery_gates(None)
+
+    async def _requeue(planned, started, category):
+        return True
+
+    rt._requeue_active_turn = _requeue
+    return rt
+
+
+def _planned():
+    return type(
+        "Planned", (), {"turn_id": "turn-1", "notice_generation": 0, "targets": ()}
+    )()
+
+
+def test_budget_cap_failure_parks_on_an_escalating_hold(monkeypatch):
+    """The failure handler is where the two drains fork: a cap gets the
+    timed hold (5 → 10 min across consecutive hits), a plan window gets
+    the untimed park the usage snapshot clears."""
+    now = [100.0]
+    rt = _failure_runtime(monkeypatch, now)
+
+    terminal, outcome, text = asyncio.run(
+        rt._handle_process_failure(
+            _planned(), 0.0, AgentAPIError(LITELLM_TEAM_CAP, is_drained=True)
+        )
+    )
+    assert (terminal, outcome) == (True, "drained")
+    assert rt._parked_drained is True
+    assert rt._drained_park_until == 400.0
+    assert "gateway budget cap" in rt.health.diagnostic
+    assert rt.coalescer.delays == [300.0]
+
+    now[0] = 400.0
+    assert rt._drained_park_allows_processing() is True  # the probe
+    asyncio.run(
+        rt._handle_process_failure(
+            _planned(), 0.0, AgentAPIError(LITELLM_KEY_CAP, is_drained=True)
+        )
+    )
+    assert rt._drained_park_until == 1000.0  # 600s: it escalated
+
+    rt._clear_budget_park_backoff()  # what a completed turn does
+    assert rt.next_budget_park_hold() == 300.0
+
+
+def test_plan_drain_failure_keeps_the_untimed_park(monkeypatch):
+    rt = _failure_runtime(monkeypatch, [100.0])
+    asyncio.run(
+        rt._handle_process_failure(
+            _planned(),
+            0.0,
+            AgentAPIError("Claude AI usage limit reached|1780000000", is_drained=True),
+        )
+    )
+    assert rt._parked_drained is True
+    assert rt._drained_park_until is None
+    assert rt.coalescer.delays == []


### PR DESCRIPTION
Linear: PUF-382 · pairs with cloud-infra #167 (gateway side: `disable_budget_reservation`).

## What broke

LiteLLM rejects a request over its team/key cap with `429 Budget has been exceeded!`. That text matched no usage marker in `_usage_markers`, so `classify_provider_failure` fell through to `rate_limit` — retryable — and the `claude` CLI's own 429 backoff retried underneath that. On 2026-09-08 four staging agents produced ~1,359 rejections in a day at up to ~180 req/min, each counted by the gateway against the same budget, and none of them could speak in NorthStar until the wallet was topped up.

## What changes

| Layer | Before | After |
|---|---|---|
| `_usage_markers` | budget wording → `rate_limit` | → drained; `looks_like_budget_cap()` distinguishes a cap from a plan window |
| runtime (`global_inbox_degraded/_runtime`) | drained park cleared only by the host `/usage` snapshot — which a sandbox never gets | cap → **timed hold** 5 → 10 → 20 → 30 min (reset on a completed turn), wakes during the hold re-arm it, one probe when it expires; plan-window park unchanged |
| worker | `_enter_drained(agent_id, resets_at)` | `+ budget_cap=`; status error and operator DM say "budget exceeded at the gateway", no predicted reset; usage snapshot does **not** clear a cap |
| `local_runtime` | CLI retries 429s with its default backoff | gateway-routed agents launch with `CLAUDE_CODE_MAX_RETRIES=2` |

`CLAUDE_CODE_MAX_RETRIES` is not in `ENV_OVERRIDE_WHITELIST`, so there is no operator override to respect; it is set unconditionally when a gateway key is present.

## Tests

- `test_drained_state.py`: LiteLLM team / key / user-limiter wording → drained + `plan_drained`; cap is a strict subset of drained; settle routes a cap with `budget_cap=True`; ENTER sets the cap error and marks the episode; usage snapshot leaves a cap alone; hold blocks wakes and re-arms, then probes once regardless of the snapshot; plan park still waits for the snapshot; hold escalates and resets; `notify()` cannot release a hold; failure handler picks the hold and escalates it / keeps the untimed park for a plan window.
- `test_claude_api_key_policy.py`: gateway spec carries `CLAUDE_CODE_MAX_RETRIES=2`; direct-provider spec does not.
- Every guard was mutation-checked: removing it fails its test.
- Full suite green locally (see the run in the PR conversation).

## Not in this PR

- The gateway's own reservation inflation — cloud-infra #167.
- Any change to the `codex` harness's retry knobs (no gateway budget wording observed there yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH1X6t2bVu8PxgeX4Wg4sG
