### PR TITLE
Import LingTai Agents and synchronize authoritative names

### DIFF
--- a/docs/engineering/lingtai-name-sync-acceptance.md
+++ b/docs/engineering/lingtai-name-sync-acceptance.md
@@ -1,0 +1,36 @@
+# LingTai 名称同步与编辑边界验收
+
+截至 2026-09-12；维护者 @peter-stei-5525-5d5ebaa5，服务端协作者 @boris-cher-7418-1578233d。
+
+## 用户确认的要求
+
+- 灵台修改 NAME 后，Puffo 自动反映；描述可以不显示。
+- Puffo 不提供会被下一次来源同步覆盖的改名入口。这是必需关闭项。
+- 保持来源权威和单向性：无名仍为 null，“未命名”只用于显示。
+
+## 实施与证据清单
+
+| 项目 | 当前证据 | 状态 |
+| --- | --- | --- |
+| 来源读取 | 共用 read_source_profile；.agent.json 优先，仅不存在时回退 init.json；运行期回退空名、缺失name字段、损坏均不清空，仅当前文件显式null可清 | 已有解析测试及新增同步测试通过 |
+| 自动同步 | daemon 独立任务每轮完成后等待30秒，只向自己身份 PATCH display_name；成功才缓存 | 745dc0f7；全量pytest通过，2项环境跳过 |
+| 失败与重试 | 10秒/Agent超时，失败记daemon日志，下轮重试；不写源文件 | 同步测试验证网络失败重试、损坏保留、成功去重 |
+| 正常改名实际传播 | 本地运行daemon；修改fixture名后约21.5秒网页自动显示新名 | name-sync-rename.png / name-sync-live.json；当前仅owner账号 |
+| 有名→null→有名 | daemon和Web单测通过；旧服务端不支持显式null | 服务端改动及真实双账号验收待完成 |
+| 启动/预热旧快照 | LingTai不走旧sync_full_profile，防止名字被导入快照覆盖 | 新同步测试通过 |
+| Web资料页编辑入口 | managedProfile关闭profileWritable及runtime编辑；提交适配器再次拒绝来源字段修改 | 既有实现，真实页面复验待完成 |
+| Web名称清空 | server明确null时不能回退旧portal名；资料页使用实时profile投影 | 新回归先红后绿，资料页联调待完成 |
+| Control edit_agent | guarded_edit_params在任何写入前拒绝来源字段变更 | 既有实现和测试 |
+| CLI rename/profile | 审计发现原先绕过guard；现已补拒绝 | 同步测试含CLI拒绝与配置未改断言，已通过 |
+| Qt桌面编辑 | 审计发现原先可改名并直接写配置；现已设来源字段只读并在保存入口拒绝 | Qt真实控件测试验证只读、保存按钮禁用、强行调用handler仍拒绝，21项通过 |
+| 服务端签名PATCH | 自动来源发布需要Agent签名写接口；不能把同一签名入口整体禁掉 | 显式null协议由Boris负责；不将本机文件手改/直接持钥API视为普通产品入口 |
+| 说明文案 | 删除“永远停留导入快照”的说明，改为连接时同步名称 | 工作区已改；随新增编辑边界更新release |
+
+描述、提示词、模型、capabilities和工作区内容均不进入名称PATCH。对本地fixture的名称写入是测试操作；同步器自身只读源文件。尚未合并或发布。
+
+## 原创建入口复验触发条件
+
+- AddMemberToChannelModal若新增scope=space生产挂载，需实测该创建入口。
+- Mobile Cloud若移除max-md:hidden，需补真实手机创建入口测试。
+
+这两处在先前17/17可达入口验收中已标为不可达，不计作真实点击通过。

--- a/docs/engineering/lingtai-name-sync-acceptance.md
+++ b/docs/engineering/lingtai-name-sync-acceptance.md
@@ -16,10 +16,10 @@
 | 自动同步 | daemon 独立任务每轮完成后等待30秒，只向自己身份 PATCH display_name；成功才缓存 | 745dc0f7；全量pytest通过，2项环境跳过 |
 | 失败与重试 | 10秒/Agent超时，失败记daemon日志，下轮重试；不写源文件 | 同步测试验证网络失败重试、损坏保留、成功去重 |
 | 正常改名实际传播 | 本地运行daemon；修改fixture名后约21.5秒网页自动显示新名 | name-sync-rename.png / name-sync-live.json；随后owner与non-owner聊天页14.2秒同步；两边已打开完整资料页5.5秒同步 |
-| 有名→null→有名 | daemon和Web单测通过；旧服务端不支持显式null | 服务端改动及真实双账号验收待完成 |
+| 有名→null→有名 | server三态PATCH支持显式null；daemon和Web回归通过 | 通过：两账号真实清空12.9秒、重新命名30.0秒；两边原始缓存均明确null，源文件未被同步器改写 |
 | 启动/预热旧快照 | LingTai不走旧sync_full_profile，防止名字被导入快照覆盖 | 新同步测试通过 |
 | Web资料页编辑入口 | managedProfile关闭profileWritable及runtime编辑；提交适配器再次拒绝来源字段修改 | 真实owner资料页无改名/编辑资料按钮，提示在灵台修改；name-sync-profile-owner.png/.txt |
-| Web名称清空 | server明确null时不能回退旧portal名；资料页使用实时profile投影 | 新回归先红后绿；资料页双账号正常改名通过，null清空待服务端联调 |
+| Web名称清空 | server明确null时不能回退旧portal名；资料页使用实时profile投影 | 新回归先红后绿；资料页双账号正常改名通过，null清空/恢复已通过真实双账号验证 |
 | Control edit_agent | guarded_edit_params在任何写入前拒绝来源字段变更 | 既有实现和测试 |
 | CLI rename/profile | 审计发现原先绕过guard；现已补拒绝 | 同步测试含CLI拒绝与配置未改断言，已通过 |
 | Qt桌面编辑 | 审计发现原先可改名并直接写配置；现已设来源字段只读并在保存入口拒绝 | Qt真实控件测试验证只读、保存按钮禁用、强行调用handler仍拒绝，21项通过 |
@@ -40,3 +40,25 @@
 - CLI/Qt将role、soul及运行时编辑一并保持只读是有意沿用灵台管理边界；不能通过换运行时或本地persona编辑绕开名称管理。
 - 来源当前文件丢失时，即使init.json有旧的非空名字也不在运行期回退发布，避免旧名覆盖最新自命名值；导入发现仍保留原回退兼容规则。
 - nickname是否作为另一个显示值尚未决定，本轮没有发布nickname。描述没有已确认的公开权威字段，因此不读取提示词来生成描述。
+
+## LingTai 权威字段与已知上游行为
+
+以下来源为 @lingtai-de-3574-d881bf55 对 lingtai-kernel origin/main 的源码核查（2026-09-12，消息199035）；本轮没有额外进行灵台自命名重启实验。
+
+- agent_name 为本轮唯一名称来源。identity.py:29 的 _set_name 只允许从无名设置一次，没有清空操作；change_name.py:144 的改名技能会保持 init.json 与 .agent.json 一致，可跨重启保存。
+- nickname 可变可清（identity.py:42），但它的显示优先级尚未决定，本轮没有同步它。
+- .agent.json 没有自由文本 description（identity.py:83）。profile/soul是运行时指令及工作区内容，不应被生成或复制成公开描述。
+- 运行期 system(name_set) 只写 .agent.json，不改 init.json。CLI与ACP构造时从init.json取名（cli.py:138、166、182）；恢复当前manifest主要用于molt_count等状态（228–234），构造后按内存name重写manifest（base_agent:703）。因此仅运行期自命名的Agent可能重启后再次变成显式null。
+- 上述“当前manifest存在且明确null”是权威值变化，Puffo会同步清空；这与文件丢失不能证明清空不同。是否让运行期自命名同时持久化init.json归上游产品决定，本轮不特判或伪造保留名。
+
+## 最终集成结果
+
+- Web 9b217098；daemon e48b168b；server 18d3538（Boris e398d2a8的同内容cherry-pick）。
+- Server补丁独立验证：profiles39、v2 identities27、WS107；完整lib1428通过/3忽略。组合Docker镜像构建并在隔离本地栈运行成功。
+- 两个真实账号（owner / non-owner）打开聊天和资料页，未刷新即收到更新。清空时两边原始profile缓存均为null，分别显示“未命名”/“Unnamed”；恢复时两边收到同一个真实名称。
+- 本轮source mutation由验收脚本执行，每阶段比较写入后的完整.agent.json与同步后字节，均未被同步器改写；随后恢复原来的测试名称。
+- 证据位于workspace artifacts/lingtai-import/restoration/name-sync-*.json/.png。此文档只记录已执行证据，先前e24a97a0验收包的导入与工具调用证据继续适用，名称同步由本轮补充。
+
+上游待定项由 LingTai 协作者登记于 [lingtai-kernel#1709](https://github.com/Lingtai-AI/lingtai-kernel/issues/1709)，本轮没有改变灵台自命名的持久化策略。
+
+CI检查：daemon e48b168b 的pre-commit与Python3.11/3.12均通过；Web与server CI仍在等待完成，不能称为三仓全部CI通过。

--- a/docs/engineering/lingtai-name-sync-acceptance.md
+++ b/docs/engineering/lingtai-name-sync-acceptance.md
@@ -12,14 +12,14 @@
 
 | 项目 | 当前证据 | 状态 |
 | --- | --- | --- |
-| 来源读取 | 共用 read_source_profile；.agent.json 优先，仅不存在时回退 init.json；运行期回退空名、缺失name字段、损坏均不清空，仅当前文件显式null可清 | 已有解析测试及新增同步测试通过 |
+| 来源读取 | 共用 read_source_profile；.agent.json 优先，仅不存在时回退 init.json；运行期只跟随当前.agent.json，不发布任何bootstrap回退值；缺失文件/字段、损坏均保留，仅显式null可清 | 已有解析测试及新增同步测试通过 |
 | 自动同步 | daemon 独立任务每轮完成后等待30秒，只向自己身份 PATCH display_name；成功才缓存 | 745dc0f7；全量pytest通过，2项环境跳过 |
 | 失败与重试 | 10秒/Agent超时，失败记daemon日志，下轮重试；不写源文件 | 同步测试验证网络失败重试、损坏保留、成功去重 |
-| 正常改名实际传播 | 本地运行daemon；修改fixture名后约21.5秒网页自动显示新名 | name-sync-rename.png / name-sync-live.json；当前仅owner账号 |
+| 正常改名实际传播 | 本地运行daemon；修改fixture名后约21.5秒网页自动显示新名 | name-sync-rename.png / name-sync-live.json；随后owner与non-owner聊天页14.2秒同步；两边已打开完整资料页5.5秒同步 |
 | 有名→null→有名 | daemon和Web单测通过；旧服务端不支持显式null | 服务端改动及真实双账号验收待完成 |
 | 启动/预热旧快照 | LingTai不走旧sync_full_profile，防止名字被导入快照覆盖 | 新同步测试通过 |
-| Web资料页编辑入口 | managedProfile关闭profileWritable及runtime编辑；提交适配器再次拒绝来源字段修改 | 既有实现，真实页面复验待完成 |
-| Web名称清空 | server明确null时不能回退旧portal名；资料页使用实时profile投影 | 新回归先红后绿，资料页联调待完成 |
+| Web资料页编辑入口 | managedProfile关闭profileWritable及runtime编辑；提交适配器再次拒绝来源字段修改 | 真实owner资料页无改名/编辑资料按钮，提示在灵台修改；name-sync-profile-owner.png/.txt |
+| Web名称清空 | server明确null时不能回退旧portal名；资料页使用实时profile投影 | 新回归先红后绿；资料页双账号正常改名通过，null清空待服务端联调 |
 | Control edit_agent | guarded_edit_params在任何写入前拒绝来源字段变更 | 既有实现和测试 |
 | CLI rename/profile | 审计发现原先绕过guard；现已补拒绝 | 同步测试含CLI拒绝与配置未改断言，已通过 |
 | Qt桌面编辑 | 审计发现原先可改名并直接写配置；现已设来源字段只读并在保存入口拒绝 | Qt真实控件测试验证只读、保存按钮禁用、强行调用handler仍拒绝，21项通过 |
@@ -34,3 +34,9 @@
 - Mobile Cloud若移除max-md:hidden，需补真实手机创建入口测试。
 
 这两处在先前17/17可达入口验收中已标为不可达，不计作真实点击通过。
+
+## 公开范围与运行期来源边界
+
+- CLI/Qt将role、soul及运行时编辑一并保持只读是有意沿用灵台管理边界；不能通过换运行时或本地persona编辑绕开名称管理。
+- 来源当前文件丢失时，即使init.json有旧的非空名字也不在运行期回退发布，避免旧名覆盖最新自命名值；导入发现仍保留原回退兼容规则。
+- nickname是否作为另一个显示值尚未决定，本轮没有发布nickname。描述没有已确认的公开权威字段，因此不读取提示词来生成描述。

--- a/docs/engineering/lingtai-name-sync-acceptance.md
+++ b/docs/engineering/lingtai-name-sync-acceptance.md
@@ -54,11 +54,13 @@
 ## 最终集成结果
 
 - Web 9b217098；daemon e48b168b；server 18d3538（Boris e398d2a8的同内容cherry-pick）。
-- Server补丁独立验证：profiles39、v2 identities27、WS107；完整lib1428通过/3忽略。组合Docker镜像构建并在隔离本地栈运行成功。
+- Server补丁独立验证：profiles39、v2 identities27、WS107；组合18d3538完整lib1429通过/0失败/3忽略（Boris seq199053复核）。组合Docker镜像构建并在隔离本地栈运行成功。
 - 两个真实账号（owner / non-owner）打开聊天和资料页，未刷新即收到更新。清空时两边原始profile缓存均为null，分别显示“未命名”/“Unnamed”；恢复时两边收到同一个真实名称。
 - 本轮source mutation由验收脚本执行，每阶段比较写入后的完整.agent.json与同步后字节，均未被同步器改写；随后恢复原来的测试名称。
 - 证据位于workspace artifacts/lingtai-import/restoration/name-sync-*.json/.png。此文档只记录已执行证据，先前e24a97a0验收包的导入与工具调用证据继续适用，名称同步由本轮补充。
 
 上游待定项由 LingTai 协作者登记于 [lingtai-kernel#1709](https://github.com/Lingtai-AI/lingtai-kernel/issues/1709)，本轮没有改变灵台自命名的持久化策略。
 
-CI检查：daemon e48b168b 的pre-commit与Python3.11/3.12均通过；Web与server CI仍在等待完成，不能称为三仓全部CI通过。
+CI检查：daemon e48b168b 的pre-commit与Python3.11/3.12均通过；Web CI出现3项失败，server剩一项检查在运行；不能称为三仓全部CI通过。
+
+部署顺序约束（Boris seq199053源码复核）：先部署Server #370，再部署daemon #349。旧Server会忽略display_name:null但仍返回成功，新daemon因此缓存已发布，无法保证清空生效。当前没有自动兼容协商替代此顺序。Web #955 的 CI 发现3项失败：Boris确认2项billing在基线上同样失败；新增重试测试存在等待失败态不足的问题，已补等待失败态，CreateAgentModal整文件21项通过；推送后继续检查CI。

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -804,6 +804,10 @@ def cmd_agent_rename(args: argparse.Namespace) -> int:
         print(f"error: agent {agent_id!r} not found", file=sys.stderr)
         return 2
     cfg = AgentConfig.load(agent_id)
+    from .control.lingtai_profile import is_lingtai_runtime
+    if is_lingtai_runtime(cfg.runtime):
+        print("error: LingTai owns this agent's name; edit it in LingTai", file=sys.stderr)
+        return 2
     old_name = cfg.display_name
     if new_name == old_name:
         print(f"agent {agent_id!r} display_name already {new_name!r}")
@@ -922,6 +926,11 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
         print(f"server_url:    {cfg.puffo_core.server_url}")
         return 0
 
+    from .control.lingtai_profile import is_lingtai_runtime
+    if is_lingtai_runtime(cfg.runtime):
+        print("error: LingTai owns this agent's profile; edit it in LingTai", file=sys.stderr)
+        return 2
+
     # Validation mirrors the control provision contract so the CLI fails
     # locally before bothering the server.
     if role_short_arg is not None and role_arg is None and not cfg.role:
@@ -938,9 +947,7 @@ def cmd_agent_profile(args: argparse.Namespace) -> int:
         print("error: --role-short must be at most 32 characters", file=sys.stderr)
         return 2
 
-    # Build the wire patch + apply locally in lock-step. agent.yml
-    # writes happen first so a server-side hiccup doesn't lose what
-    # the operator typed; the sync warning surfaces after.
+    # Persist locally before publishing; a network failure must not lose edits.
     patch: dict[str, Any] = {}
     if isinstance(display_name_arg, str):
         new_name = display_name_arg.strip() or cfg.display_name

--- a/src/puffo_agent/portal/control/client.py
+++ b/src/puffo_agent/portal/control/client.py
@@ -377,6 +377,12 @@ def _set_agent_state(agent_slug: str | None, state: str) -> dict:
 
 async def _execute_edit(agent_slug: str | None, params: dict) -> dict:
     cfg = AgentConfig.load(agent_slug)
+    from .lingtai_profile import guarded_edit_params
+
+    try:
+        params = guarded_edit_params(cfg, params)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
     patch, prompt_changed = _apply_edit_profile_fields(cfg, params)
     runtime_changed, error = _apply_edit_runtime(cfg, params)
     if error is not None:

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import sys
+import time
 from pathlib import Path
 
 from ..state import AgentConfig, discover_agents, home_dir
@@ -94,6 +95,42 @@ def _executable_paths(known: list[Path]) -> list[str]:
     return result
 
 
+def _search_executable_folder(value: object) -> dict:
+    root = _absolute(value, "executable_root")
+    if not root.is_dir():
+        raise ValueError("LingTai executable search location must be a directory")
+    result = {"ok": True, "executables": [], "executable": None, "agents": [],
+              "roots": [], "warnings": [], "searched_executable_root": str(root)}
+    deadline = time.monotonic() + 3
+    pending = [(root, 0)]
+    visited = 0
+    while pending:
+        directory, depth = pending.pop()
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    visited += 1
+                    if visited > 10000 or time.monotonic() >= deadline:
+                        result["warnings"].append("results_truncated")
+                        return _bounded_result(result)
+                    if entry.is_dir(follow_symlinks=False):
+                        if entry.name in {".git", "node_modules", "__pycache__"}:
+                            continue
+                        if depth < 8:
+                            pending.append((Path(entry.path), depth + 1))
+                        else:
+                            result["warnings"].append("results_truncated")
+                    elif entry.name in {"lingtai-agent", "lingtai-agent.exe"}:
+                        if entry.is_file() and os.access(entry.path, os.X_OK):
+                            result["executables"].append(entry.path)
+                            if len(result["executables"]) >= 8:
+                                result["warnings"].append("results_truncated")
+                                return _bounded_result(result)
+        except OSError:
+            result["warnings"].append("search_unreadable")
+    return _bounded_result(result)
+
+
 async def _query(executable: str, root: Path, registry: Path) -> list[dict]:
     process = await asyncio.create_subprocess_exec(
         executable, "puffo-v0", "discover", "--root", str(root),
@@ -161,6 +198,8 @@ async def discover_lingtai(params: dict, *, operator: str | None) -> dict:
 
 
 async def _discover(params: dict, operator: str) -> dict:
+    if "executable_root" in params:
+        return await asyncio.to_thread(_search_executable_folder, params["executable_root"])
     known, default_roots, warnings = await asyncio.to_thread(_known_paths, operator)
     executables = await asyncio.to_thread(_executable_paths, known)
     if params.get("executable"):

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -129,8 +129,8 @@ def _normalize(row: object, root: Path) -> dict:
     directory = _absolute(row.get("agent_dir"), "agent_dir")
     if not directory.is_relative_to(root) or not (directory / "init.json").is_file():
         raise ValueError("LingTai discovery returned an agent outside the search folder")
-    name, status = row.get("display_name"), row.get("status")
-    if not isinstance(name, str) or not isinstance(status, str):
+    status = row.get("status")
+    if not isinstance(status, str):
         raise ValueError("LingTai discovery returned an invalid agent state")
     workspace = row.get("workspace")
     if workspace is None:
@@ -142,7 +142,7 @@ def _normalize(row: object, root: Path) -> dict:
     if status == "available" and not workspace_path.is_dir():
         raise ValueError("LingTai discovery returned a missing working folder")
     return {
-        "display_name": name[:200], "agent_dir": str(directory),
+        "source_dir_name": directory.name, "agent_dir": str(directory),
         **asdict(read_source_profile(directory)),
         "description": None, "profile_source": "lingtai",
         "workspace": str(workspace_path), "status": status,

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from .lingtai_profile import source_agent_name
+from dataclasses import asdict
+
+from .lingtai_profile import read_source_profile
 
 import asyncio
 import json
@@ -141,7 +143,7 @@ def _normalize(row: object, root: Path) -> dict:
         raise ValueError("LingTai discovery returned a missing working folder")
     return {
         "display_name": name[:200], "agent_dir": str(directory),
-        "agent_name": source_agent_name(directory),
+        **asdict(read_source_profile(directory)),
         "description": None, "profile_source": "lingtai",
         "workspace": str(workspace_path), "status": status,
         "runtime_id": row.get("runtime_id"),

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
-
 from .lingtai_profile import read_source_profile
 
 import asyncio
@@ -178,9 +176,12 @@ def _normalize(row: object, root: Path) -> dict:
     # Keep drifted registrations visible even when their workspace is missing.
     if status == "available" and not workspace_path.is_dir():
         raise ValueError("LingTai discovery returned a missing working folder")
+    source = read_source_profile(directory)
     return {
         "source_dir_name": directory.name, "agent_dir": str(directory),
-        **asdict(read_source_profile(directory)),
+        "agent_name": source.agent_name, "name_source_file": source.name_source_file,
+        "profile_read_error": source.profile_read_error,
+        "import_display_name": source.import_display_name,
         "description": None, "profile_source": "lingtai",
         "workspace": str(workspace_path), "status": status,
         "runtime_id": row.get("runtime_id"),

--- a/src/puffo_agent/portal/control/lingtai_discovery.py
+++ b/src/puffo_agent/portal/control/lingtai_discovery.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from .lingtai_profile import source_agent_name
+
 import asyncio
 import json
 import os
@@ -139,6 +141,8 @@ def _normalize(row: object, root: Path) -> dict:
         raise ValueError("LingTai discovery returned a missing working folder")
     return {
         "display_name": name[:200], "agent_dir": str(directory),
+        "agent_name": source_agent_name(directory),
+        "description": None, "profile_source": "lingtai",
         "workspace": str(workspace_path), "status": status,
         "runtime_id": row.get("runtime_id"),
         "formerly_bound_runtime_id": row.get("formerly_bound_runtime_id"),

--- a/src/puffo_agent/portal/control/lingtai_profile.py
+++ b/src/puffo_agent/portal/control/lingtai_profile.py
@@ -16,7 +16,7 @@ _PROFILE_FIELDS = frozenset({"display_name", "role", "role_short", "soul", "prof
 @dataclass(frozen=True)
 class SourceProfile:
     agent_name: str | None
-    profile_name_source: str | None
+    name_source_file: str | None
     profile_read_error: str | None
     import_display_name: str | None
 

--- a/src/puffo_agent/portal/control/lingtai_profile.py
+++ b/src/puffo_agent/portal/control/lingtai_profile.py
@@ -5,6 +5,7 @@ import json
 import os
 import stat
 from pathlib import Path
+from dataclasses import dataclass
 
 from ..state import AgentConfig, RuntimeConfig
 
@@ -12,26 +13,59 @@ _MAX_INIT_BYTES = 1024 * 1024
 _PROFILE_FIELDS = frozenset({"display_name", "role", "role_short", "soul", "profile"})
 
 
-def source_agent_name(directory: Path) -> str | None:
-    """Read a bounded regular init file; directory labels are never identity."""
+@dataclass(frozen=True)
+class SourceProfile:
+    agent_name: str | None
+    profile_name_source: str | None
+    profile_read_error: str | None
+    import_display_name: str | None
+
+
+def _read_source_object(path: Path) -> dict:
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW)
+    with os.fdopen(fd, "rb") as stream:
+        if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+            raise ValueError("source metadata must be a regular file")
+        data = stream.read(_MAX_INIT_BYTES + 1)
+    if len(data) > _MAX_INIT_BYTES:
+        raise ValueError("source metadata exceeds the size limit")
+    document = json.loads(data)
+    if not isinstance(document, dict):
+        raise ValueError("source metadata must be an object")
+    return document
+
+
+def read_source_profile(directory: Path) -> SourceProfile:
+    """Only an absent .agent.json allows the legacy init manifest fallback."""
+    source = ".agent.json"
     try:
-        fd = os.open(directory / "init.json", os.O_RDONLY | os.O_NONBLOCK)
-        with os.fdopen(fd, "rb") as stream:
-            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
-                return None
-            data = stream.read(_MAX_INIT_BYTES + 1)
-        if len(data) > _MAX_INIT_BYTES:
-            return None
-        document = json.loads(data)
-        manifest = document.get("manifest") if isinstance(document, dict) else None
-        name = manifest.get("agent_name") if isinstance(manifest, dict) else None
-        if not isinstance(name, str) or not name.strip() or len(name) > 200:
-            return None
-        if any(ord(char) < 32 or ord(char) == 127 for char in name):
-            return None
-        return name
+        try:
+            metadata = _read_source_object(directory / source)
+        except FileNotFoundError:
+            try:
+                (directory / ".agent.json.corrupt").lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                raise ValueError("source metadata was quarantined as corrupt")
+            source = "init.json"
+            document = _read_source_object(directory / source)
+            metadata = document.get("manifest", {})
+            if not isinstance(metadata, dict):
+                raise ValueError("manifest must be an object")
+        name = metadata.get("agent_name")
+        if name is not None and not isinstance(name, str):
+            raise ValueError("agent_name must be a string or null")
+        if isinstance(name, str):
+            if len(name) > 200 or any(ord(char) < 32 or ord(char) == 127 for char in name):
+                raise ValueError("agent_name is not a safe display name")
+            if not name.strip():
+                name = None
+        return SourceProfile(name, source, None, name or "Unnamed Agent")
+    except FileNotFoundError:
+        return SourceProfile(None, None, "source_unreadable", None)
     except (OSError, ValueError, RecursionError):
-        return None
+        return SourceProfile(None, source, "source_unreadable", None)
 
 
 def is_lingtai_runtime(runtime: RuntimeConfig) -> bool:
@@ -41,9 +75,13 @@ def is_lingtai_runtime(runtime: RuntimeConfig) -> bool:
 
 
 def validate_import_profile(payload: dict, directory: Path) -> None:
-    name = source_agent_name(directory)
-    if name is None:
-        raise ValueError("LingTai source agent_name is unavailable; check init.json")
+    source = read_source_profile(directory)
+    if source.profile_read_error:
+        raise ValueError("LingTai source profile cannot be read; check its metadata files")
+    name = source.import_display_name
+    selected = payload["runtime"]["lingtai"]
+    if "agent_name" not in selected or selected["agent_name"] != source.agent_name:
+        raise ValueError("LingTai source name changed or does not match; refresh discovery")
     if payload.get("display_name") != name:
         raise ValueError("LingTai source name changed or does not match; refresh discovery")
     if any(payload.get(key) not in (None, "") for key in ("role", "role_short", "soul")):

--- a/src/puffo_agent/portal/control/lingtai_profile.py
+++ b/src/puffo_agent/portal/control/lingtai_profile.py
@@ -61,7 +61,7 @@ def read_source_profile(directory: Path) -> SourceProfile:
                 raise ValueError("agent_name is not a safe display name")
             if not name.strip():
                 name = None
-        return SourceProfile(name, source, None, name or "Unnamed Agent")
+        return SourceProfile(name, source, None, name or "")
     except FileNotFoundError:
         return SourceProfile(None, None, "source_unreadable", None)
     except (OSError, ValueError, RecursionError):
@@ -86,7 +86,8 @@ def validate_import_profile(payload: dict, directory: Path) -> None:
         raise ValueError("LingTai source name changed or does not match; refresh discovery")
     if any(payload.get(key) not in (None, "") for key in ("role", "role_short", "soul")):
         raise ValueError("LingTai owns its role and description; persona overrides are not allowed")
-    if payload.get("profile") != f"# {name}\n":
+    expected_profile = f"# {name}\n" if name else ""
+    if payload.get("profile") != expected_profile:
         raise ValueError("LingTai import requires the generated technical bridge profile")
 
 

--- a/src/puffo_agent/portal/control/lingtai_profile.py
+++ b/src/puffo_agent/portal/control/lingtai_profile.py
@@ -19,6 +19,7 @@ class SourceProfile:
     name_source_file: str | None
     profile_read_error: str | None
     import_display_name: str | None
+    name_is_explicit_null: bool = False
 
 
 def _read_source_object(path: Path) -> dict:
@@ -61,7 +62,7 @@ def read_source_profile(directory: Path) -> SourceProfile:
                 raise ValueError("agent_name is not a safe display name")
             if not name.strip():
                 name = None
-        return SourceProfile(name, source, None, name or "")
+        return SourceProfile(name, source, None, name or "", "agent_name" in metadata and metadata["agent_name"] is None)
     except FileNotFoundError:
         return SourceProfile(None, None, "source_unreadable", None)
     except (OSError, ValueError, RecursionError):

--- a/src/puffo_agent/portal/control/lingtai_profile.py
+++ b/src/puffo_agent/portal/control/lingtai_profile.py
@@ -1,0 +1,85 @@
+"""Source-owned LingTai profile metadata and portal edit policy."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from ..state import AgentConfig, RuntimeConfig
+
+_MAX_INIT_BYTES = 1024 * 1024
+_PROFILE_FIELDS = frozenset({"display_name", "role", "role_short", "soul", "profile"})
+
+
+def source_agent_name(directory: Path) -> str | None:
+    """Read a bounded regular init file; directory labels are never identity."""
+    try:
+        fd = os.open(directory / "init.json", os.O_RDONLY | os.O_NONBLOCK)
+        with os.fdopen(fd, "rb") as stream:
+            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+                return None
+            data = stream.read(_MAX_INIT_BYTES + 1)
+        if len(data) > _MAX_INIT_BYTES:
+            return None
+        document = json.loads(data)
+        manifest = document.get("manifest") if isinstance(document, dict) else None
+        name = manifest.get("agent_name") if isinstance(manifest, dict) else None
+        if not isinstance(name, str) or not name.strip() or len(name) > 200:
+            return None
+        if any(ord(char) < 32 or ord(char) == 127 for char in name):
+            return None
+        return name
+    except (OSError, ValueError, RecursionError):
+        return None
+
+
+def is_lingtai_runtime(runtime: RuntimeConfig) -> bool:
+    from ...agent.harness.drivers.acp import _lingtai_constrained_profile
+
+    return bool(_lingtai_constrained_profile(tuple(runtime.harness_command)))
+
+
+def validate_import_profile(payload: dict, directory: Path) -> None:
+    name = source_agent_name(directory)
+    if name is None:
+        raise ValueError("LingTai source agent_name is unavailable; check init.json")
+    if payload.get("display_name") != name:
+        raise ValueError("LingTai source name changed or does not match; refresh discovery")
+    if any(payload.get(key) not in (None, "") for key in ("role", "role_short", "soul")):
+        raise ValueError("LingTai owns its role and description; persona overrides are not allowed")
+    if payload.get("profile") != f"# {name}\n":
+        raise ValueError("LingTai import requires the generated technical bridge profile")
+
+
+def guarded_edit_params(cfg: AgentConfig, params: dict) -> dict:
+    """Reject source edits before writes, removing accepted unchanged values."""
+    if not is_lingtai_runtime(cfg.runtime):
+        return params
+    from ..profile_sync import extract_soul_body
+
+    result = dict(params)
+    protected = _PROFILE_FIELDS.intersection(params)
+    profile = ""
+    if protected.intersection({"soul", "profile"}):
+        try:
+            profile = cfg.resolve_profile_path().read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError("LingTai profile cannot be verified for an unchanged edit") from exc
+    current = {"display_name": cfg.display_name, "role": cfg.role,
+               "role_short": cfg.role_short, "profile": profile,
+               "soul": extract_soul_body(profile)}
+    if any(params[key] != current[key] for key in protected):
+        raise ValueError("LingTai owns this agent's profile; edit it in LingTai")
+    for key in protected:
+        result.pop(key)
+    runtime = params.get("runtime")
+    if isinstance(runtime, dict):
+        current_runtime = {"kind": cfg.runtime.kind, "provider": cfg.runtime.provider,
+                           "harness": cfg.runtime.harness,
+                           "harness_command": cfg.runtime.harness_command,
+                           "model": cfg.runtime.model,
+                           "inference_level": cfg.runtime.inference_level}
+        if any(key in runtime and runtime[key] != value for key, value in current_runtime.items()):
+            raise ValueError("LingTai import runtime cannot be replaced through profile editing")
+    return result

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -89,7 +89,6 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
         operator_root_key_b64,
     )
     core_fields = _verify_core(core, bound_slug, device_cert)
-    profile_fields = _verify_profile(payload, bound_slug)
     try:
         lingtai = parse_lingtai_launch(runtime_input.get("lingtai"))
     except (ValueError, OSError) as exc:
@@ -101,8 +100,11 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
             validate_import_profile(payload, lingtai.agent_dir)
         except ValueError as exc:
             raise ProvisionError(str(exc)) from exc
-        profile_fields = (payload["display_name"], *profile_fields[1:])
+        profile_fields = (payload["display_name"], str(payload.get("avatar_url") or "").strip(),
+                          "", "", payload["profile"])
         runtime_input = {**runtime_input, "harness_command": lingtai.argv()}
+    else:
+        profile_fields = _verify_profile(payload, bound_slug)
     runtime = _verify_runtime(runtime_input)
     desired_skills, desired_mcps = _verify_desired(payload)
     server_url, slug, device_id, space_id, operator_slug = core_fields

--- a/src/puffo_agent/portal/control/provision.py
+++ b/src/puffo_agent/portal/control/provision.py
@@ -34,6 +34,7 @@ from ..state import (
     is_valid_agent_id,
 )
 from .certs import CertError, verify_device_cert, verify_identity_cert, verify_slug_binding
+from .lingtai_profile import validate_import_profile
 from .lingtai import LingtaiLaunch, parse_lingtai_launch, provision_lingtai, revoke_lingtai
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,11 @@ def verify_agent_bundle(payload: dict, operator_root_key_b64: str) -> dict:
     if lingtai is not None:
         if runtime_input.get("kind") != RUNTIME_CLI_LOCAL or runtime_input.get("harness") != "acp":
             raise ProvisionError("LingTai requires the cli-local ACP runtime")
+        try:
+            validate_import_profile(payload, lingtai.agent_dir)
+        except ValueError as exc:
+            raise ProvisionError(str(exc)) from exc
+        profile_fields = (payload["display_name"], *profile_fields[1:])
         runtime_input = {**runtime_input, "harness_command": lingtai.argv()}
     runtime = _verify_runtime(runtime_input)
     desired_skills, desired_mcps = _verify_desired(payload)
@@ -381,6 +387,7 @@ async def provision_agent_from_bundle(
     launch = context["lingtai"]
     if launch is not None:
         try:
+            validate_import_profile(payload, launch.agent_dir)
             await provision_lingtai(launch)
         except (ValueError, OSError, asyncio.TimeoutError) as exc:
             raise ProvisionError(f"LingTai runtime provisioning failed: {exc}") from exc

--- a/src/puffo_agent/portal/daemon.py
+++ b/src/puffo_agent/portal/daemon.py
@@ -221,6 +221,11 @@ class Daemon:
                 spawn(self.codex_refresher.run_loop(self._stop), name="codex_refresher.run_loop"),
             )
         )
+        from .lingtai_profile_sync import LingtaiProfileSync
+
+        runtime.runtime_tasks.append(
+            spawn(LingtaiProfileSync().run_loop(self._stop), name="lingtai_profile_sync")
+        )
         from .control.client import ControlManager
 
         runtime.control_manager = ControlManager()

--- a/src/puffo_agent/portal/lingtai_profile_sync.py
+++ b/src/puffo_agent/portal/lingtai_profile_sync.py
@@ -56,6 +56,10 @@ class LingtaiProfileSync:
         source = read_source_profile(directory)
         if source.profile_read_error:
             return
+        # A lost current manifest can expose an unnamed bootstrap manifest;
+        # that is not evidence of an intentional name clear after import.
+        if source.agent_name is None and (source.name_source_file != ".agent.json" or not source.name_is_explicit_null):
+            return
         snapshot = (cfg.puffo_core.server_url, cfg.puffo_core.slug,
                     tuple(cfg.runtime.harness_command), str(directory), source.agent_name)
         if self._published.get(cfg.id) == snapshot:

--- a/src/puffo_agent/portal/lingtai_profile_sync.py
+++ b/src/puffo_agent/portal/lingtai_profile_sync.py
@@ -1,0 +1,94 @@
+"""Daemon-owned, read-only projection of LingTai names to Puffo identities."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from .control.lingtai_profile import _read_source_object, is_lingtai_runtime, read_source_profile
+from .state import AgentConfig, discover_agents, home_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _source_directory(command: list[str]) -> Path | None:
+    """Resolve only the active binding in Puffo's registry, never a guessed folder."""
+    flags: dict[str, str] = {}
+    for index, arg in enumerate(command):
+        if arg in {"--registry", "--runtime-id"} and index + 1 < len(command):
+            flags[arg] = command[index + 1]
+        elif arg.startswith(("--registry=", "--runtime-id=")):
+            key, value = arg.split("=", 1)
+            flags[key] = value
+    registry = home_dir().resolve() / "lingtai" / "runtime-registry.json"
+    if flags.get("--registry") != str(registry) or not flags.get("--runtime-id"):
+        return None
+    try:
+        document = _read_source_object(registry)
+        entries = document.get("runtimes")
+        if not isinstance(entries, dict):
+            return None
+        entry = entries.get(flags["--runtime-id"])
+        if not isinstance(entry, dict) or entry.get("status") != "active":
+            return None
+        if entry.get("runtime_id") != flags["--runtime-id"]:
+            return None
+        directory = entry.get("agent_dir")
+        if isinstance(directory, str) and Path(directory).is_absolute():
+            return Path(directory)
+    except (OSError, ValueError, RecursionError):
+        pass
+    return None
+
+
+class LingtaiProfileSync:
+    """Single lifecycle owner; remember only successfully published source names."""
+
+    def __init__(self) -> None:
+        self._published: dict[str, tuple] = {}
+
+    async def sync_one(self, cfg: AgentConfig) -> None:
+        if not is_lingtai_runtime(cfg.runtime) or cfg.puffo_core.transport == "bridge":
+            return
+        directory = _source_directory(cfg.runtime.harness_command)
+        if directory is None:
+            return
+        source = read_source_profile(directory)
+        if source.profile_read_error:
+            return
+        snapshot = (cfg.puffo_core.server_url, cfg.puffo_core.slug,
+                    tuple(cfg.runtime.harness_command), str(directory), source.agent_name)
+        if self._published.get(cfg.id) == snapshot:
+            return
+        from .profile_sync import sync_agent_profile
+
+        # Only the public source name crosses this boundary. No prompt, model,
+        # description, nickname, or workspace content is published.
+        await sync_agent_profile(cfg, {"display_name": source.agent_name})
+        current = AgentConfig.load(cfg.id)
+        if current.runtime != cfg.runtime or current.puffo_core != cfg.puffo_core:
+            return
+        name = source.agent_name or ""
+        if current.display_name != name:
+            current.display_name = name
+            current.save()
+        self._published[cfg.id] = snapshot
+
+    async def run_loop(self, stop: asyncio.Event) -> None:
+        while not stop.is_set():
+            ids = set(discover_agents())
+            self._published = {key: value for key, value in self._published.items() if key in ids}
+            for agent_id in sorted(ids):
+                if stop.is_set():
+                    return
+                try:
+                    cfg = AgentConfig.load(agent_id)
+                    if cfg.puffo_core.is_configured():
+                        async with asyncio.timeout(10):
+                            await self.sync_one(cfg)
+                except Exception as exc:  # noqa: BLE001 — isolate each identity; retry next pass
+                    logger.warning("agent %s: LingTai name sync failed: %s", agent_id, exc)
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=30)
+            except TimeoutError:
+                pass

--- a/src/puffo_agent/portal/lingtai_profile_sync.py
+++ b/src/puffo_agent/portal/lingtai_profile_sync.py
@@ -58,7 +58,9 @@ class LingtaiProfileSync:
             return
         # A lost current manifest can expose an unnamed bootstrap manifest;
         # that is not evidence of an intentional name clear after import.
-        if source.agent_name is None and (source.name_source_file != ".agent.json" or not source.name_is_explicit_null):
+        if source.name_source_file != ".agent.json":
+            return
+        if source.agent_name is None and not source.name_is_explicit_null:
             return
         snapshot = (cfg.puffo_core.server_url, cfg.puffo_core.slug,
                     tuple(cfg.runtime.harness_command), str(directory), source.agent_name)

--- a/src/puffo_agent/portal/profile_sync.py
+++ b/src/puffo_agent/portal/profile_sync.py
@@ -226,6 +226,12 @@ async def sync_full_profile(cfg: AgentConfig) -> None:
     ``# Soul`` section extracted from profile.md. Soul is omitted
     when profile.md is missing OR has no soul-like heading — the
     server's stored value is preserved rather than clobbered."""
+    from .control.lingtai_profile import is_lingtai_runtime
+
+    # LingTai names have one daemon-owned publisher. Startup/warm snapshots
+    # must never race it by restoring an old imported name or local persona.
+    if is_lingtai_runtime(cfg.runtime):
+        return
     # Repair a stale on-disk role_short BEFORE syncing, so a restart fixes
     # the chip instead of pushing the stale value back to the server.
     if cfg.role:

--- a/src/puffo_agent/portal/ui/widgets/agent_detail.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_detail.py
@@ -426,6 +426,11 @@ class AgentDetail(QWidget):
         self._owner_slug.setText(
             f"{owner_name} ({owner_slug})" if owner_name and owner_name != owner_slug else owner_slug
         )
+        from ...control.lingtai_profile import is_lingtai_runtime
+        managed_profile = is_lingtai_runtime(cfg.runtime)
+        for field in (self._display_name, self._role, self._role_short, self._soul):
+            field.setReadOnly(managed_profile)
+            field.setToolTip("Managed in LingTai; edit the source there." if managed_profile else "")
         self._display_name.setText(cfg.display_name)
         self._role.setText(cfg.role)
         self._role_short.setText(cfg.role_short)
@@ -492,7 +497,10 @@ class AgentDetail(QWidget):
             self._initial_snapshot is not None
             and self._snapshot() != self._initial_snapshot
         )
-        self._save_btn.setEnabled(dirty)
+        from ...control.lingtai_profile import is_lingtai_runtime
+        managed = self._cfg is not None and is_lingtai_runtime(self._cfg.runtime)
+        self._save_btn.setEnabled(dirty and not managed)
+        self._save_btn.setToolTip("Edit this profile and runtime in LingTai." if managed else "")
         self._revert_btn.setEnabled(dirty)
 
     def _update_action_buttons(self) -> None:
@@ -886,6 +894,10 @@ class AgentDetail(QWidget):
         if not self._cfg or not self._agent_id:
             return
         cfg = self._cfg
+        from ...control.lingtai_profile import is_lingtai_runtime
+        if is_lingtai_runtime(cfg.runtime):
+            QMessageBox.warning(self, "Save", "This profile and runtime are managed in LingTai; edit them there.")
+            return
 
         previous_context_config = (
             cfg.runtime.kind,

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1535,6 +1535,11 @@ class Worker:
             "model": model,
             "inference_level": getattr(rt, "inference_level", ""),
         }
+        if harness == "acp":
+            from .control.lingtai_profile import is_lingtai_runtime
+
+            if is_lingtai_runtime(rt):
+                info["profile_source"] = "lingtai"
         adapter = getattr(self, "_adapter", None)
         context_limits = getattr(adapter, "context_limits", None)
         limits = context_limits() if callable(context_limits) else (None, None)

--- a/tests/test_agent_sync.py
+++ b/tests/test_agent_sync.py
@@ -622,6 +622,9 @@ async def test_lingtai_source_name_sync_retries_clear_and_preserves_other_fields
     (source / "init.json").write_text('{"manifest":{"agent_name":null}}')
     await monitor.sync_one(cfg)
     assert len(posted) == 2  # Missing current manifest must not clear a self-chosen name.
+    (source / "init.json").write_text('{"manifest":{"agent_name":"Stale bootstrap"}}')
+    await monitor.sync_one(cfg)
+    assert len(posted) == 2  # Nor can a stale bootstrap name roll back the current one.
     manifest.write_text('{}')
     await monitor.sync_one(cfg)
     assert len(posted) == 2  # A missing field is not an explicit clear either.

--- a/tests/test_agent_sync.py
+++ b/tests/test_agent_sync.py
@@ -564,3 +564,62 @@ async def test_control_edit_role_rewrites_profile_role_line(monkeypatch):
     text = profile.read_text(encoding="utf-8")
     assert "**Role:** coder: new description\n" in text
     assert "helper: old" not in text
+
+@pytest.mark.asyncio
+async def test_lingtai_source_name_sync_retries_clear_and_preserves_other_fields(tmp_path, monkeypatch):
+    """A failed rename must retry; null clears, corrupt/revoked sources never overwrite."""
+    import json
+    from puffo_agent.portal.lingtai_profile_sync import LingtaiProfileSync
+    from puffo_agent.portal.state import RuntimeConfig
+    home = isolated_home()
+    write_test_agent(home, "source-bot")
+    cfg = AgentConfig.load("source-bot")
+    source = tmp_path / "source"
+    source.mkdir()
+    manifest = source / ".agent.json"
+    registry = Path(home).resolve() / "lingtai" / "runtime-registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(json.dumps({"runtimes": {"bound": {
+        "runtime_id": "bound", "agent_dir": str(source), "status": "active",
+    }}}))
+    cfg.runtime = RuntimeConfig(kind="cli-local", harness="acp", harness_command=[
+        "/bin/lingtai-agent", "acp", "--profile", "puffo-v1",
+        "--runtime-id", "bound", "--registry", str(registry),
+    ])
+    cfg.display_name = "Old"
+    cfg.save()
+    posted = []
+    fail = True
+    async def patch_profile(config, patch):
+        nonlocal fail
+        posted.append(patch)
+        if fail:
+            fail = False
+            raise OSError("offline")
+    monkeypatch.setattr("puffo_agent.portal.profile_sync.sync_agent_profile", patch_profile)
+    await sync_full_profile(cfg)
+    assert posted == []  # A warm/startup snapshot must not restore the imported name.
+    monitor = LingtaiProfileSync()
+    manifest.write_text('{"agent_name":"New", "system_prompt":"PRIVATE"}')
+    with pytest.raises(OSError):
+        await monitor.sync_one(cfg)
+    assert AgentConfig.load(cfg.id).display_name == "Old"
+    await monitor.sync_one(cfg)
+    assert AgentConfig.load(cfg.id).display_name == "New"
+    await monitor.sync_one(AgentConfig.load(cfg.id))
+    assert posted == [{"display_name": "New"}] * 2
+    assert manifest.read_text() == '{"agent_name":"New", "system_prompt":"PRIVATE"}'
+    manifest.write_text('broken')
+    await monitor.sync_one(cfg)
+    assert len(posted) == 2
+    manifest.write_text('{"agent_name":null}')
+    await monitor.sync_one(cfg)
+    assert posted[-1] == {"display_name": None}
+    assert AgentConfig.load(cfg.id).display_name == ""
+    manifest.write_text('{"agent_name":"Reborn"}')
+    await monitor.sync_one(cfg)
+    assert posted[-1] == {"display_name": "Reborn"}
+    registry.write_text('{"runtimes":{}}')
+    manifest.write_text('{"agent_name":"Unbound"}')
+    await monitor.sync_one(cfg)
+    assert posted[-1] == {"display_name": "Reborn"}

--- a/tests/test_agent_sync.py
+++ b/tests/test_agent_sync.py
@@ -588,6 +588,12 @@ async def test_lingtai_source_name_sync_retries_clear_and_preserves_other_fields
     ])
     cfg.display_name = "Old"
     cfg.save()
+    import argparse
+    from puffo_agent.portal.cli import cmd_agent_rename, cmd_agent_profile
+    before_config = cfg.display_name
+    assert cmd_agent_rename(argparse.Namespace(id=cfg.id, display_name="Ghost")) == 2
+    assert cmd_agent_profile(argparse.Namespace(id=cfg.id, display_name="Ghost", role=None, role_short=None)) == 2
+    assert AgentConfig.load(cfg.id).display_name == before_config
     posted = []
     fail = True
     async def patch_profile(config, patch):
@@ -612,6 +618,13 @@ async def test_lingtai_source_name_sync_retries_clear_and_preserves_other_fields
     manifest.write_text('broken')
     await monitor.sync_one(cfg)
     assert len(posted) == 2
+    manifest.unlink()
+    (source / "init.json").write_text('{"manifest":{"agent_name":null}}')
+    await monitor.sync_one(cfg)
+    assert len(posted) == 2  # Missing current manifest must not clear a self-chosen name.
+    manifest.write_text('{}')
+    await monitor.sync_one(cfg)
+    assert len(posted) == 2  # A missing field is not an explicit clear either.
     manifest.write_text('{"agent_name":null}')
     await monitor.sync_one(cfg)
     assert posted[-1] == {"display_name": None}

--- a/tests/test_cloud_status_telemetry.py
+++ b/tests/test_cloud_status_telemetry.py
@@ -149,3 +149,12 @@ async def test_worker_registers_reconnect_status_callback():
             "health": "unknown",
         },
     )]
+
+
+def test_runtime_inventory_exposes_legacy_lingtai_profile_ownership():
+    """Portal locks must work for imports created before metadata fields existed."""
+    agent = AgentConfig(id="imported", runtime=RuntimeConfig(
+        kind="cli-local", provider="openai", harness="acp",
+        harness_command=["/tmp/custom-wrapper", "acp", "--profile=puffo-v1", "--runtime-id", "stable"],
+    ))
+    assert Worker(DaemonConfig(), agent)._runtime_info()["profile_source"] == "lingtai"

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -1009,3 +1009,44 @@ async def test_concurrent_identical_env_edits_are_idempotent(home):
     assert AgentConfig.load("scout").env_overrides == {
         "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["display_name", "role", "role_short", "soul", "profile", "runtime"])
+async def test_lingtai_edit_rejected_atomically_for_legacy_import(home, change):
+    """Legacy argv-derived ownership must prevent partial config/profile writes."""
+    write_test_agent(home, "scout")
+    cfg = AgentConfig.load("scout")
+    cfg.runtime.kind = "cli-local"
+    cfg.runtime.harness = "acp"
+    cfg.runtime.provider = "openai"
+    cfg.runtime.harness_command = ["/tmp/renamed-cli", "acp", "--profile=puffo-v1", "--runtime-id", "stable"]
+    cfg.save()
+    from puffo_agent.portal.state import agent_yml_path
+    config_before = agent_yml_path("scout").read_bytes()
+    profile = cfg.resolve_profile_path()
+    profile_before = profile.read_bytes() if profile.exists() else None
+    value = {"harness": "codex"} if change == "runtime" else "Override"
+    result = await execute_command("edit", "scout", {change: value, "avatar_url": "changed"})
+    assert result["ok"] is False
+    assert agent_yml_path("scout").read_bytes() == config_before
+    assert (profile.read_bytes() if profile.exists() else None) == profile_before
+
+
+@pytest.mark.asyncio
+async def test_lingtai_edit_allows_unchanged_name_without_profile_sync(home, monkeypatch):
+    """General edit clients may include read-only unchanged values without failing avatar edits."""
+    write_test_agent(home, "scout")
+    cfg = AgentConfig.load("scout")
+    cfg.runtime.kind = "cli-local"
+    cfg.runtime.harness = "acp"
+    cfg.runtime.provider = "openai"
+    cfg.runtime.harness_command = ["/tmp/lingtai", "acp", "--profile", "puffo-v0"]
+    cfg.save()
+    patches = []
+    async def sync(cfg, patch):
+        patches.append(patch)
+    monkeypatch.setattr(cc, "_sync_edit_profile", sync)
+    result = await execute_command("edit", "scout", {"display_name": cfg.display_name, "avatar_url": "avatar"})
+    assert result["ok"] is True
+    assert patches == [{"avatar_url": "avatar"}]

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -452,7 +452,7 @@ async def test_lingtai_browser_create_preserves_workspace_and_registry(tmp_path,
     workspace = tmp_path / "existing-workspace"
     source.mkdir()
     workspace.mkdir()
-    (source / "init.json").write_text("{}")
+    (source / "init.json").write_text('{"manifest":{"agent_name":"Helper"}}')
     marker = tmp_path / "cli-args.json"
     executable = tmp_path / "lingtai-agent"
     executable.write_text(
@@ -461,6 +461,7 @@ async def test_lingtai_browser_create_preserves_workspace_and_registry(tmp_path,
     )
     executable.chmod(0o700)
     payload, operator = _payload()
+    payload.update(role="", role_short="", profile="# Helper\n")
     payload["runtime"] = {
         "kind": "cli-local", "harness": "acp", "provider": "openai",
         "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(workspace)},
@@ -478,7 +479,7 @@ async def test_lingtai_browser_create_preserves_workspace_and_registry(tmp_path,
     for field in ["--runtime-id", "--registry"]:
         assert argv[argv.index(field) + 1] == provision_args[provision_args.index(field) + 1]
     assert provision_args[provision_args.index("--agent-dir") + 1] == str(source)
-    assert (source / "init.json").read_text() == "{}"
+    assert (source / "init.json").read_text() == '{"manifest":{"agent_name":"Helper"}}'
 
 
 @pytest.mark.asyncio
@@ -489,11 +490,12 @@ async def test_lingtai_provision_failure_leaves_identity_unmaterialized(tmp_path
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "daemon"))
     source = tmp_path / "source"
     source.mkdir()
-    (source / "init.json").write_text("{}")
+    (source / "init.json").write_text('{"manifest":{"agent_name":"Helper"}}')
     executable = tmp_path / "lingtai-agent"
     executable.write_text(f"#!{sys.executable}\nimport sys\nprint('error: puffo-v0 runtime registry parent directory is owned by another user', file=sys.stderr)\nraise SystemExit(1)\n")
     executable.chmod(0o700)
     payload, operator = _payload()
+    payload.update(role="", role_short="", profile="# Helper\n")
     payload["runtime"] = {
         "kind": "cli-local", "harness": "acp", "provider": "openai",
         "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(source)},
@@ -514,8 +516,9 @@ def lingtai_creation(tmp_path, monkeypatch):
     monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path / "daemon"))
     source = tmp_path / "source"
     source.mkdir()
-    (source / "init.json").write_text("{}")
+    (source / "init.json").write_text('{"manifest":{"agent_name":"Helper"}}')
     payload, operator = _payload()
+    payload.update(role="", role_short="", profile="# Helper\n")
     payload["runtime"] = {
         "kind": "cli-local", "harness": "acp", "provider": "openai",
         "lingtai": {"executable": sys.executable, "agent_dir": str(source), "workspace": str(source)},
@@ -602,3 +605,33 @@ async def test_lingtai_repeated_cancellation_finishes_rollback(lingtai_creation,
         await task
     assert not associations
     assert caught.value.args == ("first cancellation",)
+
+
+@pytest.mark.parametrize("change", ["display_name", "role", "soul", "profile", "source", "missing_source"])
+def test_lingtai_import_rejects_source_profile_drift_before_creation(lingtai_creation, change):
+    """A stale browser choice or persona payload must never materialize identity."""
+    from pathlib import Path
+
+    payload, operator, associations = lingtai_creation
+    if change in ("source", "missing_source"):
+        source = Path(payload["runtime"]["lingtai"]["agent_dir"])
+        (source / "init.json").write_text('{"manifest":{"agent_name":"Changed"}}' if change == "source" else "{}")
+    else:
+        payload[change] = "Override"
+    with pytest.raises(ProvisionError, match="LingTai"):
+        verify_agent_bundle(payload, operator)
+    assert not associations
+
+
+@pytest.mark.asyncio
+async def test_lingtai_source_drift_during_preflight_cannot_register(lingtai_creation):
+    """An async preflight must not turn source validation into a stale snapshot."""
+    from pathlib import Path
+
+    payload, operator, associations = lingtai_creation
+    async def preflight(context):
+        source = Path(payload["runtime"]["lingtai"]["agent_dir"])
+        (source / "init.json").write_text('{"manifest":{"agent_name":"Changed"}}')
+    with pytest.raises(ProvisionError, match="source name changed"):
+        await provision_agent_from_bundle(payload, operator, preflight=preflight)
+    assert not associations

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -638,8 +638,8 @@ async def test_lingtai_source_drift_during_preflight_cannot_register(lingtai_cre
 
 
 @pytest.mark.parametrize("name", [None, ""])
-def test_unnamed_lingtai_import_uses_fixed_placeholder_not_init_name(lingtai_creation, name):
-    """Readable unnamed sources can import without exposing an operator rename bypass."""
+def test_unnamed_lingtai_import_preserves_empty_profile_without_name(lingtai_creation, name):
+    """Unnamed sources persist empty facts, with no invented name or slug fallback."""
     import json
     from pathlib import Path
 
@@ -647,8 +647,14 @@ def test_unnamed_lingtai_import_uses_fixed_placeholder_not_init_name(lingtai_cre
     source = Path(payload["runtime"]["lingtai"]["agent_dir"])
     (source / ".agent.json").write_text(json.dumps({"agent_name": name}))
     payload["runtime"]["lingtai"]["agent_name"] = None
-    payload.update(display_name="Unnamed Agent", profile="# Unnamed Agent\n")
-    assert verify_agent_bundle(payload, operator)["display_name"] == "Unnamed Agent"
+    payload.update(display_name="", profile="")
+    context = verify_agent_bundle(payload, operator)
+    assert context["display_name"] == ""
+    assert context["profile_text"] == ""
+    write_agent_from_context(context)
+    cfg = AgentConfig.load(context["agent_id"])
+    assert cfg.display_name == ""
+    assert cfg.resolve_profile_path().read_text() == ""
     payload.update(display_name="Helper", profile="# Helper\n")
     with pytest.raises(ProvisionError, match="source name changed"):
         verify_agent_bundle(payload, operator)

--- a/tests/test_control_provision.py
+++ b/tests/test_control_provision.py
@@ -464,7 +464,7 @@ async def test_lingtai_browser_create_preserves_workspace_and_registry(tmp_path,
     payload.update(role="", role_short="", profile="# Helper\n")
     payload["runtime"] = {
         "kind": "cli-local", "harness": "acp", "provider": "openai",
-        "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(workspace)},
+        "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(workspace), "agent_name": "Helper"},
     }
 
     async def materialize(context):
@@ -498,7 +498,7 @@ async def test_lingtai_provision_failure_leaves_identity_unmaterialized(tmp_path
     payload.update(role="", role_short="", profile="# Helper\n")
     payload["runtime"] = {
         "kind": "cli-local", "harness": "acp", "provider": "openai",
-        "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(source)},
+        "lingtai": {"executable": str(executable), "agent_dir": str(source), "workspace": str(source), "agent_name": "Helper"},
     }
     materialized = []
 
@@ -521,7 +521,7 @@ def lingtai_creation(tmp_path, monkeypatch):
     payload.update(role="", role_short="", profile="# Helper\n")
     payload["runtime"] = {
         "kind": "cli-local", "harness": "acp", "provider": "openai",
-        "lingtai": {"executable": sys.executable, "agent_dir": str(source), "workspace": str(source)},
+        "lingtai": {"executable": sys.executable, "agent_dir": str(source), "workspace": str(source), "agent_name": "Helper"},
     }
     associations = set()
 
@@ -635,3 +635,40 @@ async def test_lingtai_source_drift_during_preflight_cannot_register(lingtai_cre
     with pytest.raises(ProvisionError, match="source name changed"):
         await provision_agent_from_bundle(payload, operator, preflight=preflight)
     assert not associations
+
+
+@pytest.mark.parametrize("name", [None, ""])
+def test_unnamed_lingtai_import_uses_fixed_placeholder_not_init_name(lingtai_creation, name):
+    """Readable unnamed sources can import without exposing an operator rename bypass."""
+    import json
+    from pathlib import Path
+
+    payload, operator, _ = lingtai_creation
+    source = Path(payload["runtime"]["lingtai"]["agent_dir"])
+    (source / ".agent.json").write_text(json.dumps({"agent_name": name}))
+    payload["runtime"]["lingtai"]["agent_name"] = None
+    payload.update(display_name="Unnamed Agent", profile="# Unnamed Agent\n")
+    assert verify_agent_bundle(payload, operator)["display_name"] == "Unnamed Agent"
+    payload.update(display_name="Helper", profile="# Helper\n")
+    with pytest.raises(ProvisionError, match="source name changed"):
+        verify_agent_bundle(payload, operator)
+
+
+@pytest.mark.parametrize("selection", ["missing", "named-placeholder", "unnamed-to-named"])
+def test_lingtai_import_requires_exact_nullable_name_snapshot(lingtai_creation, selection):
+    """Placeholder display equality must not mask named/unnamed source drift."""
+    from pathlib import Path
+
+    payload, operator, _ = lingtai_creation
+    source = Path(payload["runtime"]["lingtai"]["agent_dir"])
+    if selection == "missing":
+        del payload["runtime"]["lingtai"]["agent_name"]
+    else:
+        payload.update(display_name="Unnamed Agent", profile="# Unnamed Agent\n")
+        selected_name = "Unnamed Agent" if selection == "named-placeholder" else None
+        payload["runtime"]["lingtai"]["agent_name"] = selected_name
+        (source / ".agent.json").write_text(
+            '{"agent_name":null}' if selected_name else '{"agent_name":"Unnamed Agent"}'
+        )
+    with pytest.raises(ProvisionError, match="source name changed"):
+        verify_agent_bundle(payload, operator)

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -158,10 +158,11 @@ def test_candidate_metadata_never_substitutes_directory_label(tmp_path, document
     assert row["agent_name"] == expected
     assert row["profile_read_error"] == error
     assert row["profile_name_source"] == "init.json"
-    assert row["import_display_name"] == (None if error else expected or "Unnamed Agent")
+    assert row["import_display_name"] == (None if error else expected or "")
     assert row["description"] is None
     assert row["profile_source"] == "lingtai"
-    assert row["display_name"] == "CLI Label"
+    assert row["source_dir_name"] == "misleading-name"
+    assert "display_name" not in row
 
 
 @pytest.mark.parametrize("source, expected, error", [
@@ -182,7 +183,7 @@ def test_existing_agent_metadata_is_exclusive_even_when_unnamed(tmp_path, source
     assert row["agent_name"] == expected
     assert row["profile_read_error"] == error
     assert row["profile_name_source"] == ".agent.json"
-    assert row["import_display_name"] == (None if error else expected or "Unnamed Agent")
+    assert row["import_display_name"] == (None if error else expected or "")
 
 
 def test_agent_metadata_permission_error_is_not_absence(tmp_path, monkeypatch):

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -227,3 +227,27 @@ def test_corrupt_marker_prevents_only_absent_primary_fallback(tmp_path, primary_
     assert row["agent_name"] == ("Recovered" if primary_present else None)
     assert row["profile_read_error"] == (None if primary_present else "source_unreadable")
     assert row["import_display_name"] == ("Recovered" if primary_present else None)
+
+
+@pytest.mark.asyncio
+async def test_executable_folder_search_is_scoped_and_does_not_run_candidates(tmp_path, monkeypatch):
+    """The executable field must search its folder, never run discoveries or follow directory links."""
+    root = tmp_path / "selected"
+    binary = root / ".venv" / "bin" / "lingtai-agent"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 99\n")
+    binary.chmod(0o700)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "lingtai-agent").write_text("#!/bin/sh\nexit 99\n")
+    (outside / "lingtai-agent").chmod(0o700)
+    (root / "escape").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(discovery, "_known_paths", lambda operator: ([], [], []))
+    monkeypatch.setattr(discovery, "_executable_paths", lambda known: ["/unrelated/lingtai-agent"])
+    async def forbidden(*args):
+        pytest.fail("binary search ran the candidate")
+    monkeypatch.setattr(discovery, "_query", forbidden)
+    result = await discovery.discover_lingtai({"executable_root": str(root)}, operator="owner")
+    assert result["ok"] and result["executables"] == [str(binary)]
+    assert result["searched_executable_root"] == str(root)
+    assert result["agents"] == []

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -139,3 +139,23 @@ async def test_invalid_explicit_root_returns_actionable_error(monkeypatch, root)
     result = await discovery.discover_lingtai({"root": root}, operator="owner")
     assert result["ok"] is False
     assert result["error"]
+
+
+@pytest.mark.parametrize("document, expected", [
+    ('{"manifest":{"agent_name":"Source Name"}}', "Source Name"),
+    ('{"manifest":{}}', None),
+    ('not json', None),
+    ('{"manifest":{"agent_name":""}}', None),
+    (' ' * (1024 * 1024 + 1), None),
+], ids=['valid', 'missing', 'malformed', 'empty', 'oversize'])
+def test_candidate_metadata_never_substitutes_directory_label(tmp_path, document, expected):
+    """Missing/invalid source identity stays visible but cannot become a basename import."""
+    directory = tmp_path / "misleading-name"
+    directory.mkdir()
+    (directory / "init.json").write_text(document)
+    row = discovery._normalize({"agent_dir": str(directory), "display_name": "CLI Label",
+                                "status": "available"}, tmp_path)
+    assert row["agent_name"] == expected
+    assert row["description"] is None
+    assert row["profile_source"] == "lingtai"
+    assert row["display_name"] == "CLI Label"

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -157,7 +157,7 @@ def test_candidate_metadata_never_substitutes_directory_label(tmp_path, document
                                 "status": "available"}, tmp_path)
     assert row["agent_name"] == expected
     assert row["profile_read_error"] == error
-    assert row["profile_name_source"] == "init.json"
+    assert row["name_source_file"] == "init.json"
     assert row["import_display_name"] == (None if error else expected or "")
     assert row["description"] is None
     assert row["profile_source"] == "lingtai"
@@ -182,7 +182,7 @@ def test_existing_agent_metadata_is_exclusive_even_when_unnamed(tmp_path, source
                                 "status": "available"}, tmp_path)
     assert row["agent_name"] == expected
     assert row["profile_read_error"] == error
-    assert row["profile_name_source"] == ".agent.json"
+    assert row["name_source_file"] == ".agent.json"
     assert row["import_display_name"] == (None if error else expected or "")
 
 

--- a/tests/test_lingtai_discovery.py
+++ b/tests/test_lingtai_discovery.py
@@ -141,14 +141,14 @@ async def test_invalid_explicit_root_returns_actionable_error(monkeypatch, root)
     assert result["error"]
 
 
-@pytest.mark.parametrize("document, expected", [
-    ('{"manifest":{"agent_name":"Source Name"}}', "Source Name"),
-    ('{"manifest":{}}', None),
-    ('not json', None),
-    ('{"manifest":{"agent_name":""}}', None),
-    (' ' * (1024 * 1024 + 1), None),
+@pytest.mark.parametrize("document, expected, error", [
+    ('{"manifest":{"agent_name":"Source Name"}}', "Source Name", None),
+    ('{"manifest":{}}', None, None),
+    ('not json', None, "source_unreadable"),
+    ('{"manifest":{"agent_name":""}}', None, None),
+    (' ' * (1024 * 1024 + 1), None, "source_unreadable"),
 ], ids=['valid', 'missing', 'malformed', 'empty', 'oversize'])
-def test_candidate_metadata_never_substitutes_directory_label(tmp_path, document, expected):
+def test_candidate_metadata_never_substitutes_directory_label(tmp_path, document, expected, error):
     """Missing/invalid source identity stays visible but cannot become a basename import."""
     directory = tmp_path / "misleading-name"
     directory.mkdir()
@@ -156,6 +156,73 @@ def test_candidate_metadata_never_substitutes_directory_label(tmp_path, document
     row = discovery._normalize({"agent_dir": str(directory), "display_name": "CLI Label",
                                 "status": "available"}, tmp_path)
     assert row["agent_name"] == expected
+    assert row["profile_read_error"] == error
+    assert row["profile_name_source"] == "init.json"
+    assert row["import_display_name"] == (None if error else expected or "Unnamed Agent")
     assert row["description"] is None
     assert row["profile_source"] == "lingtai"
     assert row["display_name"] == "CLI Label"
+
+
+@pytest.mark.parametrize("source, expected, error", [
+    ('{"agent_name":"Current"}', "Current", None),
+    ('{"agent_name":null}', None, None),
+    ('{"agent_name":""}', None, None),
+    ('{}', None, None),
+    ('bad json', None, "source_unreadable"),
+    ('{"agent_name":42}', None, "source_unreadable"),
+    (' ' * (1024 * 1024 + 1), None, "source_unreadable"),
+], ids=['named', 'null', 'empty', 'missing-name', 'malformed', 'invalid-type', 'oversize'])
+def test_existing_agent_metadata_is_exclusive_even_when_unnamed(tmp_path, source, expected, error):
+    """Existing .agent.json must never silently fall back to stale init identity."""
+    (tmp_path / "init.json").write_text('{"manifest":{"agent_name":"Stale Init"}}')
+    (tmp_path / ".agent.json").write_text(source)
+    row = discovery._normalize({"agent_dir": str(tmp_path), "display_name": "Directory Label",
+                                "status": "available"}, tmp_path)
+    assert row["agent_name"] == expected
+    assert row["profile_read_error"] == error
+    assert row["profile_name_source"] == ".agent.json"
+    assert row["import_display_name"] == (None if error else expected or "Unnamed Agent")
+
+
+def test_agent_metadata_permission_error_is_not_absence(tmp_path, monkeypatch):
+    """Unreadable current metadata cannot be replaced with a stale readable init name."""
+    from puffo_agent.portal.control import lingtai_profile
+
+    (tmp_path / "init.json").write_text('{"manifest":{"agent_name":"Stale Init"}}')
+    original_open = lingtai_profile.os.open
+    def deny_source(path, flags):
+        if path.name == ".agent.json":
+            raise PermissionError("blocked")
+        return original_open(path, flags)
+    monkeypatch.setattr(lingtai_profile.os, "open", deny_source)
+    row = discovery._normalize({"agent_dir": str(tmp_path), "display_name": "Label",
+                                "status": "available"}, tmp_path)
+    assert row["agent_name"] is None
+    assert row["profile_read_error"] == "source_unreadable"
+    assert row["import_display_name"] is None
+
+
+def test_agent_metadata_symlink_is_not_a_fallback(tmp_path):
+    """Unsafe source indirection must not import a different identity or use init fallback."""
+    (tmp_path / "init.json").write_text('{"manifest":{"agent_name":"Stale Init"}}')
+    (tmp_path / ".agent.json").symlink_to(tmp_path / "missing")
+    row = discovery._normalize({"agent_dir": str(tmp_path), "display_name": "Label",
+                                "status": "available"}, tmp_path)
+    assert row["profile_read_error"] == "source_unreadable"
+    assert row["import_display_name"] is None
+
+
+@pytest.mark.parametrize("primary_present", [False, True])
+def test_corrupt_marker_prevents_only_absent_primary_fallback(tmp_path, primary_present):
+    """LingTai quarantine must not turn a corrupt source into a stale init import."""
+    (tmp_path / "init.json").write_text('{"manifest":{"agent_name":"Stale Init"}}')
+    (tmp_path / ".agent.json.corrupt").write_text("corrupt previous metadata")
+    if primary_present:
+        (tmp_path / ".agent.json").write_text('{"agent_name":"Recovered"}')
+    row = discovery._normalize({"agent_dir": str(tmp_path), "display_name": "Label",
+                                "status": "available", "workspace": None}, tmp_path)
+    assert row["workspace"] == str(tmp_path)
+    assert row["agent_name"] == ("Recovered" if primary_present else None)
+    assert row["profile_read_error"] == (None if primary_present else "source_unreadable")
+    assert row["import_display_name"] == ("Recovered" if primary_present else None)

--- a/tests/test_ui_context_threshold.py
+++ b/tests/test_ui_context_threshold.py
@@ -343,3 +343,24 @@ def test_save_rejects_oversized_utf8_fields(
 
     assert warnings
     assert message in warnings[0][-1]
+
+
+def test_lingtai_editor_cannot_persist_a_ghost_name(qapp, agent_home, monkeypatch):
+    """Desktop UI and its save handler both reject source-owned profile edits."""
+    cfg = AgentConfig.load("threshold-ui")
+    cfg.runtime.harness = "acp"
+    cfg.runtime.harness_command = ["/bin/lingtai-agent", "acp", "--profile", "puffo-v1"]
+    cfg.save()
+    view = agent_detail.AgentDetail()
+    view.bind(cfg.id)
+    assert view._display_name.isReadOnly()
+    assert view._role.isReadOnly()
+    assert view._soul.isReadOnly()
+    view._display_name.setText("Ghost")
+    view._check_dirty()
+    assert not view._save_btn.isEnabled()
+    warnings = []
+    monkeypatch.setattr(agent_detail.QMessageBox, "warning", lambda *args: warnings.append(args))
+    view._on_save()
+    assert warnings
+    assert AgentConfig.load(cfg.id).display_name == cfg.display_name


### PR DESCRIPTION
Import existing LingTai Agents using authoritative source names, then keep those names synchronized while the connected Puffo daemon runs. Ordinary Puffo creation remains separate.

Discovery and manual validation reject corrupt/quarantined source metadata and preserve unnamed profiles. Executable-folder discovery is bounded and does not execute search candidates. A daemon-owned publisher checks active bindings after each 30-second interval, sends only display_name, retries failed updates, and never writes LingTai source files. Runtime synchronization uses the current .agent.json only: missing or corrupt files and missing name fields preserve the last published name; explicit null clears it. Import discovery retains its init.json fallback compatibility.

Imported profiles remain source-managed. Control edits reject changes; CLI rename/profile and Qt editing now also refuse them before writing. Startup/warm snapshot sync skips LingTai to avoid restoring stale names. The acceptance document lists each entry point, evidence, and remaining integration checks: docs/engineering/lingtai-name-sync-acceptance.md.

Validation: relevant tests and Python structure checks pass, and the full daemon suite exits successfully with inherited CODEX_HOME removed (two environment-specific skips). Qt controls were tested directly for read-only fields, disabled Save, and handler rejection. Prior named/unnamed imports completed two real model/tool/result/reply turns. Live owner and non-owner chat and profile pages automatically receive ordinary name updates; server-null clear/restore passed on both accounts, with explicit null in both raw caches. Requires puffo-ai/puffo-server#370 for explicit name clearing. No merge or deployment.


Rollout requirement: deploy server PR #370 before this daemon change. Older servers silently ignore display_name:null while reporting success, which would let the daemon incorrectly cache a completed clear. See docs/engineering/lingtai-name-sync-acceptance.md. Boris reran the combined server 18d3538 lib suite: 1429 passed, 0 failed, 3 ignored.

CI: all checks passed on c02d080e (pre-commit and Python 3.11/3.12 test suites).
