### PR TITLE
fix(runtime): bound the re-arm after a turn that makes no progress (PUF-382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A turn that cannot make progress no longer re-runs at full speed.**
+  `_wake_remaining_pending` re-arms the runtime whenever rows stay pending, and
+  it did so at *zero* delay, so a turn that admits none of its announced batch
+  re-ran as fast as it could fail — roughly one turn a second, three gateway
+  calls each. That is the amplifier that turned one unreadable provider failure
+  into ~180 requests a minute against a capped LLM gateway (staging
+  2026-09-09), and it is independent of *why* the turn failed: any driver gap,
+  present or future, reaches it. The first re-arm after a no-progress turn stays
+  immediate, since a single deferral is legitimate; consecutive ones now back
+  off 5 → 300 s and reset on any turn that admits its batch. Real ingress still
+  cuts through, because the coalescer only ever lets a deadline move earlier.
+  (PUF-382)
 - **A gateway budget cap no longer turns into a retry storm.** LiteLLM's
   `Budget has been exceeded!` 429 was classified as a transient rate limit and
   retried — by the harness and by the `claude` CLI's own backoff loop — at up

--- a/src/puffo_agent/agent/global_inbox_degraded.py
+++ b/src/puffo_agent/agent/global_inbox_degraded.py
@@ -16,6 +16,16 @@ DEGRADED_RECOVERY_MAX_SECONDS = 300.0
 BUDGET_PARK_BASE_SECONDS = 300.0
 BUDGET_PARK_MAX_SECONDS = 1800.0
 
+# no-progress re-arm: a turn that consumed none of its announced batch leaves
+# the rows pending, and ``_wake_remaining_pending`` re-arms at ZERO delay. One
+# such turn is a legitimate deferral, so the first re-arm stays immediate; a
+# repeat is a turn that cannot make progress, and re-running it at full speed
+# is how a single unreadable provider failure became ~180 gateway requests a
+# minute (PUF-382). An externally-triggered notify() still cuts through: the
+# coalescer only ever lets a deadline move EARLIER.
+NO_PROGRESS_REARM_BASE_SECONDS = 5.0
+NO_PROGRESS_REARM_MAX_SECONDS = 300.0
+
 
 class DegradedRecoveryMixin:
     """State owner for ``GlobalInboxRuntime``'s failure gates."""
@@ -30,6 +40,8 @@ class DegradedRecoveryMixin:
         # timed hold for a budget-cap park; None = wait for drained_check
         self._drained_park_until: float | None = None
         self._budget_park_attempts = 0
+        # consecutive turns that admitted none of their announced batch
+        self._no_progress_rearm_attempts = 0
 
     def _clear_degraded_backoff(self) -> None:
         self._degraded = False
@@ -91,6 +103,28 @@ class DegradedRecoveryMixin:
 
     def _clear_budget_park_backoff(self) -> None:
         self._budget_park_attempts = 0
+
+    def note_no_progress_turn(self) -> None:
+        """Count a turn that admitted none of its announced batch."""
+        self._no_progress_rearm_attempts += 1
+
+    def _clear_no_progress_rearm_backoff(self) -> None:
+        self._no_progress_rearm_attempts = 0
+
+    def next_no_progress_rearm_delay(self) -> float:
+        """Delay before re-arming after a no-progress turn (0 → 5 → 300 s).
+
+        Zero for the first, so a single deferral keeps today's immediate
+        follow-up; doubling after that, so a turn that cannot progress stops
+        spinning. Reset by any turn that admits its batch.
+        """
+        if self._no_progress_rearm_attempts <= 1:
+            return 0.0
+        return min(
+            NO_PROGRESS_REARM_BASE_SECONDS
+            * 2 ** (self._no_progress_rearm_attempts - 2),
+            NO_PROGRESS_REARM_MAX_SECONDS,
+        )
 
     def _drained_park_allows_processing(self) -> bool:
         if self._parked_drained:

--- a/src/puffo_agent/agent/global_inbox_runtime.py
+++ b/src/puffo_agent/agent/global_inbox_runtime.py
@@ -1334,7 +1334,15 @@ class GlobalInboxRuntime(
         if await self.store.get_notice_candidates(
             self.adapter.get_provider_session_id()
         ):
-            self.notify()
+            delay = self.next_no_progress_rearm_delay()
+            if delay <= 0.0:
+                self.notify()
+                return
+            # Backed-off self re-arm. Deliberately NOT self.notify(): that
+            # clears the degraded backoff and pins the delay to 0 whenever no
+            # turn is active, which is exactly the spin being bounded here.
+            # Real ingress still calls notify() and still cuts through.
+            self.coalescer.notify(delay_seconds=delay)
 
     async def _handle_process_failure(
         self, planned: PlannedTurn, process_started: float, exc: Exception
@@ -1432,6 +1440,9 @@ class GlobalInboxRuntime(
                     process_outcome = settled
                     if settled == "succeeded":
                         self._clear_budget_park_backoff()
+                        self._clear_no_progress_rearm_backoff()
+                    elif settled == "no_progress":
+                        self.note_no_progress_turn()
                 else:
                     terminal_error = "provider returned without correlated admission"
                     self._degrade(terminal_error)

--- a/tests/test_no_progress_turn_guard.py
+++ b/tests/test_no_progress_turn_guard.py
@@ -15,6 +15,7 @@ suppress it.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from types import SimpleNamespace
 
@@ -233,3 +234,240 @@ def test_cancel_leaves_other_resolutions_alone(streak, health_after_turn, expect
     w = SimpleNamespace(runtime=rt, _no_progress_turns=streak)
     StandardWorkerRun._settle_process_health(w, "agent-b", "cancelled", None)
     assert rt.health == expected
+
+
+# ── Re-arm cadence after a no-progress turn ──────────────────────────────
+# The guard above names the turn; this half bounds how fast it repeats.
+# ``_wake_remaining_pending`` re-arms at ZERO delay whenever rows stay pending,
+# so a turn that can never admit its batch re-runs as fast as it can fail. On
+# staging 2026-09-09 one agent behind a capped LLM gateway turned that into 354
+# rejected requests in two minutes (~1 turn/s, 3 gateway calls each) until the
+# streak guard cancelled it. (PUF-382)
+
+
+class _Coalescer:
+    def __init__(self):
+        self.delays: list[float] = []
+
+    def notify(self, *, delay_seconds=None):
+        self.delays.append(delay_seconds)
+
+
+class _Store:
+    def __init__(self, *, pending=True, candidates=True):
+        self._pending, self._candidates = pending, candidates
+
+    async def get_pending(self, limit=1):
+        return [object()] if self._pending else []
+
+    async def get_notice_candidates(self, session_id):
+        return [object()] if self._candidates else []
+
+
+def _rearm_runtime(**store_kw):
+    """A runtime with only what ``_wake_remaining_pending`` touches."""
+    rt = GlobalInboxRuntime.__new__(GlobalInboxRuntime)
+    rt._init_recovery_gates(None)
+    rt.store = _Store(**store_kw)
+    rt.adapter = SimpleNamespace(get_provider_session_id=lambda: "session")
+    rt.coalescer = _Coalescer()
+    rt.notified = 0
+
+    def _notify():
+        rt.notified += 1
+
+    rt.notify = _notify
+    return rt
+
+
+def test_a_single_no_progress_turn_still_re_arms_immediately():
+    """One deferral is legitimate — today's immediate follow-up is kept, so
+    the common case is not slowed by the bound below."""
+    rt = _rearm_runtime()
+    rt.note_no_progress_turn()
+    asyncio.run(rt._wake_remaining_pending())
+    assert (rt.notified, rt.coalescer.delays) == (1, [])
+
+
+def test_repeated_no_progress_backs_off_instead_of_spinning():
+    """The second and later re-arms go through the coalescer with a delay.
+    Without this the loop is bounded only by how fast the provider fails."""
+    rt = _rearm_runtime()
+    for _ in range(2):
+        rt.note_no_progress_turn()
+    asyncio.run(rt._wake_remaining_pending())
+    assert rt.coalescer.delays == [5.0]
+    assert rt.notified == 0, "notify() would pin the delay back to zero"
+
+    rt.note_no_progress_turn()
+    asyncio.run(rt._wake_remaining_pending())
+    rt.note_no_progress_turn()
+    asyncio.run(rt._wake_remaining_pending())
+    assert rt.coalescer.delays == [5.0, 10.0, 20.0]
+
+
+def test_the_backoff_is_bounded():
+    rt = _rearm_runtime()
+    for _ in range(40):
+        rt.note_no_progress_turn()
+    assert rt.next_no_progress_rearm_delay() == 300.0
+
+
+def test_a_turn_that_admits_its_batch_clears_the_backoff():
+    rt = _rearm_runtime()
+    for _ in range(5):
+        rt.note_no_progress_turn()
+    assert rt.next_no_progress_rearm_delay() > 0.0
+    rt._clear_no_progress_rearm_backoff()  # what a `succeeded` settle does
+    rt.note_no_progress_turn()
+    asyncio.run(rt._wake_remaining_pending())
+    assert (rt.notified, rt.coalescer.delays) == (1, [])
+
+
+def test_nothing_re_arms_when_there_is_no_pending_work():
+    """The bound must not invent a wake: an empty pending set or no notice
+    candidate still re-arms nothing at all."""
+    for kw in ({"pending": False}, {"candidates": False}):
+        rt = _rearm_runtime(**kw)
+        for _ in range(3):
+            rt.note_no_progress_turn()
+        asyncio.run(rt._wake_remaining_pending())
+        assert (rt.notified, rt.coalescer.delays) == (0, []), kw
+
+
+def test_a_degraded_runtime_still_owns_its_own_backoff():
+    rt = _rearm_runtime()
+    rt._degraded = True
+    for _ in range(3):
+        rt.note_no_progress_turn()
+    asyncio.run(rt._wake_remaining_pending())
+    assert (rt.notified, rt.coalescer.delays) == (0, [])
+
+
+@pytest.mark.asyncio
+async def test_real_ingress_cuts_through_a_backed_off_re_arm():
+    """A message arriving mid-backoff must not wait it out. The runtime's own
+    re-arm is a deadline like any other, and the coalescer only ever lets a
+    deadline move EARLIER — the same guarantee proved for the degraded backoff
+    in ``test_coalescer_pulls_a_pending_long_deadline_into_the_normal_window``.
+    """
+    from puffo_agent.agent.inbox_scheduler import InboxCoalescer
+
+    now = 100.0
+    sleeps: list[float] = []
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    def monotonic():
+        return now
+
+    async def sleep(delay):
+        nonlocal now
+        sleeps.append(delay)
+        entered.set()
+        await release.wait()
+        now += delay
+
+    coalescer = InboxCoalescer(sleep=sleep, monotonic=monotonic)
+    rt = _rearm_runtime()
+    rt.coalescer = coalescer
+    for _ in range(6):  # attempts 1..6 → 0, 5, 10, 20, 40, 80
+        rt.note_no_progress_turn()
+    await rt._wake_remaining_pending()
+    assert coalescer._deadlines[0] == pytest.approx(now + 80.0)
+
+    waiter = asyncio.create_task(coalescer.wait_for_burst())
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    entered.clear()
+    coalescer.notify(delay_seconds=0.0)  # a message arrives
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    assert sleeps[0] == pytest.approx(80.0) and sleeps[1] == pytest.approx(0.0)
+    release.set()
+    await asyncio.wait_for(waiter, timeout=1)
+
+
+def test_the_escalation_ladder_is_explicit():
+    """Pinned by value: 0 s for the first, then doubling from 5 s to a 300 s
+    ceiling. A silent change here changes how long a wedged agent sleeps."""
+    rt = _rearm_runtime()
+    ladder = []
+    for _ in range(9):
+        rt.note_no_progress_turn()
+        ladder.append(rt.next_no_progress_rearm_delay())
+    assert ladder == [0.0, 5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 300.0, 300.0]
+
+
+# ── The loop itself ──────────────────────────────────────────────────────
+# The tests above pin the helpers. This one drives the real ``process_once``
+# so the *wiring* is covered too: deleting the counter call or the reset in
+# the settle block must fail a test, not just look wrong in review.
+
+
+def _loop_runtime(outcomes):
+    """A runtime whose turns settle as ``outcomes`` says, with the real
+    ``process_once`` / ``_wake_remaining_pending`` bodies and everything else
+    stubbed to the shortest thing that lets the turn reach its settle."""
+    from puffo_agent.agent.global_inbox_types import RuntimeHealth
+
+    rt = _rearm_runtime()
+    rt.health = RuntimeHealth()
+    rt._boundary = asyncio.Lock()
+    rt._turn_state_lock = asyncio.Lock()
+    rt._autonomous_settle_pending = None
+    rt._autonomous_turn_id = ""
+    rt.process_outcome = None
+    rt.attempts = SimpleNamespace(reset=lambda: None)
+    rt.active = SimpleNamespace(turn_id="turn-1", provider_session_id="s", provider_turn_id="t")
+    rt.adapter = SimpleNamespace(
+        get_provider_session_id=lambda: "session",
+        register_admission_callback=lambda *a, **k: None,
+    )
+    planned = SimpleNamespace(
+        turn_id="turn-1", notice_message_ids=("m1",), targets=(), notice_generation=0,
+        planning_cycle_key="cycle",
+    )
+    settled = iter(outcomes)
+
+    async def _noop(*a, **k):
+        return None
+
+    async def _true(*a, **k):
+        return True
+
+    rt._replay_deferred_autonomous_start = _noop
+    rt.plan_pending = lambda: _immediate(planned)
+    rt._resolve_context_plan = lambda p: _immediate(p)
+    rt._notice_is_current = _true
+    rt._start_notice_unless_autonomous = _true
+    rt._invoke_turn_with_retries = _noop
+    rt._health_outcome_for_turn = lambda p: next(settled)
+    rt._mark_active_processed = _noop
+    rt._notify_status_terminal = _noop
+    rt._finalize_process = lambda *a, **k: None
+    return rt
+
+
+def _immediate(value):
+    async def _run():
+        return value
+    return _run()
+
+
+def test_a_wedged_turn_stops_spinning_after_the_first_repeat():
+    """The storm, reproduced: every turn settles ``no_progress`` and the rows
+    stay pending. Before the bound, each pass re-armed at zero delay and the
+    loop ran as fast as the provider could fail."""
+    rt = _loop_runtime(["no_progress"] * 4)
+    for _ in range(4):
+        assert asyncio.run(rt.process_once()) is True
+    assert rt.notified == 1, "only the first repeat re-arms immediately"
+    assert rt.coalescer.delays == [5.0, 10.0, 20.0]
+
+
+def test_a_turn_that_makes_progress_clears_the_bound():
+    """A recovered provider must not stay throttled: the next wedged turn
+    starts the ladder again from immediate."""
+    rt = _loop_runtime(["no_progress", "no_progress", "succeeded", "no_progress"])
+    for _ in range(4):
+        asyncio.run(rt.process_once())
+    assert rt.coalescer.delays == [5.0], "one backed-off re-arm, before the success"
+    assert rt.notified == 3, "first repeat, the success, and the fresh streak"


### PR DESCRIPTION
Linear: PUF-382 · the follow-up noted on #335 ("that cadence should back off").

## What this is

#327 made a gateway budget cap terminal. #335 made the failure *visible* to the harness. Neither touches the thing that turned one failure into a storm: **the loop that re-runs a turn making no progress, immediately, forever.**

```
turn settles no_progress  ->  rows stay pending
   -> _wake_remaining_pending()  ->  self.notify()
   -> notify() sets delay = 0.0 (no active turn)
   -> coalescer fires at once  ->  process_once()  ->  repeat
```

Measured on staging 2026-09-09: ~1 turn/s, 3 gateway calls each, 354 rejected requests from one agent in two minutes, ending only when the no-progress streak guard cancelled the turn. Nothing in that chain depends on *why* the turn failed, so any future driver gap or provider failure reaches it the same way.

## Change

| | Before | After |
|---|---|---|
| 1st no-progress re-arm | immediate | immediate (unchanged — one deferral is legitimate) |
| 2nd, 3rd, … | immediate | 5, 10, 20, 40, 80, 160, 300 s (capped) |
| reset | never | any turn that admits its batch |
| a message arrives mid-backoff | n/a | cuts through — a coalescer deadline may only move earlier |
| degraded runtime | owns its own backoff | unchanged |

Two hunks: the ladder + counters next to the existing degraded/budget backoffs in `global_inbox_degraded.py`, and the settle/re-arm wiring in `global_inbox_runtime.py`.

The backed-off re-arm deliberately calls `coalescer.notify(delay_seconds=…)` rather than `self.notify()`, because `notify()` clears the degraded backoff **and** pins the delay to zero whenever no turn is active — which is precisely the spin being bounded. Real ingress still goes through `notify()` and is unaffected.

## Tests

New tests drive the real `process_once`, not only the helpers — the first coverage of that settle path — so the wiring is pinned, not just the arithmetic: a wedged turn stops spinning after the first repeat; a turn that makes progress clears the bound; a degraded runtime keeps its own backoff; nothing re-arms with no pending work; the ladder is pinned by value; ingress cuts through a deep backoff using the real coalescer with an injected clock.

Six mutants, all killed, including the original bug (re-arm always immediate) and the two wiring deletions that an earlier round of these tests let survive.

## Not in this PR

- Why the turns were misclassified in the first place: #335.
- The no-progress streak guard's own threshold and cancel behaviour, which is unchanged.
- Any change to the degraded or budget-park ladders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH1X6t2bVu8PxgeX4Wg4sG
