### PR TITLE
fix(harness): deliver pi/opencode/acp assistant text under the consumed key

### DIFF
--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -731,7 +731,7 @@ class AcpDriver(Driver):
             await self._emit(
                 HarnessEventType.ASSISTANT_DELTA,
                 turn=turn,
-                data={"block_id": block_id, "delta": text},
+                data={"block_id": block_id, "text": text},
                 native_payload=update,
             )
             return

--- a/src/puffo_agent/agent/harness/drivers/opencode_protocol.py
+++ b/src/puffo_agent/agent/harness/drivers/opencode_protocol.py
@@ -91,7 +91,7 @@ def normalize_opencode_frame(
         return (
             event(
                 HarnessEventType.ASSISTANT_DELTA,
-                {"block_id": block_id, "delta": text},
+                {"block_id": block_id, "text": text},
             ),
             event(HarnessEventType.ASSISTANT_COMPLETED, {"block_id": block_id}),
         )

--- a/src/puffo_agent/agent/harness/drivers/pi_protocol.py
+++ b/src/puffo_agent/agent/harness/drivers/pi_protocol.py
@@ -364,7 +364,7 @@ def _normalize_message_update(
         return (
             event(
                 HarnessEventType.ASSISTANT_DELTA,
-                {"block_id": block_id, "delta": str(delta.get("delta") or "")},
+                {"block_id": block_id, "text": str(delta.get("delta") or "")},
             ),
         )
     if delta_type == "text_end":

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -240,7 +240,7 @@ async def test_prompt_admission_updates_and_response_form_one_terminal():
         event for event in events
         if event.type is HarnessEventType.ASSISTANT_DELTA
     )
-    assert delta.data == {"block_id": "message_1", "delta": "answer"}
+    assert delta.data == {"block_id": "message_1", "text": "answer"}
     tool = next(
         event for event in events
         if event.type is HarnessEventType.TOOL_COMPLETED

--- a/tests/test_acp_sdk_conformance.py
+++ b/tests/test_acp_sdk_conformance.py
@@ -122,7 +122,7 @@ async def test_official_sdk_v1_round_trip_streams_update_then_terminal():
         event for event in events
         if event.type is HarnessEventType.ASSISTANT_DELTA
     ]
-    assert delta.data["delta"] == "echo:hello"
+    assert delta.data["text"] == "echo:hello"
     assert events[-1].data["outcome"] == "succeeded"
 
     await asyncio.wait_for(driver.close(), timeout=2)

--- a/tests/test_assistant_text_contract.py
+++ b/tests/test_assistant_text_contract.py
@@ -106,6 +106,11 @@ async def _acp_events() -> list[HarnessEvent]:
                 content=TextContentBlock(type="text", text=chunk),
             ),
         )
+    # Close through the driver's own end-of-turn path rather than posting a
+    # completed event the driver may never send.
+    await driver._finish_turn(
+        TURN, HarnessEventType.TURN_COMPLETED, {"outcome": "succeeded"}
+    )
     events: list[HarnessEvent] = []
     while not driver._events.empty():
         events.append(driver._events.get_nowait())
@@ -232,29 +237,26 @@ async def _run_turn(harness, tmp_path, monkeypatch):
 
     task = asyncio.create_task(adapter.run_turn(ctx))
     await _wait_until(lambda: bool(adapter.manager._turn_refs))
-    # Drivers close their own blocks at different points (pi on text_end,
-    # opencode per frame, acp at end of turn); close whatever is still open so
-    # every harness reaches the projector's emit point the same way.
-    closed = {
-        event.data.get("block_id") for event in driver_events
+    # Every assistant_completed below comes from the harness itself -- pi on
+    # text_end, opencode per text part, acp from _finish_turn -- so the test
+    # cannot pass by closing a block the driver never closes. Only the turn
+    # terminal is supplied here, and only for the harnesses whose terminal is
+    # driver-side rather than part of the normalized frame.
+    assert [
+        event for event in driver_events
         if event.type is HarnessEventType.ASSISTANT_COMPLETED
-    }
-    open_blocks = [
-        block for block in dict.fromkeys(
-            event.data.get("block_id") for event in driver_events
-            if event.type is HarnessEventType.ASSISTANT_DELTA
-        )
-        if block not in closed
-    ]
+    ], f"{harness}: no assistant_completed came from the harness itself"
+    has_terminal = any(
+        event.type is HarnessEventType.TURN_COMPLETED
+        for event in driver_events
+    )
     for event in [
         _lifecycle(HarnessEventType.TURN_STARTED, {}),
         *driver_events,
-        *(
-            _lifecycle(HarnessEventType.ASSISTANT_COMPLETED,
-                       {"block_id": block})
-            for block in open_blocks
-        ),
-        _lifecycle(HarnessEventType.TURN_COMPLETED, {"outcome": "succeeded"}),
+        *([] if has_terminal else [
+            _lifecycle(HarnessEventType.TURN_COMPLETED,
+                       {"outcome": "succeeded"}),
+        ]),
     ]:
         await driver.queue.put(event)
     result = await asyncio.wait_for(task, timeout=5)

--- a/tests/test_assistant_text_contract.py
+++ b/tests/test_assistant_text_contract.py
@@ -65,14 +65,21 @@ def _pi_events() -> list[HarnessEvent]:
 
 
 def _opencode_events() -> list[HarnessEvent]:
-    """Real ``normalize_opencode_frame`` output; each frame carries the text
-    accumulated so far, so the projector must not concatenate them blindly."""
+    """Real ``normalize_opencode_frame`` output for a multi-step answer.
+
+    ``opencode run --format json`` emits one ``text`` frame per completed text
+    part, each with its own part id and its whole text (measured against
+    the shipped binary: a tool-using turn produced ``prt_…MkS`` "START" then
+    ``prt_…USt`` "DONE 42"). Several parts is how one answer arrives in
+    pieces, so that is what the projector has to keep whole.
+    """
     events: list[HarnessEvent] = []
-    for chunk in CHUNKS:
+    for index, chunk in enumerate(CHUNKS):
         events.extend(
             normalize_opencode_frame(
                 {"type": "text", "sessionID": "ses",
-                 "part": {"id": "prt", "type": "text", "text": chunk}},
+                 "part": {"id": f"prt_{index}", "type": "text",
+                          "text": chunk}},
                 session_ref=SESSION,
                 turn_ref=TURN,
             )
@@ -273,17 +280,7 @@ async def test_driver_text_reaches_the_routed_reply(
     )
 
 
-@pytest.mark.parametrize("harness", [
-    "pi",
-    pytest.param("opencode", marks=pytest.mark.xfail(
-        strict=True,
-        reason="opencode closes a block after every text fragment while "
-               "reusing the part id, so the projector emits the first "
-               "fragment and dedupes the rest -- tracked separately from the "
-               "payload-key fix",
-    )),
-    "acp",
-])
+@pytest.mark.parametrize("harness", ["pi", "opencode", "acp"])
 @pytest.mark.asyncio
 async def test_driver_text_reaches_the_profile_log(
     harness, tmp_path, monkeypatch,

--- a/tests/test_assistant_text_contract.py
+++ b/tests/test_assistant_text_contract.py
@@ -1,0 +1,87 @@
+"""Driver text deltas must arrive under the key their consumer reads.
+
+Each driver's own tests pin the payload it emits, and the projector's tests pin
+what it does with a canonical payload — but nothing tied the two together, so
+three drivers shipped ``assistant_delta`` under a key the projector never reads
+and every plain-text answer was dropped on the way to the Profile Log.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from puffo_agent.agent.harness.driver import (
+    HarnessEvent,
+    HarnessEventType,
+    SessionRef,
+    TurnRef,
+)
+from puffo_agent.agent.harness.drivers.opencode_protocol import (
+    normalize_opencode_frame,
+)
+from puffo_agent.agent.harness.drivers.pi_protocol import normalize_pi_event
+from puffo_agent.agent.harness.runtime import local_runtime
+
+SESSION = SessionRef("logical")
+TURN = TurnRef("turn-1")
+
+
+def _pi_text_events() -> list[HarnessEvent]:
+    events: list[HarnessEvent] = []
+    for delta in (
+        {"type": "text_delta", "contentIndex": 0, "delta": "hello"},
+        {"type": "text_end", "contentIndex": 0},
+    ):
+        events.extend(
+            normalize_pi_event(
+                {"type": "message_update", "assistantMessageEvent": delta},
+                session_ref=SESSION,
+                turn_ref=TURN,
+            )
+        )
+    return events
+
+
+def _opencode_text_events() -> list[HarnessEvent]:
+    return list(
+        normalize_opencode_frame(
+            {
+                "type": "text",
+                "sessionID": "ses_123",
+                "part": {"id": "prt_text", "type": "text", "text": "hello"},
+            },
+            session_ref=SESSION,
+            turn_ref=TURN,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "build_events",
+    [_pi_text_events, _opencode_text_events],
+    ids=["pi", "opencode"],
+)
+def test_driver_text_reaches_the_legacy_status_projector(
+    build_events, monkeypatch,
+):
+    emitted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        local_runtime,
+        "_emit_status",
+        lambda agent_id, event, payload: emitted.append((event, payload)),
+    )
+    projector = local_runtime._LegacyStatusProjector("agent")
+    projector.project(
+        HarnessEvent.normalized(
+            type=HarnessEventType.TURN_STARTED,
+            driver="driver",
+            session_ref=SESSION,
+            turn_ref=TURN,
+            data={},
+        )
+    )
+
+    for event in build_events():
+        projector.project(event)
+
+    assert emitted == [("assistant_text", {"text": "hello"})]

--- a/tests/test_assistant_text_contract.py
+++ b/tests/test_assistant_text_contract.py
@@ -1,40 +1,78 @@
-"""Driver text deltas must arrive under the key their consumer reads.
+"""Driver text must survive the trip to both consumers, not just be emitted.
 
-Each driver's own tests pin the payload it emits, and the projector's tests pin
-what it does with a canonical payload — but nothing tied the two together, so
-three drivers shipped ``assistant_delta`` under a key the projector never reads
-and every plain-text answer was dropped on the way to the Profile Log.
+Each driver's own tests pin the payload it produces and the consumers' tests
+pin what they do with a canonical payload, but nothing ran one into the other.
+That gap let three drivers ship ``turn.assistant_delta`` under a key neither
+consumer reads: the Profile Log lost every ``assistant_text`` record and
+``TurnResult.reply`` came back empty, so an agent that answered in plain text
+instead of calling a tool said nothing at all.
+
+Each case below drives one harness's real emit path, then asserts the text
+arrives whole at both consumers -- the legacy status projector and the runtime
+manager's reply accumulation -- across several deltas.
 """
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
+from puffo_agent.agent.adapters.base import TurnContext
+from puffo_agent.agent.harness.drivers.codex import CODEX_CAPABILITIES
 from puffo_agent.agent.harness.driver import (
+    Driver,
     HarnessEvent,
     HarnessEventType,
+    RuntimeOpened,
+    RuntimeRef,
+    RuntimeSpec,
     SessionRef,
     TurnRef,
+    TurnStarted,
+    UnsupportedCapability,
 )
 from puffo_agent.agent.harness.drivers.opencode_protocol import (
     normalize_opencode_frame,
 )
 from puffo_agent.agent.harness.drivers.pi_protocol import normalize_pi_event
-from puffo_agent.agent.harness.runtime import local_runtime
+from puffo_agent.agent.runtime_event_outbox import RuntimeEventOutbox
 
-SESSION = SessionRef("logical")
-TURN = TurnRef("turn-1")
+TURN = TurnRef("driver-turn")
+SESSION = SessionRef("native-session")
+CHUNKS = ("QA-", "TEXT-", "OK")
+ANSWER = "".join(CHUNKS)
 
 
-def _pi_text_events() -> list[HarnessEvent]:
+def _pi_events() -> list[HarnessEvent]:
+    """Real ``normalize_pi_event`` output for a multi-delta text block."""
+    frames = [
+        {"type": "message_update",
+         "assistantMessageEvent": {"type": "text_delta", "contentIndex": 0,
+                                   "delta": chunk}}
+        for chunk in CHUNKS
+    ]
+    frames.append({"type": "message_update",
+                   "assistantMessageEvent": {"type": "text_end",
+                                             "contentIndex": 0}})
     events: list[HarnessEvent] = []
-    for delta in (
-        {"type": "text_delta", "contentIndex": 0, "delta": "hello"},
-        {"type": "text_end", "contentIndex": 0},
-    ):
+    for frame in frames:
         events.extend(
-            normalize_pi_event(
-                {"type": "message_update", "assistantMessageEvent": delta},
+            normalize_pi_event(frame, session_ref=SESSION, turn_ref=TURN)
+        )
+    return events
+
+
+def _opencode_events() -> list[HarnessEvent]:
+    """Real ``normalize_opencode_frame`` output; each frame carries the text
+    accumulated so far, so the projector must not concatenate them blindly."""
+    events: list[HarnessEvent] = []
+    for chunk in CHUNKS:
+        events.extend(
+            normalize_opencode_frame(
+                {"type": "text", "sessionID": "ses",
+                 "part": {"id": "prt", "type": "text", "text": chunk}},
                 session_ref=SESSION,
                 turn_ref=TURN,
             )
@@ -42,46 +80,226 @@ def _pi_text_events() -> list[HarnessEvent]:
     return events
 
 
-def _opencode_text_events() -> list[HarnessEvent]:
-    return list(
-        normalize_opencode_frame(
-            {
-                "type": "text",
-                "sessionID": "ses_123",
-                "part": {"id": "prt_text", "type": "text", "text": "hello"},
-            },
-            session_ref=SESSION,
-            turn_ref=TURN,
+async def _acp_events() -> list[HarnessEvent]:
+    """Real ``AcpDriver._session_update`` output, drained from its queue."""
+    from acp.schema import AgentMessageChunk, TextContentBlock
+
+    from puffo_agent.agent.harness.drivers.acp import AcpDriver
+
+    driver = AcpDriver()
+    driver._native_session_id = "acp-session"
+    driver._session_ref = SESSION
+    driver._active = TURN
+    for chunk in CHUNKS:
+        await driver._session_update(
+            "acp-session",
+            AgentMessageChunk(
+                session_update="agent_message_chunk",
+                message_id="message_1",
+                content=TextContentBlock(type="text", text=chunk),
+            ),
         )
+    events: list[HarnessEvent] = []
+    while not driver._events.empty():
+        events.append(driver._events.get_nowait())
+    return events
+
+
+class _QueueDriver(Driver):
+    """A driver whose event stream is whatever the test puts on the queue."""
+
+    def __init__(self):
+        self.queue: asyncio.Queue = asyncio.Queue()
+        self.turn = TURN
+
+    async def open(self, spec, resume=None):
+        return RuntimeOpened(
+            RuntimeRef("runtime"), SESSION, "native-session", False,
+            CODEX_CAPABILITIES, SimpleNamespace(),
+        )
+
+    async def start_turn(self, input):
+        return TurnStarted(self.turn, "native-turn")
+
+    async def steer_turn(self, turn, input):
+        return UnsupportedCapability("steer")
+
+    async def cancel_turn(self, turn):
+        return UnsupportedCapability("cancel")
+
+    async def context_status(self):
+        return UnsupportedCapability("context_status")
+
+    async def compact(self, request):
+        return UnsupportedCapability("compact")
+
+    async def resolve_permission(self, request, decision):
+        return UnsupportedCapability("permission")
+
+    def events(self):
+        async def iterate():
+            while True:
+                yield await self.queue.get()
+        return iterate()
+
+    async def close(self):
+        return None
+
+
+def _lifecycle(type_: HarnessEventType, data: dict) -> HarnessEvent:
+    return HarnessEvent.normalized(
+        type=type_, driver="harness", session_ref=SESSION, turn_ref=TURN,
+        native_session_id="native-session", native_turn_id="native-turn",
+        data=data,
     )
 
 
-@pytest.mark.parametrize(
-    "build_events",
-    [_pi_text_events, _opencode_text_events],
-    ids=["pi", "opencode"],
-)
-def test_driver_text_reaches_the_legacy_status_projector(
-    build_events, monkeypatch,
-):
-    emitted: list[tuple[str, dict]] = []
+def _build_adapter(tmp_path, driver, monkeypatch):
+    import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
+    from puffo_agent.agent.harness.runtime.local_runtime import (
+        PreparedLocalRuntime,
+        build_local_runtime_adapter,
+    )
+
+    class _StubPreparer:
+        agent_id = "agent"
+
+    prepared = PreparedLocalRuntime(
+        harness_name="codex",
+        spec=RuntimeSpec(str(tmp_path)),
+        native_session_id="",
+        migration_source="fresh",
+        legacy_session_path=tmp_path / "legacy.json",
+        preparer=_StubPreparer(),
+    )
+    outbox = RuntimeEventOutbox(tmp_path / "runtime_events.db")
+    monkeypatch.setattr(local_runtime, "build_driver", lambda name: driver)
+    adapter = build_local_runtime_adapter(
+        prepared, outbox=outbox, logical_session_ref="logical-session"
+    )
+    return adapter, outbox
+
+
+def _reporter_emits(monkeypatch):
+    emits: list[tuple[str, dict]] = []
+
+    async def fake_emit(agent_slug, event, payload):
+        emits.append((event, payload))
+
+    import puffo_agent.portal.control.reporter as reporter_mod
+
     monkeypatch.setattr(
-        local_runtime,
-        "_emit_status",
-        lambda agent_id, event, payload: emitted.append((event, payload)),
+        reporter_mod, "get_reporter", lambda: SimpleNamespace(emit=fake_emit)
     )
-    projector = local_runtime._LegacyStatusProjector("agent")
-    projector.project(
-        HarnessEvent.normalized(
-            type=HarnessEventType.TURN_STARTED,
-            driver="driver",
-            session_ref=SESSION,
-            turn_ref=TURN,
-            data={},
+    return emits
+
+
+async def _run_turn(harness, tmp_path, monkeypatch):
+    """Drive one harness's real events through a real adapter.
+
+    Returns the routed reply and every ``assistant_text`` the Profile Log
+    received, so each contract below can assert one thing.
+    """
+    if harness == "pi":
+        driver_events = _pi_events()
+    elif harness == "opencode":
+        driver_events = _opencode_events()
+    else:
+        driver_events = await _acp_events()
+
+    assert [
+        event for event in driver_events
+        if event.type is HarnessEventType.ASSISTANT_DELTA
+    ], f"{harness} produced no assistant_delta to carry the answer"
+
+    emits = _reporter_emits(monkeypatch)
+    driver = _QueueDriver()
+    adapter, outbox = _build_adapter(tmp_path, driver, monkeypatch)
+    ctx = TurnContext(
+        system_prompt="system",
+        messages=[{"role": "user", "content": "reply in plain text"}],
+        workspace_dir=str(tmp_path),
+        claude_dir=str(tmp_path),
+        memory_dir=str(tmp_path / "memory"),
+    )
+
+    task = asyncio.create_task(adapter.run_turn(ctx))
+    await _wait_until(lambda: bool(adapter.manager._turn_refs))
+    # Drivers close their own blocks at different points (pi on text_end,
+    # opencode per frame, acp at end of turn); close whatever is still open so
+    # every harness reaches the projector's emit point the same way.
+    closed = {
+        event.data.get("block_id") for event in driver_events
+        if event.type is HarnessEventType.ASSISTANT_COMPLETED
+    }
+    open_blocks = [
+        block for block in dict.fromkeys(
+            event.data.get("block_id") for event in driver_events
+            if event.type is HarnessEventType.ASSISTANT_DELTA
         )
+        if block not in closed
+    ]
+    for event in [
+        _lifecycle(HarnessEventType.TURN_STARTED, {}),
+        *driver_events,
+        *(
+            _lifecycle(HarnessEventType.ASSISTANT_COMPLETED,
+                       {"block_id": block})
+            for block in open_blocks
+        ),
+        _lifecycle(HarnessEventType.TURN_COMPLETED, {"outcome": "succeeded"}),
+    ]:
+        await driver.queue.put(event)
+    result = await asyncio.wait_for(task, timeout=5)
+    texts = [payload["text"] for event, payload in emits
+             if event == "assistant_text"]
+
+    await adapter.aclose()
+    outbox.close()
+    return result, texts
+
+
+@pytest.mark.parametrize("harness", ["pi", "opencode", "acp"])
+@pytest.mark.asyncio
+async def test_driver_text_reaches_the_routed_reply(
+    harness, tmp_path, monkeypatch,
+):
+    """``TurnResult.reply`` is what gets sent to the channel or DM; losing it
+    means an agent that answers without calling a tool says nothing."""
+    result, _ = await _run_turn(harness, tmp_path, monkeypatch)
+
+    assert ANSWER in result.reply, (
+        f"{harness}: the plain-text answer never reached TurnResult.reply"
     )
 
-    for event in build_events():
-        projector.project(event)
 
-    assert emitted == [("assistant_text", {"text": "hello"})]
+@pytest.mark.parametrize("harness", [
+    "pi",
+    pytest.param("opencode", marks=pytest.mark.xfail(
+        strict=True,
+        reason="opencode closes a block after every text fragment while "
+               "reusing the part id, so the projector emits the first "
+               "fragment and dedupes the rest -- tracked separately from the "
+               "payload-key fix",
+    )),
+    "acp",
+])
+@pytest.mark.asyncio
+async def test_driver_text_reaches_the_profile_log(
+    harness, tmp_path, monkeypatch,
+):
+    """The web Profile Log renders these ``assistant_text`` records."""
+    _, texts = await _run_turn(harness, tmp_path, monkeypatch)
+
+    assert texts, f"{harness}: no assistant_text status was ever reported"
+    assert ANSWER in "".join(texts), (
+        f"{harness}: the Profile Log record lost part of the answer"
+    )
+
+
+async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition did not become true")
+        await asyncio.sleep(0.001)

--- a/tests/test_opencode_driver.py
+++ b/tests/test_opencode_driver.py
@@ -263,7 +263,7 @@ async def test_jsonl_reader_does_not_split_valid_unicode_line_separators():
         event for event in events
         if event.type is HarnessEventType.ASSISTANT_DELTA
     ]
-    assert delta.data["delta"] == text
+    assert delta.data["text"] == text
     await driver.close()
 
 

--- a/tests/test_opencode_live_e2e.py
+++ b/tests/test_opencode_live_e2e.py
@@ -166,7 +166,7 @@ async def test_real_opencode_driver_loads_skill_and_reports_context(tmp_path: Pa
             for event in events
         ), events
         assert "".join(
-            str(event.data.get("delta") or "")
+            str(event.data.get("text") or "")
             for event in events
             if event.type is HarnessEventType.ASSISTANT_DELTA
         ) == "SENTINEL-OPENCODE-SKILL"
@@ -204,7 +204,7 @@ async def test_real_opencode_driver_loads_skill_and_reports_context(tmp_path: Pa
                 break
         assert driver._native_session_id == native_session_id
         assert "SENTINEL-OPENCODE-SKILL" in "".join(
-            str(event.data.get("delta") or "")
+            str(event.data.get("text") or "")
             for event in continued
             if event.type is HarnessEventType.ASSISTANT_DELTA
         )

--- a/tests/test_opencode_protocol.py
+++ b/tests/test_opencode_protocol.py
@@ -79,7 +79,7 @@ def test_text_frame_emits_one_completed_output_block():
         HarnessEventType.ASSISTANT_DELTA,
         HarnessEventType.ASSISTANT_COMPLETED,
     ]
-    assert events[0].data == {"block_id": "prt_text", "delta": "hello"}
+    assert events[0].data == {"block_id": "prt_text", "text": "hello"}
     assert events[1].data == {"block_id": "prt_text"}
     assert all(event.native_session_id == "ses_123" for event in events)
 

--- a/tests/test_pi_driver.py
+++ b/tests/test_pi_driver.py
@@ -802,7 +802,7 @@ async def test_unicode_separator_inside_a_string_does_not_split_a_frame():
     proc.push_raw(payload.encode() + b"\n")
     events = await _drain_events(driver, 1)
     assert events[0].type == HarnessEventType.ASSISTANT_DELTA
-    assert events[0].data["delta"] == "before after"
+    assert events[0].data["text"] == "before after"
     await driver.close()
 
 


### PR DESCRIPTION
## What breaks today

`pi`, `opencode`, and `acp` emit `turn.assistant_delta` as `{"block_id": …, "delta": …}`, while both consumers read `"text"`:

- `_LegacyStatusProjector` (`local_runtime.py:970`) — feeds the web Profile Log's `assistant_text`
- `runtime_manager.py:1312` — accumulates `assistant_text_parts` → `TurnResult.reply`

No consumer reads `"delta"`. So for those three harnesses every plain-text answer is dropped twice: nothing appears in the web log, **and** the routed reply is the empty string — an agent that answers without calling `send_message` says nothing at all.

`claude_code` and `codex` already emit `"text"` and are unaffected.

## Evidence

Staging QA (2.0.4a2, two opencode + two pi agents): across the whole daemon log there are 118 `tool_use`, 110 `turn_start`, 30 `turn_complete` and **zero** `assistant_text` status events. A pi agent asked to answer in plain text produced `content type=text` in its native session file at 18:45:28Z; the web log showed only `read_inbox`/`mark_covered` and the DM was never delivered.

## Why the tests missed it

Each driver's tests assert the payload that driver emits; the projector's test asserts what the projector does given a canonical payload. Nothing tied the two together, so both sides stayed green while disagreeing.

`tests/test_assistant_text_contract.py` closes that: it runs each driver's own normalizer output through the real projector and asserts `assistant_text` comes out. Reverting either driver key to `"delta"` turns it red (verified).

## Verification

- full suite 4024 passed / 2 skipped; pre-commit all hooks green
- mutation-checked: revert `pi_protocol` and `opencode_protocol` to `"delta"` ⇒ both contract cases fail; restore ⇒ green

*(pushed with operator credentials on behalf of agent linus-torv-7742-c643a3f4)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)