### PR TITLE
fix(credentials): anchor the Keychain host lock on the login UID, not $HOME

### DIFF
--- a/src/puffo_agent/portal/credential_refresh.py
+++ b/src/puffo_agent/portal/credential_refresh.py
@@ -56,6 +56,34 @@ from ..tasks import spawn
 logger = logging.getLogger(__name__)
 
 
+def _login_home() -> Path:
+    """The login account's real home, ignoring ``$HOME``.
+
+    ``KeychainBackend``'s canonical store is the system Keychain, whose
+    ACL is keyed on **UID + signing identity, not HOME**. Its host lock
+    and disk fallthrough must therefore be anchored the same way the
+    resource itself is keyed, or two daemons running as one user reach
+    the same Keychain entry through two different lock files and stop
+    excluding each other.
+
+    ``Path.home()`` follows ``$HOME``, and giving a second daemon its own
+    ``HOME`` is exactly how a staging instance is normally set up — so
+    the host lock lost its meaning precisely in the configuration it was
+    written for. Read the passwd record instead.
+
+    ``FileBackend`` deliberately keeps using ``$HOME``: there the
+    canonical store *is* ``~/.claude/.credentials.json``, so a distinct
+    ``HOME`` is a genuinely distinct credential that should not share a
+    lock.
+    """
+    try:
+        import pwd
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:  # noqa: BLE001 - non-POSIX or unreadable passwd
+        return Path.home()
+
+
 REFRESH_POLL_SECONDS = 120
 REFRESH_SAFETY_MARGIN_SECONDS = 10 * 60
 REFRESH_ONESHOT_TIMEOUT_SECONDS = 120
@@ -656,7 +684,7 @@ class KeychainBackend:
     def refresh_lock_path(self) -> Path:
         # Anchor outside PUFFO_AGENT_HOME so production and staging daemons
         # coordinate access to the same login Keychain credential.
-        return Path.home() / ".claude" / ".puffo-refresh.lock"
+        return _login_home() / ".claude" / ".puffo-refresh.lock"
 
     def expires_in_seconds(self) -> int | None:
         """Cache → Keychain → disk file. The disk fallthrough handles
@@ -691,7 +719,7 @@ class KeychainBackend:
                 return secs
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
-        disk_blob = _read_disk_credentials_blob(Path.home())
+        disk_blob = _read_disk_credentials_blob(_login_home())
         if disk_blob is not None:
             logger.warning(
                 "keychain-backend expires_in read: falling through to disk "
@@ -708,7 +736,7 @@ class KeychainBackend:
                 "nor disk file readable",
                 kr.error if not kr.ok else "unparseable-blob",
             )
-        secs = _disk_expires_in_seconds(Path.home())
+        secs = _disk_expires_in_seconds(_login_home())
         if secs is not None:
             logger.debug(
                 "keychain-backend expires_in read: source=disk secs=%d", secs,
@@ -717,7 +745,7 @@ class KeychainBackend:
 
     async def refresh(self) -> RefreshOutcome:
         from ..macos.keychain import read_keychain_blob
-        host_home = Path.home()
+        host_home = _login_home()
         kr_before = read_keychain_blob()
         before_blob = kr_before.blob if kr_before.ok else None
         disk_before = _read_disk_credentials_blob(host_home)
@@ -824,7 +852,7 @@ class KeychainBackend:
         the target already matches, so fan-out from concurrent
         ``ensure_fresh`` callers stays cheap."""
         cache_blob = self.cache.read()
-        blob = cache_blob or _read_disk_credentials_blob(Path.home())
+        blob = cache_blob or _read_disk_credentials_blob(_login_home())
         if not blob:
             return False
         if cache_blob is None:
@@ -892,7 +920,7 @@ class KeychainBackend:
         # Keychain bootstrap failed — fall through to disk file so the
         # daemon can still serve agents on hosts where Claude Code's
         # Keychain write silently fails (launchd session-context).
-        disk_blob = _read_disk_credentials_blob(Path.home())
+        disk_blob = _read_disk_credentials_blob(_login_home())
         if disk_blob is None:
             logger.warning(
                 "keychain-backend bootstrap: no Keychain (%s) and no "
@@ -920,7 +948,7 @@ class KeychainBackend:
         kr = read_keychain_blob()
         blob: Optional[str] = kr.blob if kr.ok and kr.blob else None
         if blob is None:
-            blob = _read_disk_credentials_blob(Path.home())
+            blob = _read_disk_credentials_blob(_login_home())
         if blob is None:
             logger.debug(
                 "keychain poll: neither Keychain (%s) nor disk file "

--- a/tests/test_macos_credential_manager.py
+++ b/tests/test_macos_credential_manager.py
@@ -368,6 +368,19 @@ def _make_keychain_backend(home: Path) -> cr.KeychainBackend:
     return cr.KeychainBackend(home=home, cache=cache)
 
 
+def _passwd_home() -> Path:
+    """The login account's home, read independently of the code under test.
+
+    Deliberately NOT ``Path.home()``: every Puffo agent runs with an
+    overridden ``$HOME``, so ``Path.home()`` is a sandbox path here.
+    Asserting against it would compare the production helper to itself
+    and pass no matter which home the daemon actually used.
+    """
+    import pwd
+
+    return Path(pwd.getpwuid(os.getuid()).pw_dir)
+
+
 def test_keychain_backend_bootstrap_reads_keychain(monkeypatch, tmp_path):
     """``bootstrap`` should populate the cache from Keychain. The
     refresher calls this once on daemon-loop entry."""
@@ -493,11 +506,20 @@ def test_keychain_backend_refresh_uses_real_home(monkeypatch, tmp_path):
     backend = _make_keychain_backend(tmp_path)
     backend.cache.write(_BLOB)
 
+    # Run under an overridden $HOME — the daemon's normal condition (every
+    # agent, and any staging instance, sets its own HOME). Without this the
+    # assertions below would compare Path.home() to itself and could never
+    # fail, which is how the sandbox-HOME regression got in.
+    sandbox_home = tmp_path / "sandbox-home"
+    sandbox_home.mkdir()
+    monkeypatch.setenv("HOME", str(sandbox_home))
+
     outcome = asyncio.run(backend.refresh())
     assert outcome == cr.RefreshOutcome.REFRESHED
-    # HOME = real user HOME, not a sandbox tempdir.
-    assert spawned["env"]["HOME"] == str(Path.home())
-    assert spawned["cwd"] == str(Path.home())
+    # HOME = real login HOME, not the sandbox one we just set.
+    assert spawned["env"]["HOME"] == str(_passwd_home())
+    assert spawned["cwd"] == str(_passwd_home())
+    assert spawned["env"]["HOME"] != str(sandbox_home)
     # Sentinel against #37512 regression — must never set this env var.
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in spawned["env"]
     # Cache is now synced to the rotated blob (read straight from Keychain).
@@ -732,7 +754,7 @@ def test_refresher_with_keychain_backend_refreshes_when_close_to_expiry(
     assert spawned, "backend.refresh should have run claude --print"
     # Refresh uses real HOME — same model as FileBackend.
     env = spawned[0]
-    assert env["HOME"] == str(Path.home())
+    assert env["HOME"] == str(_passwd_home())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -957,3 +979,65 @@ def test_poll_external_rotation_detects_disk_rotation_when_keychain_dead(
     assert rotated is True
     assert backend._last_propagated_blob == _REFRESHED_BLOB
     assert backend.cache.read() == _REFRESHED_BLOB
+
+
+def test_keychain_lock_path_ignores_home_override(monkeypatch, tmp_path):
+    """Two daemons running as one user must reach the same host lock.
+
+    The Keychain entry they both refresh is keyed on UID, not HOME, so a
+    staging daemon started with its own ``HOME`` (the normal way to stand
+    one up) must not get its own lock file — that would silently drop the
+    mutual exclusion this lock exists to provide.
+
+    Regression for the anchor mismatch: ``refresh_lock_path`` used
+    ``Path.home()``, which follows ``$HOME``.
+    """
+    prod_home = tmp_path / "prod"
+    staging_home = tmp_path / "staging" / "hosthome"
+    login_home = tmp_path / "login"
+    for h in (prod_home, staging_home, login_home):
+        h.mkdir(parents=True)
+
+    monkeypatch.setattr(cr, "_login_home", lambda: login_home)
+
+    monkeypatch.setenv("HOME", str(prod_home))
+    prod_lock = _make_keychain_backend(prod_home).refresh_lock_path
+
+    monkeypatch.setenv("HOME", str(staging_home))
+    staging_lock = _make_keychain_backend(staging_home).refresh_lock_path
+
+    # Same UID, different HOME (and different PUFFO_AGENT_HOME) => one lock.
+    assert prod_lock == staging_lock
+    # And it is anchored on the login account, not on either $HOME.
+    assert prod_lock == login_home / ".claude" / ".puffo-refresh.lock"
+    assert prod_home not in prod_lock.parents
+    assert staging_home not in staging_lock.parents
+
+
+def test_login_home_ignores_home_env():
+    """``_login_home`` reads the passwd record, so ``$HOME`` can't move it."""
+    import pwd
+
+    real = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    before = cr._login_home()
+    os.environ["HOME"] = "/tmp/definitely-not-the-login-home"
+    try:
+        assert cr._login_home() == real
+        assert cr._login_home() == before
+        # Guard the premise: Path.home() *does* move, which is the bug.
+        assert Path.home() != real
+    finally:
+        os.environ["HOME"] = str(real)
+
+
+def test_file_backend_still_follows_home(tmp_path):
+    """FileBackend must NOT be UID-anchored.
+
+    On Linux / Windows the canonical store *is* ``$HOME/.claude``, so a
+    distinct HOME is a genuinely distinct credential that should keep its
+    own lock. Guards against over-applying the Keychain fix.
+    """
+    a = cr.FileBackend(host_home=tmp_path / "a")
+    b = cr.FileBackend(host_home=tmp_path / "b")
+    assert a.refresh_lock_path != b.refresh_lock_path
+    assert a.refresh_lock_path == tmp_path / "a" / ".claude" / ".puffo-refresh.lock"


### PR DESCRIPTION
## The bug

`KeychainBackend.refresh_lock_path` returned `Path.home()/.claude/.puffo-refresh.lock`, with a comment stating it is anchored outside `PUFFO_AGENT_HOME` **specifically so production and staging daemons coordinate access to the same login Keychain credential**. The module docstring says the same: the host lock exists so rotating refresh tokens "can't be raced by workers or sibling daemon processes."

But `Path.home()` follows `$HOME`. The comment guards against the wrong variable — and giving a second daemon its own `HOME` is exactly how a staging instance is normally stood up. The lock file moves with it, and the two daemons stop excluding each other while still refreshing the **same** Keychain entry.

**The guarantee fails precisely in the configuration it was written for.**

## Observed

On this host, right now:

```
-rw-------  Aug 18  /Users/glimmer/.claude/.puffo-refresh.lock
-rw-------  Sep  9  .../workspace/staging-qa/hosthome/.claude/.puffo-refresh.lock
```

Two daemons, one Keychain credential, two different lock files. The prod daemon runs with `HOME=/Users/glimmer` (equal to the passwd home); the staging daemon runs with `HOME=.../staging-qa/hosthome`, which is what splits the lock.

The refresher is also not gated on having Claude agents — `daemon.py` spawns `refresher.run_loop` unconditionally and `_tick` decides purely on the canonical credential's expiry, which on macOS is the shared Keychain. So a staging daemon with zero Claude agents still enters the refresh decision.

### Correction (was overstated in the first version of this description)

An earlier draft of this text claimed that because *every Puffo agent* runs with an overridden `$HOME`, the divergence is "the normal state on any host." **That is withdrawn — it does not follow.** The refresh lock is taken only in `CredentialRefresher._refresh_now`, and `CredentialRefresher` is constructed only in `portal/daemon.py`. Agent worker processes never take this lock, so their `HOME` is irrelevant to it.

The precondition is narrower and should be stated exactly: **two or more daemons on one host whose `$HOME` values differ, sharing one UID-keyed Keychain entry.** That is the documented staging-alongside-production setup the original comment names — and it is what is running on this machine — but it is not a property of every host. A single-daemon host running as the login user sees no divergence.

## The fix

The Keychain entry is keyed on **UID + signing identity, not HOME** (as the module docstring itself notes). The lock, and the disk fallthrough that backs it up when a launchd-context Keychain write silently fails, must be keyed the same way the resource is. Adds `_login_home()`, which reads the passwd record, and uses it for all seven `KeychainBackend` sites.

**`FileBackend` deliberately keeps following `$HOME`.** On Linux/Windows the canonical store *is* `$HOME/.claude/.credentials.json`, so a distinct `HOME` is a genuinely distinct credential that *should* keep its own lock. `test_file_backend_still_follows_home` pins that asymmetry so the fix isn't over-applied later.

## Scope — what this does not do

This serializes **Puffo daemons against each other**. It does not, and cannot, exclude non-Puffo writers: the operator's own `claude` CLI and an agent's claude self-refreshing on a 401 both rotate the credential without taking this lock. That is why `poll_external_rotation` / `_detect_external_rotation` exist, and they remain the mechanism for those cases. Nothing here should be read as making the credential safe against arbitrary external rotation.

The evidence here establishes that concurrent refresh is **reachable and unserialized**, not that a specific token collision has already occurred. No such collision has been observed. The in-lock re-check and external-rotation detection will often absorb the race benignly, so the exposure is intermittent rather than certain.

## Two sentinels that could never have fired

`test_keychain_backend_refresh_uses_real_home` and `test_refresher_with_keychain_backend_refreshes_when_close_to_expiry` both asserted:

```python
assert env["HOME"] == str(Path.home())   # "real HOME, not a sandbox HOME"
```

That compares the production helper against itself — it passes under *any* `HOME`, including the sandbox HOME the docstring says it is guarding against. This is why the regression could land under a test that reads like it covers it.

Both now assert against an independently read passwd home, and the refresh test executes under a deliberately overridden `$HOME` so it exercises the real condition.

## Verification

- Full suite green: 0 failed, 2 skipped (live-e2e opt-in; Windows-only `CREATE_NO_WINDOW`).
- `ruff` clean; `tools/check_python_structure.py` passes.
- **Mutation-checked** — reverting the anchor to `Path.home()` turns all three tests red, and the new lock-path test fails on the *data* (two divergent paths), reproducing exactly the two-file divergence observed on disk.

Author verification only; formal credential-side review is Boris's seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)