### PR TITLE
fix: bound OpenCode discovery and safely reclaim temporary files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # *same* env without colliding. CLI binary stays `puffo-agent`; home
 # dir stays `~/.puffo-agent/`.
 name = "puffo-agent"
-version = "2.0.5a2"
+version = "2.0.5a3"
 description = "Run AI bots on Puffo.ai — local daemon that supervises many bot accounts and handles their LLM loops."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/puffo_agent/agent/cli_bin.py
+++ b/src/puffo_agent/agent/cli_bin.py
@@ -164,9 +164,9 @@ def opencode_has_accessible_models() -> bool:
     executable = resolve_opencode_bin()
     if not executable:
         return False
-    from .opencode_auth import list_opencode_models
+    from .opencode_auth import discover_opencode_models
 
-    return bool(list_opencode_models(executable))
+    return bool(discover_opencode_models(executable))
 
 
 def _resolve(name: str, env_var: str, bundle_paths: list[Path]) -> str | None:

--- a/src/puffo_agent/agent/harness/drivers/opencode.py
+++ b/src/puffo_agent/agent/harness/drivers/opencode.py
@@ -219,7 +219,7 @@ class OpenCodeDriver(Driver):
         self._resumed = False
         self._session_announced = False
         self._proc: Any = None
-        self._turn_temp: tempfile.TemporaryDirectory | None = None
+        self._temporary_children: dict[str, Any] = {}
         self._active = TurnRef("")
         self._active_native_turn_id = ""
         self._turn_generation = 0
@@ -327,34 +327,41 @@ class OpenCodeDriver(Driver):
         )
 
     async def _spawn(self, spec: RuntimeSpec, prompt: str) -> Any:
-        self._turn_temp = tempfile.TemporaryDirectory(prefix="puffo-opencode-turn-")
+        scratch = self._new_child_temp("puffo-opencode-turn-")
         spec = dataclasses.replace(spec, environment={
             **dict(spec.environment),
-            **{name: self._turn_temp.name for name in ("TMPDIR", "TMP", "TEMP")},
+            **{name: scratch for name in ("TMPDIR", "TMP", "TEMP")},
         })
-        command = build_opencode_run_command(
-            spec,
-            prompt=prompt,
-            native_session_id=self._native_session_id,
-        )
-        if self.process_factory is not None:
-            # One call with the declared signature. Retrying on TypeError
-            # could create a second child when the factory itself failed.
-            proc = self.process_factory(command, spec)
-            return await proc if asyncio.iscoroutine(proc) else proc
-        executable, *arguments = command
-        env = dict(spec.environment)
-        return await asyncio.create_subprocess_exec(
-            *normalize_launch_argv(executable),
-            *arguments,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=spec.workspace_dir or None,
-            env=env,
-            limit=16 * 1024 * 1024,
-            **process_group_spawn_kwargs(),
-        )
+        try:
+            command = build_opencode_run_command(
+                spec,
+                prompt=prompt,
+                native_session_id=self._native_session_id,
+            )
+            if self.process_factory is not None:
+                # One call with the declared signature. Retrying on TypeError
+                # could create a second child when the factory itself failed.
+                proc = self.process_factory(command, spec)
+                proc = await proc if asyncio.iscoroutine(proc) else proc
+                self._temporary_children[scratch] = proc
+                return proc
+            executable, *arguments = command
+            env = dict(spec.environment)
+            proc = await asyncio.create_subprocess_exec(
+                *normalize_launch_argv(executable),
+                *arguments,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=spec.workspace_dir or None,
+                env=env,
+                limit=16 * 1024 * 1024,
+                **process_group_spawn_kwargs(),
+            )
+            self._temporary_children[scratch] = proc
+            return proc
+        finally:
+            self._cleanup_child_temps(finished_spawn=scratch)
 
     async def steer_turn(self, turn: TurnRef, input: TurnInput):
         return UnsupportedCapability("steer")
@@ -399,7 +406,7 @@ class OpenCodeDriver(Driver):
         # a throwaway. Preserve HOME, config roots, and the workspace cwd:
         # custom providers/plugins and project opencode.json are part of the
         # real model registry and must remain visible.
-        scratch = tempfile.mkdtemp(prefix="oc-models-")
+        scratch = self._new_child_temp("oc-models-")
         try:
             try:
                 proc = await asyncio.create_subprocess_exec(
@@ -421,6 +428,7 @@ class OpenCodeDriver(Driver):
                     limit=16 * 1024 * 1024,
                     **process_group_spawn_kwargs(),
                 )
+                self._temporary_children[scratch] = proc
                 out, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
             except (OSError, asyncio.TimeoutError):
                 return
@@ -433,7 +441,7 @@ class OpenCodeDriver(Driver):
                         task_name="opencode.context_window.wait",
                     )
         finally:
-            shutil.rmtree(scratch, ignore_errors=True)
+            self._cleanup_child_temps(finished_spawn=scratch)
         self._context_window = _window_from_models_output(
             out.decode("utf-8", "replace"), model_id
         )
@@ -531,12 +539,15 @@ class OpenCodeDriver(Driver):
     async def _summarize_via_serve(
         self, spec: RuntimeSpec, native_session_id: str
     ) -> None:
-        with tempfile.TemporaryDirectory(prefix="puffo-opencode-serve-") as scratch:
+        scratch = self._new_child_temp("puffo-opencode-serve-")
+        try:
             spec = dataclasses.replace(spec, environment={
                 **dict(spec.environment),
                 **{name: scratch for name in ("TMPDIR", "TMP", "TEMP")},
             })
             await self._summarize_with_environment(spec, native_session_id)
+        finally:
+            self._cleanup_child_temps(finished_spawn=scratch)
 
     async def _summarize_with_environment(
         self, spec: RuntimeSpec, native_session_id: str
@@ -566,6 +577,7 @@ class OpenCodeDriver(Driver):
             limit=16 * 1024 * 1024,
             **process_group_spawn_kwargs(),
         )
+        self._temporary_children[spec.environment["TMPDIR"]] = proc
         self._serve_proc = proc
         try:
             base_url = await asyncio.wait_for(
@@ -634,7 +646,7 @@ class OpenCodeDriver(Driver):
         return iterate()
 
     async def close(self) -> None:
-        if self._closed:
+        if self._closed and not self._temporary_children:
             return
         self._closed = True
         self._terminal_reason = "runtime_closed"
@@ -653,7 +665,7 @@ class OpenCodeDriver(Driver):
                 timeout=CLEANUP_TIMEOUT_SECONDS,
             )
             self._stderr_reader = None
-        self._cleanup_turn_temp()
+        self._cleanup_child_temps()
         self._proc = None
         self._active = TurnRef("")
         self._active_native_turn_id = ""
@@ -667,21 +679,21 @@ class OpenCodeDriver(Driver):
                 timeout=CLEANUP_TIMEOUT_SECONDS,
             )
             self._compact_task = None
-        serve = self._serve_proc
-        if serve is not None:
-            # Cancellation unwound _summarize_via_serve before its own
-            # cleanup ran; take the whole serve tree down here.
-            await collect_cleanup_errors(
-                shutdown_process_tree(
-                    serve,
-                    waiter=None,
-                    timeout=_SHUTDOWN_GRACE_SECONDS,
-                    task_name="opencode.serve.close_wait",
-                ),
-                errors,
-                timeout=CLEANUP_TIMEOUT_SECONDS,
-            )
-            self._serve_proc = None
+        # Failed or cancelled shutdowns retain both child and directory.
+        for child in tuple(self._temporary_children.values()):
+            if child is not None and child.returncode is None:
+                await collect_cleanup_errors(
+                    shutdown_process_tree(
+                        child,
+                        waiter=None,
+                        timeout=_SHUTDOWN_GRACE_SECONDS,
+                        task_name="opencode.retained.close_wait",
+                    ),
+                    errors,
+                    timeout=CLEANUP_TIMEOUT_SECONDS,
+                )
+        self._cleanup_child_temps()
+        self._serve_proc = None
         self._spec = None
         self._context = ContextStatus(stale=True)
         # A reopened driver may carry a different model; the old window
@@ -896,7 +908,7 @@ class OpenCodeDriver(Driver):
                     native_turn_id=self._active_native_turn_id,
                     data=data,
                 )
-        self._cleanup_turn_temp()
+        self._cleanup_child_temps()
         self._proc = None
         self._active = TurnRef("")
         self._active_native_turn_id = ""
@@ -915,20 +927,31 @@ class OpenCodeDriver(Driver):
                 await self._settle_turn_task(proc)
         finally:
             if generation == self._turn_generation:
-                self._cleanup_turn_temp()
+                self._cleanup_child_temps()
                 self._proc = None
                 self._active = TurnRef("")
                 self._active_native_turn_id = ""
                 self._accepted = None
                 self._turn_task = None
 
-    def _cleanup_turn_temp(self) -> None:
-        # Never remove files from underneath a child that failed to stop.
-        if self._proc is not None and self._proc.returncode is None:
-            return
-        if self._turn_temp is not None:
-            self._turn_temp.cleanup()
-            self._turn_temp = None
+    def _new_child_temp(self, prefix: str) -> str:
+        self._cleanup_child_temps()
+        if self._temporary_children:
+            raise RuntimeError("previous OpenCode child is still running; close must retry shutdown")
+        # Explicit ownership: a GC finalizer must never delete a live child's
+        # files after an interrupted shutdown or replacement Driver.
+        scratch = tempfile.mkdtemp(prefix=prefix)
+        self._temporary_children[scratch] = None
+        return scratch
+
+    def _cleanup_child_temps(self, *, finished_spawn: str = "") -> None:
+        for scratch, child in tuple(self._temporary_children.items()):
+            if child is None and scratch != finished_spawn:
+                continue
+            if child is not None and child.returncode is None:
+                continue
+            shutil.rmtree(scratch)
+            del self._temporary_children[scratch]
 
     async def _settle_turn_task(self, proc: Any) -> None:
         task = self._turn_task

--- a/src/puffo_agent/agent/harness/drivers/opencode.py
+++ b/src/puffo_agent/agent/harness/drivers/opencode.py
@@ -220,6 +220,7 @@ class OpenCodeDriver(Driver):
         self._session_announced = False
         self._proc: Any = None
         self._temporary_children: dict[str, Any] = {}
+        self._child_spawns: dict[str, asyncio.Future[Any]] = {}
         self._active = TurnRef("")
         self._active_native_turn_id = ""
         self._turn_generation = 0
@@ -342,12 +343,13 @@ class OpenCodeDriver(Driver):
                 # One call with the declared signature. Retrying on TypeError
                 # could create a second child when the factory itself failed.
                 proc = self.process_factory(command, spec)
-                proc = await proc if asyncio.iscoroutine(proc) else proc
+                proc = (await self._await_child_spawn(scratch, proc)
+                        if asyncio.iscoroutine(proc) else proc)
                 self._temporary_children[scratch] = proc
                 return proc
             executable, *arguments = command
             env = dict(spec.environment)
-            proc = await asyncio.create_subprocess_exec(
+            proc = await self._await_child_spawn(scratch, asyncio.create_subprocess_exec(
                 *normalize_launch_argv(executable),
                 *arguments,
                 stdin=asyncio.subprocess.DEVNULL,
@@ -357,7 +359,7 @@ class OpenCodeDriver(Driver):
                 env=env,
                 limit=16 * 1024 * 1024,
                 **process_group_spawn_kwargs(),
-            )
+            ))
             self._temporary_children[scratch] = proc
             return proc
         finally:
@@ -409,7 +411,7 @@ class OpenCodeDriver(Driver):
         scratch = self._new_child_temp("oc-models-")
         try:
             try:
-                proc = await asyncio.create_subprocess_exec(
+                proc = await self._await_child_spawn(scratch, asyncio.create_subprocess_exec(
                     *normalize_launch_argv(spec.executable),
                     "models",
                     provider,
@@ -427,7 +429,7 @@ class OpenCodeDriver(Driver):
                     stderr=asyncio.subprocess.PIPE,
                     limit=16 * 1024 * 1024,
                     **process_group_spawn_kwargs(),
-                )
+                ))
                 self._temporary_children[scratch] = proc
                 out, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
             except (OSError, asyncio.TimeoutError):
@@ -562,7 +564,8 @@ class OpenCodeDriver(Driver):
         import aiohttp
 
         password = uuid.uuid4().hex
-        proc = await asyncio.create_subprocess_exec(
+        scratch = spec.environment["TMPDIR"]
+        proc = await self._await_child_spawn(scratch, asyncio.create_subprocess_exec(
             *normalize_launch_argv(spec.executable),
             "serve",
             "--hostname",
@@ -576,7 +579,7 @@ class OpenCodeDriver(Driver):
             stderr=asyncio.subprocess.PIPE,
             limit=16 * 1024 * 1024,
             **process_group_spawn_kwargs(),
-        )
+        ))
         self._temporary_children[spec.environment["TMPDIR"]] = proc
         self._serve_proc = proc
         try:
@@ -679,6 +682,12 @@ class OpenCodeDriver(Driver):
                 timeout=CLEANUP_TIMEOUT_SECONDS,
             )
             self._compact_task = None
+        # Waiting on a shield keeps repeated close cancellation from reaching
+        # subprocess transport initialization. A later close can retry.
+        for task in tuple(self._child_spawns.values()):
+            await collect_cleanup_errors(
+                asyncio.shield(task), errors, timeout=CLEANUP_TIMEOUT_SECONDS,
+            )
         # Failed or cancelled shutdowns retain both child and directory.
         for child in tuple(self._temporary_children.values()):
             if child is not None and child.returncode is None:
@@ -934,6 +943,40 @@ class OpenCodeDriver(Driver):
                 self._accepted = None
                 self._turn_task = None
 
+    async def _await_child_spawn(self, scratch: str, pending: Any) -> Any:
+        async def register():
+            try:
+                child = await pending
+            except (FileNotFoundError, PermissionError) as exc:
+                # OS exec/chdir refusal identifies the failed path and leaves
+                # no running child. Other initialization errors can come from
+                # failed transport cleanup: keep their directory and error.
+                if exc.filename is not None:
+                    self._child_spawns.pop(scratch, None)
+                    self._cleanup_child_temps(finished_spawn=scratch)
+                raise
+            self._temporary_children[scratch] = child
+            return child
+
+        task = spawn(register(), name="opencode.spawn")
+        self._child_spawns[scratch] = task
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            # If the handle already arrived, stop it here. Otherwise close
+            # will await the retained task and take ownership of its result.
+            errors: list[BaseException] = [exc]
+            child = self._temporary_children.get(scratch)
+            if child is not None:
+                await collect_cleanup_errors(
+                    shutdown_process_tree(
+                        child, waiter=None, timeout=_SHUTDOWN_GRACE_SECONDS,
+                        task_name="opencode.cancelled_spawn.wait",
+                    ),
+                    errors, timeout=CLEANUP_TIMEOUT_SECONDS,
+                )
+            raise_collected_errors("OpenCode spawn cancellation cleanup failed", errors)
+
     def _new_child_temp(self, prefix: str) -> str:
         self._cleanup_child_temps()
         if self._temporary_children:
@@ -946,12 +989,13 @@ class OpenCodeDriver(Driver):
 
     def _cleanup_child_temps(self, *, finished_spawn: str = "") -> None:
         for scratch, child in tuple(self._temporary_children.items()):
-            if child is None and scratch != finished_spawn:
+            if child is None and (scratch != finished_spawn or scratch in self._child_spawns):
                 continue
             if child is not None and child.returncode is None:
                 continue
             shutil.rmtree(scratch)
             del self._temporary_children[scratch]
+            self._child_spawns.pop(scratch, None)
 
     async def _settle_turn_task(self, proc: Any) -> None:
         task = self._turn_task

--- a/src/puffo_agent/agent/harness/drivers/opencode.py
+++ b/src/puffo_agent/agent/harness/drivers/opencode.py
@@ -219,6 +219,7 @@ class OpenCodeDriver(Driver):
         self._resumed = False
         self._session_announced = False
         self._proc: Any = None
+        self._turn_temp: tempfile.TemporaryDirectory | None = None
         self._active = TurnRef("")
         self._active_native_turn_id = ""
         self._turn_generation = 0
@@ -326,6 +327,11 @@ class OpenCodeDriver(Driver):
         )
 
     async def _spawn(self, spec: RuntimeSpec, prompt: str) -> Any:
+        self._turn_temp = tempfile.TemporaryDirectory(prefix="puffo-opencode-turn-")
+        spec = dataclasses.replace(spec, environment={
+            **dict(spec.environment),
+            **{name: self._turn_temp.name for name in ("TMPDIR", "TMP", "TEMP")},
+        })
         command = build_opencode_run_command(
             spec,
             prompt=prompt,
@@ -403,6 +409,7 @@ class OpenCodeDriver(Driver):
                     "--verbose",
                     env={
                         **dict(spec.environment),
+                        **{name: scratch for name in ("TMPDIR", "TMP", "TEMP")},
                         "XDG_DATA_HOME": f"{scratch}/xdg-data",
                         "APPDATA": f"{scratch}/appdata",
                         "LOCALAPPDATA": f"{scratch}/localappdata",
@@ -524,6 +531,16 @@ class OpenCodeDriver(Driver):
     async def _summarize_via_serve(
         self, spec: RuntimeSpec, native_session_id: str
     ) -> None:
+        with tempfile.TemporaryDirectory(prefix="puffo-opencode-serve-") as scratch:
+            spec = dataclasses.replace(spec, environment={
+                **dict(spec.environment),
+                **{name: scratch for name in ("TMPDIR", "TMP", "TEMP")},
+            })
+            await self._summarize_with_environment(spec, native_session_id)
+
+    async def _summarize_with_environment(
+        self, spec: RuntimeSpec, native_session_id: str
+    ) -> None:
         """Run one summarize against a transient loopback server.
 
         The server shares the per-turn children's storage (same env, same
@@ -636,6 +653,7 @@ class OpenCodeDriver(Driver):
                 timeout=CLEANUP_TIMEOUT_SECONDS,
             )
             self._stderr_reader = None
+        self._cleanup_turn_temp()
         self._proc = None
         self._active = TurnRef("")
         self._active_native_turn_id = ""
@@ -878,6 +896,7 @@ class OpenCodeDriver(Driver):
                     native_turn_id=self._active_native_turn_id,
                     data=data,
                 )
+        self._cleanup_turn_temp()
         self._proc = None
         self._active = TurnRef("")
         self._active_native_turn_id = ""
@@ -896,11 +915,20 @@ class OpenCodeDriver(Driver):
                 await self._settle_turn_task(proc)
         finally:
             if generation == self._turn_generation:
+                self._cleanup_turn_temp()
                 self._proc = None
                 self._active = TurnRef("")
                 self._active_native_turn_id = ""
                 self._accepted = None
                 self._turn_task = None
+
+    def _cleanup_turn_temp(self) -> None:
+        # Never remove files from underneath a child that failed to stop.
+        if self._proc is not None and self._proc.returncode is None:
+            return
+        if self._turn_temp is not None:
+            self._turn_temp.cleanup()
+            self._turn_temp = None
 
     async def _settle_turn_task(self, proc: Any) -> None:
         task = self._turn_task

--- a/src/puffo_agent/agent/harness/drivers/opencode_protocol.py
+++ b/src/puffo_agent/agent/harness/drivers/opencode_protocol.py
@@ -33,8 +33,6 @@ def build_opencode_run_command(
         command.extend(("--model", spec.model))
     if native_session_id:
         command.extend(("--session", native_session_id))
-    if spec.permission_mode == "bypassPermissions":
-        command.append("--auto")
     command.extend(spec.launch_args)
     command.append(prompt)
     return tuple(command)

--- a/src/puffo_agent/agent/harness/runtime/local_runtime.py
+++ b/src/puffo_agent/agent/harness/runtime/local_runtime.py
@@ -421,6 +421,13 @@ class LocalRuntimePreparer:
         mcp_servers = self._project_protocol_mcp(
             controlled, opencode_config, tuple(launch_args)
         )
+        if (
+            self.harness_name == "opencode"
+            and self.agent_cfg.runtime.permission_mode == "bypassPermissions"
+        ):
+            # Use native config only for the explicitly selected mode, not the
+            # legacy normalizer's fallback for unsupported permission modes.
+            opencode_config["permission"] = "allow"
         if opencode_config:
             controlled["OPENCODE_CONFIG_CONTENT"] = json.dumps(
                 opencode_config

--- a/src/puffo_agent/agent/model_catalog.py
+++ b/src/puffo_agent/agent/model_catalog.py
@@ -472,13 +472,13 @@ def _opencode_models(*, fetch: bool) -> tuple[ModelOption, ...]:
     if cached is not None or not fetch:
         return cached if cached is not None else _stale_models("opencode")
     from .cli_bin import resolve_opencode_bin
-    from .opencode_auth import OpenCodeProbeError, list_opencode_model_catalog
+    from .opencode_auth import OpenCodeProbeError, discover_opencode_models
 
     executable = resolve_opencode_bin()
     if not executable:
         return _store_models("opencode", ())
     try:
-        models = list_opencode_model_catalog(executable)
+        models = discover_opencode_models(executable)
     except OpenCodeProbeError:
         return _stale_models("opencode")
     from ..mcp.config import OPENCODE_INFERENCE_LEVELS

--- a/src/puffo_agent/agent/opencode_auth.py
+++ b/src/puffo_agent/agent/opencode_auth.py
@@ -11,9 +11,14 @@ runtime can actually launch.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
+import tempfile
+import threading
+import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 from .._proc import no_window_kwargs
@@ -55,15 +60,22 @@ def _run_opencode_models(
     if verbose:
         command.append("--verbose")
     try:
-        completed = subprocess.run(
-            command,
-            check=False,
-            capture_output=True,
-            text=True,
-            env=build_child_environment(),
-            timeout=timeout_seconds,
-            **no_window_kwargs(),
-        )
+        # OpenCode extracts native libraries on every process start. Own only
+        # this invocation's temp files; subprocess.run kills/waits on timeout
+        # before TemporaryDirectory removes them.
+        with tempfile.TemporaryDirectory(prefix="puffo-opencode-probe-") as scratch:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **build_child_environment(),
+                    **{name: scratch for name in ("TMPDIR", "TMP", "TEMP")},
+                },
+                timeout=timeout_seconds,
+                **no_window_kwargs(),
+            )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise OpenCodeProbeError("OpenCode model check could not complete") from exc
 
@@ -201,3 +213,64 @@ def opencode_model_status(executable: str, model: str) -> OpenCodeModelStatus:
 def opencode_model_is_available(executable: str, model: str) -> bool:
     """Compatibility bool view of :func:`opencode_model_status`."""
     return opencode_model_status(executable, model) == "ready"
+
+
+@dataclass(frozen=True)
+class _Discovery:
+    expires: float
+    models: tuple[OpenCodeModel, ...] = ()
+    error: str = ""
+    files: tuple = ()
+
+
+_discovery_lock = threading.Lock()
+_discovery_cache: dict[tuple, _Discovery] = {}
+
+
+def _discovery_files(environment: dict[str, str], executable: str) -> tuple:
+    """Notice native login/logout and ordinary config edits without reading secrets."""
+    home = Path(environment.get("HOME") or environment.get("USERPROFILE") or Path.home())
+    data = Path(environment.get("XDG_DATA_HOME") or home / ".local/share")
+    config = Path(environment.get("XDG_CONFIG_HOME") or home / ".config")
+    paths = [Path(executable), data / "opencode/auth.json"]
+    for root in (config / "opencode", *Path.cwd().parents, Path.cwd()):
+        paths.extend(root / name for name in ("opencode.json", "opencode.jsonc"))
+    stamps = []
+    for path in paths:
+        try:
+            stat = path.stat()
+            stamp = (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size, stat.st_ino)
+        except OSError:
+            stamp = None
+        stamps.append((str(path), stamp))
+    return tuple(stamps)
+
+
+def discover_opencode_models(executable: str) -> tuple[OpenCodeModel, ...]:
+    """Bound expensive advisory discovery; admission probes remain uncached.
+
+    Readiness and the picker share a result for five minutes. Failed discovery
+    retries after 30 seconds. Environment/cwd changes select a separate view;
+    native auth/config edits invalidate the view. Admission always probes live.
+    """
+    environment = build_child_environment()
+    key = (executable, os.getcwd(), tuple(sorted(environment.items())))
+    files = _discovery_files(environment, executable)
+    # ponytail: serialize these short probes, including cache misses, so a
+    # heartbeat and UI refresh cannot launch duplicate CLI processes.
+    with _discovery_lock:
+        now = time.monotonic()
+        cached = _discovery_cache.get(key)
+        if cached is None or cached.expires <= now or cached.files != files:
+            try:
+                models = list_opencode_model_catalog(executable)
+                cached = _Discovery(time.monotonic() + 300, models, files=files)
+            except OpenCodeProbeError as exc:
+                cached = _Discovery(time.monotonic() + 30, error=str(exc), files=files)
+            # Bound retained environment views in a long-running daemon.
+            if key not in _discovery_cache and len(_discovery_cache) >= 16:
+                del _discovery_cache[next(iter(_discovery_cache))]
+            _discovery_cache[key] = cached
+        if cached.error:
+            raise OpenCodeProbeError(cached.error)
+        return cached.models

--- a/src/puffo_agent/agent/opencode_auth.py
+++ b/src/puffo_agent/agent/opencode_auth.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -232,8 +233,32 @@ def _discovery_files(environment: dict[str, str], executable: str) -> tuple:
     home = Path(environment.get("HOME") or environment.get("USERPROFILE") or Path.home())
     data = Path(environment.get("XDG_DATA_HOME") or home / ".local/share")
     config = Path(environment.get("XDG_CONFIG_HOME") or home / ".config")
-    paths = [Path(executable), data / "opencode/auth.json"]
-    for root in (config / "opencode", *Path.cwd().parents, Path.cwd()):
+    global_config = config / "opencode"
+    paths = [Path(executable), data / "opencode/auth.json",
+             global_config / "config.json", global_config / "config"]
+    roots = [global_config, Path(environment.get("OPENCODE_TEST_HOME") or home) / ".opencode"]
+    for root in (*Path.cwd().parents, Path.cwd()):
+        roots.extend((root, root / ".opencode"))
+    # Native v1.3.17 config/config.ts and config/paths.ts. Only forwarded
+    # child variables participate; parent-only overrides have no effect.
+    if environment.get("OPENCODE_CONFIG"):
+        paths.append(Path(environment["OPENCODE_CONFIG"]))
+    if environment.get("OPENCODE_CONFIG_DIR"):
+        roots.append(Path(environment["OPENCODE_CONFIG_DIR"]))
+    if sys.platform == "darwin":
+        import pwd
+
+        managed = Path("/Library/Application Support/opencode")
+        preferences = Path("/Library/Managed Preferences")
+        username = pwd.getpwuid(os.getuid()).pw_name
+        paths.extend(root / "ai.opencode.managed.plist"
+                     for root in (preferences, preferences / username))
+    elif sys.platform == "win32":
+        managed = Path(environment.get("ProgramData") or "C:\\ProgramData") / "opencode"
+    else:
+        managed = Path("/etc/opencode")
+    roots.append(Path(environment.get("OPENCODE_TEST_MANAGED_CONFIG_DIR") or managed))
+    for root in roots:
         paths.extend(root / name for name in ("opencode.json", "opencode.jsonc"))
     stamps = []
     for path in paths:
@@ -255,10 +280,10 @@ def discover_opencode_models(executable: str) -> tuple[OpenCodeModel, ...]:
     """
     environment = build_child_environment()
     key = (executable, os.getcwd(), tuple(sorted(environment.items())))
-    files = _discovery_files(environment, executable)
     # ponytail: serialize these short probes, including cache misses, so a
     # heartbeat and UI refresh cannot launch duplicate CLI processes.
     with _discovery_lock:
+        files = _discovery_files(environment, executable)
         now = time.monotonic()
         cached = _discovery_cache.get(key)
         if cached is None or cached.expires <= now or cached.files != files:

--- a/tests/test_local_runtime_migration.py
+++ b/tests/test_local_runtime_migration.py
@@ -375,14 +375,15 @@ async def test_pi_uses_shared_binary_resolver(puffo_home, monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("harness", "command"),
+    ("harness", "command", "permission_mode"),
     [
-        ("opencode", []),
-        ("acp", ["/opt/bin/opencode", "acp"]),
+        ("opencode", [], "bypassPermissions"),
+        ("opencode", [], "default"),
+        ("acp", ["/opt/bin/opencode", "acp"], "bypassPermissions"),
     ],
 )
 async def test_generic_runtime_projects_puffo_tools(
-    puffo_home, monkeypatch, harness, command,
+    puffo_home, monkeypatch, harness, command, permission_mode,
 ):
     import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
 
@@ -396,6 +397,7 @@ async def test_generic_runtime_projects_puffo_tools(
             provider="anthropic",
             harness=harness,
             harness_command=command,
+            permission_mode=permission_mode,
         ),
         puffo_core=PuffoCoreConfig(
             server_url="http://localhost:3000",
@@ -418,11 +420,16 @@ async def test_generic_runtime_projects_puffo_tools(
     instruction_path = Path(inline["instructions"][0])
     assert instruction_path.read_text(encoding="utf-8") == "managed prompt"
     if harness == "opencode":
+        if permission_mode == "bypassPermissions":
+            assert inline["permission"] == "allow"
+        else:
+            assert "permission" not in inline
         assert inline["mcp"]["puffo"]["command"] == [
             server.command,
             *server.args,
         ]
     else:
+        assert "permission" not in inline
         assert "mcp" not in inline
 
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -243,7 +243,7 @@ def test_opencode_catalog_uses_models_visible_to_native_cli(monkeypatch):
     from puffo_agent.agent.opencode_auth import OpenCodeModel
 
     monkeypatch.setattr(
-        "puffo_agent.agent.opencode_auth.list_opencode_model_catalog",
+        "puffo_agent.agent.opencode_auth.discover_opencode_models",
         lambda executable: (
             OpenCodeModel("opencode/big-pickle"),
             OpenCodeModel(
@@ -298,7 +298,7 @@ def test_opencode_catalog_drops_logged_out_provider_after_short_ttl(monkeypatch)
         (ModelOption("deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-pro"),),
     )
     monkeypatch.setattr(
-        "puffo_agent.agent.opencode_auth.list_opencode_model_catalog",
+        "puffo_agent.agent.opencode_auth.discover_opencode_models",
         lambda executable: (),
     )
     monkeypatch.setattr(

--- a/tests/test_opencode_auth.py
+++ b/tests/test_opencode_auth.py
@@ -223,3 +223,133 @@ def test_unexpected_native_failure_is_not_misreported_as_logged_out(monkeypatch)
 
     with pytest.raises(OpenCodeProbeError):
         list_opencode_models("/opt/bin/opencode", provider="deepseek")
+
+
+@pytest.mark.parametrize("outcome", ["success", "error", "timeout"])
+def test_probe_removes_its_temporary_files_without_touching_parent(
+    monkeypatch, tmp_path, outcome,
+):
+    """Every probe must reclaim CLI extraction files, including failed probes."""
+    from pathlib import Path
+    import tempfile
+
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    for name in ("TMPDIR", "TMP", "TEMP"):
+        monkeypatch.setenv(name, str(tmp_path))
+    sentinel = tmp_path / "unrelated.so"
+    sentinel.write_bytes(b"keep")
+    directories = []
+
+    def fake_run(command, **kwargs):
+        directory = Path(kwargs["env"]["TMPDIR"])
+        directories.append(directory)
+        (directory / "extracted.so").write_bytes(b"library")
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(command, 5)
+        return _completed(code=1 if outcome == "error" else 0, stdout="a/b\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    if outcome == "success":
+        assert list_opencode_models("opencode") == ("a/b",)
+    else:
+        with pytest.raises(OpenCodeProbeError):
+            list_opencode_models("opencode")
+    assert directories and all(not path.exists() for path in directories)
+    assert sentinel.read_bytes() == b"keep"
+    assert list(tmp_path.iterdir()) == [sentinel]
+
+
+def test_discovery_reuses_probe_but_preflight_stays_fresh(monkeypatch):
+    """Heartbeat readiness and picker must share one probe; admission is live."""
+    from puffo_agent.agent import cli_bin, model_catalog
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return _completed(code=0, stdout="a/b\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_bin, "resolve_opencode_bin", lambda: "/test/discovery")
+    monkeypatch.setattr(model_catalog, "_cache", {})
+    for _ in range(3):
+        assert cli_bin.opencode_has_accessible_models()
+        assert model_catalog.provider_models("opencode", fetch=True)[1].id == "a/b"
+    assert calls == [["/test/discovery", "models", "--verbose"]]
+    assert opencode_model_status("/test/discovery", "a/b") == "ready"
+    assert calls[-1] == ["/test/discovery", "models", "a"]
+    assert len(calls) == 2
+
+
+def test_discovery_refreshes_on_expiry_auth_edit_and_failure(monkeypatch, tmp_path):
+    """Long-lived discovery must see login changes and back off failed probes."""
+    from puffo_agent.agent import opencode_auth as auth
+
+    monkeypatch.setattr(auth, "_discovery_cache", {})
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    now = [0.0]
+    monkeypatch.setattr(auth.time, "monotonic", lambda: now[0])
+    calls = []
+    fail = [False]
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return _completed(code=2 if fail[0] else 0, stdout="a/b\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    auth.discover_opencode_models("test")
+    now[0] = 299
+    auth.discover_opencode_models("test")
+    assert len(calls) == 1
+    now[0] = 300
+    auth.discover_opencode_models("test")
+    assert len(calls) == 2
+    path = tmp_path / "opencode/auth.json"
+    path.parent.mkdir()
+    path.write_text("{}")
+    auth.discover_opencode_models("test")
+    assert len(calls) == 3
+    path.unlink()
+    fail[0] = True
+    now[0] = 301
+    for _ in range(3):
+        with pytest.raises(OpenCodeProbeError):
+            auth.discover_opencode_models("test")
+    assert len(calls) == 5  # verbose, then compatibility fallback, once
+    now[0] = 332
+    fail[0] = False
+    assert auth.discover_opencode_models("test") == (OpenCodeModel("a/b"),)
+    assert len(calls) == 6
+
+
+def test_simultaneous_discovery_shares_one_probe(monkeypatch):
+    """Concurrent UI/heartbeat refreshes cannot duplicate an expensive probe."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+    from puffo_agent.agent import opencode_auth as auth
+
+    monkeypatch.setattr(auth, "_discovery_cache", {})
+    entered = threading.Event()
+    release = threading.Event()
+    second_started = threading.Event()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        entered.set()
+        assert release.wait(5)
+        return _completed(code=0, stdout="a/b\n")
+
+    def second():
+        second_started.set()
+        return auth.discover_opencode_models("concurrent")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with ThreadPoolExecutor(2) as pool:
+        first = pool.submit(auth.discover_opencode_models, "concurrent")
+        assert entered.wait(5)
+        other = pool.submit(second)
+        assert second_started.wait(5)
+        release.set()
+        assert first.result() == other.result() == (OpenCodeModel("a/b"),)
+    assert len(calls) == 1

--- a/tests/test_opencode_auth.py
+++ b/tests/test_opencode_auth.py
@@ -353,3 +353,44 @@ def test_simultaneous_discovery_shares_one_probe(monkeypatch):
         release.set()
         assert first.result() == other.result() == (OpenCodeModel("a/b"),)
     assert len(calls) == 1
+
+
+@pytest.mark.parametrize("relative", [
+    "config/opencode/config.json", "config/opencode/config",
+    "config/opencode/opencode.jsonc", "project/.opencode/opencode.json",
+    "project/.opencode/opencode.jsonc", "home/.opencode/opencode.json",
+    "managed/opencode.json", "managed/opencode.jsonc", "custom.json",
+    "custom-dir/opencode.jsonc",
+])
+def test_discovery_invalidates_native_config_create_edit_delete(monkeypatch, tmp_path, relative):
+    """Native config edits must not leave readiness on the pre-edit model set."""
+    from puffo_agent.agent import opencode_auth as auth
+
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(auth, "_discovery_cache", {})
+    monkeypatch.setattr(auth, "build_child_environment", lambda: {
+        "HOME": str(tmp_path / "home"), "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        "XDG_DATA_HOME": str(tmp_path / "data"),
+        "OPENCODE_TEST_MANAGED_CONFIG_DIR": str(tmp_path / "managed"),
+        "OPENCODE_CONFIG": str(tmp_path / "custom.json"),
+        "OPENCODE_CONFIG_DIR": str(tmp_path / "custom-dir"),
+    })
+    path = tmp_path / relative
+    calls = []
+
+    def probe(command, **kwargs):
+        calls.append(command)
+        model = path.read_text() if path.exists() else "a/missing"
+        return _completed(code=0, stdout=model + "\n")
+
+    monkeypatch.setattr(subprocess, "run", probe)
+    assert auth.discover_opencode_models("test") == (OpenCodeModel("a/missing"),)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for value in ("a/created", "a/edited-longer"):
+        path.write_text(value)
+        assert auth.discover_opencode_models("test") == (OpenCodeModel(value),)
+    path.unlink()
+    assert auth.discover_opencode_models("test") == (OpenCodeModel("a/missing"),)
+    assert len(calls) == 4

--- a/tests/test_opencode_compaction.py
+++ b/tests/test_opencode_compaction.py
@@ -241,3 +241,34 @@ def test_summarize_requires_documented_true_acknowledgement():
         _require_summarize_ack(200, "okay")
     with pytest.raises(RuntimeError, match="unexpected acknowledgement"):
         _require_summarize_ack(200, "false")
+
+
+@pytest.mark.asyncio
+async def test_serve_cancellation_reaps_before_reclaiming_temp(monkeypatch, tmp_path):
+    """Cancelling compaction must reclaim the transient server's native files."""
+    from pathlib import Path
+
+    proc = _TurnProcess()
+    entered = asyncio.Event()
+    directories = []
+
+    async def spawn(*command, **kwargs):
+        directory = Path(kwargs["env"]["TMPDIR"])
+        directories.append(directory)
+        (directory / "native.so").write_bytes(b"library")
+        entered.set()
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+    driver = OpenCodeDriver()
+    task = asyncio.create_task(driver._summarize_via_serve(
+        RuntimeSpec(str(tmp_path), executable="opencode",
+                    environment={"TMPDIR": str(tmp_path)}), "session",
+    ))
+    await asyncio.wait_for(entered.wait(), 1)
+    assert (directories[0] / "native.so").exists()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proc.returncode is not None
+    assert all(not p.exists() for p in directories)

--- a/tests/test_opencode_context_status.py
+++ b/tests/test_opencode_context_status.py
@@ -176,3 +176,47 @@ def test_window_parser_matches_on_object_id_not_line_pairing():
     assert _window_from_models_output(_MODELS_OUTPUT, "absent-model") is None
     assert _window_from_models_output("not json at all { broken", "x") is None
     assert _window_from_models_output("", "x") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_registry_probe_cleans_temp_after_exit_or_cancel(monkeypatch, tmp_path, cancel):
+    """The separate context lookup must not leave native libraries in host TMP."""
+    from pathlib import Path
+
+    proc = _TurnProcess()
+    entered = asyncio.Event()
+    directories = []
+
+    async def communicate():
+        entered.set()
+        if cancel:
+            await asyncio.Event().wait()
+        proc.exit()
+        return _MODELS_OUTPUT.encode(), b""
+
+    proc.communicate = communicate
+
+    async def spawn(*command, **kwargs):
+        directory = Path(kwargs["env"]["TMPDIR"])
+        directories.append(directory)
+        (directory / "native.so").write_bytes(b"library")
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+    driver = OpenCodeDriver()
+    task = asyncio.create_task(driver.open(RuntimeSpec(
+        str(tmp_path), executable="opencode", model="opencode/hy3-free",
+        environment={"TMPDIR": str(tmp_path)},
+    )))
+    await asyncio.wait_for(entered.wait(), 1)
+    if cancel:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        await task
+        assert driver._context_window == 190000
+    assert proc.returncode is not None
+    assert directories and all(not p.exists() for p in directories)
+    await driver.close()

--- a/tests/test_opencode_driver.py
+++ b/tests/test_opencode_driver.py
@@ -874,3 +874,83 @@ async def test_second_cancel_during_shutdown_keeps_files_for_close(monkeypatch, 
     await driver.close()
     assert proc.returncode is not None
     assert not directories[0].exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["turn", "context", "serve"])
+@pytest.mark.parametrize("spawn_result", ["handle", "error", "cancelled"])
+async def test_pending_spawn_survives_caller_and_close_cancellation(
+    monkeypatch, tmp_path, operation, spawn_result,
+):
+    """A child may exist before transport initialization hands us its handle."""
+    import shutil
+    from pathlib import Path
+    from puffo_agent.agent.harness.drivers import opencode
+
+    proc = _TurnProcess()
+    entered, release = asyncio.Event(), asyncio.Event()
+    directories = []
+    spawn_cancelled = False
+
+    async def create(*args, **kwargs):
+        nonlocal spawn_cancelled
+        directory = Path(kwargs["env"]["TMPDIR"])
+        directories.append(directory)
+        (directory / "native.so").touch()
+        entered.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            spawn_cancelled = True
+            raise
+        if spawn_result == "error":
+            raise OSError("transport initialization cleanup failed")
+        if spawn_result == "cancelled":
+            raise asyncio.CancelledError("spawn internally cancelled")
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create)
+    monkeypatch.setattr(opencode, "CLEANUP_TIMEOUT_SECONDS", 0.03)
+    driver = OpenCodeDriver()
+    spec = RuntimeSpec(str(tmp_path), executable="opencode")
+    await driver.open(spec)
+    work = (driver.start_turn(TurnInput("hello")) if operation == "turn" else
+            driver._resolve_context_window(spec) if operation == "context" else
+            driver._summarize_via_serve(spec, "session"))
+    task = asyncio.create_task(work)
+    await asyncio.wait_for(entered.wait(), 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert (directories[0] / "native.so").exists()
+    assert proc.returncode is None
+
+    # Repeated cancellation and the close deadline must not cancel spawn.
+    closing = asyncio.create_task(driver.close())
+    await asyncio.sleep(0)
+    closing.cancel()
+    await asyncio.sleep(0)
+    closing.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await closing
+    assert not spawn_cancelled
+    assert (directories[0] / "native.so").exists()
+    with pytest.raises(RuntimeError, match="still running"):
+        await driver._spawn(spec, "second")
+
+    release.set()
+    try:
+        if spawn_result == "handle":
+            await driver.close()
+            assert proc.returncode is not None
+            assert not directories[0].exists()
+        else:
+            # An exception without a handle is not proof no child was born.
+            with pytest.raises(BaseException):
+                await driver.close()
+            assert proc.returncode is None
+            assert (directories[0] / "native.so").exists()
+    finally:
+        proc.exit()
+        proc.eof()
+        shutil.rmtree(directories[0], ignore_errors=True)

--- a/tests/test_opencode_driver.py
+++ b/tests/test_opencode_driver.py
@@ -750,3 +750,127 @@ async def test_turn_reclaims_native_temp_files_after_child_stops(tmp_path, outco
         assert directories and all(not path.exists() for path in directories)
     finally:
         await driver.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["turn", "context", "serve"])
+@pytest.mark.parametrize("failure", [OSError, asyncio.TimeoutError, asyncio.CancelledError])
+async def test_failed_shutdown_preserves_child_files_until_retry(
+    monkeypatch, tmp_path, operation, failure,
+):
+    """An interrupted shutdown must not free live-child storage or allow reuse."""
+    from pathlib import Path
+    from puffo_agent.agent.harness.drivers import opencode
+
+    proc = _TurnProcess()
+    entered = asyncio.Event()
+    directories = []
+
+    def factory(command, spec):
+        directory = Path(dict(spec.environment)["TMPDIR"])
+        directories.append(directory)
+        (directory / "native.so").write_bytes(b"library")
+        entered.set()
+        return proc
+
+    async def create(*args, **kwargs):
+        return factory(args, RuntimeSpec(str(tmp_path), environment=kwargs["env"]))
+
+    async def communicate():
+        await asyncio.Event().wait()
+
+    async def cannot_stop(*args, **kwargs):
+        raise failure("shutdown interrupted")
+
+    proc.communicate = communicate
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create)
+    monkeypatch.setattr(opencode, "shutdown_process_tree", cannot_stop)
+    driver = OpenCodeDriver(factory)
+    spec = RuntimeSpec(str(tmp_path), executable="opencode")
+    await driver.open(spec)
+    if operation == "turn":
+        work = driver.start_turn(TurnInput("hello"))
+    elif operation == "context":
+        work = driver._resolve_context_window(spec)
+    else:
+        work = driver._summarize_via_serve(spec, "session")
+    task = asyncio.create_task(work)
+    await asyncio.wait_for(entered.wait(), 1)
+    task.cancel()
+    with pytest.raises(BaseException):
+        await task
+    driver._cleanup_child_temps()
+    assert proc.returncode is None
+    assert (directories[0] / "native.so").exists()
+    with pytest.raises(RuntimeError, match="still running"):
+        await driver._spawn(spec, "second")
+    assert len(directories) == 1
+    with pytest.raises(BaseException):
+        await driver.close()
+    assert (directories[0] / "native.so").exists()
+
+    async def stop(child, **kwargs):
+        if child is not None:
+            child.exit()
+            child.eof()
+        waiter = kwargs.get("waiter")
+        if waiter is not None:
+            await waiter
+
+    monkeypatch.setattr(opencode, "shutdown_process_tree", stop)
+    await driver.close()
+    assert proc.returncode is not None
+    assert not directories[0].exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["context", "serve"])
+async def test_second_cancel_during_shutdown_keeps_files_for_close(monkeypatch, tmp_path, operation):
+    """A second cancellation during the shutdown await cannot free a live child."""
+    from pathlib import Path
+    from puffo_agent.agent.harness.drivers import opencode
+
+    proc = _TurnProcess()
+    started, stopping = asyncio.Event(), asyncio.Event()
+    directories = []
+
+    async def create(*args, **kwargs):
+        directory = Path(kwargs["env"]["TMPDIR"])
+        directories.append(directory)
+        (directory / "native.so").touch()
+        started.set()
+        return proc
+
+    async def communicate():
+        await asyncio.Event().wait()
+
+    async def slow_stop(*args, **kwargs):
+        stopping.set()
+        await asyncio.Event().wait()
+
+    proc.communicate = communicate
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create)
+    monkeypatch.setattr(opencode, "shutdown_process_tree", slow_stop)
+    driver = OpenCodeDriver()
+    spec = RuntimeSpec(str(tmp_path), executable="opencode")
+    work = (driver._resolve_context_window(spec) if operation == "context"
+            else driver._summarize_via_serve(spec, "session"))
+    task = asyncio.create_task(work)
+    await asyncio.wait_for(started.wait(), 1)
+    task.cancel()
+    await asyncio.wait_for(stopping.wait(), 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proc.returncode is None
+    assert (directories[0] / "native.so").exists()
+
+    async def stop(child, **kwargs):
+        if child is not None:
+            child.exit()
+            child.eof()
+
+    monkeypatch.setattr(opencode, "shutdown_process_tree", stop)
+    await driver.close()
+    assert proc.returncode is not None
+    assert not directories[0].exists()

--- a/tests/test_opencode_driver.py
+++ b/tests/test_opencode_driver.py
@@ -709,3 +709,44 @@ def _assert_process_exited(pid: int) -> None:
             return
         time.sleep(0.01)
     raise AssertionError(f"descendant process {pid} is still alive")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "failed", "close", "spawn_error"])
+async def test_turn_reclaims_native_temp_files_after_child_stops(tmp_path, outcome):
+    """Repeated real turns must not accumulate the CLI's extracted libraries."""
+    from pathlib import Path
+
+    directories = []
+    proc = _TurnProcess()
+
+    def factory(command, spec):
+        directory = Path(dict(spec.environment)["TMPDIR"])
+        directories.append(directory)
+        (directory / "native.so").write_bytes(b"library")
+        if outcome == "spawn_error":
+            raise OSError("cannot spawn")
+        proc.feed({"type": "step_start", "sessionID": "ses_tmp",
+                   "part": {"messageID": "msg_tmp"}})
+        return proc
+
+    driver = OpenCodeDriver(factory)
+    await driver.open(RuntimeSpec(str(tmp_path), environment={"TMPDIR": str(tmp_path)}))
+    try:
+        if outcome == "spawn_error":
+            with pytest.raises(OSError):
+                await driver.start_turn(TurnInput("hello"))
+        else:
+            await driver.start_turn(TurnInput("hello"))
+            assert (directories[0] / "native.so").exists()
+            if outcome == "close":
+                await driver.close()
+            else:
+                proc.exit(1 if outcome == "failed" else 0)
+                proc.eof()
+                await asyncio.wait_for(
+                    _next_matching(driver.events(), HarnessEventType.TURN_COMPLETED), 2,
+                )
+        assert directories and all(not path.exists() for path in directories)
+    finally:
+        await driver.close()

--- a/tests/test_opencode_protocol.py
+++ b/tests/test_opencode_protocol.py
@@ -42,7 +42,6 @@ def test_run_command_resumes_by_session_and_keeps_prompt_positional():
         "openai/gpt-5",
         "--session",
         "ses_123",
-        "--auto",
         "--title",
         "Puffo",
         "one semantic input",

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "puffo-agent"
-version = "2.0.5a2"
+version = "2.0.5a3"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Changes
- Share bounded, invalidated model discovery cache and isolate Puffo-owned OpenCode temporary files.
- Preserve child ownership across cancellation and interrupted shutdown; reclaim only after termination.
- Replace unsupported --auto with native permission config for explicitly selected bypassPermissions only.

## Verification
- Independent review approved 6c9dd1d: no Critical/Important findings; native runtime compatibility separately reviewed.
- Final exact combination f8bbd5f: 4404 tests passed, 2 skipped; Ruff, structure and diff checks passed.
- Real Linux OpenCode 1.3.17: discovery rounds reduced calls 2/4/6 to 1/1/1 and residual extracted libraries 2/4/6 to 0/0/0. Model failure, cancellation and delayed process-handle cleanup verified.
- Successful prepared-driver inference and actual Puffo delivery remain unverified; not claimed by this fix.
- Nonblocking limitation: custom test process factories must preserve native filename-bearing spawn error semantics.

Scoped for TestPyPI 2.0.5a3; no production release.