### PR TITLE
fix: explain Linux desktop libraries without downgrading installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ loaded as `cli-local` and keep their persisted profile and state.
 
 ## 2. Install
 
+### Linux requirements
+
+The 2.0.5 prereleases include PySide6 in every installation. Use a glibc-based
+distribution such as Debian or Ubuntu. Alpine/musl cannot resolve the required
+PySide6 wheels; adding OS graphics libraries does not fix that wheel mismatch.
+For a Linux container deployment, use a Debian/Ubuntu base image.
+
+On a minimal Debian/Ubuntu image, desktop imports also need system libraries:
+
+```bash
+sudo apt-get update
+sudo apt-get install libgl1 libegl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+```
+
+These packages were verified with the published 2.0.5a4 wheel on Debian 12
+x86_64 (Python 3.11, glibc 2.36). A headless daemon (`puffo-agent start`)
+starts without these graphics libraries. An actual desktop session needs a
+working display server and its Qt platform dependencies as well; creating an
+offscreen Qt application is only a smoke check, not interactive desktop validation.
+On small VMs, prefer `uv tool install` to reduce installation overhead.
+
+### Python package
+
 If you manage Python with `uv` (uv-managed interpreter, common on
 macOS via Homebrew + uv), use the `uv tool` path — `pip install`
 fails with PEP 668 `externally-managed-environment` on uv-managed

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -281,12 +281,15 @@ def cmd_config(args: argparse.Namespace) -> int:
 # Shown when a GUI entry point (``start --ui`` / ``start --background``) is
 # invoked but its required PySide6 dependency cannot be imported.
 _GUI_EXTRA_HINT = (
-    "the desktop UI dependency (PySide6) could not be imported. "
-    "Repair the installation with:\n\n    pip install --upgrade --force-reinstall puffo-agent\n"
-    "or, for a uv tool install:\n"
-    "    uv tool install --force puffo-agent\n\n"
-    "(the headless daemon — `puffo-agent start` with no UI flag — runs "
-    "without it.)"
+    "The desktop UI dependency could not be imported.\n"
+    "If the PySide6 Python package is missing, repair it using your original "
+    "installation source and version; a default-index reinstall can downgrade "
+    "a prerelease.\n\n"
+    "If the error names a missing shared library (.so), reinstalling the Python "
+    "package does not supply OS libraries. On Debian/Ubuntu, install:\n\n"
+    "    sudo apt-get install libgl1 libegl1 libxkbcommon0 libdbus-1-3 libfontconfig1\n\n"
+    "The headless daemon (`puffo-agent start` with no UI flag) runs without "
+    "the desktop libraries."
 )
 
 
@@ -300,8 +303,8 @@ def cmd_start(args: argparse.Namespace) -> int:
             from .ui.tray import run_tray
 
             return run_tray()
-        except ImportError:
-            print(_GUI_EXTRA_HINT, file=sys.stderr)
+        except ImportError as exc:
+            print(f"Import error: {exc}\n\n{_GUI_EXTRA_HINT}", file=sys.stderr)
             return 1
     if getattr(args, "background", False):
         from .background import spawn_background
@@ -316,8 +319,8 @@ def cmd_start(args: argparse.Namespace) -> int:
             from .ui.launcher import launch
 
             return launch()
-        except ImportError:
-            print(_GUI_EXTRA_HINT, file=sys.stderr)
+        except ImportError as exc:
+            print(f"Import error: {exc}\n\n{_GUI_EXTRA_HINT}", file=sys.stderr)
             return 1
     logging.basicConfig(
         level=logging.INFO,

--- a/tests/test_slim_packaging_headless.py
+++ b/tests/test_slim_packaging_headless.py
@@ -88,7 +88,7 @@ def test_gui_command_with_missing_dependency_yields_actionable_hint(
     pyside6_blocked, capsys,
 ):
     """`start --ui` with PySide6 absent returns non-zero and prints the
-    `pip install --upgrade --force-reinstall puffo-agent` hint instead of ModuleNotFoundError."""
+    repair hint preserving the original version instead of a downgrade command."""
     cli = importlib.import_module("puffo_agent.portal.cli")
     args = argparse.Namespace(
         ui=True, tray_runner=False, background=False, with_local_bridge=False,
@@ -97,7 +97,9 @@ def test_gui_command_with_missing_dependency_yields_actionable_hint(
     assert rc != 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "pip install --upgrade --force-reinstall puffo-agent" in combined
+    assert "original installation source and version" in combined
+    assert "force-reinstall puffo-agent" not in combined
+    assert "libdbus-1-3" in combined
 
 
 def test_tray_command_with_missing_dependency_yields_actionable_hint(
@@ -112,4 +114,6 @@ def test_tray_command_with_missing_dependency_yields_actionable_hint(
     assert rc != 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "pip install --upgrade --force-reinstall puffo-agent" in combined
+    assert "original installation source and version" in combined
+    assert "force-reinstall puffo-agent" not in combined
+    assert "libdbus-1-3" in combined


### PR DESCRIPTION
On minimal Debian, the installed desktop package fails to import because OS shared libraries are absent. The old repair hint recommended an unversioned reinstall, which does not supply those libraries and can downgrade a TestPyPI prerelease to stable. Show the actual import error first, give Debian/Ubuntu system-package guidance, and preserve the original source/version for Python package repairs. Document the glibc requirement and Alpine/musl wheel limitation.

Validation: published a4 wheel installed with uv on E2B Debian12 x86_64/Python3.11/glibc2.36; headless daemon startup/status/graceful shutdown passed before installing graphics libraries; offscreen QApplication passed after installing the documented five OS packages. All four short-lived sandboxes were destroyed. No model credentials or live Agent/message workflow were used.

4405 tests passed, 2 expected skips in isolated HOME/PUFFO_AGENT_HOME with CODEX_HOME unset. Two existing regression tests fail before the hint change and pass after it. Independent review, Ruff and structural checks passed. This does not add Alpine support or prove interactive Linux desktop behavior.
