### PR TITLE
fix: select desktop dependencies without blocking Linux installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,32 @@ python -m puffo_agent start --detach
 App Control is enforced before Puffo code starts, so administrators may also
 need to allow the generated launcher under the machine's policy.
 
-The standard install includes desktop window and tray support as well as
-foreground and detached headless daemon modes. No extra installation option
-is needed. Headless modes do not initialize Qt.
+The installation and startup commands are the same on every platform:
+
+- macOS and Windows install desktop window and tray dependencies automatically.
+- Linux installs the headless Agent without requiring Qt. The first explicit
+  `start --ui` or tray-backed `start --background` automatically installs missing
+  PySide6 into the Python environment running Puffo. This first desktop setup
+  needs network access and either `uv` on PATH or pip in that environment. It
+  does not reinstall or upgrade Puffo itself. Subsequent desktop starts reuse Qt.
+- `start` and `start --detach` never install or initialize Qt. If an upgrade
+  rebuilds the environment, the next desktop start prepares Qt again as needed.
+
+Linux desktop use also requires OS graphics libraries. On Debian/Ubuntu:
+
+```bash
+sudo apt-get install libgl1 libegl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+```
+
+Puffo does not run privileged OS package installation automatically. Missing
+system libraries are reported without repeatedly downloading PySide6. An
+explicit desktop request fails if the desktop cannot start; it is never silently
+changed into headless mode. Alpine/musl has no compatible PySide6 wheel, so desktop
+modes are unavailable there even though the base installation no longer requires
+Qt. Use a supported glibc desktop distribution for GUI operation.
+
+Existing `puffo-agent[gui]` installations remain supported for environments that
+preinstall desktop dependencies. No extra selection is needed for normal use.
 
 For contributors working from a source checkout:
 
@@ -116,7 +139,7 @@ lazy-creates `~/.puffo-agent/` on first run with sensible defaults (server
 
 | Command | What it does |
 | --- | --- |
-| `puffo-agent start` | Run the daemon (foreground). `--detach` runs headless in the background; `--ui` and tray-backed `--background` use the included desktop support. |
+| `puffo-agent start` | Run the daemon (foreground). `--detach` runs headless in the background; `--ui` and tray-backed `--background` prepare and use desktop support. |
 | `puffo-agent status` | Is it alive? which agents are running? |
 | `puffo-agent stop` | Graceful shutdown from any terminal (`--timeout`, default 60s) |
 | `puffo-agent version` | Print the installed `puffo-agent` version |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,12 @@ dependencies = [
     # poisoning the claude session. It's lazy-imported, so the keyless
     # boot chain still never pulls PIL into sys.modules.
     "pillow>=10.0",
+    "packaging>=24.0",
     "pyhpke>=0.6",
     "psutil>=5.9",
-    # Desktop support is included in every install and upgrade.
-    "pyside6>=6.7",
+    # Desktop defaults stay automatic on macOS/Windows. Linux servers do not
+    # require Qt; explicit desktop commands prepare it in the active environment.
+    "pyside6>=6.7; platform_system == 'Darwin' or platform_system == 'Windows'",
     "python-socks>=2.4",
     "pyyaml>=6.0",
     # Windows has no system IANA timezone database; usage reset parsing needs it.
@@ -66,8 +68,8 @@ dependencies = [
 # this extra is a no-op for a base install. Kept so the historical
 # "pip install puffo-agent[attachments]" hint still resolves.
 attachments = ["pillow>=10.0"]
-# Compatibility alias for older installation instructions; GUI is now included.
-gui = []
+# Keep existing explicit desktop installations working on every supported OS.
+gui = ["pyside6>=6.7"]
 # cli-local / cli-docker adapters don't need extra Python deps; they
 # shell out to the `claude` binary (cli-local) or Docker (cli-docker).
 # pip install --editable ".[dev]"  — needed to run the test suite.
@@ -76,6 +78,7 @@ gui = []
 # `@pytest.mark.asyncio`. Without it, those tests silently skip and
 # anything using async fixtures errors out.
 dev = [
+    "pyside6>=6.7",
     "pre-commit>=4.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/src/puffo_agent/portal/background.py
+++ b/src/puffo_agent/portal/background.py
@@ -13,8 +13,8 @@ import os
 import subprocess
 import sys
 import time
-from importlib.util import find_spec
 
+from .desktop_dependencies import desktop_error_message, prepare_desktop
 from .state import (
     DAEMON_STARTUP_OBSERVATION_SECONDS,
     DaemonStartupState,
@@ -31,11 +31,6 @@ from .state import (
 _DETACHED_PROCESS = 0x00000008
 _CREATE_NEW_PROCESS_GROUP = 0x00000200
 _CREATE_BREAKAWAY_FROM_JOB = 0x01000000
-_GUI_EXTRA_HINT = (
-    "puffo-agent start --background could not import the desktop dependency "
-    "(PySide6). Repair with: pip install --upgrade --force-reinstall puffo-agent or "
-    "uv tool install --force puffo-agent"
-)
 
 
 def tray_runner_command() -> list[str]:
@@ -193,7 +188,9 @@ def spawn_background() -> int:
     foreground caller, which exits immediately afterward."""
     if (existing := _existing_daemon_result()) is not None:
         return existing
-    if find_spec("PySide6") is None:
-        print(_GUI_EXTRA_HINT, file=sys.stderr)
+    try:
+        prepare_desktop()
+    except ImportError as exc:
+        print(desktop_error_message(exc), file=sys.stderr)
         return 1
     return _spawn_detached(tray_runner_command(), tray=True)

--- a/src/puffo_agent/portal/cli.py
+++ b/src/puffo_agent/portal/cli.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from .cli_parser import build_parser as build_cli_parser
+from .desktop_dependencies import desktop_error_message, prepare_desktop
 from .state import (
     AgentConfig,
     DaemonConfig,
@@ -278,18 +279,6 @@ def cmd_config(args: argparse.Namespace) -> int:
     return 0
 
 
-# Shown when a GUI entry point (``start --ui`` / ``start --background``) is
-# invoked but its required PySide6 dependency cannot be imported.
-_GUI_EXTRA_HINT = (
-    "the desktop UI dependency (PySide6) could not be imported. "
-    "Repair the installation with:\n\n    pip install --upgrade --force-reinstall puffo-agent\n"
-    "or, for a uv tool install:\n"
-    "    uv tool install --force puffo-agent\n\n"
-    "(the headless daemon — `puffo-agent start` with no UI flag — runs "
-    "without it.)"
-)
-
-
 def cmd_start(args: argparse.Namespace) -> int:
     # The PySide6 import inside run_tray/launch is deferred to call time,
     # so the ImportError surfaces from the call, not the ``from .ui...``
@@ -297,11 +286,12 @@ def cmd_start(args: argparse.Namespace) -> int:
     # instead of a raw ModuleNotFoundError traceback.
     if getattr(args, "tray_runner", False):
         try:
+            prepare_desktop()
             from .ui.tray import run_tray
 
             return run_tray()
-        except ImportError:
-            print(_GUI_EXTRA_HINT, file=sys.stderr)
+        except ImportError as exc:
+            print(desktop_error_message(exc), file=sys.stderr)
             return 1
     if getattr(args, "background", False):
         from .background import spawn_background
@@ -313,11 +303,12 @@ def cmd_start(args: argparse.Namespace) -> int:
         return spawn_headless_background()
     if getattr(args, "ui", False):
         try:
+            prepare_desktop()
             from .ui.launcher import launch
 
             return launch()
-        except ImportError:
-            print(_GUI_EXTRA_HINT, file=sys.stderr)
+        except ImportError as exc:
+            print(desktop_error_message(exc), file=sys.stderr)
             return 1
     logging.basicConfig(
         level=logging.INFO,

--- a/src/puffo_agent/portal/desktop_dependencies.py
+++ b/src/puffo_agent/portal/desktop_dependencies.py
@@ -1,0 +1,116 @@
+"""Prepare desktop dependencies only for an explicitly requested GUI mode."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import importlib.util
+import shutil
+import site
+import subprocess
+import sys
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+from puffo_agent._proc import no_window_kwargs
+
+_GUI_REQUIREMENT = "pyside6>=6.7"
+
+
+def prepare_desktop() -> None:
+    """Install missing Qt into this interpreter, then check its shared libraries.
+
+    Headless entry points never call this. Never reinstall puffo-agent: doing so
+    could change its version or source, particularly for a TestPyPI installation.
+    Existing but broken Qt installations are reported without another download.
+    """
+    if _needs_desktop_install():
+        _install_desktop()
+        importlib.invalidate_caches()
+    importlib.import_module("PySide6.QtWidgets")
+
+
+def _needs_desktop_install() -> bool:
+    if importlib.util.find_spec("PySide6") is None:
+        return True
+    try:
+        version = importlib.metadata.version("PySide6")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise ImportError(
+            "PySide6 is present but its installation metadata is missing."
+        ) from exc
+    return version not in Requirement(_GUI_REQUIREMENT).specifier
+
+
+def _install_desktop() -> None:
+    # uv tool environments need not contain pip. An explicit interpreter also
+    # works with custom UV_TOOL_DIR paths and avoids changing another install.
+    if _is_user_install():
+        if importlib.util.find_spec("pip") is None:
+            raise ImportError(
+                "Automatic desktop setup for a user installation requires pip in this interpreter."
+            )
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "--user",
+            _GUI_REQUIREMENT,
+        ]
+    elif uv := shutil.which("uv"):
+        command = [uv, "pip", "install", "--python", sys.executable, _GUI_REQUIREMENT]
+    elif importlib.util.find_spec("pip") is not None:
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-cache-dir",
+            _GUI_REQUIREMENT,
+        ]
+    else:
+        raise ImportError(
+            "Automatic desktop setup needs uv on PATH or pip in this Python environment."
+        )
+
+    print("Preparing desktop support for this Python environment…", file=sys.stderr)
+    try:
+        result = subprocess.run(command, check=False, timeout=600, **no_window_kwargs())
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ImportError(
+            "Automatic desktop setup could not finish; retry the same command."
+        ) from exc
+    if result.returncode:
+        raise ImportError(
+            f"Automatic desktop setup failed (installer exit {result.returncode}). Check the installer error above "
+            "and retry the same command after resolving it."
+        )
+
+
+def _is_user_install() -> bool:
+    """A pip --user install must not try to write to the system interpreter."""
+    if not site.ENABLE_USER_SITE:
+        return False
+    try:
+        installed = importlib.metadata.distribution("puffo-agent").locate_file("")
+    except importlib.metadata.PackageNotFoundError:
+        return False  # source checkout, rather than an installed distribution
+    return (
+        Path(installed)
+        .resolve()
+        .is_relative_to(Path(site.getusersitepackages()).resolve())
+    )
+
+
+def desktop_error_message(exc: ImportError) -> str:
+    return (
+        f"Desktop support could not start: {exc}\n\n"
+        "A missing system shared library (.so) is not fixed by reinstalling Python packages.\n"
+        "On Debian/Ubuntu, the Qt runtime libraries can be installed with:\n"
+        "    sudo apt-get install libgl1 libegl1 libxkbcommon0 libdbus-1-3 libfontconfig1\n"
+        "Alpine/musl has no compatible PySide6 wheel.\n"
+        "The requested desktop mode has not been replaced with a headless daemon."
+    )

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -100,19 +100,22 @@ def test_headless_background_reports_existing_daemon_stalled(monkeypatch, capsys
 
 def test_spawn_background_preflights_gui_before_detach(monkeypatch, capsys):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
-    monkeypatch.setattr(bg, "find_spec", lambda _name: None)
+    def unavailable():
+        raise ImportError("Qt setup failed")
+
+    monkeypatch.setattr(bg, "prepare_desktop", unavailable)
 
     def _no_spawn(*_args, **_kwargs):
         raise AssertionError("must not detach without the GUI dependency")
 
     monkeypatch.setattr(bg.subprocess, "Popen", _no_spawn)
     assert bg.spawn_background() == 1
-    assert "uv tool install --force puffo-agent" in capsys.readouterr().err
+    assert "Qt setup failed" in capsys.readouterr().err
 
 
 def test_spawn_background_detaches_child(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
-    monkeypatch.setattr(bg, "find_spec", lambda _name: object())
+    monkeypatch.setattr(bg, "prepare_desktop", lambda: None)
     monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
     monkeypatch.setattr(
         bg,
@@ -148,7 +151,7 @@ def test_spawn_background_keeps_a_live_child_after_observation_timeout(
     monkeypatch, tmp_path, capsys
 ):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
-    monkeypatch.setattr(bg, "find_spec", lambda _name: object())
+    monkeypatch.setattr(bg, "prepare_desktop", lambda: None)
     monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
     monkeypatch.setattr(
         bg,
@@ -205,7 +208,7 @@ def test_spawn_background_reports_child_exit_before_ready(
     monkeypatch, tmp_path, capsys
 ):
     monkeypatch.setattr(bg, "is_daemon_alive", lambda: False)
-    monkeypatch.setattr(bg, "find_spec", lambda _name: object())
+    monkeypatch.setattr(bg, "prepare_desktop", lambda: None)
     monkeypatch.setattr(bg, "background_log_path", lambda: tmp_path / "background.log")
     monkeypatch.setattr(
         bg,

--- a/tests/test_desktop_dependencies.py
+++ b/tests/test_desktop_dependencies.py
@@ -1,0 +1,178 @@
+"""Guard environment targeting, lazy setup, and GUI failure semantics."""
+
+import argparse
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from puffo_agent.portal import desktop_dependencies as desktop
+
+
+@pytest.mark.parametrize("installer", ["uv", "pip"])
+def test_explicit_ui_prepares_only_qt_in_current_interpreter(monkeypatch, installer):
+    """GUI setup must not install into PATH Python or change puffo-agent's version."""
+    from puffo_agent.portal import cli
+
+    installed = False
+    calls = []
+    monkeypatch.setattr(
+        desktop.shutil, "which", lambda _: "/tools/uv" if installer == "uv" else None
+    )
+    monkeypatch.setattr(
+        desktop.importlib.util,
+        "find_spec",
+        lambda name: object() if installed or name == "pip" else None,
+    )
+
+    def run(command, **kwargs):
+        nonlocal installed
+        calls.append(command)
+        installed = True
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(desktop.subprocess, "run", run)
+    original_import = desktop.importlib.import_module
+    monkeypatch.setattr(
+        desktop.importlib,
+        "import_module",
+        lambda name, *args: (
+            object() if name == "PySide6.QtWidgets" else original_import(name, *args)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules, "puffo_agent.portal.ui.launcher", SimpleNamespace(launch=lambda: 4)
+    )
+    args = argparse.Namespace(ui=True, tray_runner=False, background=False)
+    assert cli.cmd_start(args) == 4
+    prefix = (
+        ["/tools/uv", "pip", "install", "--python", sys.executable]
+        if installer == "uv"
+        else [sys.executable, "-m", "pip", "install", "--no-cache-dir"]
+    )
+    assert calls == [prefix + ["pyside6>=6.7"]]
+    # A second launch must not contact an installer when Qt is already present.
+    assert cli.cmd_start(args) == 4
+    assert len(calls) == 1
+
+
+def test_broken_shared_library_does_not_trigger_reinstallation(monkeypatch):
+    """libGL failures must not repeatedly download an already installed Qt."""
+    monkeypatch.setattr(desktop.importlib.util, "find_spec", lambda _: object())
+    monkeypatch.setattr(
+        desktop.subprocess, "run", lambda *a, **k: pytest.fail("must not reinstall")
+    )
+
+    def broken_import(_):
+        raise ImportError("libGL.so.1: cannot open shared object file")
+
+    monkeypatch.setattr(desktop.importlib, "import_module", broken_import)
+    with pytest.raises(ImportError, match="libGL.so.1"):
+        desktop.prepare_desktop()
+
+
+def test_existing_qt_below_minimum_is_upgraded(monkeypatch):
+    """Removing Qt from Linux base requirements must not leave unsupported old Qt."""
+    calls = []
+    monkeypatch.setattr(desktop.importlib.util, "find_spec", lambda _: object())
+    monkeypatch.setattr(desktop.importlib.metadata, "version", lambda _: "6.6.3")
+    monkeypatch.setattr(desktop.shutil, "which", lambda _: "/tools/uv")
+    monkeypatch.setattr(
+        desktop.subprocess,
+        "run",
+        lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0),
+    )
+    monkeypatch.setattr(desktop.importlib, "import_module", lambda _: object())
+    desktop.prepare_desktop()
+    assert calls == [
+        ["/tools/uv", "pip", "install", "--python", sys.executable, "pyside6>=6.7"]
+    ]
+
+
+@pytest.mark.parametrize("has_pip", [True, False])
+def test_user_install_preserves_user_site_even_when_uv_is_on_path(
+    monkeypatch, tmp_path, has_pip
+):
+    """pip --user users must not be redirected into a system installation."""
+    calls = []
+    user_site = tmp_path / "site-packages"
+    monkeypatch.setattr(desktop.site, "ENABLE_USER_SITE", True)
+    monkeypatch.setattr(desktop.site, "getusersitepackages", lambda: str(user_site))
+    monkeypatch.setattr(
+        desktop.importlib.metadata,
+        "distribution",
+        lambda _: SimpleNamespace(locate_file=lambda _: user_site),
+    )
+    monkeypatch.setattr(
+        desktop.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "pip" and has_pip else None,
+    )
+    monkeypatch.setattr(desktop.shutil, "which", lambda _: "/tools/uv")
+    monkeypatch.setattr(
+        desktop.subprocess,
+        "run",
+        lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0),
+    )
+    monkeypatch.setattr(desktop.importlib, "import_module", lambda _: object())
+    if not has_pip:
+        with pytest.raises(ImportError, match="user installation requires pip"):
+            desktop.prepare_desktop()
+        assert calls == []
+        return
+    desktop.prepare_desktop()
+    assert calls == [
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "--user",
+            "pyside6>=6.7",
+        ]
+    ]
+
+
+@pytest.mark.parametrize("failure", [1, "timeout", "missing_installer"])
+def test_gui_setup_failure_remains_a_gui_failure(monkeypatch, capsys, failure):
+    """Failed downloads must not launch UI or silently start a headless daemon."""
+    from puffo_agent.portal import cli
+
+    monkeypatch.setattr(desktop.importlib.util, "find_spec", lambda _: None)
+    monkeypatch.setattr(
+        desktop.shutil,
+        "which",
+        lambda _: None if failure == "missing_installer" else "/tools/uv",
+    )
+
+    def run(*args, **kwargs):
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(args[0], 600)
+        return SimpleNamespace(returncode=failure)
+
+    monkeypatch.setattr(desktop.subprocess, "run", run)
+    monkeypatch.setitem(
+        sys.modules,
+        "puffo_agent.portal.ui.launcher",
+        SimpleNamespace(launch=lambda: pytest.fail("setup failed")),
+    )
+    assert cli.cmd_start(argparse.Namespace(ui=True)) == 1
+    assert "Desktop support could not start" in capsys.readouterr().err
+
+
+def test_headless_start_never_prepares_gui(monkeypatch):
+    """A server's ordinary start remains offline with respect to desktop setup."""
+    from puffo_agent.portal import cli
+
+    async def daemon():
+        return 7
+
+    monkeypatch.setattr(
+        desktop.subprocess, "run", lambda *a, **k: pytest.fail("headless installation")
+    )
+    monkeypatch.setitem(
+        sys.modules, "puffo_agent.portal.daemon", SimpleNamespace(run_daemon=daemon)
+    )
+    assert cli.cmd_start(argparse.Namespace()) == 7

--- a/tests/test_slim_packaging_headless.py
+++ b/tests/test_slim_packaging_headless.py
@@ -1,6 +1,6 @@
 """Slim-packaging guard (Item A): the daemon / CLI path must import and
-run with PySide6 absent, and a GUI command with a missing dependency
-must fail with the actionable install hint — not a raw traceback.
+run with PySide6 absent, and failed automatic GUI setup must return an
+actionable error rather than a raw traceback or a main-package reinstall.
 
 Deterministic in any environment: we block ``PySide6`` (and its
 submodules) via ``sys.modules[...] = None`` regardless of whether the
@@ -19,17 +19,24 @@ from pathlib import Path
 import pytest
 
 
-def test_plain_install_requires_gui_dependency():
-    """A plain uv force-upgrade must not silently remove desktop support."""
+@pytest.mark.parametrize(
+    "system, required", [("Darwin", True), ("Windows", True), ("Linux", False)]
+)
+def test_plain_install_selects_gui_dependency_by_system(system, required):
+    """Linux servers must install without Qt; desktop defaults survive upgrades."""
     project = tomllib.loads(
         (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text()
     )["project"]
     from packaging.requirements import Requirement
 
     requirements = [Requirement(value) for value in project["dependencies"]]
-    assert any(
-        req.name.lower() == "pyside6" and req.marker is None
-        for req in requirements
+    assert (
+        any(
+            req.name.lower() == "pyside6"
+            and (req.marker is None or req.marker.evaluate({"platform_system": system}))
+            for req in requirements
+        )
+        is required
     )
 
 
@@ -58,6 +65,14 @@ def pyside6_blocked(monkeypatch):
             monkeypatch.delitem(sys.modules, name, raising=False)
         elif name.startswith("puffo_agent.portal.ui"):
             monkeypatch.delitem(sys.modules, name, raising=False)
+    from puffo_agent.portal import desktop_dependencies
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        desktop_dependencies.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1),
+    )
     yield
 
 
@@ -85,31 +100,40 @@ def test_cli_import_does_not_eagerly_import_daemon(pyside6_blocked):
 
 
 def test_gui_command_with_missing_dependency_yields_actionable_hint(
-    pyside6_blocked, capsys,
+    pyside6_blocked,
+    capsys,
 ):
-    """`start --ui` with PySide6 absent returns non-zero and prints the
-    `pip install --upgrade --force-reinstall puffo-agent` hint instead of ModuleNotFoundError."""
+    """Failed `start --ui` setup must not recommend a potentially downgrading reinstall."""
     cli = importlib.import_module("puffo_agent.portal.cli")
     args = argparse.Namespace(
-        ui=True, tray_runner=False, background=False, with_local_bridge=False,
+        ui=True,
+        tray_runner=False,
+        background=False,
+        with_local_bridge=False,
     )
     rc = cli.cmd_start(args)
     assert rc != 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "pip install --upgrade --force-reinstall puffo-agent" in combined
+    assert "Desktop support could not start" in combined
+    assert "force-reinstall" not in combined
 
 
 def test_tray_command_with_missing_dependency_yields_actionable_hint(
-    pyside6_blocked, capsys,
+    pyside6_blocked,
+    capsys,
 ):
     """Same guard for the `start --tray-runner` entry point."""
     cli = importlib.import_module("puffo_agent.portal.cli")
     args = argparse.Namespace(
-        ui=False, tray_runner=True, background=False, with_local_bridge=False,
+        ui=False,
+        tray_runner=True,
+        background=False,
+        with_local_bridge=False,
     )
     rc = cli.cmd_start(args)
     assert rc != 0
     captured = capsys.readouterr()
     combined = captured.out + captured.err
-    assert "pip install --upgrade --force-reinstall puffo-agent" in combined
+    assert "Desktop support could not start" in combined
+    assert "force-reinstall" not in combined


### PR DESCRIPTION
Linux installs currently require PySide6 even for a headless server, so platforms without a Qt wheel cannot install the Agent. Keep existing pip/uv commands and startup modes: macOS/Windows retain automatic desktop dependencies; Linux installs without Qt and prepares it only when an explicit desktop command first needs it.

The shared preparation path covers `--ui`, `--background`, and the tray runner. It targets the active interpreter or existing pip user site, upgrades Qt below the supported minimum, and never reinstalls Puffo. Missing OS libraries fail explicitly without repeated Python-package installation or changing GUI requests into headless startup. pip setup disables cache after an E2B cached-wheel preparation failure; the failure's root cause was not established. Headless commands never prepare Qt.

Supersedes #360's documentation/error-only approach. #359 (desktop compacting display) remains independent.

Validation:
- Final full suite: **4417 passed, 2 skipped** (70.41s). Skips: opt-in real OpenCode turn and native Windows process flags.
- 49 focused compatibility tests; new failure paths demonstrated red before fixes or with bounded mutations. Independent review by Fabrice found no remaining code issues.
- E2B Debian 12: real pip/uv installs without Qt, headless start/status/stop, first-use Qt preparation, missing OS library failure, offscreen GUI after OS library installation, and uv force reinstall followed by automatic tray dependency recovery.
- Final targeted E2B pip user-site setup/reuse passed with system Python unchanged. All three short-lived sandboxes destroyed.
- Isolated macOS pip/uv installs include Qt; native UI start/status/stop and uv force reinstall passed. Production daemon was not restarted.
- uv cross-platform resolution: musl Linux excludes Qt; Windows includes it. Pre-commit, Ruff and Python structural checks pass.

Limits: no actual Alpine daemon, native Windows execution, interactive Linux desktop, or model/message round trip in this change's validation. Linux OS graphics libraries are still a system prerequisite. Initial Linux GUI setup needs network and an available package installer; ordinary installation/headless use does not. Broad Debian/Mac probes preceded the final narrow user-site/no-cache guards, which received targeted E2B and final regression verification.
