### PR TITLE
fix(acp): honour permission_mode instead of always asking a human

### DIFF
--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -248,6 +248,7 @@ class AcpDriver(Driver):
         self._fallback_block_id = ""
         self._capabilities = acp_capabilities(session_resume=False)
         self._model_selection = ""
+        self._permission_mode = ""
         self._spawn_warnings: tuple[str, ...] = ()
         self._driver_authority: DriverAuthorityServer | None = None
         self._closed = False
@@ -266,6 +267,10 @@ class AcpDriver(Driver):
             self._closed = False
             self._events = asyncio.Queue()
         launch = self._validate_launch_plan(spec)
+        # Captured per run, not per request: launch configuration, not a
+        # remembered decision. Nothing derived from it outlives a single
+        # request, so the peer's turn-scoped permission contract holds.
+        self._permission_mode = spec.permission_mode
         self._proc = await self._spawn(launch)
         if self._proc.stdin is None or self._proc.stdout is None:
             raise RuntimeError("ACP child did not expose stdio pipes")
@@ -851,13 +856,40 @@ class AcpDriver(Driver):
         if session_id != self._native_session_id or not self._active.value:
             return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
         ref = PermissionRef(f"permission_{uuid.uuid4().hex}")
-        future = asyncio.get_running_loop().create_future()
-        self._permissions[ref] = (future, options)
+        # ``bypassPermissions`` means the operator has pre-authorised this
+        # runtime's tool use, so answer immediately instead of parking the
+        # request on a human. The sibling drivers express the same policy at
+        # launch (codex ``approvalPolicy: never``, opencode ``--auto``); ACP
+        # has no such switch because in ACP the client *is* the authority, so
+        # answering on the spot is where the policy lands here.
+        #
+        # The answer is derived from this request alone and nothing is stored:
+        # no future is registered, no grant is cached, and the peer still asks
+        # again next turn. That keeps LingTai's turn-scoped permission
+        # contract intact -- this is not a persistent-permission capability.
+        auto_allow = self._permission_mode == "bypassPermissions"
+        selected_auto = _allow_shaped_permission(options) if auto_allow else None
+        if auto_allow and selected_auto is None:
+            # Deliberately NOT ``_preferred_permission``: that one falls back
+            # to ``options[0]`` when nothing allow-shaped is offered, which for
+            # a human approval is a reasonable last resort but here would let
+            # us return "allowed" carrying a *reject* option id. With no
+            # allow-shaped option there is no consent to give, so fall through
+            # to the human instead of inventing one.
+            auto_allow = False
+        future: asyncio.Future[PermissionDecision] | None = None
+        if not auto_allow:
+            future = asyncio.get_running_loop().create_future()
+            self._permissions[ref] = (future, options)
         await self._emit(
             HarnessEventType.PERMISSION_REQUESTED,
             turn=self._active,
             data={
                 "permission_ref": str(ref),
+                # Says what actually happened: an auto-allowed request was
+                # never pending, so a reader must not score it as an
+                # unanswered prompt.
+                "auto_allowed": auto_allow,
                 "tool_call_ref": str(getattr(tool_call, "tool_call_id", "")),
                 "label": str(getattr(tool_call, "title", "")),
                 "options": tuple(
@@ -871,6 +903,15 @@ class AcpDriver(Driver):
             },
             native_payload=tool_call,
         )
+        if auto_allow:
+            assert selected_auto is not None
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(
+                    outcome="selected",
+                    option_id=selected_auto.option_id,
+                )
+            )
+        assert future is not None
         decision = await future
         self._permissions.pop(ref, None)
         if decision is PermissionDecision.DENY:
@@ -935,6 +976,23 @@ class AcpDriver(Driver):
     def _require_active(self, turn: TurnRef) -> None:
         if turn != self._active or not self._active.value:
             raise RuntimeError("stale or foreign active turn")
+
+
+def _allow_shaped_permission(
+    options: list[PermissionOption],
+) -> PermissionOption | None:
+    """An option that actually grants, or ``None``.
+
+    Unlike :func:`_preferred_permission` this never falls back to an
+    arbitrary option: a caller that auto-approves must not be handed a
+    ``reject_once`` entry to "allow" with.
+    """
+
+    for kind in ("allow_once", "allow_always"):
+        for option in options:
+            if option.kind == kind:
+                return option
+    return None
 
 
 def _preferred_permission(

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -42,6 +42,13 @@ from puffo_agent.agent.harness.driver import (
     TurnInput,
 )
 from puffo_agent.agent.harness.support.subprocess_io import ProcessTreeShutdownError
+from puffo_agent.agent.harness.runtime.docker_runtime import (
+    _sanitise_permission_mode as _docker_sanitise_permission_mode,
+)
+from puffo_agent.agent.harness.runtime.local_runtime import (
+    VALID_PERMISSION_MODES,
+    _sanitise_permission_mode as _local_sanitise_permission_mode,
+)
 
 
 class _FakeProcess:
@@ -914,3 +921,46 @@ async def test_bypass_permissions_will_not_allow_with_a_reject_only_option_set()
     assert response.outcome.outcome == "cancelled"
     harness.conn.prompt_result.set_result(PromptResponse(stop_reason="cancelled"))
     await driver.close()
+
+
+def test_widening_permission_modes_needs_an_operator_answer_path():
+    """Tripwire: nothing in production can currently ask a human.
+
+    Both runtimes coerce every configured ``permission_mode`` to
+    ``bypassPermissions``, and every RuntimeSpec is built from that sanitised
+    value — so the waiting branch of ``_request_permission`` is reachable only
+    from tests. The docstring above
+    (``test_bypass_permissions_answers_without_a_human``) states that as prose;
+    this binds it.
+
+    Widening this set is a one-line change that silently activates the wait.
+    Before doing so, confirm something presents ``turn.permission_requested``
+    to an operator and calls ``runtime.resolve_permission``. Puffo sets no
+    timeout of its own, so without that path every tool call runs out the ACP
+    peer's timeout and is then DENIED.
+    """
+
+    assert VALID_PERMISSION_MODES == frozenset({"bypassPermissions"}), (
+        "permission_mode gained a reachable value, so the ask-a-human branch "
+        "is now live. Verify an operator-facing answer path exists "
+        "(turn.permission_requested -> runtime.resolve_permission) before "
+        "shipping this, or every tool call becomes a timeout-then-deny."
+    )
+
+
+def test_both_runtimes_agree_on_which_permission_modes_exist():
+    """The docker sanitiser hardcodes its own set instead of importing one.
+
+    Two copies of the same guard drift silently: widening the local constant
+    would leave docker still coercing, so the same agent config would ask a
+    human on one runtime and not the other. Compare behaviour, not the
+    literals, so this keeps working if either side is refactored.
+    """
+
+    probes = ["bypassPermissions", "ask", "acceptEdits", "plan", "", "default"]
+    local = {mode: _local_sanitise_permission_mode(mode, "agent") for mode in probes}
+    docker = {mode: _docker_sanitise_permission_mode(mode, "agent") for mode in probes}
+    assert local == docker, (
+        "local_runtime and docker_runtime disagree about permission modes; "
+        "they hold separate copies of the same allow-list."
+    )

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -403,7 +403,12 @@ async def test_permission_request_waits_for_typed_driver_resolution():
         harness.process_factory,
         connection_factory=harness.connection_factory,
     )
-    await driver.open(RuntimeSpec("/workspace", executable="agent"))
+    # Explicitly non-bypass: RuntimeSpec defaults to "bypassPermissions", so
+    # without this the driver answers on its own and this test would silently
+    # stop covering the human path it exists to pin.
+    await driver.open(
+        RuntimeSpec("/workspace", executable="agent", permission_mode="ask")
+    )
     stream = driver.events()
     await driver.start_turn(TurnInput("hello"))
     permission = asyncio.create_task(harness.client.request_permission(
@@ -806,4 +811,106 @@ async def test_session_calls_receive_the_projected_mcp_servers(
     assert [(e.name, e.value) for e in server.env] == [
         ("PUFFO_AGENT_ID", "agent_test")
     ]
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_answers_without_a_human():
+    """``bypassPermissions`` must not park a tool call on an operator.
+
+    The runtime only ever supplies this mode (VALID_PERMISSION_MODES holds
+    exactly one value), so an unattended agent depends on this path entirely.
+    """
+
+    harness = _Harness()
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(
+        RuntimeSpec(
+            "/workspace", executable="agent", permission_mode="bypassPermissions"
+        )
+    )
+    stream = driver.events()
+    await driver.start_turn(TurnInput("hello"))
+    # No resolve_permission() anywhere: if the driver waits, this await times out.
+    response = await asyncio.wait_for(
+        harness.client.request_permission(
+            [
+                PermissionOption(
+                    option_id="deny", name="Deny", kind="reject_once"
+                ),
+                PermissionOption(
+                    option_id="allow", name="Allow once", kind="allow_once"
+                ),
+            ],
+            "acp_session",
+            ToolCallStart(
+                session_update="tool_call", tool_call_id="tool_1", title="shell"
+            ),
+        ),
+        timeout=1,
+    )
+    assert response.outcome.outcome == "selected"
+    assert response.outcome.option_id == "allow"
+    events = await asyncio.wait_for(
+        _collect_through(stream, HarnessEventType.PERMISSION_REQUESTED), timeout=1
+    )
+    # The record must say it was auto-allowed, not look like an unanswered prompt.
+    assert events[-1].data["auto_allowed"] is True
+    # Nothing retained: no pending future, so no cross-request grant exists to
+    # reuse. This is the property that keeps the peer's turn-scoped permission
+    # contract intact.
+    assert driver._permissions == {}
+    harness.conn.prompt_result.set_result(PromptResponse(stop_reason="cancelled"))
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_will_not_allow_with_a_reject_only_option_set():
+    """Auto-approval needs something that actually grants.
+
+    ``_preferred_permission`` falls back to ``options[0]``; reusing it here
+    would return outcome="selected" carrying a *reject* option id -- an
+    "approval" that denies. With nothing allow-shaped on offer the driver must
+    fall back to asking a human.
+    """
+
+    harness = _Harness()
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(
+        RuntimeSpec(
+            "/workspace", executable="agent", permission_mode="bypassPermissions"
+        )
+    )
+    stream = driver.events()
+    await driver.start_turn(TurnInput("hello"))
+    pending = asyncio.create_task(
+        harness.client.request_permission(
+            [
+                PermissionOption(
+                    option_id="deny", name="Deny", kind="reject_once"
+                ),
+            ],
+            "acp_session",
+            ToolCallStart(
+                session_update="tool_call", tool_call_id="tool_1", title="shell"
+            ),
+        )
+    )
+    events = await asyncio.wait_for(
+        _collect_through(stream, HarnessEventType.PERMISSION_REQUESTED), timeout=1
+    )
+    assert events[-1].data["auto_allowed"] is False
+    # Still pending on a human rather than silently "allowing" with a denial.
+    assert not pending.done()
+    ref = PermissionRef(str(events[-1].data["permission_ref"]))
+    await driver.resolve_permission(ref, PermissionDecision.DENY)
+    response = await asyncio.wait_for(pending, timeout=1)
+    assert response.outcome.outcome == "cancelled"
+    harness.conn.prompt_result.set_result(PromptResponse(stop_reason="cancelled"))
     await driver.close()


### PR DESCRIPTION
The ACP driver never read `spec.permission_mode`. Its sibling drivers do —
codex sets `approvalPolicy: "never"` and opencode passes `--auto` — so a
runtime configured for `bypassPermissions` still parked every tool call on an
operator, waiting on a `resolve_permission` that no product UI can send.

`VALID_PERMISSION_MODES` holds exactly one value (`bypassPermissions`) and the
runtime coerces anything else to it, so this was not a policy knob with a
default: unattended operation was impossible on this path.

## Approach

ACP has no launch-time equivalent of those flags — in ACP the client *is* the
authority, so the policy lands where the request is answered. The answer is
derived from the single request in hand: no future is registered, no grant is
cached, and the peer still asks again next turn. That keeps the LingTai ACP
contract's turn-scoped permissions intact and is distinct from a persistent
permission capability (their `ACP001` fails anyone claiming one). Reviewed on
the LingTai side against that contract.

Auto-approval deliberately does **not** reuse `_preferred_permission`, which
falls back to `options[0]`; with a reject-only option set that would return
`outcome="selected"` carrying a denial. `_allow_shaped_permission` returns
`None` instead and the request falls through to a human.

The emitted event carries `auto_allowed` so the record distinguishes an
auto-approved request from one still waiting on a person.

## Verification

- Two new tests; both fail against unpatched `acp.py` (negative control).
- Targeted mutation: swapping the auto path back to the lenient selector
  reddens only the reject-only test, so it pins that specific defect.
- A pre-existing test was implicitly relying on the bug — it used the default
  spec (which *is* `bypassPermissions`) while asserting a human wait. Now
  explicitly non-bypass so it still covers that path.
- 779 passed across the acp/driver/authority/lingtai/runtime selection.
- Exercised end to end on a local full stack: two unattended rounds with zero
  `runtime.resolve_permission` sent, four tool calls all `auto_allowed=true`,
  replies delivered to the browser.

## Note for reviewers

With this merged there is no product configuration that restores a human
approval step on the ACP path, because `VALID_PERMISSION_MODES` has one member
and no UI renders the permission request. Making human confirmation a real
option needs both a new member in that frozenset and a frontend affordance —
tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)