### PR TITLE
fix(opencode): carry per-turn token usage into the terminal

### DIFF
--- a/src/puffo_agent/agent/harness/drivers/opencode.py
+++ b/src/puffo_agent/agent/harness/drivers/opencode.py
@@ -229,6 +229,7 @@ class OpenCodeDriver(Driver):
         self._events: asyncio.Queue[HarnessEvent | None] = asyncio.Queue()
         self._terminal_reason = ""
         self._provider_failed = False
+        self._turn_usage: dict[str, int] = {}
         self._context = ContextStatus(stale=True)
         self._context_window: int | None = None
         self._compact_task: asyncio.Task[None] | None = None
@@ -290,6 +291,7 @@ class OpenCodeDriver(Driver):
         self._provider_failed = False
         self._terminal_reason = ""
         self._last_provider_error = ""
+        self._turn_usage = {}
         self._turn_generation += 1
         generation = self._turn_generation
         self._accepted = asyncio.get_running_loop().create_future()
@@ -429,7 +431,25 @@ class OpenCodeDriver(Driver):
             out.decode("utf-8", "replace"), model_id
         )
 
+    def _absorb_turn_usage(self, usage: dict[str, Any]) -> None:
+        """OpenCode reports usage once per step, and a turn runs several steps.
+
+        Token counts accumulate across steps; ``total_tokens`` is the step's
+        context occupancy rather than a running sum, so only the newest one
+        stands (see ``_usage_data``).
+        """
+        merged = dict(self._turn_usage)
+        for key, value in usage.items():
+            if not isinstance(value, int):
+                continue
+            if key == "total_tokens":
+                merged[key] = value
+            else:
+                merged[key] = merged.get(key, 0) + value
+        self._turn_usage = merged
+
     def _absorb_context_update(self, event: HarnessEvent) -> HarnessEvent:
+        self._absorb_turn_usage(event.data)
         total = event.data.get("total_tokens")
         if not isinstance(total, int) or total <= 0:
             # A step_finish without a usable total (e.g. an aborted step)
@@ -838,9 +858,10 @@ class OpenCodeDriver(Driver):
             }
             if diagnostic:
                 data["diagnostic"] = diagnostic
+            data.update(self._turn_usage)
         else:
             type_ = HarnessEventType.TURN_COMPLETED
-            data = {"outcome": "succeeded"}
+            data = {"outcome": "succeeded", **self._turn_usage}
         terminal: HarnessEvent | None = None
         if accepted is not None and accepted.done() and not accepted.cancelled():
             try:

--- a/tests/test_opencode_driver.py
+++ b/tests/test_opencode_driver.py
@@ -139,6 +139,52 @@ async def test_turn_terminal_waits_for_both_process_exit_and_stream_eof(
 
 
 @pytest.mark.asyncio
+async def test_turn_usage_accumulates_across_steps():
+    """OpenCode reports usage per step_finish and a turn runs several steps.
+
+    The terminal is what the runtime reads token counts from, so a turn that
+    never carries them reports 0/0 no matter what the provider measured.
+    """
+    proc = _TurnProcess()
+    driver = OpenCodeDriver(lambda command, _spec: proc)
+    await driver.open(RuntimeSpec("/workspace"))
+    stream = driver.events()
+    started = asyncio.create_task(driver.start_turn(TurnInput("hello")))
+    proc.feed({
+        "type": "step_start",
+        "sessionID": "ses_1",
+        "part": {"messageID": "msg_1"},
+    })
+    await asyncio.wait_for(started, timeout=1)
+    terminal = asyncio.create_task(
+        _next_matching(stream, HarnessEventType.TURN_COMPLETED)
+    )
+    for tokens in (
+        {"input": 100, "output": 10, "reasoning": 1,
+         "cache": {"read": 5, "write": 0}, "total": 1000},
+        {"input": 250, "output": 30, "reasoning": 2,
+         "cache": {"read": 7, "write": 0}, "total": 1400},
+    ):
+        proc.feed({
+            "type": "step_finish",
+            "sessionID": "ses_1",
+            "part": {"messageID": "msg_1", "tokens": tokens},
+        })
+    proc.exit()
+    proc.eof()
+
+    event = await asyncio.wait_for(terminal, timeout=1)
+    assert event.data["outcome"] == "succeeded"
+    assert event.data["input_tokens"] == 350
+    assert event.data["output_tokens"] == 40
+    assert event.data["reasoning_tokens"] == 3
+    assert event.data["cache_read_tokens"] == 12
+    # Context occupancy is the newest step's, not a sum.
+    assert event.data["total_tokens"] == 1400
+    await driver.close()
+
+
+@pytest.mark.asyncio
 async def test_second_turn_resumes_native_session_and_emits_one_session_boundary():
     processes = [_TurnProcess(), _TurnProcess()]
     commands = []


### PR DESCRIPTION
## What breaks today

OpenCode reports token usage on every `step_finish` frame, and the driver normalizes it correctly (`_usage_data` → `input_tokens`/`output_tokens`/`reasoning_tokens`/cache/`total_tokens`). But `_absorb_context_update` only feeds `total_tokens` into context tracking, and the `TURN_COMPLETED` payload is built as `{"outcome": "succeeded"}` — **no token counts at all**.

`runtime_manager` reads `input_tokens`/`output_tokens` off the terminal, so every OpenCode turn reports 0/0 and the web Done row shows 0/0 regardless of what the provider measured.

Same shape as the pi defect fixed in #329, different driver; found when a3's browser retest showed pi Done 2259/98 while OpenCode stayed 0/0.

## Evidence the raw usage exists

Captured from the shipped binary (`opencode run --format json`), one `step_finish`:

```
{"total": 7955, "input": 6141, "output": 22, "reasoning": 0, "cache": {"write": 0, "read": 1792}}
```

## The fix

Accumulate usage across a turn's steps and emit it on the terminal. Token counts sum; `total_tokens` keeps the newest step's value, because it is that step's context occupancy rather than a running total (already documented in `_usage_data`).

## Verification

- New `test_turn_usage_accumulates_across_steps`: two `step_finish` frames ⇒ terminal carries 350/40, reasoning 3, cache_read 12, and `total_tokens` 1400 (newest, not summed).
- Mutation-checked: drop the usage from the terminal ⇒ the test fails; restore ⇒ green.
- Full suite 4031 passed / 2 skipped; pre-commit green.

*(pushed with operator credentials on behalf of agent linus-torv-7742-c643a3f4)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)