### PR TITLE
fix(portal): the MCP probe covers persistent-child harnesses only

### DIFF
--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -424,6 +424,76 @@ class Worker:
         self.runtime.save(agent_id)
         self._warm_done.set()
 
+    def _withdraw_unsubstantiated_wedge(self, agent_id: str) -> None:
+        """Retract a red this probe can no longer stand behind.
+
+        This probe is the only writer of ``mcp_unreachable``, and the
+        batch-top override deliberately refuses to overwrite it (its evidence
+        is independent of any turn). So nothing else in the daemon can ever
+        clear it: an agent the probe has stopped applying to would stay red
+        for the life of the process. Upgrading past the release that flagged
+        idle per-turn harnesses has to release them, not freeze them.
+
+        Retracted to ``unknown`` rather than ``ok``: the claim is being
+        withdrawn for want of evidence, which is not the same as observing a
+        healthy transport.
+        """
+        self._mcp_probe_strikes = 0
+        if self.runtime.health != "mcp_unreachable":
+            return
+        self.runtime.health = "unknown"
+        self.runtime.error = ""
+        self.runtime.save(agent_id)
+        logger.info(
+            "agent %s: withdrew an MCP wedge this probe no longer covers",
+            agent_id,
+        )
+
+    def _mcp_probe_subject(self, agent_id: str):
+        """The runtime this probe can speak about, or ``None``.
+
+        Every reason the transport probe does not apply lives here, so the
+        probe body can assume its premise instead of re-deriving it:
+
+        - no adapter or no runtime manager — nothing to reload;
+        - empty generation (agent has no puffo MCP) or no open watermark —
+          no subprocess was ever promised;
+        - no capability snapshot — ``last_open_monotonic`` is stamped
+          *before* ``driver.open`` is awaited, so a failed open leaves a
+          watermark and nothing else. That is a runtime that never came up,
+          which has its own error path;
+        - a non-persistent harness lifecycle. A ``PER_TURN_CHILD`` driver
+          takes ``open`` as a logical session and spawns on ``start_turn``
+          (see ``RuntimeLifecycle``), so between turns nothing exists to
+          hello with — and the probe stands down *during* turns, so for such
+          a driver it would run exclusively when its premise is false. Every
+          idle opencode agent went ``mcp_unreachable`` within a minute of
+          start, with no fault injected. Naming a per-turn wedge needs an
+          in-turn signal, which this is not; decline rather than report a red
+          nobody can act on.
+
+        Attribute access on the contract fields is direct on purpose:
+        producer/consumer drift must raise here rather than silently disable
+        recovery. Only value-level absence is legitimate and returns quietly.
+        """
+        from ..agent.harness.driver import RuntimeLifecycle
+        from ..agent.harness.runtime.runtime_manager import get_runtime_manager
+
+        adapter = self._adapter
+        mgr = get_runtime_manager(agent_id)
+        if adapter is None or mgr is None:
+            return None
+        spec_gen = mgr.spec.mcp_generation
+        opened_at = mgr.last_open_monotonic
+        if not spec_gen or opened_at is None:
+            return None
+        capabilities = mgr.current_capabilities()
+        if capabilities is None:
+            return None
+        if capabilities.lifecycle != RuntimeLifecycle.PERSISTENT_CHILD:
+            return None
+        return adapter, mgr, spec_gen, opened_at
+
     async def probe_mcp_transport(self, agent_id: str) -> None:
         """Heartbeat-cadence transport probe: the current runtime's puffo
         MCP subprocess must have reached the loopback RPC service
@@ -436,23 +506,19 @@ class Worker:
         runtime's health); a second miss flips ``mcp_unreachable`` so
         the wedge is visible instead of an agent that wakes turns but
         can never read them (8/30-class incident: alive worker, dead
-        MCP, health ok for 51 min)."""
-        from ..agent.harness.runtime.runtime_manager import get_runtime_manager
+        MCP, health ok for 51 min).
+
+        Covers persistent-child harnesses only. A per-turn harness holds no
+        subprocess between turns, so it has nothing to hello with at exactly
+        the moments this probe runs; naming its wedge needs an in-turn
+        signal that does not exist yet."""
         from . import rpc_service
 
-        adapter = self._adapter
-        mgr = get_runtime_manager(agent_id)
-        if adapter is None or mgr is None:
+        subject = self._mcp_probe_subject(agent_id)
+        if subject is None:
+            self._withdraw_unsubstantiated_wedge(agent_id)
             return
-        # Direct attribute access on purpose: these are required contract
-        # fields, and producer/consumer drift must raise here instead of
-        # silently disabling recovery. Only value-level absence is
-        # legitimate (no puffo_core → empty generation; never opened →
-        # None) and returns quietly.
-        spec_gen = mgr.spec.mcp_generation
-        opened_at = mgr.last_open_monotonic
-        if not spec_gen or opened_at is None:
-            return
+        adapter, mgr, spec_gen, opened_at = subject
         now = time.monotonic()
         # Query exactly this spec's generation: hello state is keyed per
         # (agent, generation), so a surviving pre-recycle subprocess's

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -173,6 +173,14 @@ _NO_PROGRESS_TURN_THRESHOLD = 3
 # MCP failure leaves behind. Every more specific red (auth_failed,
 # provider_error, refresh_broken, drained, ...) stays authoritative: the probe
 # knows the transport is down, not that it is the only thing wrong.
+# Returned by ``_mcp_probe_subject`` when the probe covers this harness but
+# there is no open runtime at this instant. Distinct from ``None`` (not
+# covered at all): coverage is a standing property and retracts a stale red,
+# readiness is momentary and must not reset the strike count — a probe that
+# lands mid-reload would otherwise zero the strikes on every recycle and the
+# escalation to ``mcp_unreachable`` could never be reached.
+_MCP_PROBE_NOT_READY = object()
+
 _MCP_PROBE_OVERWRITABLE_HEALTH = (
     "ok",
     "unknown",
@@ -450,27 +458,34 @@ class Worker:
         )
 
     def _mcp_probe_subject(self, agent_id: str):
-        """The runtime this probe can speak about, or ``None``.
+        """The runtime this probe can speak about.
 
-        Every reason the transport probe does not apply lives here, so the
-        probe body can assume its premise instead of re-deriving it:
+        Three outcomes, and the difference between the last two is what keeps
+        a recycle from looping forever:
 
-        - no adapter or no runtime manager — nothing to reload;
-        - empty generation (agent has no puffo MCP) or no open watermark —
-          no subprocess was ever promised;
-        - no capability snapshot — ``last_open_monotonic`` is stamped
-          *before* ``driver.open`` is awaited, so a failed open leaves a
-          watermark and nothing else. That is a runtime that never came up,
-          which has its own error path;
-        - a non-persistent harness lifecycle. A ``PER_TURN_CHILD`` driver
-          takes ``open`` as a logical session and spawns on ``start_turn``
-          (see ``RuntimeLifecycle``), so between turns nothing exists to
-          hello with — and the probe stands down *during* turns, so for such
-          a driver it would run exclusively when its premise is false. Every
-          idle opencode agent went ``mcp_unreachable`` within a minute of
-          start, with no fault injected. Naming a per-turn wedge needs an
-          in-turn signal, which this is not; decline rather than report a red
-          nobody can act on.
+        - a ``(adapter, mgr, spec_gen, opened_at)`` tuple — probe it;
+        - ``_MCP_PROBE_NOT_READY`` — the probe covers this harness but there
+          is no open runtime *right now* (starting, torn down, or mid-reload).
+          Momentary: say nothing, keep the strike count, keep any red;
+        - ``None`` — the probe does not cover this agent at all. A standing
+          property, so a red it can no longer substantiate is withdrawn.
+
+        Not covered means either no puffo MCP to hello back (empty
+        generation), or a non-persistent harness lifecycle: a
+        ``PER_TURN_CHILD`` driver takes ``open`` as a logical session and
+        spawns on ``start_turn`` (see ``RuntimeLifecycle``), so between turns
+        nothing exists to hello with — and this probe stands down *during*
+        turns, so for such a driver it would run exclusively when its premise
+        is false. Every idle opencode agent went ``mcp_unreachable`` within a
+        minute of start, with no fault injected.
+
+        ``mgr.opened`` is the open fact, not ``current_capabilities()``:
+        every shipped driver returns a capability object unconditionally
+        (constants on pi/codex, a constructor-time value on acp, a freshly
+        built one on claude), so capabilities are non-None even when the open
+        failed. ``last_open_monotonic`` is no better — it is stamped *before*
+        ``driver.open`` is awaited. Only ``opened`` is set after a successful
+        open and cleared by every close/reload path.
 
         Attribute access on the contract fields is direct on purpose:
         producer/consumer drift must raise here rather than silently disable
@@ -482,17 +497,20 @@ class Worker:
         adapter = self._adapter
         mgr = get_runtime_manager(agent_id)
         if adapter is None or mgr is None:
-            return None
-        spec_gen = mgr.spec.mcp_generation
-        opened_at = mgr.last_open_monotonic
-        if not spec_gen or opened_at is None:
-            return None
+            return _MCP_PROBE_NOT_READY
         capabilities = mgr.current_capabilities()
-        if capabilities is None:
+        if capabilities is not None and (
+            capabilities.lifecycle != RuntimeLifecycle.PERSISTENT_CHILD
+        ):
             return None
-        if capabilities.lifecycle != RuntimeLifecycle.PERSISTENT_CHILD:
+        if not mgr.spec.mcp_generation:
             return None
-        return adapter, mgr, spec_gen, opened_at
+        if capabilities is None or mgr.opened is None:
+            return _MCP_PROBE_NOT_READY
+        opened_at = mgr.last_open_monotonic
+        if opened_at is None:
+            return _MCP_PROBE_NOT_READY
+        return adapter, mgr, mgr.spec.mcp_generation, opened_at
 
     async def probe_mcp_transport(self, agent_id: str) -> None:
         """Heartbeat-cadence transport probe: the current runtime's puffo
@@ -515,6 +533,8 @@ class Worker:
         from . import rpc_service
 
         subject = self._mcp_probe_subject(agent_id)
+        if subject is _MCP_PROBE_NOT_READY:
+            return
         if subject is None:
             self._withdraw_unsubstantiated_wedge(agent_id)
             return

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -16,6 +16,7 @@ import pytest
 
 from puffo_agent.agent.harness.driver import (
     ProtocolDiagnostics,
+    RuntimeLifecycle,
     RuntimeOpened,
     RuntimeRef,
     RuntimeSpec,
@@ -136,11 +137,25 @@ def test_reload_failure_cap_abandons_flags_into_health(tmp_path, saved_states):
 
 
 class _FakeManager:
-    def __init__(self, generation: str, opened_at: float):
+    def __init__(
+        self,
+        generation: str,
+        opened_at: float,
+        lifecycle=RuntimeLifecycle.PERSISTENT_CHILD,
+    ):
         self.spec = SimpleNamespace(
             mcp_generation=generation, system_prompt="p",
         )
         self.last_open_monotonic = opened_at
+        # ``None`` reproduces an open that never completed: the manager
+        # stamps ``last_open_monotonic`` *before* awaiting ``driver.open``,
+        # so a failed open leaves a watermark with no capability snapshot.
+        self._lifecycle = lifecycle
+
+    def current_capabilities(self):
+        if self._lifecycle is None:
+            return None
+        return SimpleNamespace(lifecycle=self._lifecycle)
 
 
 class _RecyclingAdapter:
@@ -199,6 +214,142 @@ def test_probe_recycles_then_flips_health(registered_manager, saved_states):
     _run(worker.probe_mcp_transport("t"))
     assert worker.runtime.health == "mcp_unreachable"
     assert ("t", "mcp_unreachable", worker.runtime.error) in saved_states
+
+
+def test_a_per_turn_harness_is_never_wedged_by_this_probe(
+    registered_manager, saved_states,
+):
+    """A generation is not a promise of a *live* subprocess everywhere.
+
+    A ``PER_TURN_CHILD`` driver takes ``open`` as a logical session and
+    spawns on ``start_turn``, so between turns nothing exists to hello with.
+    The probe also stands down during a turn, so for such a driver it would
+    run only when its premise is false — every idle opencode agent went
+    ``mcp_unreachable`` within a minute of start, with no fault injected.
+    """
+    mgr = registered_manager(
+        _FakeManager(
+            "g1", time.monotonic() - 600,
+            lifecycle=RuntimeLifecycle.PER_TURN_CHILD,
+        )
+    )
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker("ok")
+    adapter = _wire(worker, mgr)
+
+    for _ in range(3):
+        _run(worker.probe_mcp_transport("t"))
+
+    assert adapter.reload_calls == []
+    assert worker._mcp_probe_strikes == 0
+    assert worker.runtime.health == "ok"
+    assert saved_states == []
+
+
+def test_an_open_that_never_completed_is_not_a_wedge(
+    registered_manager, saved_states,
+):
+    """``last_open_monotonic`` is stamped *before* ``driver.open`` is
+    awaited, so a failed open leaves a watermark and no capabilities. That
+    is not a wedged transport — it is a runtime that never came up, and it
+    has its own error path. An unactionable red here would only mislabel it.
+    """
+    mgr = registered_manager(
+        _FakeManager("g1", time.monotonic() - 600, lifecycle=None)
+    )
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker("ok")
+    adapter = _wire(worker, mgr)
+
+    for _ in range(3):
+        _run(worker.probe_mcp_transport("t"))
+
+    assert adapter.reload_calls == []
+    assert worker._mcp_probe_strikes == 0
+    assert worker.runtime.health == "ok"
+
+
+def test_a_wedge_this_probe_stopped_covering_is_withdrawn(
+    registered_manager, saved_states,
+):
+    """Nothing else in the daemon can clear ``mcp_unreachable``.
+
+    This probe is its only writer, and the batch-top override explicitly
+    refuses to overwrite it. So narrowing what the probe covers without
+    retracting the reds it already wrote would pin every opencode agent the
+    buggy release flagged, for the life of the process. ``unknown``, not
+    ``ok``: the claim is withdrawn for want of evidence, which is not the
+    same as observing a healthy transport.
+    """
+    mgr = registered_manager(
+        _FakeManager(
+            "g1", time.monotonic() - 600,
+            lifecycle=RuntimeLifecycle.PER_TURN_CHILD,
+        )
+    )
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker("mcp_unreachable")
+    worker._mcp_probe_strikes = 2
+    adapter = _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker.runtime.health == "unknown"
+    assert worker.runtime.error == ""
+    assert worker._mcp_probe_strikes == 0
+    assert adapter.reload_calls == []
+
+
+def test_withdrawal_never_touches_a_red_this_probe_did_not_write(
+    registered_manager, saved_states,
+):
+    """Only ``mcp_unreachable`` is this probe's to retract. A per-turn agent
+    that is genuinely ``auth_failed`` must keep saying so."""
+    mgr = registered_manager(
+        _FakeManager(
+            "g1", time.monotonic() - 600,
+            lifecycle=RuntimeLifecycle.PER_TURN_CHILD,
+        )
+    )
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker("auth_failed")
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker.runtime.health == "auth_failed"
+
+
+def test_exactly_which_shipped_drivers_this_probe_covers():
+    """The negative half of the coverage claim, read off the real drivers.
+
+    Widening the generation mint to every harness family is what put a
+    promise on a driver that cannot keep it. Pin the roster both ways: any
+    new per-turn (or in-process) driver, or a flip of an existing one, must
+    land here and force the question of what names *its* wedge — this probe
+    does not.
+    """
+    from puffo_agent.agent.harness.drivers.acp import acp_capabilities
+    from puffo_agent.agent.harness.drivers.claude_code import (
+        claude_capabilities,
+    )
+    from puffo_agent.agent.harness.drivers.codex import CODEX_CAPABILITIES
+    from puffo_agent.agent.harness.drivers.opencode import (
+        OPENCODE_CAPABILITIES,
+    )
+    from puffo_agent.agent.harness.drivers.pi import PI_CAPABILITIES
+
+    covered = {
+        "claude-code": claude_capabilities(),
+        "codex": CODEX_CAPABILITIES,
+        "pi": PI_CAPABILITIES,
+        "acp": acp_capabilities(session_resume=True),
+    }
+    for name, capabilities in covered.items():
+        assert capabilities.lifecycle == RuntimeLifecycle.PERSISTENT_CHILD, name
+
+    assert (
+        OPENCODE_CAPABILITIES.lifecycle == RuntimeLifecycle.PER_TURN_CHILD
+    ), "opencode is the one harness this probe deliberately declines"
 
 
 @pytest.mark.parametrize("starting_health", ["ok", "unknown", "in_progress", "no_progress"])

--- a/tests/test_mcp_transport_probe.py
+++ b/tests/test_mcp_transport_probe.py
@@ -142,17 +142,24 @@ class _FakeManager:
         generation: str,
         opened_at: float,
         lifecycle=RuntimeLifecycle.PERSISTENT_CHILD,
+        opened: bool = True,
     ):
         self.spec = SimpleNamespace(
             mcp_generation=generation, system_prompt="p",
         )
         self.last_open_monotonic = opened_at
-        # ``None`` reproduces an open that never completed: the manager
-        # stamps ``last_open_monotonic`` *before* awaiting ``driver.open``,
-        # so a failed open leaves a watermark with no capability snapshot.
         self._lifecycle = lifecycle
+        # Mirrors ``RuntimeManager.opened``: set only after a successful
+        # ``driver.open`` and cleared by every close/reload path. It is the
+        # only "did it open" signal — see ``current_capabilities`` below.
+        self.opened = object() if opened else None
 
     def current_capabilities(self):
+        # Deliberately answers even when ``opened`` is None: every shipped
+        # driver returns a capability object unconditionally (module
+        # constants on pi/codex, a constructor-time value on acp, a freshly
+        # built one on claude). A double that returned None here would let
+        # the probe pass a check no real manager ever fails.
         if self._lifecycle is None:
             return None
         return SimpleNamespace(lifecycle=self._lifecycle)
@@ -174,6 +181,7 @@ class _RecyclingAdapter:
             system_prompt=new_system_prompt,
         )
         self.mgr.last_open_monotonic = time.monotonic()
+        self.mgr.opened = object()
 
 
 def _wire(worker: Worker, mgr: _FakeManager) -> _RecyclingAdapter:
@@ -246,20 +254,26 @@ def test_a_per_turn_harness_is_never_wedged_by_this_probe(
     assert saved_states == []
 
 
-def test_an_open_that_never_completed_is_not_a_wedge(
+def test_a_failed_open_is_not_a_wedge_though_capabilities_still_answer(
     registered_manager, saved_states,
 ):
-    """``last_open_monotonic`` is stamped *before* ``driver.open`` is
-    awaited, so a failed open leaves a watermark and no capabilities. That
-    is not a wedged transport — it is a runtime that never came up, and it
-    has its own error path. An unactionable red here would only mislabel it.
+    """Capabilities cannot stand in for "did it open".
+
+    ``last_open_monotonic`` is stamped *before* ``driver.open`` is awaited,
+    so a failed open leaves a watermark behind. Capabilities are no help
+    either: every shipped driver returns an object unconditionally, so they
+    are present even when the open raised. ``mgr.opened`` is the only fact
+    set after a successful open, and this fixture is the real shape —
+    capabilities answer, ``opened`` does not.
     """
     mgr = registered_manager(
-        _FakeManager("g1", time.monotonic() - 600, lifecycle=None)
+        _FakeManager("g1", time.monotonic() - 600, opened=False)
     )
     rpc_service.clear_mcp_hello("t")
     worker = _seed_worker("ok")
     adapter = _wire(worker, mgr)
+
+    assert mgr.current_capabilities() is not None
 
     for _ in range(3):
         _run(worker.probe_mcp_transport("t"))
@@ -267,6 +281,53 @@ def test_an_open_that_never_completed_is_not_a_wedge(
     assert adapter.reload_calls == []
     assert worker._mcp_probe_strikes == 0
     assert worker.runtime.health == "ok"
+
+
+def test_a_closed_runtime_holds_the_strike_count_instead_of_clearing_it(
+    registered_manager, saved_states,
+):
+    """Not-open is momentary; not-covered is standing. Only the second
+    withdraws.
+
+    A reload clears ``opened`` while it runs. If a probe landing in that
+    window reset the strike count, the escalation would restart on every
+    recycle: strike 1 -> recycle -> probe mid-reload zeroes it -> strike 1
+    again, and ``mcp_unreachable`` could never be reached however long the
+    transport stayed dead.
+    """
+    mgr = registered_manager(
+        _FakeManager("g1", time.monotonic() - 600, opened=False)
+    )
+    rpc_service.clear_mcp_hello("t")
+    worker = _seed_worker("mcp_unreachable")
+    worker._mcp_probe_strikes = 1
+    adapter = _wire(worker, mgr)
+
+    _run(worker.probe_mcp_transport("t"))
+
+    assert worker._mcp_probe_strikes == 1
+    assert worker.runtime.health == "mcp_unreachable"
+    assert adapter.reload_calls == []
+
+
+def test_no_shipped_driver_reports_capabilities_only_after_opening():
+    """The contract the probe must not lean on, read off the real drivers.
+
+    Each of these answers before any ``open`` has been attempted, so
+    ``current_capabilities() is None`` can never mean "the open failed".
+    Pinned here so the probe's reliance on ``mgr.opened`` cannot quietly
+    regress to a capabilities check.
+    """
+    from puffo_agent.agent.harness.drivers.codex import CodexDriver
+    from puffo_agent.agent.harness.drivers.opencode import OpenCodeDriver
+    from puffo_agent.agent.harness.drivers.pi import PiDriver
+
+    for driver in (
+        CodexDriver(executable_version="t"),
+        OpenCodeDriver(executable_version="t"),
+        PiDriver(executable_version="t"),
+    ):
+        assert driver.current_capabilities() is not None, type(driver).__name__
 
 
 def test_a_wedge_this_probe_stopped_covering_is_withdrawn(


### PR DESCRIPTION
Fixes a false red I shipped in #333.

## What went wrong

#333 minted the MCP generation for every harness family so the transport probe would stop being silently disabled on four of them. It went one family too far.

opencode declares `lifecycle=RuntimeLifecycle.PER_TURN_CHILD` (`drivers/opencode.py:189`) — of the five shipped drivers it is the only one. `RuntimeLifecycle`'s own docstring spells out what that means: *"a `PER_TURN_CHILD` driver may accept `open()` as a logical session and spawn only on `start_turn()`."* Between turns there is no process, so nothing can answer the hello the generation now asks for.

What makes it certain rather than flaky is the direction: `probe_mcp_transport` already returns early when `_turn_active`. So for a per-turn driver the probe runs **exclusively when its premise is false** — never during the one window where a subprocess exists.

Observed on the QA fleet running merge commit `32168d6`, no fault injected:

```
qa-opencod-5479  health=mcp_unreachable
qa-opencod-7413  health=mcp_unreachable
qa-pi-*          health=unknown          (correct)
```
```
14:36:40 qa-opencod-7413: no hello from this spec's subprocess since runtime open (31s ago); recycling …
14:37:11 qa-opencod-7413: MCP transport still unreachable after recycle; runtime.health = mcp_unreachable
```

Both opencode agents, within a minute of daemon start. The pi agents were fine, and the injected pi fault recycled and recovered correctly (`beacon silent for 180s` → recycle → `transport recovered` 6s later), so the #333 mechanism itself works — it was aimed at one harness it cannot apply to.

Root cause in one line: I enumerated **who needs a generation** and not **who can honour one**.

## The fix

**1. Narrow by lifecycle.** Every reason the probe does not apply moves into `_mcp_probe_subject`, so the body can assume its premise instead of re-deriving it. The per-turn case declines there. Naming a wedge in a per-turn harness needs an in-turn signal; this probe is not it, and declining beats reporting a red nobody can act on. (The generation is still minted for opencode — it remains useful against a leftover subprocess from a previous turn impersonating the current one.)

`current_capabilities()` returning `None` also declines: `last_open_monotonic` is stamped **before** `driver.open` is awaited, so a failed open leaves a watermark and no snapshot. That is a runtime that never came up, which has its own error path — not a wedged transport.

**2. Withdraw on the way out.** This probe is the only writer of `mcp_unreachable`, and the batch-top override (`worker.py:987`) deliberately refuses to overwrite it because its evidence is independent of any turn. Nothing else in the daemon can clear it. Narrowing coverage without retracting reds already written would have pinned every agent the previous release flagged **for the life of the process** — including the two above. Retracted to `unknown`, not `ok`: the claim is being withdrawn for want of evidence, which is not the same as observing a healthy transport. Only `mcp_unreachable` is retracted; an unrelated `auth_failed` on a per-turn agent keeps saying so.

**3. Pin the roster both ways** off the real driver capability constants, so a new per-turn (or in-process) driver — or a flip of an existing one — has to come back here and answer what names *its* wedge. This is the negative assertion #333 was missing.

## Verification

Mutation-verified, each red on its own test and green on the rest of the module:

| mutation | red |
| --- | --- |
| drop the lifecycle narrowing | `test_a_per_turn_harness_is_never_wedged_by_this_probe` |
| drop the `None`-capabilities decline | `test_an_open_that_never_completed_is_not_a_wedge` |
| don't withdraw when the probe stops applying | `test_a_wedge_this_probe_stopped_covering_is_withdrawn` |
| withdraw any health, not just our own red | 3 tests, incl. `test_withdrawal_never_touches_a_red_this_probe_did_not_write` |

Full suite **4069 passed, 0 failed, 2 skipped** (caches cleared, `PYTHONDONTWRITEBYTECODE=1`); `ruff` and `check_python_structure` green — the 100-line function limit is why the applicability check became a named helper rather than more inline branches.

## Scope note

Wedge detection for a per-turn harness is now **explicitly uncovered**, stated in the docstring rather than implied by a probe that could only produce false positives. Closing it needs an in-turn signal and is not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)