### PR TITLE
fix: ignore completed Claude assistant replays

### DIFF
--- a/src/puffo_agent/agent/harness/drivers/claude_code.py
+++ b/src/puffo_agent/agent/harness/drivers/claude_code.py
@@ -136,6 +136,10 @@ class ClaudeCodeCliDriver(Driver):
         self._message_lifecycle_v1 = False
         self._owned_commands: set[str] = set()
         self._terminal_commands: set[str] = set()
+        self._active_assistant_ids: set[tuple[str, str]] = set()
+        # Keep completed identities across process reopen/resume. UUIDs are
+        # scoped to the native session, not to a local driver turn reference.
+        self._completed_assistant_ids: set[tuple[str, str]] = set()
         self._gated_command_id = ""
         self._gated_ack: asyncio.Future[_InputAckOutcome] | None = None
         self._result_input_tokens = 0
@@ -552,6 +556,7 @@ class ClaudeCodeCliDriver(Driver):
         self._pending_uuid = ""
 
     def _reset_turn_tracking(self, primary_command_id: str = "") -> None:
+        self._active_assistant_ids.clear()
         self._settle_gated_ack(_InputAckOutcome.REJECTED)
         self._gated_command_id = ""
         self._active_provider_error = None
@@ -781,6 +786,12 @@ class ClaudeCodeCliDriver(Driver):
         )
 
     async def _handle_assistant(self, frame: dict[str, Any]) -> None:
+        frame_uuid = str(frame.get("uuid") or "")
+        if frame_uuid:
+            identity = (self._native_session_id, frame_uuid)
+            if identity in self._completed_assistant_ids:
+                return
+            self._active_assistant_ids.add(identity)
         if not self._active.value:
             # No daemon-started turn is open, yet the CLI is producing
             # assistant output: a background task woke the model after the
@@ -953,6 +964,7 @@ class ClaudeCodeCliDriver(Driver):
         await self._finish_turn(self._last_result_payload or native_payload)
 
     async def _finish_turn(self, native_payload: dict[str, Any]) -> None:
+        self._completed_assistant_ids.update(self._active_assistant_ids)
         outcome = "failed" if self._result_error_code else "succeeded"
         data: dict[str, Any] = {
             "outcome": outcome,

--- a/tests/test_claude_autonomous_driver.py
+++ b/tests/test_claude_autonomous_driver.py
@@ -68,3 +68,59 @@ async def test_daemon_turn_is_refused_while_an_autonomous_run_is_active():
 
 async def _noop_write(frame):
     del frame
+
+
+@pytest.mark.parametrize("lifecycle", [False, True])
+@pytest.mark.asyncio
+async def test_completed_daemon_assistant_ids_do_not_leak_into_successor(lifecycle):
+    """All completed-turn frame IDs, not just its first ID, are stale."""
+    driver = ClaudeCodeCliDriver()
+    driver._native_session_id = "native"
+    driver._session_ref = SessionRef("native")
+    driver._message_lifecycle_v1 = lifecycle
+    driver._write = _noop_write
+    await driver.start_turn(TurnInput("first", client_correlation_id="command"))
+    frames = [
+        {"type": "assistant", "uuid": identity,
+         "message": {"content": [{"type": "text", "text": identity}]}}
+        for identity in ("first-output", "last-output")
+    ]
+    for frame in frames:
+        await driver._handle(frame)
+    await driver._handle({
+        "type": "result", "subtype": "success", "user_message_uuid": "command",
+    })
+    if lifecycle:
+        await driver._handle({
+            "type": "command_lifecycle", "command_uuid": "command", "state": "completed",
+        })
+    assert not driver._active.value
+    await driver.start_turn(TurnInput("second", client_correlation_id="next-command"))
+    successor = driver._active
+    while not driver._events.empty():
+        driver._events.get_nowait()
+    for frame in frames:
+        await driver._handle(frame)
+    assert driver._events.empty()
+    assert driver._active == successor
+    await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_completed_assistant_identity_is_scoped_to_native_session():
+    """Reopening the same session retains dedup; a new session may reuse IDs."""
+    driver = ClaudeCodeCliDriver()
+    driver._native_session_id = "original"
+    driver._session_ref = SessionRef("original")
+    frame = {"type": "assistant", "uuid": "same-id", "message": {"content": []}}
+    await driver._handle(frame)
+    await driver._handle({"type": "result", "subtype": "success"})
+    await driver.close()
+    driver._prepare_reopen()
+    await driver._handle(frame)
+    assert not driver._active.value
+    driver._native_session_id = "different"
+    driver._session_ref = SessionRef("different")
+    await driver._handle(frame)
+    assert driver._active.value
+    await driver.close()

--- a/tests/test_claude_runtime_recovery.py
+++ b/tests/test_claude_runtime_recovery.py
@@ -67,3 +67,60 @@ async def test_invalid_resume_result_has_stable_error_code(is_error):
 
     completed = await driver._events.get()
     assert completed.data["error_code"] == "invalid_resume"
+
+
+@pytest.mark.asyncio
+async def test_completed_assistant_replay_cannot_arm_watchdog(monkeypatch, tmp_path):
+    """Replaying a completed raw frame must not quarantine an idle session."""
+    import asyncio
+
+    from test_runtime_manager_failures import _ControllableDriver
+    from puffo_agent.agent.turn_recovery import read_recovery
+
+    loop = asyncio.get_running_loop()
+    now = [loop.time()]
+    monkeypatch.setattr(loop, "time", lambda: now[0])
+    decoder = ClaudeCodeCliDriver()
+    decoder._session_ref = SessionRef("native-session")
+    decoder._native_session_id = "native-session"
+    manager = RuntimeManager(
+        _ControllableDriver(), RuntimeSpec(str(tmp_path), task_timeout_seconds=5),
+        native_session_id="native-session",
+    )
+    reported = []
+
+    async def callback(event):
+        reported.append(event)
+
+    manager.autonomous_callback = callback
+
+    async def feed(frame):
+        await decoder._handle(frame)
+        while not decoder._events.empty():
+            await manager._consume_event_locked(decoder._events.get_nowait())
+
+    assistant = {
+        "type": "assistant", "uuid": "completed-assistant",
+        "message": {"content": [{"type": "text", "text": "done"}]},
+    }
+    result = {"type": "result", "subtype": "success", "is_error": False}
+    try:
+        await feed(assistant)
+        await feed(result)
+        completed_events = len(reported)
+        await feed(assistant)
+        await asyncio.sleep(0)
+        now[0] += 6
+        for _ in range(12):
+            await asyncio.sleep(0)
+        assert manager.driver.close_calls == 0
+        assert read_recovery(str(tmp_path)) is None
+        assert manager.active_turn_ref is None
+        assert len(reported) == completed_events
+        # Genuine background work must still be adopted and completed.
+        await feed({**assistant, "uuid": "new-assistant"})
+        assert manager.active_turn_ref is not None
+        await feed(result)
+        assert manager.active_turn_ref is None
+    finally:
+        await manager.close()


### PR DESCRIPTION
Fix completed assistant replay arming a false autonomous watchdog. Session-scoped completed identities survive process reopen; genuine successors remain accepted. Independently reviewed by Jeff: 74 focused tests passed, full suite 4360 passed / 2 skipped, original raw-frame reproduction no longer closes provider or creates recovery. Cache is Driver-lifetime only, not persistent across daemon replacement. Native Windows and Docker end-to-end acceptance remain outstanding. TestPyPI 2.0.5a1 does not include this fix.