### PR TITLE
fix: show compaction activity in the local agent list

### DIFF
--- a/src/puffo_agent/portal/state.py
+++ b/src/puffo_agent/portal/state.py
@@ -1026,6 +1026,7 @@ class RuntimeState:
     """
 
     status: str = "stopped"  # starting | running | paused | error | stopped
+    activity: str | None = None  # transient harness activity, independent of lifecycle
     started_at: int = 0
     updated_at: int = 0
     msg_count: int = 0
@@ -1104,6 +1105,7 @@ class RuntimeState:
             return None
         return cls(
             status=raw.get("status", "stopped"),
+            activity=raw.get("activity"),
             started_at=int(raw.get("started_at", 0)),
             updated_at=int(raw.get("updated_at", 0)),
             msg_count=int(raw.get("msg_count", 0)),
@@ -1121,6 +1123,8 @@ class RuntimeState:
     def save(self, agent_id: str) -> None:
         import json
 
+        if self.status not in {"starting", "running"}:
+            self.activity = None
         self.updated_at = int(time.time())
         path = runtime_json_path(agent_id)
         # CLI staleness gate is 30s; throttle pure-updated_at writes

--- a/src/puffo_agent/portal/ui/widgets/agent_list.py
+++ b/src/puffo_agent/portal/ui/widgets/agent_list.py
@@ -53,6 +53,7 @@ class AgentSummary:
     model: str
     slug: str
     avatar_url: str
+    activity: str | None = None
 
     @classmethod
     def for_id(cls, agent_id: str) -> AgentSummary:
@@ -83,6 +84,7 @@ class AgentSummary:
             model=model,
             slug=slug,
             avatar_url=avatar_url,
+            activity=rt.activity if rt else None,
         )
 
 
@@ -143,10 +145,16 @@ class _Row(QWidget):
         self._name_label.setText(name)
         runtime_blurb_parts = [p for p in (summary.harness, summary.model) if p]
         self._sub_label.setText(" · ".join(runtime_blurb_parts) or "—")
+        compacting = (
+            summary.activity == "compacting"
+            and summary.status in {"running", "starting"}
+        )
+        if compacting:
+            self._sub_label.setText("Compacting context… · " + self._sub_label.text())
         self._dot.setStyleSheet(
             f"color: {_STATUS_COLOUR.get(summary.status, '#9aa0a6')}; font-size: 14pt;"
         )
-        self._dot.setToolTip(summary.status)
+        self._dot.setToolTip("Compacting context" if compacting else summary.status)
 
 
 class AgentList(QWidget):
@@ -217,7 +225,11 @@ class AgentList(QWidget):
         loader = summaries_loader or _default_loader
         all_rows = loader()
         all_rows.sort(key=lambda s: (_STATUS_ORDER.get(s.status, 9), s.display_name.lower(), s.id))
-        rows = [r for r in all_rows if r.status == "running"] if self._running_only else all_rows
+        rows = [
+            r for r in all_rows
+            if r.status == "running"
+            or (r.status == "starting" and r.activity == "compacting")
+        ] if self._running_only else all_rows
 
         running_count = sum(1 for r in all_rows if r.status == "running")
         self._count_label.setText(f"{running_count} running / {len(all_rows)} total")

--- a/src/puffo_agent/portal/worker.py
+++ b/src/puffo_agent/portal/worker.py
@@ -1372,6 +1372,7 @@ class Worker:
         if self._task is not None and not self._task.done():
             return self._task
         self.runtime.status = "starting"
+        self.runtime.activity = None
         self.runtime.error = ""
         self.runtime.save(self.agent_cfg.id)
         self._task = spawn(self._run(), name="run")

--- a/src/puffo_agent/portal/worker_run.py
+++ b/src/puffo_agent/portal/worker_run.py
@@ -436,6 +436,13 @@ class StandardWorkerRun:
         worker._pending_activity = None
 
         async def emit_activity(activity: str | None) -> None:
+            # The desktop list reads the local snapshot, including during
+            # warm-up before the server reporter is attached.
+            worker.runtime.activity = activity
+            try:
+                worker.runtime.save(agent_id)
+            except OSError:
+                logger.warning("agent %s: activity snapshot write failed", agent_id, exc_info=True)
             # The overlay flips synchronously (event order preserved);
             # the heartbeat push runs detached because this callback
             # fires under the runtime command lock and a slow status
@@ -1100,6 +1107,7 @@ class StandardWorkerRun:
             except (asyncio.CancelledError, Exception):
                 pass
         worker.runtime.status = "stopped"
+        worker.runtime.activity = None
         worker.runtime.save(context.paths.agent_id)
         if context.runtime_event_outbox is not None:
             # The Runtime Manager's reader is what feeds this outbox, so it has

--- a/tests/test_ui_compacting.py
+++ b/tests/test_ui_compacting.py
@@ -1,0 +1,90 @@
+"""Desktop compaction activity follows the worker snapshot independently per agent."""
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from puffo_agent.portal.state import RuntimeState
+from puffo_agent.portal.ui.widgets.agent_list import AgentList, AgentSummary
+
+
+@pytest.fixture
+def local_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("PUFFO_AGENT_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_worker_activity_reaches_local_snapshot_before_reporter(local_home, monkeypatch):
+    import puffo_agent.agent.harness.runtime.local_runtime as local_runtime
+    from puffo_agent.portal.worker_run import StandardWorkerRun
+
+    captured = {}
+    def builder(prepared, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace()
+    monkeypatch.setattr(local_runtime, "build_local_runtime_adapter", builder)
+    worker = SimpleNamespace(runtime=RuntimeState(status="running"))
+    prepared = SimpleNamespace(
+        native_session_id="", harness_name="codex",
+        preparer=SimpleNamespace(agent_id="desktop-test"),
+        spec=SimpleNamespace(mcp_generation=""),
+    )
+    await StandardWorkerRun(worker)._bind_driver_runtime(
+        SimpleNamespace(set_active_turn=lambda *a, **kw: None), prepared, {},
+    )
+    sink = captured["activity_sink"]
+    for activity in ("compacting", None, "compacting", None):
+        await sink(activity)
+        summary = AgentSummary.for_id("desktop-test")
+        assert summary.status == "running"
+        assert summary.activity == activity
+        assert worker._pending_activity == activity
+
+
+def test_multiple_agents_display_and_clear_activity(local_home):
+    app = QApplication.instance() or QApplication([])
+    view = AgentList()
+    for agent_id in ("one", "two"):
+        RuntimeState(status="running", activity="compacting").save(agent_id)
+    loader = lambda: [AgentSummary.for_id(a) for a in ("one", "two")]
+    view.refresh(loader)
+    assert view._list.count() == 2
+    assert all("Compacting" in row._sub_label.text() for row in view._rows.values())
+    RuntimeState(status="running").save("one")
+    view.refresh(loader)
+    assert "Compacting" not in view._rows["one"]._sub_label.text()
+    assert "Compacting" in view._rows["two"]._sub_label.text()
+    view.close()
+    app.processEvents()
+
+
+def test_long_warm_compaction_remains_visible(local_home, monkeypatch):
+    import time
+    app = QApplication.instance() or QApplication([])
+    RuntimeState(status="starting", activity="compacting").save("warm")
+    updated = RuntimeState.load("warm").updated_at
+    monkeypatch.setattr(time, "time", lambda: updated + 60)
+    assert AgentSummary.for_id("warm").activity == "compacting"
+    view = AgentList()
+    view.refresh(lambda: [AgentSummary.for_id("warm")])
+    assert view._list.count() == 1
+    assert "Compacting" in view._rows["warm"]._sub_label.text()
+    view.close()
+    app.processEvents()
+
+
+@pytest.mark.parametrize("status", ["stopped", "paused", "error"])
+def test_inactive_agent_does_not_show_old_compaction(local_home, status):
+    app = QApplication.instance() or QApplication([])
+    view = AgentList()
+    view._running_only = False
+    RuntimeState(status=status, activity="compacting").save("inactive")
+    assert RuntimeState.load("inactive").activity is None
+    view.refresh(lambda: [AgentSummary.for_id("inactive")])
+    assert "Compacting" not in view._rows["inactive"]._sub_label.text()
+    view.close()
+    app.processEvents()


### PR DESCRIPTION
The local Agent list only read lifecycle status, so compaction never appeared even when harness activity reached the server. Persist activity in the local runtime snapshot and show it per Agent, including startup compaction under the default filter; clear it on completion and inactive lifecycle states.

Validation: 4411 passed, 2 expected skips in an isolated HOME and PUFFO_AGENT_HOME with CODEX_HOME unset; 6 new regression cases fail against the unchanged a4 baseline. Independent review passed, plus Ruff and structural checks. Real provider-triggered compaction and interactive production UI have not been exercised.
