### PR TITLE
chore: prepare 2.0.5a2 test release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.5a1"
+version = "2.0.5a2"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.5a1"
+version = "2.0.5a2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Version-only update from 2.0.5a1 to 2.0.5a2 in pyproject.toml and uv.lock, based on merged replay fix #355. uv lock --check and wheel/sdist build passed. Intended for TestPyPI only; no production release. Independent review in progress.