### PR TITLE
fix(oracle): track LingTai's current authority API; make dropped continuations audible

### DIFF
--- a/scripts/verify_lingtai_driver_authority.py
+++ b/scripts/verify_lingtai_driver_authority.py
@@ -27,12 +27,32 @@ now documented as "correlation material only ... never a grant".
 So this oracle now checks COUNTS on both sides -- exactly one adjudication and
 exactly one provider call -- which still reddens ``replay`` (two adjudications)
 and ``fanout`` (two provider calls).  It does NOT check request-to-response
-CORRELATION, and it cannot: nothing observable from outside binds a particular
-provider call to a particular adjudication.  A provider call executing under a
-DIFFERENT adjudication's id would pass every assertion here.
+CORRELATION: a provider call executing under a DIFFERENT adjudication's id
+would pass every assertion here.  Do not read a green run as covering that axis.
 
-Do not read a green run as covering that axis.  Closing it needs either a
-LingTai-side observable or a test inside LingTai; it is not an oracle bug.
+An earlier version of this note claimed the correlation check "cannot" be
+restored because nothing observable binds a call to an adjudication.  That
+claim was wrong -- asserted without enumerating what is actually reachable.
+At least two candidate observables exist:
+
+* ``lingtai.kernel.provider_admission.current_provider_admission()`` is
+  exported and readable at the provider call site; ``RootProviderAdmission``
+  carries ``correlation_id``, documented as audit/routing material.  This is
+  ROOT-TURN scoped, not per-call.
+* ``AuthorityAuditRecord.call_id`` on the Puffo side is the client-supplied
+  per-call id echoed back into the audit record.
+
+Whether those two join into a genuine per-call correlation is UNVERIFIED.
+Note the granularity trap: the accessor LingTai removed
+(``current_provider_call_audit_id``) was the PER-CALL one, while the surviving
+``correlation_id`` hangs off ``RootProviderAdmission`` and is ROOT-TURN scoped.
+So restoring per-call correlation forks into either (a) a LingTai-side per-call
+observable, which first needs to establish why the old accessor was deliberately
+removed -- a design decision, not an oracle question -- or (b) threading the
+Puffo-side ``call_id`` end to end.  Neither branch has been shown to work.
+
+The honest status is therefore "not currently checked, closability unverified",
+not "impossible".
 """
 
 from __future__ import annotations

--- a/scripts/verify_lingtai_driver_authority.py
+++ b/scripts/verify_lingtai_driver_authority.py
@@ -15,6 +15,24 @@ Run it from the Puffo repository root, naming the LingTai checkout explicitly:
 
 Repeat with ``replay`` and ``fanout``.  Baseline must exit 0; both negative
 modes must exit non-zero at their respective count assertions.
+
+COVERAGE NOTE — what this oracle stopped verifying, and why
+-----------------------------------------------------------
+It once asserted that the provider call ran under *the same audit id* as the
+adjudication that admitted it, by reading ``current_provider_call_audit_id()``
+inside the provider.  LingTai removed that accessor: the audit id is no longer
+propagated to the provider call site, and ``ProviderCallDecision.audit_id`` is
+now documented as "correlation material only ... never a grant".
+
+So this oracle now checks COUNTS on both sides -- exactly one adjudication and
+exactly one provider call -- which still reddens ``replay`` (two adjudications)
+and ``fanout`` (two provider calls).  It does NOT check request-to-response
+CORRELATION, and it cannot: nothing observable from outside binds a particular
+provider call to a particular adjudication.  A provider call executing under a
+DIFFERENT adjudication's id would pass every assertion here.
+
+Do not read a green run as covering that axis.  Closing it needs either a
+LingTai-side observable or a test inside LingTai; it is not an oracle bug.
 """
 
 from __future__ import annotations
@@ -49,23 +67,21 @@ def _load_components(lingtai_src: Path) -> tuple[Any, ...]:
     # any installed copy; the explicitly named LingTai checkout is second.
     sys.path[:0] = [str(puffo_src), str(lingtai_src)]
 
-    from lingtai.adapters.acp.driver_authority import DriverAuthorityAdapter
+    from lingtai.adapters.acp.driver_authority import DriverAuthorityClient
     from lingtai.kernel.provider_admission import (
         ProviderAdmittedLLMService,
         RootProviderAdmission,
         bind_provider_admission,
         clear_provider_admission,
-        current_provider_call_audit_id,
     )
     from puffo_agent.agent.harness.driver_authority_server import DriverAuthorityServer
 
     return (
-        DriverAuthorityAdapter,
+        DriverAuthorityClient,
         ProviderAdmittedLLMService,
         RootProviderAdmission,
         bind_provider_admission,
         clear_provider_admission,
-        current_provider_call_audit_id,
         DriverAuthorityServer,
     )
 
@@ -79,9 +95,14 @@ def _require(condition: bool, message: str) -> None:
 def _validate_oracle(
     adjudications: list[str],
     provider_calls: list[str | None],
-    trace_after_call: str | None,
 ) -> str:
-    """Validate the one-adjudication/one-provider-call delivery contract."""
+    """Validate the one-adjudication/one-provider-call delivery contract.
+
+    LingTai removed the per-call audit id, so a provider call can no longer be
+    matched to its adjudication BY IDENTITY: fan-out is caught by the call
+    COUNT alone, and the post-call leak check is gone entirely. See the
+    coverage note in the module docstring for what that costs.
+    """
     _require(
         len(adjudications) == 1,
         f"expected one adjudication, observed {len(adjudications)}",
@@ -89,10 +110,9 @@ def _validate_oracle(
     audit_id = adjudications[0]
     _require(isinstance(audit_id, str), "adjudication audit ID is not a string")
     _require(
-        provider_calls == [audit_id],
-        "provider call count or audit ID does not match the adjudication",
+        len(provider_calls) == 1,
+        f"expected one provider call, observed {len(provider_calls)}",
     )
-    _require(trace_after_call is None, "provider audit context leaked after the call")
     return audit_id
 
 
@@ -103,7 +123,6 @@ def main(*, mode: str, lingtai_src: Path) -> None:
         root_provider_admission,
         bind_provider_admission,
         clear_provider_admission,
-        current_provider_call_audit_id,
         driver_authority_server,
     ) = _load_components(lingtai_src)
 
@@ -112,11 +131,14 @@ def main(*, mode: str, lingtai_src: Path) -> None:
             self.provider_calls: list[str | None] = []
             self.fanout = fanout
 
-        def generate(self, _prompt: str) -> str:
-            audit_id = current_provider_call_audit_id()
-            self.provider_calls.append(audit_id)
+        def generate(self, prompt: str) -> str:
+            # The admitting audit id is no longer observable here — LingTai
+            # deliberately stopped propagating it to the provider call site
+            # (``ProviderCallDecision.audit_id`` is documented as correlation
+            # material only).  Record the prompt so fan-out is still counted.
+            self.provider_calls.append(prompt)
             if self.fanout:
-                self.provider_calls.append(audit_id)
+                self.provider_calls.append(prompt)
             return "generated"
 
     server = driver_authority_server()
@@ -147,12 +169,10 @@ def main(*, mode: str, lingtai_src: Path) -> None:
         print(f"mode={mode}")
         print(f"adjudications={len(adjudications)} ids={adjudications}")
         print(f"provider_calls={len(inner.provider_calls)} ids={inner.provider_calls}")
-        print(f"trace_after_call={current_provider_call_audit_id()!r}")
 
         _validate_oracle(
             adjudications,
             inner.provider_calls,
-            current_provider_call_audit_id(),
         )
     finally:
         if adapter is not None:

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -364,7 +364,7 @@ class RuntimeManager:
         self.native_turn_id = ""
         self._terminal.pop(logical, None)
         self._permission_refs.clear()
-        self._continuation_admissions.clear()
+        self._discard_pending_admissions("turn_abandoned")
         if not retire:
             return
         # Keep session: close prevents overlap; dead -> invalid_resume.
@@ -1044,7 +1044,34 @@ class RuntimeManager:
         self._active_driver_turn_ref = None
         self.native_turn_id = ""
         self._permission_refs.clear()
+        self._discard_pending_admissions("turn_completed")
+
+    def _discard_pending_admissions(self, reason: str) -> None:
+        """Drop staged continuations at a turn boundary, audibly.
+
+        A continuation is retired here only when no tool result ever released
+        it.  On the ACP path that is the visible end of a lost post-commit
+        receipt: the argument-correlation fallback is unreachable (those facts
+        carry no ``arguments``), so nothing else can admit it, and the
+        mismatch warning below is never reached either.  Dropping silently
+        left the symptom -- a continuation that never fires -- with no trace
+        on the side that actually experiences it.
+
+        Deliberate cancellation (``register_continuation_callback(None)``)
+        clears the list directly and is NOT routed here: a signal that also
+        fires on the intended case stops being read.
+        """
+        pending = len(self._continuation_admissions)
         self._continuation_admissions.clear()
+        if not pending:
+            return
+        logger.warning(
+            "continuation admissions discarded without a tool result "
+            "reason=%s count=%d native_turn=%s",
+            reason,
+            pending,
+            self.native_turn_id or "",
+        )
 
     def register_continuation(
         self,

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -358,13 +358,14 @@ class RuntimeManager:
         self, logical: TurnRef, *, retire: bool
     ) -> None:
         # admission unknown -> retry must replay the durable payload
+        provider_turn_id = self.native_turn_id
         self._input_admitted = False
         self.active_turn_ref = None
         self._active_driver_turn_ref = None
         self.native_turn_id = ""
         self._terminal.pop(logical, None)
         self._permission_refs.clear()
-        self._discard_pending_admissions("turn_abandoned")
+        self._discard_pending_admissions("turn_abandoned", provider_turn_id)
         if not retire:
             return
         # Keep session: close prevents overlap; dead -> invalid_resume.
@@ -1040,13 +1041,16 @@ class RuntimeManager:
             future.set_result(event)
         if self._active_driver_turn_ref is not None:
             self._turn_refs.pop(self._active_driver_turn_ref, None)
+        provider_turn_id = self.native_turn_id
         self.active_turn_ref = None
         self._active_driver_turn_ref = None
         self.native_turn_id = ""
         self._permission_refs.clear()
-        self._discard_pending_admissions("turn_completed")
+        self._discard_pending_admissions("turn_completed", provider_turn_id)
 
-    def _discard_pending_admissions(self, reason: str) -> None:
+    def _discard_pending_admissions(
+        self, reason: str, provider_turn_id: str
+    ) -> None:
         """Drop staged continuations at a turn boundary, audibly.
 
         A continuation is retired here only when no tool result ever released
@@ -1060,6 +1064,11 @@ class RuntimeManager:
         Deliberate cancellation (``register_continuation_callback(None)``)
         clears the list directly and is NOT routed here: a signal that also
         fires on the intended case stops being read.
+
+        ``provider_turn_id`` is passed in, not read off ``self``: every call
+        site resets ``native_turn_id`` as part of the same teardown, so
+        reading it here would have logged an empty field on every single
+        discard -- an attribution slot that looks populated and never is.
         """
         pending = len(self._continuation_admissions)
         self._continuation_admissions.clear()
@@ -1070,7 +1079,7 @@ class RuntimeManager:
             "reason=%s count=%d provider_turn_id=%s",
             reason,
             pending,
-            self.native_turn_id or "",
+            provider_turn_id or "",
         )
 
     def register_continuation(

--- a/src/puffo_agent/agent/harness/runtime/runtime_manager.py
+++ b/src/puffo_agent/agent/harness/runtime/runtime_manager.py
@@ -1066,8 +1066,8 @@ class RuntimeManager:
         if not pending:
             return
         logger.warning(
-            "continuation admissions discarded without a tool result "
-            "reason=%s count=%d native_turn=%s",
+            "puffo_admission_continuation_discarded "
+            "reason=%s count=%d provider_turn_id=%s",
             reason,
             pending,
             self.native_turn_id or "",

--- a/tests/test_acp_receipt_loss_probe.py
+++ b/tests/test_acp_receipt_loss_probe.py
@@ -86,3 +86,58 @@ async def test_receipt_lost_on_acp_is_never_admitted():
     )
     assert admitted == [], "fallback unexpectedly released the admission"
     assert len(manager._continuation_admissions) == 1, "admission should still hang"
+
+
+@pytest.mark.asyncio
+async def test_lost_receipt_is_audible_when_the_turn_ends(caplog):
+    """The Puffo-side signal: a continuation dropped un-released is logged."""
+    driver, manager = await _fresh()
+    admitted = []
+    manager.register_continuation(
+        _recorder(admitted), "cycle", tool_names=("read_inbox",),
+        tool_arguments={"limit": 1}, correlation_receipt="receipt-x",
+    )
+    await manager._admit_matching_tool_result(
+        _acp_fact(manager, driver, call_id="c1", receipt="receipt-x", committed=False)
+    )
+    assert admitted == []
+    with caplog.at_level("WARNING"):
+        manager._discard_pending_admissions("turn_completed")
+    assert "continuation admissions discarded without a tool result" in caplog.text
+    assert "count=1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_released_continuation_leaves_no_warning(caplog):
+    """Negative control: the signal must not fire when nothing was lost."""
+    driver, manager = await _fresh()
+    admitted = []
+    manager.register_continuation(
+        _recorder(admitted), "cycle", tool_names=("read_inbox",),
+        tool_arguments={"limit": 1}, correlation_receipt="receipt-x",
+    )
+    await manager._admit_matching_tool_result(
+        _acp_fact(manager, driver, call_id="c1", receipt="receipt-x", committed=True)
+    )
+    assert len(admitted) == 1
+    with caplog.at_level("WARNING"):
+        manager._discard_pending_admissions("turn_completed")
+    assert "continuation admissions discarded" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_deliberate_cancellation_stays_silent(caplog):
+    """A signal that also fires on the intended case stops being read."""
+    from puffo_agent.agent.harness.runtime.runtime_manager import RuntimeManagerAdapter
+
+    driver, manager = await _fresh()
+    admitted = []
+    manager.register_continuation(
+        _recorder(admitted), "cycle", tool_names=("read_inbox",),
+        tool_arguments={"limit": 1}, correlation_receipt="receipt-x",
+    )
+    adapter = RuntimeManagerAdapter(manager)
+    with caplog.at_level("WARNING"):
+        adapter.register_continuation_callback(None)
+    assert not manager._continuation_admissions
+    assert "continuation admissions discarded" not in caplog.text

--- a/tests/test_acp_receipt_loss_probe.py
+++ b/tests/test_acp_receipt_loss_probe.py
@@ -1,0 +1,88 @@
+"""Measure what Puffo does when the ACP committed-fact receipt never arrives.
+
+Question under test (Boris, for the LingTai admission-loss A/B decision):
+when the reliable receipt is lost, does the argument-correlation fallback in
+``_admit_matching_tool_result`` still release the pending continuation?
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+
+from puffo_agent.agent.harness.driver import HarnessEvent, SessionRef, TurnInput
+from puffo_agent.agent.harness.runtime.runtime_manager import (
+    RuntimeManager,
+    RuntimeSpec,
+)
+from test_runtime_manager_failures import _ControllableDriver
+
+
+def _acp_fact(manager, driver, *, call_id, receipt, committed, tool_name="read_inbox"):
+    """An ACP-shaped tool_result fact -- exactly the keys acp.py emits."""
+    native = {
+        "_puffo_internal": "tool_result",
+        "tool_call_id": call_id,
+        "tool_name": tool_name,
+        "is_error": False,
+    }
+    if committed:
+        native["provider_context_committed"] = True
+        native["admission_binding"] = hashlib.sha256(
+            f"{call_id}\x00{receipt}".encode("utf-8")
+        ).hexdigest()
+    return HarnessEvent.normalized(
+        type="turn.tool_completed",
+        driver="acp",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        native_session_id=manager.native_session_id,
+        native_turn_id=manager.native_turn_id,
+        data={"tool_call_ref": call_id, "label": tool_name, "outcome": "succeeded"},
+        native_payload=native,
+    )
+
+
+def _recorder(sink):
+    async def _cb(event):
+        sink.append(event)
+    return _cb
+
+
+async def _fresh():
+    driver = _ControllableDriver()
+    manager = RuntimeManager(driver, RuntimeSpec("/tmp"), driver_name="acp")
+    await manager.open()
+    await manager.start_turn(TurnInput("notice"))
+    return driver, manager
+
+
+@pytest.mark.asyncio
+async def test_control_receipt_present_admits():
+    """Positive control: with the receipt, the continuation IS released."""
+    driver, manager = await _fresh()
+    admitted = []
+    manager.register_continuation(
+        _recorder(admitted), "cycle", tool_names=("read_inbox",),
+        tool_arguments={"limit": 1}, correlation_receipt="receipt-x",
+    )
+    await manager._admit_matching_tool_result(
+        _acp_fact(manager, driver, call_id="c1", receipt="receipt-x", committed=True)
+    )
+    assert len(admitted) == 1
+    assert not manager._continuation_admissions
+
+
+@pytest.mark.asyncio
+async def test_receipt_lost_on_acp_is_never_admitted():
+    """The measurement: receipt lost -> fallback CANNOT rescue it on ACP."""
+    driver, manager = await _fresh()
+    admitted = []
+    manager.register_continuation(
+        _recorder(admitted), "cycle", tool_names=("read_inbox",),
+        tool_arguments={"limit": 1}, correlation_receipt="receipt-x",
+    )
+    await manager._admit_matching_tool_result(
+        _acp_fact(manager, driver, call_id="c1", receipt="receipt-x", committed=False)
+    )
+    assert admitted == [], "fallback unexpectedly released the admission"
+    assert len(manager._continuation_admissions) == 1, "admission should still hang"

--- a/tests/test_acp_receipt_loss_probe.py
+++ b/tests/test_acp_receipt_loss_probe.py
@@ -103,7 +103,7 @@ async def test_lost_receipt_is_audible_when_the_turn_ends(caplog):
     assert admitted == []
     with caplog.at_level("WARNING"):
         manager._discard_pending_admissions("turn_completed")
-    assert "continuation admissions discarded without a tool result" in caplog.text
+    assert "puffo_admission_continuation_discarded" in caplog.text
     assert "count=1" in caplog.text
 
 
@@ -122,7 +122,7 @@ async def test_a_released_continuation_leaves_no_warning(caplog):
     assert len(admitted) == 1
     with caplog.at_level("WARNING"):
         manager._discard_pending_admissions("turn_completed")
-    assert "continuation admissions discarded" not in caplog.text
+    assert "puffo_admission_continuation_discarded" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -140,4 +140,4 @@ async def test_deliberate_cancellation_stays_silent(caplog):
     with caplog.at_level("WARNING"):
         adapter.register_continuation_callback(None)
     assert not manager._continuation_admissions
-    assert "continuation admissions discarded" not in caplog.text
+    assert "puffo_admission_continuation_discarded" not in caplog.text

--- a/tests/test_acp_receipt_loss_probe.py
+++ b/tests/test_acp_receipt_loss_probe.py
@@ -102,9 +102,10 @@ async def test_lost_receipt_is_audible_when_the_turn_ends(caplog):
     )
     assert admitted == []
     with caplog.at_level("WARNING"):
-        manager._discard_pending_admissions("turn_completed")
+        manager._discard_pending_admissions("turn_completed", "turn-direct")
     assert "puffo_admission_continuation_discarded" in caplog.text
     assert "count=1" in caplog.text
+    assert "provider_turn_id=turn-direct" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -121,7 +122,7 @@ async def test_a_released_continuation_leaves_no_warning(caplog):
     )
     assert len(admitted) == 1
     with caplog.at_level("WARNING"):
-        manager._discard_pending_admissions("turn_completed")
+        manager._discard_pending_admissions("turn_completed", "turn-direct")
     assert "puffo_admission_continuation_discarded" not in caplog.text
 
 
@@ -141,3 +142,41 @@ async def test_deliberate_cancellation_stays_silent(caplog):
         adapter.register_continuation_callback(None)
     assert not manager._continuation_admissions
     assert "puffo_admission_continuation_discarded" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_the_real_turn_boundary_still_carries_the_turn_id(caplog):
+    """Regression control for a dead attribution field.
+
+    The tests above call ``_discard_pending_admissions`` directly, so they
+    never execute the teardown that surrounds it.  Both real call sites
+    reset ``native_turn_id`` as part of that teardown, so a version that
+    read the id off ``self`` logged an empty ``provider_turn_id`` on every
+    discard while every assertion above still passed.  This drives
+    ``_complete_turn`` itself and pins the id to a value the fixture set.
+    """
+    driver, manager = await _fresh()
+    admitted = []
+    manager.register_continuation(
+        _recorder(admitted), "cycle", tool_names=("read_inbox",),
+        tool_arguments={"limit": 1}, correlation_receipt="receipt-x",
+    )
+    await manager._admit_matching_tool_result(
+        _acp_fact(manager, driver, call_id="c1", receipt="receipt-x", committed=False)
+    )
+    assert admitted == []
+    manager.native_turn_id = "turn-real-42"
+    done = HarnessEvent.normalized(
+        type="turn.completed",
+        driver="acp",
+        session_ref=SessionRef(manager.native_session_id),
+        turn_ref=driver.turn,
+        native_session_id=manager.native_session_id,
+        native_turn_id=manager.native_turn_id,
+        data={},
+    )
+    with caplog.at_level("WARNING"):
+        manager._complete_turn(done, driver.turn)
+    assert "puffo_admission_continuation_discarded" in caplog.text
+    assert "provider_turn_id=turn-real-42" in caplog.text
+    assert "provider_turn_id= " not in caplog.text

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -210,12 +210,12 @@ def test_acceptance_oracle_checks_survive_python_optimization() -> None:
     code = """
 from scripts.verify_lingtai_driver_authority import _validate_oracle
 
-_validate_oracle(["audit-ok"], ["audit-ok"], None)
+_validate_oracle(["audit-ok"], ["prompt"])
 invalid = (
-    ([], [], None),
-    (["audit-a", "audit-b"], ["audit-a"], None),
-    (["audit-a"], ["audit-b"], None),
-    (["audit-a"], ["audit-a"], "audit-a"),
+    ([], []),
+    (["audit-a", "audit-b"], ["prompt"]),
+    (["audit-a"], ["prompt", "prompt"]),
+    (["audit-a"], []),
 )
 for case in invalid:
     try:
@@ -223,6 +223,15 @@ for case in invalid:
     except SystemExit:
         continue
     raise RuntimeError(f"optimized oracle accepted invalid case: {case!r}")
+
+# Pin the COVERAGE LOSS rather than deleting the cases that no longer fail.
+# LingTai stopped propagating the per-call audit id, so the oracle can no
+# longer tell an adjudication from the call it supposedly authorized, and the
+# post-call leak check is gone.  Both of these once raised; asserting that
+# they now pass keeps the loss visible, and turns any future restoration of
+# identity checking into a red test rather than a silent divergence from the
+# coverage note in the script's docstring.
+_validate_oracle(["audit-a"], ["a-prompt-from-some-other-adjudication"])
 """
     completed = subprocess.run(
         [sys.executable, "-O", "-c", code],


### PR DESCRIPTION
## Why

`scripts/verify_lingtai_driver_authority.py` — our cross-repo check that Puffo still
supplies LingTai's driver authority correctly — **fails at import against LingTai's
current main**. It imports two symbols that no longer exist upstream:

- `DriverAuthorityAdapter` → renamed `DriverAuthorityClient`
- `current_provider_call_audit_id` → **removed outright**

So the check has been silently unrunnable. This restores it, and is explicit about
what it can no longer verify.

## What the second one costs us (please read this part)

The removed symbol was the **per-call** observable. The surviving `correlation_id`
is **root-turn** granularity. So `_validate_oracle` can no longer match a provider
call to its adjudication **by identity** — fan-out is now caught by the call
**count** alone, and the post-call context-leak check is gone. That weakening is
recorded in the module docstring's coverage note rather than papered over.

Closing that gap needs one of: LingTai reintroducing a per-call observable (which
needs their rationale for removing it), or Puffo threading `call_id` end to end.
**Neither has been shown to work** — the note says "not verified", not "impossible".

## Also here

- A lost ACP receipt is pinned to never be admitted by the fallback path.
- A continuation dropped without a tool result now emits a warning with a
  greppable event name (`puffo_admission_continuation_discarded`) instead of
  vanishing. Deliberate cancellation is *not* routed to it.

## Verification

- Rebased onto `main` (`0c16ae6e`). The oracle-script commit needed real
  re-expression, not a replay: `main` had refactored the same file into a
  `_validate_oracle` helper that takes the removed audit id.
- `104 passed` across the ACP / admission / context-controller / runtime-manager
  test files.
- Control run: these commits were green on their old base and **red** on `dev`
  (`test_control_receipt_present_admits` fails there) — `dev` is 53 commits
  behind `main` and lacks the post-commit admission work this builds on. Hence
  `main` as the base, not `dev`.