### PR TITLE
fix(agent): a rejected Pi credential is an auth failure, and Pi operators stop being sent to Claude's login

### DIFF
--- a/src/puffo_agent/agent/_auth_markers.py
+++ b/src/puffo_agent/agent/_auth_markers.py
@@ -37,6 +37,16 @@ _PROVIDER_DIAGNOSTIC_AUTH_MARKERS: tuple[str, ...] = (
     "invalid credential",
     "token revoked",
     "authentication token is expired",
+    # Observed from Pi/openai-codex with a rejected credential:
+    # "Could not parse your authentication token. Please try signing in
+    # again."  Pi flattens the provider error to `error.message` before we
+    # see it (no code, no HTTP status), so this text is the only signal
+    # this hop gets.  Both markers below name authentication or signing in
+    # explicitly, so a generic tokenizer failure ("unexpected token in
+    # JSON") stays a plain provider error.
+    "authentication token",
+    "sign in again",
+    "signing in again",
 )
 
 

--- a/src/puffo_agent/agent/_auth_markers.py
+++ b/src/puffo_agent/agent/_auth_markers.py
@@ -41,9 +41,9 @@ _PROVIDER_DIAGNOSTIC_AUTH_MARKERS: tuple[str, ...] = (
     # "Could not parse your authentication token. Please try signing in
     # again."  Pi flattens the provider error to `error.message` before we
     # see it (no code, no HTTP status), so this text is the only signal
-    # this hop gets.  Both markers below name authentication or signing in
-    # explicitly, so a generic tokenizer failure ("unexpected token in
-    # JSON") stays a plain provider error.
+    # this hop gets.  All three markers below name authentication or
+    # signing in explicitly, so a generic tokenizer failure ("unexpected
+    # token in JSON") stays a plain provider error.
     "authentication token",
     "sign in again",
     "signing in again",

--- a/src/puffo_agent/agent/_invite_strings.py
+++ b/src/puffo_agent/agent/_invite_strings.py
@@ -134,6 +134,57 @@ def format_oauth_expired(agent_id: str, agent_display_name: str = "") -> str:
     )
 
 
+_HARNESS_LABELS = {
+    "pi": "Pi",
+    "opencode": "OpenCode",
+    "gemini": "Gemini",
+}
+
+
+def format_generic_oauth_expired(
+    agent_id: str, agent_display_name: str = "", harness: str = "",
+) -> str:
+    """Operator DM for a harness with no verified re-login command.
+
+    Deliberately names the harness but *not* a command. The Claude copy
+    used to be the fallback for every non-Codex harness, which told Pi
+    and OpenCode operators to run `claude auth login` for a CLI they may
+    not even have installed. Guessing a replacement is the same mistake:
+    `pi auth` exposes `print-api-key` / `print-bearer-token` / `check`
+    and no `login` at all, so a plausible-looking `pi auth login` would
+    be just as wrong. Naming the harness and leaving the how to the
+    operator is the honest form until a command is verified per harness.
+    """
+    label = (
+        f"**{agent_display_name}** (`{agent_id}`)"
+        if agent_display_name else f"`{agent_id}`"
+    )
+    name = _HARNESS_LABELS.get(harness, harness) or "provider"
+    return (
+        f"⚠️ {label} — my {name} sign-in was rejected, so I can't answer "
+        "you until it's renewed.\n"
+        "\n"
+        "**On the computer where puffo-agent is running:**\n"
+        f"1. Re-authenticate {name} the same way you first signed it in.\n"
+        "2. Come back here and send me a message — I'll pick up where I "
+        "left off.\n"
+        "\n"
+        f"(No command is given because {name} has no single verified "
+        "re-login command; running the wrong CLI's login would not fix "
+        "this agent.)\n"
+        "\n"
+        f"⚠️ {label} — 我的 {name} 登录被拒绝，需要重新授权后才能"
+        "继续回复。\n"
+        "\n"
+        "**在运行 puffo-agent 的电脑上：**\n"
+        f"1. 用你当初登录 {name} 的方式重新授权。\n"
+        "2. 回到这里发一条消息即可恢复。\n"
+        "\n"
+        f"（这里不给具体命令：{name} 没有单一且已核实的重新登录命令，"
+        "跑错 CLI 的登录并不能修好这只 Agent。）"
+    )
+
+
 def format_anthropic_api_key_rejected(
     agent_id: str, agent_display_name: str = "",
 ) -> str:

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -818,13 +818,17 @@ class Worker:
         from ..agent._invite_strings import (
             format_anthropic_api_key_rejected,
             format_codex_oauth_expired,
+            format_generic_oauth_expired,
             format_oauth_expired,
         )
 
         display_name = getattr(self.agent_cfg, "display_name", "") or self.agent_cfg.id
-        # Codex agents need the Codex recovery command, not the Claude
-        # one; otherwise the operator runs the wrong CLI and assumes
-        # the alert is broken. Harness is the cheapest signal we have.
+        # Each provider needs its own recovery command; running the wrong
+        # CLI's login leaves the agent broken and makes the alert look
+        # false. Harness is the cheapest signal we have. Anything we have
+        # not verified a command for gets the generic copy rather than
+        # inheriting Claude's — a Pi agent told to run `claude auth login`
+        # is worse than one told to re-authenticate Pi.
         runtime = getattr(self.agent_cfg, "runtime", None)
         harness = getattr(runtime, "harness", "") if runtime is not None else ""
         if getattr(self, "_claude_api_key_mode", False):
@@ -833,8 +837,12 @@ class Worker:
             )
         elif harness == "codex":
             text = format_codex_oauth_expired(self.agent_cfg.id, display_name)
-        else:
+        elif harness in ("", "claude-code"):
             text = format_oauth_expired(self.agent_cfg.id, display_name)
+        else:
+            text = format_generic_oauth_expired(
+                self.agent_cfg.id, display_name, harness
+            )
         try:
             await client._send_dm(operator_slug, text, root_id="")
         except Exception as exc:

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -272,7 +272,11 @@ def test_the_prose_tier_is_not_widened_by_this_fix():
 
     assert looks_like_provider_auth_error(PI_REJECTED_CREDENTIAL) is True
     assert looks_like_auth_error(PI_REJECTED_CREDENTIAL) is False
-    # Prose that merely mentions signing in stays clean on both tiers.
+    # Prose that merely mentions signing in stays clean on the *prose*
+    # tier.  It does match the diagnostic tier — "signing in again" is a
+    # marker there now — which is exactly why the split matters:
+    # `looks_like_provider_auth_error` is only ever handed provider
+    # diagnostics, never agent output.
     assert looks_like_auth_error(
         "I can walk you through how signing in again works"
     ) is False

--- a/tests/test_auth_error_classification.py
+++ b/tests/test_auth_error_classification.py
@@ -164,3 +164,115 @@ def test_enter_auth_failed_survives_refresh_kick_raising():
     Worker._enter_auth_failed(w, "t-agent")   # no crash
     assert w.runtime.health == "auth_failed"
     assert w.dm_fired == [1]
+
+
+# ── provider diagnostics: Pi / openai-codex rejected credential ────
+#
+# Observed on a QA agent whose credential was deliberately invalidated
+# (2026-09-09).  Pi answered with this exact sentence and the daemon
+# classified it `provider_error`: the operator saw "The provider could
+# not complete the turn.", `_enter_auth_failed` never fired, so no
+# operator DM was sent and the UI gave no hint that a re-login was
+# needed.  The turn just requeued behind an exponential backoff.
+#
+# Pi builds this message with `createErrorMessage()`, which flattens the
+# provider error to `error.message` — no code, no HTTP status survives.
+# The text really is all this hop gets, so the fix has to live in the
+# marker list rather than in a structured field.
+
+PI_REJECTED_CREDENTIAL = (
+    "Could not parse your authentication token. Please try signing in again."
+)
+
+
+def test_pi_rejected_credential_text_is_classified_as_authentication():
+    from puffo_agent.agent.provider_failures import (
+        classify_provider_failure, provider_failure,
+    )
+
+    code = classify_provider_failure(
+        status=None, diagnostic=PI_REJECTED_CREDENTIAL
+    )
+    assert code == "authentication"
+    # The whole point of the classification: is_auth is what makes the
+    # worker flip auth_failed and DM the operator.
+    assert provider_failure(code).is_auth is True
+
+
+def test_pi_message_end_frame_reports_an_auth_failure_code():
+    """The real failing hop, not just the matcher underneath it.
+
+    This is the frame Pi actually emitted; classifying the string
+    correctly is worthless if this translation still reports
+    `provider_error`.
+    """
+    from puffo_agent.agent.harness.driver import SessionRef, TurnRef
+    from puffo_agent.agent.harness.drivers.pi_protocol import (
+        normalize_pi_event,
+    )
+
+    events = normalize_pi_event(
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [],
+                "api": "openai-codex-responses",
+                "provider": "openai-codex",
+                "model": "gpt-5.6-terra",
+                "usage": {"input": 0, "output": 0},
+                "stopReason": "error",
+                "errorMessage": PI_REJECTED_CREDENTIAL,
+                "timestamp": 1789002329865,
+            },
+        },
+        session_ref=SessionRef("s"),
+        turn_ref=TurnRef("t"),
+    )
+    codes = [
+        e.data.get("failure_code") for e in events
+        if e.data.get("code") == "assistant_error"
+    ]
+    assert codes == ["authentication"]
+
+
+@pytest.mark.parametrize("diagnostic", [
+    # Ordinary parse failures must stay generic: an operator told to
+    # "sign in again" over a malformed JSON body would chase the wrong
+    # problem, and the agent would be parked in auth_failed for a fault
+    # that re-logging in cannot fix.
+    "Unexpected token < in JSON at position 0",
+    "Could not parse the response body",
+    "SyntaxError: Unexpected token } in JSON",
+    "Failed to parse token stream from provider",
+    # NOTE: "Tokenizer error: invalid token sequence in prompt" also belongs
+    # here, but it already classifies as `authentication` on unmodified main
+    # via the pre-existing "invalid token" marker.  That false positive
+    # predates this fix and narrowing that marker is a behaviour change
+    # outside this PR's scope, so it is reported separately rather than
+    # asserted here.
+])
+def test_ordinary_parse_failures_are_not_called_auth(diagnostic):
+    from puffo_agent.agent.provider_failures import classify_provider_failure
+
+    assert classify_provider_failure(
+        status=None, diagnostic=diagnostic
+    ) != "authentication"
+
+
+def test_the_prose_tier_is_not_widened_by_this_fix():
+    """`looks_like_auth_error` runs against free-form agent prose, where
+    a substring hit is far more likely to be someone *talking* about
+    signing in.  The new markers belong to the provider-diagnostic tier
+    only; this pins that split so a later edit cannot quietly move them.
+    """
+    from puffo_agent.agent._auth_markers import (
+        looks_like_auth_error, looks_like_provider_auth_error,
+    )
+
+    assert looks_like_provider_auth_error(PI_REJECTED_CREDENTIAL) is True
+    assert looks_like_auth_error(PI_REJECTED_CREDENTIAL) is False
+    # Prose that merely mentions signing in stays clean on both tiers.
+    assert looks_like_auth_error(
+        "I can walk you through how signing in again works"
+    ) is False

--- a/tests/test_auth_failed_dm_notification.py
+++ b/tests/test_auth_failed_dm_notification.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from puffo_agent.agent._invite_strings import format_oauth_expired
@@ -517,17 +519,57 @@ def test_missing_runtime_falls_back_to_claude_copy():
     assert "Claude Code sign-in has expired" in captured["text"]
 
 
-def test_unknown_harness_falls_back_to_claude_copy():
-    """Forward-compat: a harness name we don't recognise yet (hermes,
-    gemini-cli, future provider) defaults to the Claude copy. Better
-    than silent no-DM until we add the specific copy."""
+def test_unknown_harness_gets_the_generic_copy_not_the_claude_one():
+    """A harness we have no verified re-login command for must not
+    inherit Claude's.
+
+    This replaces an earlier pin that defaulted every unknown harness to
+    the Claude copy on the grounds that it beat sending no DM at all.
+    That reasoning had only two options in view; the generic copy is a
+    third, and it is strictly better — the operator still gets a DM, and
+    it no longer tells a Pi or OpenCode operator to run `claude auth
+    login` for a CLI that may not be installed and would not fix this
+    agent even if it were.
+    """
     from puffo_agent.portal import worker as worker_module
 
     w, captured = _make_dispatch_stub("hermes")
     coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
     asyncio.new_event_loop().run_until_complete(coro)
 
-    assert "Claude Code sign-in has expired" in captured["text"]
+    assert "claude auth login" not in captured["text"]
+    assert "Claude Code sign-in" not in captured["text"]
+    # Still a real, actionable DM rather than silence.
+    assert "hermes sign-in was rejected" in captured["text"]
+    assert "send me a message" in captured["text"]
+
+
+@pytest.mark.parametrize("harness,label", [
+    ("pi", "Pi"),
+    ("opencode", "OpenCode"),
+])
+def test_pi_and_opencode_are_never_told_to_run_claude_login(harness, label):
+    """The case that made this necessary.
+
+    A QA Pi agent (running an openai-codex model) had its credential
+    rejected. Once classification was fixed it would have reached this
+    DM path and been handed Claude's recovery steps.
+    """
+    from puffo_agent.portal import worker as worker_module
+
+    w, captured = _make_dispatch_stub(harness)
+    coro = worker_module.Worker._notify_operator_of_auth_failed_oauth(w)
+    asyncio.new_event_loop().run_until_complete(coro)
+
+    text = captured["text"]
+    assert "claude auth login" not in text
+    assert "Claude Code" not in text
+    assert "codex login" not in text
+    assert f"{label} sign-in was rejected" in text
+    assert f"{label} 登录被拒绝" in text
+    # No invented command: `pi auth` has print-api-key / print-bearer-token
+    # / check and no `login`, so a plausible-looking one would be wrong.
+    assert "auth login" not in text
 
 
 # ── PUF-310: format_codex_oauth_expired bilingual copy ─────────────


### PR DESCRIPTION
A deliberately invalidated credential on an isolated QA agent produced `health=provider_error`, not `auth_failed`. Pi answers a rejected credential with:

> Could not parse your authentication token. Please try signing in again.

None of the 25 auth marker phrases match it — `authentication token` is not `authentication failed`, and `could not parse your … token` is not `invalid token` — so `classify_provider_failure` falls through to `provider_error`.

## What that one miss costs

Observed, not inferred — all three measured during the injected fault:

1. **The operator is never told.** `_enter_auth_failed` never fires, so the DM that exists precisely to say "your credential died" is never sent. Zero auth-notification activity in the whole window.
2. **The UI gives no direction.** The operator sees `The provider could not complete the turn.` with nothing pointing at a re-login.
3. **The turn requeues behind an exponential backoff (5/10/20/40s).** Observed alongside the above, but measured **not** to change after this fix — a later injected-fault round still produced 4 requeued admissions. Listed here as context, not as something this PR addresses; I originally wrote it as a cost of the misclassification, which was an inference I had not tested.

Net effect is an agent that goes quiet with a generic error and no notification — the same silent-failure shape users report as "the agent just stopped answering".

## Why the fix is a text marker and not a structured field

Preferred route first: there is no structured error to use. Pi builds the failing assistant message with `createErrorMessage()`, which flattens the provider error to `error.message` before it reaches the wire — no error code, no HTTP status, nothing but `stopReason: "error"` and the sentence. The persisted session record confirms the same shape. The text really is all this hop gets.

## Commit 1 — classification

Three markers added, to the **provider-diagnostic tier only**: `authentication token`, `sign in again`, `signing in again`. Each names authentication or signing in explicitly, so a generic tokenizer failure stays a plain provider error.

The prose tier (`looks_like_auth_error`, which runs against free-form agent output where a substring hit is far more likely to be someone *talking* about signing in) is deliberately untouched, and a test pins that split.

## Commit 2 — recovery wording

Fixing classification exposed the next problem: the auth-failed DM picked the Codex copy for `harness == "codex"` and **the Claude copy for everything else**. A Pi agent running an openai-codex model would have been told to run `claude auth login` — a CLI its operator may not have installed, and one that would not fix the agent if they did.

This is not hypothetical. A sibling path already does it: when the host credential refresh fails, every registered agent is flipped with `Claude Code sign-in couldn't be refreshed… run `claude auth login`` — including Pi agents that never touch Claude.

Harnesses with no verified re-login command now get a generic bilingual copy that names the harness and stops there. **Naming a command would repeat the same mistake in a new costume**: `pi auth` exposes `print-api-key`, `print-bearer-token` and `check`, and no `login` at all, so a plausible-looking `pi auth login` would be equally wrong. Claude and Codex keep their verified commands; a missing runtime block still falls back to Claude for the legacy `agent_cfg` shape.

This replaces a test that pinned the old fallback on the grounds that the Claude copy beat sending no DM. That reasoning had only two options in view; the generic copy is a third and is strictly better — the operator still gets a DM, correctly attributed.

## Tests

- The real sentence classifies as `authentication` and carries `is_auth=True`.
- **The real hop**: Pi's actual `message_end` frame through `normalize_pi_event` reports `failure_code == "authentication"`. Classifying the string correctly is worthless if the translation still reports `provider_error`.
- Counter-examples: ordinary parse failures stay generic, so nobody is told to "sign in again" over a malformed JSON body.
- The prose tier is asserted *not* widened.
- Pi and OpenCode never receive `claude auth login`, and the generic copy invents no command.

All six new assertions fail on unmodified main and pass with the change. Full suite: 4078 passed, 2 skipped (Windows-only; live-E2E behind an env flag). `pre-commit run --all-files`: all gates pass.

## Found but deliberately not fixed here

1. `Tokenizer error: invalid token sequence in prompt` already classifies as `authentication` on **unmodified main**, via the pre-existing `invalid token` marker. That false positive predates this change; narrowing that marker is a behaviour change outside this PR's scope, so it is recorded in a comment beside the counter-example list rather than silently altered.
2. The host-refresh fan-out writes one provider's failure onto every registered agent, with that provider's recovery command. Same defect class, second site, out of scope here.

## Verified on a live agent, with one limit

An injected-fault acceptance round confirmed the **notification dispatch**: the operator DM read "my Pi sign-in was rejected" with no `claude auth login`.

It did **not** verify the classification change. That round never reached the provider — it died at the pre-delivery credential gate (#337), which produces `auth_failed` and a correctly-attributed DM without contacting the provider at all. The classification path remains covered by the automated test through Pi's real `message_end` frame, and unproven on real hardware until #337 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
