### PR TITLE
Discover installed LingTai runtimes and existing agents

### DIFF
--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -33,6 +33,7 @@ from ...tasks import spawn
 
 log = logging.getLogger("puffo_agent.control")
 
+BACKGROUND_OPS = frozenset({"create", "discover_lingtai"})
 RECONNECT_BACKOFF_SECONDS = 3.0
 ME_INTERVAL_SECONDS = 30.0
 # Codex's probe costs a real (tiny) turn — slow cadence; refresh_usage is on-demand.
@@ -814,7 +815,7 @@ class MachineControlClient:
             execution = self._execute_and_ack(
                 (
                     None
-                    if background_create and command_id and decrypted["op"] == "create"
+                    if background_create and command_id and decrypted["op"] in BACKGROUND_OPS
                     else ws
                 ),
                 command_id,
@@ -824,7 +825,7 @@ class MachineControlClient:
             )
             if command_id:
                 self._inflight_command_ids.add(str(command_id))
-            if background_create and command_id and decrypted["op"] in {"create", "discover_lingtai"}:
+            if background_create and command_id and decrypted["op"] in BACKGROUND_OPS:
                 # A first Docker image build can take minutes. Keep that wait
                 # out of the one machine-control receive loop so pause/resume,
                 # runtime decisions, and other operators remain responsive.

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -297,6 +297,10 @@ async def execute_command(
     """
     if op in {"runtime.cancel_turn", "runtime.resolve_permission"}:
         return await _execute_runtime_command(op, agent_slug, params, command_id)
+    if op == "discover_lingtai":
+        from .lingtai_discovery import discover_lingtai
+
+        return await discover_lingtai(params, operator=paired_root_pubkey)
     if op in ("pause", "resume", "edit", "archive", "refresh"):
         if not agent_slug or not agent_yml_path(agent_slug).exists():
             # Re-archive of an already-archived agent is idempotent OK.
@@ -820,7 +824,7 @@ class MachineControlClient:
             )
             if command_id:
                 self._inflight_command_ids.add(str(command_id))
-            if background_create and command_id and decrypted["op"] == "create":
+            if background_create and command_id and decrypted["op"] in {"create", "discover_lingtai"}:
                 # A first Docker image build can take minutes. Keep that wait
                 # out of the one machine-control receive loop so pause/resume,
                 # runtime decisions, and other operators remain responsive.

--- a/src/puffo_agent/portal/control/lingtai.py
+++ b/src/puffo_agent/portal/control/lingtai.py
@@ -71,17 +71,23 @@ async def revoke_lingtai(launch: LingtaiLaunch) -> None:
 async def _command(launch: LingtaiLaunch, args: list[str]) -> None:
     process = await asyncio.create_subprocess_exec(
         str(launch.executable), *args, cwd=launch.workspace,
-        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE,
+        limit=8193,
     )
     try:
-        code = await asyncio.wait_for(process.wait(), timeout=30)
+        async with asyncio.timeout(30):
+            assert process.stderr is not None
+            try:
+                error = await process.stderr.readexactly(8193)
+                raise ValueError("LingTai error output exceeded the size limit")
+            except asyncio.IncompleteReadError as exc:
+                error = exc.partial
+            code = await process.wait()
     except BaseException:
         if process.returncode is None:
             process.kill()
         await process.wait()
         raise
     if code:
-        raise ValueError(
-            "LingTai runtime provisioning failed; check the initialized folders "
-            "and install a LingTai version supporting --registry"
-        )
+        detail = error.decode("utf-8", errors="replace").strip()
+        raise ValueError(detail or f"LingTai command failed with exit code {code}")

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -22,16 +22,21 @@ def _absolute(value: object, field: str) -> Path:
     return Path(value).resolve(strict=True)
 
 
-def _known_paths(operator: str) -> tuple[list[Path], list[Path]]:
+def _known_paths(operator: str) -> tuple[list[Path], list[Path], list[str]]:
     executables: list[Path] = []
     roots = [Path.home() / ".lingtai"]
+    warnings: list[str] = []
     registry = _registry_entries()
     # Reuse only this operator's existing associations; do not expose another
     # paired operator's agent configuration through the automatic inventory.
     for agent_id in discover_agents():
         if not is_owner(agent_id, operator):
             continue
-        cfg = AgentConfig.load(agent_id)
+        try:
+            cfg = AgentConfig.load(agent_id, allow_invalid_runtime=True)
+        except (OSError, ValueError, RuntimeError):
+            warnings.append("invalid_candidate")
+            continue
         argv = cfg.runtime.harness_command
         if len(argv) < 4 or argv[1:4] != ["acp", "--profile", "puffo-v1"]:
             continue
@@ -45,7 +50,7 @@ def _known_paths(operator: str) -> tuple[list[Path], list[Path]]:
                 directory = Path(entry["agent_dir"])
                 if directory.is_absolute():
                     roots.append(directory)
-    return executables, roots
+    return executables, roots, warnings
 
 
 
@@ -82,7 +87,7 @@ def _executable_paths(known: list[Path]) -> list[str]:
                 result.append(path)
         except OSError:
             continue
-    return result[:8]
+    return result
 
 
 async def _query(executable: str, root: Path, registry: Path) -> list[dict]:
@@ -143,7 +148,14 @@ def _normalize(row: object, root: Path) -> dict:
 async def discover_lingtai(params: dict, *, operator: str | None) -> dict:
     if not operator:
         return {"ok": False, "error": "LingTai discovery requires a paired operator"}
-    known, default_roots = await asyncio.to_thread(_known_paths, operator)
+    try:
+        return await _discover(params, operator)
+    except (OSError, ValueError) as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+async def _discover(params: dict, operator: str) -> dict:
+    known, default_roots, warnings = await asyncio.to_thread(_known_paths, operator)
     executables = await asyncio.to_thread(_executable_paths, known)
     if params.get("executable"):
         explicit = _absolute(params["executable"], "executable")
@@ -157,10 +169,13 @@ async def discover_lingtai(params: dict, *, operator: str | None) -> dict:
     if params.get("root"):
         selected = _absolute(params["root"], "root")
         roots = [selected, selected / ".lingtai"]
-    roots = list(dict.fromkeys(path.resolve() for path in roots if path.is_dir()))[:_MAX_ROOTS]
+    roots = list(dict.fromkeys(path.resolve() for path in roots if path.is_dir()))
+    if len(roots) > _MAX_ROOTS or len(executables) > 8:
+        warnings.append("results_truncated")
+    roots, executables = roots[:_MAX_ROOTS], executables[:8]
     result = {
         "ok": True, "executables": executables, "executable": executable,
-        "roots": [str(root) for root in roots], "agents": [], "warnings": [],
+        "roots": [str(root) for root in roots], "agents": [], "warnings": warnings,
     }
     if not executable:
         return _bounded_result(result)
@@ -191,7 +206,7 @@ def _bounded_result(result: dict) -> dict:
     # budget so a large inventory is partial rather than replaced by a marker.
     result["warnings"] = list(dict.fromkeys(result["warnings"]))
     result["partial"] = bool(result["warnings"])
-    result["truncated"] = False
+    result["truncated"] = "results_truncated" in result["warnings"]
     for field in ("agents", "roots", "executables"):
         while len(json.dumps(result).encode()) > 12 * 1024 and result[field]:
             result[field].pop()

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -1,0 +1,198 @@
+"""Read-only LingTai discovery for an authenticated machine operator."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from ..state import AgentConfig, discover_agents, home_dir
+from .ownership import is_owner
+
+_MAX_OUTPUT = 1024 * 1024
+_MAX_ROOTS = 16
+
+
+def _absolute(value: object, field: str) -> Path:
+    if not isinstance(value, str) or not value.strip() or not Path(value).is_absolute():
+        raise ValueError(f"LingTai {field} must be an absolute path on this machine")
+    return Path(value).resolve(strict=True)
+
+
+def _known_paths(operator: str) -> tuple[list[Path], list[Path]]:
+    executables: list[Path] = []
+    roots = [Path.home() / ".lingtai"]
+    registry = _registry_entries()
+    # Reuse only this operator's existing associations; do not expose another
+    # paired operator's agent configuration through the automatic inventory.
+    for agent_id in discover_agents():
+        if not is_owner(agent_id, operator):
+            continue
+        cfg = AgentConfig.load(agent_id)
+        argv = cfg.runtime.harness_command
+        if len(argv) < 4 or argv[1:4] != ["acp", "--profile", "puffo-v1"]:
+            continue
+        executables.append(Path(argv[0]))
+        workspace = cfg.resolve_workspace_dir()
+        roots.extend([workspace, workspace / ".lingtai"])
+        if "--runtime-id" in argv:
+            index = argv.index("--runtime-id") + 1
+            entry = registry.get(argv[index]) if index < len(argv) else None
+            if isinstance(entry, dict) and isinstance(entry.get("agent_dir"), str):
+                directory = Path(entry["agent_dir"])
+                if directory.is_absolute():
+                    roots.append(directory)
+    return executables, roots
+
+
+
+def _registry_entries() -> dict:
+    # Location hints only; LingTai's discover remains the authority on state.
+    path = home_dir().resolve() / "lingtai" / "runtime-registry.json"
+    try:
+        with path.open("rb") as stream:
+            data = stream.read(_MAX_OUTPUT + 1)
+        if len(data) > _MAX_OUTPUT:
+            return {}
+        payload = json.loads(data)
+        entries = payload.get("runtimes") if isinstance(payload, dict) else None
+        return entries if isinstance(entries, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _executable_paths(known: list[Path]) -> list[str]:
+    found = shutil.which("lingtai-agent")
+    candidates = ([Path(found)] if found else []) + known + [
+        Path(sys.executable).parent / "lingtai-agent",
+        Path.home() / ".local" / "bin" / "lingtai-agent",
+        Path("/opt/homebrew/bin/lingtai-agent"),
+        Path("/usr/local/bin/lingtai-agent"),
+    ]
+    result = []
+    for candidate in candidates:
+        try:
+            # Keep the executable symlink spelling: virtualenv launchers may
+            # derive their environment from it.
+            path = str(candidate.absolute())
+            if candidate.is_file() and os.access(candidate, os.X_OK) and path not in result:
+                result.append(path)
+        except OSError:
+            continue
+    return result[:8]
+
+
+async def _query(executable: str, root: Path, registry: Path) -> list[dict]:
+    process = await asyncio.create_subprocess_exec(
+        executable, "puffo-v0", "discover", "--root", str(root),
+        "--registry", str(registry), "--json",
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        limit=_MAX_OUTPUT + 1,
+    )
+    try:
+        async with asyncio.timeout(10):
+            assert process.stdout is not None
+            output = await process.stdout.readexactly(_MAX_OUTPUT + 1)
+            raise ValueError("LingTai discovery result is too large")
+    except asyncio.IncompleteReadError as exc:
+        output = exc.partial
+        # EOF can precede process exit; bound this wait separately too.
+        await asyncio.wait_for(process.wait(), timeout=2)
+    finally:
+        if process.returncode is None:
+            process.kill()
+        await process.wait()
+    if process.returncode:
+        raise ValueError("LingTai discovery failed; check the installation and search folder")
+    payload = json.loads(output)
+    rows = payload.get("runtimes") if isinstance(payload, dict) else None
+    if not isinstance(rows, list) or len(rows) > 500:
+        raise ValueError("LingTai discovery returned an invalid result")
+    return rows
+
+
+def _normalize(row: object, root: Path) -> dict:
+    if not isinstance(row, dict):
+        raise ValueError("LingTai discovery returned an invalid agent")
+    directory = _absolute(row.get("agent_dir"), "agent_dir")
+    if not directory.is_relative_to(root) or not (directory / "init.json").is_file():
+        raise ValueError("LingTai discovery returned an agent outside the search folder")
+    name, status = row.get("display_name"), row.get("status")
+    if not isinstance(name, str) or not isinstance(status, str):
+        raise ValueError("LingTai discovery returned an invalid agent state")
+    workspace = row.get("workspace")
+    if workspace is None:
+        workspace = str(directory)
+    if not isinstance(workspace, str) or not Path(workspace).is_absolute():
+        raise ValueError("LingTai discovery returned an invalid working folder")
+    workspace_path = Path(workspace)
+    # Keep drifted registrations visible even when their workspace is missing.
+    if status == "available" and not workspace_path.is_dir():
+        raise ValueError("LingTai discovery returned a missing working folder")
+    return {
+        "display_name": name[:200], "agent_dir": str(directory),
+        "workspace": str(workspace_path), "status": status,
+        "runtime_id": row.get("runtime_id"),
+        "formerly_bound_runtime_id": row.get("formerly_bound_runtime_id"),
+    }
+
+
+async def discover_lingtai(params: dict, *, operator: str | None) -> dict:
+    if not operator:
+        return {"ok": False, "error": "LingTai discovery requires a paired operator"}
+    known, default_roots = await asyncio.to_thread(_known_paths, operator)
+    executables = await asyncio.to_thread(_executable_paths, known)
+    if params.get("executable"):
+        explicit = _absolute(params["executable"], "executable")
+        if not explicit.is_file() or not os.access(explicit, os.X_OK):
+            raise ValueError("LingTai executable must be an executable file")
+        executable = str(explicit)
+        executables = list(dict.fromkeys([executable, *executables]))
+    else:
+        executable = executables[0] if executables else None
+    roots = default_roots
+    if params.get("root"):
+        selected = _absolute(params["root"], "root")
+        roots = [selected, selected / ".lingtai"]
+    roots = list(dict.fromkeys(path.resolve() for path in roots if path.is_dir()))[:_MAX_ROOTS]
+    result = {
+        "ok": True, "executables": executables, "executable": executable,
+        "roots": [str(root) for root in roots], "agents": [], "warnings": [],
+    }
+    if not executable:
+        return _bounded_result(result)
+    registry = home_dir().resolve() / "lingtai" / "runtime-registry.json"
+    agents = {}
+    # A single request has a bounded total budget even with many known roots.
+    try:
+        async with asyncio.timeout(25):
+            for root in roots:
+                try:
+                    rows = await _query(executable, root, registry)
+                    for row in rows:
+                        try:
+                            agent = _normalize(row, root)
+                            agents[agent["agent_dir"]] = agent
+                        except (OSError, ValueError):
+                            result["warnings"].append("invalid_candidate")
+                except (OSError, ValueError, TimeoutError):
+                    result["warnings"].append("discovery_failed")
+    except TimeoutError:
+        result["warnings"].append("discovery_timeout")
+    result["agents"] = list(agents.values())
+    return _bounded_result(result)
+
+
+def _bounded_result(result: dict) -> dict:
+    # The server persists at most 16 KiB per command result. Stay below that
+    # budget so a large inventory is partial rather than replaced by a marker.
+    result["warnings"] = list(dict.fromkeys(result["warnings"]))
+    for field in ("agents", "roots", "executables"):
+        while len(json.dumps(result).encode()) > 12 * 1024 and result[field]:
+            result[field].pop()
+            if "results_truncated" not in result["warnings"]:
+                result["warnings"].append("results_truncated")
+    return result

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -190,9 +190,13 @@ def _bounded_result(result: dict) -> dict:
     # The server persists at most 16 KiB per command result. Stay below that
     # budget so a large inventory is partial rather than replaced by a marker.
     result["warnings"] = list(dict.fromkeys(result["warnings"]))
+    result["partial"] = bool(result["warnings"])
+    result["truncated"] = False
     for field in ("agents", "roots", "executables"):
         while len(json.dumps(result).encode()) > 12 * 1024 and result[field]:
             result[field].pop()
+            result["partial"] = True
+            result["truncated"] = True
             if "results_truncated" not in result["warnings"]:
                 result["warnings"].append("results_truncated")
     return result

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -491,7 +491,7 @@ async def test_lingtai_provision_failure_leaves_identity_unmaterialized(tmp_path
     source.mkdir()
     (source / "init.json").write_text("{}")
     executable = tmp_path / "lingtai-agent"
-    executable.write_text(f"#!{sys.executable}\nraise SystemExit(1)\n")
+    executable.write_text(f"#!{sys.executable}\nimport sys\nprint('error: puffo-v0 runtime registry parent directory is owned by another user', file=sys.stderr)\nraise SystemExit(1)\n")
     executable.chmod(0o700)
     payload, operator = _payload()
     payload["runtime"] = {
@@ -503,7 +503,7 @@ async def test_lingtai_provision_failure_leaves_identity_unmaterialized(tmp_path
     async def materialize(context):
         materialized.append(context)
 
-    with pytest.raises(ProvisionError, match="LingTai runtime provisioning failed"):
+    with pytest.raises(ProvisionError, match="registry parent directory is owned by another user"):
         await provision_agent_from_bundle(payload, operator, materialize=materialize)
     assert materialized == []
     assert not (tmp_path / "daemon/agents/helper-1234/agent.yml").exists()

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -95,3 +95,4 @@ def test_inventory_fits_server_result_budget():
     assert len(json.dumps(result).encode()) < 16 * 1024
     assert result["agents"]
     assert "results_truncated" in result["warnings"]
+    assert result["partial"] and result["truncated"]

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -28,7 +28,7 @@ async def test_discovery_cli_contract_and_hidden_root(tmp_path, monkeypatch):
         "print(json.dumps({'runtimes': rows}))\n"
     )
     executable.chmod(0o700)
-    monkeypatch.setattr(discovery, "_known_paths", lambda operator: ([], []))
+    monkeypatch.setattr(discovery, "_known_paths", lambda operator: ([], [], []))
     monkeypatch.setattr(discovery, "_executable_paths", lambda known: [])
     result = await discovery.discover_lingtai(
         {"executable": str(executable), "root": str(root)}, operator="owner",
@@ -48,7 +48,8 @@ def test_default_inventory_uses_only_owned_associations(tmp_path, monkeypatch):
         "runtime-mine": {"agent_dir": str(owned)},
         "runtime-other": {"agent_dir": str(other)},
     })
-    def config(agent_id):
+    def config(agent_id, *, allow_invalid_runtime):
+        assert allow_invalid_runtime
         assert agent_id == "mine"
         return SimpleNamespace(
             runtime=SimpleNamespace(harness_command=[
@@ -56,7 +57,7 @@ def test_default_inventory_uses_only_owned_associations(tmp_path, monkeypatch):
             ]), resolve_workspace_dir=lambda: owned,
         )
     monkeypatch.setattr(discovery.AgentConfig, "load", config)
-    executables, roots = discovery._known_paths("operator")
+    executables, roots, warnings = discovery._known_paths("operator")
     assert str(executables[0]) == "/mine/lingtai-agent"
     assert owned in roots and owned / ".lingtai" in roots
     assert other not in roots
@@ -96,3 +97,45 @@ def test_inventory_fits_server_result_budget():
     assert result["agents"]
     assert "results_truncated" in result["warnings"]
     assert result["partial"] and result["truncated"]
+
+
+def test_invalid_owned_config_does_not_abort_inventory(monkeypatch):
+    monkeypatch.setattr(discovery, "discover_agents", lambda: ["broken", "unfinished"])
+    monkeypatch.setattr(discovery, "is_owner", lambda *args: True)
+    monkeypatch.setattr(discovery, "_registry_entries", lambda: {})
+    def config(agent_id, *, allow_invalid_runtime):
+        assert allow_invalid_runtime
+        if agent_id == "broken":
+            raise RuntimeError("malformed harness_command")
+        return SimpleNamespace(runtime=SimpleNamespace(harness_command=[]))
+    monkeypatch.setattr(discovery.AgentConfig, "load", config)
+    executables, roots, warnings = discovery._known_paths("owner")
+    assert executables == []
+    assert warnings == ["invalid_candidate"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("root_count, executable_count", [(17, 1), (1, 9)])
+async def test_search_scope_limits_are_explicit(tmp_path, monkeypatch, root_count, executable_count):
+    roots = [tmp_path / str(i) for i in range(root_count)]
+    for root in roots:
+        root.mkdir()
+    monkeypatch.setattr(discovery, "_known_paths", lambda operator: ([], roots, []))
+    monkeypatch.setattr(discovery, "_executable_paths", lambda known: [f"/bin/cli{i}" for i in range(executable_count)])
+    async def query(*args):
+        return []
+    monkeypatch.setattr(discovery, "_query", query)
+    result = await discovery.discover_lingtai({}, operator="owner")
+    assert result["ok"] and result["partial"] and result["truncated"]
+    assert result["warnings"] == ["results_truncated"]
+    assert len(result["roots"]) <= 16 and len(result["executables"]) <= 8
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("root", ["relative", "/missing-lingtai-discovery-test-folder"])
+async def test_invalid_explicit_root_returns_actionable_error(monkeypatch, root):
+    monkeypatch.setattr(discovery, "_known_paths", lambda operator: ([], [], []))
+    monkeypatch.setattr(discovery, "_executable_paths", lambda known: [])
+    result = await discovery.discover_lingtai({"root": root}, operator="owner")
+    assert result["ok"] is False
+    assert result["error"]

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -1,0 +1,97 @@
+"""Discovery must preserve CLI state, existing folders, and operator isolation."""
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.portal.control import lingtai_discovery as discovery
+
+
+@pytest.mark.asyncio
+async def test_discovery_cli_contract_and_hidden_root(tmp_path, monkeypatch):
+    """A hidden project root and null workspace must produce an importable row."""
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "daemon"))
+    root = tmp_path / "project"
+    agent = root / ".lingtai" / "writer"
+    agent.mkdir(parents=True)
+    (agent / "init.json").write_text("{}")
+    executable = tmp_path / "lingtai-agent"
+    executable.write_text(
+        f"#!{sys.executable}\nimport json, sys\n"
+        "assert sys.argv[1:3] == ['puffo-v0', 'discover']\n"
+        "assert '--registry' in sys.argv and '--json' in sys.argv\n"
+        f"rows = [dict(agent_dir={str(agent)!r}, display_name='writer', workspace=None, "
+        "status='available', runtime_id=None)] "
+        f"if sys.argv[sys.argv.index('--root') + 1] == {str(root / '.lingtai')!r} else []\n"
+        "print(json.dumps({'runtimes': rows}))\n"
+    )
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery, "_known_paths", lambda operator: ([], []))
+    monkeypatch.setattr(discovery, "_executable_paths", lambda known: [])
+    result = await discovery.discover_lingtai(
+        {"executable": str(executable), "root": str(root)}, operator="owner",
+    )
+    assert result["warnings"] == []
+    assert result["agents"][0]["workspace"] == str(agent)
+    assert result["agents"][0]["status"] == "available"
+    assert not (tmp_path / "daemon").exists(), "discovery must not provision or create a registry"
+
+
+def test_default_inventory_uses_only_owned_associations(tmp_path, monkeypatch):
+    """Another operator's executable and location must not leak into defaults."""
+    owned, other = tmp_path / "mine", tmp_path / "other"
+    monkeypatch.setattr(discovery, "discover_agents", lambda: ["mine", "other"])
+    monkeypatch.setattr(discovery, "is_owner", lambda agent_id, operator: agent_id == "mine")
+    monkeypatch.setattr(discovery, "_registry_entries", lambda: {
+        "runtime-mine": {"agent_dir": str(owned)},
+        "runtime-other": {"agent_dir": str(other)},
+    })
+    def config(agent_id):
+        assert agent_id == "mine"
+        return SimpleNamespace(
+            runtime=SimpleNamespace(harness_command=[
+                "/mine/lingtai-agent", "acp", "--profile", "puffo-v1", "--runtime-id", "runtime-mine",
+            ]), resolve_workspace_dir=lambda: owned,
+        )
+    monkeypatch.setattr(discovery.AgentConfig, "load", config)
+    executables, roots = discovery._known_paths("operator")
+    assert str(executables[0]) == "/mine/lingtai-agent"
+    assert owned in roots and owned / ".lingtai" in roots
+    assert other not in roots
+
+
+@pytest.mark.asyncio
+async def test_missing_pairing_does_not_scan(monkeypatch):
+    """Machine inventory must not be callable without an authenticated operator."""
+    def forbidden(*args):
+        pytest.fail("filesystem scan ran without a pairing")
+    monkeypatch.setattr(discovery, "_known_paths", forbidden)
+    assert not (await discovery.discover_lingtai({}, operator=None))["ok"]
+
+
+def test_candidate_keeps_binding_state_and_rejects_outside_root(tmp_path):
+    """Bound candidates cannot silently become available or escape the selected root."""
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (agent / "init.json").write_text("{}")
+    row = dict(agent_dir=str(agent), display_name="agent", workspace=str(agent),
+               status="bound", runtime_id="existing")
+    assert discovery._normalize(row, tmp_path)["runtime_id"] == "existing"
+    assert discovery._normalize(row, tmp_path)["status"] == "bound"
+    row.update(status="stale_binding", workspace=str(tmp_path / "missing"))
+    assert discovery._normalize(row, tmp_path)["status"] == "stale_binding"
+    with pytest.raises(ValueError, match="outside"):
+        discovery._normalize(row, tmp_path / "different")
+
+
+def test_inventory_fits_server_result_budget():
+    """Many candidates must not cause the server to replace the whole result."""
+    result = discovery._bounded_result({
+        "ok": True, "executable": "/bin/lingtai-agent", "executables": [],
+        "roots": [], "warnings": [], "agents": [{"agent_dir": "x" * 2000} for _ in range(50)],
+    })
+    assert len(json.dumps(result).encode()) < 16 * 1024
+    assert result["agents"]
+    assert "results_truncated" in result["warnings"]


### PR DESCRIPTION
Importing a LingTai agent currently requires three absolute paths. Add the paired-machine command `discover_lingtai` so the web app can locate installed executables and list existing agents through LingTai's read-only `puffo-v0 discover --json` interface.

Default locations come from PATH/common executable locations, the operator's existing associations, their workspaces and explicit `.lingtai` roots. Optional `root` and `executable` inputs support another project/install. Null workspace defaults to the existing agent directory; registered and drifted states remain intact. Discovery is bounded in time/output and returns explicit partial/truncated flags and warnings below the server's 16 KiB persisted-result limit. Provision failures preserve bounded CLI error text. No LingTai upstream changes or running-service changes.

Stacked on #346. Companion web change: https://github.com/puffo-ai/puffo-core-han-group/pull/950. Discovery is an inventory, not admission approval; provision remains authoritative. Arbitrary project locations cannot be enumerated without an index and may require an explicit root.

Validation: latest daemon suite excluding the two host-configuration-mutating modules (`test_agent_install.py`, `test_host_mcp_handler.py`) finished with 4,052 passed, 2 skipped and 1 failure: installed OpenCode `debug skill` timed out after 30 seconds in `test_desired_skill_is_discoverable_by_real_opencode_cli`. A single isolated rerun of that OpenCode test passed. Ten discovery tests and the full provision test file pass (49 combined); Python structural checks pass. The earlier real installed LingTai read-only smoke verified hidden-root discovery, null-workspace defaulting and no registry creation. The active manual-test stack was not restarted.

Review follow-up: incomplete runtime configurations are loaded permissively and malformed per-agent configs are skipped with `invalid_candidate`. Input root/executable limits now set partial/truncated as well as output limits. Explicit path errors return actionable error text. Both background dispatch decisions share `BACKGROUND_OPS`; discovery warning values remain closed.
