### PR TITLE
feat(lingtai): consolidate directory provisioning and ACP runtime support

### DIFF
--- a/src/puffo_agent/agent/harness/driver_authority_server.py
+++ b/src/puffo_agent/agent/harness/driver_authority_server.py
@@ -166,6 +166,16 @@ class DriverAuthorityServer:
             while True:
                 request = self._recv_frame(record)
                 response, child = self._handle_request(record, request)
+                # Correlation is stamped here, at the one point every response
+                # passes through on its way to the wire. A peer that matches
+                # responses to requests by call_id rejects any reply that omits
+                # it, and this server has ten leaf response paths; threading a
+                # parameter through each one means a path added later can drop
+                # the echo silently. Only a request that correlates gets a
+                # correlation key back.
+                request_call_id = request.get("call_id")
+                if isinstance(request_call_id, str):
+                    response["call_id"] = request_call_id
                 try:
                     self._send_frame(record.server_socket, response, child=child)
                 finally:
@@ -218,15 +228,12 @@ class DriverAuthorityServer:
                 self._claim_probe()
             record.state = _LeaseState.CLAIMED
             binding = record.binding
-        response = {
+        return {
             "version": PROTOCOL_VERSION,
             "role": binding.role,
             "launch_id": binding.launch_id,
             "capability": binding.capability,
         }
-        if call_id is not None:
-            response["call_id"] = call_id
-        return response
 
     def _authorize_derived_launch(
         self, record: _EndpointRecord, request: dict[str, Any], *, call_id: str | None = None
@@ -336,15 +343,12 @@ class DriverAuthorityServer:
                 call_id,
             )
         )
-        response = {
+        return {
             "version": PROTOCOL_VERSION,
             "state": state,
             "reason_code": reason_code,
             "audit_id": audit_id,
         }
-        if call_id is not None:
-            response["call_id"] = call_id
-        return response
 
     @staticmethod
     def _send_frame(

--- a/src/puffo_agent/agent/harness/driver_authority_server.py
+++ b/src/puffo_agent/agent/harness/driver_authority_server.py
@@ -187,43 +187,49 @@ class DriverAuthorityServer:
         self, record: _EndpointRecord, request: dict[str, Any]
     ) -> tuple[dict[str, Any], socket.socket | None]:
         operation = request.get("op")
+        call_id = request.get("call_id")
+        if not isinstance(call_id, str):
+            call_id = None
         if request.get("version") != PROTOCOL_VERSION or not isinstance(operation, str):
             return self._decision(
-                record, "malformed", "indeterminate", "malformed_request"
+                record, "malformed", "indeterminate", "malformed_request", call_id=call_id
             ), None
         if operation == "hello":
-            return self._claim(record), None
+            return self._claim(record, call_id=call_id), None
         with self._lock:
             claimed = record.state is _LeaseState.CLAIMED
         if not claimed:
-            return self._mismatch(record, operation), None
+            return self._mismatch(record, operation, call_id=call_id), None
         if operation == "authorize_derived_launch":
-            return self._authorize_derived_launch(record, request)
+            return self._authorize_derived_launch(record, request, call_id=call_id)
         if operation == "authorize_provider_call":
             return self._authorize_provider_call(record, request), None
         return self._decision(
-            record, operation, "indeterminate", "unsupported_operation"
+            record, operation, "indeterminate", "unsupported_operation", call_id=call_id
         ), None
 
-    def _claim(self, record: _EndpointRecord) -> dict[str, Any]:
+    def _claim(self, record: _EndpointRecord, *, call_id: str | None = None) -> dict[str, Any]:
         with self._lock:
             if record.state is not _LeaseState.ISSUED:
                 return self._record_decision_locked(
-                    record, "hello", "denied", "endpoint_already_claimed"
+                    record, "hello", "denied", "endpoint_already_claimed", call_id=call_id
                 )
             if self._claim_probe is not None:
                 self._claim_probe()
             record.state = _LeaseState.CLAIMED
             binding = record.binding
-        return {
+        response = {
             "version": PROTOCOL_VERSION,
             "role": binding.role,
             "launch_id": binding.launch_id,
             "capability": binding.capability,
         }
+        if call_id is not None:
+            response["call_id"] = call_id
+        return response
 
     def _authorize_derived_launch(
-        self, record: _EndpointRecord, request: dict[str, Any]
+        self, record: _EndpointRecord, request: dict[str, Any], *, call_id: str | None = None
     ) -> tuple[dict[str, Any], socket.socket | None]:
         binding = record.binding
         if binding.role != "root":
@@ -232,13 +238,14 @@ class DriverAuthorityServer:
                 "authorize_derived_launch",
                 "denied",
                 "nested_derived_launch_denied",
+                call_id=call_id,
             ), None
         capability = request.get("capability")
         if request.get("launch_id") != binding.launch_id or capability not in {
             "daemon",
             "avatar",
         }:
-            return self._mismatch(record, "authorize_derived_launch"), None
+            return self._mismatch(record, "authorize_derived_launch", call_id=call_id), None
         child_binding = _EndpointBinding(
             launch_id=f"launch_{uuid.uuid4().hex}",
             role="derived",
@@ -249,7 +256,7 @@ class DriverAuthorityServer:
         child_record, child_endpoint = self._issue_endpoint(child_binding)
         self._start_record(child_record)
         response = self._decision(
-            record, "authorize_derived_launch", "granted", "allowed"
+            record, "authorize_derived_launch", "granted", "allowed", call_id=call_id
         )
         response["admission_id"] = f"admission_{uuid.uuid4().hex}"
         return response, child_endpoint
@@ -329,12 +336,15 @@ class DriverAuthorityServer:
                 call_id,
             )
         )
-        return {
+        response = {
             "version": PROTOCOL_VERSION,
             "state": state,
             "reason_code": reason_code,
             "audit_id": audit_id,
         }
+        if call_id is not None:
+            response["call_id"] = call_id
+        return response
 
     @staticmethod
     def _send_frame(

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -267,9 +267,8 @@ class AcpDriver(Driver):
             self._closed = False
             self._events = asyncio.Queue()
         launch = self._validate_launch_plan(spec)
-        # Captured per run, not per request: launch configuration, not a
-        # remembered decision. Nothing derived from it outlives a single
-        # request, so the peer's turn-scoped permission contract holds.
+        # Run configuration, not a remembered decision: derived permission
+        # decisions last one request, preserving the peer's turn scope.
         self._permission_mode = spec.permission_mode
         self._proc = await self._spawn(launch)
         if self._proc.stdin is None or self._proc.stdout is None:

--- a/src/puffo_agent/agent/harness/drivers/acp.py
+++ b/src/puffo_agent/agent/harness/drivers/acp.py
@@ -248,6 +248,7 @@ class AcpDriver(Driver):
         self._fallback_block_id = ""
         self._capabilities = acp_capabilities(session_resume=False)
         self._model_selection = ""
+        self._permission_mode = ""
         self._spawn_warnings: tuple[str, ...] = ()
         self._driver_authority: DriverAuthorityServer | None = None
         self._closed = False
@@ -266,6 +267,10 @@ class AcpDriver(Driver):
             self._closed = False
             self._events = asyncio.Queue()
         launch = self._validate_launch_plan(spec)
+        # Captured per run, not per request: launch configuration, not a
+        # remembered decision. Nothing derived from it outlives a single
+        # request, so the peer's turn-scoped permission contract holds.
+        self._permission_mode = spec.permission_mode
         self._proc = await self._spawn(launch)
         if self._proc.stdin is None or self._proc.stdout is None:
             raise RuntimeError("ACP child did not expose stdio pipes")
@@ -851,13 +856,40 @@ class AcpDriver(Driver):
         if session_id != self._native_session_id or not self._active.value:
             return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
         ref = PermissionRef(f"permission_{uuid.uuid4().hex}")
-        future = asyncio.get_running_loop().create_future()
-        self._permissions[ref] = (future, options)
+        # ``bypassPermissions`` means the operator has pre-authorised this
+        # runtime's tool use, so answer immediately instead of parking the
+        # request on a human. The sibling drivers express the same policy at
+        # launch (codex ``approvalPolicy: never``, opencode ``--auto``); ACP
+        # has no such switch because in ACP the client *is* the authority, so
+        # answering on the spot is where the policy lands here.
+        #
+        # The answer is derived from this request alone and nothing is stored:
+        # no future is registered, no grant is cached, and the peer still asks
+        # again next turn. That keeps LingTai's turn-scoped permission
+        # contract intact -- this is not a persistent-permission capability.
+        auto_allow = self._permission_mode == "bypassPermissions"
+        selected_auto = _allow_shaped_permission(options) if auto_allow else None
+        if auto_allow and selected_auto is None:
+            # Deliberately NOT ``_preferred_permission``: that one falls back
+            # to ``options[0]`` when nothing allow-shaped is offered, which for
+            # a human approval is a reasonable last resort but here would let
+            # us return "allowed" carrying a *reject* option id. With no
+            # allow-shaped option there is no consent to give, so fall through
+            # to the human instead of inventing one.
+            auto_allow = False
+        future: asyncio.Future[PermissionDecision] | None = None
+        if not auto_allow:
+            future = asyncio.get_running_loop().create_future()
+            self._permissions[ref] = (future, options)
         await self._emit(
             HarnessEventType.PERMISSION_REQUESTED,
             turn=self._active,
             data={
                 "permission_ref": str(ref),
+                # Says what actually happened: an auto-allowed request was
+                # never pending, so a reader must not score it as an
+                # unanswered prompt.
+                "auto_allowed": auto_allow,
                 "tool_call_ref": str(getattr(tool_call, "tool_call_id", "")),
                 "label": str(getattr(tool_call, "title", "")),
                 "options": tuple(
@@ -871,6 +903,15 @@ class AcpDriver(Driver):
             },
             native_payload=tool_call,
         )
+        if auto_allow:
+            assert selected_auto is not None
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(
+                    outcome="selected",
+                    option_id=selected_auto.option_id,
+                )
+            )
+        assert future is not None
         decision = await future
         self._permissions.pop(ref, None)
         if decision is PermissionDecision.DENY:
@@ -935,6 +976,23 @@ class AcpDriver(Driver):
     def _require_active(self, turn: TurnRef) -> None:
         if turn != self._active or not self._active.value:
             raise RuntimeError("stale or foreign active turn")
+
+
+def _allow_shaped_permission(
+    options: list[PermissionOption],
+) -> PermissionOption | None:
+    """An option that actually grants, or ``None``.
+
+    Unlike :func:`_preferred_permission` this never falls back to an
+    arbitrary option: a caller that auto-approves must not be handed a
+    ``reject_once`` entry to "allow" with.
+    """
+
+    for kind in ("allow_once", "allow_always"):
+        for option in options:
+            if option.kind == kind:
+                return option
+    return None
 
 
 def _preferred_permission(

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -570,8 +570,11 @@ def build_capabilities() -> dict:
         # names (gemini, kimi, opencode …), so no single binary probe can
         # stand for it; admission is checked per-target at creation time.
         "acp": HarnessReadiness("degraded", "target_probe_required", "ready"),
+        # Presence advertises the directory-association creation contract.
+        # The operator supplies the executable, so check that target at create.
+        "lingtai": HarnessReadiness("degraded", "target_probe_required", "ready"),
     }
-    cli_tools = {name: r.legacy for name, r in readiness.items()}
+    cli_tools = {name: r.legacy for name, r in readiness.items() if name != "lingtai"}
     # Frozen wire quirks, kept byte-stable for old portal consumers:
     # opencode historically meant binary-present (credentials unknown), and
     # "acp" mirrored that opencode binary status. New consumers read

--- a/src/puffo_agent/portal/control/lingtai.py
+++ b/src/puffo_agent/portal/control/lingtai.py
@@ -1,0 +1,87 @@
+"""Operator-selected LingTai folders at the machine creation boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..state import home_dir
+
+
+@dataclass(frozen=True)
+class LingtaiLaunch:
+    executable: Path
+    agent_dir: Path
+    workspace: Path
+    registry: Path
+    runtime_id: str
+
+    def argv(self) -> list[str]:
+        return [
+            str(self.executable), "acp", "--profile", "puffo-v1",
+            "--runtime-id", self.runtime_id, "--registry", str(self.registry),
+        ]
+
+
+def parse_lingtai_launch(raw: object) -> LingtaiLaunch | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("runtime.lingtai must be an object")
+    paths = {}
+    for key in ("executable", "agent_dir", "workspace"):
+        value = raw.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"LingTai {key} is required")
+        path = Path(value)
+        if not path.is_absolute():
+            raise ValueError(f"LingTai {key} must be an absolute path on this machine")
+        paths[key] = path.resolve(strict=True)
+    if not paths["executable"].is_file() or not os.access(paths["executable"], os.X_OK):
+        raise ValueError("LingTai executable must be an executable file")
+    if not paths["agent_dir"].is_dir() or not (paths["agent_dir"] / "init.json").is_file():
+        raise ValueError("LingTai agent_dir must contain init.json")
+    if not paths["workspace"].is_dir():
+        raise ValueError("LingTai workspace must be an existing directory")
+    return LingtaiLaunch(
+        **paths,
+        registry=home_dir().resolve() / "lingtai" / "runtime-registry.json",
+        runtime_id="puffo-" + uuid.uuid4().hex,
+    )
+
+
+async def provision_lingtai(launch: LingtaiLaunch) -> None:
+    await _command(launch, [
+        "puffo-v0", "provision", "--runtime-id", launch.runtime_id,
+        "--agent-dir", str(launch.agent_dir), "--workspace", str(launch.workspace),
+        "--registry", str(launch.registry),
+    ])
+
+
+async def revoke_lingtai(launch: LingtaiLaunch) -> None:
+    await _command(launch, [
+        "puffo-v0", "revoke", "--runtime-id", launch.runtime_id,
+        "--registry", str(launch.registry),
+    ])
+
+
+async def _command(launch: LingtaiLaunch, args: list[str]) -> None:
+    process = await asyncio.create_subprocess_exec(
+        str(launch.executable), *args, cwd=launch.workspace,
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        code = await asyncio.wait_for(process.wait(), timeout=30)
+    except BaseException:
+        if process.returncode is None:
+            process.kill()
+        await process.wait()
+        raise
+    if code:
+        raise ValueError(
+            "LingTai runtime provisioning failed; check the initialized folders "
+            "and install a LingTai version supporting --registry"
+        )

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -355,6 +355,10 @@ async def _rollback_lingtai(launch: LingtaiLaunch) -> None:
         try:
             await asyncio.shield(cleanup)
         except asyncio.CancelledError:
+            # Finish bounded cleanup and let the caller re-raise its original
+            # failure, even if that failure was not a cancellation. Later
+            # cancellations do not replace it; reconsider this policy before
+            # using this helper under structured cancellation (e.g. TaskGroup).
             continue
         except Exception:
             break

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -13,6 +13,7 @@ from ...crypto.canonical import canonicalize_for_signing
 from ...crypto.encoding import base64url_decode
 from ...crypto.primitives import ed25519_verify
 from ...mcp.config import supported_inference_levels
+from ...tasks import spawn
 from ..host_assets import _atomic_write_private, _ensure_private_directory
 from ..runtime_matrix import (
     RUNTIME_CLI_LOCAL,
@@ -33,7 +34,7 @@ from ..state import (
     is_valid_agent_id,
 )
 from .certs import CertError, verify_device_cert, verify_identity_cert, verify_slug_binding
-from .lingtai import parse_lingtai_launch, provision_lingtai, revoke_lingtai
+from .lingtai import LingtaiLaunch, parse_lingtai_launch, provision_lingtai, revoke_lingtai
 
 logger = logging.getLogger(__name__)
 
@@ -344,6 +345,25 @@ def write_agent_from_context(context: dict) -> dict:
     return {"agent_id": agent_id, "agent_dir": str(target)}
 
 
+async def _rollback_lingtai(launch: LingtaiLaunch) -> None:
+    # Own and join the cleanup task: shielding alone would leave it detached
+    # when the request receives another cancellation during daemon shutdown.
+    cleanup = spawn(
+        asyncio.wait_for(revoke_lingtai(launch), timeout=30), name="lingtai.rollback",
+    )
+    while not cleanup.done():
+        try:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            continue
+        except Exception:
+            break
+    try:
+        cleanup.result()
+    except (Exception, asyncio.CancelledError):
+        logger.warning("LingTai rollback failed for runtime %s", launch.runtime_id)
+
+
 async def provision_agent_from_bundle(
     payload: dict,
     operator_root_key_b64: str,
@@ -366,10 +386,7 @@ async def provision_agent_from_bundle(
         result = write_agent_from_context(context)
     except BaseException:
         if launch is not None:
-            try:
-                await revoke_lingtai(launch)
-            except Exception:
-                logger.warning("LingTai rollback failed for runtime %s", launch.runtime_id)
+            await _rollback_lingtai(launch)
         raise
     result.update(
         device_id=context["device_id"],

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import shutil
@@ -32,6 +33,7 @@ from ..state import (
     is_valid_agent_id,
 )
 from .certs import CertError, verify_device_cert, verify_identity_cert, verify_slug_binding
+from .lingtai import parse_lingtai_launch, provision_lingtai, revoke_lingtai
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +88,14 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
     )
     core_fields = _verify_core(core, bound_slug, device_cert)
     profile_fields = _verify_profile(payload, bound_slug)
+    try:
+        lingtai = parse_lingtai_launch(runtime_input.get("lingtai"))
+    except (ValueError, OSError) as exc:
+        raise ProvisionError(str(exc)) from exc
+    if lingtai is not None:
+        if runtime_input.get("kind") != RUNTIME_CLI_LOCAL or runtime_input.get("harness") != "acp":
+            raise ProvisionError("LingTai requires the cli-local ACP runtime")
+        runtime_input = {**runtime_input, "harness_command": lingtai.argv()}
     runtime = _verify_runtime(runtime_input)
     desired_skills, desired_mcps = _verify_desired(payload)
     server_url, slug, device_id, space_id, operator_slug = core_fields
@@ -103,6 +113,7 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
         "space_id": space_id,
         "operator_slug": operator_slug,
         "runtime": runtime,
+        "lingtai": lingtai,
         "desired_skills": desired_skills,
         "desired_mcps": desired_mcps,
         "bundle": bundle,
@@ -318,6 +329,7 @@ def write_agent_from_context(context: dict) -> dict:
                 operator_slug=context["operator_slug"],
             ),
             runtime=context["runtime"],
+            workspace_dir=str(context["lingtai"].workspace) if context.get("lingtai") else "workspace",
             triggers=TriggerRules(),
             desired_skills=context["desired_skills"],
             desired_mcps=context["desired_mcps"],
@@ -342,9 +354,23 @@ async def provision_agent_from_bundle(
     context = verify_agent_bundle(payload, operator_root_key_b64)
     if preflight is not None:
         await preflight(context)
-    if materialize is not None:
-        await materialize(context)
-    result = write_agent_from_context(context)
+    launch = context["lingtai"]
+    if launch is not None:
+        try:
+            await provision_lingtai(launch)
+        except (ValueError, OSError, asyncio.TimeoutError) as exc:
+            raise ProvisionError(f"LingTai runtime provisioning failed: {exc}") from exc
+    try:
+        if materialize is not None:
+            await materialize(context)
+        result = write_agent_from_context(context)
+    except BaseException:
+        if launch is not None:
+            try:
+                await revoke_lingtai(launch)
+            except Exception:
+                logger.warning("LingTai rollback failed for runtime %s", launch.runtime_id)
+        raise
     result.update(
         device_id=context["device_id"],
         role=context["role"],

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -42,6 +42,13 @@ from puffo_agent.agent.harness.driver import (
     TurnInput,
 )
 from puffo_agent.agent.harness.support.subprocess_io import ProcessTreeShutdownError
+from puffo_agent.agent.harness.runtime.docker_runtime import (
+    _sanitise_permission_mode as _docker_sanitise_permission_mode,
+)
+from puffo_agent.agent.harness.runtime.local_runtime import (
+    VALID_PERMISSION_MODES,
+    _sanitise_permission_mode as _local_sanitise_permission_mode,
+)
 
 
 class _FakeProcess:
@@ -914,3 +921,46 @@ async def test_bypass_permissions_will_not_allow_with_a_reject_only_option_set()
     assert response.outcome.outcome == "cancelled"
     harness.conn.prompt_result.set_result(PromptResponse(stop_reason="cancelled"))
     await driver.close()
+
+
+def test_widening_permission_modes_needs_an_operator_answer_path():
+    """Tripwire: nothing in production can currently ask a human.
+
+    Both runtimes coerce every configured ``permission_mode`` to
+    ``bypassPermissions``, and every RuntimeSpec is built from that sanitised
+    value — so the waiting branch of ``_request_permission`` is reachable only
+    from tests. The docstring above
+    (``test_bypass_permissions_answers_without_a_human``) states that as prose;
+    this binds it.
+
+    Widening this set is a one-line change that silently activates the wait.
+    Before doing so, confirm something presents ``turn.permission_requested``
+    to an operator and calls ``runtime.resolve_permission``. Puffo sets no
+    timeout of its own, so without that path every tool call runs out the ACP
+    peer's timeout and is then DENIED.
+    """
+
+    assert VALID_PERMISSION_MODES == frozenset({"bypassPermissions"}), (
+        "permission_mode gained a reachable value, so the ask-a-human branch "
+        "is now live. Verify an operator-facing answer path exists "
+        "(turn.permission_requested -> runtime.resolve_permission) before "
+        "shipping this, or every tool call becomes a timeout-then-deny."
+    )
+
+
+def test_both_runtimes_agree_on_which_permission_modes_exist():
+    """The docker sanitiser hardcodes its own set instead of importing one.
+
+    Two copies of the same guard drift silently: widening the local constant
+    would leave docker still coercing, so the same agent config would ask a
+    human on one runtime and not the other. Compare behaviour, not the
+    literals, so this keeps working if either side is refactored.
+    """
+
+    probes = ["bypassPermissions", "ask", "acceptEdits", "plan", "", "default"]
+    local = {mode: _local_sanitise_permission_mode(mode, "agent") for mode in probes}
+    docker = {mode: _docker_sanitise_permission_mode(mode, "agent") for mode in probes}
+    assert local == docker, (
+        "local_runtime and docker_runtime disagree about permission modes; "
+        "they hold separate copies of the same allow-list."
+    )

--- a/tests/test_acp_driver.py
+++ b/tests/test_acp_driver.py
@@ -403,7 +403,12 @@ async def test_permission_request_waits_for_typed_driver_resolution():
         harness.process_factory,
         connection_factory=harness.connection_factory,
     )
-    await driver.open(RuntimeSpec("/workspace", executable="agent"))
+    # Explicitly non-bypass: RuntimeSpec defaults to "bypassPermissions", so
+    # without this the driver answers on its own and this test would silently
+    # stop covering the human path it exists to pin.
+    await driver.open(
+        RuntimeSpec("/workspace", executable="agent", permission_mode="ask")
+    )
     stream = driver.events()
     await driver.start_turn(TurnInput("hello"))
     permission = asyncio.create_task(harness.client.request_permission(
@@ -806,4 +811,106 @@ async def test_session_calls_receive_the_projected_mcp_servers(
     assert [(e.name, e.value) for e in server.env] == [
         ("PUFFO_AGENT_ID", "agent_test")
     ]
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_answers_without_a_human():
+    """``bypassPermissions`` must not park a tool call on an operator.
+
+    The runtime only ever supplies this mode (VALID_PERMISSION_MODES holds
+    exactly one value), so an unattended agent depends on this path entirely.
+    """
+
+    harness = _Harness()
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(
+        RuntimeSpec(
+            "/workspace", executable="agent", permission_mode="bypassPermissions"
+        )
+    )
+    stream = driver.events()
+    await driver.start_turn(TurnInput("hello"))
+    # No resolve_permission() anywhere: if the driver waits, this await times out.
+    response = await asyncio.wait_for(
+        harness.client.request_permission(
+            [
+                PermissionOption(
+                    option_id="deny", name="Deny", kind="reject_once"
+                ),
+                PermissionOption(
+                    option_id="allow", name="Allow once", kind="allow_once"
+                ),
+            ],
+            "acp_session",
+            ToolCallStart(
+                session_update="tool_call", tool_call_id="tool_1", title="shell"
+            ),
+        ),
+        timeout=1,
+    )
+    assert response.outcome.outcome == "selected"
+    assert response.outcome.option_id == "allow"
+    events = await asyncio.wait_for(
+        _collect_through(stream, HarnessEventType.PERMISSION_REQUESTED), timeout=1
+    )
+    # The record must say it was auto-allowed, not look like an unanswered prompt.
+    assert events[-1].data["auto_allowed"] is True
+    # Nothing retained: no pending future, so no cross-request grant exists to
+    # reuse. This is the property that keeps the peer's turn-scoped permission
+    # contract intact.
+    assert driver._permissions == {}
+    harness.conn.prompt_result.set_result(PromptResponse(stop_reason="cancelled"))
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_bypass_permissions_will_not_allow_with_a_reject_only_option_set():
+    """Auto-approval needs something that actually grants.
+
+    ``_preferred_permission`` falls back to ``options[0]``; reusing it here
+    would return outcome="selected" carrying a *reject* option id -- an
+    "approval" that denies. With nothing allow-shaped on offer the driver must
+    fall back to asking a human.
+    """
+
+    harness = _Harness()
+    driver = AcpDriver(
+        harness.process_factory,
+        connection_factory=harness.connection_factory,
+    )
+    await driver.open(
+        RuntimeSpec(
+            "/workspace", executable="agent", permission_mode="bypassPermissions"
+        )
+    )
+    stream = driver.events()
+    await driver.start_turn(TurnInput("hello"))
+    pending = asyncio.create_task(
+        harness.client.request_permission(
+            [
+                PermissionOption(
+                    option_id="deny", name="Deny", kind="reject_once"
+                ),
+            ],
+            "acp_session",
+            ToolCallStart(
+                session_update="tool_call", tool_call_id="tool_1", title="shell"
+            ),
+        )
+    )
+    events = await asyncio.wait_for(
+        _collect_through(stream, HarnessEventType.PERMISSION_REQUESTED), timeout=1
+    )
+    assert events[-1].data["auto_allowed"] is False
+    # Still pending on a human rather than silently "allowing" with a denial.
+    assert not pending.done()
+    ref = PermissionRef(str(events[-1].data["permission_ref"]))
+    await driver.resolve_permission(ref, PermissionDecision.DENY)
+    response = await asyncio.wait_for(pending, timeout=1)
+    assert response.outcome.outcome == "cancelled"
+    harness.conn.prompt_result.set_result(PromptResponse(stop_reason="cancelled"))
     await driver.close()

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import os
+import sys
 
 import pytest
 
@@ -505,3 +507,98 @@ async def test_lingtai_provision_failure_leaves_identity_unmaterialized(tmp_path
         await provision_agent_from_bundle(payload, operator, materialize=materialize)
     assert materialized == []
     assert not (tmp_path / "daemon/agents/helper-1234/agent.yml").exists()
+
+
+@pytest.fixture
+def lingtai_creation(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "daemon"))
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "init.json").write_text("{}")
+    payload, operator = _payload()
+    payload["runtime"] = {
+        "kind": "cli-local", "harness": "acp", "provider": "openai",
+        "lingtai": {"executable": sys.executable, "agent_dir": str(source), "workspace": str(source)},
+    }
+    associations = set()
+
+    async def register(launch):
+        associations.add((launch.runtime_id, launch.registry))
+
+    async def revoke(launch):
+        associations.remove((launch.runtime_id, launch.registry))
+
+    monkeypatch.setattr(provision, "provision_lingtai", register)
+    monkeypatch.setattr(provision, "revoke_lingtai", revoke)
+    return payload, operator, associations
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["materialize", "write"])
+async def test_lingtai_creation_failure_revokes_association(lingtai_creation, monkeypatch, stage):
+    """Either post-registration failure must revoke the same registry entry."""
+    payload, operator, associations = lingtai_creation
+    original = RuntimeError("creation failed")
+
+    async def materialize(context):
+        assert associations
+        if stage == "materialize":
+            raise original
+
+    def write(context):
+        raise original
+
+    monkeypatch.setattr(provision, "write_agent_from_context", write)
+    with pytest.raises(RuntimeError) as caught:
+        await provision_agent_from_bundle(payload, operator, materialize=materialize)
+    assert caught.value is original
+    assert not associations
+
+
+@pytest.mark.asyncio
+async def test_lingtai_rollback_failure_preserves_original_error(lingtai_creation, monkeypatch, caplog):
+    """Cleanup failure must be logged without replacing the creation error."""
+    payload, operator, _ = lingtai_creation
+    original = RuntimeError("materialize failed")
+
+    async def materialize(context):
+        raise original
+
+    async def revoke(launch):
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr(provision, "revoke_lingtai", revoke)
+    with pytest.raises(RuntimeError) as caught:
+        await provision_agent_from_bundle(payload, operator, materialize=materialize)
+    assert caught.value is original
+    assert "LingTai rollback failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_lingtai_repeated_cancellation_finishes_rollback(lingtai_creation, monkeypatch):
+    """A second shutdown cancellation must not interrupt revoke or replace the first."""
+    payload, operator, associations = lingtai_creation
+    materializing = asyncio.Event()
+    revoking = asyncio.Event()
+    release = asyncio.Event()
+
+    async def materialize(context):
+        materializing.set()
+        await asyncio.Event().wait()
+
+    async def revoke(launch):
+        revoking.set()
+        await release.wait()
+        associations.remove((launch.runtime_id, launch.registry))
+
+    monkeypatch.setattr(provision, "revoke_lingtai", revoke)
+    task = asyncio.create_task(provision_agent_from_bundle(payload, operator, materialize=materialize))
+    await asyncio.wait_for(materializing.wait(), 2)
+    task.cancel("first cancellation")
+    await asyncio.wait_for(revoking.wait(), 2)
+    task.cancel("second cancellation")
+    release.set()
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await task
+    assert not associations
+    assert caught.value.args == ("first cancellation",)

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -437,3 +437,71 @@ def test_partial_write_is_cleaned_up(tmp_path, monkeypatch):
     with pytest.raises(KeyError):
         write_agent_from_context(context)
     assert not (tmp_path / "agents/helper-1234").exists()
+
+
+@pytest.mark.asyncio
+async def test_lingtai_browser_create_preserves_workspace_and_registry(tmp_path, monkeypatch):
+    """Browser-selected folders must survive provision into the driver argv/cwd."""
+    import json
+    import sys
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "daemon"))
+    source = tmp_path / "existing-lingtai"
+    workspace = tmp_path / "existing-workspace"
+    source.mkdir()
+    workspace.mkdir()
+    (source / "init.json").write_text("{}")
+    marker = tmp_path / "cli-args.json"
+    executable = tmp_path / "lingtai-agent"
+    executable.write_text(
+        f"#!{sys.executable}\nimport json,sys\n"
+        f"open({str(marker)!r}, 'w').write(json.dumps(sys.argv[1:]))\n"
+    )
+    executable.chmod(0o700)
+    payload, operator = _payload()
+    payload["runtime"] = {
+        "kind": "cli-local", "harness": "acp", "provider": "openai",
+        "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(workspace)},
+    }
+
+    async def materialize(context):
+        assert marker.exists(), "runtime must be provisioned before remote identity materializes"
+
+    await provision_agent_from_bundle(payload, operator, materialize=materialize)
+    cfg = AgentConfig.load("helper-1234")
+    argv = cfg.runtime.harness_command
+    provision_args = json.loads(marker.read_text())
+    assert cfg.resolve_workspace_dir() == workspace
+    assert argv[:4] == [str(executable), "acp", "--profile", "puffo-v1"]
+    for field in ["--runtime-id", "--registry"]:
+        assert argv[argv.index(field) + 1] == provision_args[provision_args.index(field) + 1]
+    assert provision_args[provision_args.index("--agent-dir") + 1] == str(source)
+    assert (source / "init.json").read_text() == "{}"
+
+
+@pytest.mark.asyncio
+async def test_lingtai_provision_failure_leaves_identity_unmaterialized(tmp_path, monkeypatch):
+    """An unusable LingTai runtime must not leave a running Puffo agent behind."""
+    import sys
+
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "daemon"))
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "init.json").write_text("{}")
+    executable = tmp_path / "lingtai-agent"
+    executable.write_text(f"#!{sys.executable}\nraise SystemExit(1)\n")
+    executable.chmod(0o700)
+    payload, operator = _payload()
+    payload["runtime"] = {
+        "kind": "cli-local", "harness": "acp", "provider": "openai",
+        "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(source)},
+    }
+    materialized = []
+
+    async def materialize(context):
+        materialized.append(context)
+
+    with pytest.raises(ProvisionError, match="LingTai runtime provisioning failed"):
+        await provision_agent_from_bundle(payload, operator, materialize=materialize)
+    assert materialized == []
+    assert not (tmp_path / "daemon/agents/helper-1234/agent.yml").exists()

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -518,10 +518,13 @@ _ROOT_LAUNCH_ID = "root-echo"
 
 
 def _paths_on_a_fresh_root(launch_id: str) -> list[dict[str, Any]]:
-    """Requests answered on a root endpoint, in order; hello claims it.
+    """Requests answered on a root endpoint, in order; the first hello claims it.
 
-    The second entry deliberately runs before any hello elsewhere in the
-    suite: ``_unclaimed_endpoint_request`` covers the pre-claim branch.
+    Every entry after that runs against a claimed endpoint, so this list
+    reaches eight of the ten leaf response paths. The pre-claim branch and
+    the nested-derived denial need different endpoint state and are covered
+    by ``test_unclaimed_endpoint_response_echoes_call_id`` and
+    ``test_nested_derived_launch_denial_echoes_call_id``.
     """
     return [
         {"version": 1, "op": "hello"},

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -488,3 +488,104 @@ async def test_constrained_lingtai_rejects_spawn_paths_that_cannot_pass_fds() ->
                 )
             )
         )
+
+
+def _root_client(server: DriverAuthorityServer, launch_id: str) -> socket.socket:
+    return _client(server.issue_root(launch_id=launch_id))
+
+
+def _every_answered_request(launch_id: str) -> list[dict[str, Any]]:
+    """One request per response path the server can take, hello first."""
+    return [
+        {"version": 1, "op": "hello"},
+        # Second hello: the endpoint is single-use, so this is the denied path.
+        {"version": 1, "op": "hello"},
+        {"version": 99, "op": "hello"},  # malformed_request
+        {"version": 1, "op": "no_such_operation"},  # unsupported_operation
+        {
+            "version": 1,
+            "op": "authorize_provider_call",
+            "launch_id": launch_id,
+            "provider": "llm",
+            "capability": "root",
+        },  # granted
+        {
+            "version": 1,
+            "op": "authorize_provider_call",
+            "launch_id": "not-the-binding",
+            "provider": "llm",
+            "capability": "root",
+        },  # endpoint_binding_mismatch
+        {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "launch_id": launch_id,
+            "capability": "daemon",
+        },  # granted, carries a child descriptor
+        {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "launch_id": "not-the-binding",
+            "capability": "daemon",
+        },  # mismatch
+    ]
+
+
+def test_every_response_echoes_the_request_call_id() -> None:
+    """A correlating peer rejects any response that drops its ``call_id``.
+
+    Asserted over every response path rather than the two that happened to
+    break LingTai, so a response constructor added later cannot reintroduce
+    the omission on a path nobody enumerated.
+    """
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-echo")
+    try:
+        for request in _every_answered_request("root-echo"):
+            call_id = str(uuid.uuid4())
+            response, fds = _request(client, {**request, "call_id": call_id})
+            _close_fds(fds)
+            assert response.get("call_id") == call_id, (
+                f"op={request['op']} version={request['version']} "
+                f"dropped call_id; response keys={sorted(response)}"
+            )
+    finally:
+        client.close()
+        server.close()
+
+
+def test_response_omits_call_id_when_the_request_did_not_correlate() -> None:
+    """Requests that send no ``call_id`` keep their existing response shape."""
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-uncorrelated")
+    try:
+        for request in _every_answered_request("root-uncorrelated"):
+            response, fds = _request(client, request)
+            _close_fds(fds)
+            assert "call_id" not in response, (
+                f"op={request['op']} invented a call_id the caller never sent: "
+                f"{response!r}"
+            )
+    finally:
+        client.close()
+        server.close()
+
+
+def test_lingtai_hello_correlation_is_accepted_end_to_end() -> None:
+    """The exact exchange LingTai performs before it will bind authority."""
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-lingtai")
+    try:
+        call_id = str(uuid.uuid4())
+        response, fds = _request(
+            client, {"version": 1, "op": "hello", "call_id": call_id}
+        )
+        assert fds == []
+        # LingTai's driver_authority client raises
+        # DriverAuthorityTransportError unless this comparison holds.
+        assert response.get("call_id") == call_id
+        assert response["role"] == "root"
+        assert response["launch_id"] == "root-lingtai"
+    finally:
+        client.close()
+        server.close()

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -494,12 +494,38 @@ def _root_client(server: DriverAuthorityServer, launch_id: str) -> socket.socket
     return _client(server.issue_root(launch_id=launch_id))
 
 
-def _every_answered_request(launch_id: str) -> list[dict[str, Any]]:
-    """One request per response path the server can take, hello first."""
+def _derived_client(server: DriverAuthorityServer, root: socket.socket) -> socket.socket:
+    """A claimed derived (non-root) endpoint, for the nested-denial path."""
+    _hello(root)  # the root endpoint must be claimed before it can derive
+    grant, fds = _request(
+        root,
+        {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "call_id": str(uuid.uuid4()),
+            "launch_id": _ROOT_LAUNCH_ID,
+            "capability": "daemon",
+        },
+    )
+    assert grant["state"] == "granted", grant
+    assert len(fds) == 1, fds
+    child = socket.socket(fileno=fds[0])
+    _hello(child)
+    return child
+
+
+_ROOT_LAUNCH_ID = "root-echo"
+
+
+def _paths_on_a_fresh_root(launch_id: str) -> list[dict[str, Any]]:
+    """Requests answered on a root endpoint, in order; hello claims it.
+
+    The second entry deliberately runs before any hello elsewhere in the
+    suite: ``_unclaimed_endpoint_request`` covers the pre-claim branch.
+    """
     return [
         {"version": 1, "op": "hello"},
-        # Second hello: the endpoint is single-use, so this is the denied path.
-        {"version": 1, "op": "hello"},
+        {"version": 1, "op": "hello"},  # endpoint_already_claimed
         {"version": 99, "op": "hello"},  # malformed_request
         {"version": 1, "op": "no_such_operation"},  # unsupported_operation
         {
@@ -534,14 +560,23 @@ def _every_answered_request(launch_id: str) -> list[dict[str, Any]]:
 def test_every_response_echoes_the_request_call_id() -> None:
     """A correlating peer rejects any response that drops its ``call_id``.
 
-    Asserted over every response path rather than the two that happened to
-    break LingTai, so a response constructor added later cannot reintroduce
-    the omission on a path nobody enumerated.
+    Ten leaf response paths reach the wire. Eight are reachable on a fresh
+    root endpoint; the other two need different endpoint state, so they get
+    their own cases below rather than being quietly absent:
+    ``test_unclaimed_endpoint_response_echoes_call_id`` (a non-hello request
+    before the endpoint is claimed) and
+    ``test_nested_derived_launch_denial_echoes_call_id`` (a derived endpoint
+    asking to derive again).
+
+    The guarantee itself does not come from this enumeration: the echo is
+    stamped once in ``_serve`` before ``_send_frame``, so a response path
+    added later is covered by construction. These cases prove that stamp is
+    live on every path we can name.
     """
     server = DriverAuthorityServer()
-    client = _root_client(server, "root-echo")
+    client = _root_client(server, _ROOT_LAUNCH_ID)
     try:
-        for request in _every_answered_request("root-echo"):
+        for request in _paths_on_a_fresh_root(_ROOT_LAUNCH_ID):
             call_id = str(uuid.uuid4())
             response, fds = _request(client, {**request, "call_id": call_id})
             _close_fds(fds)
@@ -554,12 +589,69 @@ def test_every_response_echoes_the_request_call_id() -> None:
         server.close()
 
 
+def test_unclaimed_endpoint_response_echoes_call_id() -> None:
+    """A non-hello request before the endpoint is claimed is still a response."""
+    server = DriverAuthorityServer()
+    client = _root_client(server, "root-unclaimed")
+    try:
+        call_id = str(uuid.uuid4())
+        response, fds = _request(
+            client,
+            {
+                "version": 1,
+                "op": "authorize_provider_call",
+                "call_id": call_id,
+                "launch_id": "root-unclaimed",
+                "provider": "llm",
+                "capability": "root",
+            },
+        )
+        _close_fds(fds)
+        assert response["reason_code"] == "endpoint_binding_mismatch"
+        assert response.get("call_id") == call_id, response
+    finally:
+        client.close()
+        server.close()
+
+
+def test_nested_derived_launch_denial_echoes_call_id() -> None:
+    """A derived endpoint asking to derive again is denied -- and correlated."""
+    server = DriverAuthorityServer()
+    root = _root_client(server, _ROOT_LAUNCH_ID)
+    child = None
+    try:
+        child = _derived_client(server, root)
+        call_id = str(uuid.uuid4())
+        response, fds = _request(
+            child,
+            {
+                "version": 1,
+                "op": "authorize_derived_launch",
+                "call_id": call_id,
+                "launch_id": "anything",
+                "capability": "daemon",
+            },
+        )
+        _close_fds(fds)
+        assert response["reason_code"] == "nested_derived_launch_denied"
+        assert response.get("call_id") == call_id, response
+    finally:
+        if child is not None:
+            child.close()
+        root.close()
+        server.close()
+
+
 def test_response_omits_call_id_when_the_request_did_not_correlate() -> None:
-    """Requests that send no ``call_id`` keep their existing response shape."""
+    """Requests that send no ``call_id`` keep their existing response shape.
+
+    An uncorrelated request must not receive an invented or null correlation
+    key; two existing tests assert hello responses by exact dict equality.
+    """
     server = DriverAuthorityServer()
     client = _root_client(server, "root-uncorrelated")
     try:
-        for request in _every_answered_request("root-uncorrelated"):
+        for request in _paths_on_a_fresh_root("root-uncorrelated"):
             response, fds = _request(client, request)
             _close_fds(fds)
             assert "call_id" not in response, (

--- a/tests/test_driver_authority_server.py
+++ b/tests/test_driver_authority_server.py
@@ -255,6 +255,63 @@ def test_provider_calls_are_adjudicated_independently_with_readable_audit_ids() 
         server.close()
 
 
+def test_protocol_responses_echo_request_call_id() -> None:
+    """LingTai correlates every authority response to its request."""
+
+    server = DriverAuthorityServer()
+    root = _client(server.issue_root(launch_id="root-call-id"))
+    child: socket.socket | None = None
+    try:
+        root_hello_id = uuid.uuid4().hex
+        root_hello, fds = _request(
+            root, {"version": 1, "op": "hello", "call_id": root_hello_id}
+        )
+        assert fds == []
+        assert root_hello["call_id"] == root_hello_id
+
+        launch_id = uuid.uuid4().hex
+        launch, child_fds = _request(
+            root,
+            {
+                "version": 1,
+                "op": "authorize_derived_launch",
+                "call_id": launch_id,
+                "launch_id": "root-call-id",
+                "capability": "daemon",
+            },
+        )
+        assert launch["call_id"] == launch_id
+        child = socket.socket(fileno=child_fds.pop())
+
+        child_hello_id = uuid.uuid4().hex
+        child_hello, fds = _request(
+            child, {"version": 1, "op": "hello", "call_id": child_hello_id}
+        )
+        assert fds == []
+        assert child_hello["call_id"] == child_hello_id
+
+        provider_id = uuid.uuid4().hex
+        provider, fds = _request(
+            child,
+            {
+                "version": 1,
+                "op": "authorize_provider_call",
+                "call_id": provider_id,
+                "launch_id": child_hello["launch_id"],
+                "provider": "llm",
+                "capability": "daemon",
+            },
+        )
+        assert fds == []
+        assert provider["call_id"] == provider_id
+    finally:
+        _close_fds(child_fds if "child_fds" in locals() else [])
+        if child is not None:
+            child.close()
+        root.close()
+        server.close()
+
+
 def test_root_can_issue_one_hop_but_derived_cannot_issue_nested_child() -> None:
     server = DriverAuthorityServer()
     root = _client(server.issue_root(launch_id="root-parent"))

--- a/tests/test_driver_lifecycle_capabilities.py
+++ b/tests/test_driver_lifecycle_capabilities.py
@@ -15,6 +15,11 @@ from puffo_agent.agent.harness.driver import (
     SessionRef,
     SteerCapability,
 )
+from puffo_agent.agent.harness import (
+    SUPPORTED_LOCAL_DRIVERS,
+    UnsupportedDriver,
+    build_driver,
+)
 from puffo_agent.agent.harness.runtime.runtime_manager import RuntimeManagerAdapter
 
 
@@ -30,6 +35,27 @@ def _shipped_capabilities():
 
 def test_shipped_drivers_declare_lifecycle_and_busy_delivery():
     for name, caps in _shipped_capabilities().items():
+        assert RuntimeLifecycle(caps.lifecycle), name
+        assert BusyDelivery(caps.busy_delivery), name
+
+
+def test_every_buildable_driver_declares_lifecycle_and_busy_delivery():
+    """Bind the roster, not just its listed members.
+
+    ``_shipped_capabilities`` is hand-kept and names two drivers (plus one
+    claude-code variant), while ``SUPPORTED_LOCAL_DRIVERS`` admits five. A
+    driver added to the factory — acp, opencode and pi already are — is
+    examined by nothing here, and so is the next one. Deriving the set from the
+    factory means adding a driver without declaring its lifecycle fails, rather
+    than passing silently.
+    """
+
+    for name in sorted(SUPPORTED_LOCAL_DRIVERS):
+        driver = build_driver(name)
+        assert not isinstance(driver, UnsupportedDriver), name
+        caps = driver.current_capabilities()
+        assert caps is not None, f"{name} declares no capabilities"
+        # Constructing the enum rejects a value outside it.
         assert RuntimeLifecycle(caps.lifecycle), name
         assert BusyDelivery(caps.busy_delivery), name
 

--- a/tests/test_harness_readiness.py
+++ b/tests/test_harness_readiness.py
@@ -87,6 +87,7 @@ def test_capabilities_report_truth_beside_frozen_legacy(monkeypatch):
         "pi": {"state": "unavailable", "reason": "need_login"},
         "opencode": {"state": "ready", "reason": ""},
         "acp": {"state": "degraded", "reason": "target_probe_required"},
+        "lingtai": {"state": "degraded", "reason": "target_probe_required"},
     }
 
 


### PR DESCRIPTION
Enables Puffo to create and run an initialized LingTai agent directory through ACP, persist its workspace and registry association, correlate driver authority replies, and honor the selected ACP permission mode.

Consolidates #311, #342, #344 and the original #346 into this single daemon merge target. Post-provision failures perform bounded rollback even across repeated cancellation, then re-raise the original failure. The cleanup does not guarantee recovery from a hard process kill. Operator-selected workspaces may be shared; they are not registry directories or an isolation boundary.

Validation: 4,043 passed, 2 skipped in the combined Python run; excludes test_agent_install.py and test_host_mcp_handler.py because their inherited CODEX_HOME fixtures can modify the host configuration. This is not an unmodified full-suite pass. Ruff and the Python structural check pass. The only post-run change compresses an ACP comment by one line to meet the 100-line function check. Combined-build browser evidence is recorded below.

Companion LingTai PR: Lingtai-AI/lingtai-kernel#1690 at ad11d7bc. No merge or release has been performed.

ACP policy decision: this change makes ACP consume the existing platform permission mode. The current platform accepts only bypassPermissions (VALID_PERMISSION_MODES has one entry), defaults to it, and its runtime sanitizers also fall back to it for unknown values. There is currently no supported configuration value that requests manual ACP permission handling. ACP therefore automatically selects an allow-shaped option under that mode; when no allow-shaped option exists it asks the operator. This aligns ACP with the existing platform default, including the default-allow behavior. It does not change the platform-wide defaults. The forwarded call_id remains necessary for AuthorityAuditRecord; the wire-level stamp separately correlates response frames.

Review boundaries: the prior provisioning/rollback review covered d414e15a, not the entire consolidated head. The combined head includes the final source branches of #311, #342 and #344; review of the new combination remains separately tracked.

Latest local validation: installed daemon b9fad710, frontend ca78938c (#949), and local LingTai merge ea2a3a63 created LingTai Demo in the browser, joined its group automatically, completed two real Claude read_inbox/send_message rounds H/I with previous-round recall, and returned idle without manual permission commands. Existing registered test account; registration was not repeated.

LingTai dependency synchronized: owner pushed #1690 to ad11d7bc7b1473bb69e354aa7a5bf142e7fbec84. Fetched and verified its complete tree equals the tested local ea2a3a63 tree, 11e43c511d078943c9b75884947fefe027328ded; full git diff is empty. H/I acceptance therefore covers the same source content now in #1690. The installed wheel remains built from local ea2a3a63; no rebuild or restart was performed during manual testing. Plain 133f4352 lacked #1694 and failed messaging. The consolidated PRs remain unmerged.
