### PR TITLE
docs(changelog): fix two inconsistencies in the 2.0.4 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,12 @@ reverted before this release (#322) and is **not** included.
   exact models before provisioning identity state, and discovers standard
   per-user OpenCode installations even under a narrow daemon `PATH`. Existing
   ACP-over-OpenCode configurations continue to load unchanged. (#305)
+- **Generic Monid paid-data tools.** Native agents can prepare arbitrary
+  allowlisted provider capabilities for free, inspect their input schema and
+  quoted price, then execute a budget-gated spend without holding vendor keys
+  or funds. Results carry provenance, failures require honest fallback
+  labeling, and retry keys prevent accidental duplicate charges. (#308)
+  *Reverted by #322 and not present in `2.0.4`.*
 - **Cross-platform daemon autostart.** `puffo-agent autostart
   enable|disable|status` installs per-user launchd, systemd, or Windows startup
   registration. Machine linking enables it by default, with an explicit


### PR DESCRIPTION
Two review findings on #340, both mine.

**The `Removed` note contradicted itself.** It says the `2.0.4a1` notes "still list" the Monid tools — but #340 deleted that entry, so the sentence was false as written. Restoring the historical entry is the better of the two fixes: a pre-release's notes are a record of what it announced, and rewriting that is worse than annotating it. The entry is back, marked inline as reverted by #322, so the historical section and the `Removed` note now agree.

**"Twelve PRs" listed thirteen** (#304, #312, #317, #320, #324, #325, #326, #328, #329, #331, #332, #333, #334).

No version or code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)