### PR TITLE
fix(portal): scope a refresher to the harness whose credentials it owns

### DIFF
--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -475,13 +475,31 @@ class Daemon:
         except OSError as exc:
             logger.warning("agent %s: couldn't remove restart.flag: %s", agent_id, exc)
 
-    def _refresher_for(self, agent_cfg: AgentConfig) -> CredentialRefresher:
-        """Pick the right refresher for an agent's harness. Codex
-        agents only need their own auth.json refresh; claude-code +
-        every other harness routes through the Claude refresher."""
-        if (agent_cfg.runtime.harness or "claude-code") == "codex":
+    def _refresher_for(
+        self, agent_cfg: AgentConfig
+    ) -> CredentialRefresher | None:
+        """The refresher that actually owns this agent's credentials, or
+        ``None`` when no daemon refresher does.
+
+        Only the harnesses in ``_DAEMON_REFRESH_HARNESSES`` have a backend
+        here: claude-code via ``FileBackend``/``KeychainBackend``, codex via
+        ``CodexFileBackend``. Pi projects its own ``auth.json`` through
+        ``sync_host_pi_auth_view`` and OpenCode carries its own credentials;
+        neither has anything for a refresher to refresh.
+
+        This used to fall through to the Claude refresher for every
+        non-codex harness, which put Pi and OpenCode agents on a refresher
+        that could not help them and could block them: the pre-delivery
+        gate (``_ensure_fresh_for``) then failed on an expired *Claude*
+        token, so a Pi agent with a perfectly valid credential never
+        reached its own provider (#337).
+        """
+        harness = agent_cfg.runtime.harness or "claude-code"
+        if harness == "codex":
             return self.codex_refresher
-        return self.refresher
+        if harness == "claude-code":
+            return self.refresher
+        return None
 
     def _register_with_refresher(
         self,
@@ -499,6 +517,13 @@ class Daemon:
         ):
             return
         refresher = self._refresher_for(agent_cfg)
+        if refresher is None:
+            # No daemon refresher owns this harness's credentials. Registering
+            # anyway would subscribe the agent to another provider's failure
+            # fan-out (`_flip_refresh_broken` / `_flip_auth_failed`) and to an
+            # `on_refresh_success` that would clear its reds for an unrelated
+            # reason.
+            return
         refresher.register_agent(agent_home_dir(agent_cfg.id))
         agent_id = agent_cfg.id
 
@@ -553,7 +578,13 @@ class Daemon:
     def _notify_refresh_for(self, agent_cfg: AgentConfig):
         if Daemon._uses_claude_api_key(self, agent_cfg):
             return None
-        return self._refresher_for(agent_cfg).notify_refresh_needed
+        refresher = self._refresher_for(agent_cfg)
+        # None for harnesses no refresher owns: there is nothing to wake, and
+        # waking the Claude refresher on a Pi 401 only re-probes an unrelated
+        # provider. The worker already null-checks this.
+        return (
+            refresher.notify_refresh_needed if refresher is not None else None
+        )
 
     def _ensure_fresh_for(self, agent_cfg: AgentConfig):
         # Gateway/VK mode (runtime.llm_base_url set): the LLM key is a static
@@ -567,7 +598,10 @@ class Daemon:
             or Daemon._uses_claude_api_key(self, agent_cfg)
         ):
             return None
-        return self._refresher_for(agent_cfg).ensure_fresh
+        refresher = self._refresher_for(agent_cfg)
+        # No owning refresher -> no pre-delivery gate. The worker already
+        # treats None as "skip the gate" (same path gateway/VK mode uses).
+        return refresher.ensure_fresh if refresher is not None else None
 
     def _uses_claude_api_key(self, agent_cfg: AgentConfig) -> bool:
         runtime = agent_cfg.runtime

--- a/tests/test_refresher_ownership_scope.py
+++ b/tests/test_refresher_ownership_scope.py
@@ -1,0 +1,244 @@
+"""A refresher must only speak for the harness whose credentials it owns.
+
+#337: ``Daemon._refresher_for`` routed every non-codex harness to the Claude
+refresher. That refresher has no Pi or OpenCode backend, so it could not help
+those agents — but it could stop them. Its ``ensure_fresh`` is the worker's
+pre-delivery gate, so an expired *Claude* token on the host blocked Pi and
+OpenCode turns from ever reaching their own provider, and its failure fan-out
+marked them red with Claude's recovery steps.
+
+Measured on a QA host: ``turn.admitted`` at 18:33:41,431 -> the gate refreshed
+an expired Claude token for 6.4s -> ``turn.failed`` at 18:33:47,867 with zero
+provider events in between. The Pi agent's own credential was valid and never
+used.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.portal.daemon import Daemon
+
+# The harnesses a daemon refresher actually has a backend for. Everything else
+# carries its own credentials and must not be gated on someone else's.
+OWNED = ["claude-code", "codex"]
+UNOWNED = ["pi", "opencode", "gemini", "some-future-harness"]
+
+
+class _StubRefresher:
+    def __init__(self) -> None:
+        self.registered: list = []
+        self.success_callbacks: list = []
+
+    def register_agent(self, home) -> None:
+        self.registered.append(home)
+
+    def register_on_refresh_success(self, cb) -> None:
+        self.success_callbacks.append(cb)
+
+    def ensure_fresh(self, *_a, **_k) -> bool:  # pragma: no cover - identity
+        return True
+
+    def notify_refresh_needed(self, *_a, **_k) -> None:  # pragma: no cover
+        return None
+
+
+def _daemon() -> Daemon:
+    d = Daemon.__new__(Daemon)
+    d.refresher = _StubRefresher()
+    d.codex_refresher = _StubRefresher()
+    d.daemon_cfg = SimpleNamespace()
+    return d
+
+
+def _cfg(harness: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="agent-1",
+        runtime=SimpleNamespace(
+            harness=harness, llm_base_url="", kind="cli-local",
+        ),
+    )
+
+
+def _worker() -> SimpleNamespace:
+    return SimpleNamespace(
+        runtime=SimpleNamespace(health="ok"),
+        _auth_failed_notification_sent=False,
+        _refresh_success_callback=None,
+    )
+
+
+# ── the pre-delivery gate ──
+
+@pytest.mark.parametrize("harness", UNOWNED)
+def test_unowned_harness_has_no_pre_delivery_gate(harness):
+    """The blocker itself: no gate means an unrelated provider's expired
+    credential can no longer stop this agent's turn."""
+    assert _daemon()._ensure_fresh_for(_cfg(harness)) is None
+
+
+def test_claude_code_keeps_its_gate():
+    d = _daemon()
+    assert d._ensure_fresh_for(_cfg("claude-code")) == d.refresher.ensure_fresh
+
+
+def test_codex_keeps_its_gate():
+    d = _daemon()
+    assert (
+        d._ensure_fresh_for(_cfg("codex")) == d.codex_refresher.ensure_fresh
+    )
+
+
+# ── registration / failure fan-out ──
+
+@pytest.mark.parametrize("harness", UNOWNED)
+def test_unowned_harness_is_registered_with_no_refresher(harness):
+    """Registration is what subscribes an agent to the failure fan-out."""
+    d = _daemon()
+    d._register_with_refresher(_cfg(harness), _worker())
+    assert d.refresher.registered == []
+    assert d.codex_refresher.registered == []
+    assert d.refresher.success_callbacks == []
+    assert d.codex_refresher.success_callbacks == []
+
+
+def test_claude_code_is_still_registered():
+    d = _daemon()
+    d._register_with_refresher(_cfg("claude-code"), _worker())
+    assert len(d.refresher.registered) == 1
+    assert d.codex_refresher.registered == []
+
+
+def test_codex_is_still_registered():
+    d = _daemon()
+    d._register_with_refresher(_cfg("codex"), _worker())
+    assert len(d.codex_refresher.registered) == 1
+    assert d.refresher.registered == []
+
+
+@pytest.mark.parametrize("harness", UNOWNED)
+def test_unowned_harness_gets_no_refresh_wakeup(harness):
+    """A Pi 401 must not wake the Claude refresher to probe Anthropic."""
+    assert _daemon()._notify_refresh_for(_cfg(harness)) is None
+
+
+@pytest.mark.parametrize("harness", OWNED)
+def test_owned_harness_keeps_its_refresh_wakeup(harness):
+    assert _daemon()._notify_refresh_for(_cfg(harness)) is not None
+
+
+# ── the behaviour the wiring exists for ──
+#
+# The tests above assert what `_ensure_fresh_for` returns. This one drives the
+# real gate in `StandardWorkerRun._execute_global_turn` to prove the outcome
+# Peter asked for: with the Claude refresher failing, a Pi turn still reaches
+# its own provider, and a genuine auth failure is still reported.
+
+class _FailingGate:
+    """Stands in for an expired host Claude credential: ensure_fresh False."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self) -> bool:
+        self.calls += 1
+        return False
+
+
+def _turn_worker(ensure_fresh_token):
+    reached = {"provider": False}
+
+    class _Puffo:
+        async def handle_global_inbox_turn(self, planned):
+            reached["provider"] = True
+            return "reply"
+
+    worker = SimpleNamespace(
+        _turn_active=False,
+        _reload_lock=asyncio.Lock(),
+        _ensure_fresh_token=ensure_fresh_token,
+        agent_cfg=SimpleNamespace(runtime=SimpleNamespace(kind="cli-local")),
+        # save(): _flip_health_in_progress persists the transition, so the
+        # stub needs it. Reaching that call is itself evidence the gate was
+        # skipped rather than short-circuited.
+        runtime=SimpleNamespace(
+            health="ok", error="", save=lambda _agent_id: None,
+        ),
+        _maybe_wake_refresher_if_auth_failed=lambda _agent_id: None,
+        _entered_auth_failed=False,
+    )
+
+    def _enter_auth_failed(_agent_id):
+        worker._entered_auth_failed = True
+    worker._enter_auth_failed = _enter_auth_failed
+
+    context = SimpleNamespace(
+        paths=SimpleNamespace(agent_id="agent-1"),
+        puffo=_Puffo(),
+    )
+    return worker, context, reached
+
+
+def _run_turn(worker, context):
+    from puffo_agent.portal import worker_run as wr
+
+    run = wr.StandardWorkerRun.__new__(wr.StandardWorkerRun)
+    run.worker = worker
+
+    async def _noop_refresh(_ctx):
+        return None
+    run._apply_refresh = _noop_refresh
+
+    return asyncio.new_event_loop().run_until_complete(
+        run._execute_global_turn(context, planned=object())
+    )
+
+
+@pytest.mark.parametrize("harness", UNOWNED)
+def test_unowned_turn_reaches_its_provider_while_claude_refresh_fails(harness):
+    """The blocker, end to end, at the point where it actually bit.
+
+    The gate handed to the worker is the one the *daemon* chooses, so this
+    drives ``_ensure_fresh_for`` rather than hardcoding ``None`` — otherwise
+    reverting the daemon fix would leave the test green while the bug is back.
+    The Claude refresher here fails every ``ensure_fresh`` call, standing in
+    for the expired host token measured on the QA host.
+    """
+    d = _daemon()
+    d.refresher.ensure_fresh = _FailingGate()
+    d.codex_refresher.ensure_fresh = _FailingGate()
+
+    gate = d._ensure_fresh_for(_cfg(harness))
+    worker, context, reached = _turn_worker(ensure_fresh_token=gate)
+
+    assert _run_turn(worker, context) == "reply"
+    assert reached["provider"] is True, (
+        "the turn must reach its own provider; before #337 it died at a gate "
+        "belonging to a provider this agent does not use"
+    )
+    assert worker._entered_auth_failed is False
+    assert d.refresher.ensure_fresh.calls == 0, (
+        "the Claude refresher must not even be consulted for this harness"
+    )
+
+
+def test_a_gated_harness_with_a_failing_refresh_still_reports_auth_failure():
+    """The other half: scoping must not silence real auth failures.
+
+    A claude-code agent keeps its gate, so a failing refresh still enters
+    auth_failed and never reaches the provider.
+    """
+    from puffo_agent.portal import worker as worker_module
+
+    gate = _FailingGate()
+    worker, context, reached = _turn_worker(ensure_fresh_token=gate)
+    with pytest.raises(worker_module.AgentAPIError) as excinfo:
+        _run_turn(worker, context)
+
+    assert excinfo.value.is_auth is True
+    assert gate.calls == 1
+    assert worker._entered_auth_failed is True
+    assert reached["provider"] is False


### PR DESCRIPTION
Closes #337. Release blocker — it stops Pi/OpenCode agents delivering, and it silently invalidated the #336 acceptance round.

## The defect

`Daemon._refresher_for` routed every non-codex harness to the Claude refresher:

```python
if (agent_cfg.runtime.harness or "claude-code") == "codex":
    return self.codex_refresher
return self.refresher          # <- everything else
```

That refresher has no Pi or OpenCode backend (`FileBackend` / `CodexFileBackend` / `KeychainBackend` only), so it could never help those agents. It could, however, stop them: its `ensure_fresh` is the worker's pre-delivery gate at `worker_run.py:713`, which raises **before** `handle_global_inbox_turn`.

`ensure_fresh()` returns True only if the credential has `expires_in > 0` after a refresh attempt. So an expired, unrefreshable host **Claude** token blocked every Pi and OpenCode turn — regardless of those agents' own credential health.

## Measured

QA host, agent `harness=pi`, `model=openai-codex/*`, own credential valid:

```
18:33:41,431  turn.admitted
18:33:41,432  refreshing credentials (expires_in=-629, by_agent=False)   <- the gate, 1ms later
18:33:47,831  claude credential refresh ok (disk file unchanged)          <- refreshed, not rotated
18:33:47,867  turn.failed  error_type=AgentAPIError  error_code=None      <- 36ms later
```

Zero provider events between `turn.admitted` and `turn.failed`. The Pi token was never used.

Thirty minutes earlier, same agent and same injected fault, host Claude token still inside its safety margin: no `refreshing credentials` line at all, gate passed, turn reached the provider and failed with `ProviderFailureError / provider_error`. **The only difference between the two runs was an unrelated provider's token expiry.**

## Why it mattered beyond the blocking

The gate produces `auth_failed` *and* a correctly harness-attributed operator DM without contacting the provider. During #336 acceptance that combination looked exactly like a passing provider-classification test. The round was re-judged as not proving classification, and the missing `turn_start` plus a `None` error code were the only signals that anything was wrong.

## The fix

`_refresher_for` returns `None` for harnesses no daemon refresher backs, using the `_DAEMON_REFRESH_HARNESSES = ("claude-code", "codex")` the module already declares. All three consumers honour it:

| consumer | before | after |
|---|---|---|
| `_register_with_refresher` | subscribed to the Claude failure fan-out | not registered |
| `_ensure_fresh_for` | Claude `ensure_fresh` as the delivery gate | `None` — no gate |
| `_notify_refresh_for` | a Pi 401 woke the Claude refresher | `None` |

`None` was already the "skip the gate" path used by gateway/VK mode, so no new mechanism is added, and no refresh backend is introduced. Claude and Codex keep their existing behaviour, pinned by tests.

## Tests

23 new, covering both legs Peter specified:

- **A Pi/OpenCode turn reaches its own provider while the Claude refresher fails every call** — driven through `_ensure_fresh_for` and the real `_execute_global_turn`, asserting the Claude refresher is not consulted at all.
- **A gated harness with a failing refresh still reports auth failure** — scoping must not silence real failures; claude-code keeps its gate, enters `auth_failed`, and never reaches the provider.
- Registration, gate, and wakeup pinned for both owned and unowned harnesses, parametrised over `pi`, `opencode`, `gemini`, and an unknown future name.

16 of the 23 fail with the production change reverted, and the end-to-end one dies on the exact production error, `AgentAPIError: credential refresh failed before delivery`.

An earlier draft of that test passed `None` directly instead of asking the daemon for it; it stayed green when the fix was reverted, so it pinned nothing. Routing it through `_ensure_fresh_for` is what makes it a regression.

Full suite: 4092 passed, 2 skipped (Windows-only; live E2E behind an env flag). `pre-commit run --all-files`: all gates pass.

## Not addressed here

Recorded separately at review request, not mixed in:

1. The turn still requeues on a backoff after an auth failure — measured unchanged, and unchanged by this PR too.
2. `turn.failed` carries a hardcoded `error_category="provider_error"` literal, and the pre-delivery gate's exception has no `error_code`, so neither field distinguishes "died at the gate" from "provider rejected the credential". That opacity is what made this defect hard to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)