### PR TITLE
test(harness): bind the driver roster, not just its listed members

### DIFF
--- a/tests/test_driver_lifecycle_capabilities.py
+++ b/tests/test_driver_lifecycle_capabilities.py
@@ -15,6 +15,11 @@ from puffo_agent.agent.harness.driver import (
     SessionRef,
     SteerCapability,
 )
+from puffo_agent.agent.harness import (
+    SUPPORTED_LOCAL_DRIVERS,
+    UnsupportedDriver,
+    build_driver,
+)
 from puffo_agent.agent.harness.runtime.runtime_manager import RuntimeManagerAdapter
 
 
@@ -30,6 +35,27 @@ def _shipped_capabilities():
 
 def test_shipped_drivers_declare_lifecycle_and_busy_delivery():
     for name, caps in _shipped_capabilities().items():
+        assert RuntimeLifecycle(caps.lifecycle), name
+        assert BusyDelivery(caps.busy_delivery), name
+
+
+def test_every_buildable_driver_declares_lifecycle_and_busy_delivery():
+    """Bind the roster, not just its listed members.
+
+    ``_shipped_capabilities`` is hand-kept and names two drivers (plus one
+    claude-code variant), while ``SUPPORTED_LOCAL_DRIVERS`` admits five. A
+    driver added to the factory — acp, opencode and pi already are — is
+    examined by nothing here, and so is the next one. Deriving the set from the
+    factory means adding a driver without declaring its lifecycle fails, rather
+    than passing silently.
+    """
+
+    for name in sorted(SUPPORTED_LOCAL_DRIVERS):
+        driver = build_driver(name)
+        assert not isinstance(driver, UnsupportedDriver), name
+        caps = driver.current_capabilities()
+        assert caps is not None, f"{name} declares no capabilities"
+        # Constructing the enum rejects a value outside it.
         assert RuntimeLifecycle(caps.lifecycle), name
         assert BusyDelivery(caps.busy_delivery), name
 


### PR DESCRIPTION
## The gap

`_shipped_capabilities()` in `tests/test_driver_lifecycle_capabilities.py` is a
hand-kept dict naming `codex` and `claude-code` (plus one claude-code variant).
`SUPPORTED_LOCAL_DRIVERS` admits five:

```
acp, claude-code, codex, opencode, pi
```

So the loop underneath checks two of the five. `acp`, `opencode` and `pi` have
no lifecycle / busy-delivery conformance coverage at all, and neither would the
next driver anyone registers.

Checking every member of a list never checks the list.

## The change

One test, deriving its subjects from `SUPPORTED_LOCAL_DRIVERS` via
`build_driver`, asserting each admitted driver declares capabilities and that
its lifecycle and busy-delivery are valid enum members. All five construct with
no arguments and already implement `current_capabilities()`, so this covers the
three that were unexamined without any production change.

It asserts validity, not specific values — the correct lifecycle for a
not-yet-written driver isn't knowable here. The existing hand-kept test keeps
pinning exact values for the drivers it names, so the two are complementary
rather than one replacing the other.

## Negative control

Registering a factory entry whose driver returns no capabilities reddens the
new test and leaves the hand-kept one green — which is exactly the blindness
being fixed. Restored after measuring.

`tests/test_driver_lifecycle_capabilities.py` + `tests/test_harness_driver.py`:
52 tests green. No production code touched.

I am not self-merging.