### PR TITLE
fix(pi): read per-turn usage from the message_end message object

### DIFF
--- a/src/puffo_agent/agent/harness/drivers/pi.py
+++ b/src/puffo_agent/agent/harness/drivers/pi.py
@@ -559,7 +559,7 @@ class PiDriver(Driver):
             native_turn_id=self._active.value,
         ):
             if event.type == HarnessEventType.CONTEXT_UPDATED:
-                self._turn_usage = dict(event.data)
+                self._absorb_turn_usage(event.data)
             if event.type == HarnessEventType.RUNTIME_WARNING:
                 code = event.data.get("code")
                 if code == "assistant_error":
@@ -685,6 +685,19 @@ class PiDriver(Driver):
                 native_payload=native_payload,
             )
         )
+
+    def _absorb_turn_usage(self, usage: dict[str, Any]) -> None:
+        """Pi reports usage once per assistant response, and one Puffo turn
+        holds several response/tool cycles. Token counts accumulate across
+        responses; ``context_tokens`` is a running context size, so only the
+        newest snapshot stands."""
+        merged = dict(self._turn_usage)
+        for key, value in usage.items():
+            if key == "context_tokens":
+                merged[key] = value
+            else:
+                merged[key] = merged.get(key, 0) + value
+        self._turn_usage = merged
 
     def _reset_turn(self) -> None:
         self._turn_outcome = "succeeded"

--- a/src/puffo_agent/agent/harness/drivers/pi_protocol.py
+++ b/src/puffo_agent/agent/harness/drivers/pi_protocol.py
@@ -197,7 +197,12 @@ def _normalize_pi_lifecycle(
         events: list[HarnessEvent] = [
             event(HarnessEventType.ASSISTANT_COMPLETED, {"block_id": ""})
         ]
-        usage = _usage_data(frame.get("usage"))
+        # Pi puts per-turn usage on the message object, not the frame:
+        # a captured 0.8x ``message_end`` frame has only {message, type} at
+        # the top level. The frame-level read is kept first for older
+        # emitters that did report it there.
+        message_usage = message.get("usage") if isinstance(message, dict) else None
+        usage = _usage_data(frame.get("usage") or message_usage)
         if usage:
             events.append(event(HarnessEventType.CONTEXT_UPDATED, usage))
         return tuple(events)
@@ -461,6 +466,7 @@ def _usage_data(usage: Any) -> dict[str, int]:
         "output_tokens": _nonnegative_int(usage.get("output")),
         "cache_read_tokens": _nonnegative_int(usage.get("cacheRead")),
         "cache_write_tokens": _nonnegative_int(usage.get("cacheWrite")),
+        "reasoning_tokens": _nonnegative_int(usage.get("reasoning")),
         "context_tokens": _nonnegative_int(usage.get("totalTokens")),
     }
 

--- a/tests/test_pi_driver.py
+++ b/tests/test_pi_driver.py
@@ -489,6 +489,54 @@ async def test_extension_vetoed_resume_is_a_failure_not_a_success():
 
 
 @pytest.mark.asyncio
+async def test_turn_usage_accumulates_across_assistant_responses():
+    """Pi reports usage once per assistant response; a Puffo turn holds many.
+
+    Overwriting on each response would report only the final tool-loop leg's
+    tokens at turn end. Context size is a running snapshot, not a sum.
+    """
+    proc = FakePiProcess()
+    driver, _ = await _open(proc)
+    started = asyncio.create_task(driver.start_turn(TurnInput("hello")))
+    await proc.answer_next()
+    await started
+
+    def usage(inp, out, reasoning, total):
+        return {
+            "input": inp,
+            "output": out,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "reasoning": reasoning,
+            "totalTokens": total,
+        }
+
+    for frame in (
+        {"type": "agent_start"},
+        {
+            "type": "message_end",
+            "message": {"role": "assistant", "usage": usage(100, 10, 4, 1000)},
+        },
+        {
+            "type": "message_end",
+            "message": {"role": "assistant", "usage": usage(250, 30, 6, 1400)},
+        },
+        {"type": "agent_end", "willRetry": False},
+        {"type": "agent_settled"},
+    ):
+        proc.push(frame)
+
+    events = await _drain_events(driver, 7)
+    terminal = events[-1]
+    assert terminal.type == HarnessEventType.TURN_COMPLETED
+    assert terminal.data["input_tokens"] == 350
+    assert terminal.data["output_tokens"] == 40
+    assert terminal.data["reasoning_tokens"] == 10
+    assert terminal.data["context_tokens"] == 1400
+    await driver.close()
+
+
+@pytest.mark.asyncio
 async def test_exactly_one_terminal_arrives_at_agent_settled():
     """A full run emits its single TURN_COMPLETED only once settled."""
     proc = FakePiProcess()

--- a/tests/test_pi_driver.py
+++ b/tests/test_pi_driver.py
@@ -333,6 +333,36 @@ def test_pi_turn_events_do_not_become_puffo_turn_boundaries():
         }
 
 
+def test_message_end_reads_usage_from_the_message_object():
+    """Captured 0.8x ``message_end`` frames carry usage only on the message.
+
+    Reading the frame top level alone left the turn's usage empty, so every
+    Pi turn reported input/output as 0/0 downstream.
+    """
+    events = normalize_pi_event(
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "usage": {
+                    "input": 1050,
+                    "output": 5,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "reasoning": 24,
+                    "totalTokens": 1055,
+                },
+            },
+        },
+        session_ref=SessionRef("s"),
+        turn_ref=TurnRef("t"),
+    )
+    usage = {e.type: e for e in events}[HarnessEventType.CONTEXT_UPDATED].data
+    assert usage["input_tokens"] == 1050
+    assert usage["output_tokens"] == 5
+    assert usage["reasoning_tokens"] == 24
+
+
 def test_queue_update_reports_counts_not_queued_message_text():
     events = normalize_pi_event(
         {


### PR DESCRIPTION
## Problem
Staging QA (web "Done 0/0" on every Pi turn) traced to the Pi driver reading per-turn usage from the frame top level: `pi_protocol.py` message_end branch calls `_usage_data(frame.get("usage"))`, but a captured Pi 0.8x `message_end` frame has only `{message, type}` at the top level — the usage object lives at `message.usage` (real capture: `input=1050, output=5`). `_turn_usage` therefore stays empty, TURN_COMPLETED carries no token fields, `TurnResult(0,0)` reaches the reporter, and the web Logs show Done 0/0 while the native Pi session records non-zero usage.

## Fix
- Read `message.usage` when the frame-level field is absent (frame-level kept first for older emitters).
- Map `reasoning` → `reasoning_tokens` in `_usage_data` (present in captured frames, previously dropped). Note: `runtime_manager` forwards only input/output/context to `TurnResult`; reasoning stays at the harness-event level for now.

## Evidence / tests
- New regression test uses the captured frame shape; mutation-checked (fails on the old frame-level read, passes with the fix).
- `tests/test_pi_driver.py` + `tests/test_pi_rpc_conformance.py`: 74 passed. pre-commit (incl. structural limits) green on changed files.

Found during staging 2.0.4a2 QA (agent-harness-adapter channel, 9/9); fix should ride the next staging alpha (2.0.4a3) so the Done token retest runs against a published artifact.

*(pushed with operator credentials on behalf of agent linus-torv-7742-c643a3f4)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)