### PR TITLE
fix(harness): mint the MCP generation for every harness family

### DIFF
--- a/src/puffo_agent/agent/harness/runtime/docker_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/docker_runtime.py
@@ -128,6 +128,8 @@ class DockerRuntimePreparer:
             agent_cfg.runtime.docker_memory_reservation
             or daemon_cfg.docker_memory_reservation
         )
+        # Minted per spec build in ``refresh_spec``.
+        self._mcp_generation = ""
         self._docker_bin = "docker"
         self._desired_extras: dict[str, dict] = {}
         self._desired_installed = False
@@ -165,6 +167,15 @@ class DockerRuntimePreparer:
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
         self.agent_home.mkdir(parents=True, exist_ok=True)
         self.memory_dir.mkdir(parents=True, exist_ok=True)
+        # One mint for both container harnesses — see the cli-local twin in
+        # ``LocalRuntimePreparer.refresh_spec``. A per-harness mint is how
+        # codex ended up with the transport probe silently disabled.
+        # Empty when there is no Puffo MCP to hello back: the probe treats a
+        # generation as a promise that a subprocess will report in, and an
+        # agent without MCP must not be recycled waiting for one.
+        self._mcp_generation = (
+            uuid.uuid4().hex if self._container_puffo_mcp_env() else ""
+        )
         if self.harness_name == HARNESS_CLAUDE_CODE:
             await self._sync_claude_host_assets()
             return self._prepare_claude_spec(system_prompt)
@@ -277,22 +288,17 @@ class DockerRuntimePreparer:
                 self.agent_id,
                 inference,
             )
-        mcp_env = self._container_puffo_mcp_env()
-        mcp_generation = ""
+        mcp_env = self._container_puffo_mcp_env_with_generation()
         if mcp_env:
-            # Minted per config write; the subprocess echoes it back over
-            # RPC (mcp-hello) so the worker's transport probe can tell
-            # "this spec's MCP reached us" from a stale predecessor.
-            mcp_generation = uuid.uuid4().hex
+            # The subprocess echoes the generation back over RPC (mcp-hello)
+            # so the worker's transport probe can tell "this spec's MCP
+            # reached us" from a stale predecessor.
             config_host = self.workspace_dir / ".puffo-agent" / "mcp-config.json"
             write_cli_mcp_config(
                 config_host,
                 command="python3",
                 args=["-m", "puffo_agent.mcp.puffo_core_server"],
-                env={
-                    **mcp_env,
-                    "PUFFO_MCP_GENERATION": mcp_generation,
-                },
+                env=mcp_env,
             )
             launch_args.extend(
                 ["--mcp-config", "/workspace/.puffo-agent/mcp-config.json"]
@@ -340,7 +346,7 @@ class DockerRuntimePreparer:
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
             auto_compact_threshold_pct=compact_pct,
             auto_compact_threshold_tokens=compact_tokens,
-            mcp_generation=mcp_generation,
+            mcp_generation=self._mcp_generation,
         )
 
     def _codex_gateway_provider(self) -> dict[str, str] | None:
@@ -349,6 +355,19 @@ class DockerRuntimePreparer:
             llm_base_url=self.agent_cfg.runtime.llm_base_url,
             api_key=self.agent_cfg.runtime.api_key,
         )
+
+    def _container_puffo_mcp_env_with_generation(self) -> dict[str, str] | None:
+        """The container MCP environment, generation included.
+
+        Both harnesses go through here so the subprocess can echo the
+        generation back over ``mcp-hello``; without it the daemon-side
+        probe returns early on an empty spec generation and a wedged
+        transport is never detected.
+        """
+        env = self._container_puffo_mcp_env()
+        if not env:
+            return None
+        return {**env, "PUFFO_MCP_GENERATION": self._mcp_generation}
 
     def _container_puffo_mcp_env(self) -> dict[str, str] | None:
         pc = self.agent_cfg.puffo_core
@@ -399,7 +418,7 @@ class DockerRuntimePreparer:
             "inference_level": self.agent_cfg.runtime.inference_level,
             "provider": gateway,
         }
-        puffo_env = self._container_puffo_mcp_env()
+        puffo_env = self._container_puffo_mcp_env_with_generation()
         if puffo_env:
             config_kwargs.update(
                 {
@@ -460,6 +479,7 @@ class DockerRuntimePreparer:
             sandbox=CONTAINER_SANDBOX,
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
             auto_compact_threshold_pct=compact_pct,
+            mcp_generation=self._mcp_generation,
         )
 
     def _legacy_session_path(self) -> Path:

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -332,6 +332,9 @@ class LocalRuntimePreparer:
         self._desired_installed = False
         self._desired_codex_extras: dict[str, dict] = {}
         self._puffo_core_env = self._build_puffo_core_env()
+        # Minted per spec build in ``refresh_spec`` — see
+        # ``_puffo_core_child_env``.
+        self._mcp_generation = ""
 
     async def prepare(
         self,
@@ -376,6 +379,12 @@ class LocalRuntimePreparer:
         if self.harness_name == "claude-code":
             self._sync_claude_host_state()
         await self._install_desired_once()
+        # One mint for every harness family. The daemon-side transport probe
+        # is keyed on this value, and a per-harness mint is exactly how three
+        # families ended up with the probe silently disabled: the value must
+        # be born at the single point every spec build passes through, not at
+        # each spawn site that happens to remember it.
+        self._mcp_generation = uuid.uuid4().hex if self._puffo_core_env else ""
         if self.harness_name == "codex":
             return self._prepare_codex_spec(system_prompt)
         if self.harness_name == "claude-code":
@@ -418,6 +427,7 @@ class LocalRuntimePreparer:
             permission_mode=self.permission_mode,
             sandbox=self.sandbox,
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
+            mcp_generation=self._mcp_generation,
         )
 
     def _resolve_generic_command(self) -> tuple[str, list[str]]:
@@ -515,14 +525,15 @@ class LocalRuntimePreparer:
         ``test_spec_mcp_servers_are_forwarded_into_the_acp_launch_plan``.
         """
         mcp_servers: tuple[McpServerSpec, ...] = ()
-        if self._puffo_core_env:
+        puffo_core_env = self._puffo_core_child_env()
+        if puffo_core_env:
             puffo_command = default_python_executable()
             puffo_args = ("-m", "puffo_agent.mcp.puffo_core_server")
             puffo_server = McpServerSpec(
                 name="puffo",
                 command=puffo_command,
                 args=puffo_args,
-                environment=self._puffo_core_env,
+                environment=puffo_core_env,
             )
             if self.harness_name == "pi":
                 # Pi has no MCP client. Its attested extension bridge carries
@@ -542,7 +553,7 @@ class LocalRuntimePreparer:
                     "puffo": {
                         "type": "local",
                         "command": [puffo_command, *puffo_args],
-                        "environment": self._puffo_core_env,
+                        "environment": puffo_core_env,
                     }
                 }
         else:
@@ -572,6 +583,23 @@ class LocalRuntimePreparer:
             )
         )
         return controlled
+
+    def _puffo_core_child_env(self) -> dict[str, str] | None:
+        """The MCP subprocess environment, generation included.
+
+        Every spawn site goes through here so the subprocess can echo the
+        generation back over ``mcp-hello``; without it
+        ``_make_hello_startup`` returns ``None``, no hello is ever sent, and
+        ``Worker.probe_mcp_transport`` returns early on the empty spec
+        generation — a dead transport with no recycle and no
+        ``mcp_unreachable``.
+        """
+        if not self._puffo_core_env:
+            return None
+        return {
+            **self._puffo_core_env,
+            "PUFFO_MCP_GENERATION": self._mcp_generation,
+        }
 
     def _build_puffo_core_env(self) -> dict[str, str] | None:
         pc = self.agent_cfg.puffo_core
@@ -689,20 +717,16 @@ class LocalRuntimePreparer:
                     inference,
                 )
         mcp_path = agent_dir(self.agent_id) / "mcp-config.json"
-        mcp_generation = ""
-        if self._puffo_core_env:
-            # Minted per config write; the subprocess echoes it back over
-            # RPC (mcp-hello) so the worker's transport probe can tell
-            # "this spec's MCP reached us" from a stale predecessor.
-            mcp_generation = uuid.uuid4().hex
+        puffo_core_env = self._puffo_core_child_env()
+        if puffo_core_env:
+            # The subprocess echoes the generation back over RPC (mcp-hello)
+            # so the worker's transport probe can tell "this spec's MCP
+            # reached us" from a stale predecessor.
             write_cli_mcp_config(
                 mcp_path,
                 command=default_python_executable(),
                 args=["-m", "puffo_agent.mcp.puffo_core_server"],
-                env={
-                    **self._puffo_core_env,
-                    "PUFFO_MCP_GENERATION": mcp_generation,
-                },
+                env=puffo_core_env,
             )
             launch_args.extend(["--mcp-config", str(mcp_path)])
         else:
@@ -754,7 +778,7 @@ class LocalRuntimePreparer:
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
             auto_compact_threshold_pct=compact_pct,
             auto_compact_threshold_tokens=compact_tokens,
-            mcp_generation=mcp_generation,
+            mcp_generation=self._mcp_generation,
         )
 
     def _prepare_codex_spec(self, system_prompt: str) -> RuntimeSpec:
@@ -773,11 +797,12 @@ class LocalRuntimePreparer:
             "inference_level": self.agent_cfg.runtime.inference_level,
             "provider": gateway,
         }
-        if self._puffo_core_env:
+        puffo_core_env = self._puffo_core_child_env()
+        if puffo_core_env:
             config_kwargs.update({
                 "command": default_python_executable(),
                 "args": ["-m", "puffo_agent.mcp.puffo_core_server"],
-                "env": self._puffo_core_env,
+                "env": puffo_core_env,
             })
         write_codex_mcp_config(codex_home / "config.toml", **config_kwargs)
 
@@ -833,6 +858,7 @@ class LocalRuntimePreparer:
             sandbox=self.sandbox,
             task_timeout_seconds=self.agent_cfg.runtime.task_timeout_seconds,
             auto_compact_threshold_pct=compact_pct,
+            mcp_generation=self._mcp_generation,
         )
 
     def _codex_gateway_provider(self) -> dict[str, str] | None:

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -101,6 +101,21 @@ class StatusReporter:
         # write, and each body is built under it, so wire order matches
         # state order and the last write carries the newest state.
         self._send_lock = asyncio.Lock()
+        # Set by ``request_immediate_heartbeat`` so a health change does not
+        # have to wait out the remaining interval.
+        self._wake = asyncio.Event()
+
+    def request_immediate_heartbeat(self) -> None:
+        """Ask the loop to send the next heartbeat now.
+
+        ``runtime.health`` only travels on heartbeats, so without this a red
+        written just after a turn settles waits up to a full interval before
+        the server hears about it — long enough to be read as "never
+        reported". Deliberately fire-and-forget: the caller has already
+        persisted the health locally, and a heartbeat that fails must not
+        undo or delay that. The periodic tick stays as the fallback.
+        """
+        self._wake.set()
 
     async def run_heartbeat_loop(self) -> None:
         # Native agents POST /agents/me/heartbeat; keyless bridge agents emit a
@@ -117,10 +132,17 @@ class StatusReporter:
         try:
             await self._send_heartbeat()
             while not stop.is_set():
+                # One event carries both wake-ups: an early tick requested by
+                # a health change, and shutdown (``stop`` sets it too). Waiting
+                # on a single event keeps this a plain wait instead of a pair
+                # of racing tasks.
                 try:
-                    await asyncio.wait_for(stop.wait(), timeout=self._interval)
+                    await asyncio.wait_for(
+                        self._wake.wait(), timeout=self._interval,
+                    )
                 except asyncio.TimeoutError:
                     pass
+                self._wake.clear()
                 if stop.is_set():
                     break
                 await self._send_heartbeat()
@@ -141,6 +163,9 @@ class StatusReporter:
     def stop(self) -> None:
         if self._run_stop is not None:
             self._run_stop.set()
+            # The loop waits on ``_wake``; without this, shutdown would sit
+            # out the rest of the interval before noticing.
+            self._wake.set()
         if self._processing_reports is not None:
             self._processing_reports.stop()
 

--- a/src/puffo_agent/agent/status_reporter.py
+++ b/src/puffo_agent/agent/status_reporter.py
@@ -51,6 +51,8 @@ class StatusReporter:
         runtime_provider: Optional[Callable[[], dict[str, Any]]] = None,
         status_sender: Optional[Callable[..., Awaitable[None]]] = None,
         processing_reports: ProcessingReportDispatcher | None = None,
+        on_loop_start: Optional[Callable[[], None]] = None,
+        on_loop_stop: Optional[Callable[[], None]] = None,
     ) -> None:
         self._http = http
         # Keyless (bridge) agents can't sign the HTTP status routes, so the
@@ -104,6 +106,13 @@ class StatusReporter:
         # Set by ``request_immediate_heartbeat`` so a health change does not
         # have to wait out the remaining interval.
         self._wake = asyncio.Event()
+        # An external wake registry is bound for exactly as long as the
+        # heartbeat loop runs: waking a loop that is not running does nothing,
+        # and ws-local reuses one reporter across attaches, spawning a fresh
+        # loop each time. Binding at construction and releasing at ``stop``
+        # would unbind on the first detach and never rebind.
+        self._on_loop_start = on_loop_start
+        self._on_loop_stop = on_loop_stop
 
     def request_immediate_heartbeat(self) -> None:
         """Ask the loop to send the next heartbeat now.
@@ -129,6 +138,8 @@ class StatusReporter:
         replay_task = None
         if self._processing_reports is not None:
             replay_task = spawn(self._processing_reports.run(), name="processing_reports.run")
+        if self._on_loop_start is not None:
+            self._on_loop_start()
         try:
             await self._send_heartbeat()
             while not stop.is_set():
@@ -159,6 +170,11 @@ class StatusReporter:
                     logger.warning("processing report replay stopped", exc_info=True)
             if self._run_stop is stop:
                 self._run_stop = None
+            if self._on_loop_stop is not None:
+                try:
+                    self._on_loop_stop()
+                except Exception:  # noqa: BLE001 - teardown must not raise
+                    logger.warning("status reporter unbind failed", exc_info=True)
 
     def stop(self) -> None:
         if self._run_stop is not None:

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1042,6 +1042,7 @@ class RuntimeState:
     def save(self, agent_id: str) -> None:
         import json
 
+        self._notify_health_change(agent_id)
         self.updated_at = int(time.time())
         path = runtime_json_path(agent_id)
         # CLI staleness gate is 30s; throttle pure-updated_at writes
@@ -1065,6 +1066,46 @@ class RuntimeState:
             json.dump(asdict(self), f, indent=2)
         os.replace(tmp, path)
         _RUNTIME_LAST_SAVE[key] = (sig, self.updated_at)
+
+    def _notify_health_change(self, agent_id: str) -> None:
+        """Fire the registered listener when ``health`` actually changed.
+
+        Every health writer already funnels through ``save``, so this is the
+        one place that cannot be forgotten — a per-writer notification is the
+        same "whoever remembers" shape that left the transport probe
+        unwired on three harness families.
+
+        Runs before the throttle check on purpose: an unchanged-signature
+        save is throttled, but a health change always changes the signature,
+        and a listener must never be skipped because of write throttling.
+        """
+        listener = _RUNTIME_HEALTH_LISTENERS.get(agent_id)
+        previous = _RUNTIME_LAST_HEALTH.get(agent_id)
+        _RUNTIME_LAST_HEALTH[agent_id] = self.health
+        if listener is None or previous is None or previous == self.health:
+            return
+        try:
+            listener()
+        except Exception:  # noqa: BLE001
+            # Publishing is best-effort; the local write is authoritative and
+            # must complete even if nobody can be told about it.
+            logger.debug(
+                "runtime health listener for %s raised", agent_id, exc_info=True,
+            )
+
+
+# Fires when an agent's runtime health changes; the daemon registers the
+# status reporter here so a red reaches the server without waiting out the
+# heartbeat interval. The periodic heartbeat stays as the fallback.
+_RUNTIME_HEALTH_LISTENERS: dict[str, Any] = {}
+_RUNTIME_LAST_HEALTH: dict[str, str] = {}
+
+
+def set_runtime_health_listener(agent_id: str, listener: Any) -> None:
+    if listener is None:
+        _RUNTIME_HEALTH_LISTENERS.pop(agent_id, None)
+    else:
+        _RUNTIME_HEALTH_LISTENERS[agent_id] = listener
 
 
 # Keyed by resolved path so test tmp_path reuse doesn't collide.

--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1042,7 +1042,6 @@ class RuntimeState:
     def save(self, agent_id: str) -> None:
         import json
 
-        self._notify_health_change(agent_id)
         self.updated_at = int(time.time())
         path = runtime_json_path(agent_id)
         # CLI staleness gate is 30s; throttle pure-updated_at writes
@@ -1066,6 +1065,7 @@ class RuntimeState:
             json.dump(asdict(self), f, indent=2)
         os.replace(tmp, path)
         _RUNTIME_LAST_SAVE[key] = (sig, self.updated_at)
+        self._notify_health_change(agent_id)
 
     def _notify_health_change(self, agent_id: str) -> None:
         """Fire the registered listener when ``health`` actually changed.
@@ -1075,9 +1075,11 @@ class RuntimeState:
         same "whoever remembers" shape that left the transport probe
         unwired on three harness families.
 
-        Runs before the throttle check on purpose: an unchanged-signature
-        save is throttled, but a health change always changes the signature,
-        and a listener must never be skipped because of write throttling.
+        Called only after ``os.replace`` succeeds, so a listener that reads
+        the runtime file sees the health it is being told about, and a save
+        that fails to land tells nobody. The throttled early return above
+        cannot skip a health change: ``health`` is part of the write
+        signature, so a change always misses the unchanged-signature branch.
         """
         listener = _RUNTIME_HEALTH_LISTENERS.get(agent_id)
         previous = _RUNTIME_LAST_HEALTH.get(agent_id)
@@ -1106,6 +1108,19 @@ def set_runtime_health_listener(agent_id: str, listener: Any) -> None:
         _RUNTIME_HEALTH_LISTENERS.pop(agent_id, None)
     else:
         _RUNTIME_HEALTH_LISTENERS[agent_id] = listener
+
+
+def clear_runtime_health_listener(agent_id: str, listener: Any) -> None:
+    """Drop ``listener`` only while it is still the registered one.
+
+    A reporter's teardown can land after its successor has already claimed
+    the slot — a cancelled heartbeat loop runs its ``finally`` whenever the
+    event loop next gets to it. An unconditional pop would then silence a
+    live reporter, and health would quietly fall back to the periodic tick
+    with nothing to show that it had.
+    """
+    if _RUNTIME_HEALTH_LISTENERS.get(agent_id) is listener:
+        _RUNTIME_HEALTH_LISTENERS.pop(agent_id, None)
 
 
 # Keyed by resolved path so test tmp_path reuse doesn't collide.

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -52,6 +52,7 @@ from .state import (
     agent_home_dir,
     claude_cli_api_key,
     docker_shared_dir as docker_shared_dir,
+    set_runtime_health_listener,
 )
 from ..tasks import spawn
 
@@ -159,6 +160,24 @@ def _refresh_flag_is_pending(flag: Path) -> bool:
 # before the agent stops being reported healthy. One such turn is a normal
 # deferral; a run of them means the provider is not reaching the Inbox at all.
 _NO_PROGRESS_TURN_THRESHOLD = 3
+
+# Health values the MCP transport probe may replace with ``mcp_unreachable``.
+# "ok"/"unknown" mean nothing is known to be wrong. The other two are the
+# states a wedged transport actually produces, and both are *symptoms* this
+# probe can name the cause of:
+#   in_progress  — a turn was admitted and never settled;
+#   no_progress  — turns keep waking and consuming none of their batch,
+#                  whose remediation text points at provider credentials.
+# Excluding them meant the diagnosis was skipped in exactly the states a real
+# MCP failure leaves behind. Every more specific red (auth_failed,
+# provider_error, refresh_broken, drained, ...) stays authoritative: the probe
+# knows the transport is down, not that it is the only thing wrong.
+_MCP_PROBE_OVERWRITABLE_HEALTH = (
+    "ok",
+    "unknown",
+    "in_progress",
+    "no_progress",
+)
 
 
 def _claude_cli_api_key(daemon_cfg: DaemonConfig, harness_name: str) -> str:
@@ -483,7 +502,7 @@ class Worker:
                 agent_id, adapter, mgr, cause=cause, spec_gen=spec_gen,
             )
             return
-        if self.runtime.health in ("ok", "unknown"):
+        if self.runtime.health in _MCP_PROBE_OVERWRITABLE_HEALTH:
             self.runtime.health = "mcp_unreachable"
             self.runtime.error = (
                 "puffo MCP subprocess never reached the daemon RPC "
@@ -1488,6 +1507,12 @@ class Worker:
             runtime_provider=self._runtime_info,
             status_sender=bridge.send_status if bridge is not None else None,
             processing_reports=processing_reports,
+        )
+        # health only travels on heartbeats; without this a red written just
+        # after a turn settles waits out the interval before the server hears
+        # it. The periodic tick remains the fallback.
+        set_runtime_health_listener(
+            self.agent_cfg.id, reporter.request_immediate_heartbeat,
         )
         if bridge is not None:
             bridge.add_connected_callback(reporter.report_current_status)

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -52,6 +52,7 @@ from .state import (
     agent_home_dir,
     claude_cli_api_key,
     docker_shared_dir as docker_shared_dir,
+    clear_runtime_health_listener,
     set_runtime_health_listener,
 )
 from ..tasks import spawn
@@ -1501,18 +1502,30 @@ class Worker:
                 register_connected = getattr(client, "add_connected_callback", None)
                 if callable(register_connected):
                     register_connected(processing_reports.on_transport_connected)
+        agent_id = self.agent_cfg.id
+
+        # health only travels on heartbeats; without this a red written just
+        # after a turn settles waits out the interval before the server hears
+        # it. The periodic tick remains the fallback.
+        #
+        # One stable callable, bound and released together, so the module
+        # global is scoped to a running loop instead of outliving a stopped
+        # worker — and so neither shutdown path has to remember separately.
+        def _wake_heartbeat() -> None:
+            reporter.request_immediate_heartbeat()
+
         reporter = StatusReporter(
             client.http,
             runtime_health_provider=lambda: self.runtime.health,
             runtime_provider=self._runtime_info,
             status_sender=bridge.send_status if bridge is not None else None,
             processing_reports=processing_reports,
-        )
-        # health only travels on heartbeats; without this a red written just
-        # after a turn settles waits out the interval before the server hears
-        # it. The periodic tick remains the fallback.
-        set_runtime_health_listener(
-            self.agent_cfg.id, reporter.request_immediate_heartbeat,
+            on_loop_start=lambda: set_runtime_health_listener(
+                agent_id, _wake_heartbeat
+            ),
+            on_loop_stop=lambda: clear_runtime_health_listener(
+                agent_id, _wake_heartbeat
+            ),
         )
         if bridge is not None:
             bridge.add_connected_callback(reporter.report_current_status)

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -1146,6 +1146,153 @@ def test_a_failed_publish_never_blocks_the_local_health_write(tmp_path, monkeypa
     assert written["health"] == "mcp_unreachable"
 
 
+def test_the_listener_is_told_a_health_it_can_already_read(tmp_path, monkeypatch):
+    """The listener publishes the health the daemon just decided, so it must
+    fire after the file lands, not before.
+
+    Notifying first makes the announced value and the stored value two
+    independent reads of a half-finished write, and lets a save that never
+    lands announce itself anyway.
+    """
+    from puffo_agent.portal.state import (
+        set_runtime_health_listener,
+        _RUNTIME_LAST_HEALTH,
+        runtime_json_path,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    _RUNTIME_LAST_HEALTH.pop("order", None)
+    observed: list[str] = []
+
+    def _read_the_file():
+        observed.append(
+            json.loads(
+                runtime_json_path("order").read_text(encoding="utf-8")
+            )["health"]
+        )
+
+    runtime = RuntimeState(status="running", health="ok")
+    runtime.save("order")
+    set_runtime_health_listener("order", _read_the_file)
+    try:
+        runtime.health = "mcp_unreachable"
+        runtime.save("order")
+    finally:
+        set_runtime_health_listener("order", None)
+
+    assert observed == ["mcp_unreachable"]
+
+
+def test_a_write_that_never_lands_announces_nothing_and_stays_pending(
+    tmp_path, monkeypatch
+):
+    """A failed save must not fire the listener — and must not consume the
+    change either. The next successful save still has to report it, or a
+    transient disk error would silently drop a red for good."""
+    from puffo_agent.portal import state as state_module
+    from puffo_agent.portal.state import (
+        set_runtime_health_listener,
+        _RUNTIME_LAST_HEALTH,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    _RUNTIME_LAST_HEALTH.pop("nodisk", None)
+    fired: list[str] = []
+
+    runtime = RuntimeState(status="running", health="ok")
+    runtime.save("nodisk")
+    set_runtime_health_listener("nodisk", lambda: fired.append(runtime.health))
+    real_replace = state_module.os.replace
+    try:
+        def _fail(src, dst):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(state_module.os, "replace", _fail)
+        runtime.health = "mcp_unreachable"
+        with pytest.raises(OSError):
+            runtime.save("nodisk")
+        assert fired == []
+
+        monkeypatch.setattr(state_module.os, "replace", real_replace)
+        runtime.save("nodisk")
+        assert fired == ["mcp_unreachable"]
+    finally:
+        set_runtime_health_listener("nodisk", None)
+
+
+@pytest.mark.asyncio
+async def test_the_health_listener_lives_exactly_as_long_as_the_loop():
+    """The registry is a module global, so a reporter that stops must not
+    stay reachable through it — and a reporter that starts again must be
+    reachable again.
+
+    Both halves are load-bearing. ws-local reuses one reporter across
+    attaches, spawning a fresh heartbeat loop each time and calling ``stop``
+    on every detach: binding at construction and releasing at ``stop`` would
+    unbind on the first detach and never rebind, silently retiring the
+    immediate push for the rest of the agent's life.
+    """
+    from puffo_agent.portal.state import _RUNTIME_HEALTH_LISTENERS
+
+    class _Bridge:
+        async def send_status(self, status, **kwargs):
+            return None
+
+        def add_connected_callback(self, callback):
+            return None
+
+    worker = Worker(
+        DaemonConfig(),
+        AgentConfig(
+            id="teardown-agent",
+            runtime=RuntimeConfig(kind="cli-local", harness="codex"),
+        ),
+    )
+    reporter = worker._build_status_reporter(
+        SimpleNamespace(http=SimpleNamespace(keyless=True), _bridge=_Bridge())
+    )
+    try:
+        assert "teardown-agent" not in _RUNTIME_HEALTH_LISTENERS
+
+        for _attach in range(2):
+            loop_task = spawn_task(reporter.run_heartbeat_loop())
+            await _settle()
+            assert "teardown-agent" in _RUNTIME_HEALTH_LISTENERS
+
+            reporter.stop()
+            await loop_task
+            assert "teardown-agent" not in _RUNTIME_HEALTH_LISTENERS
+    finally:
+        _RUNTIME_HEALTH_LISTENERS.pop("teardown-agent", None)
+
+
+def test_a_late_unbind_never_silences_the_reporter_that_replaced_it():
+    """A cancelled loop runs its ``finally`` whenever the event loop next
+    gets to it, which can be after a rebuilt reporter has claimed the slot.
+    Releasing by identity keeps the live one registered."""
+    from puffo_agent.portal.state import (
+        _RUNTIME_HEALTH_LISTENERS,
+        clear_runtime_health_listener,
+        set_runtime_health_listener,
+    )
+
+    def _old():
+        pass
+
+    def _new():
+        pass
+
+    try:
+        set_runtime_health_listener("succeeded-agent", _old)
+        set_runtime_health_listener("succeeded-agent", _new)
+        clear_runtime_health_listener("succeeded-agent", _old)
+        assert _RUNTIME_HEALTH_LISTENERS.get("succeeded-agent") is _new
+        clear_runtime_health_listener("succeeded-agent", _new)
+        assert "succeeded-agent" not in _RUNTIME_HEALTH_LISTENERS
+    finally:
+        _RUNTIME_HEALTH_LISTENERS.pop("succeeded-agent", None)
+
+
 def spawn_task(coro):
     return asyncio.ensure_future(coro)
 

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -720,7 +720,9 @@ def test_hello_beacon_refires_after_interval(monkeypatch):
 # ── per-spawn config generation ────────────────────────────────────────
 
 
-def test_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
+def _local_preparer(tmp_path, monkeypatch, *, harness, agent_id, command=()):
+    """A preparer wired for one harness family, with only the host lookups
+    that would leave the sandbox stubbed out."""
     import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
     from puffo_agent.agent.harness.runtime.local_runtime import (
         LocalRuntimePreparer,
@@ -728,32 +730,146 @@ def test_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
 
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
-    monkeypatch.setattr(
-        local_runtime, "resolve_claude_bin", lambda: "/bin/claude",
-    )
     monkeypatch.setattr(local_runtime, "is_macos", lambda: False)
+    for name, value in (
+        ("resolve_claude_bin", "/bin/claude"),
+        ("resolve_codex_bin", "/bin/codex"),
+        ("resolve_pi_bin", "/bin/pi"),
+        ("resolve_opencode_bin", "/bin/opencode"),
+    ):
+        monkeypatch.setattr(local_runtime, name, lambda _v=value: _v)
+
+    async def _no_install(**_kwargs):
+        return {}
+
+    monkeypatch.setattr(local_runtime, "run_spawn_install", _no_install)
+    provider = {
+        "claude-code": "anthropic",
+        "codex": "openai",
+    }.get(harness, "")
+    # codex refuses to build a spec without auth; the gateway branch is the
+    # one that needs no host credential file.
+    gateway = (
+        {"llm_base_url": "http://gateway.invalid", "api_key": "k"}
+        if harness == "codex" else {}
+    )
     config = AgentConfig(
-        id="gen-test",
+        id=agent_id,
         runtime=RuntimeConfig(
-            kind="cli-local", provider="anthropic", harness="claude-code",
+            kind="cli-local",
+            provider=provider,
+            harness=harness,
+            harness_command=list(command),
+            **gateway,
         ),
         puffo_core=PuffoCoreConfig(
             slug="bot-gen", device_id="d1", space_id="sp1",
         ),
     )
-    preparer = LocalRuntimePreparer(DaemonConfig(), config)
+    return LocalRuntimePreparer(DaemonConfig(), config)
 
-    first = preparer._prepare_claude_spec("prompt")
-    config_doc = json.loads(
-        (tmp_path / "puffo" / "agents" / "gen-test" / "mcp-config.json")
-        .read_text(encoding="utf-8")
+
+# Every harness family the daemon can spawn a Puffo MCP subprocess for.
+# ``acp`` needs an explicit command; the rest resolve a binary.
+_MCP_HARNESS_FAMILIES = [
+    ("claude-code", ()),
+    ("codex", ()),
+    ("pi", ()),
+    ("opencode", ()),
+    ("acp", ("lingtai-agent", "acp")),
+]
+
+
+@pytest.mark.parametrize("harness,command", _MCP_HARNESS_FAMILIES)
+def test_every_harness_family_mints_a_generation(
+    harness, command, tmp_path, monkeypatch,
+):
+    """The probe is keyed on ``spec.mcp_generation``; an empty one makes
+    ``Worker.probe_mcp_transport`` return early, so a family that does not
+    mint has *no* wedge detection at all — and nothing logs that.
+
+    This is the assertion that was missing when the mint lived only in the
+    claude-code branch: pi, opencode, acp and codex shipped with the
+    detector silently disabled.
+    """
+    preparer = _local_preparer(
+        tmp_path, monkeypatch,
+        harness=harness, agent_id=f"gen-{harness}", command=command,
     )
-    written = config_doc["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]
-    second = preparer._prepare_claude_spec("prompt")
 
-    assert first.mcp_generation and second.mcp_generation
+    first = asyncio.run(preparer.refresh_spec("prompt"))
+    second = asyncio.run(preparer.refresh_spec("prompt"))
+
+    assert first.mcp_generation, f"{harness} spec carries no mcp_generation"
+    # A recycle must not be able to accept the predecessor's hello.
     assert first.mcp_generation != second.mcp_generation
-    assert written == first.mcp_generation
+
+
+@pytest.mark.parametrize("harness,command", _MCP_HARNESS_FAMILIES)
+def test_every_harness_family_hands_the_generation_to_the_subprocess(
+    harness, command, tmp_path, monkeypatch,
+):
+    """Minting is only half of it: the subprocess must receive the value,
+    because ``_make_hello_startup`` returns ``None`` on an empty
+    ``PUFFO_MCP_GENERATION`` and then never sends a hello at all."""
+    preparer = _local_preparer(
+        tmp_path, monkeypatch,
+        harness=harness, agent_id=f"env-{harness}", command=command,
+    )
+
+    spec = asyncio.run(preparer.refresh_spec("prompt"))
+    delivered = _delivered_generations(preparer, spec, tmp_path, harness)
+
+    assert delivered, f"{harness} spawns no Puffo MCP subprocess environment"
+    for value in delivered:
+        assert value == spec.mcp_generation
+
+
+def _delivered_generations(preparer, spec, tmp_path, harness):
+    """Every PUFFO_MCP_GENERATION this spec actually hands a subprocess.
+
+    Each family carries the server differently — CLI config file, TOML,
+    protocol projection, inline JSON, or the pi bridge — so the value has
+    to be read back out of the shape that family really uses.
+    """
+    found = [
+        server.environment.get("PUFFO_MCP_GENERATION", "")
+        for server in spec.mcp_servers
+    ]
+    if harness == "claude-code":
+        document = json.loads(
+            (tmp_path / "puffo" / "agents" / f"env-{harness}"
+             / "mcp-config.json").read_text(encoding="utf-8")
+        )
+        found.append(
+            document["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]
+        )
+    elif harness == "codex":
+        from puffo_agent.portal.state import agent_codex_user_dir
+
+        config = (
+            agent_codex_user_dir(preparer.agent_id) / "config.toml"
+        ).read_text(encoding="utf-8")
+        found.extend(
+            line.split("=", 1)[1].strip().strip('"')
+            for line in config.splitlines()
+            if line.strip().startswith("PUFFO_MCP_GENERATION")
+        )
+    elif harness == "opencode":
+        inline = json.loads(spec.environment["OPENCODE_CONFIG_CONTENT"])
+        found.append(
+            inline["mcp"]["puffo"]["environment"]["PUFFO_MCP_GENERATION"]
+        )
+    elif harness == "pi":
+        # Pi has no MCP client; the attested bridge carries the whole server
+        # spec as JSON, so the generation has to survive that encoding too.
+        from puffo_agent.agent.harness.drivers.pi_bridge import (
+            BRIDGE_CONFIG_ENV,
+        )
+
+        bridge = json.loads(spec.environment[BRIDGE_CONFIG_ENV])
+        found.append(bridge["environment"]["PUFFO_MCP_GENERATION"])
+    return [value for value in found if value]
 
 
 def test_docker_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -201,6 +201,78 @@ def test_probe_recycles_then_flips_health(registered_manager, saved_states):
     assert ("t", "mcp_unreachable", worker.runtime.error) in saved_states
 
 
+@pytest.mark.parametrize("starting_health", ["ok", "unknown", "in_progress", "no_progress"])
+def test_wedge_is_named_from_the_states_a_wedge_actually_leaves_behind(
+    starting_health, registered_manager, saved_states,
+):
+    """A real MCP failure rarely leaves health at ``ok``.
+
+    The turn it breaks is admitted (``in_progress``) or keeps waking and
+    consuming nothing (``no_progress``), so gating the flip on ok/unknown
+    skipped the diagnosis in exactly the states the fault produces — the
+    generic symptom stayed, and its remediation text points at provider
+    credentials.
+    """
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker(starting_health)
+    _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+    mgr.last_open_monotonic = time.monotonic() - 120
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker._mcp_probe_strikes == 2
+    assert worker.runtime.health == "mcp_unreachable"
+
+
+@pytest.mark.parametrize(
+    "specific_red",
+    ["auth_failed", "provider_error", "refresh_broken", "drained",
+     "extra_usage_required", "unhandled_error"],
+)
+def test_wedge_never_overwrites_a_more_specific_cause(
+    specific_red, registered_manager, saved_states,
+):
+    """The probe knows the transport is down, not that it is the only
+    thing wrong. Widening the overwrite set must not turn into "the last
+    writer wins" — a credential failure outranks it."""
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker(specific_red)
+    _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+    mgr.last_open_monotonic = time.monotonic() - 120
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker.runtime.health == specific_red
+
+
+@pytest.mark.parametrize("starting_health", ["in_progress", "no_progress"])
+def test_recovery_clears_the_wedge_from_the_widened_states(
+    starting_health, registered_manager, saved_states,
+):
+    """Only checking that it turns red would miss a red that cannot come
+    down: once the subprocess hellos back, health must return to ok."""
+    mgr = registered_manager(_FakeManager("g1", time.monotonic() - 120))
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker(starting_health)
+    _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+    mgr.last_open_monotonic = time.monotonic() - 120
+    _run(worker.probe_mcp_transport("t"))
+    assert worker.runtime.health == "mcp_unreachable"
+
+    rpc_service.record_mcp_hello("t", mgr.spec.mcp_generation)
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker.runtime.health == "ok"
+    assert worker.runtime.error == ""
+    assert worker._mcp_probe_strikes == 0
+
+
 def test_recycle_mints_new_generation_and_late_old_hello_stays_red(
     registered_manager, saved_states,
 ):
@@ -872,10 +944,91 @@ def _delivered_generations(preparer, spec, tmp_path, harness):
     return [value for value in found if value]
 
 
-def test_docker_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
-    """cli-docker Claude gets the same per-write generation as
-    cli-local — without it the transport probe exits early and Docker
-    agents have no wedge recovery at all."""
+def _docker_preparer(tmp_path, monkeypatch, *, harness, agent_id):
+    from puffo_agent.agent.harness.runtime.docker_runtime import (
+        DockerRuntimePreparer,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
+    gateway = (
+        {"llm_base_url": "http://gateway.invalid", "api_key": "k"}
+        if harness == "codex" else {}
+    )
+    config = AgentConfig(
+        id=agent_id,
+        runtime=RuntimeConfig(
+            kind="cli-docker",
+            provider="anthropic" if harness == "claude-code" else "openai",
+            harness=harness,
+            **gateway,
+        ),
+        puffo_core=PuffoCoreConfig(
+            slug="bot-gen-d", device_id="d1", space_id="sp1",
+        ),
+    )
+    return DockerRuntimePreparer(DaemonConfig(), config)
+
+
+@pytest.mark.parametrize("harness", ["claude-code", "codex"])
+def test_docker_spec_mints_fresh_generation(harness, tmp_path, monkeypatch):
+    """Both container harnesses need the per-build generation: without it
+    the transport probe exits early and the agent has no wedge recovery.
+
+    codex shipped without one while claude had it — the same per-harness
+    mint that left cli-local pi/opencode/acp unwired.
+    """
+    preparer = _docker_preparer(
+        tmp_path, monkeypatch, harness=harness, agent_id=f"gen-docker-{harness}",
+    )
+
+    first = asyncio.run(preparer.refresh_spec("prompt"))
+    second = asyncio.run(preparer.refresh_spec("prompt"))
+
+    assert first.mcp_generation, f"docker {harness} carries no mcp_generation"
+    assert first.mcp_generation != second.mcp_generation
+
+
+@pytest.mark.parametrize("harness", ["claude-code", "codex"])
+def test_docker_hands_the_generation_to_the_subprocess(
+    harness, tmp_path, monkeypatch,
+):
+    preparer = _docker_preparer(
+        tmp_path, monkeypatch, harness=harness, agent_id=f"env-docker-{harness}",
+    )
+
+    spec = asyncio.run(preparer.refresh_spec("prompt"))
+
+    if harness == "claude-code":
+        document = json.loads(
+            (preparer.workspace_dir / ".puffo-agent" / "mcp-config.json")
+            .read_text(encoding="utf-8")
+        )
+        delivered = [
+            document["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]
+        ]
+    else:
+        config = (preparer.codex_home / "config.toml").read_text(
+            encoding="utf-8"
+        )
+        delivered = [
+            line.split("=", 1)[1].strip().strip('"')
+            for line in config.splitlines()
+            if line.strip().startswith("PUFFO_MCP_GENERATION")
+        ]
+
+    assert delivered, f"docker {harness} hands the subprocess no generation"
+    for value in delivered:
+        assert value == spec.mcp_generation
+
+
+def test_no_puffo_core_means_no_generation_to_wait_for(tmp_path, monkeypatch):
+    """A generation is a promise that some subprocess will hello back.
+
+    An agent with no Puffo MCP configured has nobody to make that promise,
+    so it must stay empty — otherwise the probe would recycle it forever
+    waiting for a hello that cannot come.
+    """
     from puffo_agent.agent.harness.runtime.docker_runtime import (
         DockerRuntimePreparer,
     )
@@ -883,24 +1036,120 @@ def test_docker_claude_spec_mints_fresh_generation(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "host"))
     config = AgentConfig(
-        id="gen-docker",
+        id="no-core-docker",
         runtime=RuntimeConfig(
             kind="cli-docker", provider="anthropic", harness="claude-code",
-        ),
-        puffo_core=PuffoCoreConfig(
-            slug="bot-gen-d", device_id="d1", space_id="sp1",
         ),
     )
     preparer = DockerRuntimePreparer(DaemonConfig(), config)
 
-    first = preparer._prepare_claude_spec("prompt")
-    config_doc = json.loads(
-        (preparer.workspace_dir / ".puffo-agent" / "mcp-config.json")
-        .read_text(encoding="utf-8")
-    )
-    written = config_doc["mcpServers"]["puffo"]["env"]["PUFFO_MCP_GENERATION"]
-    second = preparer._prepare_claude_spec("prompt")
+    spec = asyncio.run(preparer.refresh_spec("prompt"))
 
-    assert first.mcp_generation and second.mcp_generation
-    assert first.mcp_generation != second.mcp_generation
-    assert written == first.mcp_generation
+    assert spec.mcp_generation == ""
+
+
+# ── health reaches the server without waiting out the heartbeat ─────────
+
+
+def test_health_change_wakes_the_heartbeat(tmp_path, monkeypatch):
+    """``runtime.health`` only travels on heartbeats, so a red written
+    just after a turn settles used to wait out the whole interval before
+    the server heard about it — long enough to read as "never reported".
+
+    The periodic tick stays: this only shortens the wait.
+    """
+    from puffo_agent.agent.status_reporter import StatusReporter
+    from puffo_agent.portal.state import (
+        set_runtime_health_listener,
+        _RUNTIME_LAST_HEALTH,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    _RUNTIME_LAST_HEALTH.pop("hb", None)
+    sent: list[str] = []
+
+    class _Http:
+        keyless = False
+
+        async def post(self, path, body):
+            sent.append(body.get("health", ""))
+            return {}
+
+    async def _drive():
+        reporter = StatusReporter(
+            _Http(),
+            heartbeat_interval_s=3600.0,  # never fires on its own in this test
+            runtime_health_provider=lambda: runtime.health,
+        )
+        set_runtime_health_listener("hb", reporter.request_immediate_heartbeat)
+        loop_task = spawn_task(reporter.run_heartbeat_loop())
+        try:
+            await _settle()
+            assert sent == ["ok"], sent
+
+            runtime.health = "mcp_unreachable"
+            runtime.save("hb")
+            await _settle()
+            assert sent == ["ok", "mcp_unreachable"], sent
+
+            # An unchanged health must not add wire traffic.
+            runtime.save("hb")
+            await _settle()
+            assert sent == ["ok", "mcp_unreachable"], sent
+
+            # Recovery travels on the same path, not just the failure.
+            runtime.health = "ok"
+            runtime.save("hb")
+            await _settle()
+            assert sent == ["ok", "mcp_unreachable", "ok"], sent
+        finally:
+            set_runtime_health_listener("hb", None)
+            loop_task.cancel()
+            try:
+                await loop_task
+            except asyncio.CancelledError:
+                pass
+
+    runtime = RuntimeState(status="running", health="ok")
+    runtime.save("hb")  # seed the baseline; no listener registered yet
+    asyncio.run(_drive())
+
+
+def test_a_failed_publish_never_blocks_the_local_health_write(tmp_path, monkeypatch):
+    """The local file is authoritative. If the listener raises, health must
+    still be persisted — the daemon cannot lose its own diagnosis because
+    the server was unreachable."""
+    from puffo_agent.portal.state import (
+        set_runtime_health_listener,
+        _RUNTIME_LAST_HEALTH,
+        runtime_json_path,
+    )
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "puffo"))
+    _RUNTIME_LAST_HEALTH.pop("boom", None)
+
+    def _explode():
+        raise RuntimeError("transport is down")
+
+    runtime = RuntimeState(status="running", health="ok")
+    runtime.save("boom")
+    set_runtime_health_listener("boom", _explode)
+    try:
+        runtime.health = "mcp_unreachable"
+        runtime.save("boom")
+    finally:
+        set_runtime_health_listener("boom", None)
+
+    written = json.loads(
+        runtime_json_path("boom").read_text(encoding="utf-8")
+    )
+    assert written["health"] == "mcp_unreachable"
+
+
+def spawn_task(coro):
+    return asyncio.ensure_future(coro)
+
+
+async def _settle():
+    for _ in range(10):
+        await asyncio.sleep(0)


### PR DESCRIPTION
## The defect

The MCP transport wedge probe is keyed on `RuntimeSpec.mcp_generation`. Both halves of the handshake fail **quietly** when it is empty:

- daemon side — `Worker.probe_mcp_transport` returns early on `if not spec_gen`;
- subprocess side — `puffo_core_server._make_hello_startup` returns `None`, so no `mcp-hello` is ever sent.

The mint lived only in `_prepare_claude_spec` (and `docker_runtime`). The **generic** path (pi / opencode / acp / gemini) and the **codex** path built their MCP environment straight from `_puffo_core_env` and returned a spec with no generation.

⇒ On those families the wedge detector did not exist: no recycle, no `mcp_unreachable`, and **no log line saying so**.

## Reproduced on a shipping build (2.0.4a4, staging QA)

Killed both `puffo_core_server` subprocesses of a pi agent. For the next 13 minutes: no recycle, no `mcp_unreachable`, `health` stuck at `in_progress`. The agent kept waking turns — the UI recorded three `Using` tool calls whose RPCs **never arrived at the daemon** (0 hits, against a `POST /v1/rpc/<agent>/read-inbox 200` on the same agent's healthy turn). Only the generic `no_progress` fallback eventually fired, whose error text points at provider credentials.

Corroborating: `mcp-hello` appears **0 times** in the whole daemon log, and a live MCP subprocess of an untouched pi agent has `PUFFO_RPC_URL` set but no `PUFFO_MCP_GENERATION` — the env channel works; the variable was simply never put in it.

This is the 8/30-class incident the probe was written for, reproducible today on three of four harness families.

## The fix

Mint once in `refresh_spec` — the single point every spec build passes through — and route all three spawn sites through a new `_puffo_core_child_env()` so the value reaches the subprocess in whatever shape the family actually uses: CLI config file, codex TOML, protocol projection, opencode inline JSON, or the pi bridge blob.

A per-harness mint is exactly how this happened; adding a fourth copy would repeat it.

## Tests

Per harness family (`claude-code`, `codex`, `pi`, `opencode`, `acp`), driving the real `refresh_spec`:

1. the spec carries a non-empty `mcp_generation`;
2. consecutive builds differ — a recycle must not be able to accept its predecessor's hello;
3. the subprocess is handed the **matching** value, read back out of that family's own encoding.

**Mutation check:** restricting the mint back to `claude-code` turns all eight non-claude cases red and leaves claude green.

Full suite green; `ruff` and `tools/check_python_structure.py` clean.

## Not in this PR

- `health` changes wait up to 60s for the next heartbeat before reaching the server (last `agent.status` frame preceded the flip by 128ms). Tracked separately at @peter-stei-5525-5d5ebaa5's request.
- The `no_progress` error text points at credentials even when the inbox-side observer has already logged `possible MCP control-plane failure`.
- Web-side rendering of these states is puffo-core-han-group#928.